### PR TITLE
DUOS-754 Fixed Step 2 Error Label Rendering [risk=no]

### DIFF
--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { a, br, div, fieldset, h, h3, input, label, span, textarea } from 'react-hyperscript-helpers';
 import isNil from 'lodash/fp/isNil';
 import isEmpty from 'lodash/fp/isEmpty';
@@ -46,6 +46,12 @@ export default function DataAccessRequest(props) {
     setter(value);
     formFieldChange(dataset);
   };
+
+  useEffect(() => {
+    setProjectTitle(props.projectTitle);
+    setRus(props.rus);
+    setNonTechRus(props.nonTechRus);
+  }, [props.rus, props.nonTechRus, props.projectTitle]);
 
   return (
     div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [


### PR DESCRIPTION
Addresses [DUOS-754](https://broadinstitute.atlassian.net/browse/DUOS-754).

Essentially the UI does not remove the error labels immediately after an input field is filled and focus is moved away from if (onBlur). Labels do go away when changing steps and there are no issues saving the input values onto the dar formData. Problem is easily solved by updating variables with a useEffect hook with associated variables as dependencies.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
