### PR TITLE
[DUOS-471][risk=no] Enforce eRA Auth for DAR submissions

### DIFF
--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -15,8 +15,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
       isAuthorized: false,
       expirationCount: 0,
       nihUsername: '',
-      nihError: false,
-      validationError: _.isNil(props.validationError) ? false : props.validationError
+      nihError: false
     };
     this.authenticateAsNIHFCUser = this.authenticateAsNIHFCUser.bind(this);
     this.getResearcherProperties = this.getResearcherProperties.bind(this);
@@ -115,12 +114,12 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   }
 
   render() {
-    const validationErrorStyle = this.state.validationError ? {
+    const validationErrorStyle = _.isNil(this.props.validationError) ? {} : {
       color: "#D13B07",
       border: "1px solid #D13B07",
       borderRadius: 5,
       padding: 6
-    } : {};
+    };
     const nihErrorMessage = 'Something went wrong. Please try again.';
     return (
       div({ className: this.props.className }, [

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -104,7 +104,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   };
 
   render() {
-    const validationErrorStyle = (!_.isNil(this.props.validationError) && this.props.validationError) ? {
+    const validationErrorStyle = _.get(this.props, 'validationError', false) ? {
       color: "#D13B07",
       border: "1px solid #D13B07",
       borderRadius: 5,

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -40,10 +40,9 @@ export const eRACommons = hh(class eRACommons extends React.Component {
     let isFcUser = this.verifyUser();
     if (!isFcUser) {
       Researcher.getPropertiesByResearcherId(currentUserId).then(
-        response => {
-          isFcUser = this.registerUserToFC(response);
-        },
-        () => this.setState({ nihError: true }));
+        (response) => isFcUser = this.registerUserToFC(response),
+        () => this.setState({ nihError: true })
+      );
     }
     if (isFcUser) {
       const parsedToken = qs.parse(searchArg);
@@ -110,7 +109,8 @@ export const eRACommons = hh(class eRACommons extends React.Component {
 
   async deleteNihAccount() {
     AuthenticateNIH.eliminateAccount().then(
-      () => this.getResearcherProperties()
+      () => this.getResearcherProperties(),
+      () => this.setState({ nihError: true })
     );
   }
 

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -16,7 +16,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
       expirationCount: 0,
       nihUsername: '',
       nihError: false,
-      nihErrorMessage: 'Something went wrong. Please try again.'
+      validationError: _.isNil(props.validationError) ? false : props.validationError
     };
     this.authenticateAsNIHFCUser = this.authenticateAsNIHFCUser.bind(this);
     this.getResearcherProperties = this.getResearcherProperties.bind(this);
@@ -115,19 +115,27 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   }
 
   render() {
+    const validationErrorStyle = this.state.validationError ? {
+      color: "#D13B07",
+      border: "1px solid #D13B07",
+      borderRadius: 5,
+      padding: 6
+    } : {};
+    const nihErrorMessage = 'Something went wrong. Please try again.';
     return (
       div({ className: this.props.className }, [
         label({ className: 'control-label' }, ['NIH eRA Commons ID']),
         div({ isRendered: (!this.state.isAuthorized || this.state.expirationCount < 0) }, [
           a({ onClick: this.redirectToNihLogin, target: '_blank', className: 'auth-button ERACommons' }, [
-            div({ className: 'logo' }, []),
-            span({}, ['Authenticate your account'])
+            div({style: validationErrorStyle}, [
+              span({}, ['Authenticate your account'])
+            ]),
           ])
         ]),
         span({
           className: 'cancel-color required-field-error-span',
           isRendered: this.state.nihError
-        }, [this.state.nihErrorMessage]),
+        }, [nihErrorMessage]),
         div({ isRendered: (this.state.isAuthorized) }, [
           div({
             isRendered: this.state.expirationCount >= 0,

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -9,32 +9,22 @@ import { Storage } from '../libs/storage';
 
 export const eRACommons = hh(class eRACommons extends React.Component {
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      isAuthorized: false,
-      expirationCount: 0,
-      nihUsername: '',
-      nihError: false
-    };
-    this.authenticateAsNIHFCUser = this.authenticateAsNIHFCUser.bind(this);
-    this.getResearcherProperties = this.getResearcherProperties.bind(this);
-    this.verifyToken = this.verifyToken.bind(this);
-    this.verifyUser = this.verifyUser.bind(this);
-    this.registerUserToFC = this.registerUserToFC.bind(this);
-    this.redirectToNihLogin = this.redirectToNihLogin.bind(this);
-    this.deleteNihAccount = this.deleteNihAccount.bind(this);
+  state = {
+    isAuthorized: false,
+    expirationCount: 0,
+    nihUsername: '',
+    nihError: false
   };
 
-  async componentDidMount() {
+  componentDidMount = async () => {
     if (this.props.location !== undefined && this.props.location.search !== '') {
       this.authenticateAsNIHFCUser(this.props.location.search);
     } else {
       this.getResearcherProperties();
     }
-  }
+  };
 
-  async authenticateAsNIHFCUser(searchArg) {
+  authenticateAsNIHFCUser = async (searchArg) => {
     const currentUserId = Storage.getCurrentUser().dacUserId;
     let isFcUser = this.verifyUser();
     if (!isFcUser) {
@@ -57,7 +47,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
     }
   };
 
-  async getResearcherProperties() {
+  getResearcherProperties = async () => {
     const currentUserId = Storage.getCurrentUser().dacUserId;
     Researcher.getPropertiesByResearcherId(currentUserId).then(response => {
       const isAuthorized = _.isNil(response.eraAuthorized) ? false : JSON.parse(response.eraAuthorized);
@@ -71,9 +61,9 @@ export const eRACommons = hh(class eRACommons extends React.Component {
         return prev;
       });
     });
-  }
+  };
 
-  async verifyToken(parsedToken) {
+  verifyToken = async (parsedToken) => {
     return await AuthenticateNIH.verifyNihToken(parsedToken).then(
       (decoded) => decoded,
       () => {
@@ -81,45 +71,45 @@ export const eRACommons = hh(class eRACommons extends React.Component {
         return null;
       }
     );
-  }
+  };
 
-  async verifyUser() {
+  verifyUser = async () => {
     const isFcUser = await AuthenticateNIH.fireCloudVerifyUser().catch(
       () => {
         this.setState({ nihError: true });
         return false;
       });
     return isFcUser !== undefined && isFcUser !== false && isFcUser.enabled.google === true;
-  }
+  };
 
-  async registerUserToFC(properties) {
+  registerUserToFC = async (properties) => {
     return await AuthenticateNIH.fireCloudRegisterUser(properties).then(
       () => true,
       () => {
         this.setState({ nihError: true });
         return false;
       });
-  }
+  };
 
-  async redirectToNihLogin() {
+  redirectToNihLogin = async () => {
     const nihUrl = `${ await Config.getNihUrl() }?redirect-url=`;
     window.location.href = nihUrl.concat(window.location.origin + '/' + this.props.destination + '?jwt%3D%7Btoken%7D');
-  }
+  };
 
-  async deleteNihAccount() {
+  deleteNihAccount = async () => {
     AuthenticateNIH.eliminateAccount().then(
       () => this.getResearcherProperties(),
       () => this.setState({ nihError: true })
     );
-  }
+  };
 
   render() {
-    const validationErrorStyle = _.isNil(this.props.validationError) ? {} : {
+    const validationErrorStyle = (!_.isNil(this.props.validationError) && this.props.validationError) ? {
       color: "#D13B07",
       border: "1px solid #D13B07",
       borderRadius: 5,
       padding: 6
-    };
+    } : {};
     const nihErrorMessage = 'Something went wrong. Please try again.';
     return (
       div({ className: this.props.className }, [

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -61,7 +61,6 @@ export const eRACommons = hh(class eRACommons extends React.Component {
 
   async getResearcherProperties() {
     const currentUserId = Storage.getCurrentUser().dacUserId;
-    // Refresh the user's researcher properties for the current state.
     Researcher.getPropertiesByResearcherId(currentUserId).then(response => {
       const isAuthorized = _.isNil(response.eraAuthorized) ? false : JSON.parse(response.eraAuthorized);
       const expirationCount = _.isNil(response.eraExpiration) ? 0 : AuthenticateNIH.expirationCount(response.eraExpiration);

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -59,14 +59,14 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   getResearcherProperties = async () => {
     const currentUserId = Storage.getCurrentUser().dacUserId;
     Researcher.getPropertiesByResearcherId(currentUserId).then(response => {
-      const isAuthorized = _.isNil(response.eraAuthorized) ? false : JSON.parse(response.eraAuthorized);
-      const expirationCount = _.isNil(response.eraExpiration) ? 0 : AuthenticateNIH.expirationCount(response.eraExpiration);
+      const isAuthorized = JSON.parse(_.get(response, 'eraAuthorized', "false"));
+      const expirationCount = AuthenticateNIH.expirationCount(_.get(response, 'eraExpiration', 0));
       const nihValid = isAuthorized && expirationCount > 0;
       this.props.onNihStatusUpdate(nihValid);
       this.setState(prev => {
         prev.isAuthorized = isAuthorized;
         prev.expirationCount = expirationCount;
-        prev.nihUsername = _.isNil(response.nihUsername) ? '' : response.nihUsername;
+        prev.nihUsername = _.get(response, 'nihUsername', '');
         return prev;
       });
     });

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -113,7 +113,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
     const nihErrorMessage = 'Something went wrong. Please try again.';
     return (
       div({ className: this.props.className }, [
-        label({ className: 'control-label' }, ['NIH eRA Commons ID']),
+        label({ className: 'control-label' }, ['NIH eRA Commons ID*']),
         div({ isRendered: (!this.state.isAuthorized || this.state.expirationCount < 0) }, [
           a({ onClick: this.redirectToNihLogin, target: '_blank', className: 'auth-button ERACommons' }, [
             div({style: validationErrorStyle}, [

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -13,7 +13,8 @@ export const eRACommons = hh(class eRACommons extends React.Component {
     isAuthorized: false,
     expirationCount: 0,
     nihUsername: '',
-    nihError: false
+    nihError: false,
+    isHovered: false
   };
 
   componentDidMount = async () => {
@@ -22,6 +23,14 @@ export const eRACommons = hh(class eRACommons extends React.Component {
     } else {
       this.getResearcherProperties();
     }
+  };
+
+  onMouseEnter = () => {
+    this.setState({ isHovered: true });
+  };
+
+  onMouseLeave = () => {
+    this.setState({ isHovered: false });
   };
 
   authenticateAsNIHFCUser = async (searchArg) => {
@@ -104,21 +113,56 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   };
 
   render() {
-    const validationErrorStyle = _.get(this.props, 'validationError', false) ? {
-      color: "#D13B07",
-      border: "1px solid #D13B07",
-      borderRadius: 5,
-      padding: 6
+    const logoStyle = {
+      height: 27,
+      width: 38,
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'contain',
+      backgroundImage: 'url("/images/era-commons-logo.png")',
+      display: 'inline-block'
+    };
+    const buttonHoverState = {
+      boxShadow: '1px 1px 3px #00609f'
+    };
+    const buttonNormalState = {
+      height: 34,
+      width: 210,
+      display: 'block',
+      border: '1px solid #d3d3d3',
+      padding: 3,
+      textAlign: 'center',
+      marginTop: 3,
+      backgroundColor: '#fff',
+      borderRadius: 2,
+      boxShadow: '1px 1px 3px #999999',
+      cursor: 'pointer',
+      color: '#999',
+      fontWeight: 500,
+      fontSize: '.9em',
+      transition: 'all .2s ease'
+    };
+    const validationErrorState = _.get(this.props, 'validationError', false) ? {
+      color: '#D13B07'
     } : {};
+    const buttonStyle =
+      _.merge(this.state.isHovered ? _.merge(buttonNormalState, buttonHoverState) : buttonNormalState, validationErrorState);
     const nihErrorMessage = 'Something went wrong. Please try again.';
+
     return (
       div({ className: this.props.className }, [
         label({ className: 'control-label' }, ['NIH eRA Commons ID*']),
-        div({ isRendered: (!this.state.isAuthorized || this.state.expirationCount < 0) }, [
-          a({ onClick: this.redirectToNihLogin, target: '_blank', className: 'auth-button ERACommons' }, [
-            div({style: validationErrorStyle}, [
-              span({}, ['Authenticate your account'])
-            ]),
+        div({
+          isRendered: (!this.state.isAuthorized || this.state.expirationCount < 0)
+        }, [
+          a({
+            style: buttonStyle,
+            onMouseEnter: this.onMouseEnter,
+            onMouseLeave: this.onMouseLeave,
+            onClick: this.redirectToNihLogin,
+            target: '_blank'
+          }, [
+            div({ style: logoStyle }),
+            span({ style: { verticalAlign: '50%' } }, ['Authenticate your account'])
           ])
         ]),
         span({

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -1,0 +1,93 @@
+import _ from 'lodash';
+import React from 'react';
+import { a, button, div, hh, label, span } from 'react-hyperscript-helpers';
+import { Storage } from '../libs/storage';
+import { AuthenticateNIH, Researcher } from '../libs/ajax';
+import { Config } from '../libs/config';
+
+
+export const eRACommons = hh(class eRACommons extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      rpProperties: props.rpProperties,
+      nihError: false,
+      nihErrorMessage: 'Something went wrong. Please try again. '
+    };
+    this.redirectToNihLogin = this.redirectToNihLogin.bind(this);
+    this.deleteNihAccount = this.deleteNihAccount.bind(this);
+  };
+
+  isAuthorized = () => {
+    return _.isNil(this.props.rpProperties.eraAuthorized) ? false : JSON.parse(this.props.rpProperties.eraAuthorized);
+  };
+
+  expirationCount = () => {
+    return _.isNil(this.props.rpProperties.eraExpiration) ? 0 : AuthenticateNIH.expirationCount(this.props.rpProperties.eraExpiration);
+  };
+
+  nihUsername = () => {
+    return _.isNil(this.props.rpProperties.nihUsername) ? '' : this.props.rpProperties.nihUsername;
+  };
+
+  async verifyToken(parsedToken) {
+    return await AuthenticateNIH.verifyNihToken(parsedToken).then(
+      (decoded) => decoded,
+      (error) => {
+        this.setState({ nihError: true });
+        return null;
+      }
+    );
+  }
+
+  async redirectToNihLogin() {
+    const nihUrl = `${ await Config.getNihUrl() }?redirect-url=`;
+    const landingUrl = nihUrl.concat(window.location.origin + '/' + this.props.destination + '?jwt%3D%7Btoken%7D');
+    // Storage.setData('dar_application', this.state.formData);
+    window.location.href = landingUrl;
+  }
+
+  async deleteNihAccount() {
+    AuthenticateNIH.eliminateAccount().then(result => {
+      this.setState(prev => {
+        prev.rpProperties = Researcher.getPropertiesByResearcherId(Storage.getCurrentUser().dacUserId);
+        // prev.eraAuthorized = false;
+        return prev;
+      });
+    });
+  }
+
+  render() {
+    return (
+      div({ className: this.props.className }, [
+        label({ className: 'control-label' }, ['NIH eRA Commons ID']),
+        div({ isRendered: (!this.isAuthorized() || this.expirationCount() < 0) }, [
+          a({ onClick: this.redirectToNihLogin, target: '_blank', className: 'auth-button ERACommons' }, [
+            div({ className: 'logo' }, []),
+            span({}, ['Authenticate your account'])
+          ])
+        ]),
+        span({
+          className: 'cancel-color required-field-error-span',
+          isRendered: this.state.nihError
+        }, [this.state.nihErrorMessage]),
+        div({ isRendered: (this.isAuthorized()) }, [
+          div({
+            isRendered: this.expirationCount() >= 0,
+            className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding'
+          }, [
+            div({ className: 'auth-id' }, [this.nihUsername()]),
+            button({ type: 'button', onClick: this.deleteNihAccount, className: 'close auth-clear' }, [
+              span({ className: 'glyphicon glyphicon-remove-circle', 'data-tip': 'Clear account', 'data-for': 'tip_clearNihAccount' })
+            ])
+          ]),
+          div({ className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 no-padding auth-message' }, [
+            div({ isRendered: this.expirationCount() >= 0 }, ['Your NIH authentication will expire in ' + this.expirationCount() + ' days']),
+            div({ isRendered: this.expirationCount() < 0 }, ['Your NIH authentication has expired'])
+          ])
+        ])
+      ])
+    );
+  }
+});

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -1,9 +1,10 @@
 import _ from 'lodash';
+import * as qs from 'query-string';
 import React from 'react';
 import { a, button, div, hh, label, span } from 'react-hyperscript-helpers';
-import { Storage } from '../libs/storage';
 import { AuthenticateNIH, Researcher } from '../libs/ajax';
 import { Config } from '../libs/config';
+import { Storage } from '../libs/storage';
 
 
 export const eRACommons = hh(class eRACommons extends React.Component {
@@ -11,58 +12,121 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      rpProperties: props.rpProperties,
+      rpProperties: {},
+      isAuthorized: false,
+      expirationCount: 0,
+      nihUsername: '',
       nihError: false,
       nihErrorMessage: 'Something went wrong. Please try again. '
     };
+    this.authenticateAsNIHFCUser = this.authenticateAsNIHFCUser.bind(this);
+    this.getResearcherProperties = this.getResearcherProperties.bind(this);
+    this.verifyToken = this.verifyToken.bind(this);
+    this.verifyUser = this.verifyUser.bind(this);
+    this.registerUserToFC = this.registerUserToFC.bind(this);
     this.redirectToNihLogin = this.redirectToNihLogin.bind(this);
     this.deleteNihAccount = this.deleteNihAccount.bind(this);
   };
 
-  isAuthorized = () => {
-    return _.isNil(this.props.rpProperties.eraAuthorized) ? false : JSON.parse(this.props.rpProperties.eraAuthorized);
+  async componentDidMount() {
+    if (this.props.location !== undefined && this.props.location.search !== '') {
+      this.authenticateAsNIHFCUser();
+    } else {
+      this.getResearcherProperties();
+    }
+  }
+
+  async authenticateAsNIHFCUser() {
+    const currentUserId = Storage.getCurrentUser().dacUserId;
+    // Parse the token received from NIH for eRA Commons login and save it to FC/Terra
+    let isFcUser = this.verifyUser();
+    if (!isFcUser) {
+      Researcher.getPropertiesByResearcherId(currentUserId).then(
+        response => {
+          isFcUser = this.registerUserToFC(response);
+        },
+        () => this.setState({ nihError: true }));
+    }
+    if (isFcUser) {
+      const parsedToken = qs.parse(this.props.location.search);
+      this.verifyToken(parsedToken).then(
+        (decodedNihAccount) => {
+          AuthenticateNIH.saveNihUsr(decodedNihAccount).then(
+            () => this.getResearcherProperties(),
+            () => this.setState({ nihError: true })
+          );
+        },
+        () => this.setState({ nihError: true })
+      );
+    }
   };
 
-  expirationCount = () => {
-    return _.isNil(this.props.rpProperties.eraExpiration) ? 0 : AuthenticateNIH.expirationCount(this.props.rpProperties.eraExpiration);
-  };
-
-  nihUsername = () => {
-    return _.isNil(this.props.rpProperties.nihUsername) ? '' : this.props.rpProperties.nihUsername;
-  };
+  async getResearcherProperties() {
+    const currentUserId = Storage.getCurrentUser().dacUserId;
+    // Refresh the user's researcher properties for the current state.
+    Researcher.getPropertiesByResearcherId(currentUserId).then(response => {
+      const isAuthorized = _.isNil(response.eraAuthorized) ? false : JSON.parse(response.eraAuthorized);
+      const expirationCount = _.isNil(response.eraExpiration) ? 0 : AuthenticateNIH.expirationCount(response.eraExpiration);
+      const nihValid = isAuthorized && expirationCount > 0;
+      this.props.onNihStatusUpdate(nihValid);
+      this.setState(prev => {
+        prev.rpProperties = response;
+        prev.isAuthorized = isAuthorized;
+        prev.expirationCount = expirationCount;
+        prev.nihUsername = _.isNil(response.nihUsername) ? '' : response.nihUsername;
+        return prev;
+      });
+    });
+  }
 
   async verifyToken(parsedToken) {
     return await AuthenticateNIH.verifyNihToken(parsedToken).then(
       (decoded) => decoded,
-      (error) => {
+      () => {
         this.setState({ nihError: true });
         return null;
       }
     );
   }
 
+  async verifyUser() {
+    let isFcUser = await AuthenticateNIH.fireCloudVerifyUser().catch(
+      () => {
+        this.setState({ nihError: true });
+        return false;
+      });
+    return isFcUser !== undefined && isFcUser !== false && isFcUser.enabled.google === true;
+  }
+
+  async registerUserToFC(properties) {
+    return await AuthenticateNIH.fireCloudRegisterUser(properties).then(
+      () => {
+        // user has been successfully registered to firecloud.
+        return true;
+      },
+      () => {
+        this.setState({ nihError: true });
+        return false;
+      });
+  }
+
   async redirectToNihLogin() {
     const nihUrl = `${ await Config.getNihUrl() }?redirect-url=`;
-    const landingUrl = nihUrl.concat(window.location.origin + '/' + this.props.destination + '?jwt%3D%7Btoken%7D');
-    // Storage.setData('dar_application', this.state.formData);
-    window.location.href = landingUrl;
+    window.location.href = nihUrl.concat(window.location.origin + '/' + this.props.destination + '?jwt%3D%7Btoken%7D');
   }
 
   async deleteNihAccount() {
-    AuthenticateNIH.eliminateAccount().then(result => {
-      this.setState(prev => {
-        prev.rpProperties = Researcher.getPropertiesByResearcherId(Storage.getCurrentUser().dacUserId);
-        // prev.eraAuthorized = false;
-        return prev;
+    AuthenticateNIH.eliminateAccount().then(
+      result => {
+        this.getResearcherProperties();
       });
-    });
   }
 
   render() {
     return (
       div({ className: this.props.className }, [
         label({ className: 'control-label' }, ['NIH eRA Commons ID']),
-        div({ isRendered: (!this.isAuthorized() || this.expirationCount() < 0) }, [
+        div({ isRendered: (!this.state.isAuthorized || this.state.expirationCount < 0) }, [
           a({ onClick: this.redirectToNihLogin, target: '_blank', className: 'auth-button ERACommons' }, [
             div({ className: 'logo' }, []),
             span({}, ['Authenticate your account'])
@@ -72,19 +136,19 @@ export const eRACommons = hh(class eRACommons extends React.Component {
           className: 'cancel-color required-field-error-span',
           isRendered: this.state.nihError
         }, [this.state.nihErrorMessage]),
-        div({ isRendered: (this.isAuthorized()) }, [
+        div({ isRendered: (this.state.isAuthorized) }, [
           div({
-            isRendered: this.expirationCount() >= 0,
+            isRendered: this.state.expirationCount >= 0,
             className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding'
           }, [
-            div({ className: 'auth-id' }, [this.nihUsername()]),
+            div({ className: 'auth-id' }, [this.state.nihUsername]),
             button({ type: 'button', onClick: this.deleteNihAccount, className: 'close auth-clear' }, [
               span({ className: 'glyphicon glyphicon-remove-circle', 'data-tip': 'Clear account', 'data-for': 'tip_clearNihAccount' })
             ])
           ]),
           div({ className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 no-padding auth-message' }, [
-            div({ isRendered: this.expirationCount() >= 0 }, ['Your NIH authentication will expire in ' + this.expirationCount() + ' days']),
-            div({ isRendered: this.expirationCount() < 0 }, ['Your NIH authentication has expired'])
+            div({ isRendered: this.state.expirationCount >= 0 }, ['Your NIH authentication will expire in ' + this.state.expirationCount + ' days']),
+            div({ isRendered: this.state.expirationCount < 0 }, ['Your NIH authentication has expired'])
           ])
         ])
       ])

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -174,12 +174,34 @@ export const eRACommons = hh(class eRACommons extends React.Component {
             isRendered: this.state.expirationCount >= 0,
             className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding'
           }, [
-            div({ className: 'auth-id' }, [this.state.nihUsername]),
-            button({ type: 'button', onClick: this.deleteNihAccount, className: 'close auth-clear' }, [
+            div({
+              style: {
+                float: 'left',
+                fontWeight: 500,
+                display: 'inline',
+                paddingTop: 5
+              }
+            }, [this.state.nihUsername]),
+            button({
+              style: {
+                float: 'left',
+                margin: '2px 0 0 10px'
+              },
+              type: 'button',
+              onClick: this.deleteNihAccount,
+              className: 'close'
+            }, [
               span({ className: 'glyphicon glyphicon-remove-circle', 'data-tip': 'Clear account', 'data-for': 'tip_clearNihAccount' })
             ])
           ]),
-          div({ className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 no-padding auth-message' }, [
+          div({
+            style: {
+              marginTop: 8,
+              fontStyle: 'italic',
+              display: 'block'
+            },
+            className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 no-padding'
+          }, [
             div({ isRendered: this.state.expirationCount >= 0 }, ['Your NIH authentication will expire in ' + this.state.expirationCount + ' days']),
             div({ isRendered: this.state.expirationCount < 0 }, ['Your NIH authentication has expired'])
           ])

--- a/src/pages/DataAccessRequestApplication.css
+++ b/src/pages/DataAccessRequestApplication.css
@@ -17,69 +17,6 @@ ol.rp-agreement {
   margin-left: 33px;
 }
 
-.auth-button.eRACommons {
-  height: 34px;
-  width: 210px;
-  border: none;
-  border-radius: 3px;
-  display: block;
-  border: 1px solid #d3d3d3;
-  padding: 3px;
-  text-align: center;
-  margin-top: 3px;
-  background-color: #fff;
-  border-radius: 2px;
-  box-shadow: 1px 1px 3px #999;
-  cursor: pointer;
-  color: #999;
-  font-weight: 500;
-  font-size: 0.9em;
-  transition: all 0.2s ease;
-}
-
-.auth-button.eRACommons:hover {
-  box-shadow: 1px 1px 5px #00609f;
-}
-
-.auth-button.eRACommons .logo {
-  height: 27px;
-  width: 38px;
-  background-size: cover !important;
-  background-image: url('/images/era-commons-logo.png');
-  display: inline-block;
-}
-
-.auth-button.eRACommons span {
-  vertical-align: 50%;
-}
-
-.auth-button {
-  margin-top: 3px;
-}
-
-.auth-id {
-  float: left;
-  font-weight: 500;
-  display: inline;
-  padding-top: 5px;
-}
-
-.auth-clear {
-  float: left;
-  margin: 2px 0 0 10px;
-}
-
-.auth-message {
-  margin-top: 8px;
-  font-style: italic;
-  display: block;
-}
-
-.auth-message div {
-  color: #777777;
-  display: block;
-}
-
 a.btn-primary,
 a.btn-secondary {
   padding-top: 10px;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -38,8 +38,6 @@ class DataAccessRequestApplication extends Component {
       showDialogSubmit: false,
       showDialogSave: false,
       step: 1,
-      // nihError: false,
-      // nihErrorMessage:"Something went wrong. Please try again. ",
       formData: {
         datasets: [],
         dar_code: null,
@@ -219,7 +217,6 @@ class DataAccessRequestApplication extends Component {
       prev.rpProperties = rpProperties;
       prev.completed = completed;
       prev.formData = formData;
-      // prev.expirationCount = expirationCount;
       if (formData.nameDAA !== '') {
         prev.file.name = formData.nameDAA;
       }

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -122,10 +122,9 @@ class DataAccessRequestApplication extends Component {
     this.handleFileChange = this.handleFileChange.bind(this);
     this.handleOpenModal = this.handleOpenModal.bind(this);
     this.handleCloseModal = this.handleCloseModal.bind(this);
-    this.onNihStatusUpdate = this.onNihStatusUpdate.bind(this);
   }
 
-  onNihStatusUpdate(nihValid) {
+  onNihStatusUpdate = (nihValid) => {
     if (this.state.nihValid !== nihValid) {
       this.setState(prev => {
         prev.nihValid = nihValid;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -389,12 +389,13 @@ class DataAccessRequestApplication extends Component {
       && !this.isValid(this.state.formData.linkedIn)
       && !this.isValid(this.state.formData.researcherGate)
       && !this.isValid(this.state.formData.orcid)
+      && !this.state.nihValid
       && !this.isValid(this.state.formData.uploadFile)) {
       isLinkedInInvalid = true;
       isOrcidInvalid = true;
       isResearcherGateInvalid = true;
       isDAAInvalid = true;
-      isNihInvalid = !this.state.nihValid;
+      isNihInvalid = true;
       showValidationMessages = true;
     }
     this.setState(prev => {

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -26,12 +26,11 @@ class DataAccessRequestApplication extends Component {
     this.state = {
       nihValid: false,
       rpProperties: {},
-      // expirationCount: -1,
       disableOkBtn: false,
       showValidationMessages: false,
       optionMessage: noOptionMessage,
       file: {
-        name: '',
+        name: ''
       },
       showModal: false,
       completed: '',
@@ -82,15 +81,6 @@ class DataAccessRequestApplication extends Component {
       },
       step1: {
         inputResearcher: {
-          invalid: false
-        },
-        inputLinkedIn: {
-          invalid: false
-        },
-        inputOrcid: {
-          invalid: false
-        },
-        inputResearcherGate: {
           invalid: false
         },
         inputInvestigator: {
@@ -191,7 +181,7 @@ class DataAccessRequestApplication extends Component {
       formData.zipcode = rpProperties.zipcode != null ? rpProperties.zipcode : '';
       formData.country = rpProperties.country != null ? rpProperties.country : '';
       formData.state = rpProperties.state != null ? rpProperties.state : '';
-      formData.piName = rpProperties.piName !== null ? rpProperties.piName : '' ;
+      formData.piName = rpProperties.piName !== null ? rpProperties.piName : '';
       formData.nameDAA = rpProperties.nameDAA != null ? rpProperties.nameDAA : '';
       formData.urlDAA = rpProperties.urlDAA != null ? rpProperties.urlDAA : '';
       formData.academicEmail = rpProperties.academicEmail != null ? rpProperties.academicEmail : '';
@@ -228,7 +218,7 @@ class DataAccessRequestApplication extends Component {
   getOntologies(formData) {
     let ontologies = {};
     if (formData.ontologies !== undefined && formData.ontologies !== null) {
-      ontologies = formData.ontologies.map(function (item) {
+      ontologies = formData.ontologies.map(function(item) {
         return {
           key: item.id,
           value: item.id,
@@ -239,19 +229,21 @@ class DataAccessRequestApplication extends Component {
     }
     return ontologies;
   }
+
   processDataSet(datasetIdList) {
-    return datasetIdList.map(function (item) {
+    return datasetIdList.map(function(item) {
       return {
         value: item.id,
         label: item.concatenation
       };
     });
   }
+
   handleFileChange(event) {
     if (event.target.files !== undefined && event.target.files[0]) {
       let file = event.target.files[0];
       this.setState({
-        file: file,
+        file: file
       });
     }
   };
@@ -307,13 +299,15 @@ class DataAccessRequestApplication extends Component {
       if (field === 'onegender' && value === false) {
         prev.formData.gender = '';
       }
-      prev.formData[field] = value; return prev;
+      prev.formData[field] = value;
+      return prev;
     }, () => this.checkValidations());
   };
 
   handleGenderChange = (e, value) => {
     this.setState(prev => {
-      prev.formData.gender = value; return prev;
+      prev.formData.gender = value;
+      return prev;
     }, () => this.checkValidations());
   };
   step1 = (e) => {
@@ -367,10 +361,11 @@ class DataAccessRequestApplication extends Component {
   };
 
   verifyStep1() {
-    let isTitleInvalid = false, isResearcherInvalid = false,
-      isInvestigatorInvalid = false, isLinkedInInvalid = false,
-      isOrcidInvalid = false, isResearcherGateInvalid = false,
-      isDAAInvalid = false, showValidationMessages = false,
+    let isTitleInvalid = false,
+      isResearcherInvalid = false,
+      isInvestigatorInvalid = false,
+      isDAAInvalid = false,
+      showValidationMessages = false,
       isNihInvalid = !this.state.nihValid;
 
     if (!this.isValid(this.state.formData.projectTitle)) {
@@ -391,9 +386,9 @@ class DataAccessRequestApplication extends Component {
       && !this.isValid(this.state.formData.orcid)
       && !this.state.nihValid
       && !this.isValid(this.state.formData.uploadFile)) {
-      isLinkedInInvalid = true;
-      isOrcidInvalid = true;
-      isResearcherGateInvalid = true;
+      // isLinkedInInvalid = true;
+      // isOrcidInvalid = true;
+      // isResearcherGateInvalid = true;
       isDAAInvalid = true;
       isNihInvalid = true;
       showValidationMessages = true;
@@ -402,10 +397,10 @@ class DataAccessRequestApplication extends Component {
       prev.step1.inputTitle.invalid = isTitleInvalid;
       prev.step1.inputResearcher.invalid = isResearcherInvalid;
       prev.step1.inputInvestigator.invalid = isInvestigatorInvalid;
-      prev.step1.inputLinkedIn.invalid = isLinkedInInvalid;
+      // prev.step1.inputLinkedIn.invalid = isLinkedInInvalid;
       prev.step1.inputNih.invalid = isNihInvalid;
-      prev.step1.inputOrcid.invalid = isOrcidInvalid;
-      prev.step1.inputResearcherGate.invalid = isResearcherGateInvalid;
+      // prev.step1.inputOrcid.invalid = isOrcidInvalid;
+      // prev.step1.inputResearcherGate.invalid = isResearcherGateInvalid;
       prev.step4.uploadFile.invalid = isDAAInvalid;
       if (prev.showValidationMessages === false) prev.showValidationMessages = showValidationMessages;
       return prev;
@@ -524,7 +519,8 @@ class DataAccessRequestApplication extends Component {
       let ontologies = [];
       for (let ontology of this.state.formData.ontologies) {
         ontologies.push(ontology.item);
-      };
+      }
+      ;
       this.setState(prev => {
         if (ontologies.length > 0) {
           prev.formData.ontologies = ontologies;
@@ -544,7 +540,10 @@ class DataAccessRequestApplication extends Component {
         });
         formData.datasetId = ds;
         formData.userId = Storage.getCurrentUser().dacUserId;
-        this.setState(prev => { prev.disableOkBtn = true; return prev; });
+        this.setState(prev => {
+          prev.disableOkBtn = true;
+          return prev;
+        });
         DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
           formData.urlDAA = response.urlDAA;
           formData.nameDAA = response.nameDAA;
@@ -579,13 +578,16 @@ class DataAccessRequestApplication extends Component {
   };
 
   dialogHandlerSave = (answer) => (e) => {
-    this.setState(prev => { prev.disableOkBtn = true; return prev; });
+    this.setState(prev => {
+      prev.disableOkBtn = true;
+      return prev;
+    });
     if (answer === true) {
       let ontologies = [];
       for (let ontology of this.state.formData.ontologies) {
         ontologies.push(ontology.item);
-      };
-      let datasets = this.state.formData.datasets.map(function (item) {
+      }
+      let datasets = this.state.formData.datasets.map(function(item) {
         return {
           id: item.value,
           concatenation: item.label
@@ -648,7 +650,7 @@ class DataAccessRequestApplication extends Component {
 
   searchDataSets(query, callback) {
     DAR.getAutoCompleteDS(query).then(items => {
-      let options = items.map(function (item) {
+      let options = items.map(function(item) {
         return {
           key: item.id,
           value: item.id,
@@ -664,7 +666,7 @@ class DataAccessRequestApplication extends Component {
     let options = [];
     DAR.getAutoCompleteOT(query).then(
       items => {
-        options = items.map(function (item) {
+        options = items.map(function(item) {
           return {
             key: item.id,
             value: item.id,
@@ -700,274 +702,298 @@ class DataAccessRequestApplication extends Component {
 
     const { problemSavingRequest, showValidationMessages, atLeastOneCheckboxChecked, step1, step2, step3, step4 } = this.state;
 
-    const genderLabels = ['Female', "Male"];
+    const genderLabels = ['Female', 'Male'];
     const genderValues = ['F', 'M'];
 
     const profileUnsubmitted = span({}, [
-      "Please submit ",
-      h(Link, { to: "/profile", className: "hover-color" }, ["Your Profile"]),
-      " to be able to create a Data Access Request"
+      'Please submit ',
+      h(Link, { to: '/profile', className: 'hover-color' }, ['Your Profile']),
+      ' to be able to create a Data Access Request'
     ]);
 
     const profileSubmitted = span({}, [
-      "Please make sure ",
-      h(Link, { to: "/profile", className: "hover-color" }, ["Your Profile"]),
-      " is updated, as it will be submited with your DAR Application"
+      'Please make sure ',
+      h(Link, { to: '/profile', className: 'hover-color' }, ['Your Profile']),
+      ' is updated, as it will be submited with your DAR Application'
     ]);
 
     return (
 
-      div({ className: "container" }, [
-        div({ className: "col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12" }, [
-          div({ className: "row no-margin" }, [
-            div({ className: (this.state.formData.dar_code !== null ? 'col-lg-10 col-md-9 col-sm-9 ' : this.state.formData.dar_code === null ? 'col-lg-12 col-md-12 col-sm-12 ' : 'col-xs-12 no-padding') }, [
+      div({ className: 'container' }, [
+        div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
+          div({ className: 'row no-margin' }, [
+            div({
+              className: (this.state.formData.dar_code !== null ?
+                'col-lg-10 col-md-9 col-sm-9 ' :
+                this.state.formData.dar_code === null ? 'col-lg-12 col-md-12 col-sm-12 ' : 'col-xs-12 no-padding')
+            }, [
               PageHeading({
-                id: "requestApplication", imgSrc: "/images/icon_add_access.png", iconSize: "medium", color: "access", title: "Data Access Request Application",
-                description: "The section below includes a series of questions intended to allow our Data Access Committee to evaluate a newly developed semi-automated process of data access control."
+                id: 'requestApplication', imgSrc: '/images/icon_add_access.png', iconSize: 'medium', color: 'access',
+                title: 'Data Access Request Application',
+                description: 'The section below includes a series of questions intended to allow our Data Access Committee to evaluate a newly developed semi-automated process of data access control.'
               })
             ]),
-            div({ isRendered: this.state.formData.dar_code !== null, className: "col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding" }, [
-              a({ id: "btn_back", onClick: this.back, className: "btn-primary btn-back" }, [
-                i({ className: "glyphicon glyphicon-chevron-left" }), "Back"
+            div({ isRendered: this.state.formData.dar_code !== null, className: 'col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding' }, [
+              a({ id: 'btn_back', onClick: this.back, className: 'btn-primary btn-back' }, [
+                i({ className: 'glyphicon glyphicon-chevron-left' }), 'Back'
               ])
             ])
           ]),
-          hr({ className: "section-separator" }),
+          hr({ className: 'section-separator' }),
 
-          div({ className: "row fsi-row-lg-level fsi-row-md-level multi-step-buttons no-margin" }, [
+          div({ className: 'row fsi-row-lg-level fsi-row-md-level multi-step-buttons no-margin' }, [
 
             a({
-              id: "btn_step_1",
+              id: 'btn_step_1',
               onClick: this.step1,
-              className: "col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title "
+              className: 'col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title '
                 + (this.state.step === 1 ? 'active' : '')
             }, [
-                small({}, ["Step 1"]),
-                "Researcher Information",
-                span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" }, [])
-              ]),
+              small({}, ['Step 1']),
+              'Researcher Information',
+              span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' }, [])
+            ]),
 
             a({
-              id: "btn_step_2",
+              id: 'btn_step_2',
               onClick: this.step2,
-              className: "col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title "
+              className: 'col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title '
                 + (this.state.step === 2 ? 'active' : '')
             }, [
-                small({}, ["Step 2"]),
-                "Data Access Request",
-                span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" }, [])
-              ]),
+              small({}, ['Step 2']),
+              'Data Access Request',
+              span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' }, [])
+            ]),
 
             a({
-              id: "btn_step_3",
+              id: 'btn_step_3',
               onClick: this.step3,
-              className: "col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title "
+              className: 'col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title '
                 + (this.state.step === 3 ? 'active' : '')
             }, [
-                small({}, ["Step 3"]),
-                "Research Purpose Statement",
-                span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" }, [])
-              ]),
+              small({}, ['Step 3']),
+              'Research Purpose Statement',
+              span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' }, [])
+            ]),
 
             a({
-              id: "btn_step_4",
+              id: 'btn_step_4',
               onClick: this.step4,
-              className: "col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title "
+              className: 'col-lg-3 col-md-3 col-sm-12 col-xs-12 access-color jumbotron box-vote multi-step-title '
                 + (this.state.step === 4 ? 'active' : '')
             }, [
-                small({}, ["Step 4"]),
-                "Data Use Agreements",
-                span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" }, [])
-              ])
+              small({}, ['Step 4']),
+              'Data Use Agreements',
+              span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' }, [])
+            ])
           ])
         ]),
-        form({ name: "form", "noValidate": true }, [
-          div({ id: "form-views" }, [
+        form({ name: 'form', 'noValidate': true }, [
+          div({ id: 'form-views' }, [
 
             ConfirmationDialog({
-              title: 'Save changes?', disableOkBtn: this.state.disableOkBtn, disableNoBtn: this.state.disableOkBtn, color: 'access', showModal: this.state.showDialogSave, action: { label: "Yes", handler: this.dialogHandlerSave }
-            }, [div({ className: "dialog-description" }, ["Are you sure you want to save this Data Access Request? Previous changes will be overwritten."]),]),
+              title: 'Save changes?', disableOkBtn: this.state.disableOkBtn, disableNoBtn: this.state.disableOkBtn, color: 'access',
+              showModal: this.state.showDialogSave, action: { label: 'Yes', handler: this.dialogHandlerSave }
+            }, [
+              div({ className: 'dialog-description' },
+                ['Are you sure you want to save this Data Access Request? Previous changes will be overwritten.'])
+            ]),
 
             div({ isRendered: this.state.step === 1 }, [
-              div({ className: "col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12" }, [
+              div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
                 fieldset({ disabled: this.state.formData.dar_code !== null }, [
 
-                  div({ isRendered: this.state.completed === false, className: "rp-alert" }, [
-                    Alert({ id: "profileUnsubmitted", type: "danger", title: profileUnsubmitted })
+                  div({ isRendered: this.state.completed === false, className: 'rp-alert' }, [
+                    Alert({ id: 'profileUnsubmitted', type: 'danger', title: profileUnsubmitted })
                   ]),
-                  div({ isRendered: this.state.completed === true, className: "rp-alert" }, [
-                    Alert({ id: "profileSubmitted", type: "info", title: profileSubmitted })
+                  div({ isRendered: this.state.completed === true, className: 'rp-alert' }, [
+                    Alert({ id: 'profileSubmitted', type: 'info', title: profileSubmitted })
                   ]),
 
-                  h3({ className: "rp-form-title access-color" }, ["1. Researcher Information"]),
+                  h3({ className: 'rp-form-title access-color' }, ['1. Researcher Information']),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, ["1.1 Researcher*"]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, ['1.1 Researcher*'])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       input({
-                        type: "text",
-                        name: "researcher",
-                        id: "inputResearcher",
+                        type: 'text',
+                        name: 'researcher',
+                        id: 'inputResearcher',
                         value: this.state.formData.researcher,
                         disabled: true,
                         className: step1.inputResearcher.invalid && showValidationMessages ? 'form-control required-field-error' : 'form-control',
                         required: true
                       }),
-                      span({ isRendered: (step1.inputResearcher.invalid) && (showValidationMessages), className: "cancel-color required-field-error-span" }, ["Required field"]),
+                      span({
+                        isRendered: (step1.inputResearcher.invalid) && (showValidationMessages), className: 'cancel-color required-field-error-span'
+                      }, ['Required field'])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group checkbox' }, [
                       input({
-                        type: "checkbox",
-                        id: "chk_collaborator",
-                        name: "checkCollaborator",
-                        className: "checkbox-inline rp-checkbox",
+                        type: 'checkbox',
+                        id: 'chk_collaborator',
+                        name: 'checkCollaborator',
+                        className: 'checkbox-inline rp-checkbox',
                         disabled: this.state.formData.dar_code !== null,
                         checked: checkCollaborator,
                         onChange: this.handleCheckboxChange
                       }),
-                      label({ className: "regular-checkbox rp-choice-questions", htmlFor: "chk_collaborator" }, ["I am a collaborator of the PI/Data Custodian for the selected dataset(s)"]),
+                      label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_collaborator' },
+                        ['I am a collaborator of the PI/Data Custodian for the selected dataset(s)'])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-6 col-xs-12" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "1.2 Researcher Identification",
-                        div({ isRendered: this.state.formData.checkCollaborator !== true, className: "display-inline" }, ["*"]),
-                        div({ isRendered: this.state.formData.checkCollaborator === true, className: "display-inline italic" }, [" (optional)"]),
-                        span({ className: "default-color" }, ["Please authenticate your eRA Commons account or provide a link to one of your other profiles:"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '1.2 Researcher Identification',
+                        div({ isRendered: this.state.formData.checkCollaborator !== true, className: 'display-inline' }, ['*']),
+                        div({ isRendered: this.state.formData.checkCollaborator === true, className: 'display-inline italic' }, [' (optional)']),
+                        span({ className: 'default-color' },
+                          ['Please authenticate your eRA Commons account. Other profiles are optional:'])
                       ])
                     ]),
 
-                    span({ isRendered: (step1.inputResearcherGate.invalid) && (showValidationMessages), className: "col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span" }, ["At least one of the following fields is required"]),
+                    span({
+                      isRendered: showValidationMessages, className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span'
+                    }, ['NIH eRA Authentication is required']),
 
-                    div({ className: "row no-margin" }, [
+                    div({ className: 'row no-margin' }, [
                       eRACommons({
-                        className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group",
-                        destination: "dar_application",
+                        className: 'col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group',
+                        destination: 'dar_application',
                         onNihStatusUpdate: this.onNihStatusUpdate,
-                        location: this.props.location
+                        location: this.props.location,
+                        validationError: showValidationMessages
                       }),
-                      div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group" }, [
-                        label({ className: "control-label" }, ["LinkedIn Profile"]),
+                      div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group' }, [
+                        label({ className: 'control-label' }, ['LinkedIn Profile']),
                         input({
-                          type: "text",
-                          name: "linkedIn",
-                          id: "inputLinkedIn",
+                          type: 'text',
+                          name: 'linkedIn',
+                          id: 'inputLinkedIn',
                           value: linkedIn,
                           onChange: this.handleChange,
                           disabled: false,
-                          className: step1.inputLinkedIn.invalid && showValidationMessages ? 'form-control required-field-error' : 'form-control',
+                          className: 'form-control',
                           required: true
                         })
                       ])
                     ]),
 
-                    div({ className: "row no-margin" }, [
-                      div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12" }, [
-                        label({ className: "control-label" }, ["ORCID iD"]),
+                    div({ className: 'row no-margin' }, [
+                      div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-12' }, [
+                        label({ className: 'control-label' }, ['ORCID iD']),
                         input({
-                          type: "text",
-                          name: "orcid",
-                          id: "inputOrcid",
+                          type: 'text',
+                          name: 'orcid',
+                          id: 'inputOrcid',
                           value: orcid,
                           onChange: this.handleChange,
                           disabled: false,
-                          className: step1.inputOrcid.invalid && showValidationMessages ? 'form-control required-field-error' : 'form-control',
+                          className: 'form-control',
                           required: true
                         })
                       ]),
 
-                      div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12" }, [
-                        label({ className: "control-label" }, ["ResearchGate ID"]),
+                      div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-12' }, [
+                        label({ className: 'control-label' }, ['ResearchGate ID']),
                         input({
-                          type: "text",
-                          name: "researcherGate",
-                          id: "inputResearcherGate",
+                          type: 'text',
+                          name: 'researcherGate',
+                          id: 'inputResearcherGate',
                           value: researcherGate,
                           onChange: this.handleChange,
                           disabled: false,
-                          className: step1.inputResearcherGate.invalid && showValidationMessages ? 'form-control required-field-error' : 'form-control',
+                          className: 'form-control',
                           required: true
                         })
                       ])
                     ])
                   ]),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "1.3 Principal Investigator* ",
-                        span({}, ["By typing in the name of the principal investigator, I certify that he or she is aware of this research study."]),]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '1.3 Principal Investigator* ',
+                        span({}, ['By typing in the name of the principal investigator, I certify that he or she is aware of this research study.'])
+                      ])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       input({
-                        type: "text",
-                        name: "investigator",
-                        id: "inputInvestigator",
+                        type: 'text',
+                        name: 'investigator',
+                        id: 'inputInvestigator',
                         value: investigator,
                         disabled: true,
                         className: step1.inputInvestigator.invalid && showValidationMessages ? 'form-control required-field-error' : 'form-control',
                         required: true
                       }),
-                      span({ className: "cancel-color required-field-error-span", isRendered: (step1.inputInvestigator.invalid) && (showValidationMessages) }, ["Required field"])
+                      span({
+                        className: 'cancel-color required-field-error-span', isRendered: (step1.inputInvestigator.invalid) && (showValidationMessages)
+                      }, ['Required field'])
                     ])
                   ]),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "1.4 Descriptive Title of Project* ",
-                        span({}, ["Please note that coordinated requests by collaborating institutions should each use the same title."]),
-                      ]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '1.4 Descriptive Title of Project* ',
+                        span({}, ['Please note that coordinated requests by collaborating institutions should each use the same title.'])
+                      ])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group rp-last-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group rp-last-group' }, [
                       input({
-                        type: "text",
-                        name: "projectTitle",
-                        id: "inputTitle",
-                        maxLength: "256",
+                        type: 'text',
+                        name: 'projectTitle',
+                        id: 'inputTitle',
+                        maxLength: '256',
                         value: this.state.formData.projectTitle,
                         onChange: this.handleChange,
                         className: step1.inputTitle.invalid && showValidationMessages ? 'form-control required-field-error' : 'form-control',
                         required: true,
                         disabled: this.state.formData.dar_code !== null
                       }),
-                      span({ className: "cancel-color required-field-error-span", isRendered: step1.inputTitle.invalid && showValidationMessages }, ["Required field"])
+                      span({ className: 'cancel-color required-field-error-span', isRendered: step1.inputTitle.invalid && showValidationMessages },
+                        ['Required field'])
                     ])
                   ])
                 ]),
 
-                div({ className: "row no-margin" }, [
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                    a({ id: "btn_next", onClick: this.step2, className: "btn-primary f-right access-background" }, [
-                      "Next Step", span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" }),
+                div({ className: 'row no-margin' }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                    a({ id: 'btn_next', onClick: this.step2, className: 'btn-primary f-right access-background' }, [
+                      'Next Step', span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' })
                     ]),
 
-                    a({ id: "btn_save", isRendered: this.state.formData.dar_code === null, onClick: this.partialSave, className: "btn-secondary f-right access-color" }, ["Save"])
+                    a({
+                      id: 'btn_save', isRendered: this.state.formData.dar_code === null, onClick: this.partialSave,
+                      className: 'btn-secondary f-right access-color'
+                    }, ['Save'])
                   ])
                 ])
               ])
             ]),
 
             div({ isRendered: this.state.step === 2 }, [
-              div({ className: "col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12" }, [
+              div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
                 fieldset({ disabled: this.state.formData.dar_code !== null }, [
 
-                  h3({ className: "rp-form-title access-color" }, ["2. Data Access Request"]),
+                  h3({ className: 'rp-form-title access-color' }, ['2. Data Access Request']),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "2.1 Select Dataset(s)*",
-                        span({}, ["Please start typing the Dataset Name, Sample Collection ID, or PI of the dataset(s) for which you would like to request access:"]),
-                      ]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '2.1 Select Dataset(s)*',
+                        span({},
+                          ['Please start typing the Dataset Name, Sample Collection ID, or PI of the dataset(s) for which you would like to request access:'])
+                      ])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       h(AsyncSelect, {
-                        id: "sel_datasets",
+                        id: 'sel_datasets',
                         key: this.state.formData.datasets.value,
                         isDisabled: this.state.formData.dar_code !== null,
                         isMulti: true,
@@ -976,492 +1002,577 @@ class DataAccessRequestApplication extends Component {
                         value: this.state.formData.datasets,
                         noOptionsMessage: () => this.state.optionMessage,
                         loadingMessage: () => this.state.optionMessage,
-                        classNamePrefix: "select",
-                        placeholder: "Dataset Name, Sample Collection ID, or PI",
-                        className: step2.inputDatasets.invalid && showValidationMessages ? ' required-select-error select-autocomplete' : 'select-autocomplete',
+                        classNamePrefix: 'select',
+                        placeholder: 'Dataset Name, Sample Collection ID, or PI',
+                        className: step2.inputDatasets.invalid && showValidationMessages ?
+                          ' required-select-error select-autocomplete' :
+                          'select-autocomplete'
 
                       }),
-                      span({ className: "cancel-color required-field-error-span", isRendered: step2.inputDatasets.invalid && showValidationMessages }, ["Required field"]),
-                    ]),
+                      span({ className: 'cancel-color required-field-error-span', isRendered: step2.inputDatasets.invalid && showValidationMessages },
+                        ['Required field'])
+                    ])
 
                   ]),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "2.2 Research use statement (RUS)* ",
-                        span({}, ["A RUS is a brief description of the applicant’s proposed use of the dataset(s). The RUS will be reviewed by all parties responsible for data covered by this Data Access Request. Please note that if access is approved, you agree that the RUS, along with your name and institution, will be included on this website to describe your research project to the public.",
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '2.2 Research use statement (RUS)* ',
+                        span({}, [
+                          'A RUS is a brief description of the applicant’s proposed use of the dataset(s). The RUS will be reviewed by all parties responsible for data covered by this Data Access Request. Please note that if access is approved, you agree that the RUS, along with your name and institution, will be included on this website to describe your research project to the public.',
                           br(),
-                          "Please enter your RUS in the area below. The RUS should be one or two paragraphs in length and include research objectives, the study design, and an analysis plan (including the phenotypic characteristics that will be tested for association with genetic variants). If you are requesting multiple datasets, please describe how you will use them. Examples of RUS can be found at ",
-                          a({ target: "_blank", href: "http://epi.grants.cancer.gov/dac/examples.html" }, ["here"], ".")
-                        ]),
-                      ]),
+                          'Please enter your RUS in the area below. The RUS should be one or two paragraphs in length and include research objectives, the study design, and an analysis plan (including the phenotypic characteristics that will be tested for association with genetic variants). If you are requesting multiple datasets, please describe how you will use them. Examples of RUS can be found at ',
+                          a({ target: '_blank', href: 'http://epi.grants.cancer.gov/dac/examples.html' }, ['here'], '.')
+                        ])
+                      ])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       textarea({
                         value: this.state.formData.rus, onChange: this.handleChange,
-                        name: "rus",
-                        id: "inputRUS",
+                        name: 'rus',
+                        id: 'inputRUS',
                         className: step2.inputRUS.invalid && showValidationMessages ? ' required-field-error form-control' : 'form-control',
-                        rows: "6",
+                        rows: '6',
                         required: true,
-                        placeholder: "Please limit your RUS to 2200 characters.",
+                        placeholder: 'Please limit your RUS to 2200 characters.',
                         disabled: this.state.formData.dar_code !== null
                       }),
-                      span({ className: "cancel-color required-field-error-span", isRendered: step2.inputRUS.invalid && showValidationMessages }, ["Required field"]),
-                    ]),
+                      span({ className: 'cancel-color required-field-error-span', isRendered: step2.inputRUS.invalid && showValidationMessages },
+                        ['Required field'])
+                    ])
                   ]),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "2.3 Non-Technical summary* ",
-                        span({}, ["Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below)."
-                        ]),
-                      ]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '2.3 Non-Technical summary* ',
+                        span({}, [
+                          'Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below).'
+                        ])
+                      ])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       textarea({
                         value: this.state.formData.non_tech_rus,
                         onChange: this.handleChange,
-                        name: "non_tech_rus",
-                        id: "inputNonTechRUS",
+                        name: 'non_tech_rus',
+                        id: 'inputNonTechRUS',
                         className: step2.inputNonTechRUS.invalid && showValidationMessages ? 'required-field-error form-control' : 'form-control',
-                        rows: "3",
+                        rows: '3',
                         required: true,
-                        placeholder: "Please limit your non-technical summary to 1100 characters.",
+                        placeholder: 'Please limit your non-technical summary to 1100 characters.',
                         disabled: this.state.formData.dar_code !== null
                       }),
-                      span({ className: "cancel-color required-field-error-span", isRendered: step2.inputNonTechRUS.invalid && showValidationMessages }, ["Required field"]),
-                    ]),
+                      span(
+                        { className: 'cancel-color required-field-error-span', isRendered: step2.inputNonTechRUS.invalid && showValidationMessages },
+                        ['Required field'])
+                    ])
                   ]),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "2.4 Type of Research* ",
-                        span({}, ["Select all applicable options."]),
-                      ]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '2.4 Type of Research* ',
+                        span({}, ['Select all applicable options.'])
+                      ])
                     ]),
-                    div({ className: "row no-margin" }, [
-                      span({ className: "cancel-color required-field-error-span", isRendered: !atLeastOneCheckboxChecked && showValidationMessages, style: { 'marginLeft': '15px' } }, ["At least one of the following fields is required"]),
+                    div({ className: 'row no-margin' }, [
+                      span({
+                        className: 'cancel-color required-field-error-span', isRendered: !atLeastOneCheckboxChecked && showValidationMessages,
+                        style: { 'marginLeft': '15px' }
+                      }, ['At least one of the following fields is required'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: diseases,
                           onChange: this.handleCheckboxChange,
                           name: 'diseases',
-                          id: "checkDiseases",
-                          type: "checkbox",
-                          className: "checkbox-inline rp-checkbox",
-                          disabled: (this.state.formData.dar_code !== null),
+                          id: 'checkDiseases',
+                          type: 'checkbox',
+                          className: 'checkbox-inline rp-checkbox',
+                          disabled: (this.state.formData.dar_code !== null)
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkDiseases" }, [
-                          span({}, ["2.4.1 Disease-related studies: "]),
-                          "The primary purpose of the research is to learn more about a particular disease or disorder (e.g., type 2 diabetes), a trait (e.g., blood pressure), or a set of related conditions (e.g., autoimmune diseases, psychiatric disorders)."
-                        ]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkDiseases' }, [
+                          span({}, ['2.4.1 Disease-related studies: ']),
+                          'The primary purpose of the research is to learn more about a particular disease or disorder (e.g., type 2 diabetes), a trait (e.g., blood pressure), or a set of related conditions (e.g., autoimmune diseases, psychiatric disorders).'
+                        ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: methods,
                           onChange: this.handleCheckboxChange,
-                          id: "checkMethods",
-                          type: "checkbox",
+                          id: 'checkMethods',
+                          type: 'checkbox',
                           disabled: (this.state.formData.dar_code !== null),
-                          className: "checkbox-inline rp-checkbox",
-                          name: "methods",
+                          className: 'checkbox-inline rp-checkbox',
+                          name: 'methods'
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkMethods" }, [
-                          span({}, ["2.4.2 Methods development and validation studies: "]),
-                          "The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data (e.g., developing more powerful methods to detect epistatic, gene-environment, or other types of complex interactions in genome-wide association studies). Data will be used for developing and/or validating new methods."
-                        ]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkMethods' }, [
+                          span({}, ['2.4.2 Methods development and validation studies: ']),
+                          'The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data (e.g., developing more powerful methods to detect epistatic, gene-environment, or other types of complex interactions in genome-wide association studies). Data will be used for developing and/or validating new methods.'
+                        ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: controls,
                           onChange: this.handleCheckboxChange,
-                          id: "checkControls",
-                          type: "checkbox",
+                          id: 'checkControls',
+                          type: 'checkbox',
                           disabled: (this.state.formData.dar_code !== null),
-                          className: "checkbox-inline rp-checkbox",
-                          name: "controls",
+                          className: 'checkbox-inline rp-checkbox',
+                          name: 'controls'
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkControls" }, [
-                          span({}, ["2.4.3 Controls: "]),
-                          "The reason for this request is to increase the number of controls available for a comparison group (e.g., a case-control study)."
-                        ]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkControls' }, [
+                          span({}, ['2.4.3 Controls: ']),
+                          'The reason for this request is to increase the number of controls available for a comparison group (e.g., a case-control study).'
+                        ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: population,
                           onChange: this.handleCheckboxChange,
-                          id: "checkPopulation",
-                          type: "checkbox",
+                          id: 'checkPopulation',
+                          type: 'checkbox',
                           disabled: (this.state.formData.dar_code !== null),
-                          className: "checkbox-inline rp-checkbox",
-                          name: "population",
+                          className: 'checkbox-inline rp-checkbox',
+                          name: 'population'
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkPopulation" }, [
-                          span({}, ["2.4.4 Population structure or normal variation studies: "]),
-                          "The primary purpose of the research is to understand variation in the general population (e.g., genetic substructure of a population)."
-                        ]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkPopulation' }, [
+                          span({}, ['2.4.4 Population structure or normal variation studies: ']),
+                          'The primary purpose of the research is to understand variation in the general population (e.g., genetic substructure of a population).'
+                        ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: hmb,
                           onChange: this.handleCheckboxChange,
-                          id: "checkHmb",
-                          type: "checkbox",
-                          className: "checkbox-inline rp-checkbox",
-                          name: "hmb",
-                          disabled: (this.state.formData.dar_code !== null),
+                          id: 'checkHmb',
+                          type: 'checkbox',
+                          className: 'checkbox-inline rp-checkbox',
+                          name: 'hmb',
+                          disabled: (this.state.formData.dar_code !== null)
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkHmb" }, [
-                          span({}, ["2.4.5 Health/medical/biomedical research: "]),
-                          "The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition."
-                        ]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkHmb' }, [
+                          span({}, ['2.4.5 Health/medical/biomedical research: ']),
+                          'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.'
+                        ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: poa,
                           onChange: this.handleCheckboxChange,
-                          id: "checkPoa",
-                          type: "checkbox",
-                          className: "checkbox-inline rp-checkbox",
-                          name: "poa",
-                          disabled: (this.state.formData.dar_code !== null),
+                          id: 'checkPoa',
+                          type: 'checkbox',
+                          className: 'checkbox-inline rp-checkbox',
+                          name: 'poa',
+                          disabled: (this.state.formData.dar_code !== null)
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkPoa" }, [
-                          span({}, ["2.4.6 Population origins or ancestry research: "]),
-                          "The outcome of this study is expected to provide new knowledge about the origins of a certain population or its ancestry."
-                        ]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkPoa' }, [
+                          span({}, ['2.4.6 Population origins or ancestry research: ']),
+                          'The outcome of this study is expected to provide new knowledge about the origins of a certain population or its ancestry.'
+                        ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      div({ className: "checkbox" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      div({ className: 'checkbox' }, [
                         input({
                           checked: other,
                           onChange: this.handleCheckboxChange,
-                          id: "checkOther",
-                          type: "checkbox",
-                          className: "checkbox-inline rp-checkbox",
-                          name: "other",
-                          disabled: (this.state.formData.dar_code !== null),
+                          id: 'checkOther',
+                          type: 'checkbox',
+                          className: 'checkbox-inline rp-checkbox',
+                          name: 'other',
+                          disabled: (this.state.formData.dar_code !== null)
                         }),
-                        label({ className: "regular-checkbox rp-choice-questions", htmlFor: "checkOther" }, [span({}, ["2.4.7 Other:"]),]),
-                      ]),
+                        label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'checkOther' }, [span({}, ['2.4.7 Other:'])])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
 
                       textarea({
                         value: othertext,
                         onChange: this.handleChange,
-                        name: "othertext",
-                        id: "inputOtherText",
-                        maxLength: "512",
-                        rows: "2",
+                        name: 'othertext',
+                        id: 'inputOtherText',
+                        maxLength: '512',
+                        rows: '2',
                         required: this.state.formData.other,
-                        className: step2.inputOther.invalid && this.state.formData.other && showValidationMessages ? ' required-field-error form-control' : 'form-control',
-                        placeholder: "Please specify if selected (max. 512 characters)",
-                        disabled: this.state.formData.dar_code !== null || this.state.formData.other !== true,
+                        className: step2.inputOther.invalid && this.state.formData.other && showValidationMessages ?
+                          ' required-field-error form-control' :
+                          'form-control',
+                        placeholder: 'Please specify if selected (max. 512 characters)',
+                        disabled: this.state.formData.dar_code !== null || this.state.formData.other !== true
                       }),
-                      span({ className: "cancel-color required-field-error-span", isRendered: step2.inputOther.invalid && this.state.formData.other && showValidationMessages }, ["Required field"]),
-                    ]),
+                      span({
+                        className: 'cancel-color required-field-error-span',
+                        isRendered: step2.inputOther.invalid && this.state.formData.other && showValidationMessages
+                      }, ['Required field'])
+                    ])
                   ]),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "2.5 Please state the disease area(s) this study focus on ",
-                        span({}, ["Choose any number of Disease Ontology ; or none."]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '2.5 Please state the disease area(s) this study focus on ',
+                        span({}, ['Choose any number of Disease Ontology ; or none.'])
                       ])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-last-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-last-group' }, [
                       h(AsyncSelect, {
-                        id: "sel_diseases",
+                        id: 'sel_diseases',
                         isDisabled: this.state.formData.dar_code !== null,
                         isMulti: true,
                         loadOptions: (query, callback) => this.searchOntologies(query, callback),
                         onChange: (option) => this.onOntologiesChange(option),
                         value: this.state.formData.ontologies,
-                        placeholder: "Please enter one or more ontologies",
-                        className: "select-autocomplete",
-                        classNamePrefix: "select"
+                        placeholder: 'Please enter one or more ontologies',
+                        className: 'select-autocomplete',
+                        classNamePrefix: 'select'
                       })
                     ])
                   ])
                 ]),
 
-                div({ className: "row no-margin" }, [
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                    a({ id: "btn_prev", onClick: this.step1, className: "btn-primary f-left access-background" }, [
-                      span({ className: "glyphicon glyphicon-chevron-left", "aria-hidden": "true" }), "Previous Step"
+                div({ className: 'row no-margin' }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                    a({ id: 'btn_prev', onClick: this.step1, className: 'btn-primary f-left access-background' }, [
+                      span({ className: 'glyphicon glyphicon-chevron-left', 'aria-hidden': 'true' }), 'Previous Step'
                     ]),
 
-                    a({ id: "btn_next", onClick: this.step3, className: "btn-primary f-right access-background" }, [
-                      "Next Step", span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" })
+                    a({ id: 'btn_next', onClick: this.step3, className: 'btn-primary f-right access-background' }, [
+                      'Next Step', span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' })
                     ]),
 
-                    a({ id: "btn_save", isRendered: this.state.formData.dar_code === null, onClick: this.partialSave, className: "btn-secondary f-right access-color" }, ["Save"])
+                    a({
+                      id: 'btn_save', isRendered: this.state.formData.dar_code === null, onClick: this.partialSave,
+                      className: 'btn-secondary f-right access-color'
+                    }, ['Save'])
                   ])
                 ])
               ])
             ]),
 
             div({ isRendered: this.state.step === 3 }, [
-              div({ className: "col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12" }, [
+              div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
                 fieldset({ disabled: this.state.formData.dar_code !== null }, [
 
-                  h3({ className: "rp-form-title access-color" }, ["3. Research Purpose Statement"]),
+                  h3({ className: 'rp-form-title access-color' }, ['3. Research Purpose Statement']),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-title-question" }, ["3.1 In order to ensure appropriate review, please answer the questions below:"]),
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question' },
+                        ['3.1 In order to ensure appropriate review, please answer the questions below:'])
                     ]),
-                    div({ className: "row no-margin" }, [
-                      span({ className: "cancel-color required-field-error-span", isRendered: step3.inputPurposes.invalid && showValidationMessages, style: { 'marginLeft': '15px' } }, ["All fields are required"]),
+                    div({ className: 'row no-margin' }, [
+                      span({
+                        className: 'cancel-color required-field-error-span', isRendered: step3.inputPurposes.invalid && showValidationMessages,
+                        style: { 'marginLeft': '15px' }
+                      }, ['All fields are required'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.1 Will this data be used exclusively or partially for a commercial purpose?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.1 Will this data be used exclusively or partially for a commercial purpose?'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       YesNoRadioGroup({
                         value: this.state.formData.forProfit, onChange: this.handleRadioChange, id: 'forProfit', name: 'forProfit',
                         required: true
-                      }),
+                      })
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.2 Please indicate if this study is limited to one gender?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' }, ['3.1.2 Please indicate if this study is limited to one gender?'])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       YesNoRadioGroup({
                         value: this.state.formData.onegender, onChange: this.handleRadioChange, id: 'onegender', name: 'onegender',
                         required: true
                       }),
                       div({
                         isRendered: this.state.formData.onegender === 'true' || this.state.formData.onegender === true,
-                        className: "multi-step-fields", disabled: (this.state.formData.dar_code !== null)
+                        className: 'multi-step-fields', disabled: (this.state.formData.dar_code !== null)
                       }, [
-                          span({}, ["Please specify"]),
-                          div({ className: 'radio-inline' }, [
-                            genderLabels.map((option, ix) => {
-                              return (
-                                label({
-                                  key: 'gender' + ix,
-                                  onClick: (e) => this.handleGenderChange(e, genderValues[ix]),
-                                  id: "lbl_gender_" + ix,
-                                  htmlFor: "rad_gender_" + ix,
-                                  className: "radio-wrapper"
-                                }, [
-                                    input({
-                                      type: "radio",
-                                      id: "rad_gender_" + ix,
-                                      name: this.state.name,
-                                      checked: this.state.formData.gender === genderValues[ix],
-                                      onChange: () => { }
-                                    }),
-                                    span({ className: "radio-check" }),
-                                    span({ className: "radio-label" }, [genderLabels[ix]])
-                                  ])
-                              );
-                            })
-                          ])
+                        span({}, ['Please specify']),
+                        div({ className: 'radio-inline' }, [
+                          genderLabels.map((option, ix) => {
+                            return (
+                              label({
+                                key: 'gender' + ix,
+                                onClick: (e) => this.handleGenderChange(e, genderValues[ix]),
+                                id: 'lbl_gender_' + ix,
+                                htmlFor: 'rad_gender_' + ix,
+                                className: 'radio-wrapper'
+                              }, [
+                                input({
+                                  type: 'radio',
+                                  id: 'rad_gender_' + ix,
+                                  name: this.state.name,
+                                  checked: this.state.formData.gender === genderValues[ix],
+                                  onChange: () => { }
+                                }),
+                                span({ className: 'radio-check' }),
+                                span({ className: 'radio-label' }, [genderLabels[ix]])
+                              ])
+                            );
+                          })
                         ])
+                      ])
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.3 Please indicate if this study is restricted to a  pediatric population (under the age of 18)?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.3 Please indicate if this study is restricted to a  pediatric population (under the age of 18)?'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.pediatric, onChange: this.handleRadioChange, id: 'pediatric', name: 'pediatric', required: true }),
-                    ]),
-
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.4 Does the research aim involve the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization)?"]),
-                    ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.illegalbehave, onChange: this.handleRadioChange, id: 'illegalbehave', name: 'illegalbehave', required: true }),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.pediatric, onChange: this.handleRadioChange, id: 'pediatric', name: 'pediatric', required: true
+                      })
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.5 Does the research aim involve the study of alcohol or drug abuse, or abuse of other addictive products?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.4 Does the research aim involve the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization)?'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.addiction, onChange: this.handleRadioChange, id: 'addiction', name: 'addiction', required: true }),
-                    ]),
-
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.6 Does the research aim involve the study of sexual preferences or sexually transmitted diseases?"]),
-                    ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.sexualdiseases, onChange: this.handleRadioChange, id: 'sexualdiseases', name: 'sexualdiseases', required: true }),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.illegalbehave, onChange: this.handleRadioChange, id: 'illegalbehave', name: 'illegalbehave',
+                        required: true
+                      })
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.7 Does the research aim involve the study of any stigmatizing illnesses?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.5 Does the research aim involve the study of alcohol or drug abuse, or abuse of other addictive products?'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.stigmatizediseases, onChange: this.handleRadioChange, id: 'stigmatizediseases', name: 'stigmatizediseases', required: true }),
-                    ]),
-
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.8 Does the study target a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [\"SIGNIFICANTLY\"] economically or educationally disadvantaged persons)?"]),
-                    ]),
-
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.vulnerablepop, onChange: this.handleRadioChange, id: 'vulnerablepop', name: 'vulnerablepop', required: true }),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.addiction, onChange: this.handleRadioChange, id: 'addiction', name: 'addiction', required: true
+                      })
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.9 Does the research aim involve the study of Population Origins/Migration patterns?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.6 Does the research aim involve the study of sexual preferences or sexually transmitted diseases?'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.popmigration, onChange: this.handleRadioChange, id: 'popmigration', name: 'popmigration', required: true }),
-                    ]),
-
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.10 Does the research aim involve the study of psychological traits, including intelligence, attention, emotion?"]),
-                    ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.psychtraits, onChange: this.handleRadioChange, id: 'psychtraits', name: 'psychtraits', required: true }),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.sexualdiseases, onChange: this.handleRadioChange, id: 'sexualdiseases', name: 'sexualdiseases',
+                        required: true
+                      })
                     ]),
 
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                      label({ className: "control-label rp-choice-questions" }, ["3.1.11 Does the research correlate ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways that are not easily related to Health?"]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.7 Does the research aim involve the study of any stigmatizing illnesses?'])
                     ]),
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group rp-last-group" }, [
-                      YesNoRadioGroup({ value: this.state.formData.nothealth, onChange: this.handleRadioChange, id: 'nothealth', name: 'nothealth', required: true }),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.stigmatizediseases, onChange: this.handleRadioChange, id: 'stigmatizediseases',
+                        name: 'stigmatizediseases', required: true
+                      })
+                    ]),
+
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.8 Does the study target a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or ["SIGNIFICANTLY"] economically or educationally disadvantaged persons)?'])
+                    ]),
+
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.vulnerablepop, onChange: this.handleRadioChange, id: 'vulnerablepop', name: 'vulnerablepop',
+                        required: true
+                      })
+                    ]),
+
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.9 Does the research aim involve the study of Population Origins/Migration patterns?'])
+                    ]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.popmigration, onChange: this.handleRadioChange, id: 'popmigration', name: 'popmigration',
+                        required: true
+                      })
+                    ]),
+
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.10 Does the research aim involve the study of psychological traits, including intelligence, attention, emotion?'])
+                    ]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.psychtraits, onChange: this.handleRadioChange, id: 'psychtraits', name: 'psychtraits',
+                        required: true
+                      })
+                    ]),
+
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-choice-questions' },
+                        ['3.1.11 Does the research correlate ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways that are not easily related to Health?'])
+                    ]),
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group rp-last-group' }, [
+                      YesNoRadioGroup({
+                        value: this.state.formData.nothealth, onChange: this.handleRadioChange, id: 'nothealth', name: 'nothealth', required: true
+                      })
                     ])
                   ])
                 ]),
 
-                div({ className: "row no-margin" }, [
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                    a({ id: "btn_prev", onClick: this.step2, className: "btn-primary f-left access-background" }, [
-                      span({ className: "glyphicon glyphicon-chevron-left", "aria-hidden": "true" }), "Previous Step"
+                div({ className: 'row no-margin' }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                    a({ id: 'btn_prev', onClick: this.step2, className: 'btn-primary f-left access-background' }, [
+                      span({ className: 'glyphicon glyphicon-chevron-left', 'aria-hidden': 'true' }), 'Previous Step'
                     ]),
 
-                    a({ id: "btn_next", onClick: this.step4, className: "btn-primary f-right access-background" }, [
-                      "Next Step", span({ className: "glyphicon glyphicon-chevron-right", "aria-hidden": "true" })
+                    a({ id: 'btn_next', onClick: this.step4, className: 'btn-primary f-right access-background' }, [
+                      'Next Step', span({ className: 'glyphicon glyphicon-chevron-right', 'aria-hidden': 'true' })
                     ]),
 
-                    a({ id: "btn_save", isRendered: this.state.formData.dar_code === null, onClick: this.partialSave, className: "f-right btn-secondary access-color" }, ["Save"])
+                    a({
+                      id: 'btn_save', isRendered: this.state.formData.dar_code === null, onClick: this.partialSave,
+                      className: 'f-right btn-secondary access-color'
+                    }, ['Save'])
                   ])
                 ])
               ])
             ]),
 
             div({ isRendered: this.state.step === 4 }, [
-              div({ className: "col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12" }, [
+              div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
                 fieldset({ disabled: this.state.formData.dar_code !== null }, [
 
-                  h3({ className: "rp-form-title access-color" }, ["4. Data Use Agreements"]),
+                  h3({ className: 'rp-form-title access-color' }, ['4. Data Use Agreements']),
 
-                  div({ className: "form-group" }, [
-                    div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                      label({ className: "control-label rp-title-question" }, [
-                        "4.1 Data Access Agreement",
-                        div({ isRendered: this.state.formData.checkCollaborator !== true, className: "display-inline" }, ["*"]),
-                        div({ isRendered: this.state.formData.checkCollaborator === true, className: "display-inline italic" }, [" (optional)"])
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                      label({ className: 'control-label rp-title-question' }, [
+                        '4.1 Data Access Agreement',
+                        div({ isRendered: this.state.formData.checkCollaborator !== true, className: 'display-inline' }, ['*']),
+                        div({ isRendered: this.state.formData.checkCollaborator === true, className: 'display-inline italic' }, [' (optional)'])
                       ])
                     ]),
 
-                    div({ className: "row no-margin" }, [
-                      div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                        label({ className: "control-label default-color" }, ["1. Download the Data Access Agreement template and have your organization's Signing Official sign it"])
+                    div({ className: 'row no-margin' }, [
+                      div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                        label({ className: 'control-label default-color' },
+                          ['1. Download the Data Access Agreement template and have your organization\'s Signing Official sign it'])
                       ]),
 
-                      div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                        a({ id: "link_downloadAgreement", href: "BroadDataAccessAgreement.pdf", target: "_blank", className: "col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color" }, [
-                          span({ className: "glyphicon glyphicon-download" }),
-                          "Download Agreement Template"
+                      div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                        a({
+                          id: 'link_downloadAgreement', href: 'BroadDataAccessAgreement.pdf', target: '_blank',
+                          className: 'col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color'
+                        }, [
+                          span({ className: 'glyphicon glyphicon-download' }),
+                          'Download Agreement Template'
                         ])
                       ]),
 
-                      div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                        label({ className: "control-label default-color" }, ["2. Upload your template of the Data Access Agreement signed by your organization's Signing Official"]),
-                        p({ className: "rp-agreement" }, ["By uploading and submitting the Data Access Agreement with your Data Access Request application you agree to comply with all terms put forth in the agreement."])
+                      div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                        label({ className: 'control-label default-color' },
+                          ['2. Upload your template of the Data Access Agreement signed by your organization\'s Signing Official']),
+                        p({ className: 'rp-agreement' },
+                          ['By uploading and submitting the Data Access Agreement with your Data Access Request application you agree to comply with all terms put forth in the agreement.'])
                       ]),
 
-                      div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                        div({ style: { paddingTop: 7 }, className: "fileUpload col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color" }, [
-                          span({ className: "glyphicon glyphicon-upload" }),
-                          "Upload S.O. Signed Agreement",
-                          input({ id: "uploadFile", type: "file", onChange: this.handleFileChange, className: "upload", required: true })
+                      div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                        div({
+                          style: { paddingTop: 7 },
+                          className: 'fileUpload col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color'
+                        }, [
+                          span({ className: 'glyphicon glyphicon-upload' }),
+                          'Upload S.O. Signed Agreement',
+                          input({ id: 'uploadFile', type: 'file', onChange: this.handleFileChange, className: 'upload', required: true })
                         ])
                       ]),
-                      p({ id: "txt_uploadFile", className: "fileName daa", isRendered: this.state.file.name !== '' || this.state.formData.nameDAA }, [
-                        "Your currently uploaded Data Access Agreement: ",
-                        span({ className: "italic normal" }, [this.state.file.name !== '' ? this.state.file.name : this.state.formData.nameDAA]),
+                      p({ id: 'txt_uploadFile', className: 'fileName daa', isRendered: this.state.file.name !== '' || this.state.formData.nameDAA }, [
+                        'Your currently uploaded Data Access Agreement: ',
+                        span({ className: 'italic normal' }, [this.state.file.name !== '' ? this.state.file.name : this.state.formData.nameDAA])
                       ]),
-                      span({ className: "col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span", isRendered: step4.uploadFile.invalid && showValidationMessages }, ["Required field"])
+                      span({
+                        className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span',
+                        isRendered: step4.uploadFile.invalid && showValidationMessages
+                      }, ['Required field'])
                     ]),
 
-                    div({ className: "row no-margin" }, [
-                      div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                        label({ className: "control-label rp-title-question" }, ["4.2 Attestation Statement"]),
+                    div({ className: 'row no-margin' }, [
+                      div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                        label({ className: 'control-label rp-title-question' }, ['4.2 Attestation Statement'])
                       ]),
 
-                      div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                        label({ className: "control-label default-color" }, ["I attest to the following:"]),
+                      div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                        label({ className: 'control-label default-color' }, ['I attest to the following:']),
 
-                        ol({ className: "rp-agreement rp-last-group" }, [
-                          li({}, ["Data will only be used for approved research"]),
-                          li({}, ["Data confidentiality will be protected and the investigator will never make any attempt at \"re-identification\""]),
-                          li({}, ["All applicable laws, local institutional policies, and terms and procedures specific to the study’s data access policy will be followed."]),
-                          li({}, ["No attempts will be made to identify individual study participants from whom data were obtained."]),
-                          li({}, ["Data will not be sold or shared with third parties."]),
-                          li({}, ["The contributing investigator(s) who conducted the original study and the funding organizations involved in supporting the original study will be acknowledged in publications resulting from the analysis of those data."]),
+                        ol({ className: 'rp-agreement rp-last-group' }, [
+                          li({}, ['Data will only be used for approved research']),
+                          li({},
+                            ['Data confidentiality will be protected and the investigator will never make any attempt at "re-identification"']),
+                          li({},
+                            ['All applicable laws, local institutional policies, and terms and procedures specific to the study’s data access policy will be followed.']),
+                          li({}, ['No attempts will be made to identify individual study participants from whom data were obtained.']),
+                          li({}, ['Data will not be sold or shared with third parties.']),
+                          li({},
+                            ['The contributing investigator(s) who conducted the original study and the funding organizations involved in supporting the original study will be acknowledged in publications resulting from the analysis of those data.'])
                         ])
                       ])
                     ]),
 
-                    div({ className: "row no-margin" }, [
-                      div({ isRendered: showValidationMessages, className: "rp-alert" }, [
-                        Alert({ id: "formErrors", type: "danger", title: "Please, complete all required fields." })
+                    div({ className: 'row no-margin' }, [
+                      div({ isRendered: showValidationMessages, className: 'rp-alert' }, [
+                        Alert({ id: 'formErrors', type: 'danger', title: 'Please, complete all required fields.' })
                       ]),
 
-                      div({ isRendered: problemSavingRequest, className: "rp-alert" }, [
-                        Alert({ id: "problemSavingRequest", type: "danger", title: "Some errors occurred, Data Access Request Application couldn't be created." })
+                      div({ isRendered: problemSavingRequest, className: 'rp-alert' }, [
+                        Alert({
+                          id: 'problemSavingRequest', type: 'danger',
+                          title: 'Some errors occurred, Data Access Request Application couldn\'t be created.'
+                        })
                       ])
                     ])
                   ])
                 ]),
 
-                div({ className: "row no-margin" }, [
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                    a({ id: "btn_prev", onClick: this.step3, className: "f-left btn-primary access-background" }, [
-                      span({ className: "glyphicon glyphicon-chevron-left", "aria-hidden": "true" }), "Previous Step"
+                div({ className: 'row no-margin' }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                    a({ id: 'btn_prev', onClick: this.step3, className: 'f-left btn-primary access-background' }, [
+                      span({ className: 'glyphicon glyphicon-chevron-left', 'aria-hidden': 'true' }), 'Previous Step'
                     ]),
 
-                    a({ id: "btn_submit", isRendered: this.state.formData.dar_code === null, onClick: this.attestAndSave, className: "f-right btn-primary access-background bold" }, ["Attest and Send"]),
+                    a({
+                      id: 'btn_submit', isRendered: this.state.formData.dar_code === null, onClick: this.attestAndSave,
+                      className: 'f-right btn-primary access-background bold'
+                    }, ['Attest and Send']),
 
                     ConfirmationDialog({
-                      title: 'Data Request Confirmation', disableOkBtn: this.state.disableOkBtn, disableNoBtn: this.state.disableOkBtn, color: 'access', showModal: this.state.showDialogSubmit, action: { label: "Yes", handler: this.dialogHandlerSubmit }
-                    }, [div({ className: "dialog-description" }, ["Are you sure you want to send this Data Access Request Application?"]),]),
-                    h(ReactTooltip, { id: "tip_clearNihAccount", place: 'right', effect: 'solid', multiline: true, className: 'tooltip-wrapper' }),
+                      title: 'Data Request Confirmation', disableOkBtn: this.state.disableOkBtn, disableNoBtn: this.state.disableOkBtn,
+                      color: 'access', showModal: this.state.showDialogSubmit, action: { label: 'Yes', handler: this.dialogHandlerSubmit }
+                    }, [div({ className: 'dialog-description' }, ['Are you sure you want to send this Data Access Request Application?'])]),
+                    h(ReactTooltip, { id: 'tip_clearNihAccount', place: 'right', effect: 'solid', multiline: true, className: 'tooltip-wrapper' }),
 
-                    a({ id: "btn_save", isRendered: this.state.formData.dar_code === null, onClick: this.partialSave, className: "f-right btn-secondary access-color" }, ["Save"]),
+                    a({
+                      id: 'btn_save', isRendered: this.state.formData.dar_code === null, onClick: this.partialSave,
+                      className: 'f-right btn-secondary access-color'
+                    }, ['Save'])
                   ])
                 ])
               ])

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -374,7 +374,7 @@ class DataAccessRequestApplication extends Component {
       isInvestigatorInvalid = false, isLinkedInInvalid = false,
       isOrcidInvalid = false, isResearcherGateInvalid = false,
       isDAAInvalid = false, showValidationMessages = false,
-      isNihInvalid = false;
+      isNihInvalid = !this.state.nihValid;
 
     if (!this.isValid(this.state.formData.projectTitle)) {
       isTitleInvalid = true;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -847,7 +847,7 @@ class DataAccessRequestApplication extends Component {
                     ]),
 
                     span({
-                      isRendered: showValidationMessages, className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span'
+                      isRendered: (showValidationMessages && !this.state.nihValid), className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span'
                     }, ['NIH eRA Authentication is required']),
 
                     div({ className: 'row no-margin' }, [

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -1,16 +1,17 @@
+import * as qs from 'query-string';
 import { Component } from 'react';
-import { div, hr, br, h, small, h3, a, span, form, ol, li, label, button, input, textarea, p, fieldset, i } from 'react-hyperscript-helpers';
+import { a, br, div, fieldset, form, h, h3, hr, i, input, label, li, ol, p, small, span, textarea } from 'react-hyperscript-helpers';
+import { Link } from 'react-router-dom';
+import AsyncSelect from 'react-select/async';
+import ReactTooltip from 'react-tooltip';
+import { Alert } from '../components/Alert';
+import { ConfirmationDialog } from '../components/ConfirmationDialog';
+import { eRACommons } from '../components/eRACommons';
 import { PageHeading } from '../components/PageHeading';
 import { YesNoRadioGroup } from '../components/YesNoRadioGroup';
-import { Alert } from '../components/Alert';
-import AsyncSelect from 'react-select/async';
+import { AuthenticateNIH, DAR, Researcher } from '../libs/ajax';
 import { Config } from '../libs/config';
-import { ConfirmationDialog } from '../components/ConfirmationDialog';
-import ReactTooltip from 'react-tooltip';
-import { Researcher, DAR, AuthenticateNIH } from '../libs/ajax';
-import { Storage } from "../libs/storage";
-import { Link } from 'react-router-dom';
-import * as qs from 'query-string';
+import { Storage } from '../libs/storage';
 
 import './DataAccessRequestApplication.css';
 
@@ -27,7 +28,8 @@ class DataAccessRequestApplication extends Component {
     this.redirectToNihLogin = this.redirectToNihLogin.bind(this);
     this.deleteNihAccount = this.deleteNihAccount.bind(this);
     this.state = {
-      expirationCount: -1,
+      rpProperties: {},
+      // expirationCount: -1,
       disableOkBtn: false,
       showValidationMessages: false,
       optionMessage: noOptionMessage,
@@ -39,8 +41,8 @@ class DataAccessRequestApplication extends Component {
       showDialogSubmit: false,
       showDialogSave: false,
       step: 1,
-      nihError: false,
-      nihErrorMessage:"Something went wrong. Please try again. ",
+      // nihError: false,
+      // nihErrorMessage:"Something went wrong. Please try again. ",
       formData: {
         datasets: [],
         dar_code: null,
@@ -49,9 +51,9 @@ class DataAccessRequestApplication extends Component {
         non_tech_rus: '',
         other: '',
         othertext: '',
-        eraAuthorized: '',
-        nihUsername: '',
-        eraExpirationCount: '',
+        // eraAuthorized: '',
+        // nihUsername: '',
+        // eraExpirationCount: '',
         linkedIn: '',
         orcid: '',
         ontologies: [],
@@ -83,7 +85,7 @@ class DataAccessRequestApplication extends Component {
         piName: '',
         urlDAA: '',
         nameDAA: '',
-        eRACommonsID: '',
+        // eRACommonsID: '',
         pubmedId: '',
         scientificUrl: ''
       },
@@ -170,7 +172,7 @@ class DataAccessRequestApplication extends Component {
       (decoded) => decoded,
       (error) => {
         this.setState(prev => {
-          prev.nihError = true;
+          // prev.nihError = true;
           prev.formData = Storage.getData('dar_application');
           return prev;
         }, () => Storage.removeData('dar_application'));
@@ -195,7 +197,7 @@ class DataAccessRequestApplication extends Component {
       },
       (fail) => {
         this.setState(prev => {
-          prev.nihError = true;
+          // prev.nihError = true;
           prev.formData = Storage.getData('dar_application');
           return prev;
         }, () => Storage.removeData('dar_application'));
@@ -235,9 +237,9 @@ class DataAccessRequestApplication extends Component {
       formData.linkedIn = rpProperties.linkedIn !== undefined ? rpProperties.linkedIn : '';
       formData.researcherGate = rpProperties.researcherGate !== undefined ? rpProperties.researcherGate : '';
       formData.orcid = rpProperties.orcid !== undefined ? rpProperties.orcid : '';
-      formData.nihUsername = rpProperties.nihUsername !== undefined ? rpProperties.nihUsername : '';
-      formData.eraAuthorized = rpProperties.eraAuthorized !== undefined ? JSON.parse(rpProperties.eraAuthorized) : false;
-      formData.eraExpiration = rpProperties.eraExpiration !== undefined ? rpProperties.eraExpiration : false;
+      // formData.nihUsername = rpProperties.nihUsername !== undefined ? rpProperties.nihUsername : '';
+      // formData.eraAuthorized = rpProperties.eraAuthorized !== undefined ? JSON.parse(rpProperties.eraAuthorized) : false;
+      // formData.eraExpiration = rpProperties.eraExpiration !== undefined ? rpProperties.eraExpiration : false;
       formData.institution = rpProperties.institution != null ? rpProperties.institution : '';
       formData.department = rpProperties.department != null ? rpProperties.department : '';
       formData.division = rpProperties.division != null ? rpProperties.division : '';
@@ -254,12 +256,12 @@ class DataAccessRequestApplication extends Component {
       formData.piEmail = rpProperties.piEmail != null ? rpProperties.piEmail : '';
       formData.isThePi = rpProperties.isThePI !== undefined ? rpProperties.isThePI : '';
       formData.havePi = rpProperties.havePI !== undefined ? rpProperties.havePI : '';
-      formData.nihUsername = rpProperties.nihUsername !== undefined ? rpProperties.nihUsername : '';
-      formData.eRACommonsID = rpProperties.eRACommonsID !== undefined ? rpProperties.eRACommonsID : '';
+      // formData.nihUsername = rpProperties.nihUsername !== undefined ? rpProperties.nihUsername : '';
+      // formData.eRACommonsID = rpProperties.eRACommonsID !== undefined ? rpProperties.eRACommonsID : '';
       formData.pubmedId = rpProperties.pubmedID !== undefined ? rpProperties.pubmedID : '';
       formData.scientificUrl = rpProperties.scientificURL !== undefined ? rpProperties.scientificURL : '';
     }
-    let expirationCount = await AuthenticateNIH.expirationCount(rpProperties.eraExpiration);
+    // let expirationCount = await AuthenticateNIH.expirationCount(rpProperties.eraExpiration);
 
     formData.userId = Storage.getCurrentUser().dacUserId;
 
@@ -273,9 +275,10 @@ class DataAccessRequestApplication extends Component {
       completed = JSON.parse(rpProperties.completed);
     }
     this.setState(prev => {
+      prev.rpProperties = rpProperties;
       prev.completed = completed;
       prev.formData = formData;
-      prev.expirationCount = expirationCount;
+      // prev.expirationCount = expirationCount;
       if (formData.nameDAA !== '') {
         prev.file.name = formData.nameDAA;
       }
@@ -448,8 +451,8 @@ class DataAccessRequestApplication extends Component {
       && !this.isValid(this.state.formData.linkedIn)
       && !this.isValid(this.state.formData.researcherGate)
       && !this.isValid(this.state.formData.orcid)
-      && !this.isValid(this.state.formData.uploadFile)
-      && (this.state.formData.eraAuthorized !== true || this.state.expirationCount < 0)) {
+      && !this.isValid(this.state.formData.uploadFile)) {
+      // && (this.state.formData.eraAuthorized !== true)) { //} || this.state.expirationCount < 0)) {
       isLinkedInInvalid = true;
       isOrcidInvalid = true;
       isResearcherGateInvalid = true;
@@ -749,7 +752,7 @@ class DataAccessRequestApplication extends Component {
   deleteNihAccount() {
     AuthenticateNIH.eliminateAccount().then(result => {
       this.setState(prev => {
-        prev.formData.eraAuthorized = false;
+        // prev.formData.eraAuthorized = false;
         return prev;
       });
     });
@@ -919,36 +922,11 @@ class DataAccessRequestApplication extends Component {
                     span({ isRendered: (step1.inputResearcherGate.invalid) && (showValidationMessages), className: "col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span" }, ["At least one of the following fields is required"]),
 
                     div({ className: "row no-margin" }, [
-                      div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group" }, [
-                        label({ className: "control-label" }, ["NIH eRA Commons ID"]),
-                        div({ isRendered: (this.state.formData.eraAuthorized !== true || this.state.expirationCount < 0) && this.state.formData.dar_code === null }, [
-                          a({ onClick: this.redirectToNihLogin, target: "_blank", className: "auth-button eRACommons" }, [
-                            div({ className: "logo" }, []),
-                            span({}, ["Authenticate your account"])
-                          ])
-                        ]),
-                        span({
-                          className: "cancel-color required-field-error-span",
-                          isRendered: this.state.nihError
-                        }, [this.state.nihErrorMessage]),
-                        div({ isRendered: (this.state.formData.eraAuthorized === true) }, [
-                          div({ isRendered: this.state.formData.dar_code === null && this.state.expirationCount >= 0, className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                            div({ className: "auth-id" }, [this.state.formData.nihUsername]),
-                            button({ type: 'button', onClick: this.deleteNihAccount, className: "close auth-clear" }, [
-                              span({ className: "glyphicon glyphicon-remove-circle", "data-tip": "Clear account", "data-for": "tip_clearNihAccount" })
-                            ])
-                          ]),
-
-                          div({ isRendered: this.state.formData.dar_code === null, className: "col-lg-12 col-md-12 col-sm-6 col-xs-12 no-padding auth-message" }, [
-                            div({ isRendered: this.state.expirationCount >= 0 }, ["Your NIH authentication will expire in " + this.state.expirationCount + " days"]),
-                            div({ isRendered: this.state.expirationCount < 0 }, ["Your NIH authentication expired"]),
-                          ]),
-                          div({ isRendered: this.state.formData.dar_code !== null, className: "col-lg-12 col-md-12 col-sm-6 col-xs-12 no-padding" }, [
-                            div({ className: "auth-id" }, [this.state.formData.nihUsername])
-                          ])
-                        ])
-                      ]),
-
+                      eRACommons({
+                        className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group",
+                        destination: "dar_application",
+                        rpProperties: this.state.rpProperties
+                      }),
                       div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group" }, [
                         label({ className: "control-label" }, ["LinkedIn Profile"]),
                         input({

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -25,7 +25,6 @@ class DataAccessRequestApplication extends Component {
     this.verifyCheckboxes = this.verifyCheckboxes.bind(this);
     this.state = {
       nihValid: false,
-      rpProperties: {},
       disableOkBtn: false,
       showValidationMessages: false,
       optionMessage: noOptionMessage,
@@ -204,7 +203,6 @@ class DataAccessRequestApplication extends Component {
       completed = JSON.parse(rpProperties.completed);
     }
     this.setState(prev => {
-      prev.rpProperties = rpProperties;
       prev.completed = completed;
       prev.formData = formData;
       if (formData.nameDAA !== '') {
@@ -386,9 +384,6 @@ class DataAccessRequestApplication extends Component {
       && !this.isValid(this.state.formData.orcid)
       && !this.state.nihValid
       && !this.isValid(this.state.formData.uploadFile)) {
-      // isLinkedInInvalid = true;
-      // isOrcidInvalid = true;
-      // isResearcherGateInvalid = true;
       isDAAInvalid = true;
       isNihInvalid = true;
       showValidationMessages = true;
@@ -397,10 +392,7 @@ class DataAccessRequestApplication extends Component {
       prev.step1.inputTitle.invalid = isTitleInvalid;
       prev.step1.inputResearcher.invalid = isResearcherInvalid;
       prev.step1.inputInvestigator.invalid = isInvestigatorInvalid;
-      // prev.step1.inputLinkedIn.invalid = isLinkedInInvalid;
       prev.step1.inputNih.invalid = isNihInvalid;
-      // prev.step1.inputOrcid.invalid = isOrcidInvalid;
-      // prev.step1.inputResearcherGate.invalid = isResearcherGateInvalid;
       prev.step4.uploadFile.invalid = isDAAInvalid;
       if (prev.showValidationMessages === false) prev.showValidationMessages = showValidationMessages;
       return prev;
@@ -520,7 +512,6 @@ class DataAccessRequestApplication extends Component {
       for (let ontology of this.state.formData.ontologies) {
         ontologies.push(ontology.item);
       }
-      ;
       this.setState(prev => {
         if (ontologies.length > 0) {
           prev.formData.ontologies = ontologies;

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -42,7 +42,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       showDialogSave: false,
       additionalEmail: '',
       file: {
-        name: '',
+        name: ''
       },
       profile: {
         checkNotifications: false,
@@ -69,7 +69,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         state: '',
         zipcode: '',
         urlDAA: '',
-        nameDAA: '',
+        nameDAA: ''
       },
       showRequired: false,
       invalidFields: {
@@ -85,10 +85,10 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         havePI: false,
         isThePI: false,
         piName: false,
-        piEmail: false,
+        piEmail: false
       },
       showValidationMessages: false,
-      validateFields: false,
+      validateFields: false
     };
   }
 
@@ -121,7 +121,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       prev.additionalEmail = user.additionalEmail === null ? '' : user.additionalEmail;
       return prev;
     }, () => {
-      if (this.state.profile.completed !== undefined && this.state.profile.completed !== "") {
+      if (this.state.profile.completed !== undefined && this.state.profile.completed !== '') {
         this.setState(prev => {
           prev.profile.completed = JSON.parse(this.state.profile.completed);
           return prev;
@@ -149,7 +149,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     if (event.target.files !== undefined && event.target.files[0]) {
       let file = event.target.files[0];
       this.setState({
-        file: file,
+        file: file
       });
     }
   };
@@ -266,7 +266,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
   };
 
   submit(event) {
-    this.setState({validateFields: true});
+    this.setState({ validateFields: true });
     event.preventDefault();
     let errorsShowed = false;
     if (this.state.isResearcher) {
@@ -343,12 +343,12 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   saveProfile(event) {
     event.preventDefault();
-    this.setState({showDialogSave: true});
+    this.setState({ showDialogSave: true });
   }
 
   cleanObject = (obj) => {
     for (let key in obj) {
-      if (obj[key] === "") {
+      if (obj[key] === '') {
         delete obj[key];
       }
     }
@@ -448,10 +448,10 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       let profile = this.state.profile;
       profile.completed = false;
       Researcher.update(Storage.getCurrentUser().dacUserId, false, profile);
-      this.props.history.push({pathname: 'dataset_catalog'});
+      this.props.history.push({ pathname: 'dataset_catalog' });
     }
 
-    this.setState({showDialogSave: false});
+    this.setState({ showDialogSave: false });
   };
 
   render() {
@@ -460,147 +460,153 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
     return (
 
-      div({ className: "container" }, [
-        div({ className: "row no-margin" }, [
-          div({ className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12" }, [
+      div({ className: 'container' }, [
+        div({ className: 'row no-margin' }, [
+          div({ className: 'col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12' }, [
             PageHeading({
-              id: "researcherProfile",
-              color: "common",
-              title: "Your Profile",
-              description: this.state.isResearcher ? "Please complete the following information to be able to request access to dataset(s)" : ""
+              id: 'researcherProfile',
+              color: 'common',
+              title: 'Your Profile',
+              description: this.state.isResearcher ? 'Please complete the following information to be able to request access to dataset(s)' : ''
             }),
-            hr({ className: "section-separator" }),
+            hr({ className: 'section-separator' })
           ]),
-          div({ className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding" }, [
-            form({ name: "researcherForm" }, [
-              div({ className: "form-group" }, [
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
+          div({ className: 'col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding' }, [
+            form({ name: 'researcherForm' }, [
+              div({ className: 'form-group' }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
                   label({
-                    id: "lbl_profileName", className: "control-label"
-                  }, ["Full Name*"]),
+                    id: 'lbl_profileName', className: 'control-label'
+                  }, ['Full Name*']),
                   input({
-                    id: "profileName",
-                    name: "profileName",
-                    type: "text",
+                    id: 'profileName',
+                    name: 'profileName',
+                    type: 'text',
                     onChange: this.handleChange,
-                    className: (this.state.invalidFields.profileName && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                    className: (this.state.invalidFields.profileName && showValidationMessages) ?
+                      'form-control required-field-error' :
+                      'form-control',
                     value: this.state.profile.profileName,
                     required: true
                   }),
                   span({
-                    className: "cancel-color required-field-error-span",
+                    className: 'cancel-color required-field-error-span',
                     isRendered: this.state.invalidFields.profileName && showValidationMessages
-                  }, ["Full Name is required"])
+                  }, ['Full Name is required'])
                 ]),
 
-                div({ isRendered: this.state.isResearcher, className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
+                div({ isRendered: this.state.isResearcher, className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
                   label({
-                    id: "lbl_profileAcademicEmail",
-                    className: "control-label"
-                  }, ["Academic/Business Email Address*"]),
+                    id: 'lbl_profileAcademicEmail',
+                    className: 'control-label'
+                  }, ['Academic/Business Email Address*']),
                   input({
-                    id: "profileAcademicEmail",
-                    name: "academicEmail",
-                    type: "email",
+                    id: 'profileAcademicEmail',
+                    name: 'academicEmail',
+                    type: 'email',
                     onChange: this.handleChange,
                     value: this.state.profile.academicEmail,
-                    className: ((this.state.invalidFields.academicEmail) && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                    className: ((this.state.invalidFields.academicEmail) && showValidationMessages) ?
+                      'form-control required-field-error' :
+                      'form-control',
                     required: true
                   }),
                   span({
-                    className: "cancel-color required-field-error-span",
-                    isRendered: (this.state.invalidFields.academicEmail && this.state.profile.academicEmail.indexOf('@') === -1) && showValidationMessages
-                  }, ["Email Address is empty or has invalid format"]),
+                    className: 'cancel-color required-field-error-span',
+                    isRendered: (this.state.invalidFields.academicEmail && this.state.profile.academicEmail.indexOf('@') === -1) &&
+                      showValidationMessages
+                  }, ['Email Address is empty or has invalid format'])
                 ]),
 
-                div({ isRendered: this.state.isResearcher, className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group checkbox" }, [
+                div({ isRendered: this.state.isResearcher, className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group checkbox' }, [
                   input({
-                    type: "checkbox",
-                    id: "chk_sendNotificationsAcademicEmail",
-                    name: "checkNotifications",
-                    className: "checkbox-inline rp-checkbox",
+                    type: 'checkbox',
+                    id: 'chk_sendNotificationsAcademicEmail',
+                    name: 'checkNotifications',
+                    className: 'checkbox-inline rp-checkbox',
                     checked: this.state.profile.checkNotifications,
                     onChange: this.handleCheckboxChange
                   }),
-                  label({ className: "regular-checkbox rp-choice-questions", htmlFor: "chk_sendNotificationsAcademicEmail" }, ["Send Notifications to my Academic/Business Email Address"]),
+                  label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_sendNotificationsAcademicEmail' },
+                    ['Send Notifications to my Academic/Business Email Address'])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 " + (!this.state.isResearcher ? 'rp-last-group' : '') }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 ' + (!this.state.isResearcher ? 'rp-last-group' : '') }, [
                   label({
-                    id: "lbl_notificationsEmail", className: "control-label"
-                  }, ["Enter an additional email to receive DUOS notifications ", span({ className: "italic display-inline" }, ["(optional)"]),]),
+                    id: 'lbl_notificationsEmail', className: 'control-label'
+                  }, ['Enter an additional email to receive DUOS notifications ', span({ className: 'italic display-inline' }, ['(optional)'])]),
                   input({
-                    id: "additionalEmail",
-                    name: "additionalEmail",
-                    type: "text",
+                    id: 'additionalEmail',
+                    name: 'additionalEmail',
+                    type: 'text',
                     onChange: this.handleAdditionalEmailChange,
-                    className: "form-control",
-                    value: this.state.additionalEmail,
+                    className: 'form-control',
+                    value: this.state.additionalEmail
                   }),
                   span({
-                    className: "cancel-color required-field-error-span",
+                    className: 'cancel-color required-field-error-span',
                     isRendered: (this.state.additionalEmail.indexOf('@') === -1) && showValidationMessages
-                  }, ["Email Address is empty or has invalid format"])
+                  }, ['Email Address is empty or has invalid format'])
                 ])
               ]),
 
-              div({ isRendered: this.state.isResearcher, className: "form-group" }, [
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12", style: { 'marginTop': '20px' } }, [
-                  label({ className: "control-label rp-title-question default-color" }, [
-                    "Researcher Identification*",
-                    span({}, ["Please authenticate your eRA Commons account to submit Data Access Requests. Other profiles are optional:"])
-                  ]),
+              div({ isRendered: this.state.isResearcher, className: 'form-group' }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12', style: { 'marginTop': '20px' } }, [
+                  label({ className: 'control-label rp-title-question default-color' }, [
+                    'Researcher Identification*',
+                    span({}, ['Please authenticate your eRA Commons account to submit Data Access Requests. Other profiles are optional:'])
+                  ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+                  div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
                     eRACommons({
-                      className: "col-lg-4 col-md-4 col-sm-6 col-xs-12",
-                      destination: "profile",
+                      className: 'col-lg-4 col-md-4 col-sm-6 col-xs-12',
+                      destination: 'profile',
                       onNihStatusUpdate: (nihValid) => {},
                       location: this.props.location
                     }),
-                    div({ className: "col-lg-4 col-md-4 col-sm-6 col-xs-12" }, [
-                      label({ id: "lbl_profileLibraryCard", className: "control-label" }, ["NIH Library Card"]),
+                    div({ className: 'col-lg-4 col-md-4 col-sm-6 col-xs-12' }, [
+                      label({ id: 'lbl_profileLibraryCard', className: 'control-label' }, ['NIH Library Card']),
                       div({ className: 'library-flag ' + (this.state.hasLibraryCard ? 'flag-enabled' : 'flag-disabled') }, [
-                        div({ className: "library-icon"}),
-                        span({ className: "library-label"}, "Library Card")
+                        div({ className: 'library-icon' }),
+                        span({ className: 'library-label' }, 'Library Card')
                       ])
                     ])
                   ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-                    div({ className: "col-lg-4 col-md-4 col-sm-4 col-xs-12" }, [
-                      label({ id: "lbl_profileLinkedIn", className: "control-label" }, ["LinkedIn Profile"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+                  div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
+                    div({ className: 'col-lg-4 col-md-4 col-sm-4 col-xs-12' }, [
+                      label({ id: 'lbl_profileLinkedIn', className: 'control-label' }, ['LinkedIn Profile']),
                       input({
-                        id: "profileLinkedIn",
-                        name: "linkedIn",
-                        type: "text",
-                        className: "form-control",
+                        id: 'profileLinkedIn',
+                        name: 'linkedIn',
+                        type: 'text',
+                        className: 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.linkedIn
                       })
                     ]),
-                    div({ className: "col-lg-4 col-md-4 col-sm-4 col-xs-12" }, [
-                      label({ id: "lbl_profileOrcid", className: "control-label" }, ["ORCID iD"]),
+                    div({ className: 'col-lg-4 col-md-4 col-sm-4 col-xs-12' }, [
+                      label({ id: 'lbl_profileOrcid', className: 'control-label' }, ['ORCID iD']),
                       input({
-                        id: "profileOrcid",
-                        name: "orcid",
-                        type: "text",
-                        className: "form-control",
+                        id: 'profileOrcid',
+                        name: 'orcid',
+                        type: 'text',
+                        className: 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.orcid
                       })
                     ]),
-                    div({ className: "col-lg-4 col-md-4 col-sm-4 col-xs-12" }, [
-                      label({ id: "lbl_profileResearcherGate", className: "control-label" }, ["ResearchGate ID"]),
+                    div({ className: 'col-lg-4 col-md-4 col-sm-4 col-xs-12' }, [
+                      label({ id: 'lbl_profileResearcherGate', className: 'control-label' }, ['ResearchGate ID']),
                       input({
-                        id: "profileResearcherGate",
-                        name: "researcherGate",
-                        type: "text",
-                        className: "form-control",
+                        id: 'profileResearcherGate',
+                        name: 'researcherGate',
+                        type: 'text',
+                        className: 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.researcherGate
                       })
@@ -608,85 +614,91 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                   ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12", style: { 'marginTop': '20px' } }, [
-                  label({ id: "lbl_profileInstitution", className: "control-label" }, ["Institution Name*"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12', style: { 'marginTop': '20px' } }, [
+                  label({ id: 'lbl_profileInstitution', className: 'control-label' }, ['Institution Name*']),
                   input({
-                    id: "profileInstitution",
-                    name: "institution",
-                    type: "text",
-                    className: (this.state.invalidFields.institution && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                    id: 'profileInstitution',
+                    name: 'institution',
+                    type: 'text',
+                    className: (this.state.invalidFields.institution && showValidationMessages) ?
+                      'form-control required-field-error' :
+                      'form-control',
                     onChange: this.handleChange,
                     value: this.state.profile.institution,
                     required: true
                   }),
                   span({
-                    className: "cancel-color required-field-error-span",
+                    className: 'cancel-color required-field-error-span',
                     isRendered: this.state.invalidFields.institution && showValidationMessages
-                  }, ["Institution Name is required"]),
+                  }, ['Institution Name is required'])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-                      label({ id: "lbl_profileDepartment", className: "control-label" }, ["Department*"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+                  div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
+                      label({ id: 'lbl_profileDepartment', className: 'control-label' }, ['Department*']),
                       input({
-                        id: "profileDepartment",
-                        name: "department",
-                        type: "text",
-                        className: (this.state.invalidFields.department && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                        id: 'profileDepartment',
+                        name: 'department',
+                        type: 'text',
+                        className: (this.state.invalidFields.department && showValidationMessages) ?
+                          'form-control required-field-error' :
+                          'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.department,
                         required: true
                       }),
                       span({
-                        className: "cancel-color required-field-error-span",
+                        className: 'cancel-color required-field-error-span',
                         isRendered: this.state.invalidFields.department && showValidationMessages
-                      }, ["Department is required"]),
+                      }, ['Department is required'])
                     ]),
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
                       label({
-                        id: "lbl_profileDivision",
-                        className: "control-label"
-                      }, ["Division ", span({ className: "italic" }, ["(optional)"])]),
+                        id: 'lbl_profileDivision',
+                        className: 'control-label'
+                      }, ['Division ', span({ className: 'italic' }, ['(optional)'])]),
                       input({
-                        id: "profileDivision",
-                        name: "division",
-                        type: "text",
-                        className: "form-control",
+                        id: 'profileDivision',
+                        name: 'division',
+                        type: 'text',
+                        className: 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.division
                       })
                     ])
                   ])
                 ]),
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-                      label({ id: "lbl_profileAddress1", className: "control-label" }, ["Street Address 1*"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+                  div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
+                      label({ id: 'lbl_profileAddress1', className: 'control-label' }, ['Street Address 1*']),
                       input({
-                        id: "profileAddress1",
-                        name: "address1",
-                        type: "text",
-                        className: ((this.state.profile.address1 === '' || this.state.invalidFields.address1) && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                        id: 'profileAddress1',
+                        name: 'address1',
+                        type: 'text',
+                        className: ((this.state.profile.address1 === '' || this.state.invalidFields.address1) && showValidationMessages) ?
+                          'form-control required-field-error' :
+                          'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.address1,
                         required: true
                       }),
                       span({
-                        className: "cancel-color required-field-error-span",
+                        className: 'cancel-color required-field-error-span',
                         isRendered: (this.state.profile.address1 === '' || this.state.invalidFields.address1) && showValidationMessages
-                      }, ["Street Address is required"]),
+                      }, ['Street Address is required'])
                     ]),
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
                       label({
-                        id: "lbl_profileAddress2",
-                        className: "control-label"
-                      }, ["Street Address 2 ", span({ className: "italic" }, ["(optional)"])]),
+                        id: 'lbl_profileAddress2',
+                        className: 'control-label'
+                      }, ['Street Address 2 ', span({ className: 'italic' }, ['(optional)'])]),
                       input({
-                        id: "profileAddress2",
-                        name: "address2",
-                        type: "text",
-                        className: "form-control",
+                        id: 'profileAddress2',
+                        name: 'address2',
+                        type: 'text',
+                        className: 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.address2
                       })
@@ -694,93 +706,101 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                   ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-                      label({ id: "lbl_profileCity", className: "control-label" }, ["City*"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+                  div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
+                      label({ id: 'lbl_profileCity', className: 'control-label' }, ['City*']),
                       input({
-                        id: "profileCity",
-                        name: "city",
-                        type: "text",
-                        className: (this.state.invalidFields.city && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                        id: 'profileCity',
+                        name: 'city',
+                        type: 'text',
+                        className: (this.state.invalidFields.city && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.city,
                         required: true
                       }),
                       span({
-                        className: "cancel-color required-field-error-span",
+                        className: 'cancel-color required-field-error-span',
                         isRendered: this.state.invalidFields.city && showValidationMessages
-                      }, ["City is required"]),
+                      }, ['City is required'])
                     ]),
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-                      label({ id: "lbl_profileState", className: "control-label" }, ["State*"]),
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
+                      label({ id: 'lbl_profileState', className: 'control-label' }, ['State*']),
                       input({
-                        id: "profileState",
-                        name: "state",
-                        type: "text",
-                        className: (this.state.invalidFields.state && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                        id: 'profileState',
+                        name: 'state',
+                        type: 'text',
+                        className: (this.state.invalidFields.state && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.state,
                         required: true
                       }),
                       span({
-                        className: "cancel-color required-field-error-span",
+                        className: 'cancel-color required-field-error-span',
                         isRendered: this.state.invalidFields.state && showValidationMessages
-                      }, ["State is required"])
+                      }, ['State is required'])
                     ])
                   ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6 rp-group" }, [
-                      label({ id: "lbl_profileZip", className: "control-label" }, ["Zip/Postal Code*"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+                  div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6 rp-group' }, [
+                      label({ id: 'lbl_profileZip', className: 'control-label' }, ['Zip/Postal Code*']),
                       input({
-                        id: "profileZip",
-                        name: "zipcode",
-                        type: "text",
-                        className: (this.state.invalidFields.zipcode && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                        id: 'profileZip',
+                        name: 'zipcode',
+                        type: 'text',
+                        className: (this.state.invalidFields.zipcode && showValidationMessages) ?
+                          'form-control required-field-error' :
+                          'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.zipcode,
                         required: true
                       }),
                       span({
-                        className: "cancel-color required-field-error-span",
+                        className: 'cancel-color required-field-error-span',
                         isRendered: this.state.invalidFields.zipcode && showValidationMessages
-                      }, ["Zip/Postal Code is required"]),
+                      }, ['Zip/Postal Code is required'])
                     ]),
-                    div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6 rp-group" }, [
-                      label({ id: "lbl_profileCountry", className: "control-label" }, ["Country*"]),
+                    div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6 rp-group' }, [
+                      label({ id: 'lbl_profileCountry', className: 'control-label' }, ['Country*']),
                       input({
-                        id: "profileCountry",
-                        name: "country",
-                        type: "text",
-                        className: (this.state.invalidFields.country && showValidationMessages) ? 'form-control required-field-error' : "form-control",
+                        id: 'profileCountry',
+                        name: 'country',
+                        type: 'text',
+                        className: (this.state.invalidFields.country && showValidationMessages) ?
+                          'form-control required-field-error' :
+                          'form-control',
                         onChange: this.handleChange,
                         value: this.state.profile.country,
                         required: true
                       }),
                       span({
-                        className: "cancel-color required-field-error-span",
+                        className: 'cancel-color required-field-error-span',
                         isRendered: this.state.invalidFields.country && showValidationMessages
-                      }, ["Country is required"]),
-                    ]),
-                  ]),
-                ]),
+                      }, ['Country is required'])
+                    ])
+                  ])
+                ])
               ]),
 
-              div({ isRendered: this.state.isResearcher, className: "form-group" }, [
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12", style: { 'marginTop': '15px' } }, [
+              div({ isRendered: this.state.isResearcher, className: 'form-group' }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12', style: { 'marginTop': '15px' } }, [
                   label({
-                    id: "lbl_isThePI",
-                    className: "control-label ",
+                    id: 'lbl_isThePI',
+                    className: 'control-label '
                   }, [
-                      "Are you the Principal Investigator?* ",
-                      span({ className: "glyphicon glyphicon-question-sign tooltip-icon", "data-tip": "This information is required in order to classify users as bonafide researchers as part of the process of Data Access approvals.", "data-for": "tip_isthePI" })
-                    ])
+                    'Are you the Principal Investigator?* ',
+                    span({
+                      className: 'glyphicon glyphicon-question-sign tooltip-icon',
+                      'data-tip': 'This information is required in order to classify users as bonafide researchers as part of the process of Data Access approvals.',
+                      'data-for': 'tip_isthePI'
+                    })
+                  ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                   YesNoRadioGroup({
                     value: this.state.profile.isThePI,
                     onChange: this.handleRadioChange,
@@ -790,21 +810,21 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                   })
                 ]),
                 span({
-                  className: "cancel-color required-field-error-span",
+                  className: 'cancel-color required-field-error-span',
                   style: { 'marginLeft': '15px' },
                   isRendered: (this.state.profile.isThePI === null || this.state.invalidFields.isThePI) && showValidationMessages
-                }, ["Required field"])
+                }, ['Required field'])
               ]),
 
-              div({ isRendered: this.state.profile.isThePI === 'false' && this.state.isResearcher, className: "form-group" }, [
+              div({ isRendered: this.state.profile.isThePI === 'false' && this.state.isResearcher, className: 'form-group' }, [
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
                   label({
-                    className: "control-label ",
-                  }, ["Do you have a Principal Investigator?*"])
+                    className: 'control-label '
+                  }, ['Do you have a Principal Investigator?*'])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                   YesNoRadioGroup({
                     value: this.state.profile.havePI,
                     onChange: this.handleRadioChange,
@@ -814,59 +834,59 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                   })
                 ]),
                 span({
-                  className: "cancel-color required-field-error-span",
+                  className: 'cancel-color required-field-error-span',
                   style: { 'marginLeft': '15px' },
                   isRendered: (this.state.invalidFields.havePI === 'true' || this.state.invalidFields.havePI) && showValidationMessages
-                }, ["Required field"]),
+                }, ['Required field']),
 
-                div({ isRendered: this.state.profile.havePI === true || this.state.profile.havePI === 'true', className: "form-group" }, [
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                    label({ id: "lbl_profilePIName", className: "control-label" }, ["Principal Investigator Name*"]),
+                div({ isRendered: this.state.profile.havePI === true || this.state.profile.havePI === 'true', className: 'form-group' }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                    label({ id: 'lbl_profilePIName', className: 'control-label' }, ['Principal Investigator Name*']),
                     input({
-                      id: "profilePIName",
-                      name: "piName",
-                      type: "text",
-                      className: "form-control ",
+                      id: 'profilePIName',
+                      name: 'piName',
+                      type: 'text',
+                      className: 'form-control ',
                       onChange: this.handleChange,
                       value: this.state.profile.piName,
-                      required: this.state.profile.havePI === true,
+                      required: this.state.profile.havePI === true
                     }),
                     span({
-                      className: "cancel-color required-field-error-span",
+                      className: 'cancel-color required-field-error-span',
                       isRendered: (this.state.profile.piName === '' || this.state.invalidFields.piName) && showValidationMessages
-                    }, ["Principal Investigator is required"]),
+                    }, ['Principal Investigator is required'])
                   ]),
 
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
                     label({
-                      id: "lbl_profilePIEmail",
-                      className: "control-label"
-                    }, ["Principal Investigator Email Address*"]),
+                      id: 'lbl_profilePIEmail',
+                      className: 'control-label'
+                    }, ['Principal Investigator Email Address*']),
                     input({
-                      id: "profilePIEmail",
-                      name: "piEmail",
-                      type: "email",
-                      className: "form-control ",
+                      id: 'profilePIEmail',
+                      name: 'piEmail',
+                      type: 'email',
+                      className: 'form-control ',
                       onChange: this.handleChange,
                       value: this.state.profile.piEmail,
-                      required: this.state.profile.havePI === true,
+                      required: this.state.profile.havePI === true
                     }),
                     span({
-                      className: "cancel-color required-field-error-span",
+                      className: 'cancel-color required-field-error-span',
                       isRendered: (this.state.invalidFields.piEmail && this.state.profile.piEmail.indexOf('@') === -1) && showValidationMessages
-                    }, ["Email Address is empty or has invalid format"]),
+                    }, ['Email Address is empty or has invalid format'])
                   ]),
 
-                  div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
+                  div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
                     label({
-                      id: "lbl_profileEraCommons",
-                      className: "control-label"
-                    }, ["eRA Commons ID ", span({ className: "italic" }, ["(optional)"])]),
+                      id: 'lbl_profileEraCommons',
+                      className: 'control-label'
+                    }, ['eRA Commons ID ', span({ className: 'italic' }, ['(optional)'])]),
                     input({
-                      id: "profileEraCommons",
-                      name: "eRACommonsID",
-                      type: "text",
-                      className: "form-control",
+                      id: 'profileEraCommons',
+                      name: 'eRACommonsID',
+                      type: 'text',
+                      className: 'form-control',
                       onChange: this.handleChange,
                       value: this.state.profile.eRACommonsID
                     })
@@ -874,110 +894,123 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                 ])
               ]),
 
-              div({ isRendered: this.state.isResearcher, className: "form-group" }, [
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
+              div({ isRendered: this.state.isResearcher, className: 'form-group' }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
                   label({
-                    id: "lbl_profilePubmedID",
-                    className: "control-label"
-                  }, ["Pubmed ID of a publication ", span({ className: "italic" }, ["(optional)"])]),
+                    id: 'lbl_profilePubmedID',
+                    className: 'control-label'
+                  }, ['Pubmed ID of a publication ', span({ className: 'italic' }, ['(optional)'])]),
                   input({
-                    id: "profilePubmedID",
-                    name: "pubmedID",
-                    type: "text",
-                    className: "form-control",
+                    id: 'profilePubmedID',
+                    name: 'pubmedID',
+                    type: 'text',
+                    className: 'form-control',
                     onChange: this.handleChange,
                     value: this.state.profile.pubmedID
                   })
                 ]),
 
-                div({ isRendered: this.state.isResearcher, className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-last-group" }, [
+                div({ isRendered: this.state.isResearcher, className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-last-group' }, [
                   label({
-                    id: "lbl_profileScientificURL",
-                    className: "control-label"
-                  }, ["URL of a scientific publication ", span({ className: "italic" }, ["(optional)"])]),
+                    id: 'lbl_profileScientificURL',
+                    className: 'control-label'
+                  }, ['URL of a scientific publication ', span({ className: 'italic' }, ['(optional)'])]),
                   textarea({
-                    id: "profileScientificURL",
-                    name: "scientificURL",
-                    className: "form-control",
-                    maxLength: "512",
-                    rows: "3",
+                    id: 'profileScientificURL',
+                    name: 'scientificURL',
+                    className: 'form-control',
+                    maxLength: '512',
+                    rows: '3',
                     onChange: this.handleChange,
                     value: this.state.profile.scientificURL
                   })
                 ])
               ]),
 
-              div({ isRendered: this.state.isResearcher, className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                label({ className: "control-label rp-title-question default-color" }, [
-                  "Data Access Agreement ", span({ className: "italic display-inline" }, ["(optional)"]),
-                  span({ className: "default-color" }, ["Data Access Agreement will be required for submission of a Data Access Request"])
+              div({ isRendered: this.state.isResearcher, className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                label({ className: 'control-label rp-title-question default-color' }, [
+                  'Data Access Agreement ', span({ className: 'italic display-inline' }, ['(optional)']),
+                  span({ className: 'default-color' }, ['Data Access Agreement will be required for submission of a Data Access Request'])
                 ])
               ]),
 
-              div({ isRendered: this.state.isResearcher, className: "row no-margin" }, [
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                  label({ className: "control-label default-color" }, ["1. Download the Data Access Agreement template and have your organization's Signing Official sign it"])
+              div({ isRendered: this.state.isResearcher, className: 'row no-margin' }, [
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                  label({ className: 'control-label default-color' },
+                    ['1. Download the Data Access Agreement template and have your organization\'s Signing Official sign it'])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                  a({ id: "link_downloadAgreement", href: "BroadDataAccessAgreement.pdf", target: "_blank", className: "col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color" }, [
-                    span({ className: "glyphicon glyphicon-download" }),
-                    "Download Agreement Template"
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                  a({
+                    id: 'link_downloadAgreement', href: 'BroadDataAccessAgreement.pdf', target: '_blank',
+                    className: 'col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color'
+                  }, [
+                    span({ className: 'glyphicon glyphicon-download' }),
+                    'Download Agreement Template'
                   ])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                  label({ className: "control-label default-color" }, ["2. Upload your template of the Data Access Agreement signed by your organization's Signing Official"]),
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                  label({ className: 'control-label default-color' },
+                    ['2. Upload your template of the Data Access Agreement signed by your organization\'s Signing Official'])
                 ]),
 
-                div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
-                  div({ style: { paddingTop: 7 }, className: "fileUpload col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color" }, [
-                    span({ className: "glyphicon glyphicon-upload" }),
-                    "Upload S.O. Signed Agreement",
-                    input({ id: "uploadFile", type: "file", onChange: this.handleFileChange, className: "upload" })
+                div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12' }, [
+                  div({
+                    style: { paddingTop: 7 }, className: 'fileUpload col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color'
+                  }, [
+                    span({ className: 'glyphicon glyphicon-upload' }),
+                    'Upload S.O. Signed Agreement',
+                    input({ id: 'uploadFile', type: 'file', onChange: this.handleFileChange, className: 'upload' })
                   ])
                 ]),
-                p({ id: "txt_uploadFile", className: "fileName daa", isRendered: this.state.file.name !== '' || this.state.profile.nameDAA !== '' }, [
-                  "Your currently uploaded Data Access Agreement: ",
-                  span({ className: "italic normal" }, [this.state.file.name !== '' ? this.state.file.name : this.state.profile.nameDAA]),
+                p({ id: 'txt_uploadFile', className: 'fileName daa', isRendered: this.state.file.name !== '' || this.state.profile.nameDAA !== '' }, [
+                  'Your currently uploaded Data Access Agreement: ',
+                  span({ className: 'italic normal' }, [this.state.file.name !== '' ? this.state.file.name : this.state.profile.nameDAA])
                 ])
               ]),
 
-              div({ className: "row margin-top-20" }, [
-                div({ className: "col-lg-4 col-md-6 col-sm-6 col-xs-6" }, [
-                  div({ className: "italic default-color" }, ["*Required field"])
+              div({ className: 'row margin-top-20' }, [
+                div({ className: 'col-lg-4 col-md-6 col-sm-6 col-xs-6' }, [
+                  div({ className: 'italic default-color' }, ['*Required field'])
                 ]),
 
-                div({ className: "col-lg-8 col-md-6 col-sm-6 col-xs-6" }, [
-                  button({ id: "btn_submit", onClick: this.submit, className: "f-right btn-primary common-background" }, [
-                    span({ isRendered: ((!completed || completed === undefined)) && this.state.isResearcher }, ["Submit"]),
-                    span({ isRendered: (completed === true || !this.state.isResearcher) }, ["Update"]),
+                div({ className: 'col-lg-8 col-md-6 col-sm-6 col-xs-6' }, [
+                  button({ id: 'btn_submit', onClick: this.submit, className: 'f-right btn-primary common-background' }, [
+                    span({ isRendered: ((!completed || completed === undefined)) && this.state.isResearcher }, ['Submit']),
+                    span({ isRendered: (completed === true || !this.state.isResearcher) }, ['Update'])
                   ]),
                   ConfirmationDialog({
                     title: 'Submit Profile',
                     color: 'common',
                     showModal: this.state.showDialogSubmit,
-                    action: { label: "Yes", handler: this.dialogHandlerSubmit }
-                  }, [div({ className: "dialog-description" }, ["Are you sure you want to submit your Profile information?"]),]),
+                    action: { label: 'Yes', handler: this.dialogHandlerSubmit }
+                  }, [div({ className: 'dialog-description' }, ['Are you sure you want to submit your Profile information?'])]),
 
-                  button({ id: "btn_continueLater", isRendered: !completed && this.state.isResearcher, onClick: this.saveProfile, className: "f-right btn-secondary common-color" }, ["Continue later"]),
+                  button({
+                    id: 'btn_continueLater', isRendered: !completed && this.state.isResearcher, onClick: this.saveProfile,
+                    className: 'f-right btn-secondary common-color'
+                  }, ['Continue later']),
 
                   ConfirmationDialog({
-                    title: 'Continue later',
-                    color: 'common',
-                    showModal: this.state.showDialogSave,
-                    action: { label: "Yes", handler: this.dialogHandlerSave }
-                  }, [div({ className: "dialog-description" }, ["Are you sure you want to leave this page? Please remember that you need to submit your Profile information to be able to create a Data Access Request."])]
+                      title: 'Continue later',
+                      color: 'common',
+                      showModal: this.state.showDialogSave,
+                      action: { label: 'Yes', handler: this.dialogHandlerSave }
+                    }, [
+                      div({ className: 'dialog-description' },
+                        ['Are you sure you want to leave this page? Please remember that you need to submit your Profile information to be able to create a Data Access Request.'])
+                    ]
                   ),
                   h(ReactTooltip, {
-                    id: "tip_clearNihAccount",
+                    id: 'tip_clearNihAccount',
                     place: 'right',
                     effect: 'solid',
                     multiline: true,
                     className: 'tooltip-wrapper'
                   }),
                   h(ReactTooltip, {
-                    id: "tip_isthePI",
+                    id: 'tip_isthePI',
                     effect: 'solid',
                     multiline: true,
                     className: 'tooltip-wrapper'

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -547,8 +547,8 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
               div({ isRendered: this.state.isResearcher, className: "form-group" }, [
                 div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12", style: { 'marginTop': '20px' } }, [
                   label({ className: "control-label rp-title-question default-color" }, [
-                    "Researcher Identification ", span({ className: "italic display-inline" }, ["(optional)"]),
-                    span({}, ["Please authenticate your eRA Commons account or provide a link to one of your other profiles:"])
+                    "Researcher Identification*",
+                    span({}, ["Please authenticate your eRA Commons account to submit Data Access Requests. Other profiles are optional:"])
                   ]),
                 ]),
 


### PR DESCRIPTION
## Addresses
- https://broadinstitute.atlassian.net/browse/DUOS-471
- https://broadinstitute.atlassian.net/browse/DUOS-454

## Changes
- Lint formatting on the changed files results in lots of unrelated white space and quote changes.
- Extract all common code from the profile and data access request pages that both handle era commons authentication into a new component
  - Minor refactoring around the order of operations for auth
- Fix the remove era commons bug where removal didn't immediately display on-screen
- Add a callback handler for any parent components that might need to know the state of current authentication
- Enforce only eRA commons of the 4 different RI types. Other 3 are now optional
- Did *not* enforce in profile, but mark as required - currently only required for DAR submission.

## DAR Submission Enforcement
![Screen Shot 2019-11-20 at 10 25 08 AM](https://user-images.githubusercontent.com/116679/69253354-89932f80-0b82-11ea-85db-6a1df706a14f.png)

## Profile Language Update
![Screen Shot 2019-11-18 at 8 40 34 AM](https://user-images.githubusercontent.com/116679/69057078-3a60c980-09df-11ea-8139-19496c3b984b.png)
