### PR TITLE
DUOS 673 Remove user details from darInfo & describeDar refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3149,38 +3149,11 @@
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.20.0.tgz",
+      "integrity": "sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==",
       "requires": {
-        "follow-redirects": "1.5.10"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+        "follow-redirects": "^1.10.0"
       }
     },
     "axobject-query": {
@@ -16391,6 +16364,39 @@
         "rxjs": "^6.5.5"
       },
       "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "1.5.10"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "rxjs": {
           "version": "6.6.2",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "4.11.0",
     "@material-ui/icons": "4.9.1",
+    "axios": "^0.20.0",
     "bootstrap": "3.4.1",
     "chart.js": "2.9.3",
     "classnames": "2.2.6",
@@ -19,8 +20,8 @@
     "query-string": "6.13.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
-    "react-ga": "^3.1.2",
     "react-dropzone": "11.0.3",
+    "react-ga": "^3.1.2",
     "react-google-charts": "3.0.15",
     "react-google-login": "5.1.21",
     "react-hyperscript-helpers": "2.0.0",

--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -141,7 +141,7 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
                 darInfo.diseases.map((disease, rIndex) => {
                   return h(Fragment, { key: rIndex }, [
                     li({ id: 'lbl_disease_' + rIndex }, [
-                      disease
+                      disease.label
                     ])
                   ]);
                 })

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1,5 +1,4 @@
 import fileDownload from 'js-file-download';
-import * as ld from 'lodash';
 import * as fp from 'lodash/fp';
 import { Config } from './config';
 import { Models } from './models';
@@ -289,8 +288,7 @@ export const DAR = {
     // const piName = ld.get(ld.head(ld.filter(darInfo.researcherProperties, { 'propertyKey': 'piName' })), 'propertyValue', "");
     darInfo.pi = rawDar.investigator;
     darInfo.havePI = rawDar.havePI || rawDar.isThePI;
-    darInfo.profileName = researcher.displayName
-    
+    darInfo.profileName = researcher.displayName;
     // dataUse from Models.dar has properties denoting what research the data will be used for.
     // Get these properties directly from the DAR.
     const dataUseModel = fp.keys(darInfo.dataUse);

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -263,7 +263,6 @@ export const DAR = {
     darInfo.country = rawDar.country;
     darInfo.status = rawDar.status;
 
-    //NOTE:does rationale need to come from researcher or current user (guessing researcher)?
     darInfo.hasAdminComment = researcher.rationale != null;
     darInfo.adminComment = researcher.rationale;
     const purposeStatements = DataUseTranslation.generatePurposeStatement(darInfo);
@@ -283,7 +282,6 @@ export const DAR = {
     darInfo.datasets = rawDar.datasets;
     darInfo.pi = rawDar.investigator;
     darInfo.havePI = rawDar.havePI || rawDar.isThePI;
-    //NOTE:Is this meant to display the researcher name?
     darInfo.profileName = researcher.displayName;
     // dataUse from Models.dar has properties denoting what research the data will be used for.
     // Get these properties directly from the DAR.

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -281,13 +281,9 @@ export const DAR = {
     }
 
     darInfo.datasets = rawDar.datasets;
-    //NOTE: clarify assingment of these keys, I assume they refer to the researcher and not the current user?
-    // const isThePI = ld.get(ld.head(ld.filter(darInfo.researcherProperties, { 'propertyKey': 'isThePI' })), 'propertyValue', false);
-    // const havePI = ld.get(ld.head(ld.filter(darInfo.researcherProperties, { 'propertyKey': 'havePI' })), 'propertyValue', false);
-    // const profileName = ld.get(ld.head(ld.filter(darInfo.researcherProperties, { 'propertyKey': 'profileName' })), 'propertyValue', "");
-    // const piName = ld.get(ld.head(ld.filter(darInfo.researcherProperties, { 'propertyKey': 'piName' })), 'propertyValue', "");
     darInfo.pi = rawDar.investigator;
     darInfo.havePI = rawDar.havePI || rawDar.isThePI;
+    //NOTE:Is this meant to display the researcher name?
     darInfo.profileName = researcher.displayName;
     // dataUse from Models.dar has properties denoting what research the data will be used for.
     // Get these properties directly from the DAR.

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -13,7 +13,7 @@ const translations = {
   },
   diseases: (diseases) => {
     const diseaseArray = diseases.sort();
-    const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : diseaseArray[0];
+    const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : 'N/A';
     return {
       code: 'DS',
       description: 'Disease-related studies: ' + diseaseString,
@@ -106,7 +106,7 @@ export const DataUseTranslation = {
    */
 
   //NOTE: backend categorization of purposeStatement/researchType differs from front-end primary/secondary designations
-  //Should the two categories be unified or are they distinct for a reason?
+  //Reminder to phase out purposeStatement/researchType as we transition to new front-end spec
   generatePurposeStatement: (darInfo) => {
     let statementArray = [];
     if(darInfo.forProfit) {

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -12,13 +12,18 @@ const translations = {
     manualReview: true
   },
   diseases: (diseases) => {
-    const diseaseArray = diseases.sort();
-    const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : 'N/A';
+    const diseaseArray = diseases.sort().map(disease => disease.label);
+    const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : diseaseArray[0];
     return {
       code: 'DS',
       description: 'Disease-related studies: ' + diseaseString,
       manualReview: false
     };
+  },
+  researchTypeDisease: {
+    code: 'DS',
+    description: 'The primary purpose of the research is to learn more about a particular disease or disorder, a trait, or a set of related conditions.',
+    manualReview: false
   },
   other: (otherText) => {
     return {
@@ -89,7 +94,7 @@ const translations = {
   },
   notHealth: {
     code: 'OTHER',
-    description: 'The dataset will be used for the research that correlates  ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.',
+    description: 'The dataset will be used for the research that correlates ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.',
     manualReview: true
   }
 };
@@ -110,47 +115,47 @@ export const DataUseTranslation = {
   generatePurposeStatement: (darInfo) => {
     let statementArray = [];
     if(darInfo.forProfit) {
-      fp.concat(statementArray)(translations.forProfit);
+      statementArray = fp.concat(statementArray)(translations.forProfit);
     }
 
     if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'f') {
-      fp.concat(statementArray)(translations.genderFemale);
+      statementArray = fp.concat(statementArray)(translations.genderFemale);
     }
 
     if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'm') {
-      fp.concat(statementArray)(translations.genderMale);
+      statementArray = fp.concat(statementArray)(translations.genderMale);
     }
 
     if(darInfo.illegalBehavior) {
-      fp.concat(statementArray)(translations.illegalBehavior);
+      statementArray = fp.concat(statementArray)(translations.illegalBehavior);
     }
 
     if(darInfo.addiction) {
-      fp.concat(statementArray)(translations.addiction);
+      statementArray = fp.concat(statementArray)(translations.addiction);
     }
 
     if(darInfo.sexualDiseases) {
-      fp.concat(statementArray)(translations.sexualDiseases);
+      statementArray = fp.concat(statementArray)(translations.sexualDiseases);
     }
 
     if(darInfo.stigmatizedDiseases) {
-      fp.concat(statementArray)(translations.stigmatizedDiseases);
+      statementArray = fp.concat(statementArray)(translations.stigmatizedDiseases);
     }
 
     if(darInfo.vulnerablePopulation) {
-      fp.concat(statementArray)(translations.vulnerablePopulation);
+      statementArray = fp.concat(statementArray)(translations.vulnerablePopulation);
     }
 
     if(darInfo.populationMigration || darInfo.poa || darInfo.population) {
-      fp.concat(statementArray)(translations.poa);
+      statementArray = fp.concat(statementArray)(translations.poa);
     }
 
     if(darInfo.psychiatricTraits) {
-      fp.concat(statementArray)(translations.psychiatricTraits);
+      statementArray = fp.concat(statementArray)(translations.psychiatricTraits);
     }
 
     if(darInfo.notHealth) {
-      fp.concat(statementArray)(translations.notHealth);
+      statementArray = fp.concat(statementArray)(translations.notHealth);
     }
 
     return statementArray;
@@ -160,28 +165,29 @@ export const DataUseTranslation = {
     let statementArray = [];
 
     if(darInfo.diseases) {
-      fp.uniq(fp.concat(statementArray)(translations.diseases(darInfo.diseases)));
+      statementArray = fp.concat(statementArray)(translations.researchTypeDisease);
     }
 
     if(darInfo.methods) {
-      fp.concat(statementArray)(translations.method);
+      statementArray = fp.concat(statementArray)(translations.method);
     }
 
     if(darInfo.controls) {
-      fp.concat(statementArray)(translations.controls);
+      statementArray = fp.concat(statementArray)(translations.controls);
     }
 
     if(darInfo.population || darInfo.poa) {
-      fp.concat(statementArray)(translations.poa);
+      statementArray = fp.concat(statementArray)(translations.poa);
     }
 
     if(darInfo.hmb) {
-      fp.concat(statementArray)(translations.hmb);
+      statementArray = fp.concat(statementArray)(translations.hmb);
     }
 
     if(darInfo.other) {
-      fp.concat(statementArray)(darInfo.otherText);
+      statementArray = fp.concat(statementArray)(darInfo.otherText);
     }
+    return statementArray;
   },
 
   translateDarInfo: (darInfo) => {
@@ -211,7 +217,8 @@ export const DataUseTranslation = {
       dataUseSummary.primary = fp.concat(dataUseSummary.primary)(translations.poa);
     }
     if (darInfo.diseases && !fp.isEmpty(darInfo.diseases)) {
-      dataUseSummary.primary = fp.uniq(fp.concat(dataUseSummary.primary)(translations.diseases(darInfo)));
+      const diseaseTranslation = translations.diseases(fp.clone(darInfo.diseases));
+      dataUseSummary.primary = fp.uniq(fp.concat(dataUseSummary.primary)(diseaseTranslation));
     }
     if (darInfo.other) {
       dataUseSummary.primary = fp.concat(dataUseSummary.primary)(translations.other(darInfo.otherText));

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,5 +1,99 @@
 import * as fp from 'lodash/fp';
 
+const translations = {
+  hmb: {
+    code: "HMB",
+    description: 'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.',
+    manualReview: false
+  },
+  poa: {
+    code: 'POA',
+    desciption: 'The dataset will be used for the study of Population Origins/Migration patterns.',
+    manualReview: true
+  },
+  diseases: (diseases) => {
+    const diseaseArray = diseases.sort();
+    const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : diseaseArray[0];
+    return {
+      code: 'DS',
+      description: 'Disease-related studies: ' + diseaseString,
+      manualReview: false
+    };
+  },
+  other: (otherText) => {
+    return {
+      code: 'OTHER',
+      description: fp.isEmpty(otherText) ? "Not provided" : otherText,
+      manualReview: true
+    };
+  },
+  methods: {
+    code: 'MDS',
+    description: 'The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data. Data will be used for developing and/or validating new methods.',
+    manualReview: false
+  },
+  controls: {
+    code: 'CTRL',
+    description: 'The reason for this request is to increase the number of controls available for a comparison group.',
+    manualReview: false
+  },
+  forProfit: {
+    code: 'NCU',
+    description: 'The dataset will be used in a study related to a commercial purpose.',
+    manualReview: false
+  },
+  genderFemale: {
+    code: 'POP-F',
+    description: 'The dataset will be used for the study of females.',
+    manualReview: false
+  },
+  genderMale: {
+    code: 'POP-M',
+    description: 'The dataset will be used for the study of males.',
+    manualReview: false
+  },
+  pediatric: {
+    code: 'POP-P',
+    description: 'The dataset will be used for the study of children.',
+    manualReview: false
+  },
+  illegalBehavior: {
+    code: 'OTHER',
+    description: 'The dataset will be used for the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization).',
+    manualReview: true
+  },
+  addiction: {
+    code: 'OTHER',
+    description: 'The dataset will be used for the study of alcohol or drug abuse, or abuse of other addictive products.',
+    manualReview: true
+  },
+  sexualDiseases: {
+    code: 'OTHER',
+    description: 'The dataset will be used for the study of sexual preferences or sexually transmitted diseases.',
+    manualReview: true
+  },
+  stigmatizedDiseases: {
+    code: 'OTHER',
+    description: 'The dataset will be used for the study of stigmatizing illnesses.',
+    manualReview: true
+  },
+  vulnerablePopulation: {
+    code: 'OTHER',
+    description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).',
+    manualReview: true
+  },
+  psychiatricTraits: {
+    code: 'OTHER',
+    description: 'The dataset will be used for the study of psychological traits, including intelligence, attention, emotion.',
+    manualReview: true
+  },
+  notHealth: {
+    code: 'OTHER',
+    description: 'The dataset will be used for the research that correlates  ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.',
+    manualReview: true
+  }
+};
+
 export const DataUseTranslation = {
 
   /**
@@ -10,6 +104,86 @@ export const DataUseTranslation = {
    * @param darInfo
    * @returns {{primary: [{code: '', description: ''}], secondary: [{code: '', description: ''}]}}
    */
+
+  //NOTE: backend categorization of purposeStatement/researchType differs from front-end primary/secondary designations
+  //Should the two categories be unified or are they distinct for a reason?
+  generatePurposeStatement: (darInfo) => {
+    let statementArray = [];
+    if(darInfo.forProfit) {
+      fp.concat(statementArray)(translations.forProfit);
+    }
+
+    if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'f') {
+      fp.concat(statementArray)(translations.genderFemale);
+    }
+
+    if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'm') {
+      fp.concat(statementArray)(translations.genderMale);
+    }
+
+    if(darInfo.illegalBehavior) {
+      fp.concat(statementArray)(translations.illegalBehavior);
+    }
+
+    if(darInfo.addiction) {
+      fp.concat(statementArray)(translations.addiction);
+    }
+
+    if(darInfo.sexualDiseases) {
+      fp.concat(statementArray)(translations.sexualDiseases);
+    }
+
+    if(darInfo.stigmatizedDiseases) {
+      fp.concat(statementArray)(translations.stigmatizedDiseases);
+    }
+
+    if(darInfo.vulnerablePopulation) {
+      fp.concat(statementArray)(translations.vulnerablePopulation);
+    }
+
+    if(darInfo.populationMigration || darInfo.poa || darInfo.population) {
+      fp.concat(statementArray)(translations.poa);
+    }
+
+    if(darInfo.psychiatricTraits) {
+      fp.concat(statementArray)(translations.psychiatricTraits);
+    }
+
+    if(darInfo.notHealth) {
+      fp.concat(statementArray)(translations.notHealth);
+    }
+
+    return statementArray;
+  },
+
+  generateResearchTypes: (darInfo) => {
+    let statementArray = [];
+
+    if(darInfo.diseases) {
+      fp.uniq(fp.concat(statementArray)(translations.diseases(darInfo.diseases)));
+    }
+
+    if(darInfo.methods) {
+      fp.concat(statementArray)(translations.method);
+    }
+
+    if(darInfo.controls) {
+      fp.concat(statementArray)(translations.controls);
+    }
+
+    if(darInfo.population || darInfo.poa) {
+      fp.concat(statementArray)(translations.poa);
+    }
+
+    if(darInfo.hmb) {
+      fp.concat(statementArray)(translations.hmb);
+    }
+
+    if(darInfo.other) {
+      fp.concat(statementArray)(darInfo.otherText);
+    }
+  },
+
   translateDarInfo: (darInfo) => {
     let dataUseSummary = {
       primary: [],
@@ -19,12 +193,8 @@ export const DataUseTranslation = {
     // Primary Codes
 
     if (darInfo.hmb) {
-      const dataUseElement = {
-        code: 'HMB',
-        description: 'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.',
-      };
       dataUseSummary.primary = fp.concat(dataUseSummary.primary,
-        dataUseElement);
+        translations.hmb);
     }
     /**
      * TODO: Resolve confusion on consent/ontology/orsp sides
@@ -38,121 +208,55 @@ export const DataUseTranslation = {
      * Tracing this through to Ontology, both refer to http://purl.obolibrary.org/obo/DUO_0000011 which is POA
      */
     if (darInfo.poa || darInfo.population || darInfo.populationMigration) {
-      const dataUseElement = {
-        code: 'POA',
-        description: 'The dataset will be used for the study of Population Origins/Migration patterns.',
-      };
-      dataUseSummary.primary = fp.concat(dataUseSummary.primary)(dataUseElement);
+      dataUseSummary.primary = fp.concat(dataUseSummary.primary)(translations.poa);
     }
     if (darInfo.diseases && !fp.isEmpty(darInfo.diseases)) {
-      const diseaseArray = darInfo.diseases.sort();
-      const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : diseaseArray[0];
-      const dataUseElement = {
-        code: 'DS',
-        description: 'Disease-related studies: ' + diseaseString
-      };
-      dataUseSummary.primary = fp.uniq(fp.concat(dataUseSummary.primary)(dataUseElement));
+      dataUseSummary.primary = fp.uniq(fp.concat(dataUseSummary.primary)(translations.diseases(darInfo)));
     }
     if (darInfo.other) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: fp.isEmpty(darInfo.otherText) ? "Not provided" : darInfo.otherText,
-      };
-      dataUseSummary.primary = fp.concat(dataUseSummary.primary)(dataUseElement);
+      dataUseSummary.primary = fp.concat(dataUseSummary.primary)(translations.other(darInfo.otherText));
     }
 
     // Secondary Codes
 
     if (darInfo.methods) {
-      const dataUseElement = {
-        code: 'MDS',
-        description: 'The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data. Data will be used for developing and/or validating new methods.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.methods);
     }
     if (darInfo.controls) {
-      const dataUseElement = {
-        code: 'CTRL',
-        description: 'The reason for this request is to increase the number of controls available for a comparison group.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.controls);
     }
     if (darInfo.forProfit) {
-      const dataUseElement = {
-        code: 'NCU',
-        description: 'The dataset will be used in a study related to a commercial purpose.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.forProfit);
     }
     if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'f') {
-      const dataUseElement = {
-        code: 'POP-F',
-        description: 'The dataset will be used for the study of females.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.genderFemale);
     }
     if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'm') {
-      const dataUseElement = {
-        code: 'POP-M',
-        description: 'The dataset will be used for the study of males.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.genderFemale);
     }
     if (darInfo.pediatric) {
-      const dataUseElement = {
-        code: 'POP-P',
-        description: 'The dataset will  be used for the study of children.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.pediatric);
     }
     if (darInfo.illegalBehavior) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization).',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.illegalBehavior);
     }
     if (darInfo.addiction) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for the study of alcohol or drug abuse, or abuse of other addictive products.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.addiction);
     }
     if (darInfo.sexualDiseases) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for the study of sexual preferences or sexually transmitted diseases.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.sexualDiseases);
     }
     if (darInfo.stigmatizedDiseases) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for the study of stigmatizing illnesses.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.stigmatizedDiseases);
     }
     if (darInfo.vulnerablePopulation) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.vulnerablePopulation);
     }
     if (darInfo.psychiatricTraits) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for the study of psychological traits, including intelligence, attention, emotion.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.psychiatricTraits);
     }
     if (darInfo.notHealth) {
-      const dataUseElement = {
-        code: 'OTHER',
-        description: 'The dataset will be used for the research that correlates  ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.',
-      };
-      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(dataUseElement);
+      dataUseSummary.secondary = fp.concat(dataUseSummary.secondary)(translations.notHealth);
     }
 
     return dataUseSummary;


### PR DESCRIPTION
Addresses [DUOS-673](https://broadinstitute.atlassian.net/browse/DUOS-673)

Basic premise is to extract user details out of darInfo and rely on the data returned from ResearcherProfile. Additional changes also include removing dependency on the modal summary endpoint and instead using the v2 DAR GET and User GET endpoints as well as adding additional helper functions and details to the dataUseTranslation file to define purpose statements and researchTypes so that the back-end does not have to (nor should it, data presentation is a front-role responsibility) 

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
