### PR TITLE
[DUOS-591] React-GA/Google Analytics set-up

### DIFF
--- a/config/dev.json
+++ b/config/dev.json
@@ -7,7 +7,7 @@
   "gwasUrl": "",
   "profileUrl": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "nihUrl": "https://broad-shibboleth-prod.appspot.com/dev/login",
-  "gaId": "UA-173273990-1",
+  "gaId": "UA-173408794-1",
   "features": {
     "newDarUi": true
   }

--- a/config/dev.json
+++ b/config/dev.json
@@ -7,6 +7,7 @@
   "gwasUrl": "",
   "profileUrl": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "nihUrl": "https://broad-shibboleth-prod.appspot.com/dev/login",
+  "gaId": "UA-173273990-1",
   "features": {
     "newDarUi": true
   }

--- a/config/dev.json
+++ b/config/dev.json
@@ -7,7 +7,7 @@
   "gwasUrl": "",
   "profileUrl": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "nihUrl": "https://broad-shibboleth-prod.appspot.com/dev/login",
-  "gaId": "UA-173408794-1",
+  "gaId": "UA-159441671-1",
   "features": {
     "newDarUi": true
   }

--- a/config/prod.json
+++ b/config/prod.json
@@ -7,6 +7,7 @@
   "gwasUrl": "",
   "profileUrl": "https://profile-dot-broad-shibboleth-prod.appspot.com",
   "nihUrl": "https://broad-shibboleth-prod.appspot.com/login",
+  "gaId": "UA-159441671-3",
   "features": {
     "newDarUi": true
   }

--- a/config/staging.json
+++ b/config/staging.json
@@ -7,6 +7,7 @@
   "gwasUrl": "",
   "profileUrl": "https://profile-dot-broad-shibboleth-prod.appspot.com/dev",
   "nihUrl": "https://broad-shibboleth-prod.appspot.com/dev/login",
+  "gaId": "UA-159441671-2",
   "features": {
     "newDarUi": true
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12764,6 +12764,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.7.tgz",
       "integrity": "sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA=="
     },
+    "react-ga": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.1.2.tgz",
+      "integrity": "sha512-OJrMqaHEHbodm+XsnjA6ISBEHTwvpFrxco65mctzl/v3CASMSLSyUkFqz9yYrPDKGBUfNQzKCjuMJwctjlWBbw=="
+    },
     "react-google-charts": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-3.0.15.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "query-string": "6.13.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
+    "react-ga": "^3.1.2",
     "react-google-charts": "3.0.15",
     "react-google-login": "5.1.21",
     "react-hyperscript-helpers": "2.0.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,18 @@
-import React, {useState, useEffect} from 'react';
+import {useState, useEffect} from 'react';
 import ReactGA from 'react-ga';
 import { div, h } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import './App.css';
 import DuosFooter from './components/DuosFooter';
 import DuosHeader from './components/DuosHeader';
-import {useHistory} from 'react-router-dom'
+import {useHistory} from 'react-router-dom';
 
 import { SpinnerComponent as Spinner } from './components/SpinnerComponent';
 import { Storage } from './libs/storage';
 import Routes from './Routes';
 
 function App() {
-  const [loading, setLoading] = useState(false);
+  const [loading] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   let history = useHistory();
 
@@ -20,6 +20,10 @@ function App() {
     ReactGA.initialize('UA-173273990-1', {
       titleCase: false
     });
+  };
+
+  const trackPageView = (location) => {
+    ReactGA.pageview(location.pathname + location.search);
   };
 
   useEffect(() => {
@@ -30,9 +34,10 @@ function App() {
 
     Modal.setAppElement(document.getElementById('modal-root'));
     initializeReactGA();
-    history.listen((location) => {
-      ReactGA.pageview(location.pathname + location.search);
-    });
+    //call trackPageView to register initial page load
+    trackPageView(history.location);
+    //pass trackPageView as callback function for url change listener
+    history.listen(trackPageView);
     setUserIsLogged();
   }, []);
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,77 +1,66 @@
-import React from 'react';
+import React, {useState, useEffect} from 'react';
+import ReactGA from 'react-ga';
 import { div, h } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import './App.css';
 import DuosFooter from './components/DuosFooter';
 import DuosHeader from './components/DuosHeader';
+import {useHistory} from 'react-router-dom'
 
 import { SpinnerComponent as Spinner } from './components/SpinnerComponent';
 import { Storage } from './libs/storage';
 import Routes from './Routes';
 
+function App() {
+  const [loading, setLoading] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  let history = useHistory();
 
-class App extends React.Component {
+  const initializeReactGA = () => {
+    ReactGA.initialize('UA-173273990-1', {
+      titleCase: false
+    });
+  };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      loading: false,
-      isLoggedIn: false
+  useEffect(() => {
+    const setUserIsLogged = async () => {
+      const isLogged = await Storage.userIsLogged();
+      setIsLoggedIn(isLogged);
     };
-  }
 
-  showSpinner = () => {
-    this.setState({
-      loading: true
+    Modal.setAppElement(document.getElementById('modal-root'));
+    initializeReactGA();
+    history.listen((location) => {
+      ReactGA.pageview(location.pathname + location.search);
     });
-  };
+    setUserIsLogged();
+  }, []);
 
-  hideSpinner = () => {
-    this.setState({
-      loading: false
-    });
-  };
-
-  async componentDidMount() {
-    const isLogged = await Storage.userIsLogged();
-    this.setState({ isLoggedIn: isLogged });
-  };
-
-  signOut = () => {
+  const signOut = () => {
     Storage.setUserIsLogged(false);
     Storage.clearStorage();
-    this.setState({ isLoggedIn: false });
+    setIsLoggedIn(false);
   };
 
-  signIn = () => {
+  const signIn = () => {
     Storage.setUserIsLogged(true);
-    this.setState({ isLoggedIn: true });
+    setIsLoggedIn(true);
   };
 
-  componentWillMount() {
-    Modal.setAppElement(document.getElementById('modal-root'));
-  }
-
-  render() {
-
-    const { loading } = this.state;
-
-    return (
-      div({ className: 'body' }, [
-        div({ className: 'wrap' }, [
-          div({ className: 'main' }, [
-            h(DuosHeader, { onSignOut: this.signOut }),
-            h(Spinner, {
-              name: 'mainSpinner', group: 'duos', loadingImage: '/images/loading-indicator.svg'
-            }),
-            h(Routes, { onSignIn: this.signIn, isRendered: !loading, isLogged: this.state.isLoggedIn })
-          ])
-        ]),
-        h(DuosFooter, { isLogged: this.state.isLoggedIn })
-      ])
-
-    );
-  }
+  return (
+    div({ className: 'body' }, [
+      div({ className: 'wrap' }, [
+        div({ className: 'main' }, [
+          h(DuosHeader, { onSignOut: signOut }),
+          h(Spinner, {
+            name: 'mainSpinner', group: 'duos', loadingImage: '/images/loading-indicator.svg'
+          }),
+          h(Routes, { onSignIn: signIn, isRendered: !loading, isLogged: isLoggedIn })
+        ])
+      ]),
+      h(DuosFooter, { isLogged: isLoggedIn })
+    ])
+  );
 }
 
 export default App;

--- a/src/App.js
+++ b/src/App.js
@@ -37,9 +37,14 @@ function App() {
       history.listen(trackPageView);
     };
 
-    Modal.setAppElement(document.getElementById('modal-root'));
-    initializeReactGA(history);
-    setUserIsLogged();
+    const initApp = async () => {
+      Modal.setAppElement(document.getElementById('modal-root'));
+      await initializeReactGA(history);
+      await setUserIsLogged();
+    };
+
+    initApp();
+
   }, [history]);
 
   const signOut = () => {

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -17,6 +17,8 @@ export const Config = {
 
   getGoogleClientId: async () => (await getConfig()).clientId,
 
+  getGAId: async () => (await getConfig()).gaId,
+
   getFeatureFlag: async (featureName) => {
     const feature = _.get(await getConfig(), 'features', {});
     return _.get(feature, featureName, false);


### PR DESCRIPTION
PR aims to add GA integrations via the react-ga package. As of now the PR will only track pageviews however the react-ga package can be used to track even more metrics (to be defined later on). 

Some key notes on the PR that I'd be willing to discuss in a call...
- The App component was rewritten from a class component to a functional component. The reason behind it revolves around the app being an SPA. It doesn't have the normal page load/refresh behavior you would expect from a website so you have to actively listen for page views within the app. 
    - Normally this can be done by accessing the history object provided by react-router, however the app uses BrowserRouter which only allows access within components that have been wrapped with the ```withRouter``` function, meaning you would have to register a listener on every component.
    - Rather than doing that we can use a nifty React hook that has been introduced in react-router v5 called ```useHistory```, which will return the nearest history instance (basically from the closest Router parent) regardless of which type of Router you use. This allows me to set up a single listener on the app level rather than individual instances on all current and future components. But hooks can only be used within functional components, not classes, hence the refactor.
    - As a part of the refactor I noticed there were spinner methods that didn't seemed to be called or passed in as props anywhere, so I removed them. However that leaves the question of what to do with ```var loading```, which seems to change value only when the spinner functions are called.
- Currently the GA tracking id is a dummy id that I've set up to test the implementation. At some point we need to replace it with keys that are dynamically assigned based on the current environment (since you should have separate tracking ids for development, staging, and production)
