### PR TITLE
[DUOS-374][risk=no] Updates from dacManagement branch

### DIFF
--- a/src/components/modals/AddDulModal.js
+++ b/src/components/modals/AddDulModal.js
@@ -195,7 +195,7 @@ export const AddDulModal = hh(class AddDulModal extends Component {
         showModal: this.props.showModal,
         onRequestClose: this.closeHandler,
         onAfterOpen: this.afterOpenHandler,
-        imgSrc: "/images/icon_add_dul.png",
+        imgSrc: this.state.isEditMode ? "/images/icon_edit_dul.png" : "/images/icon_add_dul.png",
         color: "dul",
         title: this.state.isEditMode ? "Edit Data Use Limitations" : "Add Data Use Limitations",
         description: this.state.isEditMode ? "Edit a Data Use Limitations Record" : "Catalog a Data Use Limitation Record",

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -653,48 +653,8 @@ export const AddUserModal = hh(class AddUserModal extends Component {
             ]),
 
             div({ className: "form-group" }, [
-              label({ className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Roles"]),
+              label({ className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Role"]),
               div({ className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 bold" }, [
-                div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-
-                  div({ className: "checkbox", disabled: isMemberDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_member",
-                      className: "checkbox-inline user-checkbox",
-                      checked: isMember,
-                      onChange: this.memberChanged,
-                      disabled: isMemberDisabled,
-                    }),
-                    label({ id: "lbl_member", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_member" }, ["Member"])
-                  ]),
-
-                  div({ className: "checkbox", disabled: isChairPersonDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_chairperson",
-                      className: "checkbox-inline user-checkbox",
-                      checked: isChairPerson,
-                      onChange: this.chairpersonChanged,
-                      disabled: isChairPersonDisabled
-                    }),
-                    label({ id: "lbl_chairperson", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_chairperson" }, ["Chairperson"])
-                  ]),
-
-                  div({ className: "checkbox", disabled: isAlumniDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_alumni",
-                      checked: isAlumni,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.alumniChanged,
-                      disabled: isAlumniDisabled,
-                    }),
-                    label({ id: "lbl_alumni", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_alumni" }, ["Alumni"])
-                  ]),
-
-                ]),
-
                 div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
 
                   div({ className: "checkbox" }, [
@@ -707,29 +667,6 @@ export const AddUserModal = hh(class AddUserModal extends Component {
                     }),
                     label({ id: "lbl_admin", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_admin" }, ["Admin"])
                   ]),
-
-                  div({ className: "checkbox", disabled: isResearcherDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_researcher",
-                      checked: isResearcher,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.researcherChanged,
-                      disabled: isResearcherDisabled
-                    }),
-                    label({ id: "lbl_researcher", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_researcher" }, ["Researcher"])
-                  ]),
-
-                  div({ className: "checkbox" }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_dataOwner",
-                      checked: isDataOwner,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.dataOwnerChanged,
-                    }),
-                    label({ id: "lbl_dataOwner", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_dataOwner" }, ["Data Owner"])
-                  ])
                 ])
               ])
             ]),


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-374
This PR pulls out the small changes in the `dacManagement` branch that are unrelated to DAC or Dataset management.

## Changes

### Icon Changes
Edit vs Add:
![Screen Shot 2019-08-01 at 3 40 42 PM](https://user-images.githubusercontent.com/116679/62322380-f919cd80-b472-11e9-822d-be153c8911db.png)

![Screen Shot 2019-08-01 at 3 40 56 PM](https://user-images.githubusercontent.com/116679/62322394-fe771800-b472-11e9-9f2c-49bd05f48fdd.png)

### User Role Changes
Edit vs Add:
![Screen Shot 2019-08-01 at 3 41 18 PM](https://user-images.githubusercontent.com/116679/62322428-12bb1500-b473-11e9-9ba1-4889ac103c8f.png)

![Screen Shot 2019-08-01 at 3 41 33 PM](https://user-images.githubusercontent.com/116679/62322438-16e73280-b473-11e9-86ae-72f8bf6df4d3.png)
