### PR TITLE
[DUOS-378][risk=no] Don't build/deploy staging on develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,11 +234,15 @@ workflows:
           requires:
             - test
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: staging
       - deploy-staging:
           requires:
             - build-staging
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,14 +236,9 @@ workflows:
           filters:
             tags:
               only: staging
-            branches:
-              only: develop
       - deploy-staging:
           requires:
             - build-staging
           filters:
             tags:
               only: staging
-            branches:
-              only: develop
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: staging
+              only: /^staging.*/
       - deploy-staging:
           requires:
             - build-staging
@@ -245,4 +245,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: staging
+              only: /^staging.*/


### PR DESCRIPTION
## Addresses 
https://broadinstitute.atlassian.net/browse/DUOS-378

## Changes
The previous config did a full build/deploy to staging.