### PR TITLE
User modal fix

### DIFF
--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -21,7 +21,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
   initialState() {
     let initialValue;
 
-    let rolesState = {}
+    let rolesState = {};
     rolesState[USER_ROLES_UPPER.admin] = false;
     rolesState[USER_ROLES_UPPER.alumni] = false;
     rolesState[USER_ROLES_UPPER.chairperson] = false;
@@ -30,7 +30,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     rolesState[USER_ROLES_UPPER.researcher] = false;
 
     initialValue = {
-      loading: false,
+      loading: true,
       displayName: '',
       email: '',
       displayNameValid: false,

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -592,11 +592,14 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     const isChairPersonDisabled = isMember || isAlumni || isResearcher;
     const isAlumniDisabled = isMember || isChairPerson;
 
+    const needsDoDelegation = (this.state.delegateDacUser.needsDelegation && this.state.alternativeDACMemberUser === '');
+    const needsDacDelegation = (this.state.delegateDataOwner.needsDelegation && this.state.alternativeDataOwnerUser ==='');
+
     return (
       BaseModal({
         id: "addUserModal",
         showModal: this.props.showModal,
-        disableOkBtn: !validForm || (this.state.mode !== 'Add' && (newUserNeeded || this.state.alternativeDACMemberUser === '')),
+        disableOkBtn: !validForm || needsDacDelegation || needsDoDelegation || newUserNeeded,
         onRequestClose: this.closeHandler,
         onAfterOpen: this.afterOpenHandler,
         imgSrc: this.state.mode === 'Add' ? "/images/icon_add_user.png" : "/images/icon_edit_user.png",
@@ -784,8 +787,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
               ])
             ])
           ]),
-
-          div({ isRendered: this.state.delegateDataOwner.needsDelegation, className: "form-group rp-last-group" }, [
+          div({ isRendered: (this.state.delegateDataOwner.needsDelegation && this.state.delegateDataOwner.delegateCandidates.length > 0), className: "form-group rp-last-group" }, [
             div({ className: "row no-margin f-center" }, [
               div({ className: "control-label default-color f-center", style: { "paddingBottom": "10px" } }, ["Member responsabilities must be delegated to a different user, please select one from below:"]),
 
@@ -795,7 +797,8 @@ export const AddUserModal = hh(class AddUserModal extends Component {
                   id: "sel_alternativeDataOwner", className: "form-control col-lg-12", value: this.state.alternativeDataOwnerUser,
                   required: this.state.delegateDataOwner.needsDelegation, onChange: this.selectAlternativeDataOwnerUser, placeholder: "Select an alternative Data Owner"
                 }, [
-                    this.state.delegateDataOwner.delegateCandidates.map((user, uIndex) => {
+                  option({ value: '' }, [""]),
+                  this.state.delegateDataOwner.delegateCandidates.map((user, uIndex) => {
                       return h(Fragment, { key: uIndex }, [
                         option({ value: JSON.stringify(user) }, [user.displayName])
                       ]);

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -360,9 +360,9 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     const checkState = e.target.checked;
 
     // need to set the role in roles
+    const result = await this.searchDACUsers(USER_ROLES_UPPER.chairperson);
     if (this.state.wasChairperson) {
       if (!checkState) {
-        const result = await this.searchDACUsers(USER_ROLES_UPPER.chairperson);
         if (this.checkNoEmptyDelegateCandidates(result.needsDelegation, result.delegateCandidates, USER_ROLES_UPPER.chairperson)) {
           this.setState(prev => {
             prev.delegateMemberRequired = false;
@@ -387,7 +387,8 @@ export const AddUserModal = hh(class AddUserModal extends Component {
         });
       }
     } else {
-      if (checkState) {
+      // const result = await this.searchDACUsers(USER_ROLES_UPPER.chairperson);
+      if (checkState && result.needsDelegation) {
         this.changeChairpersonRoleAlert();
       }
       else {

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -5,6 +5,8 @@ import { User } from "../../libs/ajax";
 import { Alert } from '../Alert';
 import { USER_ROLES_UPPER } from '../../libs/utils';
 
+const ADMIN_ROLE_ID = 4;
+
 export const AddUserModal = hh(class AddUserModal extends Component {
 
   constructor(props) {
@@ -66,7 +68,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
       return;
     }
 
-    let rolesState = {}
+    let rolesState = {};
     rolesState[USER_ROLES_UPPER.admin] = false;
     rolesState[USER_ROLES_UPPER.alumni] = false;
     rolesState[USER_ROLES_UPPER.chairperson] = false;
@@ -77,9 +79,11 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     if (this.props.user && this.props.user !== undefined) {
 
       const user = await User.getByEmail(this.props.user.email);
+      let adminEmailPreference = false;
 
       user.roles.forEach(role => {
         rolesState[role.name.toUpperCase()] = true;
+        if (role.name === 'Admin') adminEmailPreference = role.emailPreference;
       });
 
       this.setState({
@@ -91,7 +95,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
         rolesState: Object.assign({}, rolesState),
         originalRolesState: Object.assign({}, rolesState),
         originalRoles: user.roles.slice(),
-        emailPreference: false,
+        emailPreference: adminEmailPreference,
         delegateDacUser: {
           needsDelegation: false,
           delegateCandidates: []
@@ -178,7 +182,8 @@ export const AddUserModal = hh(class AddUserModal extends Component {
         if (key === USER_ROLES_UPPER.admin) {
           updatedRoles.push({
             name: key,
-            emailPreference: this.state.emailPreference
+            emailPreference: this.state.emailPreference,
+            roleId: ADMIN_ROLE_ID
           });
         } else updatedRoles.push({
           name: key

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -100,6 +100,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
         },
         delegateMemberRequired: false,
         newAlternativeUserNeeded: {},
+        newUserNeeded: false,
       },
         () => {
           let r1 = this.nameRef.current;
@@ -138,6 +139,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
         wasMember: false,
         wasDataOwner: false,
         wasResearcher: false,
+        newUserNeeded: false,
         loading: false
       },
         () => {
@@ -286,7 +288,20 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     if (!valid) {
       this.errorNoAvailableCandidates(role);
     }
-    return valid;
+    this.setState({
+      newUserNeeded: this.validateNoNewUserIsNeeded()
+    }, () => {
+      return valid;
+    });
+  };
+
+  validateNoNewUserIsNeeded = () => {
+    for (var key in this.state.newAlternativeUserNeeded) {
+      if (this.state.newAlternativeUserNeeded[key] === true) {
+        return true;
+      }
+    }
+    return false;
   };
 
   emailPreferenceChanged = (e) => {
@@ -465,6 +480,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
 
   errorNoAvailableCandidates = (role) => {
     this.setState(prev => {
+      prev.newUserNeeded = true;
       prev.newAlternativeUserNeeded[role] = true;
       prev.alerts[0] = {
         type: 'danger',
@@ -503,24 +519,17 @@ export const AddUserModal = hh(class AddUserModal extends Component {
       prev.alerts = [];
       return prev;
     });
-    // const alerts = this.state.alerts.filter(alert => alert.alertType !== alertType);
-    // this.setState({
-    //   alerts: alerts
-    // });
 
-    // var l = this.alerts.length;
-    // var i = 0;
-    // while (i < l) {
-    //   if (this.alerts[i].alertType === role) {
-    //     // this.alerts.splice(i, 1);
-    //     this.setState(prev => {
-    //       prev.newAlternativeUserNeeded[role] = false;
-    //       return prev;
-    //     });
-    //     return;
-    //   }
-    //   i++;
-    // }
+     this.setState(prev => {
+      prev.newAlternativeUserNeeded[role] = false;
+      return prev;
+    },
+    () => {
+      this.setState({
+        newUserNeeded : this.validateNoNewUserIsNeeded()
+      });
+    });
+
   };
 
   handleChange(event) {
@@ -564,7 +573,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
 
   render() {
 
-    const { displayName, email, roles, rolesState, emailPreference, displayNameValid, emailValid, roleValid } = this.state;
+    const { displayName, email, roles, rolesState, newUserNeeded, emailPreference, displayNameValid, emailValid, roleValid } = this.state;
 
     // if (loading) {  return LoadingIndicator();   }
 
@@ -586,7 +595,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
       BaseModal({
         id: "addUserModal",
         showModal: this.props.showModal,
-        disableOkBtn: !validForm, //this.state.invalidForm === true || this.state.roleValid === false,
+        disableOkBtn: !validForm || newUserNeeded, //this.state.invalidForm === true || this.state.roleValid === false,
         onRequestClose: this.closeHandler,
         onAfterOpen: this.afterOpenHandler,
         imgSrc: this.state.mode === 'Add' ? "/images/icon_add_user.png" : "/images/icon_edit_user.png",

--- a/src/pages/AdminConsole.js
+++ b/src/pages/AdminConsole.js
@@ -210,6 +210,7 @@ class AdminConsole extends Component {
                   iconSize: 'default',
                 }),
                 AddUserModal({
+                  isRendered: this.state.showAddUserModal,
                   showModal: this.state.showAddUserModal,
                   onOKRequest: this.okModal,
                   onCloseRequest: this.closeModal,

--- a/src/pages/AdminManageAccess.js
+++ b/src/pages/AdminManageAccess.js
@@ -18,6 +18,7 @@ class AdminManageAccess extends Component {
     super(props);
     this.state = {
       disableBtn: false,
+      disableCancelBtn: false,
       loading: true,
       showModal: false,
       value: '',
@@ -76,7 +77,7 @@ class AdminManageAccess extends Component {
   };
 
   dialogHandlerCancel = (answer) => (e) => {
-    this.setState({ disableBtn: true });
+    this.setState({ disableBtn: answer, disableCancelBtn: answer });
     if (answer === true) {
       let electionToUpdate = {};
       electionToUpdate.status = 'Canceled';
@@ -84,32 +85,32 @@ class AdminManageAccess extends Component {
       electionToUpdate.electionId = this.state.electionId;
       Election.updateElection(this.state.electionId, electionToUpdate).then(response => {
         this.getElectionDarList();
-        this.setState({ showDialogCancel: false, disableBtn: false });
+        this.setState({ showDialogCancel: false, disableBtn: false, disableCancelBtn: false });
       });
     } else {
-      this.setState({ showDialogCancel: false, disableBtn: false });
+      this.setState({ showDialogCancel: false });
     }
   };
 
   dialogHandlerCreate = (answer) => (e) => {
-    this.setState({ disableBtn: true });
+    this.setState({ disableBtn: answer, disableCancelBtn:answer });
     if (answer === true) {
       Election.createDARElection(this.state.dataRequestId)
         .then(value => {
           this.getElectionDarList();
-          this.setState({ showDialogCreate: false, disableBtn: false});
+          this.setState({ showDialogCreate: false, disableBtn: false, disableCancelBtn: false});
         })
         .catch(errorResponse => {
           if (errorResponse.status === 500) {
-            this.setState({ alertTitle: 'Email Service Error!', alertMessage: 'The election was created but the participants couldnt be notified by Email.', disableBtn: false });
+            this.setState({ alertTitle: 'Email Service Error!', alertMessage: 'The election was created but the participants couldnt be notified by Email.', disableCancelBtn: false });
           } else {
             errorResponse.json().then(error =>
-              this.setState({ alertTitle: 'Election cannot be created!', alertMessage: error.message, disableBtn: false})
+              this.setState({ alertTitle: 'Election cannot be created!', alertMessage: error.message, disableCancelBtn: false})
             );
           }
         });
     } else {
-      this.setState({ showDialogCreate: false, alertTitle: undefined, disableBtn: false});
+      this.setState({ showDialogCreate: false, alertTitle: undefined,  alertMessage: undefined});
     }
   };
 
@@ -343,7 +344,7 @@ class AdminManageAccess extends Component {
             isRendered: this.state.showDialogCreate,
             showModal: this.state.showDialogCreate,
             disableOkBtn: this.state.disableBtn,
-            disableNoBtn: this.state.disableBtn,
+            disableNoBtn: this.state.disableCancelBtn,
             action: {
               label: "Yes",
               handler: this.dialogHandlerCreate
@@ -360,7 +361,7 @@ class AdminManageAccess extends Component {
             title: 'Cancel election?',
             color: 'cancel',
             disableOkBtn: this.state.disableBtn,
-            disableNoBtn: this.state.disableBtn,
+            disableNoBtn: this.state.disableCancelBtn,
             isRendered: this.state.showDialogCancel,
             showModal: this.state.showDialogCancel,
             action: {

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -35,7 +35,8 @@ class AdminManageDul extends Component {
       archiveCheck: true,
       alertMessage: undefined,
       alertTitle: undefined,
-      disableOkBtn: false
+      disableOkBtn: false,
+      disableCancelBtn: false
     };
 
     this.handleCloseModal = this.handleCloseModal.bind(this);
@@ -53,6 +54,7 @@ class AdminManageDul extends Component {
       prev.currentPage = 1;
       prev.electionsList.dul = duls;
       prev.disableOkBtn = false;
+      prev.disableCancelBtn = false;
       prev.showDialogArchiveOpen = false;
       prev.showDialogArchiveClosed = false;
       prev.showDialogCancel = false;
@@ -70,6 +72,7 @@ class AdminManageDul extends Component {
       prev.currentPage = 1;
       prev.electionsList.dul = updatedDul;
       prev.disableOkBtn = false;
+      prev.disableCancelBtn = false;
       prev.showDialogDelete = false;
       return prev;
     });
@@ -168,7 +171,7 @@ class AdminManageDul extends Component {
   };
 
   dialogHandlerArchive = (answer) => async (e) => {
-    this.setState({ disableOkBtn: answer });
+    this.setState({ disableOkBtn: answer, disableCancelBtn: answer });
     if (answer) {
       let electionUpdate = {};
       let election = this.state.payload;
@@ -184,7 +187,7 @@ class AdminManageDul extends Component {
   };
 
   dialogHandlerCancel = (answer) => async (e) => {
-    this.setState({ disableOkBtn: answer, archiveCheck: true });
+    this.setState({ disableOkBtn: answer, disableCancelBtn: answer, archiveCheck: true });
     if (answer) {
       let election = this.state.payload;
       let electionUpdated = {
@@ -201,7 +204,7 @@ class AdminManageDul extends Component {
   };
 
   dialogHandlerCreate = (answer) => async (e) => {
-    this.setState({ disableOkBtn: answer });
+    this.setState({ disableOkBtn: answer, disableCancelBtn: answer });
     if (answer) {
       let consentId = this.state.createId;
       Election.createElection(consentId).then(
@@ -217,12 +220,14 @@ class AdminManageDul extends Component {
             this.setState({
               alertTitle: 'Email Service Error!',
               alertMessage: 'The election was created but the participants couldn\'t be notified by Email.',
+              disableCancelBtn: false
             });
           } else {
             errorResponse.json().then(error =>
               this.setState({
                 alertTitle: 'Election cannot be created!',
                 alertMessage: error.message,
+                disableCancelBtn: false
               })
             );
           }
@@ -233,14 +238,15 @@ class AdminManageDul extends Component {
         showDialogCreate: false,
         alertTitle: undefined,
         alertMessage: undefined,
-        disableOkBtn: false
+        // disableOkBtn: false,
+        // disableCancelBtn: false
       });
     }
 
   };
 
   dialogHandlerDelete = (answer) => (e) => {
-    this.setState({ disableOkBtn: answer });
+    this.setState({ disableOkBtn: answer, disableCancelBtn: answer });
     if (answer) {
       let consentId = this.state.deleteId;
       Consent.deleteConsent(consentId).then(data => {
@@ -474,7 +480,7 @@ class AdminManageDul extends Component {
           isRendered: this.state.showDialogArchiveOpen,
           showModal: this.state.showDialogArchiveOpen,
           disableOkBtn: this.state.disableOkBtn,
-          disableNoBtn: this.state.disableOkBtn,
+          disableNoBtn: this.state.disableCancelBtn,
           title: 'Archive election?',
           color: 'dul',
           payload: this.state.payload,
@@ -490,7 +496,7 @@ class AdminManageDul extends Component {
           isRendered: this.state.showDialogArchiveClosed,
           showModal: this.state.showDialogArchiveClosed,
           disableOkBtn: this.state.disableOkBtn,
-          disableNoBtn: this.state.disableOkBtn,
+          disableNoBtn: this.state.disableCancelBtn,
           title: 'Archive election?',
           color: 'dul',
           payload: this.state.payload,
@@ -506,7 +512,7 @@ class AdminManageDul extends Component {
           isRendered: this.state.showDialogCancel,
           showModal: this.state.showDialogCancel,
           disableOkBtn: this.state.disableOkBtn,
-          disableNoBtn: this.state.disableOkBtn,
+          disableNoBtn: this.state.disableCancelBtn,
           title: 'Cancel election?',
           color: 'cancel',
           payload: this.state.payload,
@@ -543,7 +549,7 @@ class AdminManageDul extends Component {
           title: 'Create election?',
           color: 'dul',
           disableOkBtn: this.state.disableOkBtn,
-          disableNoBtn: this.state.disableOkBtn,
+          disableNoBtn: this.state.disableCancelBtn,
           action: { label: "Yes", handler: this.dialogHandlerCreate },
           alertMessage: this.state.alertMessage,
           alertTitle: this.state.alertTitle
@@ -562,7 +568,7 @@ class AdminManageDul extends Component {
           isRendered: this.state.showDialogDelete,
           showModal: this.state.showDialogDelete,
           disableOkBtn: this.state.disableOkBtn,
-          disableNoBtn: this.state.disableOkBtn,
+          disableNoBtn: this.state.disableCancelBtn,
           title: 'Delete Consent?',
           color: 'cancel',
           action: { label: "Yes", handler: this.dialogHandlerDelete }


### PR DESCRIPTION
**_Manage User:_**
- Disable save button if there is no other user to delegate roles when needed
- Display disable e-mail notification when Admin checkbox is checked
- Hide chair person delegation warning when there are no open elections

**_Manage Dul and Manage access_**
- Enable cancel button when an error occurs, both for any Manage Dul and Access modals