### PR TITLE
DUOS-321- Add sDUL to Elections

### DIFF
--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -528,7 +528,7 @@ class AccessCollect extends Component {
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
                     div({ className: "row dar-summary" }, [
                       div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                      div({ className: "response-label", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
+                      div({ className: "response-label translated-restriction", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
                     ]),
                   ]),
                 ]),

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -526,8 +526,10 @@ class AccessCollect extends Component {
                     h4({}, ["Data Use Limitations"]),
                   ]),
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
-                    div({ className: "row no-margin" }, [
-                      button({ id: "btn_downloadDataUseLetter", className: "col-lg-8 col-md-8 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: () => this.downloadDUL() }, ["Download Data Use Letter"]),
+                    div({ className: "row dar-summary" }, [
+                      div({ className: "control-label dul-color" }, ["Structured Limitations"]),
+                      // div({ className: "response-label", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
+                      div({ className: "response-label" }, ["Something"])
                     ]),
                   ]),
                 ]),

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -199,10 +199,6 @@ class AccessCollect extends Component {
     Files.getDARFile(this.state.election.referenceId);
   };
 
-  downloadDUL() {
-    Files.getDulFile(this.state.consentId, this.state.dulName);
-  };
-
   accessCollectVote = (vote, rationale) => {
     this.setState(
       prev => {

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -61,6 +61,7 @@ class AccessCollect extends Component {
           ['Pending', 0]
         ]
       },
+      translatedUseRestriction: '',
       rus: '',
       voteStatus: '',
       createDate: '',
@@ -259,6 +260,7 @@ class AccessCollect extends Component {
       prev.isQ2Expanded = false;
       prev.consentName = electionReview.associatedConsent.name;
       prev.consentId = electionReview.consent.consentId;
+      prev.translatedUseRestriction = electionReview.consent.translatedUseRestriction;
       prev.electionType = "access";
       prev.election = electionReview.election;
       prev.darOriginalFinalVote = electionReview.election.finalVote;
@@ -380,6 +382,8 @@ class AccessCollect extends Component {
       b({ className: "pipe" }, [this.state.projectTitle]),
       this.state.consentName
     ]);
+
+    const { translatedUseRestriction } = this.state;
 
     return (
       div({ className: "container container-wide" }, [
@@ -528,8 +532,7 @@ class AccessCollect extends Component {
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
                     div({ className: "row dar-summary" }, [
                       div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                      // div({ className: "response-label", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
-                      div({ className: "response-label" }, ["Something"])
+                      div({ className: "response-label", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
                     ]),
                   ]),
                 ]),

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -135,20 +135,6 @@ class AccessPreview extends Component {
     Files.getDARFile(this.props.match.params.referenceId);
   };
 
-  downloadDUL() {
-    let consentElection = undefined;
-    if (this.props.match.params.electionId !== undefined) {
-      Election.findConsentElectionByDarElection(this.props.match.params.electionId).then(data => {
-        consentElection = data;
-        if (consentElection !== undefined && consentElection.dulName !== undefined) {
-          Files.getDulFile(this.props.match.params.consentId, consentElection.dulName);
-        }
-      });
-    } else {
-      Files.getDulFile(this.state.consent.consentId, this.state.consent.dulName);
-    }
-  };
-
   toggleQ1 = (e) => {
     this.setState(prev => {
       prev.isQ1Expanded = !prev.isQ1Expanded;

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -105,7 +105,9 @@ class AccessPreview extends Component {
       consentName: '',
       isQ1Expanded: true,
       isQ2Expanded: false,
-
+      consent : {
+        translatedUseRestriction: ''
+      },
       darInfo: {
         rus: '',
         havePI: true,
@@ -168,6 +170,8 @@ class AccessPreview extends Component {
       this.state.consentName
     ]);
 
+    const { translatedUseRestriction } = this.state.consent;
+    
     return (
 
       div({ className: "container container-wide" }, [
@@ -312,8 +316,7 @@ class AccessPreview extends Component {
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
                     div({ className: "row dar-summary" }, [
                       div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                      // div({ className: "response-label", dangerouslySetInnerHTML: { __html: sDUL } }, [])
-                      div({ className: "response-label" }, ["Something"])
+                       div({ className: "response-label", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
                     ])
                   ])
                 ])

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -302,7 +302,7 @@ class AccessPreview extends Component {
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
                     div({ className: "row dar-summary" }, [
                       div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                       div({ className: "response-label", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
+                       div({ className: "response-label translated-restriction", dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
                     ])
                   ])
                 ])

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -310,8 +310,10 @@ class AccessPreview extends Component {
                     h4({}, ["Data Use Limitations"]),
                   ]),
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
-                    div({ className: "row no-margin" }, [
-                      button({ id: "btn_downloadDataUseLetter", className: "col-lg-8 col-md-8 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: () => this.downloadDUL() }, ["Download Data Use Letter"]),
+                    div({ className: "row dar-summary" }, [
+                      div({ className: "control-label dul-color" }, ["Structured Limitations"]),
+                      // div({ className: "response-label", dangerouslySetInnerHTML: { __html: sDUL } }, [])
+                      div({ className: "response-label" }, ["Something"])
                     ])
                   ])
                 ])

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -387,7 +387,7 @@ class AccessResultRecords extends Component {
 
           div({ isRendered: this.state.hasUseRestriction, className: "row dar-summary" }, [
             div({ className: "control-label access-color" }, ["Structured Research Purpose"]),
-            div({ className: "response-label", dangerouslySetInnerHTML: { __html: sDAR } }, []),
+            div({ className: "response-label translated-restriction", dangerouslySetInnerHTML: { __html: sDAR } }, []),
             a({
               onClick: () => this.download("machine-readable-DAR.json", mrDAR),
               filename: 'machine-readable-DAR.json',

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -131,9 +131,6 @@ class AccessResultRecords extends Component {
     Files.getDARFile(this.state.darElection.referenceId);
   }
 
-  downloadDUL = (e) => {
-    Files.getDulFile(this.state.electionReview.consent.consentId, this.state.electionReview.election.dulName);
-  }
 
   toggleQ1 = (e) => {
     this.setState(prev => {

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -501,7 +501,7 @@ class AccessResultRecords extends Component {
         div({ id: "dul", className: "panel-body cm-boxbody" }, [
           div({ className: "row dar-summary" }, [
             div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-            div({ className: "response-label", dangerouslySetInnerHTML: { __html: sDUL } }, []),
+            div({ className: "response-label translated-restriction", dangerouslySetInnerHTML: { __html: sDUL } }, []),
             a({
               id: "btn_downloadSDul", onClick: () => this.download("machine-readable-DUL.json", mrDUL),
               filename: 'machine-readable-DUL.json', value: mrDUL, className: "italic hover-color"

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -502,9 +502,6 @@ class AccessResultRecords extends Component {
           h4({}, ["Data Use Limitations"]),
         ]),
         div({ id: "dul", className: "panel-body cm-boxbody" }, [
-          div({ className: "row no-margin" }, [
-            button({ id: "btn_downloadDataUseLetter", className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: this.downloadDUL }, ["Download Data Use Letter"]),
-          ]),
           div({ className: "row dar-summary" }, [
             div({ className: "control-label dul-color" }, ["Structured Limitations"]),
             div({ className: "response-label", dangerouslySetInnerHTML: { __html: sDUL } }, []),

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -430,7 +430,7 @@ class AccessReview extends Component {
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
                     div({ className: "row dar-summary" }, [
                       div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                      div({ className: "response-label", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, [])
+                      div({ className: "response-label translated-restriction", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, [])
                     ]),
                   ]),
                 ]),

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -425,8 +425,10 @@ class AccessReview extends Component {
                     h4({}, ["Data Use Limitations"]),
                   ]),
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
-                    div({ className: "row no-margin" }, [
-                      button({ id: "btn_downloadDataUseLetter", className: "col-lg-8 col-md-8 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: this.downloadDUL }, ["Download Data Use Letter"]),
+                    div({ className: "row dar-summary" }, [
+                      div({ className: "control-label dul-color" }, ["Structured Limitations"]),
+                      // div({ className: "response-label", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, [])
+                      div({ className: "response-label" }, ["Something"])
                     ]),
                   ]),
                 ]),

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -252,10 +252,6 @@ class AccessReview extends Component {
     Files.getDARFile(this.props.match.params.darId);
   };
 
-  downloadDUL = (e) => {
-    Files.getDulFile(this.state.consentId, this.state.dulName);
-  };
-
   toggleQ1 = (e) => {
     this.setState(prev => {
       prev.isQ1Expanded = !prev.isQ1Expanded;

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -20,7 +20,7 @@ class AccessReview extends Component {
     this.submitRpVote = this.submitRpVote.bind(this);
     this.submitVote = this.submitVote.bind(this);
   }
-
+  
   submitRpVote = (voteStatus, rationale) => {
     let vote = this.state.rpVote;
     this.setState({ disableQ2Btn: true });
@@ -175,9 +175,15 @@ class AccessReview extends Component {
 
     Election.findConsentElectionByDarElection(vote.electionId).then(data => {
       if (data.dulName !== null && data.dulElection !== null) {
-        this.setState({ dulName: data.dulName });
+        this.setState({ 
+          dulName: data.dulName,
+          translatedUseRestriction: data.translatedUseRestriction
+        });
       } else {
-        this.setState({ dulName: consent.dulName });
+        this.setState({ 
+          dulName: consent.dulName,
+          translatedUseRestriction: consent.translatedUseRestriction
+         });
       }
     });
   }
@@ -203,6 +209,7 @@ class AccessReview extends Component {
       consentName: '',
       consentId: '',
       dulName: '',
+      translatedUseRestriction: '',
       isQ1Expanded: true,
       disableQ1Btn: false,
       isQ2Expanded: false,
@@ -427,8 +434,7 @@ class AccessReview extends Component {
                   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
                     div({ className: "row dar-summary" }, [
                       div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                      // div({ className: "response-label", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, [])
-                      div({ className: "response-label" }, ["Something"])
+                      div({ className: "response-label", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, [])
                     ]),
                   ]),
                 ]),

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -336,10 +336,6 @@ class FinalAccessReview extends Component {
     })
   }
 
-  downloadDUL = (e) => {
-    Files.getDulFile(this.state.electionReview.consent.consentId, this.state.electionReview.election.dulName);
-  }
-
   toggleQ1 = (e) => {
     this.setState(prev => {
       prev.isQ1Expanded = !prev.isQ1Expanded;

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -741,12 +741,6 @@ class FinalAccessReview extends Component {
               h4({}, ["Data Use Limitations"]),
             ]),
             div({ id: "dul", className: "panel-body cm-boxbody" }, [
-              div({ className: "row no-margin" }, [
-                button({
-                  id: "btn_downloadDataUseLetter", className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color",
-                  onClick: this.downloadDUL
-                }, ["Download Data Use Letter"]),
-              ]),
               div({ className: "row dar-summary" }, [
                 div({ className: "control-label dul-color" }, ["Structured Limitations"]),
                 div({ className: "response-label", dangerouslySetInnerHTML: { __html: this.state.sDul } }, []),

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -739,7 +739,7 @@ class FinalAccessReview extends Component {
             div({ id: "dul", className: "panel-body cm-boxbody" }, [
               div({ className: "row dar-summary" }, [
                 div({ className: "control-label dul-color" }, ["Structured Limitations"]),
-                div({ className: "response-label", dangerouslySetInnerHTML: { __html: this.state.sDul } }, []),
+                div({ className: "response-label translated-restriction", dangerouslySetInnerHTML: { __html: this.state.sDul } }, []),
                 a({
                   id: "btn_downloadSDul", onClick: () => this.download('machine-readable-DUL.json', this.state.mrDUL),
                   className: "italic hover-color"


### PR DESCRIPTION
[https://broadinstitute.atlassian.net/browse/DUOS-321](url)

In DAR election pages, instead of seeing the button to download the Data Use Letter PDF, the user should see the sDUL in the Data Use Limitation box on the right.