### PR TITLE
[DUOS-302][risk=no] Fix Alignment for Chrome

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -403,7 +403,7 @@ class DatasetCatalog extends Component {
                             ])
                           ]),
 
-                          td({ isRendered: this.state.isAdmin, style: { minWidth: '10rem' } }, [
+                          td({ isRendered: this.state.isAdmin, style: { minWidth: '11rem' } }, [
                             div({ className: 'dataset-actions' }, [
                               a({
                                 id: trIndex + '_btnDelete', name: 'btn_delete', onClick: this.openDelete(dataSet.dataSetId),


### PR DESCRIPTION
Filing under https://github.com/DataBiosphere/duos-ui/pull/new/DUOS-302
Minor style alignment so the actions column aligns the same in both FF and Chrome.

## New Chrome Screen
<img width="1274" alt="Screen Shot 2019-12-10 at 2 04 29 PM" src="https://user-images.githubusercontent.com/116679/70560361-70184e80-1b56-11ea-962a-37f0abb1bd34.png">
