### PR TITLE
[no-jira][risk=no] Remove unused config

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -4,7 +4,6 @@
   "ontologyApiUrl": "https://consent-ontology.dsde-dev.broadinstitute.org/",
   "clientId": "1087760099392-u18o6sqvb8uljmdltflohmd34h6hik9b.apps.googleusercontent.com",
   "firecloudUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org/",
-  "gwasUrl": "",
   "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html",
   "features": {
     "newDarUi": true

--- a/config/local.json
+++ b/config/local.json
@@ -4,7 +4,6 @@
   "ontologyApiUrl": "https://local.broadinstitute.org:28443/",
   "clientId": "1087760099392-u18o6sqvb8uljmdltflohmd34h6hik9b.apps.googleusercontent.com",
   "firecloudUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org/",
-  "gwasUrl": "",
   "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html",
   "features": {}
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -4,7 +4,6 @@
   "ontologyApiUrl": "https://consent-ontology.dsde-prod.broadinstitute.org/",
   "clientId": "383345696373-epss75p24k6on93kq37ccse0n626ojal.apps.googleusercontent.com",
   "firecloudUrl": "https://api.firecloud.org/",
-  "gwasUrl": "",
   "nihUrl": "https://shibboleth.dsde-prod.broadinstitute.org/link-nih-account",
   "features": {}
 }

--- a/config/staging.json
+++ b/config/staging.json
@@ -4,7 +4,6 @@
   "ontologyApiUrl": "https://consent-ontology.dsde-staging.broadinstitute.org/",
   "clientId": "1087760099392-t0nb61ehicbeuqkeftvql765ncu1707r.apps.googleusercontent.com",
   "firecloudUrl": "https://firecloud-orchestration.dsde-staging.broadinstitute.org/",
-  "gwasUrl": "",
   "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html",
   "features": {}
 }

--- a/public/config-example.json
+++ b/public/config-example.json
@@ -1,8 +1,8 @@
 {
+  "env": "local|dev|staging|prod",
   "apiUrl": "http://localhost:8180/api",
   "ontologyApiUrl": "https://ontologyURL.org/",
   "clientId": "111111111111-11111111111111111111111111111111.apps.googleusercontent.com",
-  "gwasUrl": "",
   "firecloudUrl": "https://firecloud-orchestration.dsde-dev.broadinstitute.org/",
   "nihUrl": "http://mock-nih.dev.test.firecloud.org/link-nih-account/index.html",
   "features": {


### PR DESCRIPTION
There used to be a gwas url in the research purpose section of the DAR application in the original app ([see this link](https://github.com/DataBiosphere/consent-ui/commit/092abc9f1f9a57adf55bb933b05a14f7912f295c#diff-4333aecd9e93eeba935bd610aca50ff8R16)). That is no longer in use, so removing it.