### PR TITLE
[DUOS-443][risk=no] Part 2 of updating vulnerable researcher APIs

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -899,8 +899,8 @@ export const Researcher = {
     return await res;
   },
 
-  update: async (userId, validate, researcherProperties) => {
-    const url = `${await Config.getApiUrl()}/researcher/${userId}?validate=${validate}`;
+  updateProperties: async (userId, validate, researcherProperties) => {
+    const url = `${await Config.getApiUrl()}/researcher?validate=${validate}`;
     const res = await fetchOk(url, _.mergeAll([Config.authOpts(), Config.jsonBody(researcherProperties), { method: 'PUT' }]));
     return res.json();
   },

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -407,7 +407,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
 
   updateResearcher(profile) {
-    Researcher.update(Storage.getCurrentUser().dacUserId, true, profile).then(resp => {
+    Researcher.updateProperties(Storage.getCurrentUser().dacUserId, true, profile).then(resp => {
       this.saveUser().then(resp => {
         this.setState({ showDialogSubmit: false });
         this.props.history.push({ pathname: 'dataset_catalog' });
@@ -447,7 +447,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     if (answer === true) {
       let profile = this.state.profile;
       profile.completed = false;
-      Researcher.update(Storage.getCurrentUser().dacUserId, false, profile);
+      Researcher.updateProperties(Storage.getCurrentUser().dacUserId, false, profile);
       this.props.history.push({ pathname: 'dataset_catalog' });
     }
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-443
This PR only addresses the `PUT` call in `ResearcherResource`. Other vulnerable endpoints will be addressed in follow-on PRs.
Consent PR also required: https://github.com/DataBiosphere/consent/pull/398

See also, these related PRs:
* https://github.com/DataBiosphere/consent/pull/397
* https://github.com/DataBiosphere/duos-ui/pull/225

## Changes
* Match the new API signature