### PR TITLE
[DUOS-508][risk=no] Use mock shibboleth on staging

### DIFF
--- a/config/staging.json
+++ b/config/staging.json
@@ -4,5 +4,5 @@
   "clientId": "1087760099392-t0nb61ehicbeuqkeftvql765ncu1707r.apps.googleusercontent.com",
   "firecloudUrl": "https://firecloud-orchestration.dsde-staging.broadinstitute.org/",
   "gwasUrl": "",
-  "nihUrl": "https://shibboleth.dsde-prod.broadinstitute.org/link-nih-account"
+  "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html"
 }


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-508

## Changes
* Previously, we tried to use the production shibboleth site for staging. This fails because staging orchestration is configured to decode the mock token, not the prod token. Drop back to using mock shibboleth.