### PR TITLE
[DUOS-319][risk=no] Reorder Columns

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -408,12 +408,6 @@ export const DataSet = {
     return await res.json();
   },
 
-  findDictionary: async () => {
-    const url = `${await Config.getApiUrl()}/dataset/dictionary`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
-  },
-
   findDataSets: async dacUserId => {
     const url = `${await Config.getApiUrl()}/dataset?dacUserId=${dacUserId}`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -29,7 +29,6 @@ class DatasetCatalog extends Component {
       allChecked: false,
       dataSetList: {
         catalog: [],
-        dictionary: [],
         showDialogDelete: false,
         showDialogEnable: false,
         showDialogDisable: false,
@@ -64,20 +63,14 @@ class DatasetCatalog extends Component {
         this.props.history.push('profile');
       }
     } else {
-      const dictionary = await DataSet.findDictionary();
       let catalog = await DataSet.findDataSets(this.USER_ID);
       catalog.forEach((row, index) => {
         row.checked = false;
         row.ix = index;
       });
 
-      const data = {
-        catalog: catalog,
-        dictionary: dictionary
-      };
-
       this.setState({
-        dataSetList: data,
+        dataSetList: { catalog: catalog },
         currentPage: 1
       });
     }

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -48,13 +48,12 @@ class DatasetCatalog extends Component {
     this.openConnectDataset = this.openConnectDataset.bind(this);
     this.closeConnectDatasetModal = this.closeConnectDatasetModal.bind(this);
     this.okConnectDatasetModal = this.okConnectDatasetModal.bind(this);
-    this.openTranslatedDUL = this.openTranslatedDUL.bind(this);
     this.closeTranslatedDULModal = this.closeTranslatedDULModal.bind(this);
     this.okTranslatedDULModal = this.okTranslatedDULModal.bind(this);
 
     this.download = this.download.bind(this);
-    this.selectAll = this.selectAll.bind(this);
     this.exportToRequest = this.exportToRequest.bind(this);
+    this.defaultString = this.defaultString.bind(this);
   }
 
   async getDatasets() {
@@ -316,6 +315,11 @@ class DatasetCatalog extends Component {
     });
   };
 
+  defaultString(str, defaultStr) {
+    if (str.length === 0) { return defaultStr; }
+    return str;
+  };
+
   render() {
 
     const { searchDulText, currentPage, limit } = this.state;
@@ -536,7 +540,9 @@ class DatasetCatalog extends Component {
                           td({
                             id: trIndex + '_scid', name: 'sc-id', className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '')
                           }, [
-                            get(find(dataSet.properties, p => { return p.propertyName === 'Sample Collection ID'; }), 'propertyValue', '')
+                            this.defaultString(
+                              get(find(dataSet.properties, p => { return p.propertyName === 'Sample Collection ID'; }), 'propertyValue', ''),
+                              '---')
                           ]),
 
                           td({ isRendered: this.state.isAdmin, className: 'table-items cell-size' }, [

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -64,16 +64,16 @@ class DatasetCatalog extends Component {
       }
     } else {
       const customSortOrder = {
-        "Dataset Name": 1,
-        "# of participants": 2,
-        "Phenotype/Indication": 3,
-        "Description": 4,
-        "Data Type": 5,
-        "Species": 6,
-        "Data Depositor": 7,
-        "Principal Investigator(PI)": 8,
-        "Sample Collection ID": 1000, // Not used in rendering
-        "dbGAP": 2000 // Not used in rendering
+        "Dataset Name": 0,
+        "# of participants": 1,
+        "Phenotype/Indication": 2,
+        "Description": 3,
+        "Data Type": 4,
+        "Species": 5,
+        "Data Depositor": 6,
+        "Principal Investigator(PI)": 7,
+        "dbGAP": 8,
+        "Sample Collection ID": 9
       };
       const dictionarySortFunction = o => { return customSortOrder[o.key]; };
       const dictionary = sortBy(await DataSet.findDictionary(), [dictionarySortFunction]);
@@ -474,7 +474,7 @@ class DatasetCatalog extends Component {
                         }),
 
                         td({ id: trIndex + "_consentId", name: "consentId", className: "table-items cell-size " + (!dataSet.active ? 'dataset-disabled' : '') }, [dataSet.consentId]),
-                        td({ id: trIndex + "_scid", name: "sc-id", className: "table-items cell-size " + (!dataSet.active ? 'dataset-disabled' : '') }, [dataSet.properties[1].propertyValue === '' ? "---" : dataSet.properties[1].propertyValue]),
+                        td({ id: trIndex + "_scid", name: "sc-id", className: "table-items cell-size " + (!dataSet.active ? 'dataset-disabled' : '') }, [dataSet.properties[9].propertyValue === '' ? "---" : dataSet.properties[9].propertyValue]),
                         td({ className: "table-items cell-size " + (!dataSet.active ? 'dataset-disabled' : '') }, [
                           a({ id: trIndex + "_linkTranslatedDul", name: "link_translatedDul", onClick: this.openTranslatedDUL(dataSet.translatedUseRestriction), className: (!dataSet.active ? 'dataset-disabled' : 'enabled') }, ["Translated Use Restriction"])
                         ]),

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -330,7 +330,7 @@ class DatasetCatalog extends Component {
                 iconSize: "large",
                 color: "dataset",
                 title: "Dataset Catalog",
-                description: "Datasets with an associated DUL to apply for secondary use"
+                description: "Use the table below to search and selects datasets you would like to request"
               }),
             ]),
 
@@ -345,9 +345,9 @@ class DatasetCatalog extends Component {
                 onClick: this.download,
                 className: "col-lg-5 col-md-5 col-sm-5 col-xs-5 btn-primary dataset-background"
               }, [
-                  "Download selection",
-                  span({ className: "glyphicon glyphicon-download", style: { 'marginLeft': '5px' }, "aria-hidden": "true" })
-                ]),
+                "Download selection",
+                span({ className: "glyphicon glyphicon-download", style: { 'marginLeft': '5px' }, "aria-hidden": "true" })
+              ]),
             ]),
           ]),
 
@@ -373,7 +373,7 @@ class DatasetCatalog extends Component {
                         ])
                       ]);
                     }),
-                    th({ className: "table-titles dataset-color cell-size" }, ["Consent Id"]),
+                    th({ className: "table-titles dataset-color cell-size" }, ["Consent ID"]),
                     th({ className: "table-titles dataset-color cell-size" }, ["SC-ID"]),
                     th({ className: "table-titles dataset-color cell-size" }, ["Structured Data Use Limitations"]),
                     th({ isRendered: this.state.isAdmin, className: "table-titles dataset-color cell-size" }, ["Approved Requestors"]),
@@ -391,16 +391,16 @@ class DatasetCatalog extends Component {
                             td({
                               isRendered: property.propertyName === 'Sample Collection ID'
                             }, [
-                                div({ className: "checkbox" }, [
-                                  input({
-                                    type: "checkbox",
-                                    id: trIndex + "_chkSelect",
-                                    name: "chk_select",
-                                    checked: dataSet.checked, className: "checkbox-inline user-checkbox", "add-object-id": "true", onChange: this.checkSingleRow(dataSet.ix)
-                                  }),
-                                  label({ className: "regular-checkbox rp-choice-questions", htmlFor: trIndex + "_chkSelect" }),
-                                ])
+                              div({ className: "checkbox" }, [
+                                input({
+                                  type: "checkbox",
+                                  id: trIndex + "_chkSelect",
+                                  name: "chk_select",
+                                  checked: dataSet.checked, className: "checkbox-inline user-checkbox", "add-object-id": "true", onChange: this.checkSingleRow(dataSet.ix)
+                                }),
+                                label({ className: "regular-checkbox rp-choice-questions", htmlFor: trIndex + "_chkSelect" }),
                               ])
+                            ])
                           ]);
                         }),
 
@@ -424,8 +424,8 @@ class DatasetCatalog extends Component {
                                 a({
                                   id: trIndex + "_btnConnect", name: "btn_connect", onClick: () => this.openConnectDataset(dataSet)
                                 }, [
-                                    span({ className: "cm-icon-button glyphicon glyphicon-link caret-margin " + (dataSet.isAssociatedToDataOwners ? 'dataset-color' : 'default-color'), "aria-hidden": "true", "data-tip": "Connect with Data Owner", "data-for": "tip_connect" })
-                                  ]),
+                                  span({ className: "cm-icon-button glyphicon glyphicon-link caret-margin " + (dataSet.isAssociatedToDataOwners ? 'dataset-color' : 'default-color'), "aria-hidden": "true", "data-tip": "Connect with Data Owner", "data-for": "tip_connect" })
+                                ]),
                               ])
                             ])
                           ]);
@@ -438,18 +438,18 @@ class DatasetCatalog extends Component {
                               p({ isRendered: property.propertyName !== 'dbGAP' }, [
                                 span({ id: trIndex + "_datasetName", name: "datasetName", isRendered: property.propertyName === 'Dataset Name' }),
                                 span({ id: trIndex + "_datasetId", name: "datasetId", isRendered: property.propertyName === 'Dataset ID' }),
+                                span({ id: trIndex + "_participants", name: "participants", isRendered: property.propertyName === '# of participants' }),
+                                span({ id: trIndex + "_phenotype", name: "phenotype", isRendered: property.propertyName === 'Phenotype/Indication' }),
+                                span({ id: trIndex + "_description", name: "description", isRendered: property.propertyName === 'Description' }),
                                 span({ id: trIndex + "_dataType", name: "dataType", isRendered: property.propertyName === 'Data Type' }),
                                 span({ id: trIndex + "_species", name: "species", isRendered: property.propertyName === 'Species' }),
-                                span({ id: trIndex + "_phenotype", name: "phenotype", isRendered: property.propertyName === 'Phenotype/Indication' }),
-                                span({ id: trIndex + "_participants", name: "participants", isRendered: property.propertyName === '# of participants' }),
-                                span({ id: trIndex + "_description", name: "description", isRendered: property.propertyName === 'Description' }),
                                 property.propertyValue
                               ]),
 
                               a({
                                 id: trIndex + "_linkdbGap",
                                 name: "link_dbGap",
-                                isRendered: property.propertyName === 'dbGAP',
+                                isRendered: property.propertyName === 'Repository',
                                 href: property.propertyValue,
                                 target: "_blank",
                                 className: (property.propertyValue.length > 0 ? 'enabled' : property.propertyValue.length === 0 ? 'disabled' : '')

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -1,3 +1,4 @@
+import sortBy from 'lodash/sortBy';
 import { Component, Fragment } from 'react';
 import { div, button, table, thead, tbody, th, tr, td, form, h, input, label, span, a, p } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
@@ -62,12 +63,26 @@ class DatasetCatalog extends Component {
         this.props.history.push('profile');
       }
     } else {
-
-      const dictionary = await DataSet.findDictionary();
-      const catalog = await DataSet.findDataSets(this.USER_ID);
+      const customSortOrder = {
+        "Dataset Name": 1,
+        "# of participants": 2,
+        "Phenotype/Indication": 3,
+        "Description": 4,
+        "Data Type": 5,
+        "Species": 6,
+        "Data Depositor": 7,
+        "Principal Investigator(PI)": 8,
+        "Sample Collection ID": 1000, // Not used in rendering
+        "dbGAP": 2000 // Not used in rendering
+      };
+      const dictionarySortFunction = o => { return customSortOrder[o.key]; };
+      const dictionary = sortBy(await DataSet.findDictionary(), [dictionarySortFunction]);
+      const catalogPropertySortFunction = o => { return customSortOrder[o.propertyName]; };
+      let catalog = await DataSet.findDataSets(this.USER_ID);
       catalog.forEach((row, index) => {
         row.checked = false;
         row.ix = index;
+        row.properties = sortBy(row.properties, [catalogPropertySortFunction]);
       });
 
       const data = {
@@ -449,7 +464,7 @@ class DatasetCatalog extends Component {
                               a({
                                 id: trIndex + "_linkdbGap",
                                 name: "link_dbGap",
-                                isRendered: property.propertyName === 'Repository',
+                                isRendered: property.propertyName === 'dbGAP',
                                 href: property.propertyValue,
                                 target: "_blank",
                                 className: (property.propertyValue.length > 0 ? 'enabled' : property.propertyValue.length === 0 ? 'disabled' : '')

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -72,8 +72,8 @@ class DatasetCatalog extends Component {
         "Species": 5,
         "Data Depositor": 6,
         "Principal Investigator(PI)": 7,
-        "dbGAP": 8,
-        "Sample Collection ID": 9
+        "dbGAP": 8, // Not dynamically rendered
+        "Sample Collection ID": 9 // Not dynamically rendered
       };
       const dictionarySortFunction = o => { return customSortOrder[o.key]; };
       const dictionary = sortBy(await DataSet.findDictionary(), [dictionarySortFunction]);


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-319
Recommended to hide whitespace when viewing diffs.

## Changes
Reorder columns. New display order:
* Dataset ID
* Dataset Name
* dbGAP
* Structured Data Use Limitations
* Data Type
* Phenotype/Indication
* Principal Investigator
* \# of participants
* Description
* Species
* Data Depositor
* Consent ID
* SC-ID
* Approved Requestors

### Old Screen
![Screen Shot 2019-12-04 at 8 19 44 AM](https://user-images.githubusercontent.com/116679/70145836-ed335780-166e-11ea-82b1-62615e6f83a2.png)

### New Screen
Left hand side of the table:
![Screen Shot 2019-12-05 at 10 02 05 AM](https://user-images.githubusercontent.com/116679/70246905-75386080-1746-11ea-87fa-1df513e3de29.png)

Right hand side of the table:
![Screen Shot 2019-12-05 at 10 02 14 AM](https://user-images.githubusercontent.com/116679/70246919-7b2e4180-1746-11ea-9389-552c644d2323.png)
