### PR TITLE
DUOS 680 Add Signing Official & IT Director Questions to Step 1 [rel=no]

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -16,6 +16,7 @@ import { Navigation } from "../libs/utils";
 import * as fp from 'lodash/fp';
 
 import './DataAccessRequestApplication.css';
+import { isEmpty } from 'lodash';
 
 class DataAccessRequestApplication extends Component {
 
@@ -73,7 +74,8 @@ class DataAccessRequestApplication extends Component {
         profileName: '',
         piName: '',
         pubmedId: '',
-        scientificUrl: ''
+        scientificUrl: '',
+        signingOfficial: ''
       },
       step1: {
         inputResearcher: {
@@ -329,8 +331,12 @@ class DataAccessRequestApplication extends Component {
   //method to be passed to step 4 for error checks/messaging
   step1InvalidResult(dataset) {
     const checkCollaborator = this.state.formData.checkCollaborator;
-    const {isResearcherInvalid, isInvestigatorInvalid, showValidationMessages, isNihInvalid} = dataset;
-    return isResearcherInvalid || isInvestigatorInvalid || showValidationMessages || (!checkCollaborator && isNihInvalid);
+    const {isResearcherInvalid, isInvestigatorInvalid, showValidationMessages, isNihInvalid, signingOfficial} = dataset;
+    return isResearcherInvalid
+      || isInvestigatorInvalid
+      || showValidationMessages
+      || (!checkCollaborator && isNihInvalid)
+      || isEmpty(signingOfficial);
   }
 
   verifyStep1() {
@@ -596,7 +602,8 @@ class DataAccessRequestApplication extends Component {
       labCollaborators,
       internalCollaborators,
       externalCollaborators,
-      ontologies = []
+      ontologies = [],
+      signingOfficial
     } = this.state.formData;
     const { dataRequestId } = this.props.match.params;
     const eRACommonsDestination = fp.isNil(dataRequestId) ? 'dar_application' : ('dar_application/' + dataRequestId);
@@ -738,7 +745,8 @@ class DataAccessRequestApplication extends Component {
                 researcher: this.state.formData.researcher,
                 researcherGate: researcherGate,
                 showValidationMessages: showValidationMessages,
-                nextPage: this.nextPage
+                nextPage: this.nextPage,
+                signingOfficial: signingOfficial
               }))
             ]),
 

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -75,7 +75,8 @@ class DataAccessRequestApplication extends Component {
         piName: '',
         pubmedId: '',
         scientificUrl: '',
-        signingOfficial: ''
+        signingOfficial: '',
+        itDirector: ''
       },
       step1: {
         inputResearcher: {
@@ -603,7 +604,8 @@ class DataAccessRequestApplication extends Component {
       internalCollaborators,
       externalCollaborators,
       ontologies = [],
-      signingOfficial
+      signingOfficial = '',
+      itDirector = ''
     } = this.state.formData;
     const { dataRequestId } = this.props.match.params;
     const eRACommonsDestination = fp.isNil(dataRequestId) ? 'dar_application' : ('dar_application/' + dataRequestId);
@@ -746,7 +748,8 @@ class DataAccessRequestApplication extends Component {
                 researcherGate: researcherGate,
                 showValidationMessages: showValidationMessages,
                 nextPage: this.nextPage,
-                signingOfficial: signingOfficial
+                signingOfficial,
+                itDirector
               }))
             ]),
 

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -5,6 +5,7 @@ import { a, div, fieldset, h, h3, input, label, span} from 'react-hyperscript-he
 import { eRACommons } from '../../components/eRACommons';
 import isNil from 'lodash/fp/isNil';
 import CollaboratorList from './CollaboratorList';
+import { isEmpty } from 'lodash';
 
 const profileLink = h(Link, {to:'/profile', className:'hover-color'}, ['Your Profile']);
 const profileUnsubmitted = span(["Please submit ", profileLink, " to be able to create a Data Access Request"]);
@@ -31,7 +32,7 @@ export default function ResearcherInfo(props) {
     researcher,
     researcherGate,
     showValidationMessages,
-    nextPage
+    nextPage,
   } = props;
 
   const navButtonContainerStyle = {
@@ -40,6 +41,11 @@ export default function ResearcherInfo(props) {
 
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
+  const [signingOfficial, setSigningOfficial] = useState(props.signingOfficial || '');
+
+  useEffect(() => {
+    setSigningOfficial(props.signingOfficial);
+  }, [props.signingOfficial]);
 
   useEffect(() => {
     setCheckCollaborator(props.checkCollaborator);
@@ -230,6 +236,28 @@ export default function ResearcherInfo(props) {
                 deleteBoolArray: (new Array(internalCollaborators.length).fill(false)),
                 showApproval: false})
             ])
+          ])
+        ]),
+        div({className: 'row no-margin'}, [
+          div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
+            label({className: "control-label rp-title-question"}, [
+              '1.6 Institutional Signing Official*',
+              span(['I certify the individual listed below is my Institutional Signing Official'])
+            ])
+          ]),
+          div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
+            input({
+              type: 'text',
+              defaultValue: signingOfficial,
+              name: 'signingOfficial',
+              required: true,
+              className: isEmpty(signingOfficial) && showValidationMessages ? 'form-control required-field-error' : 'form-control',
+              onBlur: (e) => formFieldChange({name: 'signingOfficial', value: e.target.value})
+            }),
+            span({
+              isRendered: showValidationMessages && isEmpty(signingOfficial),
+              className: 'cancel-color required-field-error-span'
+            }, ['Required field'])
           ])
         ]),
         div({ className: 'form-group' }, [

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -32,7 +32,7 @@ export default function ResearcherInfo(props) {
     researcher,
     researcherGate,
     showValidationMessages,
-    nextPage,
+    nextPage
   } = props;
 
   const navButtonContainerStyle = {
@@ -42,14 +42,13 @@ export default function ResearcherInfo(props) {
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
   const [signingOfficial, setSigningOfficial] = useState(props.signingOfficial || '');
+  const [itDirector, setITDirector] = useState(props.itDirector || '');
 
   useEffect(() => {
     setSigningOfficial(props.signingOfficial);
-  }, [props.signingOfficial]);
-
-  useEffect(() => {
     setCheckCollaborator(props.checkCollaborator);
-  }, [props.checkCollaborator]);
+    setITDirector(props.itDirector);
+  }, [props.signingOfficial, props.checkCollaborator, props.itDirector]);
 
   return (
     div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
@@ -256,6 +255,28 @@ export default function ResearcherInfo(props) {
             }),
             span({
               isRendered: showValidationMessages && isEmpty(signingOfficial),
+              className: 'cancel-color required-field-error-span'
+            }, ['Required field'])
+          ])
+        ]),
+        div({className: 'row no-margin'}, [
+          div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
+            label({className: "control-label rp-title-question"}, [
+              '1.7 Information Technology (IT) Director*',
+              span(['I certify the individual listed below is my IT Director'])
+            ])
+          ]),
+          div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
+            input({
+              type: 'text',
+              defaultValue: itDirector,
+              name: 'itDirector',
+              required: true,
+              className: isEmpty(itDirector) && showValidationMessages ? 'form-control required-field-error' : 'form-control',
+              onBlur: (e) => formFieldChange({name: 'itDirector', value: e.target.value})
+            }),
+            span({
+              isRendered: showValidationMessages && isEmpty(itDirector),
               className: 'cancel-color required-field-error-span'
             }, ['Required field'])
           ])


### PR DESCRIPTION
Addresses [DUOS-680](https://broadinstitute.atlassian.net/browse/DUOS-680)

PR adds Institutional Signing Official & IT Director Questions to Step 1 component with updated input validation and error styling

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
