### PR TITLE
DUOS-562 Research purpose

### DIFF
--- a/src/components/AppSummary.js
+++ b/src/components/AppSummary.js
@@ -19,6 +19,7 @@ const LOREM_IPSUM =
 
 export const AppSummary = hh(class AppSummary extends React.PureComponent {
   render() {
+    const { darInfo } = this.props;
     return div({ id: 'app-summary' },
       [
         div({ style: SUBHEADER }, "Application summary"),
@@ -51,7 +52,7 @@ export const AppSummary = hh(class AppSummary extends React.PureComponent {
             id: "rp",
             style: { margin: '32px 0px' },
           },
-          [ApplicationSection({ header: 'Research Purpose', content: LOREM_IPSUM, headerColor: Theme.palette.primary, })]
+          [ApplicationSection({ header: 'Research Purpose', content: darInfo.rus, headerColor: Theme.palette.primary, })]
         ),
         div(
           {


### PR DESCRIPTION
Right now, the four components of the application summary are `ApplicationSection` components that simply render a header and content. Since most of the sections require additional logic to format their content, they will eventually be broken out into more specific components and the `ApplicationSection` component will be renamed to `ResearchPurpose`. For now, I'm just adding the research use statement to the existing `ApplicationSection`. :)