### PR TITLE
DUOS-757 ResearchType Rendering bugfix [risk=no]

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -169,7 +169,7 @@ export const DataUseTranslation = {
     }
 
     if(darInfo.methods) {
-      statementArray = fp.concat(statementArray)(translations.method);
+      statementArray = fp.concat(statementArray)(translations.methods);
     }
 
     if(darInfo.controls) {


### PR DESCRIPTION
Addresses [DUOS-757](https://broadinstitute.atlassian.net/browse/DUOS-757)

PR corrects rendering failures due to a typo on the "methods" key when processing researchType for the darInfo data structure within describeDar(). Fix is simply correcting the typo.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
