### PR TITLE
[DUOS-379][risk=no] Trigger production deploy on production tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,15 @@ jobs:
           google_cluster: 'duos-ui-staging-cluster'
           commit: ${COMMIT}
 
+  deploy-production:
+    executor: cloud-sdk
+    steps:
+      - checkout
+      - run:
+          name: Call remote deploy job
+          command: |
+            curl -X POST https://circleci.com/api/v1.1/project/gh/broadinstitute/duos-deploy/build?circle-token=${USER_TOKEN}
+
 workflows:
   version: 2
   build-deploy:
@@ -250,5 +259,11 @@ workflows:
           filters:
             tags:
               only: /^staging.*/
+            branches:
+              ignore: /.*/
+      - deploy-production:
+          filters:
+            tags:
+              only: /^production.*/
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ jobs:
       - run:
           name: Call remote deploy job
           command: |
-            curl -X POST https://circleci.com/api/v1.1/project/gh/broadinstitute/duos-deploy/build?circle-token=${USER_TOKEN}
+            curl -X POST https://circleci.com/api/v1.1/project/gh/broadinstitute/duos-deploy/tree/master?circle-token=${USER_TOKEN}
 
 workflows:
   version: 2


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/DUOS-379 and https://github.com/broadinstitute/duos-deploy/pull/19

This PR adds a tag-based trigger for ui builds from a private repo that does production deployments.