### PR TITLE
[risk=no] New duos team with updated code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # @rushtong will be requested for
 # review when someone opens a pull request.
-@rushtong
+* @rushtong
+* @DataBiosphere/duos-devs


### PR DESCRIPTION
No jira - created new github team (@DataBiosphere/duos-devs) for duos developers.