### PR TITLE
[DUOS-745][risk=no] Add Machine Readable Consents Line to Homepage About section

### DIFF
--- a/cypress/integration/home_spec.js
+++ b/cypress/integration/home_spec.js
@@ -11,7 +11,7 @@ describe('Home', function() {
     cy.contains('Are you a Signing Official?');
     cy.contains('Are you a researcher?');
     cy.contains('Overview of DUOS');
-    cy.contains('Machine Readable Consent Guidance.')
+    cy.contains('Machine Readable Consent Guidance.');
   });
 
 });

--- a/cypress/integration/home_spec.js
+++ b/cypress/integration/home_spec.js
@@ -10,7 +10,8 @@ describe('Home', function() {
     cy.contains('Are you a DAC member?');
     cy.contains('Are you a Signing Official?');
     cy.contains('Are you a researcher?');
-    cy.contains('About DUOS');
+    cy.contains('Overview of DUOS');
+    cy.contains('Machine Readable Consent Guidance.')
   });
 
 });

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -165,15 +165,18 @@ class Home extends Component {
           div({ className: 'row', style: { margin: 'auto auto 5rem auto' } }, [
             div({ className: 'col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2' }, [
               div({}, [
-                h1({ style: header }, ['About DUOS']),
-                h3({ style: subHeader }, ['Overview of the system and development']),
+                h1({ style: header }, ['Overview of DUOS']),
                 ReadMore({
                   props: this.props,
                   readStyle: readMoreStyle,
                   content: [
                     p({ style: paragraph, key: 'p-0' }, [
-                      'Increasingly, a major challenge to data sharing is navigating the complex web of restrictions on secondary data use. Human subjects datasets often have complex and/or ambiguous restrictions on future use deduced from the original consent form, which must be respected when utilizing data. Previously, such data use restrictions were uniquely drafted across institutions, creating vast inconsistencies and requiring the investment of significant human effort to determine if researchers should be permitted to use the data.'
-                    ])
+                      'Increasingly, a major challenge to data sharing is navigating the complex web of restrictions on secondary data use. Human subjects datasets often have complex and/or ambiguous restrictions on future use deduced from the original consent form, which must be respected when utilizing data. Previously, such data use restrictions were uniquely drafted across institutions, creating vast inconsistencies and requiring the investment of significant human effort to determine if researchers should be permitted to use the data. With support from DUOS team members, the Global Alliance for Genomics and Health (GA4GH) published a solution for this ambiguous and inconsistent data sharing language in the form of their ',
+                      a({
+                        href: 'https://www.ga4gh.org/genomic-data-toolkit/regulatory-ethics-toolkit/#:~:text=Machine%20Readable%20Consent%20Guidance&text=Machine%20readable%20consent%20language%20is,to%20for%20their%20research%20purposes',
+                        target: '_blank'
+                      }, ['Machine Readable Consent Guidance.'])
+                    ]),
                   ],
                   moreContent: [
                     div({}, [


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-745
Updates the title of the 'About DUOS' section on the home page, and adds a new sentence + link to GA4GH in the first paragraph.
<img width="922" alt="Screen Shot 2020-09-17 at 4 03 22 PM" src="https://user-images.githubusercontent.com/43456581/93522358-53881e80-f8ff-11ea-9207-9f2add49448d.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
