### PR TITLE
Add jenkins script to match old repo

### DIFF
--- a/jenkins/jenkins_build.sh
+++ b/jenkins/jenkins_build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eux
+SVCACCT_FILE="dspci-wb-gcr-service-account.json"
+GCR_SVCACCT_VAULT="secret/dsde/dsp-techops/common/$SVCACCT_FILE"
+VAULT_TOKEN=${VAULT_TOKEN:-$(cat /etc/vault-token-dsde)}
+
+docker run --rm  -e VAULT_TOKEN=$VAULT_TOKEN \
+   broadinstitute/dsde-toolbox:latest vault read --format=json ${GCR_SVCACCT_VAULT} \
+   | jq .data > ${SVCACCT_FILE}
+
+./build.sh -d push -g gcr.io/broad-dsp-gcr-public/${PROJECT} -k ${SVCACCT_FILE}
+
+# clean up
+rm -f ${SVCACCT_FILE}


### PR DESCRIPTION
No Jira. This is needed for Broad's internal jenkins deploy process. See https://github.com/DataBiosphere/consent-ui/tree/develop/jenkins