### PR TITLE
[DUOS-735][risk=no] Hide entire grey section on homepage when logged in

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -123,7 +123,7 @@ class Home extends Component {
               ])
             ])
           ]),
-          div({ className: 'row', style: { background: '#eff0f2', margin: '50px 0', padding: '60px 0 72px 0' } }, [
+          div({ isRendered: !isLogged, className: 'row', style: { background: '#eff0f2', margin: '50px 0', padding: '60px 0 72px 0' } }, [
             div({ className: 'col-lg-4 col-lg-offset-1 col-md-4 col-md-offset-1'}, [
               p({ style: header }, ['Are you a DAC member?']),
               p({ style: description }, [
@@ -134,7 +134,7 @@ class Home extends Component {
                 ])
               ])
             ]),
-            div({ isRendered: !isLogged, className: 'col-lg-4 col-lg-offset-2 col-md-4 col-md-offset-2' }, [
+            div({ className: 'col-lg-4 col-lg-offset-2 col-md-4 col-md-offset-2' }, [
               p({ style: header }, ['Are you a researcher?']),
               p({ style: description }, [
                 'Click here to start your data access request!']),
@@ -149,7 +149,7 @@ class Home extends Component {
               ])
             ])
           ]),
-          div({ className: 'row' }, [
+          div({ className: 'row', style: { margin: '50px 0' } }, [
             div({ className: 'col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2' }, [
               div({}, [
                 h1({ style: header }, ['About DUOS']),


### PR DESCRIPTION
When a user logs in to DUOS, the register column on the homepage disappears. Hiding only one of the columns when logged in was ugly, so we're hiding the whole grey section to make the homepage prettier while logged in. Grey section still appears when not logged in.

<img width="1738" alt="Screen Shot 2020-08-17 at 2 35 16 PM" src="https://user-images.githubusercontent.com/43456581/90431557-37daef80-e097-11ea-805d-4e76344ef7e7.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
