### PR TITLE
[DUOS-445][risk=no] Remove unused API call

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -982,12 +982,6 @@ export const User = {
     return res.json();
   },
 
-  validateDelegation: async (role, dacUser) => {
-    const url = `${await Config.getApiUrl()}/dacuser/validateDelegation?role=` + role;
-    const res = await fetchOk(url, _.mergeAll([Config.authOpts(), Config.jsonBody(dacUser), { method: 'POST' }]));
-    return res.json();
-  },
-
   registerUser: async () => {
     const url = `${await Config.getApiUrl()}/user`;
     const res = await fetchOk(url, _.mergeAll([Config.authOpts(), { method: 'POST' }]));


### PR DESCRIPTION
## Addresses
Only addresses the `POST validateDelegation` part of https://broadinstitute.atlassian.net/browse/DUOS-445

## Changes
Remove unused API call. Requires corresponding [API PR](https://github.com/DataBiosphere/consent/pull/408)