### PR TITLE
[DUOS-436][risk=no] Add app id to all FC calls

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -4,5 +4,5 @@
   "clientId": "1087760099392-u18o6sqvb8uljmdltflohmd34h6hik9b.apps.googleusercontent.com",
   "firecloudUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org/",
   "gwasUrl": "",
-  "nihUrl": "https://shibboleth.dsde-prod.broadinstitute.org/link-nih-account"
+  "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html"
 }

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -17,7 +17,8 @@ export const Config = {
   authOpts: (token = Token.getToken()) => ({
     headers: {
       Authorization: `Bearer ${token}`,
-      Accept: 'application/json'
+      Accept: 'application/json',
+      'X-App-ID': 'DUOS'
     }
   }),
   fileOpts: (token = Token.getToken()) => ({


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-436

## Changes
Minor change to provide an app id to all outgoing FC calls. This is technically not necessary, but helpful and will be required at some point. The primary fix for DUOS-436 was configuration changes in FC to accept the OAuth client ids in the newer duos projects. 