### PR TITLE
[DUOS-744][risk=no] Move PowerBI dashboard to summary votes page

### DIFF
--- a/src/pages/SummaryVotes.js
+++ b/src/pages/SummaryVotes.js
@@ -91,7 +91,7 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
 
   getPowerBiDashboard() {
     Config.getPowerBiUrl().then(url => {
-      this.setState({powerBiUrl: url})
+      this.setState({powerBiUrl: url});
     })
   }
 

--- a/src/pages/SummaryVotes.js
+++ b/src/pages/SummaryVotes.js
@@ -92,7 +92,7 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
   getPowerBiDashboard() {
     Config.getPowerBiUrl().then(url => {
       this.setState({powerBiUrl: url});
-    })
+    });
   }
 
   handleOpenModal() {

--- a/src/pages/SummaryVotes.js
+++ b/src/pages/SummaryVotes.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import { Component } from 'react';
-import { button, div, h3, hh, hr, span } from 'react-hyperscript-helpers';
+import {button, div, h3, hh, hr, iframe, span} from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { PageSubHeading } from '../components/PageSubHeading';
 import { StatsBox } from '../components/StatsBox';
 import { PendingCases, StatFiles, Summary } from '../libs/ajax';
 import { Storage } from '../libs/storage';
 import { USER_ROLES } from '../libs/utils';
+import { Config } from '../libs/config';
 
 const authDownloadRoles = [USER_ROLES.admin, USER_ROLES.chairperson, USER_ROLES.member];
 
@@ -16,7 +17,8 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
     super(props);
     this.state = {
       showModal: false,
-      chartData: this.initialState()
+      chartData: this.initialState(),
+      powerBiUrl: ''
     };
 
     this.handleOpenModal = this.handleOpenModal.bind(this);
@@ -25,6 +27,8 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
 
   componentDidMount() {
     this.getSummaryInfo();
+    this.getPowerBiDashboard();
+
   }
 
   isAuthedToDownload() {
@@ -84,6 +88,12 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
         return prev;
       });
     });
+  }
+
+  getPowerBiDashboard() {
+    Config.getPowerBiUrl().then(url => {
+      this.setState({powerBiUrl: url})
+    })
   }
 
   handleOpenModal() {
@@ -238,6 +248,16 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
             className: "result_chart"
           }),
         ]),
+        div({}, [
+          div({ style: { overflow: 'hidden', paddingTop: '75%', position: 'relative' }}, [
+            iframe({
+              src: this.state.powerBiUrl,
+              allowFullScreen: true,
+              loading: 'lazy',
+              style: { border: '0', height: '100%', left: '0', position: 'absolute', top: '0', width: '100%' }
+            })
+          ])
+        ])
       ])
     );
   }

--- a/src/pages/SummaryVotes.js
+++ b/src/pages/SummaryVotes.js
@@ -28,7 +28,6 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
   componentDidMount() {
     this.getSummaryInfo();
     this.getPowerBiDashboard();
-
   }
 
   isAuthedToDownload() {


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/DUOS-744

As part of the updates to the About page, moving the PowerBI dashboard to the Summary Votes page underneath the other charts. Still uses a different link per environment. The dashboard on the About page is removed in a separate PR.

<img width="1738" alt="Screen Shot 2020-09-11 at 3 11 22 PM" src="https://user-images.githubusercontent.com/43456581/92963846-1d4f2880-f441-11ea-84df-15d66f06fc4a.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
