### PR TITLE
dependency: bump eslint-plugin-flowtype from 3.13.0 to 4.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,10 +113,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
       - run: npm install --silent
       - save_cache:
-          key: deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+          key: deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
           paths:
             - ~/.npm
       - run: npm test
@@ -126,7 +126,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
       - run: cp config/dev.json public/config.json
       - run: npm install --silent
       - run: npm install react-scripts --silent
@@ -144,7 +144,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
       - run: cp config/staging.json public/config.json
       - run: npm install --silent
       - run: npm install react-scripts --silent
@@ -163,7 +163,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
       - attach_workspace:
           at: .
       - push-env:
@@ -186,7 +186,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
       - attach_workspace:
           at: .
       - push-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,6 @@ jobs:
           keys:
             - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
             - deps2-{{ checksum "package.json" }}-
-            - deps2-
       - run: npm install --silent
       - save_cache:
           key: deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
@@ -130,7 +129,6 @@ jobs:
           keys:
             - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
             - deps2-{{ checksum "package.json" }}-
-            - deps2-
       - run: cp config/dev.json public/config.json
       - run: npm install --silent
       - run: npm install react-scripts --silent
@@ -150,7 +148,6 @@ jobs:
           keys:
             - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
             - deps2-{{ checksum "package.json" }}-
-            - deps2-
       - run: cp config/staging.json public/config.json
       - run: npm install --silent
       - run: npm install react-scripts --silent
@@ -171,7 +168,6 @@ jobs:
           keys:
             - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
             - deps2-{{ checksum "package.json" }}-
-            - deps2-
       - attach_workspace:
           at: .
       - push-env:
@@ -196,7 +192,6 @@ jobs:
           keys:
             - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
             - deps2-{{ checksum "package.json" }}-
-            - deps2-
       - attach_workspace:
           at: .
       - push-env:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
             - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
       - run: npm install --silent
       - save_cache:
-          - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
+          key: deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
           paths:
             - ~/.npm
       - run: npm test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,11 +113,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - deps2-{{ checksum "package.json" }}-
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
       - run: npm install --silent
       - save_cache:
-          key: deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+          - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
           paths:
             - ~/.npm
       - run: npm test
@@ -127,8 +126,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - deps2-{{ checksum "package.json" }}-
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
       - run: cp config/dev.json public/config.json
       - run: npm install --silent
       - run: npm install react-scripts --silent
@@ -146,8 +144,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - deps2-{{ checksum "package.json" }}-
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
       - run: cp config/staging.json public/config.json
       - run: npm install --silent
       - run: npm install react-scripts --silent
@@ -166,8 +163,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - deps2-{{ checksum "package.json" }}-
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
       - attach_workspace:
           at: .
       - push-env:
@@ -190,8 +186,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
-            - deps2-{{ checksum "package.json" }}-
+            - deps2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch}}
       - attach_workspace:
           at: .
       - push-env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5121,9 +5121,9 @@
       }
     },
     "eslint-plugin-flowtype": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-3.13.0.tgz",
-      "integrity": "sha512-bhewp36P+t7cEV0b6OdmoRWJCBYRiHFlqPZAG1oS3SF+Y0LQkeDvFSM4oxoxvczD1OdONCXMlJfQFiWLcV9urw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz",
+      "integrity": "sha512-W5hLjpFfZyZsXfo5anlu7HM970JBDqbEshAJUkeczP6BFCIfJXuiIBQXyberLRtOStT0OGPF8efeTbxlHk4LpQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.15"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "acorn": "7.1.1",
     "eslint": "6.8.0",
     "eslint-config-react-app": "5.2.1",
-    "eslint-plugin-flowtype": "3.13.0",
+    "eslint-plugin-flowtype": "4.6.0",
     "eslint-plugin-react": "7.19.0",
     "handlebars": "4.7.3",
     "js-yaml": "3.13.1",


### PR DESCRIPTION
Recreating https://github.com/DataBiosphere/duos-ui/pull/360 to fix the circleci cache problem
Update the caching strategy (see [this support link](https://support.circleci.com/hc/en-us/articles/360004250693-Restoring-cache-fails-with-Permission-Denied-?utm_medium=SEM&utm_source=gnb&utm_campaign=SEM-gb-DSA-Eng-ni&utm_content=&utm_term=dynamicSearch-&gclid=CjwKCAjw3-bzBRBhEiwAgnnLCuMh9QmPjyYZ-t_o6q96bvnp9reVdlv7oh-v7zpvUq_lhMvJ30WbIxoCKekQAvD_BwE))