### PR TITLE
Update to Home Page to improve user guidance

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -141,7 +141,7 @@ export const SignIn = hh(class SignIn extends Component {
           onSuccess: this.responseGoogle,
           onFailure: this.forbidden,
           icon: false,
-          buttonText: 'Sign-In'
+          buttonText: 'Start here!'
         }
       );
     }


### PR DESCRIPTION
Updating button text from "Sign In" to "Start here!" to improve user guidance, particularly for new users, in response to recent ZenDesk tickets.