### PR TITLE
DUOS-748 Set isRendered to false for Questions 1.6 to 1.9 [risk=no]

### DIFF
--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -217,8 +217,6 @@ export default function ResearcherInfo(props) {
             ])
           ])
         ]),
-
-        //NOTE: External collaborators comes after Signing officials, Cloud use, and IT Official prompts, hence the numbering as 1.9
         div({className: 'form-group'}, [
           div({className: 'row no-margin'}, [
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
@@ -245,7 +243,7 @@ export default function ResearcherInfo(props) {
             ])
           ])
         ]),
-        div({className: 'form-group'}, [
+        div({className: 'form-group', isRendered: false}, [
           div({className: 'row no-margin'}, [
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
               label({className: "control-label rp-title-question"}, [
@@ -269,7 +267,7 @@ export default function ResearcherInfo(props) {
             ])
           ])
         ]),
-        div({className: 'form-group'}, [
+        div({className: 'form-group', isRendered: false}, [
           div({className: 'row no-margin'}, [
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
               label({className: "control-label rp-title-question"}, [
@@ -293,7 +291,7 @@ export default function ResearcherInfo(props) {
             ])
           ])
         ]),
-        div({className: 'form-group'}, [
+        div({className: 'form-group', isRendered: false}, [
           div({className: 'row no-margin'}, [
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
               label({className: "control-label rp-title-question"}, [
@@ -404,7 +402,7 @@ export default function ResearcherInfo(props) {
             ])
           ])
         ]),
-        div({ className: 'form-group' }, [
+        div({ className: 'form-group', isRendered: false }, [
           div({ className: 'row no-margin' }, [
             div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
               label({ className: "control-label rp-title-question" }, [


### PR DESCRIPTION
Addresses [DUOS-748](https://broadinstitute.atlassian.net/browse/DUOS-748)

PR will hide questions 1.6 to 1.9 from view due to no back-end functionality(currently) in order to facilitate the deploy of a fix for the user profile update. Questions should be restored once back-end updates are implemented.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
