### PR TITLE
[DUOS-419][risk=no] Show configuration error when trying to sign in

### DIFF
--- a/config/staging.json
+++ b/config/staging.json
@@ -1,7 +1,7 @@
 {
   "apiUrl": "https://consent.dsde-staging.broadinstitute.org/api",
   "ontologyApiUrl": "https://consent-ontology.dsde-staging.broadinstitute.org/",
-  "clientId": "1087760099392-u18o6sqvb8uljmdltflohmd34h6hik9b.apps.googleusercontent.com",
+  "clientId": "1087760099392-t0nb61ehicbeuqkeftvql765ncu1707r.apps.googleusercontent.com",
   "firecloudUrl": "https://firecloud-orchestration.dsde-staging.broadinstitute.org/",
   "gwasUrl": "",
   "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html"

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -11,10 +11,6 @@ export const formatDate = (dateval) => {
   return datestr;
 };
 
-export const isObjectEmpty = (obj) => {
-  return Object.getOwnPropertyNames(obj).length === 0;
-};
-
 export const USER_ROLES = {
   admin: 'Admin',
   chairperson: 'Chairperson',

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -11,6 +11,10 @@ export const formatDate = (dateval) => {
   return datestr;
 };
 
+export const isObjectEmpty = (obj) => {
+  return Object.getOwnPropertyNames(obj).length === 0;
+};
+
 export const USER_ROLES = {
   admin: 'Admin',
   chairperson: 'Chairperson',

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp';
 import { Component } from 'react';
 import GoogleLogin from 'react-google-login';
 import { a, div, h, h3, img, label, span } from 'react-hyperscript-helpers';
@@ -5,7 +6,7 @@ import { Alert } from '../components/Alert';
 import { User } from '../libs/ajax';
 import { Config } from '../libs/config';
 import { Storage } from '../libs/storage';
-import { USER_ROLES, isObjectEmpty } from '../libs/utils';
+import { USER_ROLES } from '../libs/utils';
 import './Login.css';
 
 
@@ -119,10 +120,10 @@ class Login extends Component {
             img({ src: '/images/broad_logo.png', alt: 'Broad Institute Logo' }, []),
             div({ className: 'landing-box-title' }, [h3({}, ['Broad Data Use Oversight System'])]),
             div({ className: 'landing-box-google-signin' }, [
-              div({ isRendered: !isObjectEmpty(this.state.error), className: 'dialog-alert' }, [
+              div({ isRendered: !_.isEmpty(this.state.error), className: 'dialog-alert' }, [
                 Alert({ id: 'dialog', type: 'danger', title: this.state.error.title, description: this.state.error.description })
               ]),
-              div({ isRendered: isObjectEmpty(this.state.error) }, [
+              div({ isRendered: _.isEmpty(this.state.error) }, [
                 div({ className: 'new-sign' }, ['Sign in with a google account']),
                 googleLoginButton,
                 div({ className: 'new-sign' }, [

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -127,7 +127,7 @@ class Login extends Component {
                 googleLoginButton,
                 div({ className: 'new-sign' }, [
                   span({}, [
-                    'Don\'t have a Google Account? Create one ',
+                    "Don't have a Google Account? Create one ",
                     a({
                       href: 'https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup',
                       target: '_blank'

--- a/src/pages/Login.js
+++ b/src/pages/Login.js
@@ -1,18 +1,21 @@
 import { Component } from 'react';
-import { div, a, img, span, h3, h, label } from 'react-hyperscript-helpers';
 import GoogleLogin from 'react-google-login';
-import { Storage } from '../libs/storage';
-import { USER_ROLES } from '../libs/utils';
+import { a, div, h, h3, img, label, span } from 'react-hyperscript-helpers';
+import { Alert } from '../components/Alert';
 import { User } from '../libs/ajax';
-import './Login.css';
 import { Config } from '../libs/config';
+import { Storage } from '../libs/storage';
+import { USER_ROLES, isObjectEmpty } from '../libs/utils';
+import './Login.css';
+
 
 class Login extends Component {
   constructor(props) {
     super(props);
     this.state = {
       redirectUrl: this.props.match.url,
-      clientId: ''
+      clientId: '',
+      error: {},
     };
     this.getGoogleClientId();
   }
@@ -52,6 +55,10 @@ class Login extends Component {
 
   forbidden = (response) => {
     Storage.clearStorage();
+    this.setState(prev => {
+      prev.error = { "title": response.error, "description": response.details};
+      return prev;
+    });
   };
 
   // redirect() returns the initial page to be redirected when a user logs in
@@ -106,17 +113,26 @@ class Login extends Component {
     }
 
     return (
-      div({ className: "container" }, [
-        div({ className: "landing-box col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1" }, [
-          div({ className: "landing-box-brand" }, [img({ src: "/images/broad_logo.png", alt: "Broad Institute Logo" }, []),
-          div({ className: "landing-box-title" }, [h3({}, ["Broad Data Use Oversight System"]),]),
-          div({ className: "landing-box-google-signin" }, [
-            div({ className: "new-sign" }, ["Sign in with a google account"]),
-            googleLoginButton,
-              div({ className: "new-sign" }, [
-                span({}, [
-                  "Don't have a Google Account? Create one ",
-                  a({ href: "https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup", target: "_blank" }, ["here."])
+      div({ className: 'container' }, [
+        div({ className: 'landing-box col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1' }, [
+          div({ className: 'landing-box-brand' }, [
+            img({ src: '/images/broad_logo.png', alt: 'Broad Institute Logo' }, []),
+            div({ className: 'landing-box-title' }, [h3({}, ['Broad Data Use Oversight System'])]),
+            div({ className: 'landing-box-google-signin' }, [
+              div({ isRendered: !isObjectEmpty(this.state.error), className: 'dialog-alert' }, [
+                Alert({ id: 'dialog', type: 'danger', title: this.state.error.title, description: this.state.error.description })
+              ]),
+              div({ isRendered: isObjectEmpty(this.state.error) }, [
+                div({ className: 'new-sign' }, ['Sign in with a google account']),
+                googleLoginButton,
+                div({ className: 'new-sign' }, [
+                  span({}, [
+                    'Don\'t have a Google Account? Create one ',
+                    a({
+                      href: 'https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup',
+                      target: '_blank'
+                    }, ['here.'])
+                  ])
                 ])
               ])
             ])


### PR DESCRIPTION
## Addresses
See https://broadinstitute.atlassian.net/browse/DUOS-419
We had a client id configuration error for staging, but the error was being swallowed and nothing was displaying in the UI leaving the user wondering what was happening. This PR adds:
* A new oauth client id configured for the staging cluster.
* Show error instead of letting the user try to sign in.

## Error case
![Screen Shot 2019-07-31 at 11 46 17 AM](https://user-images.githubusercontent.com/116679/62226860-da3f0c80-b388-11e9-97ac-1eefe449662a.png)

## Success case
![Screen Shot 2019-07-31 at 11 47 46 AM](https://user-images.githubusercontent.com/116679/62226990-20946b80-b389-11e9-8232-8a1fd7f4d36e.png)
