### PR TITLE
DUOS-729 [risk=no] Fixed error rendering bug on step 1

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -329,8 +329,9 @@ class DataAccessRequestApplication extends Component {
 
   //method to be passed to step 4 for error checks/messaging
   step1InvalidResult(dataset) {
+    const checkCollaborator = this.state.formData.checkCollaborator;
     const {isResearcherInvalid, isInvestigatorInvalid, showValidationMessages, isNihInvalid} = dataset;
-    return isResearcherInvalid || isInvestigatorInvalid || showValidationMessages || isNihInvalid;
+    return isResearcherInvalid || isInvestigatorInvalid || showValidationMessages || (!checkCollaborator && isNihInvalid);
   }
 
   verifyStep1() {

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -98,7 +98,7 @@ export default function ResearcherInfo(props) {
           ]),
 
           span({
-            isRendered: (showValidationMessages && !nihValid), className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span'
+            isRendered: (showValidationMessages && !nihValid && !checkCollaborator), className: 'col-lg-12 col-md-12 col-sm-6 col-xs-12 cancel-color required-field-error-span'
           }, ['NIH eRA Authentication is required']),
 
           div({ className: 'row no-margin' }, [


### PR DESCRIPTION
This PR is a bugfix that addresses DUOS-729. More details can be found here https://broadinstitute.atlassian.net/browse/DUOS-729

The step 1 verification step now correctly compares the ```nihInvalid``` value alongside ```checkCollaborator``` (true if the NIH collaborator option was checked, false if unchecked) to ensure that the alert label is only rendered if era auth has NOT occurred and the user has NOT checked the NIH Intramural Researcher/internal collaborator checkbox

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
