### PR TITLE
[DUOS-547][risk=no] Hide stats page for non-admin

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -148,7 +148,8 @@ class DuosHeader extends Component {
                   ]),
 
                   li({}, [
-                    h(Link, { id: "link_help", to: helpLink }, ["Request Help"]),])
+                    h(Link, { id: 'link_help', to: helpLink }, ['Request Help'])
+                  ])
                 ]),
 
                 ul({ isRendered: !isLogged, className: 'navbar-public' }, [

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -126,7 +126,7 @@ class DuosHeader extends Component {
                     h(Link, { id: 'link_requestApplication', to: '/dar_application' }, ['Request Application'])
                   ]),
 
-                  li({ className: 'dropdown', isRendered: isLogged }, [
+                  li({ className: 'dropdown', isRendered: isAdmin }, [
                     a({ id: 'sel_statistics', role: 'button', className: 'dropdown-toggle', 'data-toggle': 'dropdown' }, [
                       div({}, ['Statistics', span({ className: 'caret caret-margin' }, [])])
                     ]),


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-547

Should have been fixed with https://github.com/DataBiosphere/duos-ui/pull/279 but it looks like it was overridden here: https://github.com/DataBiosphere/duos-ui/pull/273/files#diff-f2543dc3225a6ca7b55736b7d8cb837bR128