### PR TITLE
[no-jira][risk=no] npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8218,30 +8218,12 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
     },
     "ignore-file": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ignore-file/-/ignore-file-1.1.2.tgz",
-      "integrity": "sha1-mlsgSGqg2oP5MXkWqGASui+OkDw=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ignore-file/-/ignore-file-1.1.3.tgz",
+      "integrity": "sha512-PQL2H3ttelHPv6oeYfEQXBeArj4nTG4OHuv3Cpn21x19pnLIapkHAx7O0KzMWHc0ziw27vWS3nJiODhyaGEdyw==",
       "dev": true,
       "requires": {
-        "minimatch": "^1.0.0"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
-          "integrity": "sha1-4N0hILSeG3JM6NcUxSCCKpQ4V20=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        }
+        "minimatch": "^3.0.4"
       }
     },
     "immer": {
@@ -10583,18 +10565,11 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        }
+        "minimist": "^1.2.5"
       }
     },
     "moment": {
@@ -14219,12 +14194,6 @@
         "es-abstract": "^1.17.0-next.1",
         "object-inspect": "^1.7.0"
       }
-    },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",


### PR DESCRIPTION
## Addresses
Fixes build warnings about out of date dependencies.

Before:
```
found 281 vulnerabilities (280 low, 1 high) in 2055 scanned packages
  run `npm audit fix` to fix 281 of them.
```

After:
```
                       === npm audit security report ===                                                                                                        
found 0 vulnerabilities
 in 2051 scanned packages
```