### PR TITLE
[DUOS-417][risk=no] Show datasets associated to a DAC

### DIFF
--- a/src/components/ReadMore.js
+++ b/src/components/ReadMore.js
@@ -1,0 +1,59 @@
+import get from 'lodash/get';
+import { Component } from 'react';
+import { a, div, hh, span } from 'react-hyperscript-helpers';
+import ReactTooltip from 'react-tooltip';
+
+
+export const ReadMore = hh(class ReadMore extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      expanded: false,
+      content: get(this.props, 'content', ''),
+      className: get(this.props, 'className', ''),
+      style: get(this.props, 'style', {}),
+      charLimit: get(this.props, 'charLimit', 100),
+      readMoreText: get(this.props, 'readMoreText', 'Read More'),
+      readLessText: get(this.props, 'readLessText', 'Read Less')
+    };
+  }
+
+  componentDidMount() {
+    ReactTooltip.rebuild();
+  }
+
+  getContent = () => {
+    if (this.state.expanded) {
+      return this.state.content;
+    } else {
+      return this.state.content.slice(0, this.state.charLimit) + ' ...';
+    }
+  };
+
+  readMore = () => {
+    this.setState(prev => {
+      prev.expanded = true;
+      return prev;
+    });
+  };
+
+  readLess = () => {
+    this.setState(prev => {
+      prev.expanded = false;
+      return prev;
+    });
+  };
+
+  render() {
+    const readLink = this.state.expanded ?
+      a({ onClick: () => this.readLess() }, [this.state.readLessText]) :
+      a({ onClick: () => this.readMore() }, [this.state.readMoreText]);
+    return div({}, [
+      span({
+        className: this.state.className,
+        style: this.state.style,
+      }, this.getContent()),
+      readLink
+    ]);
+  }
+});

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -1,0 +1,22 @@
+import { Component } from 'react';
+import { div, hh } from 'react-hyperscript-helpers';
+import { BaseModal } from '../BaseModal';
+
+
+export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
+
+  render() {
+    return (BaseModal({
+      id: 'dacDatasetsModal',
+      showModal: this.props.showModal,
+      onRequestClose: this.props.onCloseRequest,
+      color: 'common',
+      type: 'informative',
+      iconSize: 'none',
+      title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
+      action: { label: 'Close', handler: this.props.onCloseRequest }
+    },
+      [div({}, [JSON.stringify(this.props.datasets)])]));
+  }
+
+});

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -1,22 +1,97 @@
+import find from 'lodash/find';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
 import { Component } from 'react';
-import { div, hh } from 'react-hyperscript-helpers';
+import { a, div, hh, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 
 
 export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
 
+  getProperty = (properties, propName) => {
+    return find(properties, p => { return p.propertyName.toLowerCase() === propName.toLowerCase(); });
+  };
+
+  getPropertyValue = (properties, propName, defaultValue) => {
+    const prop = this.getProperty(properties, propName);
+    const val = get(prop, 'propertyValue', '');
+    return isEmpty(val) ? defaultValue : val;
+  };
+
+  getDbGapLinkValue = (properties) => {
+    const href = this.getPropertyValue(properties, 'dbGAP', '');
+    return a({
+      name: 'link_dbGap',
+      href: href,
+      target: '_blank',
+      className: (href.length > 0 ? 'enabled' : 'disabled')
+    }, ['Link']);
+  };
+
+  getStructuredUseRestrictionLink = (dataset) => {
+    return a({
+      name: 'link_translatedDul',
+      // onClick: this.openTranslatedDUL(dataset.translatedUseRestriction),
+      className: (!dataset.active ? 'dataset-disabled' : 'enabled')
+    }, ['Translated Use Restriction']);
+  };
+
   render() {
     return (BaseModal({
-      id: 'dacDatasetsModal',
-      showModal: this.props.showModal,
-      onRequestClose: this.props.onCloseRequest,
-      color: 'common',
-      type: 'informative',
-      iconSize: 'none',
-      title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
-      action: { label: 'Close', handler: this.props.onCloseRequest }
-    },
-      [div({}, [JSON.stringify(this.props.datasets)])]));
+        id: 'dacDatasetsModal',
+        showModal: this.props.showModal,
+        onRequestClose: this.props.onCloseRequest,
+        color: 'common',
+        type: 'informative',
+        iconSize: 'none',
+        customStyles: { width: '80%' },
+        title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
+        action: { label: 'Close', handler: this.props.onCloseRequest }
+      },
+      [
+        div({ className: 'table-scroll', style: { margin: 0 } }, [
+          table({ className: 'table' }, [
+            thead({}, [
+              tr({}, [
+                th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Id']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Name']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['dbGap']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Structured Data Use Limitations']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Data Type']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Phenotype/Indication']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Principal Investigator(PI)']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['# of participants']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Description']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Species']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Data Depositor']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['Consent ID']),
+                th({ className: 'table-titles dataset-color cell-size' }, ['SC-ID'])
+              ])
+            ]),
+            tbody({}, [
+              // JSON.stringify(this.props.datasets),
+              this.props.datasets.map((dataset) => {
+                return tr({}, [
+                  td({ style: { position: 'relative' } }, [dataset.alias]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
+                  td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(dataset)]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, '# of participants', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Description', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Species', '---')]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Depositor', '---')]),
+                  td({ className: 'table-items cell-size' }, [dataset.consentId]),
+                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Sample Collection ID', '---')])
+                ]);
+              })
+            ])
+          ])
+        ])
+      ])
+    );
   }
 
 });

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -2,7 +2,7 @@ import find from 'lodash/find';
 import get from 'lodash/get';
 import isEmpty from 'lodash/isEmpty';
 import { Component } from 'react';
-import { a, div, hh, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
+import { a, div, hh, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 
 
@@ -15,17 +15,14 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
   getPropertyValue = (properties, propName, defaultValue) => {
     const prop = this.getProperty(properties, propName);
     const val = get(prop, 'propertyValue', '');
-    return isEmpty(val) ? defaultValue : val;
+    return isEmpty(val) ? span({ className: 'disabled' }, [defaultValue]) : val;
   };
 
   getDbGapLinkValue = (properties) => {
     const href = this.getPropertyValue(properties, 'dbGAP', '');
-    return a({
-      name: 'link_dbGap',
-      href: href,
-      target: '_blank',
-      className: (href.length > 0 ? 'enabled' : 'disabled')
-    }, ['Link']);
+    return href.length > 0 ?
+      a({ name: 'link_dbGap', href: href, target: '_blank', className: 'enabled' }, ['Link']) :
+      span({ name: 'link_dbGap', className: 'disabled' }, ['---']);
   };
 
   getStructuredUseRestrictionLink = (dataset) => {
@@ -38,59 +35,61 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
 
   render() {
     return (BaseModal({
-        id: 'dacDatasetsModal',
-        showModal: this.props.showModal,
-        onRequestClose: this.props.onCloseRequest,
-        color: 'common',
-        type: 'informative',
-        iconSize: 'none',
-        customStyles: { width: '80%' },
-        title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
-        action: { label: 'Close', handler: this.props.onCloseRequest }
-      },
-      [
-        div({ className: 'table-scroll', style: { margin: 0 } }, [
-          table({ className: 'table' }, [
-            thead({}, [
-              tr({}, [
-                th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Id']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Name']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['dbGap']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Structured Data Use Limitations']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Data Type']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Phenotype/Indication']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Principal Investigator(PI)']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['# of participants']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Description']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Species']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Data Depositor']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['Consent ID']),
-                th({ className: 'table-titles dataset-color cell-size' }, ['SC-ID'])
+          id: 'dacDatasetsModal',
+          showModal: this.props.showModal,
+          onRequestClose: this.props.onCloseRequest,
+          color: 'common',
+          type: 'informative',
+          iconSize: 'none',
+          customStyles: { width: '80%' },
+          title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
+          action: { label: 'Close', handler: this.props.onCloseRequest }
+        },
+        [
+          div({ className: 'table-scroll', style: { margin: 0 } }, [
+            table({ className: 'table' }, [
+              thead({}, [
+                tr({}, [
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Id']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Name']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['dbGap']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Structured Data Use Limitations']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Data Type']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Phenotype/Indication']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Principal Investigator(PI)']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['# of participants']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Description']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Species']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Data Depositor']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['Consent ID']),
+                  th({ className: 'table-titles dataset-color cell-size' }, ['SC-ID'])
+                ])
+              ]),
+              tbody({}, [
+                // JSON.stringify(this.props.datasets),
+                this.props.datasets.map((dataset) => {
+                  return tr({}, [
+                    td({ style: { position: 'relative' } }, [dataset.alias]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
+                    td({ className: 'table-items cell-size' }, [
+                      this.getStructuredUseRestrictionLink(dataset)
+                    ]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, '# of participants', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Description', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Species', '---')]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Depositor', '---')]),
+                    td({ className: 'table-items cell-size' }, [dataset.consentId]),
+                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Sample Collection ID', '---')])
+                  ]);
+                })
               ])
-            ]),
-            tbody({}, [
-              // JSON.stringify(this.props.datasets),
-              this.props.datasets.map((dataset) => {
-                return tr({}, [
-                  td({ style: { position: 'relative' } }, [dataset.alias]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
-                  td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(dataset)]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, '# of participants', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Description', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Species', '---')]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Depositor', '---')]),
-                  td({ className: 'table-items cell-size' }, [dataset.consentId]),
-                  td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Sample Collection ID', '---')])
-                ]);
-              })
             ])
           ])
         ])
-      ])
     );
   }
 

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -4,6 +4,7 @@ import isEmpty from 'lodash/isEmpty';
 import { Component } from 'react';
 import { a, div, hh, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
+import { ReadMore } from '../ReadMore';
 
 
 export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
@@ -26,11 +27,16 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
   };
 
   getStructuredUseRestrictionLink = (dataset) => {
-    return a({
-      name: 'link_translatedDul',
-      // onClick: this.openTranslatedDUL(dataset.translatedUseRestriction),
-      className: (!dataset.active ? 'dataset-disabled' : 'enabled')
-    }, ['Translated Use Restriction']);
+    const trimmedContent = dataset.translatedUseRestriction.trim();
+    if (isEmpty(trimmedContent)) {
+      return span({ className: 'disabled' }, ['---']);
+    }
+    return ReadMore({
+      content: trimmedContent,
+      className: 'row no-margin',
+      style: { whiteSpace: 'pre-line' },
+      charLimit: 30
+    });
   };
 
   render() {
@@ -66,15 +72,12 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
                 ])
               ]),
               tbody({}, [
-                // JSON.stringify(this.props.datasets),
                 this.props.datasets.map((dataset) => {
                   return tr({}, [
-                    td({ style: { position: 'relative' } }, [dataset.alias]),
+                    td({ className: 'table-items cell-size', style: { position: 'relative' } }, [dataset.alias]),
                     td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
                     td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
-                    td({ className: 'table-items cell-size' }, [
-                      this.getStructuredUseRestrictionLink(dataset)
-                    ]),
+                    td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(dataset)]),
                     td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),
                     td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')]),
                     td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')]),

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -173,6 +173,12 @@ export const DAC = {
     return res.json();
   },
 
+  datasets: async (dacId) => {
+    const url = `${await Config.getApiUrl()}/dac/${dacId}/datasets`;
+    const res = await fetchOk(url, Config.authOpts());
+    return res.json();
+  },
+
   membership: async (dacId) => {
     const url = `${await Config.getApiUrl()}/dac/${dacId}/membership`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/pages/AdminManageDac.js
+++ b/src/pages/AdminManageDac.js
@@ -20,6 +20,7 @@ class AdminManageDac extends Component {
     this.state = {
       currentPage: 1,
       showDacModal: false,
+      showDatasetsModal: false,
       showMembersModal: false,
       value: '',
       limit: limit,
@@ -29,8 +30,6 @@ class AdminManageDac extends Component {
       alertTitle: undefined,
       selectedDac: {}
     };
-
-    this.handlePageChange = this.handlePageChange.bind(this);
 
     this.addDac = this.addDac.bind(this);
     this.closeAddDacModal = this.closeAddDacModal.bind(this);
@@ -120,6 +119,22 @@ class AdminManageDac extends Component {
     });
   }
 
+  viewDatasets = (selectedDac) => {
+    this.setState(prev => {
+      prev.showDatasetsModal = true;
+      prev.selectedDac = selectedDac;
+      return prev;
+    });
+  };
+
+  closeViewDatasetsModal = () => {
+    this.setState(prev => {
+      prev.showDatasetsModal = false;
+      prev.selectedDac = {};
+      return prev;
+    });
+  };
+
   handleSearchDac = (query) => {
     this.setState({ searchDacText: query });
   };
@@ -193,10 +208,16 @@ class AdminManageDac extends Component {
                       title: dac.description
                     }, [dac.description]),
                     div({
-                      id: dac.dacId + '_dacDatasets',
-                      name: 'dacDatasets',
-                      className: 'col-2 cell-body text'
-                    }, ['---']),
+                      className: 'col-2 cell-body'
+                    }, [
+                      button({
+                        id: dac.dacId + '_dacDatasets',
+                        name: 'dacDatasets',
+                        className: 'cell-button hover-color',
+                        style: actionButtonStyle,
+                        onClick: () => this.viewDatasets(dac)
+                      }, ['View'])
+                    ]),
                     div({
                       className: 'col-2 cell-body f-center'
                     }, [

--- a/src/pages/AdminManageDac.js
+++ b/src/pages/AdminManageDac.js
@@ -28,7 +28,8 @@ class AdminManageDac extends Component {
       searchDUL: '',
       alertMessage: undefined,
       alertTitle: undefined,
-      selectedDac: {}
+      selectedDac: {},
+      datasets: []
     };
 
     this.addDac = this.addDac.bind(this);
@@ -120,9 +121,11 @@ class AdminManageDac extends Component {
   }
 
   viewDatasets = (selectedDac) => {
+    const datasets = DAC.datasets(selectedDac.dacId);
     this.setState(prev => {
       prev.showDatasetsModal = true;
       prev.selectedDac = selectedDac;
+      prev.datasets = datasets;
       return prev;
     });
   };
@@ -131,6 +134,7 @@ class AdminManageDac extends Component {
     this.setState(prev => {
       prev.showDatasetsModal = false;
       prev.selectedDac = {};
+      prev.datasets = [];
       return prev;
     });
   };

--- a/src/pages/AdminManageDac.js
+++ b/src/pages/AdminManageDac.js
@@ -2,6 +2,7 @@ import { Component, Fragment } from 'react';
 import { a, button, div, h, hr, span } from 'react-hyperscript-helpers';
 import ReactTooltip from 'react-tooltip';
 import { AddDacModal } from '../components/modals/AddDacModal';
+import { DacDatasetsModal } from '../components/modals/DacDatasetsModal';
 import { DacMembersModal } from '../components/modals/DacMembersModal';
 import { PageHeading } from '../components/PageHeading';
 import { PaginatorBar } from '../components/PaginatorBar';
@@ -29,7 +30,7 @@ class AdminManageDac extends Component {
       alertMessage: undefined,
       alertTitle: undefined,
       selectedDac: {},
-      datasets: []
+      selectedDatasets: []
     };
 
     this.addDac = this.addDac.bind(this);
@@ -120,12 +121,12 @@ class AdminManageDac extends Component {
     });
   }
 
-  viewDatasets = (selectedDac) => {
-    const datasets = DAC.datasets(selectedDac.dacId);
+  viewDatasets = async (selectedDac) => {
+    const datasets = await DAC.datasets(selectedDac.dacId);
     this.setState(prev => {
       prev.showDatasetsModal = true;
       prev.selectedDac = selectedDac;
-      prev.datasets = datasets;
+      prev.selectedDatasets = datasets;
       return prev;
     });
   };
@@ -134,7 +135,7 @@ class AdminManageDac extends Component {
     this.setState(prev => {
       prev.showDatasetsModal = false;
       prev.selectedDac = {};
-      prev.datasets = [];
+      prev.selectedDatasets = [];
       return prev;
     });
   };
@@ -259,6 +260,14 @@ class AdminManageDac extends Component {
             onOKRequest: this.closeViewMembersModal,
             onCloseRequest: this.closeViewMembersModal,
             dac: this.state.selectedDac
+          }),
+          DacDatasetsModal({
+            isRendered: this.state.showDatasetsModal,
+            showModal: this.state.showDatasetsModal,
+            onOKRequest: this.closeViewDatasetsModal,
+            onCloseRequest: this.closeViewDatasetsModal,
+            dac: this.state.selectedDac,
+            datasets: this.state.selectedDatasets
           }),
           AddDacModal({
             isRendered: this.state.showDacModal,


### PR DESCRIPTION
## Addresses
Partially addresses https://broadinstitute.atlassian.net/browse/DUOS-417
Requires API work: https://github.com/DataBiosphere/consent/pull/388

## Changes
Add a modal for showing the datasets associated to a DAC

### New DAC Manage Screen:
![Screen Shot 2019-12-10 at 11 23 14 AM](https://user-images.githubusercontent.com/116679/70547872-a72f3580-1b3f-11ea-999b-a494cf4415ef.png)

### Dataset View, Minimized
![Screen Shot 2019-12-10 at 11 23 21 AM](https://user-images.githubusercontent.com/116679/70547899-b615e800-1b3f-11ea-8da3-4afc8224ace5.png)

### Dataset View, Expanded
![Screen Shot 2019-12-10 at 11 23 28 AM](https://user-images.githubusercontent.com/116679/70547923-bdd58c80-1b3f-11ea-9e06-c33a646519d3.png)

### Dataset View, Handling Missing Data
![Screen Shot 2019-12-10 at 11 23 42 AM](https://user-images.githubusercontent.com/116679/70547959-cd54d580-1b3f-11ea-8023-7643a62bda9e.png)