### PR TITLE
[DUOS-554][risk=no] Header Redesign

### DIFF
--- a/src/components/DuosHeader.css
+++ b/src/components/DuosHeader.css
@@ -1,13 +1,17 @@
 .navbar-duos {
   min-height: 65px;
-  background: #333333;
+  background: #00243C;
   margin: 0 0 20px 0;
-  padding: 0 40px;
+  padding: 0 20px;
+  font-family: "Montserrat", sans-serif;
+  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16);
+  position: relative;
+  z-index: 10000;
 }
 
 @media screen and (max-width: 990px) {
   .navbar-duos {
-    padding: 0 30px;
+    padding: 0 20px;
   }
 }
 
@@ -29,7 +33,7 @@
 }
 
 .navbar-duos li a {
-  font-size: 15px;
+  font-size: 12px;
   color: #ffffff;
   transition: color 0.3s ease;
   cursor: pointer;
@@ -45,7 +49,8 @@
 }
 
 .navbar-brand img {
-  margin-top: 20px;
+  margin-top: 12px;
+  margin-right: 64px;
   padding: 0;
 }
 
@@ -110,7 +115,7 @@
 }
 
 .user-li {
-  padding: 12px 5px 10px 5px !important;
+  padding: 18px 5px 10px 5px !important;
   float: right !important;
   text-align: right;
   margin: 0 0 0 20px !important;
@@ -132,7 +137,7 @@
   padding: 10px 15px 6px 15px!important;
   color: #00609f !important;
   font-weight: normal !important;
-  font-size: 15px;
+  font-size: 12px;
   cursor: pointer;
 }
 
@@ -176,12 +181,10 @@
     width: 100%;
   }
   .obCBO .navbar-public {
-    float: right !important;
     text-align: right;
   }
   .obCBO .navbar-logged {
     text-align: left;
-    float: left;
   }
 }
 
@@ -189,7 +192,7 @@
   .navbar-brand {
     position: absolute;
     top: 0;
-    left: 30px;
+    left: 20px;
   }
   .dropdown.user-li {
     position: absolute;

--- a/src/components/DuosHeader.css
+++ b/src/components/DuosHeader.css
@@ -73,7 +73,6 @@
 }
 
 .user-dropdown li {
-  margin: 0!important;
   padding: 0!important;
 }
 

--- a/src/components/DuosHeader.css
+++ b/src/components/DuosHeader.css
@@ -27,7 +27,7 @@
 }
 
 .navbar-duos li a {
-  font-size: 12px;
+  font-size: 14px;
   color: #ffffff;
   transition: color 0.3s ease;
   cursor: pointer;
@@ -93,7 +93,7 @@
 
 .user-dropdown li a {
   margin: 0!important;
-  padding: 10px 15px 6px 15px!important;
+  padding: 10px 15px 10px 15px!important;
   color: #00609f !important;
   font-weight: normal !important;
   font-size: 12px;

--- a/src/components/DuosHeader.css
+++ b/src/components/DuosHeader.css
@@ -1,10 +1,10 @@
 .navbar-duos {
   min-height: 65px;
-  background: #00243C;
+  background: #00243c;
   margin: 0 0 20px 0;
   padding: 0 20px;
   font-family: "Montserrat", sans-serif;
-  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.26), 0 2px 10px 0 rgba(0,0,0,0.16);
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26), 0 2px 10px 0 rgba(0, 0, 0, 0.16);
   position: relative;
   z-index: 10000;
 }
@@ -67,8 +67,8 @@
 }
 
 .user-dropdown {
-  margin: 0!important;
-  padding: 0!important;
+  margin: 0 !important;
+  padding: 0 !important;
   width: auto;
 }
 
@@ -77,8 +77,8 @@
 }
 
 .user-dropdown li a {
-  margin: 0!important;
-  padding: 10px 15px 10px 15px!important;
+  margin: 0 !important;
+  padding: 10px 15px 10px 15px !important;
   color: #00609f !important;
   font-weight: normal !important;
   font-size: 12px;
@@ -86,7 +86,7 @@
 }
 
 .user-dropdown li:hover a {
-  background: #fff!important;
+  background: #fff !important;
   color: #2FA4E7 !important;
   cursor: pointer;
 }

--- a/src/components/DuosHeader.css
+++ b/src/components/DuosHeader.css
@@ -43,20 +43,6 @@
   margin: 0 0 15px 0;
 }
 
-.navbar-duos-text {
-  display: inline;
-  vertical-align: text-bottom;
-}
-
-.navbar-duos-icon {
-  display: inline-block;
-  width: 16px;
-  height: 16px;
-  margin: 0 8px 0 0;
-  transition: all 0.3s ease !important;
-  vertical-align: baseline;
-}
-
 .navbar-duos-icon-about {
   background: url('/images/navbar_icon_about.svg') no-repeat 0 0;
 }
@@ -106,12 +92,6 @@
   cursor: pointer;
 }
 
-.user-dropdown hr {
-  float: right;
-  margin: 0 !important;
-  width: 100%;
-}
-
 .navbar-open-icon,
 .navbar-close-icon {
   position: absolute;
@@ -132,7 +112,7 @@
 
 @media (min-width: 768px) {
   .obCBO {
-    padding: 0 0 0 120px;
+    padding: 0 0 0 204px;
   }
   .obCBO .navbar-public,
   .obCBO .navbar-logged {

--- a/src/components/DuosHeader.css
+++ b/src/components/DuosHeader.css
@@ -9,12 +9,6 @@
   z-index: 10000;
 }
 
-@media screen and (max-width: 990px) {
-  .navbar-duos {
-    padding: 0 20px;
-  }
-}
-
 .navbar-duos li {
   display: inline-block;
   margin: 0 20px 0 0;
@@ -46,19 +40,7 @@
 
 .navbar-brand {
   padding: 0;
-}
-
-.navbar-brand img {
-  margin-top: 12px;
-  margin-right: 64px;
-  padding: 0;
-}
-
-@media screen and (max-width: 990px) {
-  .navbar-brand{
-    left: 30px;
-    margin-bottom: 15px;
-  }
+  margin: 0 0 15px 0;
 }
 
 .navbar-duos-text {
@@ -89,29 +71,6 @@
 
 .navbar-duos-link:hover .navbar-duos-icon-help {
   background: url('/images/navbar_icon_help_hover.svg') no-repeat 0 0;
-}
-
-.navbar-join {
-  color: #5BB0CA !important;
-}
-
-.navbar-join:hover {
-  color: #ffffff !important;
-}
-
-.navbar-duos-button {
-  color: #ffffff;
-  background-color: #2899BC;
-  font-size: 16px;
-  font-weight: bold;
-  border-radius: 2px;
-  padding: 8px 35px;
-  transition: background 0.3s ease !important;
-}
-
-.navbar-duos-button:hover {
-  color: #ffffff !important;
-  background-color: #5BB0CA;
 }
 
 .user-li {

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -185,12 +185,12 @@ class DuosHeader extends Component {
                     ]),
                     ul({ className: 'dropdown-menu user-dropdown', role: 'menu' }, [
                       li({}, [
-                        h(Link, { id: 'link_statistics', to: '/summary_votes', className: 'f-left' }, ['Votes Statistics'])
+                        h(Link, { id: 'link_statistics', to: '/summary_votes' }, ['Votes Statistics'])
                       ]),
                       hr({ style: hrStyle }),
                       li({}, [
                         h(Link, {
-                          id: 'link_reviewedCases', to: '/reviewed_cases', className: 'f-left', isRendered: !(isDataOwner || isResearcher) || isAdmin
+                          id: 'link_reviewedCases', to: '/reviewed_cases', isRendered: !(isDataOwner || isResearcher) || isAdmin
                         }, ['Reviewed Cases Record'])
                       ])
                     ])

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -82,7 +82,7 @@ class DuosHeader extends Component {
       id: "btn_applyAcces",
       style: {
         color: this.state.hover ? '#2FA4E7' : '#ffffff',
-        fontSize: '12px',
+        fontSize: '14px',
         fontWeight: '500',
         background: 'transparent',
         border: 'none',
@@ -156,10 +156,7 @@ class DuosHeader extends Component {
                   ]),
 
                   li({}, [
-                    h(Link, { id: 'link_help', className: 'navbar-duos-link', to: '/FAQs' }, [
-                      div({ className: 'navbar-duos-icon navbar-duos-icon-help' }),
-                      span({ className: 'navbar-duos-text' }, ['FAQs'])
-                    ])
+                    h(Link, { id: 'link_help', to: '/FAQs' }, ['FAQs'])
                   ]),
 
                   li({ className: 'dropdown', isRendered: isAdmin }, [

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -68,6 +68,13 @@ class DuosHeader extends Component {
       isDataOwner = currentUser.isDataOwner;
     }
 
+    const duosLogoImage = {
+      width: '140px',
+      height: '40px',
+      padding: '0',
+      margin: '12px 64px 0 0'
+    }
+
     const contactUsSource = isLogged ? '/images/navbar_icon_contact_us_hover.svg' : '/images/navbar_icon_contact_us.svg';
     const contactUsIcon = isLogged ? '' : img({src: contactUsSource, style: {display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline'}});
     const contactUsText = isLogged ? 'Contact Us': span({ className: 'navbar-duos-text' }, ['Contact Us']);
@@ -80,6 +87,8 @@ class DuosHeader extends Component {
         background: 'transparent',
         border: 'none',
         outline: 'none',
+        margin: '0 20px 0 0',
+        padding: '15px 0'
       },
       onMouseEnter: this.toggleHover,
       onMouseLeave: this.toggleHover,
@@ -98,7 +107,7 @@ class DuosHeader extends Component {
       nav({ className: 'navbar-duos', role: 'navigation' }, [
         div({ className: 'row no-margin' }, [
           h(Link, { id: 'link_logo', to: '/home', className: 'navbar-brand' }, [
-            img({ style: {width: '140px', height: '40px'}, src: '/images/duos_logo.svg', alt: 'DUOS Logo'})
+            img({ style: duosLogoImage, src: '/images/duos_logo.svg', alt: 'DUOS Logo'})
           ]),
           h(ResponsiveMenu, {
             changeMenuOn: '767px',

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -1,5 +1,5 @@
-import { Component } from 'react';
-import { a, button, div, h, hr, img, li, nav, small, span, ul } from 'react-hyperscript-helpers';
+import {Component} from 'react';
+import {a, button, div, h, hr, img, li, nav, small, span, ul} from 'react-hyperscript-helpers';
 import ResponsiveMenu from 'react-responsive-navbar';
 import {Link, withRouter} from 'react-router-dom';
 import {Storage} from '../libs/storage';
@@ -75,7 +75,7 @@ class DuosHeader extends Component {
       id: "btn_applyAcces",
       style: {
         color: this.state.hover ? '#2FA4E7' : '#ffffff',
-        fontSize: '15px',
+        fontSize: '12px',
         fontWeight: '500',
         background: 'transparent',
         border: 'none',
@@ -98,7 +98,7 @@ class DuosHeader extends Component {
       nav({ className: 'navbar-duos', role: 'navigation' }, [
         div({ className: 'row no-margin' }, [
           h(Link, { id: 'link_logo', to: '/home', className: 'navbar-brand' }, [
-            img({ src: '/images/duos_logo.svg', alt: 'DUOS Logo' })
+            img({ style: {width: '140px', height: '40px'}, src: '/images/duos_logo.svg', alt: 'DUOS Logo'})
           ]),
           h(ResponsiveMenu, {
             changeMenuOn: '767px',

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -75,7 +75,7 @@ class DuosHeader extends Component {
       margin: '12px 64px 0 0'
     }
 
-    const contactUsSource = isLogged ? '/images/navbar_icon_contact_us_hover.svg' : '/images/navbar_icon_contact_us.svg';
+    const contactUsSource = this.state.hover ? '/images/navbar_icon_contact_us_hover.svg' : '/images/navbar_icon_contact_us.svg';
     const contactUsIcon = isLogged ? '' : img({src: contactUsSource, style: {display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline'}});
     const contactUsText = isLogged ? 'Contact Us': span({ className: 'navbar-duos-text' }, ['Contact Us']);
     const contactUsButton = button({

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -75,9 +75,29 @@ class DuosHeader extends Component {
       margin: '12px 64px 0 0'
     }
 
+    const navbarDuosIcon = {
+      display: 'inline-block',
+      width: '16px',
+      height: '16px',
+      margin: '0 8px 0 0',
+      transition: 'all 0.3s ease !important',
+      verticalAlign: 'baseline'
+    }
+
+    const navbarDuosText = {
+      display: 'inline',
+      verticalAlign: 'text-bottom'
+    }
+
+    const hrStyle = {
+      float: 'right',
+      margin: '0',
+      width: '100%'
+    }
+
     const contactUsSource = this.state.hover ? '/images/navbar_icon_contact_us_hover.svg' : '/images/navbar_icon_contact_us.svg';
     const contactUsIcon = isLogged ? '' : img({src: contactUsSource, style: {display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline'}});
-    const contactUsText = isLogged ? 'Contact Us': span({ className: 'navbar-duos-text' }, ['Contact Us']);
+    const contactUsText = isLogged ? 'Contact Us': span({ style: navbarDuosText }, ['Contact Us']);
     const contactUsButton = button({
       id: "btn_applyAcces",
       style: {
@@ -167,7 +187,7 @@ class DuosHeader extends Component {
                       li({}, [
                         h(Link, { id: 'link_statistics', to: '/summary_votes', className: 'f-left' }, ['Votes Statistics'])
                       ]),
-                      hr({}),
+                      hr({ style: hrStyle }),
                       li({}, [
                         h(Link, {
                           id: 'link_reviewedCases', to: '/reviewed_cases', className: 'f-left', isRendered: !(isDataOwner || isResearcher) || isAdmin
@@ -185,20 +205,20 @@ class DuosHeader extends Component {
                 ul({ isRendered: !isLogged, className: 'navbar-public' }, [
                   li({}, [
                     h(Link, { id: 'link_about', className: 'navbar-duos-link', to: '/home_about' }, [
-                      div({ className: 'navbar-duos-icon navbar-duos-icon-about' }),
-                      span({ className: 'navbar-duos-text' }, ['About'])
+                      div({ className: 'navbar-duos-icon-about', style: navbarDuosIcon }),
+                      span({ style: navbarDuosText }, ['About'])
                     ])
                   ]),
                   li({}, [
                     h(Link, { id: 'link_NHGRIpilot', className: 'navbar-duos-link', to: '/NHGRIpilotinfo' }, [
-                      div({ className: 'navbar-duos-icon navbar-duos-icon-about' }),
-                      span({ className: 'navbar-duos-text' }, ['NHGRI Pilot Info'])
+                      div({ className: 'navbar-duos-icon-about', style: navbarDuosIcon }),
+                      span({ style: navbarDuosText }, ['NHGRI Pilot Info'])
                     ])
                   ]),
                   li({}, [
                     h(Link, { id: 'link_help', className: 'navbar-duos-link', to: '/FAQs' }, [
-                      div({ className: 'navbar-duos-icon navbar-duos-icon-help' }),
-                      span({ className: 'navbar-duos-text' }, ['FAQs'])
+                      div({ className: 'navbar-duos-icon-help', style: navbarDuosIcon }),
+                      span({ style: navbarDuosText }, ['FAQs'])
                     ])
                   ]),
                   contactUsButton, supportrequestModal

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -73,7 +73,7 @@ class DuosHeader extends Component {
       height: '40px',
       padding: '0',
       margin: '12px 64px 0 0'
-    }
+    };
 
     const navbarDuosIcon = {
       display: 'inline-block',
@@ -82,18 +82,18 @@ class DuosHeader extends Component {
       margin: '0 8px 0 0',
       transition: 'all 0.3s ease !important',
       verticalAlign: 'baseline'
-    }
+    };
 
     const navbarDuosText = {
       display: 'inline',
       verticalAlign: 'text-bottom'
-    }
+    };
 
     const hrStyle = {
       float: 'right',
       margin: '0',
       width: '100%'
-    }
+    };
 
     const contactUsSource = this.state.hover ? '/images/navbar_icon_contact_us_hover.svg' : '/images/navbar_icon_contact_us.svg';
     const contactUsIcon = isLogged ? '' : img({src: contactUsSource, style: {display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline'}});


### PR DESCRIPTION
## Addresses 
https://broadinstitute.atlassian.net/browse/DUOS-554

Screenshot:
![Screen Shot 2020-08-11 at 4 40 07 PM](https://user-images.githubusercontent.com/43456581/89946785-741ed380-dbf1-11ea-8cc3-f4e03955c9c8.png)

Tried to trim down on what was in `DuosHeader.css` as much as possible or move it to a styled component if a class was relatively small and self-contained.