### PR TITLE
[no-jira][risk=no] Update deployment api version

### DIFF
--- a/conf/k8s.yml
+++ b/conf/k8s.yml
@@ -16,7 +16,7 @@ spec:
   sessionAffinity: None
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ${APPLICATION_NAME}


### PR DESCRIPTION
We recently updated all of the clusters which changed the deployment api version. Update to match what's on the cluster now.