### PR TITLE
[DUOS-601][DUOS-603][risk=no] UI changes for DAR mongo->postgres conversion

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -59,6 +59,9 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/data_owner_console" component={DataOwnerConsole} props={props} rolesAllowed={[USER_ROLES.dataOwner]} />
     <AuthenticatedRoute path="/data_owner_review/:voteId/:referenceId/:dataSetId" component={DataOwnerReview} props={props}
       rolesAllowed={[USER_ROLES.dataOwner]} />
+    {/* Order is important for processing links with embedded dataRequestIds */}
+    <AuthenticatedRoute path="/dar_application/:dataRequestId" component={DataAccessRequestApplication} props={props}
+      rolesAllowed={[USER_ROLES.researcher]} />
     <AuthenticatedRoute path="/dar_application" component={DataAccessRequestApplication} props={props}
       rolesAllowed={[USER_ROLES.researcher]} />
     <AuthenticatedRoute path="/profile" component={ResearcherProfile} props={props} rolesAllowed={[USER_ROLES.all]} />

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -8,7 +8,7 @@ export const RadioButton = (props) => {
     lineHeight: '2rem',
     color: 333,
     fontFamily: '\'Roboto\', sans-serif',
-    cursor: 'pointer',
+    cursor: props.disabled ? 'not-allowed' : 'pointer',
     position: 'relative',
   };
 
@@ -16,7 +16,7 @@ export const RadioButton = (props) => {
     fontSize: 15,
     lineHeight: '1.5rem',
     color: 333,
-    cursor: 'pointer',
+    cursor: props.disabled ? 'not-allowed' : 'pointer',
     boxSizing: 'border-box',
     position: 'absolute',
     top: 0,
@@ -35,7 +35,7 @@ export const RadioButton = (props) => {
   });
 
   const labelStyle = {
-    cursor: 'pointer',
+    cursor: props.disabled ? 'not-allowed' : 'pointer',
     color: '#603B9B',
     fontSize: 15,
     fontWeight: 'normal',

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -39,6 +39,16 @@ export const Navigation = {
               : user.isAlumni ? '/summary_votes'
                 : '/';
     history.push(page);
+  },
+  console: (user, history) => {
+    const page = user.isChairPerson ? '/chair_console'
+      : user.isMember ? '/member_console'
+        : user.isAdmin ? '/admin_console'
+          : user.isResearcher ? '/researcher_console'
+            : user.isDataOwner ? '/data_owner_console'
+              : user.isAlumni ? '/summary_votes'
+                : '/';
+    history.push(page);
   }
 };
 

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -1,6 +1,6 @@
 import * as ld from 'lodash';
 import { Component, Fragment } from 'react';
-import { a, b, button, div, h, h3, h4, hr, i, label, li, span, ul } from 'react-hyperscript-helpers';
+import { a, div, h, h3, h4, hr, i, label, span } from 'react-hyperscript-helpers';
 import { ApplicationSummary } from '../components/ApplicationSummary';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { CollectResultBox } from '../components/CollectResultBox';
@@ -12,7 +12,6 @@ import { DAR, Election, Files, Match, Researcher, Votes } from '../libs/ajax';
 import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
-import { Theme } from '../libs/theme';
 import * as Utils from '../libs/utils';
 
 

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -74,8 +74,6 @@ class DataAccessRequestApplication extends Component {
         havePi: '',
         profileName: '',
         piName: '',
-        urlDAA: '',
-        nameDAA: '',
         pubmedId: '',
         scientificUrl: ''
       },
@@ -172,8 +170,6 @@ class DataAccessRequestApplication extends Component {
     formData.country = rpProperties.country != null ? rpProperties.country : '';
     formData.state = rpProperties.state != null ? rpProperties.state : '';
     formData.piName = rpProperties.piName !== null ? rpProperties.piName : '';
-    formData.nameDAA = rpProperties.nameDAA != null ? rpProperties.nameDAA : '';
-    formData.urlDAA = rpProperties.urlDAA != null ? rpProperties.urlDAA : '';
     formData.academicEmail = rpProperties.academicEmail != null ? rpProperties.academicEmail : '';
     formData.piEmail = rpProperties.piEmail != null ? rpProperties.piEmail : '';
     formData.isThePi = rpProperties.isThePI !== undefined ? rpProperties.isThePI : '';
@@ -191,9 +187,6 @@ class DataAccessRequestApplication extends Component {
     this.setState(prev => {
       prev.completed = completed;
       prev.formData = formData;
-      if (formData.nameDAA !== '') {
-        prev.file.name = formData.nameDAA;
-      }
       return prev;
     });
 
@@ -429,25 +422,14 @@ class DataAccessRequestApplication extends Component {
           prev.disableOkBtn = true;
           return prev;
         });
-        DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-          formData.urlDAA = response.urlDAA;
-          formData.nameDAA = response.nameDAA;
-          if (formData.dar_code !== undefined && formData.dar_code !== null) {
-            DAR.updateDar(formData, formData.dar_code).then(response => {
-              this.setState({ showDialogSubmit: false });
-              Navigation.console(Storage.getCurrentUser(), this.props.history);
-            });
-          } else {
-            DAR.postDataAccessRequest(formData).then(response => {
-              this.setState({ showDialogSubmit: false });
-              Navigation.console(Storage.getCurrentUser(), this.props.history);
-            }).catch(e =>
-              this.setState(prev => {
-                prev.problemSavingRequest = true;
-                return prev;
-              }));
-          }
-        });
+        DAR.postDataAccessRequest(formData).then(response => {
+          this.setState({ showDialogSubmit: false });
+          Navigation.console(Storage.getCurrentUser(), this.props.history);
+        }).catch(e =>
+          this.setState(prev => {
+            prev.problemSavingRequest = true;
+            return prev;
+          }));
       });
     } else {
       this.setState({ showDialogSubmit: false });
@@ -486,24 +468,9 @@ class DataAccessRequestApplication extends Component {
   };
 
   savePartial() {
-
-    if (this.state.file !== undefined && this.state.file.name !== '') {
-      DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-        this.saveDAR(response);
-      });
-    } else {
-      this.saveDAR(null);
-    }
-  };
-
-  saveDAR(response) {
     let formData = this.state.formData;
     // DAR datasetId needs to be a list of ids
     formData.datasetId = fp.map('value')(formData.datasets);
-    if (response !== null) {
-      formData.urlDAA = response.urlDAA;
-      formData.nameDAA = response.nameDAA;
-    }
     if (formData.partial_dar_code === null) {
       DAR.postPartialDarRequest(formData).then(resp => {
         this.setShowDialogSave(false);
@@ -513,7 +480,7 @@ class DataAccessRequestApplication extends Component {
         this.setShowDialogSave(false);
       });
     }
-  }
+  };
 
   onDatasetsChange = (data, action) => {
     this.setState(prev => {

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -475,13 +475,16 @@ class DataAccessRequestApplication extends Component {
     }
   };
 
-  savePartial() {
+  savePartial = () => {
     let formData = this.state.formData;
     // DAR datasetId needs to be a list of ids
     formData.datasetId = fp.map('value')(formData.datasets);
-    if (formData.partial_dar_code === null) {
+    // Make sure we navigate back to the current DAR after saving.
+    const { dataRequestId } = this.props.match.params;
+    if (fp.isNil(dataRequestId)) {
       DAR.postPartialDarRequest(formData).then(resp => {
         this.setShowDialogSave(false);
+        this.props.history.replace('/dar_application/' + resp.reference_id);
       });
     } else {
       DAR.updatePartialDarRequest(formData).then(resp => {

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -135,8 +135,16 @@ class DataAccessRequestApplication extends Component {
       formData.datasetId = fp.map('value')(datasets);
     } else if (!fp.isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
+      // Same endpoint works for any dataRequestId, not just partials.
       DAR.getPartialDarRequest(dataRequestId).then(data => {
         formData = data;
+        // Handle the case where the DAR is already submitted. We have to
+        // show the single dataset that was selected for this DAR and not
+        // all of the original datasets that may have been originally selected.
+        if (!fp.isNil(formData.dar_code)) {
+          const dsId = fp.get('datasetId')(formData)[0];
+          formData.datasets = fp.filter({value: dsId.toString()})(formData.datasets);
+        }
       });
     } else {
       // Lastly, try to get the form data from local storage and clear out whatever was there previously

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -169,7 +169,7 @@ class DataAccessRequestApplication extends Component {
     formData.userId = Storage.getCurrentUser().dacUserId;
 
     let completed = false;
-    if (formData.dar_code !== null) {
+    if (!fp.isNil(formData.dar_code)) {
       completed = '';
     } else if (rpProperties.completed !== undefined) {
       completed = JSON.parse(rpProperties.completed);

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -435,12 +435,12 @@ class DataAccessRequestApplication extends Component {
           if (formData.dar_code !== undefined && formData.dar_code !== null) {
             DAR.updateDar(formData, formData.dar_code).then(response => {
               this.setState({ showDialogSubmit: false });
-              Navigation.back(Storage.getCurrentUser(), this.props.history);
+              Navigation.console(Storage.getCurrentUser(), this.props.history);
             });
           } else {
             DAR.postDataAccessRequest(formData).then(response => {
               this.setState({ showDialogSubmit: false });
-              Navigation.back(Storage.getCurrentUser(), this.props.history);
+              Navigation.console(Storage.getCurrentUser(), this.props.history);
             }).catch(e =>
               this.setState(prev => {
                 prev.problemSavingRequest = true;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -488,6 +488,7 @@ class DataAccessRequestApplication extends Component {
 
   saveDAR(response) {
     let formData = this.state.formData;
+    formData.datasetId = fp.map('value')(formData.datasets);
     if (response !== null) {
       formData.urlDAA = response.urlDAA;
       formData.nameDAA = response.nameDAA;
@@ -780,8 +781,8 @@ class DataAccessRequestApplication extends Component {
                         div({ isRendered: this.state.formData.checkCollaborator === true, className: 'display-inline italic' }, [' (optional)']),
                         span({ className: 'default-color' },
                           ['Please autenticate with ',
-                          a({ target: '_blank', href: 'https://era.nih.gov/reg-accounts/register-commons.htm' }, ['eRA Commons']),' in order to proceed. Your ORCID iD is optional.'
-                        ])
+                            a({ target: '_blank', href: 'https://era.nih.gov/reg-accounts/register-commons.htm' }, ['eRA Commons']),' in order to proceed. Your ORCID iD is optional.'
+                          ])
                       ])
                     ]),
 

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -626,7 +626,8 @@ class DataAccessRequestApplication extends Component {
       investigator = '',
       ontologies = []
     } = this.state.formData;
-
+    const { dataRequestId } = this.props.match.params;
+    const eRACommonsDestination = fp.isNil(dataRequestId) ? 'dar_application' : ('dar_application/' + dataRequestId);
     const { problemSavingRequest, showValidationMessages,  step1, step3 } = this.state;
     const isTypeOfResearchInvalid = this.isTypeOfResearchInvalid();
     const genderLabels = ['Female', 'Male'];
@@ -793,7 +794,7 @@ class DataAccessRequestApplication extends Component {
                     div({ className: 'row no-margin' }, [
                       eRACommons({
                         className: 'col-lg-6 col-md-6 col-sm-6 col-xs-12 rp-group',
-                        destination: 'dar_application',
+                        destination: eRACommonsDestination,
                         onNihStatusUpdate: this.onNihStatusUpdate,
                         location: this.props.location,
                         validationError: showValidationMessages

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -423,7 +423,6 @@ class DataAccessRequestApplication extends Component {
       }, () => {
         let formData = this.state.formData;
         // DAR datasetId needs to be a list of ids
-        // DAR datasets needs to be a list of datasets with populated information.
         formData.datasetId = fp.map('value')(formData.datasets);
         formData.userId = Storage.getCurrentUser().dacUserId;
         this.setState(prev => {
@@ -469,14 +468,15 @@ class DataAccessRequestApplication extends Component {
       return prev;
     });
     if (answer === true) {
-      let ontologies = [];
-      for (let ontology of this.state.formData.ontologies) {
-        ontologies.push(ontology.item);
-      }
+      // DAR datasetId needs to be a list of ids
+      const datasetId = fp.map('value')(this.state.formData.datasets);
+      // DAR ontologies needs to be a list of id/labels.
+      const ontologies = fp.map((o) => {return {
+        id: o.key,
+        label: o.value
+      };})(this.state.formData.ontologies);
       this.setState(prev => {
-        // DAR datasetId needs to be a list of ids
-        // DAR datasets needs to be a list of datasets with populated information.
-        prev.formData.datasetId = fp.map('value')(this.state.formData.datasets);
+        prev.formData.datasetId = datasetId;
         prev.formData.ontologies = ontologies;
         return prev;
       }, () => this.savePartial());
@@ -499,7 +499,6 @@ class DataAccessRequestApplication extends Component {
   saveDAR(response) {
     let formData = this.state.formData;
     // DAR datasetId needs to be a list of ids
-    // DAR datasets needs to be a list of datasets with populated information.
     formData.datasetId = fp.map('value')(formData.datasets);
     if (response !== null) {
       formData.urlDAA = response.urlDAA;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -110,7 +110,6 @@ class DataAccessRequestApplication extends Component {
 
   async componentDidMount() {
     await this.init();
-    // this.props.history.push('/dar_application');
     ReactTooltip.rebuild();
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     this.setState(prev => {
@@ -130,14 +129,11 @@ class DataAccessRequestApplication extends Component {
       formData = Storage.getData('dar_application') === null ? this.state.formData : Storage.getData('dar_application');
       Storage.removeData('dar_application');
     }
-    if (!fp.isNil(formData.dar_code)) {
-      formData.ontologies = this.getOntologies(formData);
-    }
-    // }
     let currentUserId = Storage.getCurrentUser().dacUserId;
     let rpProperties = await Researcher.getPropertiesByResearcherId(currentUserId);
-    formData.dar_code = formData.dar_code === undefined ? null : formData.dar_code;
-    formData.partial_dar_code = formData.partial_dar_code === undefined ? null : formData.partial_dar_code;
+    formData.dar_code = fp.isNil(formData.dar_code) ? null : formData.dar_code;
+    formData.partial_dar_code = fp.isNil(formData.partial_dar_code) ? null : formData.partial_dar_code;
+    formData.ontologies = this.formatOntologyItems(formData);
 
     formData.researcher = rpProperties.profileName != null ? rpProperties.profileName : '';
 
@@ -149,30 +145,27 @@ class DataAccessRequestApplication extends Component {
       formData.investigator = rpProperties.piName;
     }
 
-    if (formData.dar_code === null) {
-      formData.linkedIn = rpProperties.linkedIn !== undefined ? rpProperties.linkedIn : '';
-      formData.researcherGate = rpProperties.researcherGate !== undefined ? rpProperties.researcherGate : '';
-      formData.orcid = rpProperties.orcid !== undefined ? rpProperties.orcid : '';
-      formData.institution = rpProperties.institution != null ? rpProperties.institution : '';
-      formData.department = rpProperties.department != null ? rpProperties.department : '';
-      formData.division = rpProperties.division != null ? rpProperties.division : '';
-      formData.address1 = rpProperties.address1 != null ? rpProperties.address1 : '';
-      formData.address2 = rpProperties.address2 != null ? rpProperties.address2 : '';
-      formData.city = rpProperties.city != null ? rpProperties.city : '';
-      formData.zipcode = rpProperties.zipcode != null ? rpProperties.zipcode : '';
-      formData.country = rpProperties.country != null ? rpProperties.country : '';
-      formData.state = rpProperties.state != null ? rpProperties.state : '';
-      formData.piName = rpProperties.piName !== null ? rpProperties.piName : '';
-      formData.nameDAA = rpProperties.nameDAA != null ? rpProperties.nameDAA : '';
-      formData.urlDAA = rpProperties.urlDAA != null ? rpProperties.urlDAA : '';
-      formData.academicEmail = rpProperties.academicEmail != null ? rpProperties.academicEmail : '';
-      formData.piEmail = rpProperties.piEmail != null ? rpProperties.piEmail : '';
-      formData.isThePi = rpProperties.isThePI !== undefined ? rpProperties.isThePI : '';
-      formData.havePi = rpProperties.havePI !== undefined ? rpProperties.havePI : '';
-      formData.pubmedId = rpProperties.pubmedID !== undefined ? rpProperties.pubmedID : '';
-      formData.scientificUrl = rpProperties.scientificURL !== undefined ? rpProperties.scientificURL : '';
-    }
-
+    formData.linkedIn = rpProperties.linkedIn !== undefined ? rpProperties.linkedIn : '';
+    formData.researcherGate = rpProperties.researcherGate !== undefined ? rpProperties.researcherGate : '';
+    formData.orcid = rpProperties.orcid !== undefined ? rpProperties.orcid : '';
+    formData.institution = rpProperties.institution != null ? rpProperties.institution : '';
+    formData.department = rpProperties.department != null ? rpProperties.department : '';
+    formData.division = rpProperties.division != null ? rpProperties.division : '';
+    formData.address1 = rpProperties.address1 != null ? rpProperties.address1 : '';
+    formData.address2 = rpProperties.address2 != null ? rpProperties.address2 : '';
+    formData.city = rpProperties.city != null ? rpProperties.city : '';
+    formData.zipcode = rpProperties.zipcode != null ? rpProperties.zipcode : '';
+    formData.country = rpProperties.country != null ? rpProperties.country : '';
+    formData.state = rpProperties.state != null ? rpProperties.state : '';
+    formData.piName = rpProperties.piName !== null ? rpProperties.piName : '';
+    formData.nameDAA = rpProperties.nameDAA != null ? rpProperties.nameDAA : '';
+    formData.urlDAA = rpProperties.urlDAA != null ? rpProperties.urlDAA : '';
+    formData.academicEmail = rpProperties.academicEmail != null ? rpProperties.academicEmail : '';
+    formData.piEmail = rpProperties.piEmail != null ? rpProperties.piEmail : '';
+    formData.isThePi = rpProperties.isThePI !== undefined ? rpProperties.isThePI : '';
+    formData.havePi = rpProperties.havePI !== undefined ? rpProperties.havePI : '';
+    formData.pubmedId = rpProperties.pubmedID !== undefined ? rpProperties.pubmedID : '';
+    formData.scientificUrl = rpProperties.scientificURL !== undefined ? rpProperties.scientificURL : '';
     formData.userId = Storage.getCurrentUser().dacUserId;
 
     let completed = false;
@@ -192,10 +185,10 @@ class DataAccessRequestApplication extends Component {
 
   };
 
-  getOntologies(formData) {
-    let ontologies = {};
-    if (formData.ontologies !== undefined && formData.ontologies !== null) {
-      ontologies = formData.ontologies.map(function(item) {
+  formatOntologyItems = (formData) => {
+    let ontologyItems = [];
+    if (!fp.isNil(formData.ontologies)) {
+      ontologyItems = formData.ontologies.map(function(item) {
         return {
           key: item.id,
           value: item.id,
@@ -204,8 +197,8 @@ class DataAccessRequestApplication extends Component {
         };
       });
     }
-    return ontologies;
-  }
+    return ontologyItems;
+  };
 
   handleChange = (e) => {
     const field = e.target.name;
@@ -629,9 +622,9 @@ class DataAccessRequestApplication extends Component {
       controls = false,
       methods = false,
       linkedIn = '',
-      investigator = ''
+      investigator = '',
+      ontologies = []
     } = this.state.formData;
-    const { ontologies } = this.state;
 
     const { problemSavingRequest, showValidationMessages,  step1, step3 } = this.state;
     const isTypeOfResearchInvalid = this.isTypeOfResearchInvalid();

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -134,7 +134,7 @@ class DataAccessRequestApplication extends Component {
         };
       });
       formData.datasets = datasets;
-      formData.datasetId = fp.map('key')(datasets);
+      formData.datasetId = fp.map('value')(datasets);
     } else if (!fp.isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
       DAR.getPartialDarRequest(dataRequestId).then(data => {
@@ -424,7 +424,7 @@ class DataAccessRequestApplication extends Component {
         let formData = this.state.formData;
         // DAR datasetId needs to be a list of ids
         // DAR datasets needs to be a list of datasets with populated information.
-        formData.datasetId = fp.map('key')(formData.datasets);
+        formData.datasetId = fp.map('value')(formData.datasets);
         formData.userId = Storage.getCurrentUser().dacUserId;
         this.setState(prev => {
           prev.disableOkBtn = true;
@@ -476,7 +476,7 @@ class DataAccessRequestApplication extends Component {
       this.setState(prev => {
         // DAR datasetId needs to be a list of ids
         // DAR datasets needs to be a list of datasets with populated information.
-        prev.formData.datasetId = fp.map('key')(this.state.formData.datasets);
+        prev.formData.datasetId = fp.map('value')(this.state.formData.datasets);
         prev.formData.ontologies = ontologies;
         return prev;
       }, () => this.savePartial());

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -4,7 +4,7 @@ import * as Utils from '../libs/utils';
 import { PageHeading } from '../components/PageHeading';
 import { PageSubHeading } from '../components/PageSubHeading';
 import { PaginatorBar } from '../components/PaginatorBar';
-import { DAR, DataSet } from '../libs/ajax';
+import { DAR } from '../libs/ajax';
 import { Storage } from '../libs/storage';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Link } from 'react-router-dom';
@@ -30,10 +30,6 @@ class ResearcherConsole extends Component {
       showDialogDeletePDAR: false,
       alertTitle: undefined
     };
-
-    this.handleOpenModal = this.handleOpenModal.bind(this);
-    this.handleCloseModal = this.handleCloseModal.bind(this);
-    this.review = this.review.bind(this);
   }
 
   handleDarPageChange = page => {
@@ -63,51 +59,6 @@ class ResearcherConsole extends Component {
       return prev;
     });
   };
-
-  handleOpenModal() {
-    this.setState({ showModal: true });
-  }
-
-  handleCloseModal() {
-    this.setState({ showModal: false });
-  }
-
-  async review(e) {
-    const dataRequestId = e.target.getAttribute('value');
-    const SEPARATOR = ' | ';
-    let darFields = await DAR.getDarFields(dataRequestId, null);
-    let formData = darFields;
-    formData.datasetId = [];
-    for (let detail of formData.datasetDetail) {
-      let obj = {};
-
-      obj.id = detail.datasetId;
-      let ds = await this.getDsPIName(obj.id);
-
-      if (detail.objectId !== undefined && detail.objectId !== null) {
-        obj.concatenation = detail.objectId.concat(SEPARATOR, detail.name, SEPARATOR, ds.piName, SEPARATOR, ds.consentId);
-      } else {
-        obj.concatenation = detail.name.concat(SEPARATOR, ds.piName, SEPARATOR, ds.consentId);
-      }
-      formData.datasetId.push(obj);
-
-    }
-    this.props.history.push({ pathname: 'dar_application', props: { formData: formData } });
-
-  };
-
-  getDsPIName = async (dsId) => {
-    let piName = '';
-    let ds = await DataSet.getDataSetsByDatasetId(dsId);
-    ds.properties.forEach(
-      prop => {
-        if (prop.propertyName === 'Principal Investigator(PI)') {
-          piName = prop.propertyValue;
-        }
-      }
-    );
-    return { piName: piName, consentId: ds.consentId };
-  }
 
   cancelDar = (e) => {
     const dataRequestId = e.target.getAttribute('value');
@@ -250,9 +201,10 @@ class ResearcherConsole extends Component {
                     ]),
                     div({ className: "col-lg-1 col-md-1 col-sm-1 col-xs-1 cell-body f-center" }, [
                       button({
-                        id: dar.frontEndId + "_btnReview", name: "btn_review", className: "cell-button hover-color", onClick: this.review,
-                        value: dar.dataRequestId
-                      }, ["Review"]),
+                        id: dar.frontEndId + "_btnReview", name: "btn_review", className: "cell-button hover-color"
+                      }, [h(Link, {
+                        to: 'dar_application/' + dar.dataRequestId,
+                      }, ['Review'])]),
                     ])
                   ]),
                   hr({ className: "table-body-separator" })

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -114,16 +114,6 @@ class ResearcherConsole extends Component {
     this.setState({ showDialogCancelDAR: true, dataRequestId: dataRequestId, alertTitle: undefined });
   };
 
-  resume = (e) => {
-    const dataRequestId = e.target.getAttribute('value');
-
-    DAR.getPartialDarRequest(dataRequestId).then(
-      data => {
-        let formData = data;
-        this.props.history.push({ pathname: 'dar_application', props: { formData: formData } });
-      });
-  };
-
   deletePartialDar = (e) => {
     const dataRequestId = e.target.getAttribute('value');
     this.setState({ showDialogDeletePDAR: true, dataRequestId: dataRequestId, alertTitle: undefined });
@@ -309,9 +299,14 @@ class ResearcherConsole extends Component {
                       div({ id: pdar.partial_dar_code + "_partialDate", name: "partialDate", className: "col-lg-2 col-md-2 col-sm-2 col-xs-2 cell-body text" }, [Utils.formatDate(pdar.createDate)]),
                       div({ className: "col-lg-2 col-md-2 col-sm-2 col-xs-2 cell-body f-center" }, [
                         button({
-                          id: pdar.partial_dar_code + "_btnResume", name: "btn_resume", className: "cell-button hover-color", onClick: this.resume,
-                          value: pdar.dataRequestId
-                        }, ["Resume"]),
+                          id: pdar.partial_dar_code + '_btnResume',
+                          name: 'btn_resume',
+                          className: 'cell-button hover-color',
+                        }, [
+                          h(Link, {
+                            to: 'dar_application/' + pdar.dataRequestId,
+                          }, ['Resume'])],
+                        ),
                       ]),
                     ]),
                     hr({ className: "table-body-separator" })


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-603

Requires: https://github.com/DataBiosphere/consent/pull/596

## Changes
* DAR datasets and ontology updates to align with submission to dar endpoints. Previous logic used a slightly different data model between partial and completed DARs.
  * Convert datasets to the standard format expected
  * Convert datasetId to the standard format expected 
  * Convert ontologies to the standard format expected  
* Update the access points to the DAR page so the page knows which DAR it is working with
  * Load DAR on page load instead of passing in as a prop that gets lost on page reload
  * Resuming of partial DARs: Use the dar id to get the saved DAR
  * Review of submitted DARs. Use the dar id to get the saved DAR
  * New DAR from dataset selection
  * New DAR from scratch
* Code cleanup and refactoring
* New navigation method to return to the user's console
* Don't navigate after save, remain in place to continue working