### PR TITLE
[DUOS-302][risk=no] Upgrade to node 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       - image: google/cloud-sdk
   node:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:13
 
 commands:
   push-env:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The Data Use Oversight system ensures that researchers using genomics data honor
 
 Builds, tests, and deployments are handled by CircleCI.
 
-1. We use node@8 (the current LTS). On Darwin with Homebrew:
+1. We use node@13 On Darwin with Homebrew:
 
     ```sh
-    brew install node@8; brew link --overwrite node@8 --force
+    brew install node@13
     ```
 2. Update npm:
 
@@ -43,4 +43,10 @@ Builds, tests, and deployments are handled by CircleCI.
 
     ```sh
     npm start
+    ```
+### Running under Docker
+
+    ```sh
+    docker build -f Dockerfile-dev . -t duos-ui
+    docker run -p 80:80 duos-ui:latest
     ```


### PR DESCRIPTION
## Addresses
Maintenance for https://broadinstitute.atlassian.net/browse/DUOS-302
See also: https://github.com/DataBiosphere/duos-ui/pull/268

## Changes
* Readme update for building/running under docker (have tested locally)
* Update circleci node image to match the dev builder