### PR TITLE
DUOS-771 correctly processed otherText for researchType statements [risk=no]

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -28,7 +28,7 @@ const translations = {
   other: (otherText) => {
     return {
       code: 'OTHER',
-      description: fp.isEmpty(otherText) ? "Not provided" : otherText,
+      description: fp.isEmpty(otherText) ? "Other: Not provided" : otherText,
       manualReview: true
     };
   },
@@ -185,7 +185,7 @@ export const DataUseTranslation = {
     }
 
     if(darInfo.other) {
-      statementArray = fp.concat(statementArray)(darInfo.otherText);
+      statementArray = fp.concat(statementArray)(translations.other(darInfo.otherText));
     }
     return statementArray;
   },


### PR DESCRIPTION
Addresses [DUOS-771](https://broadinstitute.atlassian.net/browse/DUOS-771)

Component fails to render due to incorrect processing of otherText within researchTypes (darInfo). Fix is to pass the string to the processing function within translations and append that value to the running list of statements for render.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
