### PR TITLE
[DUOS-506][risk=no] Fix user role display

### DIFF
--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -6,6 +6,7 @@ import { User } from "../libs/ajax";
 import { PaginatorBar } from '../components/PaginatorBar';
 import ReactTooltip from 'react-tooltip';
 import { SearchBox } from '../components/SearchBox';
+import _ from 'lodash';
 
 class AdminManageUsers extends Component {
 
@@ -177,16 +178,10 @@ class AdminManageUsers extends Component {
                 div({ id: user.dacUserId + "_name", name: "userName", className: "col-lg-2 col-md-2 col-sm-2 col-xs-2 cell-body text" }, [user.displayName]),
                 div({ id: user.dacUserId + "_email", name: "userEmail", className: "col-lg-3 col-md-3 col-sm-3 col-xs-3 cell-body text" }, [user.email]),
                 div({ id: user.dacUserId + "_roles", name: "userRoles", className: "col-lg-4 col-md-4 col-sm-3 col-xs-3 cell-body text bold" }, [
-                  user.roles.map((role, eIndex) =>
-                    span({ key: user.dacUserId + "_roles_" + eIndex, id: user.dacUserId + "_roles_" + eIndex, className: "admin-users-list" }, [
-                      span({ className: "enabled default-color", isRendered: role.name === 'Admin' }, ["Admin"]),
-                      span({ className: "enabled default-color", isRendered: role.name === 'Member' }, ["Member"]),
-                      span({ className: "enabled default-color", isRendered: role.name === 'Chairperson' }, ["Chairperson"]),
-                      span({ className: "enabled default-color", isRendered: role.name === 'Alumni' }, ["Alumni"]),
-                      span({ className: "enabled default-color", isRendered: role.name === 'Researcher' }, ["Researcher"]),
-                      span({ className: "enabled default-color", isRendered: role.name === 'DataOwner' }, ["Data Owner"]),
-                    ])
-                  )
+                  span({ className: "admin-users-list"},
+                    _.map(_.sortedUniq(_.map(user.roles, 'name')),
+                      (n) => {return span({ className: "enabled default-color"}, n);})
+                  ),
                 ]),
                 div({ className: "col-lg-1 col-md-1 col-sm-2 col-xs-2 cell-body f-center" }, [
                   button({

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -1,12 +1,13 @@
-import { Component, Fragment } from 'react';
-import { div, button, hr, a, span, h } from 'react-hyperscript-helpers';
-import { PageHeading } from '../components/PageHeading';
-import { AddUserModal } from '../components/modals/AddUserModal';
-import { User } from "../libs/ajax";
-import { PaginatorBar } from '../components/PaginatorBar';
-import ReactTooltip from 'react-tooltip';
-import { SearchBox } from '../components/SearchBox';
 import _ from 'lodash';
+import { Component, Fragment } from 'react';
+import { a, button, div, h, hr, span } from 'react-hyperscript-helpers';
+import ReactTooltip from 'react-tooltip';
+import { AddUserModal } from '../components/modals/AddUserModal';
+import { PageHeading } from '../components/PageHeading';
+import { PaginatorBar } from '../components/PaginatorBar';
+import { SearchBox } from '../components/SearchBox';
+import { User } from '../libs/ajax';
+
 
 class AdminManageUsers extends Component {
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-506

## Changes
Updated the logic for showing the role names that a user had. Previously, if you had duplicate roles, they would be doubled up in the display. Instead, just show the unique values. 

### Old:
![Screen Shot 2020-01-15 at 11 18 36 AM](https://user-images.githubusercontent.com/116679/72450928-27713800-3789-11ea-9d7a-d18f9ac7d587.png)

### New:
![Screen Shot 2020-01-15 at 11 18 40 AM](https://user-images.githubusercontent.com/116679/72450937-2a6c2880-3789-11ea-9284-f7e21ba63f0b.png)
