### PR TITLE
[DUOS-638][risk=no] Add notifications service

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -1,4 +1,5 @@
 {
+  "env": "dev",
   "apiUrl": "https://consent.dsde-dev.broadinstitute.org/api",
   "ontologyApiUrl": "https://consent-ontology.dsde-dev.broadinstitute.org/",
   "clientId": "1087760099392-u18o6sqvb8uljmdltflohmd34h6hik9b.apps.googleusercontent.com",

--- a/config/local.json
+++ b/config/local.json
@@ -1,4 +1,5 @@
 {
+  "env": "local",
   "apiUrl": "https://local.broadinstitute.org:27443/api",
   "ontologyApiUrl": "https://local.broadinstitute.org:28443/",
   "clientId": "1087760099392-u18o6sqvb8uljmdltflohmd34h6hik9b.apps.googleusercontent.com",

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,4 +1,5 @@
 {
+  "env": "prod",
   "apiUrl": "https://consent.dsde-prod.broadinstitute.org/api",
   "ontologyApiUrl": "https://consent-ontology.dsde-prod.broadinstitute.org/",
   "clientId": "383345696373-epss75p24k6on93kq37ccse0n626ojal.apps.googleusercontent.com",

--- a/config/staging.json
+++ b/config/staging.json
@@ -1,4 +1,5 @@
 {
+  "env": "staging",
   "apiUrl": "https://consent.dsde-staging.broadinstitute.org/api",
   "ontologyApiUrl": "https://consent-ontology.dsde-staging.broadinstitute.org/",
   "clientId": "1087760099392-t0nb61ehicbeuqkeftvql765ncu1707r.apps.googleusercontent.com",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2943,6 +2943,11 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3489,6 +3494,21 @@
         "supports-color": "^5.3.0"
       }
     },
+    "character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+    },
+    "character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+    },
+    "character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+    },
     "chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -3803,6 +3823,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -7126,6 +7151,53 @@
         }
       }
     },
+    "html-to-react": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
+      "integrity": "sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==",
+      "requires": {
+        "domhandler": "^3.0",
+        "htmlparser2": "^4.0",
+        "lodash.camelcase": "^4.3.0",
+        "ramda": "^0.26"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "domhandler": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
+          "integrity": "sha512-eKLdI5v9m67kbXQbJSNn1zjh0SDzvzWVWtX+qEI3eMjZw8daH9k8rlj1FZY9memPwjiskQFbe7vHVVJIAqoEhw==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        },
+        "domutils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
+          "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+          "requires": {
+            "dom-serializer": "^0.2.1",
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0"
+          }
+        },
+        "htmlparser2": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+          "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "domutils": "^2.0.0",
+            "entities": "^2.0.0"
+          }
+        }
+      }
+    },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz",
@@ -7543,6 +7615,20 @@
         "kind-of": "^3.0.2"
       }
     },
+    "is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+    },
+    "is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "requires": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      }
+    },
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
@@ -7605,6 +7691,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -7659,6 +7750,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-in-browser": {
       "version": "1.1.3",
@@ -7801,10 +7897,20 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-whitespace-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "is-word-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -9486,6 +9592,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9712,6 +9823,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "markdown-escapes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -9720,6 +9836,14 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdast-add-list-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
+      "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+      "requires": {
+        "unist-util-visit-parents": "1.1.2"
       }
     },
     "mdn-data": {
@@ -10861,6 +10985,19 @@
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-entities": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
+      "requires": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
       }
     },
     "parse-json": {
@@ -12107,8 +12244,7 @@
     "ramda": {
       "version": "0.26.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
-      "dev": true
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -12480,6 +12616,21 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/react-load-script/-/react-load-script-0.0.6.tgz",
       "integrity": "sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ=="
+    },
+    "react-markdown": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.3.1.tgz",
+      "integrity": "sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==",
+      "requires": {
+        "html-to-react": "^1.3.4",
+        "mdast-add-list-metadata": "1.0.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.6",
+        "remark-parse": "^5.0.0",
+        "unified": "^6.1.5",
+        "unist-util-visit": "^1.3.0",
+        "xtend": "^4.0.1"
+      }
     },
     "react-material-icon-svg": {
       "version": "3.8.0",
@@ -12867,6 +13018,28 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
+    "remark-parse": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
+      "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+      "requires": {
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^1.1.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^1.0.0",
+        "vfile-location": "^2.0.0",
+        "xtend": "^4.0.1"
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -12928,6 +13101,11 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
       "version": "2.88.2",
@@ -14186,6 +14364,11 @@
         }
       }
     },
+    "state-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -14923,6 +15106,21 @@
         "punycode": "^2.1.0"
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA=="
+    },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+    },
     "ts-pnp": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.6.tgz",
@@ -15022,6 +15220,15 @@
         }
       }
     },
+    "unherit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "requires": {
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -15045,6 +15252,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+    },
+    "unified": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
+      "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^1.1.0",
+        "trough": "^1.0.0",
+        "vfile": "^2.0.0",
+        "x-is-string": "^0.1.0"
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -15103,6 +15323,47 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+    },
+    "unist-util-remove-position": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
+      "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
+      "requires": {
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+      "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+    },
+    "unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "requires": {
+        "unist-util-visit-parents": "^2.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
+      "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
     },
     "universalify": {
       "version": "0.1.2",
@@ -15314,6 +15575,30 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vfile": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
+      "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+      "requires": {
+        "is-buffer": "^1.1.4",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^1.0.0",
+        "vfile-message": "^1.0.0"
+      }
+    },
+    "vfile-location": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
+      "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
+    },
+    "vfile-message": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+      "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+      "requires": {
+        "unist-util-stringify-position": "^1.1.1"
       }
     },
     "vm-browserify": {
@@ -17227,6 +17512,11 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
+    },
+    "x-is-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
+      "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-google-charts": "3.0.15",
     "react-google-login": "5.1.3",
     "react-hyperscript-helpers": "2.0.0",
+    "react-markdown": "4.3.1",
     "react-material-icon-svg": "3.8.0",
     "react-modal": "3.11.2",
     "react-onclickoutside": "6.9.0",

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -8,10 +8,10 @@ import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import ReportIcon from '@material-ui/icons/Report';
 
 export const Notification = (props) => {
-  const {banner} = props;
-  let bannerDiv = div({style: {display: 'none'}}, []);
+  const {notificationData} = props;
+  let notificationDiv = div({style: {display: 'none'}}, []);
 
-  if (!fp.isEmpty(banner)) {
+  if (!fp.isEmpty(notificationData)) {
     const iconStyle = {
       marginRight: '2rem',
       verticalAlign: 'middle',
@@ -19,7 +19,7 @@ export const Notification = (props) => {
       width: 30,
     };
     let icon;
-    switch (banner.level) {
+    switch (notificationData.level) {
       case 'success':
         icon = <CheckCircleIcon fill={'#3c763d'} style={ iconStyle } />;
         break;
@@ -36,15 +36,15 @@ export const Notification = (props) => {
         icon = <InfoIcon fill={'#3c763d'} style={ iconStyle } />;
         break;
     }
-    const content = <ReactMarkdown source={banner.message} linkTarget={'_blank'} className={'underlined'}/>;
-    bannerDiv = div({
+    const content = <ReactMarkdown source={notificationData.message} linkTarget={'_blank'} className={'underlined'}/>;
+    notificationDiv = div({
       style: {padding: '.5rem', paddingTop: '1.5rem'},
-      className: 'row no-margin alert alert-' + banner.level,
+      className: 'row no-margin alert alert-' + notificationData.level,
     }, [
-      div({style: {display: 'inline', float: 'left', marginTop: '-.5rem'}}, [icon]),
-      div({style: {display: 'inline', paddingTop: '1.5rem'}}, [content]),
+      div({style: {display: 'inline', float: 'left', paddingLeft: '.5rem'}}, [icon]),
+      div({style: {display: 'inline', paddingTop: '1.25rem'}}, [content]),
     ]);
   }
 
-  return bannerDiv;
+  return notificationDiv;
 };

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -1,0 +1,50 @@
+import {div} from 'react-hyperscript-helpers';
+import * as fp from 'lodash/fp';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import WarningIcon from '@material-ui/icons/Warning';
+import InfoIcon from '@material-ui/icons/Info';
+import CheckCircleIcon from '@material-ui/icons/CheckCircle';
+import ReportIcon from '@material-ui/icons/Report';
+
+export const Notification = (props) => {
+  const {banner} = props;
+  let bannerDiv = div({style: {display: 'none'}}, []);
+
+  if (!fp.isEmpty(banner)) {
+    const iconStyle = {
+      marginRight: '2rem',
+      verticalAlign: 'middle',
+      height: 30,
+      width: 30,
+    };
+    let icon;
+    switch (banner.level) {
+      case 'success':
+        icon = <CheckCircleIcon fill={'#3c763d'} style={ iconStyle } />;
+        break;
+      case 'info':
+        icon = <InfoIcon fill={'#31708f'} style={ iconStyle } />;
+        break;
+      case 'warning':
+        icon = <WarningIcon fill={'#8a6d3b'} style={ iconStyle } />;
+        break;
+      case 'danger':
+        icon = <ReportIcon fill={'#a94442'} style={ iconStyle } />;
+        break;
+      default:
+        icon = <InfoIcon fill={'#3c763d'} style={ iconStyle } />;
+        break;
+    }
+    const content = <ReactMarkdown source={banner.message} linkTarget={'_blank'} className={'underlined'}/>;
+    bannerDiv = div({
+      style: {padding: '.5rem', paddingTop: '1.5rem'},
+      className: 'row no-margin alert alert-' + banner.level,
+    }, [
+      div({style: {display: 'inline', float: 'left', marginTop: '-.5rem'}}, [icon]),
+      div({style: {display: 'inline', paddingTop: '1.5rem'}}, [content]),
+    ]);
+  }
+
+  return bannerDiv;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -59,6 +59,14 @@ a {
   cursor: pointer;
 }
 
+.underlined > p > a {
+  text-decoration: underline !important;
+}
+
+.underlined > p > a:hover {
+  text-decoration: underline !important;
+}
+
 a, input, button {
   outline: 0 !important;
   text-decoration: none !important;

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -4,6 +4,8 @@ import {Storage} from './storage';
 
 export const Config = {
 
+  getEnv: async () => (await getConfig()).env,
+
   getApiUrl: async () => (await getConfig()).apiUrl,
 
   getOntologyApiUrl: async () => (await getConfig()).ontologyApiUrl,

--- a/src/libs/notificationService.js
+++ b/src/libs/notificationService.js
@@ -1,0 +1,35 @@
+import * as fp from 'lodash/fp';
+import {Config} from './config';
+import $ from 'jquery';
+
+// https://storage.googleapis.com/broad-duos-banners/{{env}}_banners.json
+const gcs = 'https://storage.googleapis.com/broad-duos-banners';
+const bannerFileName = 'banners.json';
+
+export const NotificationService = {
+
+  /**
+   * Get the raw banner content from GCS
+   * @returns {Promise<JSON>}
+   */
+  getBanners: async () => {
+    const env = await Config.getEnv();
+    return $.getJSON(gcs + '/' + env + '_' + bannerFileName, (data) => {
+      return data;
+    });
+  },
+
+  /**
+   * Get an individual banner by its id, and active status == true
+   * @param id
+   * @returns {Promise<JSON>}
+   */
+  getBannerObjectById: async (id) => {
+    const banners = await NotificationService.getBanners();
+    if (!fp.isEmpty(banners)) {
+      return fp.find({active: true, id: id})(banners);
+    }
+    return undefined;
+  },
+
+};

--- a/src/libs/notificationService.js
+++ b/src/libs/notificationService.js
@@ -2,9 +2,9 @@ import * as fp from 'lodash/fp';
 import {Config} from './config';
 import $ from 'jquery';
 
-// https://storage.googleapis.com/broad-duos-banners/{{env}}_banners.json
+// https://storage.googleapis.com/broad-duos-banners/{{env}}_notifications.json
 const gcs = 'https://storage.googleapis.com/broad-duos-banners';
-const bannerFileName = 'banners.json';
+const bannerFileName = 'notifications.json';
 
 export const NotificationService = {
 

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -6,9 +6,11 @@ import ReactTooltip from 'react-tooltip';
 import { Alert } from '../components/Alert';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { eRACommons } from '../components/eRACommons';
+import { Notification } from '../components/Notification';
 import { PageHeading } from '../components/PageHeading';
 import { YesNoRadioGroup } from '../components/YesNoRadioGroup';
 import { DAR, Researcher } from '../libs/ajax';
+import { NotificationService } from '../libs/notificationService';
 import { Storage } from '../libs/storage';
 
 import './DataAccessRequestApplication.css';
@@ -137,6 +139,11 @@ class DataAccessRequestApplication extends Component {
     await this.init();
     this.props.history.push('/dar_application');
     ReactTooltip.rebuild();
+    const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
+    this.setState(prev => {
+      prev.notificationData = notificationData;
+      return prev;
+    });
   }
 
   async init() {
@@ -706,6 +713,7 @@ class DataAccessRequestApplication extends Component {
       div({ className: 'container' }, [
         div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
           div({ className: 'row no-margin' }, [
+            Notification({banner: this.state.notificationData}),
             div({
               className: (this.state.formData.dar_code !== null ?
                 'col-lg-10 col-md-9 col-sm-9 ' :

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -713,7 +713,7 @@ class DataAccessRequestApplication extends Component {
       div({ className: 'container' }, [
         div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
           div({ className: 'row no-margin' }, [
-            Notification({banner: this.state.notificationData}),
+            Notification({notificationData: this.state.notificationData}),
             div({
               className: (this.state.formData.dar_code !== null ?
                 'col-lg-10 col-md-9 col-sm-9 ' :

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -8,6 +8,8 @@ import { PageHeading } from '../components/PageHeading';
 import { YesNoRadioGroup } from '../components/YesNoRadioGroup';
 import { DAR, Researcher, User } from '../libs/ajax';
 import { Storage } from '../libs/storage';
+import { NotificationService } from '../libs/notificationService';
+import { Notification } from '../components/Notification';
 
 
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
@@ -30,6 +32,11 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     this.getResearcherProfile();
     ReactTooltip.rebuild();
     this.props.history.push('profile');
+    const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
+    this.setState(prev => {
+      prev.notificationData = notificationData;
+      return prev;
+    });
   }
 
   initialState() {
@@ -459,6 +466,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       div({ className: 'container' }, [
         div({ className: 'row no-margin' }, [
           div({ className: 'col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12' }, [
+            Notification({banner: this.state.notificationData}),
             PageHeading({
               id: 'researcherProfile',
               color: 'common',

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -466,7 +466,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       div({ className: 'container' }, [
         div({ className: 'row no-margin' }, [
           div({ className: 'col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12' }, [
-            Notification({banner: this.state.notificationData}),
+            Notification({notificationData: this.state.notificationData}),
             PageHeading({
               id: 'researcherProfile',
               color: 'common',


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-638

## Changes
* New config option for environment
* A new notification service that looks up a predefined environment specific notifications json in GCS. Any page can request an (active) notification by its id. Inactive notifications are ignored.
* Future plans include adding a global one that the root page will look for.

JSON has to form of:
```
[
    {
        "id": "anyUniqueId",
        "active": true|false,
        "level": "success|info|warning|danger",
        "message": "any valid markdown"
    }
]
```

For the following screenshots, note that the actual notification text is not final. The ticket calls for 
> The NIH eRA Commons service is migrating to the cloud from 4/17-4/20. DUOS users' ability to authenticate with eRA Commons may be disrupted during this window.

And that will be the final value in the notification json content.

### DAR Page (info level)
![Screen Shot 2020-04-15 at 1 24 50 PM](https://user-images.githubusercontent.com/116679/79369124-73fe1800-7f1e-11ea-8560-3f9dbf316bc7.png)

### Profile Page (info level)
![Screen Shot 2020-04-15 at 1 25 01 PM](https://user-images.githubusercontent.com/116679/79369169-87a97e80-7f1e-11ea-9bde-4b8a2a24c382.png)

### Success Level Styling
![Screen Shot 2020-04-15 at 1 28 46 PM](https://user-images.githubusercontent.com/116679/79369186-8d9f5f80-7f1e-11ea-9139-986bcac1a539.png)

### Warning Level Styling
![Screen Shot 2020-04-15 at 1 29 10 PM](https://user-images.githubusercontent.com/116679/79369203-91cb7d00-7f1e-11ea-9d63-0dbd96f422a3.png)

### Danger Level Styling
![Screen Shot 2020-04-15 at 1 29 29 PM](https://user-images.githubusercontent.com/116679/79369211-96903100-7f1e-11ea-8544-b70269cdcec7.png)

