### PR TITLE
[DUOS-380][risk=no] Show the right help links for the support link

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Modal from 'react-modal';
+import { Storage } from './libs/storage';
 import DuosHeader from './components/DuosHeader';
 import DuosFooter from './components/DuosFooter';
 import { div, h } from 'react-hyperscript-helpers';
@@ -13,7 +14,8 @@ class App extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      loading: false
+      loading: false,
+      isLoggedIn: false
     };
   }
 
@@ -29,6 +31,22 @@ class App extends React.Component {
     });
   };
 
+  async componentDidMount() {
+    const isLogged = await Storage.userIsLogged();
+    this.setState({ isLoggedIn: isLogged } );
+  };
+
+  signOut = () => {
+    Storage.setUserIsLogged(false);
+    Storage.clearStorage();
+    this.setState({ isLoggedIn: false } );
+  };
+
+  signIn = () => {
+    Storage.setUserIsLogged(true);
+    this.setState({ isLoggedIn: true } );
+  };
+
   componentWillMount() {
     Modal.setAppElement(document.getElementById('modal-root'));
   }
@@ -41,17 +59,14 @@ class App extends React.Component {
       div({ className: "body" }, [
         div({ className: "wrap" }, [
           div({ className: "main" }, [
-            h(DuosHeader, {
-            }),
+            h(DuosHeader, {onSignOut: this.signOut}),
             h(Spinner, {
               name: "mainSpinner", group: "duos", loadingImage: "/images/loading-indicator.svg"
             }),
-            h(Routes, {
-              isRendered: !loading
-            }),
+            h(Routes, { onSignIn: this.signIn, isRendered: !loading }),
           ])
         ]),
-        h(DuosFooter, {})
+        h(DuosFooter, {isLogged: this.state.isLoggedIn})
       ])
 
     );

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -41,7 +41,7 @@ const Routes = ( props ) => (
   <Switch>
     <Route exact path='/' component={Home} props={props} />
     <Route exact path='/home' component={Home} props={props} />
-    <Route path='/login' component={Login} props={props} />
+    <Route path='/login' render={(routeProps) => <Login {...routeProps} {...props} />} />
     <Route path='/home_help' component={HomeHelp} />
     <Route path='/home_about' component={HomeAbout} />
     <Route path='/home_register' component={HomeRegister} props={props} />

--- a/src/components/DuosFooter.js
+++ b/src/components/DuosFooter.js
@@ -4,7 +4,7 @@ import { div, footer, ul, li, img, a } from 'react-hyperscript-helpers';
 class DuosFooter extends Component {
 
   render() {
-
+    const supportLink = this.props.isLogged ? '/help_reports' : '/home_help';
     return (
       div({ className: "footer" }, [
         footer({ className: "main-footer" }, [
@@ -12,7 +12,7 @@ class DuosFooter extends Component {
             li({ className: "footer-links__item" }, ["\u00A9 Broad Institute"]),
             li({ className: "footer-links__item" }, [a({ target: '_blank', href: "https://www.broadinstitute.org/privacy-policy" }, ["Privacy Policy"]),]),
             li({ className: "footer-links__item" }, [a({ target: '_blank', href: "https://www.broadinstitute.org/terms-conditions" }, ["Terms of Service"]),]),
-            li({ className: "footer-links__item" }, [a({ href: "#" }, ["Support"]),]),
+            li({ className: "footer-links__item" }, [a({ href: supportLink }, ["Support"]),]),
           ]),
           img({ src: "/images/broad_logo.svg", className: "footer-logo", alt: "Broad Institute logo" })
         ])

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -8,8 +8,6 @@ import './DuosHeader.css';
 
 class DuosHeader extends Component {
 
-  navBarCollapsed = true;
-
   constructor(props) {
     super(props);
     this.state = {
@@ -18,7 +16,12 @@ class DuosHeader extends Component {
     this.signOut = this.signOut.bind(this);
   };
 
-  helpModal = (e) => {
+  signOut = () => {
+    this.props.history.push('/home');
+    this.props.onSignOut();
+  };
+
+  helpModal = () => {
     this.setState(prev => {
       prev.showHelpModal = true;
       return prev;
@@ -172,12 +175,6 @@ class DuosHeader extends Component {
         ])
       ])
     );
-  }
-
-  signOut() {
-    Storage.setUserIsLogged(false);
-    Storage.clearStorage();
-    this.props.history.push('/login');
   }
 
 }

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -41,7 +41,7 @@ class Login extends Component {
         user.isDataOwner = currentUserRoles.indexOf(USER_ROLES.dataOwner) > -1;
         user.isAlumni = currentUserRoles.indexOf(USER_ROLES.alumni) > -1;
         Storage.setCurrentUser(user);
-        Storage.setUserIsLogged(true);
+        this.props.onSignIn();
         this.redirect(user, this.state.redirectUrl);
       },
       error => {


### PR DESCRIPTION
## Addresses
Ticket https://broadinstitute.atlassian.net/browse/DUOS-380

## Changes
This was a little more complicated than I envisioned. We're doing something funky with how we're storing user login state, and that's not using state. This PR adds that to the app level as a state variable so that children components can re-render based on that.

Additionally, our Routes are not passing props correctly. The only props that are passed are the default Route ones and anything passed into `Routes` is ignored, except for the `Login` component, which this PR fixes. Will address the other routes in a different task. 

The end result is that the footer can now conditionally render the right `Support` link depending on the user's logged in state.