### PR TITLE
DUOS-768 Implement User query via ID [risk=no]

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -931,6 +931,9 @@ export const StatFiles = {
 
 export const User = {
 
+  //DEPRECATION NOTE: consider this method deprecated, a user's email can change with their employment
+  //Therefore the possibility that the email registered to a DAR will differ from the researcher's current email, leading to invalid queries
+  //Instead, use getById for more predictable results
   getByEmail: async email => {
     const url = `${await Config.getApiUrl()}/dacuser/${email}`;
     const res = await axios.get(url, Config.authOpts());

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -231,7 +231,7 @@ export const DAR = {
     const authOpts = Config.authOpts();
     const rawDarRes = await axios.get(`${apiUrl}/dar/${darId}`, authOpts);
     const rawDar = rawDarRes.data;
-    const researcher = await User.getByEmail(rawDar.academicEmail);
+    const researcher = await User.getById(rawDar.userId);
 
     let darInfo = Models.dar;
     darInfo.hmb = rawDar.hmb;
@@ -933,6 +933,12 @@ export const User = {
 
   getByEmail: async email => {
     const url = `${await Config.getApiUrl()}/dacuser/${email}`;
+    const res = await axios.get(url, Config.authOpts());
+    return res.data;
+  },
+
+  getById: async id => {
+    const url = `${await Config.getApiUrl()}/user/${id}`;
     const res = await axios.get(url, Config.authOpts());
     return res.data;
   },


### PR DESCRIPTION
Addresses [DUOS-768](https://broadinstitute.atlassian.net/browse/DUOS-768)

PR supplies bugfix regarding User querying. There are certain instances where the email tied to a DAR differs from the actual email on the researcher's user profile. The PR aims to utilize the newly implemented User query via id (back-end) for more predictable results (no ambiguity, user is either registered or not registered).

Potential followups to this PR is finding ways to optimize calls that get Researcher Properties. Currently the only difference between the User query and Researcher Properties query is that the User return lacks Library Card info, so further development of the API can help reduce redundant/overlapping calls on the front-end.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
