### PR TITLE
[DUOS-302][risk=no] Remove unused API call

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -967,12 +967,6 @@ export const User = {
     }
   },
 
-  updateMainFields: async (user, userId) => {
-    const url = `${await Config.getApiUrl()}/dacuser/mainFields/${userId}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(user), { method: 'PUT' }]));
-    return res.json();
-  },
-
   registerUser: async () => {
     const url = `${await Config.getApiUrl()}/user`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'POST' }]));


### PR DESCRIPTION
## Addresses
Partially addresses https://broadinstitute.atlassian.net/browse/DUOS-302

Remove call to the `mainFields` API which is never used and unsupported in Consent