### PR TITLE
[DUOS-345][risk=no] Updates to the add/edit user screen

### DIFF
--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -1,150 +1,71 @@
+import _ from 'lodash';
 import React, { Component, Fragment } from 'react';
-import { div, form, input, label, hh, h, select, option } from 'react-hyperscript-helpers';
-import { BaseModal } from '../BaseModal';
-import { User } from "../../libs/ajax";
+import { div, form, h, hh, input, label } from 'react-hyperscript-helpers';
+import { User } from '../../libs/ajax';
 import { Alert } from '../Alert';
-import { USER_ROLES_UPPER } from '../../libs/utils';
+import { BaseModal } from '../BaseModal';
 
-const ADMIN_ROLE_ID = 4;
+
+const adminRole = { 'roleId': 4, 'name': 'Admin' };
 
 export const AddUserModal = hh(class AddUserModal extends Component {
 
   constructor(props) {
     super(props);
 
-    this.state = this.initialState();
-
-    this.toggleState = this.toggleState.bind(this);
-    this.handleChange = this.handleChange.bind(this);
-    this.nameRef = React.createRef();
-    this.emailRef = React.createRef();
-  }
-
-  initialState() {
-    let initialValue;
-
-    let rolesState = {};
-    rolesState[USER_ROLES_UPPER.admin] = false;
-    rolesState[USER_ROLES_UPPER.alumni] = false;
-    rolesState[USER_ROLES_UPPER.chairperson] = false;
-    rolesState[USER_ROLES_UPPER.dataOwner] = false;
-    rolesState[USER_ROLES_UPPER.member] = false;
-    rolesState[USER_ROLES_UPPER.researcher] = false;
-
-    initialValue = {
+    this.state = {
       displayName: '',
       email: '',
       displayNameValid: false,
       emailValid: false,
       invalidForm: true,
       submitted: false,
-      roleValid: false,
       alerts: [],
-      rolesState: rolesState,
-      roles: [],
-      delegateDacUser: {
-        needsDelegation: false,
-        delegateCandidates: []
-      },
-      delegateDataOwner: {
-        needsDelegation: false,
-        delegateCandidates: []
-      },
-      alternativeDACMemberUser: '',
-      alternativeDataOwnerUser: ''
+      originalRoles: [],
+      updatedRoles: [],
+      emailPreference: false
     };
 
-    return initialValue;
+    this.nameRef = React.createRef();
+    this.emailRef = React.createRef();
   }
 
-  componentDidMount() {
-    this.initForm();
-  }
-
-  async initForm() {
-
+  async componentDidMount() {
     if (this.props.showModal === false) {
       return;
     }
 
-    let rolesState = {};
-    rolesState[USER_ROLES_UPPER.admin] = false;
-    rolesState[USER_ROLES_UPPER.alumni] = false;
-    rolesState[USER_ROLES_UPPER.chairperson] = false;
-    rolesState[USER_ROLES_UPPER.dataOwner] = false;
-    rolesState[USER_ROLES_UPPER.member] = false;
-    rolesState[USER_ROLES_UPPER.researcher] = false;
-
-    if (this.props.user && this.props.user !== undefined) {
-
+    if (this.props.user) {
       const user = await User.getByEmail(this.props.user.email);
-
-      user.roles.forEach(role => {
-        rolesState[role.name.toUpperCase()] = true;
-      });
-
+      const updatedRoles = _.map(user.roles, (ur) => {return { 'roleId': ur.roleId, 'name': ur.name };});
       this.setState({
-        mode: 'Edit',
-        roles: user.roles.map(role => role.name.toUpperCase()),
-        displayName: user.displayName,
-        email: user.email,
-        additionalEmail: user.additionalEmail,
-        user: user,
-        rolesState: Object.assign({}, rolesState),
-        originalRolesState: Object.assign({}, rolesState),
-        originalRoles: user.roles.slice(),
-        emailPreference: !user.emailPreference,
-        delegateDacUser: {
-          needsDelegation: false,
-          delegateCandidates: []
+          mode: 'Edit',
+          displayName: user.displayName,
+          email: user.email,
+          additionalEmail: user.additionalEmail,
+          user: user,
+          originalRoles: user.roles,
+          updatedRoles: updatedRoles,
+          emailPreference: user.emailPreference
         },
-        delegateDataOwner: {
-          needsDelegation: false,
-          delegateCandidates: []
-        },
-        delegateMemberRequired: false,
-        newAlternativeUserNeeded: {},
-        newUserNeeded: false,
-      },
         () => {
           let r1 = this.nameRef.current;
           let r2 = this.emailRef.current;
-
           this.setState({
-            wasChairperson: rolesState[USER_ROLES_UPPER.chairperson],
-            wasMember: rolesState[USER_ROLES_UPPER.member],
-            wasDataOwner: rolesState[USER_ROLES_UPPER.dataOwner],
-            wasResearcher: rolesState[USER_ROLES_UPPER.researcher],
             displayNameValid: r1.validity.valid,
-            emailValid: r2.validity.valid,
+            emailValid: r2.validity.valid
           });
         });
     } else {
       this.setState({
-        mode: 'Add',
-        roles: [],
-        displayName: '',
-        email: '',
-        additionalEmail: '',
-        rolesState: Object.assign({}, rolesState),
-        originalRolesState: Object.assign({}, rolesState),
-        emailPreference: false,
-        delegateDacUser: {
-          needsDelegation: false,
-          delegateCandidates: []
+          mode: 'Add',
+          displayName: '',
+          email: '',
+          additionalEmail: '',
+          originalRoles: [],
+          updatedRoles: [],
+          emailPreference: false
         },
-        delegateDataOwner: {
-          needsDelegation: false,
-          delegateCandidates: []
-        },
-        delegateMemberRequired: false,
-        newAlternativeUserNeeded: {},
-        wasChairperson: false,
-        wasMember: false,
-        wasDataOwner: false,
-        wasResearcher: false,
-        newUserNeeded: false,
-      },
         () => {
           let r1 = this.nameRef.current;
           let r2 = this.emailRef.current;
@@ -157,52 +78,27 @@ export const AddUserModal = hh(class AddUserModal extends Component {
   }
 
   OKHandler = async (event) => {
-
     event.persist();
-
-    let key;
-    let updatedRoles = [];
-
     this.setState({
       submitted: true
     });
-
-    const validForm = this.state.displayNameValid && this.state.emailValid && this.state.roleValid;
-
+    const validForm = this.state.displayNameValid && this.state.emailValid;
     if (validForm === false) {
       return;
     }
-
-    for (key in this.state.rolesState) {
-
-      if (this.state.rolesState[key] === true) {
-        if (key === USER_ROLES_UPPER.admin) {
-          updatedRoles.push({
-            name: key,
-            emailPreference: !this.state.emailPreference,
-            roleId: ADMIN_ROLE_ID
-          });
-        } else updatedRoles.push({
-          name: key
-        });
-      }
-    }
-
     switch (this.state.mode) {
-
       case 'Add':
         const newUser = {
           displayName: this.state.displayName,
           email: this.state.email,
-          roles: updatedRoles
+          emailPreference: this.state.emailPreference,
+          roles: this.state.updatedRoles
         };
         const createdUser = await User.create(newUser);
         this.setState({ emailValid: createdUser });
         break;
-
       case 'Edit':
         let payload = {};
-
         const editUser = {
           displayName: this.state.displayName,
           email: this.state.email,
@@ -212,22 +108,13 @@ export const AddUserModal = hh(class AddUserModal extends Component {
           dacUserId: this.state.user.dacUserId,
           researcher: this.state.user.researcher,
           status: this.state.user.status,
-          roles: updatedRoles,
+          emailPreference: this.state.emailPreference,
+          roles: this.state.updatedRoles
         };
         payload.updatedUser = editUser;
-
-        if (this.state.delegateDacUser.needsDelegation) {
-          payload.userToDelegate = JSON.parse(this.state.alternativeDACMemberUser);
-        }
-
-        if (this.state.delegateDataOwner.needsDelegation) {
-          payload.alternativeDataOwnerUser = JSON.parse(this.state.alternativeDataOwnerUser);
-        }
-
         const updatedUser = await User.update(payload, this.state.user.dacUserId);
-        this.setState({ emailValid: updatedUser});
+        this.setState({ emailValid: updatedUser });
         break;
-
       default:
         break;
     }
@@ -248,570 +135,165 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     this.props.onAfterOpen('addUser');
   };
 
-  toggleState(roleName) {
-    let rs = Object.assign({}, this.state.rolesState);
-    rs[roleName] = !rs[roleName];
-
-    this.setState(prev => {
-      prev.rolesState = Object.assign({}, rs);
-      prev.roleValid = this.validateRoles(rs);
-      prev.invalidForm = (prev.rolevValid && prev.displayNameValid && prev.emailValid);
-      return prev;
-    });
-  }
-
-  validateRoles(rs) {
-    let roleValid = false;
-    for (let key in rs) {
-      if (rs[key]) {
-        roleValid = true;
-      }
-    }
-    return roleValid;
-  }
-
-  userWas = (rol) => {
-    let match = false;
-    this.state.user.roles.forEach(role => {
-      if (role.name.toUpperCase() === rol.toUpperCase()) {
-        match = true;
-      }
-    });
-    return match;
-  };
-
-  async searchDACUsers(role) {
-  if (this.state.mode === 'Edit') {
-    let user = {
-      roles: this.props.user.roles.map(
-        (role, ix) => {
-          return { name: role.name };
-        }
-      ),
-      displayName: this.props.user.displayName,
-      email: this.props.user.email,
-    };
-    return await User.validateDelegation(role, user);
-  } else if (this.state.mode === 'Add') {
-    return { needsDelegation: true };
-  }
-  };
-
-  checkNoEmptyDelegateCandidates = async (needsDelegation, delegateCandidates, role) => {
-    const valid = needsDelegation === true && delegateCandidates.length === 0 ? false : true;
-    if (!valid) {
-      this.errorNoAvailableCandidates(role);
-    }
-     await this.setState((prev) => {
-      prev.newUserNeeded = this.validateNoNewUserIsNeeded();
-      return prev;
-    });
-    return valid;
-  };
-
-  validateNoNewUserIsNeeded = () => {
-    for (var key in this.state.newAlternativeUserNeeded) {
-      if (this.state.newAlternativeUserNeeded[key] === true) {
-        return true;
-      }
-    }
-    return false;
-  };
-
   emailPreferenceChanged = (e) => {
+    // disable notifications checkbox is not checked: -> Set email preference TRUE
+    // disable notifications checkbox is checked:     -> Set email preference FALSE
     const checkState = e.target.checked;
     this.setState({
-      emailPreference: checkState
+      emailPreference: !checkState
     });
   };
-
-  memberChanged = async (e) => {
-    const checkState = e.target.checked;
-
-    // need to set the role in roles
-    if (this.state.wasMember) {
-      if (!checkState) {
-        // removing member role, need to verify if needs to add another user as member
-        const result = await this.searchDACUsers(USER_ROLES_UPPER.member);
-        if (this.checkNoEmptyDelegateCandidates(result.needsDelegation, result.delegateCandidates, USER_ROLES_UPPER.member)) {
-          this.setState(prev => {
-            prev.delegateMemberRequired = result.needsDelegation;
-            prev.delegateDacUser.delegateCandidates = result.delegateCandidates;
-            prev.delegateDacUser.needsDelegation = result.needsDelegation;
-            return prev;
-          }, () => {
-            if (this.state.delegateDacUser.delegateCandidates.length === 1) {
-              this.setState({
-                alternativeDACMemberUser: JSON.stringify(this.state.delegateDacUser.delegateCandidates[0])
-              });
-            }
-          });
-          // return;
-        }
-      } else {
-        // adding member role to an already member, no need to do anything else
-        this.closeNoAvailableCandidatesAlert(USER_ROLES_UPPER.member);
-        this.setState(prev => {
-          prev.delegateMemberRequired = false;
-          prev.delegateDacUser.delegateCandidates = [];
-          prev.delegateDacUser.needsDelegation = false;
-          return prev;
-        });
-      }
-    } else {
-    }
-    this.toggleState(USER_ROLES_UPPER.member);
-  };
-
-  chairpersonChanged = async (e) => {
-    const checkState = e.target.checked;
-
-    // need to set the role in roles
-    const result = await this.searchDACUsers(USER_ROLES_UPPER.chairperson);
-    if (this.state.wasChairperson) {
-      if (!checkState) {
-        if (this.checkNoEmptyDelegateCandidates(result.needsDelegation, result.delegateCandidates, USER_ROLES_UPPER.chairperson)) {
-          this.setState(prev => {
-            prev.delegateMemberRequired = false;
-            prev.delegateDacUser.delegateCandidates = result.delegateCandidates;
-            prev.delegateDacUser.needsDelegation = result.needsDelegation;
-            return prev;
-          }, () => {
-            if (this.state.delegateDacUser.delegateCandidates.length === 1) {
-              this.setState({
-                alternativeDACMemberUser: JSON.stringify(this.state.delegateDacUser.delegateCandidates[0])
-              });
-            }
-          });
-        }
-      } else {
-        this.closeNoAvailableCandidatesAlert(USER_ROLES_UPPER.chairperson);
-        this.setState(prev => {
-          prev.delegateMemberRequired = false;
-          prev.delegateDacUser.delegateCandidates = [];
-          prev.delegateDacUser.needsDelegation = false;
-          return prev;
-        });
-      }
-    } else {
-      if (checkState && result.needsDelegation) {
-        this.changeChairpersonRoleAlert();
-      } else {
-        this.closeAlert('1');
-      }
-
-    }
-    this.toggleState(USER_ROLES_UPPER.chairperson);
-  };
-
-  dataOwnerChanged = async (e) => {
-    const checkState = e.target.checked;
-
-    // need to set the role in roles
-    if (this.state.wasDataOwner) {
-      if (!checkState) {
-        const result = await this.searchDACUsers(USER_ROLES_UPPER.dataOwner);
-        if (this.checkNoEmptyDelegateCandidates(result.needsDelegation, result.delegateCandidates, USER_ROLES_UPPER.dataOwner)) {
-          this.setState(prev => {
-            prev.delegateDataOwner.delegateCandidates = result.delegateCandidates;
-            prev.delegateDataOwner.needsDelegation = result.needsDelegation;
-            return prev;
-          }, () => {
-            if (this.state.delegateDataOwner.delegateCandidates.length === 1) {
-              this.setState({
-                alternativeDataOwnerUser: JSON.stringify(this.state.delegateDataOwner.delegateCandidates[0])
-              });
-            }
-          });
-          // return;
-        }
-      } else {
-        this.closeNoAvailableCandidatesAlert(USER_ROLES_UPPER.dataOwner);
-        this.setState(prev => {
-          prev.delegateDataOwner.delegateCandidates = [];
-          prev.delegateDataOwner.needsDelegation = false;
-          return prev;
-        });
-      }
-    } else {
-
-    }
-    this.toggleState(USER_ROLES_UPPER.dataOwner);
-  };
-
-  researcherChanged = (e) => {
-    const checkState = e.target.checked;
-
-    // need to set the role in roles
-    if (this.state.wasResearcher) {
-      if (!checkState) {
-        this.changeResearcherRoleAlert();
-      } else {
-        this.closeAlert('3');
-      }
-    }
-    this.toggleState(USER_ROLES_UPPER.researcher);
-  };
-
-  alumniChanged = (e) => {
-    const role = USER_ROLES_UPPER.alumni;
-    this.toggleState(role);
-  }
 
   adminChanged = (e) => {
-    const role = USER_ROLES_UPPER.admin;
-    this.toggleState(role);
-  }
-
-  /*****ALERTS*****/
-
-  changeChairpersonRoleAlert = (index) => {
+    const checkState = e.target.checked;
+    // True? add admin role to state.updatedRoles
+    // False? remove admin role from state.updatedRoles
+    let newRoles = [];
+    if (checkState) {
+      newRoles = _.concat(this.state.updatedRoles, adminRole);
+    } else {
+      newRoles = _.filter(this.state.updatedRoles, (r) => {return r.roleId !== adminRole.roleId;});
+    }
     this.setState(prev => {
-      prev.alerts[0] = {
-        type: 'danger',
-        title: 'Warning!',
-        msg: 'In order to have only one Chairperson in the system, the current Chairperson is going to become an Alumni.',
-        alertType: '1'
-      };
+      prev.updatedRoles = newRoles;
       return prev;
     });
   };
 
-  changeResearcherRoleAlert = (index) => {
-    this.setState(prev => {
-      prev.alerts[0] = {
-        type: 'danger',
-        title: 'Warning!',
-        msg: 'By removing the researcher role, the user Data Access Requests will be canceled, and all the elections related to them.',
-        alertType: '3'
-      };
-      return prev;
-    });
-  };
-
-  errorNoAvailableCandidates = (role) => {
-    this.setState(prev => {
-      prev.newUserNeeded = true;
-      prev.newAlternativeUserNeeded[role] = true;
-      prev.alerts[0] = {
-        type: 'danger',
-        title: "Edition can't be made!",
-        msg: "There are no available users to delegate " + role.toLowerCase() + " responsibilities, please add a new User.",
-        alertType: role
-      };
-      return prev;
-    });
-
-  };
-
-  errorOnEdition = (index) => {
-    this.setState(prev => {
-      prev.alerts[0] = {
-        type: 'danger',
-        title: "Edition can't be made!",
-        msg: index,
-        alertType: '2'
-      };
-      return prev;
-    });
-  };
-
-  closeAlert = (alertType) => {
-    const alerts = this.state.alerts.filter(alert => {
-      return alert.alertType !== alertType;
-    });
-    this.setState({
-      alerts: alerts
-    });
-  };
-
-  closeNoAvailableCandidatesAlert = (role) => {
-
-    this.setState(prev => {
-      prev.alerts = [];
-      prev.newAlternativeUserNeeded[role] = false;
-      return prev;
-    },
-    () => {
-      this.setState({
-        newUserNeeded : this.validateNoNewUserIsNeeded()
-      });
-    });
-
-  };
-
-  handleChange(event) {
-    const name = event.target.name;
+  handleChange = (e) => {
+    const name = e.target.name;
     const validName = name + 'Valid';
-
     this.setState({
-      [name]: event.target.value,
-      [validName]: event.currentTarget.validity.valid,
-      roleValid: this.validateRoles(this.state.rolesState)
+      [name]: e.target.value,
+      [validName]: e.currentTarget.validity.valid
     });
-  }
+  };
 
-  selectAlternativeDACMemberUser = (e) => {
-    const target = e.currentTarget;
-    const value = target.value;
-
+  formChange = () => {
     this.setState(prev => {
-      prev.alternativeDACMemberUser = value;
+      prev.invalidForm = (prev.displayNameValid && prev.emailValid);
       return prev;
     });
   };
 
-  selectAlternativeDataOwnerUser = (e) => {
-    const target = e.target;
-    const value = target.value;
-
-    this.setState(prev => {
-      prev.alternativeDataOwnerUser = value;
-      return prev;
-    });
-  };
-
-  formChange = (e) => {
-    this.setState(prev => {
-      prev.roleValid = this.validateRoles(prev.rolesState);
-      prev.invalidForm = (prev.roleValid && prev.displayNameValid && prev.emailValid);
-      return prev;
-    });
+  isAdmin = () => {
+    const admins = _.filter(this.state.updatedRoles, _.matches(adminRole));
+    return !_.isEmpty(admins);
   };
 
   render() {
-
-    const { displayName, email, rolesState, newUserNeeded, emailPreference, displayNameValid, emailValid, roleValid } = this.state;
-
-    const validForm = displayNameValid && emailValid && roleValid;
-
-    const isChairPerson = rolesState[USER_ROLES_UPPER.chairperson];
-    const isMember = rolesState[USER_ROLES_UPPER.member];
-    const isAdmin = rolesState[USER_ROLES_UPPER.admin];
-    const isResearcher = rolesState[USER_ROLES_UPPER.researcher];
-    const isDataOwner = rolesState[USER_ROLES_UPPER.dataOwner];
-    const isAlumni = rolesState[USER_ROLES_UPPER.alumni];
-
-    const isResearcherDisabled = isMember || isChairPerson;
-    const isMemberDisabled = isChairPerson || isAlumni || isResearcher;
-    const isChairPersonDisabled = isMember || isAlumni || isResearcher;
-    const isAlumniDisabled = isMember || isChairPerson;
-
-    const needsDoDelegation = (this.state.delegateDacUser.needsDelegation && this.state.alternativeDACMemberUser === '');
-    const needsDacDelegation = (this.state.delegateDataOwner.needsDelegation && this.state.alternativeDataOwnerUser ==='');
-
+    const { displayName, email, displayNameValid, emailValid } = this.state;
+    const validForm = displayNameValid && emailValid;
     return (
       BaseModal({
-        id: "addUserModal",
-        showModal: this.props.showModal,
-        disableOkBtn: !validForm || needsDacDelegation || needsDoDelegation || newUserNeeded,
-        onRequestClose: this.closeHandler,
-        onAfterOpen: this.afterOpenHandler,
-        imgSrc: this.state.mode === 'Add' ? "/images/icon_add_user.png" : "/images/icon_edit_user.png",
-        color: "common",
-        title: this.state.mode === 'Add' ? "Add User" : "Edit User",
-        description: this.state.mode === 'Add' ? "Catalog a new User in the system" : "Edit a User in the system",
-        action: { label: this.state.mode === 'Add' ? "Add" : 'Save', handler: this.OKHandler }
-      },
+          id: 'addUserModal',
+          showModal: this.props.showModal,
+          disableOkBtn: !validForm,
+          onRequestClose: this.closeHandler,
+          onAfterOpen: this.afterOpenHandler,
+          imgSrc: this.state.mode === 'Add' ? '/images/icon_add_user.png' : '/images/icon_edit_user.png',
+          color: 'common',
+          title: this.state.mode === 'Add' ? 'Add User' : 'Edit User',
+          description: this.state.mode === 'Add' ? 'Catalog a new User in the system' : 'Edit a User in the system',
+          action: { label: this.state.mode === 'Add' ? 'Add' : 'Save', handler: this.OKHandler }
+        },
         [
-          form({ className: "form-horizontal css-form", name: "userForm", encType: "multipart/form-data", onChange: this.formChange }, [
-            div({ className: "form-group first-form-group" }, [
-              label({ id: "lbl_name", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Name"]),
-              div({ className: "col-lg-9 col-md-9 col-sm-9 col-xs-8" }, [
+          form({ className: 'form-horizontal css-form', name: 'userForm', encType: 'multipart/form-data', onChange: this.formChange }, [
+            div({ className: 'form-group first-form-group' }, [
+              label({ id: 'lbl_name', className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Name']),
+              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8' }, [
                 input({
-                  type: "text",
-                  name: "displayName",
-                  id: "txt_name",
-                  className: "form-control col-lg-12 vote-input",
-                  placeholder: "User name",
+                  type: 'text',
+                  name: 'displayName',
+                  id: 'txt_name',
+                  className: 'form-control col-lg-12 vote-input',
+                  placeholder: 'User name',
                   required: true,
                   value: displayName,
                   autoFocus: true,
                   onChange: this.handleChange,
                   ref: this.nameRef
-                }),
-              ]),
+                })
+              ])
             ]),
 
-            div({ className: "form-group" }, [
-              label({ id: "lbl_email", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Google account id"]),
-              div({ className: "col-lg-9 col-md-9 col-sm-9 col-xs-8" }, [
+            div({ className: 'form-group' }, [
+              label({ id: 'lbl_email', className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Google account id']),
+              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8' }, [
                 input({
-                  type: "email",
-                  name: "email",
-                  id: "txt_email",
-                  className: "form-control col-lg-12 vote-input",
-                  placeholder: "e.g. username@broadinstitute.org",
+                  type: 'email',
+                  name: 'email',
+                  id: 'txt_email',
+                  className: 'form-control col-lg-12 vote-input',
+                  placeholder: 'e.g. username@broadinstitute.org',
                   required: true,
                   value: email,
                   onChange: this.handleChange,
                   ref: this.emailRef
-                }),
-              ]),
+                })
+              ])
             ]),
 
-            div({ className: "form-group" }, [
-              label({ className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Roles"]),
-              div({ className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 bold" }, [
-                div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-
-                  div({ className: "checkbox", disabled: isMemberDisabled }, [
+            div({ className: 'form-group' }, [
+              label({ className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Role']),
+              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold' }, [
+                div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
+                  div({ className: 'checkbox' }, [
                     input({
-                      type: "checkbox",
-                      id: "chk_member",
-                      className: "checkbox-inline user-checkbox",
-                      checked: isMember,
-                      onChange: this.memberChanged,
-                      disabled: isMemberDisabled,
+                      type: 'checkbox',
+                      id: 'chk_admin',
+                      checked: this.isAdmin(),
+                      className: 'checkbox-inline user-checkbox',
+                      onChange: this.adminChanged
                     }),
-                    label({ id: "lbl_member", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_member" }, ["Member"])
-                  ]),
-
-                  div({ className: "checkbox", disabled: isChairPersonDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_chairperson",
-                      className: "checkbox-inline user-checkbox",
-                      checked: isChairPerson,
-                      onChange: this.chairpersonChanged,
-                      disabled: isChairPersonDisabled
-                    }),
-                    label({ id: "lbl_chairperson", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_chairperson" }, ["Chairperson"])
-                  ]),
-
-                  div({ className: "checkbox", disabled: isAlumniDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_alumni",
-                      checked: isAlumni,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.alumniChanged,
-                      disabled: isAlumniDisabled,
-                    }),
-                    label({ id: "lbl_alumni", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_alumni" }, ["Alumni"])
-                  ]),
-
-                ]),
-
-                div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-6" }, [
-
-                  div({ className: "checkbox" }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_admin",
-                      checked: isAdmin,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.adminChanged,
-                    }),
-                    label({ id: "lbl_admin", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_admin" }, ["Admin"])
-                  ]),
-
-                  div({ className: "checkbox", disabled: isResearcherDisabled }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_researcher",
-                      checked: isResearcher,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.researcherChanged,
-                      disabled: isResearcherDisabled
-                    }),
-                    label({ id: "lbl_researcher", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_researcher" }, ["Researcher"])
-                  ]),
-
-                  div({ className: "checkbox" }, [
-                    input({
-                      type: "checkbox",
-                      id: "chk_dataOwner",
-                      checked: isDataOwner,
-                      className: "checkbox-inline user-checkbox",
-                      onChange: this.dataOwnerChanged,
-                    }),
-                    label({ id: "lbl_dataOwner", className: "regular-checkbox rp-choice-questions", htmlFor: "chk_dataOwner" }, ["Data Owner"])
+                    label({ id: 'lbl_admin', className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_admin' }, ['Admin'])
                   ])
                 ])
               ])
             ]),
-            div({ className: "form-group" }, [
+            div({ className: 'form-group' }, [
               div({
-                isRendered: this.state.rolesState.ADMIN,
-                className: "col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4",
+                isRendered: this.isAdmin(),
+                className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
                 style: { 'paddingLeft': '30px' }
               }, [
-                  div({ className: "checkbox" }, [
-                    input({
-                      id: "chk_emailPreference",
-                      type: "checkbox",
-                      className: "checkbox-inline user-checkbox",
-                      checked: emailPreference,
-                      onChange: this.emailPreferenceChanged,
-                    }),
-                    label({ className: "regular-checkbox rp-choice-questions bold", htmlFor: "chk_emailPreference" }, ["Disable Admin email notifications"])
-                  ])
+                div({ className: 'checkbox' }, [
+                  input({
+                    id: 'chk_emailPreference',
+                    type: 'checkbox',
+                    className: 'checkbox-inline user-checkbox',
+                    // If email preference is TRUE  -> disable checkbox is not checked
+                    // If email preference is FALSE -> disable checkbox is checked
+                    checked: !this.state.emailPreference,
+                    onChange: this.emailPreferenceChanged
+                  }),
+                  label({ className: 'regular-checkbox rp-choice-questions bold', htmlFor: 'chk_emailPreference' },
+                    ['Disable Admin email notifications'])
                 ])
+              ])
             ])
           ]),
 
           div({ isRendered: this.state.emailValid === false && this.state.submitted === true }, [
-            Alert({ id: "emailUsed", type: 'danger', title: 'Conflicts to resolve!', description: 'There is a user already registered with this google account.' })
+            Alert({
+              id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
+              description: 'There is a user already registered with this google account.'
+            })
           ]),
 
           div({ isRendered: this.state.alerts.length > 0 }, [
             this.state.alerts.map((alert, ix) => {
               return (
-                h(Fragment, { key: "alert_" + ix }, [
-                  Alert({ id: "modal_" + ix, type: alert.type, title: alert.title, description: alert.msg })
+                h(Fragment, { key: 'alert_' + ix }, [
+                  Alert({ id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg })
                 ])
               );
             })
           ]),
-
-          div({ isRendered: this.state.delegateDacUser.needsDelegation, className: "form-group rp-last-group" }, [
-            div({ className: "row no-margin f-center" }, [
-              div({ className: "control-label default-color f-center", style: { "paddingBottom": "10px" } }, ["Member responsabilities must be delegated to a different user, please select one from below:"]),
-
-              label({ id: "lbl_alternativeUser", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Alternative User"]),
-              div({ className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 " }, [
-                select({
-                  id: "sel_alternativeUser",
-                  className: "form-control col-lg-12",
-                  value: this.state.alternativeDACMemberUser,
-                  required: this.state.delegateDacUser.needsDelegation,
-                  onChange: this.selectAlternativeDACMemberUser,
-                }, [
-                    option({ value: '' }, [""]),
-                    this.state.delegateDacUser.delegateCandidates.map((user, uIndex) => {
-                      return h(Fragment, { key: uIndex }, [
-                        option({ value: JSON.stringify(user) }, [user.displayName])
-                      ]);
-                    })
-                  ])
-              ])
-            ])
-          ]),
-          div({ isRendered: (this.state.delegateDataOwner.needsDelegation && this.state.delegateDataOwner.delegateCandidates.length > 0), className: "form-group rp-last-group" }, [
-            div({ className: "row no-margin f-center" }, [
-              div({ className: "control-label default-color f-center", style: { "paddingBottom": "10px" } }, ["Member responsabilities must be delegated to a different user, please select one from below:"]),
-
-              label({ id: "lbl_alternativeDataOwner", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color" }, ["Alternative DataOwner"]),
-              div({ className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 " }, [
-                select({
-                  id: "sel_alternativeDataOwner", className: "form-control col-lg-12", value: this.state.alternativeDataOwnerUser,
-                  required: this.state.delegateDataOwner.needsDelegation, onChange: this.selectAlternativeDataOwnerUser, placeholder: "Select an alternative Data Owner"
-                }, [
-                  option({ value: '' }, [""]),
-                  this.state.delegateDataOwner.delegateCandidates.map((user, uIndex) => {
-                      return h(Fragment, { key: uIndex }, [
-                        option({ value: JSON.stringify(user) }, [user.displayName])
-                      ]);
-                    })
-                  ])
-              ])
-            ])
-          ]),
-
           div({ isRendered: false }, [
-            Alert({ id: "modal", type: "danger", title: alert.title, description: alert.msg })
-          ])])
+            Alert({ id: 'modal', type: 'danger', title: alert.title, description: alert.msg })
+          ])
+        ])
     );
   }
 });

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -2,11 +2,12 @@ import _ from 'lodash';
 import React, { Component, Fragment } from 'react';
 import { div, form, h, hh, input, label } from 'react-hyperscript-helpers';
 import { User } from '../../libs/ajax';
+import { USER_ROLES } from '../../libs/utils';
 import { Alert } from '../Alert';
 import { BaseModal } from '../BaseModal';
 
 
-const adminRole = { 'roleId': 4, 'name': 'Admin' };
+const adminRole = { 'roleId': 4, 'name': USER_ROLES.admin };
 
 export const AddUserModal = hh(class AddUserModal extends Component {
 

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -22,7 +22,6 @@ export const AddUserModal = hh(class AddUserModal extends Component {
       invalidForm: true,
       submitted: false,
       alerts: [],
-      originalRoles: [],
       updatedRoles: [],
       emailPreference: false
     };
@@ -43,9 +42,7 @@ export const AddUserModal = hh(class AddUserModal extends Component {
           mode: 'Edit',
           displayName: user.displayName,
           email: user.email,
-          additionalEmail: user.additionalEmail,
           user: user,
-          originalRoles: user.roles,
           updatedRoles: updatedRoles,
           emailPreference: user.emailPreference
         },
@@ -62,8 +59,6 @@ export const AddUserModal = hh(class AddUserModal extends Component {
           mode: 'Add',
           displayName: '',
           email: '',
-          additionalEmail: '',
-          originalRoles: [],
           updatedRoles: [],
           emailPreference: false
         },
@@ -87,32 +82,20 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     if (validForm === false) {
       return;
     }
+    let user = {
+      displayName: this.state.displayName,
+      email: this.state.email,
+      emailPreference: this.state.emailPreference,
+      roles: this.state.updatedRoles
+    };
     switch (this.state.mode) {
       case 'Add':
-        const newUser = {
-          displayName: this.state.displayName,
-          email: this.state.email,
-          emailPreference: this.state.emailPreference,
-          roles: this.state.updatedRoles
-        };
-        const createdUser = await User.create(newUser);
+        const createdUser = await User.create(user);
         this.setState({ emailValid: createdUser });
         break;
       case 'Edit':
-        let payload = {};
-        const editUser = {
-          displayName: this.state.displayName,
-          email: this.state.email,
-          additionalEmail: this.state.additionalEmail,
-          completed: this.state.user.completed,
-          createDate: this.state.user.createDate,
-          dacUserId: this.state.user.dacUserId,
-          researcher: this.state.user.researcher,
-          status: this.state.user.status,
-          emailPreference: this.state.emailPreference,
-          roles: this.state.updatedRoles
-        };
-        payload.updatedUser = editUser;
+        user.dacUserId = this.state.user.dacUserId;
+        const payload = { updatedUser: user };
         const updatedUser = await User.update(payload, this.state.user.dacUserId);
         this.setState({ emailValid: updatedUser });
         break;

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -21,16 +21,6 @@ export const USER_ROLES = {
   all: 'All'
 };
 
-export const USER_ROLES_UPPER = {
-  admin: 'ADMIN',
-  chairperson: 'CHAIRPERSON',
-  member: 'MEMBER',
-  researcher: 'RESEARCHER',
-  alumni: 'ALUMNI',
-  dataOwner: 'DATAOWNER',
-  all: 'ALL'
-};
-
 export const sleep = (milliseconds) => {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
 };


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-345
Requires Consent PR: https://github.com/DataBiosphere/consent/pull/394
Which also depends on: https://github.com/DataBiosphere/consent/pull/393

## Changes
* Removed all roles except for admin
* Significant rewrite of the code for simplification
* Have tested locally with consent branch

### Edit User Screen
<img width="1116" alt="Screen Shot 2019-12-18 at 3 20 24 PM" src="https://user-images.githubusercontent.com/116679/71120651-d894aa80-21aa-11ea-975d-ecc685db7bc7.png">

### Admin Selection
<img width="1116" alt="Screen Shot 2019-12-18 at 3 20 28 PM" src="https://user-images.githubusercontent.com/116679/71120678-e77b5d00-21aa-11ea-941e-b1bc751205b0.png">

### Admin Selection with email preference
<img width="1116" alt="Screen Shot 2019-12-18 at 3 20 33 PM" src="https://user-images.githubusercontent.com/116679/71120700-f4984c00-21aa-11ea-8108-d48bbb94a249.png">

### Add User Screen (works the same way)
<img width="1116" alt="Screen Shot 2019-12-18 at 3 20 59 PM" src="https://user-images.githubusercontent.com/116679/71120733-037efe80-21ab-11ea-85db-67f6f879b653.png">
