### PR TITLE
[risk=no] Fix peer dependency warning, update readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # DUOS UI
-This project was bootstrapped with [Create React App](https://github.com/facebookincubator/create-react-app).
 
-Guide [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
+## Data Use Oversight System
+A semi-automated management service for compliant secondary use of human genomics data.
+There are restrictions on researching human genomics data. For example: 
+"Data can only be used for breast cancer research with non-commercial purpose".
+The Data Use Oversight system ensures that researchers using genomics data honor these restrictions.
 
-Builds/deploys handled by CircleCI.
+### What is DUOS?
+* Interfaces to transform data use restrictions to machine readable codes
+* A matching algorithm that checks if a data access request is compatible with the restrictions on the data
+* Interfaces for the data access committee (DAC) to evaluate data access requests requiring manual review
 
-### Developing
+![What is DUOS](https://github.com/DataBiosphere/duos-ui/blob/develop/public/images/what_is_duos.svg)
+
+### Developers
+
+Builds, tests, and deployments are handled by CircleCI.
 
 1. We use node@8 (the current LTS). On Darwin with Homebrew:
 
@@ -22,36 +32,8 @@ Builds/deploys handled by CircleCI.
     ```sh
     npm install
     ```
-4. Start development server, which will report any lint violations as well:
+4. Start development server:
 
     ```sh
     npm start
     ```
-5. Testing:
-    
-    ```sh
-    npm test
-    ```
-    
-### TODO
-
-- Testing documentation
-- Description    
-
-### Deployment
-
-Builds are deployed with every merge to `develop` and `master`
-
-To execute a deploy manually, generate a "Personal API Token" documented here:
-
-* https://circleci.com/account/api
-
-And use the documentation here: 
-
-* https://circleci.com/docs/2.0/api-job-trigger/
-
-An example run:
-```
-curl -u <token>: -d build_parameters[CIRCLE_JOB]=deploy_dev \
-    https://circleci.com/api/v1.1/project/github/DataBiosphere/duos-ui/tree/develop
-```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6028,26 +6028,17 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.14.tgz",
-      "integrity": "sha512-E7tDoyAA8ilZIV3xDJgl18sX3M8xB9/fMw8+mfW4msLW8jlX97bAnWgT3pmaNXuvzIEgSBMnAHfuXsB2hdzfow==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-          "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.11"
-          }
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12929,6 +12920,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "dev": true
     },
     "ua-parser-js": {
       "version": "0.7.20",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "eslint": "5.16.0",
     "eslint-plugin-react": "7.12.4",
     "handlebars": "4.1.2",
-    "js-yaml": "3.13.1"
+    "js-yaml": "3.13.1",
+    "typescript": "3.5.3"
   },
   "comments": {
     "security-alerts": "handlebars and js-yaml are security related updates for indirect dependencies"


### PR DESCRIPTION
## Addresses
Minor build warning:
```
npm WARN @typescript-eslint/eslint-plugin@1.6.0 requires a peer of typescript@* but none is installed. You must install peer dependencies yourself.
```

Also revamped the readme a bit.