### PR TITLE
[DUOS-302][risk=no] Fix peer dependency warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2025,9 +2025,10 @@
       }
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+      "dev": true
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -5064,9 +5065,10 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz",
-      "integrity": "sha512-W5hLjpFfZyZsXfo5anlu7HM970JBDqbEshAJUkeczP6BFCIfJXuiIBQXyberLRtOStT0OGPF8efeTbxlHk4LpQ==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
+      "integrity": "sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -8303,6 +8305,13 @@
         "whatwg-url": "^6.4.1",
         "ws": "^5.2.0",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        }
       }
     },
     "jsesc": {
@@ -11693,7 +11702,6 @@
         "eslint": "^6.6.0",
         "eslint-config-react-app": "^5.2.0",
         "eslint-loader": "3.0.3",
-        "eslint-plugin-flowtype": "4.6.0",
         "eslint-plugin-import": "2.20.0",
         "eslint-plugin-jsx-a11y": "6.2.3",
         "eslint-plugin-react": "7.18.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
     "eject": "react-scripts eject"
   },
   "devDependencies": {
+    "acorn": "6.4.0",
     "eslint": "6.8.0",
+    "eslint-config-react-app": "5.2.0",
+    "eslint-plugin-flowtype": "3.13.0",
     "eslint-plugin-react": "7.18.3",
     "handlebars": "4.7.3",
     "js-yaml": "3.13.1",


### PR DESCRIPTION
## Addresses
Fixes the following `npm install` warnings:
```
npm WARN acorn-jsx@5.1.0 requires a peer of acorn@^6.0.0 || ^7.0.0 but none is installed. You must install peer dependencies yourself.
npm WARN eslint-config-react-app@5.2.0 requires a peer of eslint-plugin-flowtype@3.x but none is installed. You must install peer dependencies yourself.
```
