### PR TITLE
Expanding eRA Commons auth bypass ability to NIH intramural researchers

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -791,7 +791,7 @@ class DataAccessRequestApplication extends Component {
                         onChange: this.handleCheckboxChange
                       }),
                       label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_collaborator' },
-                        ['I am a collaborator of the PI/Data Custodian for the selected dataset(s)'])
+                        ['I am an NIH Intramural researcher (NIH email required) and/or collaborator of the PI/Data Custodian for the selected dataset(s)'])
                     ]),
 
                     div({ className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12' }, [


### PR DESCRIPTION
NIH intramural researchers often do not have eRA Commons IDs. We are broadening the language of the 'Internal Collaborator' bypass checkbox to allow them to bypass eRA auth and still submit a DAR.

We will need to validate their library card existence based on their nih email as a uid rather than an era id. 