### PR TITLE
[DUOS-685][risk=no] Don't pass library cards when updating user

### DIFF
--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -416,7 +416,8 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
 
   updateResearcher(profile) {
-    Researcher.updateProperties(Storage.getCurrentUser().dacUserId, true, profile).then(resp => {
+    const profileClone = _.omit(_.cloneDeep(profile), ['libraryCards']);
+    Researcher.updateProperties(Storage.getCurrentUser().dacUserId, true, profileClone).then(resp => {
       this.saveUser().then(resp => {
         this.setState({ showDialogSubmit: false });
         this.props.history.push({ pathname: 'dataset_catalog' });
@@ -452,7 +453,8 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     if (answer === true) {
       let profile = this.state.profile;
       profile.completed = false;
-      Researcher.updateProperties(Storage.getCurrentUser().dacUserId, false, profile);
+      const profileClone = _.omit(_.cloneDeep(profile), ['libraryCards']);
+      Researcher.updateProperties(Storage.getCurrentUser().dacUserId, false, profileClone);
       this.props.history.push({ pathname: 'dataset_catalog' });
     }
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-685

## Changes
The API is expecting a simple map of string -> string. If we pass in libraryCards as a list of strings, that breaks the API's json parsing.