### PR TITLE
[risk=no] Update Cache-Control settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15.7-alpine
+FROM nginx:1.17-alpine
 LABEL maintainer="grushton@broadinstitute.org"
 RUN rm -rf /etc/nginx/conf.d
 COPY conf /etc/nginx

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,6 @@
 # base image
-FROM node:9.6.1
+FROM node:9.6.1 AS builder
+LABEL maintainer="grushton@broadinstitute.org"
 
 # set working directory
 RUN mkdir /usr/src/app
@@ -9,16 +10,17 @@ WORKDIR /usr/src/app
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 
 # install and cache app dependencies
+COPY src /usr/src/app/src
+COPY public /usr/src/app/public
 COPY package.json /usr/src/app/package.json
+COPY config/dev.json /usr/src/app/public/config.json
 RUN npm install --silent
 RUN npm install react-scripts@1.1.1 -g --silent
+RUN npm run build --silent
 
-# start app
-CMD ["npm", "start"]
-
-
-# Build dev docker image
-# sudo docker build -t duos-ui-dev -f Dockerfile-dev .
-
-# run dev docker image, should watch code changes .. 
-# sudo docker run -it -v ${PWD}:/usr/src/app -v /usr/src/app/node_modules -p 3000:3000 --rm duos-ui-dev
+FROM nginx:1.17-alpine
+RUN rm -rf /etc/nginx/conf.d
+COPY conf /etc/nginx
+COPY --from=builder /usr/src/app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ Builds, tests, and deployments are handled by CircleCI.
     ```sh
     npm start
     ```
+
+### Running as a Docker image that mimics production
+
+Build a local image and then start it up.
+
+```
+docker build -f Dockerfile-dev -t duos-ui:local .
+```
+
+```
+docker run -p 80:80 duos-ui:local
+```

--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -1,5 +1,16 @@
+# Expires map
+map $sent_http_content_type $expires {
+    default                    off;
+    text/html                  epoch;
+    text/css                   max;
+    application/javascript     epoch;
+    application/json           epoch;
+    ~image/                    max;
+}
+
 server {
   listen 80;
+  expires $expires;
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;


### PR DESCRIPTION
## Addresses
No Jira. Even with [react scripts building assets with git hashes](https://facebook.github.io/create-react-app/docs/production-build#static-file-caching), we still see browser caching happening. This PR adds nginx configs to set the cache control to not cache for html, javascript, or json files.

Additionally, this PR:
* Updates nginx to latest
* Adds some readme content for developers to spin up a local dockerfile
* Updates local dockerfile so it aligns with how we build the image in Cirlceci

### Without this PR:
```
curl -v http://duos.dsp-duos-dev.broadinstitute.org
* Rebuilt URL to: http://duos.dsp-duos-dev.broadinstitute.org/
*   Trying 34.96.79.85...
* TCP_NODELAY set
* Connected to duos.dsp-duos-dev.broadinstitute.org (34.96.79.85) port 80 (#0)
> GET / HTTP/1.1
> Host: duos.dsp-duos-dev.broadinstitute.org
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx/1.15.7
< Date: Thu, 01 Aug 2019 16:05:52 GMT
< Content-Type: text/html
< Content-Length: 3573
< Last-Modified: Wed, 31 Jul 2019 20:02:45 GMT
< ETag: "5d41f3e5-df5"
< Accept-Ranges: bytes
< Via: 1.1 google
...
```

### With this PR:
```
curl -v http://localhost
* Rebuilt URL to: http://localhost/
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 80 (#0)
> GET / HTTP/1.1
> Host: localhost
> User-Agent: curl/7.54.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Server: nginx/1.17.2
< Date: Thu, 01 Aug 2019 14:41:26 GMT
< Content-Type: text/html
< Content-Length: 3573
< Last-Modified: Thu, 01 Aug 2019 13:22:56 GMT
< Connection: keep-alive
< ETag: "5d42e7b0-df5"
< Expires: Thu, 01 Jan 1970 00:00:01 GMT
< Cache-Control: no-cache
< Accept-Ranges: bytes
...
```