### PR TITLE
[no-jira] Fix data use letter download link to use correct consent id

### DIFF
--- a/src/components/AppSummary.js
+++ b/src/components/AppSummary.js
@@ -24,8 +24,8 @@ export const AppSummary = hh(class AppSummary extends React.PureComponent {
    * downloads the data use letter for this dataset
    */
   downloadDUL = () => {
-    const { referenceId, dulName } = this.props.consent;
-    Files.getDulFile(referenceId, dulName);
+    const { consentId, dulName } = this.props.consent;
+    Files.getDulFile(consentId, dulName);
   };
 
   render() {


### PR DESCRIPTION
## Addresses
Bug when downloading the Data Use Letter for a dataset.

## Changes
In a previous version, the function was using the `referenceId` of a consent election to download the file. It was changed to use a consent object that instead has a `consentId`, which is now being correctly accessed.