### PR TITLE
[DUOS-346][risk=no] Create DUL Election with a Dac

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3163,8 +3163,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3182,13 +3181,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3201,18 +3198,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3315,8 +3309,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3326,7 +3319,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3339,20 +3331,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3369,7 +3358,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3442,8 +3430,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3453,7 +3440,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3529,8 +3515,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3560,7 +3545,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3578,7 +3562,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3617,13 +3600,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -7203,8 +7184,7 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7222,13 +7202,11 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7241,18 +7219,15 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7355,8 +7330,7 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7366,7 +7340,6 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7379,20 +7352,17 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7409,7 +7379,6 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7482,8 +7451,7 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7493,7 +7461,6 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7569,8 +7536,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7600,7 +7566,6 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7618,7 +7583,6 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7657,13 +7621,11 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         }
@@ -10896,24 +10858,14 @@
       "integrity": "sha512-IzrkhzU0Uwhu8FQPRF5oyWrzLb6IFyjynKRhmyK/dDCwxs2/UMuUGyHhC8JbnStVfpL5naqaWYg24HRGSH7Kpw=="
     },
     "react-modal": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.5.1.tgz",
-      "integrity": "sha512-GxL7ycOgKC+p641cR+V1bw5dC1faL2N86/AJlzbMVmvt1totoylgkJmn9zvLuHeuarGbB7CLfHMGpeRowaj2jQ==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.11.1.tgz",
+      "integrity": "sha512-8uN744Yq0X2lbfSLxsEEc2UV3RjSRb4yDVxRQ1aGzPo86QjNOwhQSukDb8U8kR+636TRTvfMren10fgOjAy9eA==",
       "requires": {
         "exenv": "^1.2.0",
         "prop-types": "^15.5.10",
         "react-lifecycles-compat": "^3.0.0",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
+        "warning": "^4.0.3"
       }
     },
     "react-onclickoutside": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react-google-login": "3.2.1",
     "react-hyperscript-helpers": "2.0.0",
     "react-material-icon-svg": "3.5.0",
-    "react-modal": "3.5.1",
+    "react-modal": "3.11.1",
     "react-onclickoutside": "6.7.1",
     "react-paginating": "1.0.1",
     "react-responsive-navbar": "1.0.11",

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -1,3 +1,4 @@
+import _ from 'lodash/fp';
 import { Component } from 'react';
 import { button, div, h, h2, span, hh } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
@@ -62,7 +63,7 @@ export const ConfirmationDialog = hh(class ConfirmationDialog extends Component 
           isOpen: this.props.showModal,
           onAfterOpen: this.props.afterOpenModal,
           onRequestClose: this.props.onRequestClose,
-          style: customStyles,
+          style: _.mergeAll([customStyles, this.props.style]),
           contentLabel: "Modal"
         }, [
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,8 +1,8 @@
 import fileDownload from 'js-file-download';
+import filter from 'lodash/filter';
 import _ from 'lodash/fp';
 import get from 'lodash/get';
 import head from 'lodash/head';
-import filter from 'lodash/filter';
 import { Config } from './config';
 import { Models } from './models';
 import { spinnerService } from './spinner-service';
@@ -207,7 +207,7 @@ export const DAC = {
     const url = `${await Config.getApiUrl()}/dac/${dacId}/member/${userId}`;
     const res = await fetchOk(url, _.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
     return res.json();
-  },
+  }
 
 };
 
@@ -395,7 +395,7 @@ export const DAR = {
     formData.append("data", new Blob([file], { type: 'application/pdf' }));
     const res = await fetchOk(url, _.mergeAll([Config.authOpts(), { method: 'POST', body: formData }]));
     return await res.json();
-  },
+  }
 };
 
 export const DataSet = {
@@ -538,22 +538,21 @@ export const Election = {
   },
 
   updateElection: async (electionId, document) => {
-    const url = `${await Config.getApiUrl()}/election/${electionId}`;
+    const url = `${ await Config.getApiUrl() }/election/${ electionId }`;
     const res = await fetchOk(url, _.mergeAll([Config.authOpts(), Config.jsonBody(document), { method: 'PUT' }]));
     return await res.json();
   },
 
   createElection: async (consentId) => {
-    var election = {};
-    election.status = 'Open';
-    const url = `${await Config.getApiUrl()}/consent/${consentId}/election`;
+    const election = { status: 'Open' };
+    const url = `${ await Config.getApiUrl() }/consent/${ consentId }/election`;
     const res = await fetchOk(url, _.mergeAll([Config.jsonBody(election), Config.authOpts(), { method: 'POST' }]));
     return res;
   },
 
   createElectionForDac: async (consentId, dacId) => {
-    var election = {status: 'Open'};
-    const url = `${await Config.getApiUrl()}/consent/${consentId}/election/dac/${dacId}`;
+    const election = { status: 'Open' };
+    const url = `${ await Config.getApiUrl() }/consent/${ consentId }/election/dac/${ dacId }`;
     const res = await fetchOk(url, _.mergeAll([Config.jsonBody(election), Config.authOpts(), { method: 'POST' }]));
     return res;
   },
@@ -583,9 +582,7 @@ export const Election = {
   },
 
   createDARElection: async (requestId) => {
-    var election = {};
-    election.status = 'Open';
-    election.finalAccessVote = false;
+    const election = { status: 'Open', finalAccessVote: false };
     const url = `${await Config.getApiUrl()}/dataRequest/${requestId}/election`;
     const res = await fetchOk(url, _.mergeAll([Config.jsonBody(election), Config.authOpts(), { method: 'POST' }]));
     return res;

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -552,8 +552,7 @@ export const Election = {
   },
 
   createElectionForDac: async (consentId, dacId) => {
-    var election = {};
-    election.status = 'Open';
+    var election = {status: 'Open'};
     const url = `${await Config.getApiUrl()}/consent/${consentId}/election/dac/${dacId}`;
     const res = await fetchOk(url, _.mergeAll([Config.jsonBody(election), Config.authOpts(), { method: 'POST' }]));
     return res;

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -551,6 +551,14 @@ export const Election = {
     return res;
   },
 
+  createElectionForDac: async (consentId, dacId) => {
+    var election = {};
+    election.status = 'Open';
+    const url = `${await Config.getApiUrl()}/consent/${consentId}/election/dac/${dacId}`;
+    const res = await fetchOk(url, _.mergeAll([Config.jsonBody(election), Config.authOpts(), { method: 'POST' }]));
+    return res;
+  },
+
   findReviewedConsents: async () => {
     const url = `${await Config.getApiUrl()}/consent/cases/closed`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/libs/models.js
+++ b/src/libs/models.js
@@ -1,5 +1,13 @@
 export const Models = {
-  dac: { dac: {}, chairpersons: [], members: [] },
+  dac: {
+    dacId: null,
+    name: '',
+    description: '',
+    createDate: null,
+    updateDate: null,
+    chairpersons: [],
+    members: []
+  },
   dar: {
     researcherProperties: [],
     researcherId: '',

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -609,7 +609,9 @@ class AdminManageDul extends Component {
           title: 'Create election?',
           color: 'dul',
           disableOkBtn: this.state.disableOkBtn ||
-            (_.isNil(this.state.selectedElection.dacId) && _.isEmpty(this.state.selectedDac)),
+            (!_.isEmpty(this.state.dacList) &&
+              _.isNil(this.state.selectedElection.dacId) &&
+              _.isEmpty(this.state.selectedDac)),
           disableNoBtn: this.state.disableCancelBtn,
           action: { label: 'Yes', handler: this.dialogHandlerCreate },
           alertMessage: this.state.alertMessage,
@@ -617,7 +619,8 @@ class AdminManageDul extends Component {
         }, [
           div({ className: 'dialog-description' }, [
             span({}, ['Are you sure you want the DAC to vote on this case? ']),
-            div({ isRendered: _.isNil(this.state.selectedElection.dacId) }, [
+            div({ isRendered: (_.isNil(this.state.selectedElection.dacId) &&
+                !_.isEmpty(this.state.dacList)) }, [
               'This election requires a DAC assignment:',
               h(Select, {
                 classNamePrefix: 'select',

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -193,7 +193,7 @@ class AdminManageDul extends Component {
 
   openDialogCreate = (election) => (e) => {
     this.setState({
-      createWarning: (election.status === 'Closed' && election.archived !== true),
+      createWarning: (election.status === 'Closed' && !election.archived),
       showDialogCreate: true,
       selectedElection: election
     });
@@ -242,9 +242,9 @@ class AdminManageDul extends Component {
   dialogHandlerCreate = (answer) => async (e) => {
     this.setState({ disableOkBtn: answer, disableCancelBtn: answer });
     if (answer) {
-      let dac = this.state.selectedDac;
-      let election = this.state.selectedElection;
-      let consentId = election.consentId;
+      const dac = this.state.selectedDac;
+      const election = this.state.selectedElection;
+      const consentId = election.consentId;
       let electionPromise = null;
       if (_.isNil(election.dacId) && !_.isEmpty(dac)) {
         electionPromise = Election.createElectionForDac(consentId, dac.dacId);
@@ -397,13 +397,13 @@ class AdminManageDul extends Component {
                       div({
                         id: election.consentId + '_groupName',
                         name: 'groupName',
-                        className: 'col-2 cell-body text ' + ((election.groupName === false || election.groupName === null) ? 'empty' : ''),
+                        className: 'col-2 cell-body text ' + ((!election.groupName || false) ? 'empty' : ''),
                         title: election.groupName
                       }, [election.groupName]),
                       div({
                         id: election.consentId + '_version',
                         name: 'version',
-                        className: 'col-1 cell-body text ' + ((election.version === false || election.version === null) ? 'empty' : '')
+                        className: 'col-1 cell-body text ' + ((!election.version || false) ? 'empty' : '')
                       }, [election.version]),
                       div({
                         id: election.consentId + '_createDate',

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -1,13 +1,16 @@
+import _ from 'lodash';
 import { Component, Fragment } from 'react';
-import { div, hr, h, span, a, input, button, label } from 'react-hyperscript-helpers';
-import { PageHeading } from '../components/PageHeading';
-import { AddDulModal } from '../components/modals/AddDulModal';
-import { Consent, Election } from '../libs/ajax';
-import { PaginatorBar } from "../components/PaginatorBar";
-import { ConfirmationDialog } from '../components/ConfirmationDialog';
-import * as Utils from '../libs/utils';
-import { SearchBox } from '../components/SearchBox';
+import { a, button, div, h, hr, input, label, span } from 'react-hyperscript-helpers';
+import Select from 'react-select';
 import ReactTooltip from 'react-tooltip';
+import { ConfirmationDialog } from '../components/ConfirmationDialog';
+import { AddDulModal } from '../components/modals/AddDulModal';
+import { PageHeading } from '../components/PageHeading';
+import { PaginatorBar } from '../components/PaginatorBar';
+import { SearchBox } from '../components/SearchBox';
+import { Consent, DAC, Election } from '../libs/ajax';
+import * as Utils from '../libs/utils';
+
 
 const limit = 10;
 
@@ -16,6 +19,10 @@ class AdminManageDul extends Component {
   constructor(props) {
     super(props);
     this.state = {
+      selectedElection: {},
+      dacList: [],
+      selectedDac: {},
+      dacMenuOpen: false,
       currentPage: 1,
       showModal: false,
       value: '',
@@ -36,16 +43,53 @@ class AdminManageDul extends Component {
       disableOkBtn: false,
       disableCancelBtn: false
     };
-
-    this.handleCloseModal = this.handleCloseModal.bind(this);
-    this.handlePageChange = this.handlePageChange.bind(this);
-    this.addDul = this.addDul.bind(this);
-    this.closeAddDulModal = this.closeAddDulModal.bind(this);
-    this.okAddDulModal = this.okAddDulModal.bind(this);
-    this.afterAddDulModalOpen = this.afterAddDulModalOpen.bind(this);
   }
 
-  async getConsentManage() {
+  getDACs = async () => {
+    const dacs = await DAC.list();
+    this.setState(prev => {
+      prev.dacList = dacs;
+      return prev;
+    });
+  };
+
+  dacOptions = () => {
+    return this.state.dacList.map(function(item) {
+      return {
+        key: item.dacId,
+        value: item.dacId,
+        label: item.name,
+        item: item
+      };
+    });
+  };
+
+  onDacChange = (option) => {
+    this.setState(prev => {
+      if (_.isNil(option)) {
+        prev.selectedDac = {};
+      } else {
+        prev.selectedDac = option.item;
+      }
+      return prev;
+    });
+  };
+
+  onDacMenuOpen = () => {
+    this.setState(prev => {
+      prev.dacMenuOpen = true;
+      return prev;
+    });
+  };
+
+  onDacMenuClose = () => {
+    this.setState(prev => {
+      prev.dacMenuOpen = false;
+      return prev;
+    });
+  };
+
+  getConsentManage = async () => {
     const duls = await Consent.findConsentManage();
     this.setState(prev => {
       prev.currentPage = 1;
@@ -59,13 +103,14 @@ class AdminManageDul extends Component {
     }, async () => {
       ReactTooltip.rebuild();
     });
-  }
+  };
 
-  componentDidMount() {
-    this.getConsentManage();
-  }
+  componentDidMount = async () => {
+    await this.getConsentManage();
+    await this.getDACs();
+  };
 
-  removeDul(consentId) {
+  removeDul = (consentId) => {
     let updatedDul = this.state.electionsList.dul.filter(election => election.consentId !== consentId);
     this.setState(prev => {
       prev.currentPage = 1;
@@ -92,14 +137,9 @@ class AdminManageDul extends Component {
     });
   };
 
-  handleCloseModal() {
-    this.setState({ showModal: false });
-  }
-
-
-  open(electionId, page, action, status) {
-    this.props.history.push(`${page}/${electionId}`);
-  }
+  open = (electionId, page) => {
+    this.props.history.push(`${ page }/${ electionId }`);
+  };
 
   async editDul(election) {
     const consentData = await Consent.findConsentById(election.consentId);
@@ -111,32 +151,29 @@ class AdminManageDul extends Component {
     });
   };
 
-  addDul() {
+  addDul = () => {
     this.setState({
       dulToEdit: null,
       consentToEdit: null,
       showModal: true,
       isEditMode: false
     });
-  }
+  };
 
-  closeAddDulModal() {
+  closeAddDulModal = () => {
     this.setState(prev => {
       prev.showModal = false;
       return prev;
     });
-  }
+  };
 
-  async okAddDulModal() {
+  okAddDulModal = async () => {
     await this.getConsentManage();
     this.setState(prev => {
       prev.showModal = false;
       return prev;
     });
-  }
-
-  afterAddDulModalOpen() {
-  }
+  };
 
   openDialogArchive = (election) => (e) => {
     if (election.electionStatus === 'Open') {
@@ -150,15 +187,15 @@ class AdminManageDul extends Component {
     this.setState({
       createWarning: (election.status === 'Open'),
       showDialogCancel: true,
-      payload: election,
+      payload: election
     });
   };
 
-  openDialogCreate = (status, archived) => (e) => {
+  openDialogCreate = (election) => (e) => {
     this.setState({
-      createWarning: (status === 'Closed' && archived !== true),
+      createWarning: (election.status === 'Closed' && election.archived !== true),
       showDialogCreate: true,
-      createId: e.target.getAttribute('consentid')
+      selectedElection: election
     });
   };
 
@@ -205,13 +242,23 @@ class AdminManageDul extends Component {
   dialogHandlerCreate = (answer) => async (e) => {
     this.setState({ disableOkBtn: answer, disableCancelBtn: answer });
     if (answer) {
-      let consentId = this.state.createId;
-      Election.createElection(consentId).then(
+      let dac = this.state.selectedDac;
+      let election = this.state.selectedElection;
+      let consentId = election.consentId;
+      let electionPromise = null;
+      if (_.isNil(election.dacId)) {
+        electionPromise = Election.createElectionForDac(consentId, dac.dacId);
+      } else {
+        electionPromise = Election.createElection(consentId);
+      }
+      electionPromise.then(
         (value) => {
           this.setState({
             showDialogCreate: false,
             alertTitle: undefined,
-            alertMessage: undefined
+            alertMessage: undefined,
+            selectedDac: {},
+            selectedElection: {}
           });
           this.getConsentManage();
         }).catch(errorResponse => {
@@ -231,14 +278,12 @@ class AdminManageDul extends Component {
             );
           }
         }
-        );
+      );
     } else {
       this.setState({
         showDialogCreate: false,
         alertTitle: undefined,
-        alertMessage: undefined,
-        // disableOkBtn: false,
-        // disableCancelBtn: false
+        alertMessage: undefined
       });
     }
 
@@ -279,186 +324,204 @@ class AdminManageDul extends Component {
     const { currentPage, limit, searchDulText } = this.state;
 
     return (
-      div({ className: "container container-wide" }, [
-        div({ className: "row no-margin" }, [
-          div({ className: "col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding" }, [
+      div({ className: 'container container-wide' }, [
+        div({ className: 'row no-margin' }, [
+          div({ className: 'col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding' }, [
             PageHeading({
-              id: "manageDul",
-              imgSrc: "/images/icon_manage_dul.png",
-              iconSize: "medium",
-              color: "dul",
-              title: "Manage Data Use Limitations",
-              description: "Select and manage Data Use Limitations for DAC review"
-            }),
+              id: 'manageDul',
+              imgSrc: '/images/icon_manage_dul.png',
+              iconSize: 'medium',
+              color: 'dul',
+              title: 'Manage Data Use Limitations',
+              description: 'Select and manage Data Use Limitations for DAC review'
+            })
           ]),
-          div({ className: "col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding" }, [
-            div({ className: "col-lg-6 col-md-6 col-sm-7 col-xs-7" }, [
+          div({ className: 'col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding' }, [
+            div({ className: 'col-lg-6 col-md-6 col-sm-7 col-xs-7' }, [
               h(SearchBox, { id: 'manageDul', searchHandler: this.handleSearchDul, pageHandler: this.handlePageChange, color: 'dul' })
             ]),
 
             a({
               id: 'btn_addDUL',
-              className: "col-lg-6 col-md-6 col-sm-5 col-xs-5 btn-primary btn-add dul-background",
+              className: 'col-lg-6 col-md-6 col-sm-5 col-xs-5 btn-primary btn-add dul-background',
               onClick: this.addDul
             }, [
-                div({ className: "all-icons add-dul_white" }),
-                span({}, ["Add Data Use Limitations"]),
-              ])
+              div({ className: 'all-icons add-dul_white' }),
+              span({}, ['Add Data Use Limitations'])
+            ])
           ])
         ]),
-        div({ className: "jumbotron table-box" }, [
-          div({ className: "grid-9-row pushed-2" }, [
-            div({ className: "col-2 cell-header dul-color" }, ["Consent id"]),
-            div({ className: "col-2 cell-header dul-color" }, ["Consent Group Name"]),
-            div({ className: "col-1 cell-header dul-color" }, ["Election N°"]),
-            div({ className: "col-1 cell-header dul-color" }, ["Date"]),
-            div({ className: "col-1 cell-header f-center dul-color" }, ["Edit Record"]),
-            div({ className: "col-1 cell-header f-center dul-color" }, ["Election status"]),
-            div({ className: "col-1 cell-header f-center dul-color" }, ["Election actions"]),
+        div({ className: 'jumbotron table-box' }, [
+          div({ className: 'grid-9-row pushed-2' }, [
+            div({ className: 'col-2 cell-header dul-color' }, ['Consent id']),
+            div({ className: 'col-2 cell-header dul-color' }, ['Consent Group Name']),
+            div({ className: 'col-1 cell-header dul-color' }, ['Election N°']),
+            div({ className: 'col-1 cell-header dul-color' }, ['Date']),
+            div({ className: 'col-1 cell-header f-center dul-color' }, ['Edit Record']),
+            div({ className: 'col-1 cell-header f-center dul-color' }, ['Election status']),
+            div({ className: 'col-1 cell-header f-center dul-color' }, ['Election actions'])
           ]),
 
-          hr({ className: "table-head-separator" }),
+          hr({ className: 'table-head-separator' }),
 
-          this.state.electionsList.dul.filter(this.searchTable(searchDulText)).slice((currentPage - 1) * limit, currentPage * limit).map((election, eIndex) => {
-            return (
-              h(Fragment, { key: election.consentId }, [
-                div({
-                  id: election.consentId, className: "grid-9-row pushed-2 tableRow " + (election.updateStatus === true ? " list-highlighted" : "")
-                },
-                  [
-                    div({
-                      id: election.consentId + "_consentId",
-                      name: "consentId",
-                      className: "col-2 cell-body text " + (election.archived === true ? "flagged" : ""),
-                      title: election.consentName
+          this.state.electionsList.dul.filter(this.searchTable(searchDulText))
+            .slice((currentPage - 1) * limit, currentPage * limit)
+            .map((election, eIndex) => {
+              return (
+                h(Fragment, { key: election.consentId }, [
+                  div({
+                      id: election.consentId, className: 'grid-9-row pushed-2 tableRow ' + (election.updateStatus === true ? ' list-highlighted' : '')
                     },
-                      [
-                        span({
-                          id: election.consentId + "_flagConsentId",
-                          name: "flag_consentId",
-                          isRendered: election.updateStatus,
-                          className: "glyphicon glyphicon-exclamation-sign list-highlighted-item dul-color",
-                          "data-tip": "Consent has been updated",
-                          "data-for": "tip_flag"
-                        }, []),
-                        a({
-                          id: election.consentId + "_linkConsentName",
-                          name: "link_consentName",
-                          onClick: () => this.open(election.consentId, 'dul_preview', null, true)
-                        }, [election.consentName]),
-                      ]),
-                    div({
-                      id: election.consentId + "_groupName",
-                      name: "groupName",
-                      className: "col-2 cell-body text " + ((election.groupName === false || election.groupName === null) ? "empty" : ""),
-                      title: election.groupName
-                    }, [election.groupName]),
-                    div({
-                      id: election.consentId + "_version",
-                      name: "version",
-                      className: "col-1 cell-body text " + ((election.version === false || election.version === null) ? "empty" : "")
-                    }, [election.version]),
-                    div({
-                      id: election.consentId + "_createDate",
-                      name: "createDate",
-                      className: "col-1 cell-body text"
-                    }, [Utils.formatDate(election.createDate)]),
-                    div({
-                      className: "col-1 cell-body f-center",
-                      disabled: (election.electionStatus !== 'un-reviewed' || !election.editable)
-                    },
-                      [
-                        button({
-                          id: election.consentId + "_btnEditDUL",
-                          name: "btn_editDul",
-                          className: "cell-button hover-color",
-                          onClick: () => this.editDul(election)
-                        }, ["Edit"]),
-
-                      ]),
-                    div({ className: "col-1 cell-body text f-center bold" }, [
-                      span({ isRendered: election.electionStatus === 'un-reviewed' }, [
-                        a({ id: election.consentId + "_linkUnreviewed", name: "link_unreviewed", onClick: () => this.open(election.consentId, 'dul_preview', null, false) }, ["Un-reviewed"])]),
-                      span({ isRendered: election.electionStatus === 'Open' }, [
-                        a({ id: election.consentId + "_linkOpen", name: "link_open", onClick: () => this.open(election.consentId, 'dul_collect', null, false) }, ["Open"]),]),
-                      span({ isRendered: election.electionStatus === 'Canceled' }, [
-                        a({ id: election.consentId + "_linkCanceled", name: "link_canceled", onClick: () => this.open(election.consentId, 'dul_preview', null, false) }, ["Canceled"]),]),
-                      span({ isRendered: election.electionStatus === 'Closed' }, [
-                        a({ id: election.consentId + "_linkReviewed", name: "link_reviewed", onClick: () => this.open(election.electionId, 'dul_results_record', election.electionId, false) }, [election.vote]),]),
-                    ]),
-                    div({
-                      isRendered: election.electionStatus !== 'Open',
-                      className: "col-1 cell-body f-center",
-                      disabled: !election.editable
-                    },
-                      [
-                        button({
-                          id: election.consentId + "_btnCreate",
-                          name: "btn_create",
-                          consentid: election.consentId,
-                          onClick: this.openDialogCreate(election.electionStatus, election.archived),
-                          className: "cell-button hover-color"
-                        }, ["Create"]),
-                      ]),
-                    div({
-                      isRendered: election.electionStatus === 'Open',
-                      className: "col-1 cell-body f-center"
-                    },
-                      [
-                        button({
-                          id: election.consentId + "_btnCancel",
-                          name: "btn_cancel",
-                          consentid: election.consentId,
-                          onClick: this.openDialogCancel(election),
-                          className: "cell-button cancel-color"
-                        }, ["Cancel"]),
-                      ]),
-                    div({ className: "icon-actions" }, [
+                    [
                       div({
-                        className: "display-inline-block",
-                        disabled: (election.electionStatus === 'un-reviewed' || election.archived === true)
-                      }, [
-                          button({
-                            id: election.consentId + "_btnArchiveElection",
-                            name: "btn_archiveElection",
-                            onClick: this.openDialogArchive(election)
-                          }, [
-                              span({
-                                className: "glyphicon caret-margin glyphicon-inbox " + (election.archived === true ? "activated" : ""),
-                                "data-tip": "Archive election",
-                                "data-for": "tip_archive"
-                              })
-                            ])
+                          id: election.consentId + '_consentId',
+                          name: 'consentId',
+                          className: 'col-2 cell-body text ' + (election.archived === true ? 'flagged' : ''),
+                          title: election.consentName
+                        },
+                        [
+                          span({
+                            id: election.consentId + '_flagConsentId',
+                            name: 'flag_consentId',
+                            isRendered: election.updateStatus,
+                            className: 'glyphicon glyphicon-exclamation-sign list-highlighted-item dul-color',
+                            'data-tip': 'Consent has been updated',
+                            'data-for': 'tip_flag'
+                          }, []),
+                          a({
+                            id: election.consentId + '_linkConsentName',
+                            name: 'link_consentName',
+                            onClick: () => this.open(election.consentId, 'dul_preview')
+                          }, [election.consentName])
                         ]),
                       div({
-                        className: "display-inline-block",
-                        disabled: (election.electionStatus !== 'un-reviewed' || election.electionStatus === 'Canceled')
-                      }, [
+                        id: election.consentId + '_groupName',
+                        name: 'groupName',
+                        className: 'col-2 cell-body text ' + ((election.groupName === false || election.groupName === null) ? 'empty' : ''),
+                        title: election.groupName
+                      }, [election.groupName]),
+                      div({
+                        id: election.consentId + '_version',
+                        name: 'version',
+                        className: 'col-1 cell-body text ' + ((election.version === false || election.version === null) ? 'empty' : '')
+                      }, [election.version]),
+                      div({
+                        id: election.consentId + '_createDate',
+                        name: 'createDate',
+                        className: 'col-1 cell-body text'
+                      }, [Utils.formatDate(election.createDate)]),
+                      div({
+                          className: 'col-1 cell-body f-center',
+                          disabled: (election.electionStatus !== 'un-reviewed' || !election.editable)
+                        },
+                        [
                           button({
-                            id: election.consentId + "_btnDeleteDul",
-                            name: "btn_deleteDul",
+                            id: election.consentId + '_btnEditDUL',
+                            name: 'btn_editDul',
+                            className: 'cell-button hover-color',
+                            onClick: () => this.editDul(election)
+                          }, ['Edit'])
+
+                        ]),
+                      div({ className: 'col-1 cell-body text f-center bold' }, [
+                        span({ isRendered: election.electionStatus === 'un-reviewed' }, [
+                          a({
+                            id: election.consentId + '_linkUnreviewed', name: 'link_unreviewed',
+                            onClick: () => this.open(election.consentId, 'dul_preview')
+                          }, ['Un-reviewed'])
+                        ]),
+                        span({ isRendered: election.electionStatus === 'Open' }, [
+                          a({
+                            id: election.consentId + '_linkOpen', name: 'link_open',
+                            onClick: () => this.open(election.consentId, 'dul_collect')
+                          }, ['Open'])
+                        ]),
+                        span({ isRendered: election.electionStatus === 'Canceled' }, [
+                          a({
+                            id: election.consentId + '_linkCanceled', name: 'link_canceled',
+                            onClick: () => this.open(election.consentId, 'dul_preview')
+                          }, ['Canceled'])
+                        ]),
+                        span({ isRendered: election.electionStatus === 'Closed' }, [
+                          a({
+                            id: election.consentId + '_linkReviewed', name: 'link_reviewed',
+                            onClick: () => this.open(election.electionId, 'dul_results_record')
+                          }, [election.vote])
+                        ])
+                      ]),
+                      div({
+                          isRendered: election.electionStatus !== 'Open',
+                          className: 'col-1 cell-body f-center',
+                          disabled: !election.editable
+                        },
+                        [
+                          button({
+                            id: election.consentId + '_btnCreate',
+                            name: 'btn_create',
+                            consentid: election.consentId,
+                            onClick: this.openDialogCreate(election),
+                            className: 'cell-button hover-color'
+                          }, ['Create'])
+                        ]),
+                      div({
+                          isRendered: election.electionStatus === 'Open',
+                          className: 'col-1 cell-body f-center'
+                        },
+                        [
+                          button({
+                            id: election.consentId + '_btnCancel',
+                            name: 'btn_cancel',
+                            consentid: election.consentId,
+                            onClick: this.openDialogCancel(election),
+                            className: 'cell-button cancel-color'
+                          }, ['Cancel'])
+                        ]),
+                      div({ className: 'icon-actions' }, [
+                        div({
+                          className: 'display-inline-block',
+                          disabled: (election.electionStatus === 'un-reviewed' || election.archived === true)
+                        }, [
+                          button({
+                            id: election.consentId + '_btnArchiveElection',
+                            name: 'btn_archiveElection',
+                            onClick: this.openDialogArchive(election)
+                          }, [
+                            span({
+                              className: 'glyphicon caret-margin glyphicon-inbox ' + (election.archived === true ? 'activated' : ''),
+                              'data-tip': 'Archive election',
+                              'data-for': 'tip_archive'
+                            })
+                          ])
+                        ]),
+                        div({
+                          className: 'display-inline-block',
+                          disabled: (election.electionStatus !== 'un-reviewed' || election.electionStatus === 'Canceled')
+                        }, [
+                          button({
+                            id: election.consentId + '_btnDeleteDul',
+                            name: 'btn_deleteDul',
                             onClick: this.openDialogDelete(election)
                           }, [
-                              span({
-                                className: "glyphicon caret-margin glyphicon-trash",
-                                "data-tip": "Delete record",
-                                "data-for": "tip_delete"
-                              })
-                            ])
+                            span({
+                              className: 'glyphicon caret-margin glyphicon-trash',
+                              'data-tip': 'Delete record',
+                              'data-for': 'tip_delete'
+                            })
+                          ])
                         ])
-                    ])
-                  ]),
-                hr({ className: "table-body-separator" })
-              ])
-            );
-          }),
+                      ])
+                    ]),
+                  hr({ className: 'table-body-separator' })
+                ])
+              );
+            }),
           PaginatorBar({
             total: this.state.electionsList.dul.filter(this.searchTable(searchDulText)).length,
             limit: this.state.limit,
             pageCount: this.pageCount,
             currentPage: this.state.currentPage,
             onPageChange: this.handlePageChange,
-            changeHandler: this.handleSizeChange,
+            changeHandler: this.handleSizeChange
           })
         ]),
 
@@ -468,7 +531,6 @@ class AdminManageDul extends Component {
           isEditMode: this.state.isEditMode,
           onOKRequest: this.okAddDulModal,
           onCloseRequest: this.closeAddDulModal,
-          onAfterOpen: this.afterAddDulModalOpen,
           dul: this.state.dulToEdit,
           editConsent: this.state.consentToEdit
         }),
@@ -481,13 +543,14 @@ class AdminManageDul extends Component {
           title: 'Archive election?',
           color: 'dul',
           payload: this.state.payload,
-          action: { label: "Yes", handler: this.dialogHandlerArchive }
+          action: { label: 'Yes', handler: this.dialogHandlerArchive }
         }, [
-            div({ className: "dialog-description" }, [
-              span({}, ["Are you sure you want to archive this election? "]),
-              span({ className: "no-padding display-inline" }, ["The current election will be stopped without logging a result and this case will no longer be available for DAC Review."]),
-            ]),
-          ]),
+          div({ className: 'dialog-description' }, [
+            span({}, ['Are you sure you want to archive this election? ']),
+            span({ className: 'no-padding display-inline' },
+              ['The current election will be stopped without logging a result and this case will no longer be available for DAC Review.'])
+          ])
+        ]),
 
         ConfirmationDialog({
           isRendered: this.state.showDialogArchiveClosed,
@@ -497,13 +560,13 @@ class AdminManageDul extends Component {
           title: 'Archive election?',
           color: 'dul',
           payload: this.state.payload,
-          action: { label: "Yes", handler: this.dialogHandlerArchive }
+          action: { label: 'Yes', handler: this.dialogHandlerArchive }
         }, [
-            div({ className: "dialog-description" }, [
-              span({}, ["Are you sure you want to archive this election? "]),
-              span({ className: "no-padding display-inline" }, ["This election result will no longer be valid."]),
-            ]),
-          ]),
+          div({ className: 'dialog-description' }, [
+            span({}, ['Are you sure you want to archive this election? ']),
+            span({ className: 'no-padding display-inline' }, ['This election result will no longer be valid.'])
+          ])
+        ]),
 
         ConfirmationDialog({
           isRendered: this.state.showDialogCancel,
@@ -513,53 +576,69 @@ class AdminManageDul extends Component {
           title: 'Cancel election?',
           color: 'cancel',
           payload: this.state.payload,
-          action: { label: "Yes", handler: this.dialogHandlerCancel }
+          action: { label: 'Yes', handler: this.dialogHandlerCancel }
         }, [
-            div({ className: "dialog-description" }, [
-              span({}, ["Are you sure you want to cancel the current election process? "]),
-              span({ className: "no-padding display-inline" }, ["The current election will be stopped without logging a result."]),
-            ]),
-            div({ className: "form-group" }, [
-              div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding" }, [
-                div({ className: "checkbox" }, [
-                  input({
-                    id: "chk_archiveCancelElection",
-                    type: "checkbox",
-                    className: "checkbox-inline",
-                    defaultChecked: this.state.archiveCheck,
-                    onChange: this.handleArchiveCheckbox
-                  }),
-                  label({
-                    id: "lbl_archiveCancelElection",
-                    htmlFor: "chk_archiveCancelElection",
-                    className: "regular-checkbox normal"
-                  }, ["Archive election"]),
-                ]),
-              ]),
-            ]),
+          div({ className: 'dialog-description' }, [
+            span({}, ['Are you sure you want to cancel the current election process? ']),
+            span({ className: 'no-padding display-inline' }, ['The current election will be stopped without logging a result.'])
           ]),
-
+          div({ className: 'form-group' }, [
+            div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
+              div({ className: 'checkbox' }, [
+                input({
+                  id: 'chk_archiveCancelElection',
+                  type: 'checkbox',
+                  className: 'checkbox-inline',
+                  defaultChecked: this.state.archiveCheck,
+                  onChange: this.handleArchiveCheckbox
+                }),
+                label({
+                  id: 'lbl_archiveCancelElection',
+                  htmlFor: 'chk_archiveCancelElection',
+                  className: 'regular-checkbox normal'
+                }, ['Archive election'])
+              ])
+            ])
+          ])
+        ]),
 
         ConfirmationDialog({
+          style: (this.state.dacMenuOpen) ? { content: {height: '400px' }} : {},
           isRendered: this.state.showDialogCreate,
           showModal: this.state.showDialogCreate,
           title: 'Create election?',
           color: 'dul',
-          disableOkBtn: this.state.disableOkBtn,
+          disableOkBtn: this.state.disableOkBtn ||
+            (_.isNil(this.state.selectedElection.dacId) && _.isEmpty(this.state.selectedDac)),
           disableNoBtn: this.state.disableCancelBtn,
-          action: { label: "Yes", handler: this.dialogHandlerCreate },
+          action: { label: 'Yes', handler: this.dialogHandlerCreate },
           alertMessage: this.state.alertMessage,
           alertTitle: this.state.alertTitle
-
         }, [
-            div({ className: "dialog-description" }, [
-              span({}, ["Are you sure you want the DAC to vote on this case? "]),
-              span({
-                isRendered: this.state.createWarning,
-                className: "no-padding display-inline"
-              }, ["The previous election will be archived and it's result will no longer be valid."]),
-            ])
-          ]),
+          div({ className: 'dialog-description' }, [
+            span({}, ['Are you sure you want the DAC to vote on this case? ']),
+            div({ isRendered: _.isNil(this.state.selectedElection.dacId) }, [
+              'This election requires a DAC assignment:',
+              h(Select, {
+                classNamePrefix: 'select',
+                isDisabled: false,
+                isClearable: true,
+                isMulti: false,
+                isSearchable: true,
+                name: 'dac',
+                onChange: (option) => this.onDacChange(option),
+                onMenuOpen: () => this.onDacMenuOpen(),
+                onMenuClose: () => this.onDacMenuClose(),
+                options: this.dacOptions(),
+                placeholder: 'Select a Data Access Committee...'
+              })
+            ]),
+            span({
+              isRendered: this.state.createWarning,
+              className: 'no-padding display-inline'
+            }, ['The previous election will be archived and it\'s result will no longer be valid.'])
+          ])
+        ]),
 
         ConfirmationDialog({
           isRendered: this.state.showDialogDelete,
@@ -568,31 +647,31 @@ class AdminManageDul extends Component {
           disableNoBtn: this.state.disableCancelBtn,
           title: 'Delete Consent?',
           color: 'cancel',
-          action: { label: "Yes", handler: this.dialogHandlerDelete }
+          action: { label: 'Yes', handler: this.dialogHandlerDelete }
         }, [
-            div({ className: "dialog-description" }, [
-              span({}, ["Are you sure you want to delete this Consent?"]),
-            ]),
-          ]),
+          div({ className: 'dialog-description' }, [
+            span({}, ['Are you sure you want to delete this Consent?'])
+          ])
+        ]),
         h(ReactTooltip, {
-          id: "tip_archive",
+          id: 'tip_archive',
           effect: 'solid',
           multiline: true,
           className: 'tooltip-wrapper'
         }),
         h(ReactTooltip, {
-          id: "tip_delete",
+          id: 'tip_delete',
           effect: 'solid',
           multiline: true,
           className: 'tooltip-wrapper'
         }),
         h(ReactTooltip, {
-          id: "tip_flag",
+          id: 'tip_flag',
           place: 'right',
           effect: 'solid',
           multiline: true,
           className: 'tooltip-wrapper'
-        }),
+        })
       ])
     );
   }

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -625,6 +625,7 @@ class AdminManageDul extends Component {
                 isClearable: true,
                 isMulti: false,
                 isSearchable: true,
+                maxMenuHeight: 210,
                 name: 'dac',
                 onChange: (option) => this.onDacChange(option),
                 onMenuOpen: () => this.onDacMenuOpen(),

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -46,11 +46,11 @@ class AdminManageDul extends Component {
   }
 
   getDACs = async () => {
-    // const dacs = await DAC.list();
-    // this.setState(prev => {
-    //   prev.dacList = dacs;
-    //   return prev;
-    // });
+    const dacs = await DAC.list();
+    this.setState(prev => {
+      prev.dacList = dacs;
+      return prev;
+    });
   };
 
   dacOptions = () => {

--- a/src/pages/AdminManageDul.js
+++ b/src/pages/AdminManageDul.js
@@ -46,11 +46,11 @@ class AdminManageDul extends Component {
   }
 
   getDACs = async () => {
-    const dacs = await DAC.list();
-    this.setState(prev => {
-      prev.dacList = dacs;
-      return prev;
-    });
+    // const dacs = await DAC.list();
+    // this.setState(prev => {
+    //   prev.dacList = dacs;
+    //   return prev;
+    // });
   };
 
   dacOptions = () => {
@@ -246,7 +246,7 @@ class AdminManageDul extends Component {
       let election = this.state.selectedElection;
       let consentId = election.consentId;
       let electionPromise = null;
-      if (_.isNil(election.dacId)) {
+      if (_.isNil(election.dacId) && !_.isEmpty(dac)) {
         electionPromise = Election.createElectionForDac(consentId, dac.dacId);
       } else {
         electionPromise = Election.createElection(consentId);


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-346

## Changes
UI for selecting a Data Access Committee (DAC) when a consent is unassociated to one.
Requires https://github.com/DataBiosphere/consent/pull/379

* In the case that there are no DACs to select from, the existing code path is followed. The DUL election is created for the consent and no DAC is associated to it.
* In the case that there are DACs, and the consent is unassociated, we show a select menu to choose a DAC. 
* In the case that there are DACs, and the consent is already associated, we do not show a select menu to choose a DAC.

## Case 1, no DACs to select from
![Screen Shot 2019-11-21 at 1 55 27 PM](https://user-images.githubusercontent.com/116679/69367766-db14ea80-0c66-11ea-95ae-4a9be4a94b37.png)

## Case 2, some DACs to select from
![Screen Shot 2019-11-21 at 1 54 53 PM](https://user-images.githubusercontent.com/116679/69367801-f3850500-0c66-11ea-91ec-aa361bc2d852.png)

![Screen Shot 2019-11-21 at 1 55 00 PM](https://user-images.githubusercontent.com/116679/69367841-0566a800-0c67-11ea-8694-f8f51a7db286.png)
