### PR TITLE
[DUOS-446][risk=no] Remove unused DAA code

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1330,17 +1330,6 @@ input:-webkit-autofill {
   color: #777777;
 }
 
-.fileName.daa {
-  font-size: 15px;
-  color: #333;
-  margin-bottom: 10px;
-}
-
- .fileName.daa span{
-  font-weight: 400 !important;
-  font-style: italic;
-}
-
 /*///////////////////////////////////////////////////////ADMIN USERS*/
 
 .admin-users-list .enabled {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -690,11 +690,6 @@ export const Files = {
   getDARFile: async (darId) => {
     const url = `${await Config.getApiUrl()}/dataRequest/${darId}/pdf`;
     return await getFile(url, null);
-  },
-
-  getDAAFile: async (researcherId, fileName) => {
-    const url = `${await Config.getApiUrl()}/dar/downloadDAA/${researcherId}`;
-    return getFile(url, fileName);
   }
 };
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -424,13 +424,6 @@ export const DAR = {
     return manualReview;
   },
 
-  postDAA: async (fileName, file, existentFileUrl) => {
-    const url = `${await Config.getApiUrl()}/dar/storeDAA?fileName=${fileName}&existentFileUrl=${existentFileUrl}`;
-    let formData = new FormData();
-    formData.append("data", new Blob([file], { type: 'application/pdf' }));
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'POST', body: formData }]));
-    return await res.json();
-  }
 };
 
 export const DataSet = {

--- a/src/pages/DataAccessRequestRenewal.js
+++ b/src/pages/DataAccessRequestRenewal.js
@@ -445,25 +445,21 @@ class DataAccessRequestRenewal extends Component {
           prev.disableOkBtn = true;
           return prev;
         });
-        DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-          formData.urlDAA = response.urlDAA;
-          formData.nameDAA = response.nameDAA;
-          if (formData.darCode !== undefined && formData.darCode !== null) {
-            DAR.updateDar(formData, formData.darCode).then(response => {
-              this.setState({ showDialogSubmit: false });
-              this.props.history.push('researcher_console');
-            });
-          } else {
-            DAR.postDataAccessRequest(formData).then(response => {
-              this.setState({ showDialogSubmit: false });
-              this.props.history.push('researcher_console');
-            }).catch(e =>
-              this.setState(prev => {
-                prev.problemSavingRequest = true;
-                return prev;
-              }));
-          }
-        });
+        if (formData.darCode !== undefined && formData.darCode !== null) {
+          DAR.updateDar(formData, formData.darCode).then(response => {
+            this.setState({ showDialogSubmit: false });
+            this.props.history.push('researcher_console');
+          });
+        } else {
+          DAR.postDataAccessRequest(formData).then(response => {
+            this.setState({ showDialogSubmit: false });
+            this.props.history.push('researcher_console');
+          }).catch(e =>
+            this.setState(prev => {
+              prev.problemSavingRequest = true;
+              return prev;
+            }));
+        }
       });
     } else {
       this.setState({ showDialogSubmit: false });
@@ -505,14 +501,7 @@ class DataAccessRequestRenewal extends Component {
   };
 
   savePartial() {
-
-    if (this.state.file !== undefined && this.state.file.name !== '') {
-      DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-        this.saveDAR(response);
-      });
-    } else {
-      this.saveDAR(null);
-    }
+    this.saveDAR(null);
   };
 
   saveDAR(response) {

--- a/src/pages/DataAccessRequestRenewal.js
+++ b/src/pages/DataAccessRequestRenewal.js
@@ -31,9 +31,6 @@ class DataAccessRequestRenewal extends Component {
       disableOkBtn: false,
       showValidationMessages: false,
       optionMessage: noOptionMessage,
-      file: {
-        name: ''
-      },
       showModal: false,
       completed: '',
       showDialogSubmit: false,
@@ -76,8 +73,6 @@ class DataAccessRequestRenewal extends Component {
         havePi: '',
         profileName: '',
         piName: '',
-        urlDAA: '',
-        nameDAA: '',
         pubmedId: '',
         scientificUrl: ''
       },
@@ -165,8 +160,6 @@ class DataAccessRequestRenewal extends Component {
       formData.country = rpProperties.country != null ? rpProperties.country : '';
       formData.state = rpProperties.state != null ? rpProperties.state : '';
       formData.piName = rpProperties.piName !== null ? rpProperties.piName : '';
-      formData.nameDAA = rpProperties.nameDAA != null ? rpProperties.nameDAA : '';
-      formData.urlDAA = rpProperties.urlDAA != null ? rpProperties.urlDAA : '';
       formData.academicEmail = rpProperties.academicEmail != null ? rpProperties.academicEmail : '';
       formData.piEmail = rpProperties.piEmail != null ? rpProperties.piEmail : '';
       formData.isThePi = rpProperties.isThePI !== undefined ? rpProperties.isThePI : '';
@@ -189,9 +182,6 @@ class DataAccessRequestRenewal extends Component {
     this.setState(prev => {
       prev.completed = completed;
       prev.formData = formData;
-      if (formData.nameDAA !== '') {
-        prev.file.name = formData.nameDAA;
-      }
       return prev;
     });
 
@@ -506,10 +496,6 @@ class DataAccessRequestRenewal extends Component {
 
   saveDAR(response) {
     let formData = this.state.formData;
-    if (response !== null) {
-      formData.urlDAA = response.urlDAA;
-      formData.nameDAA = response.nameDAA;
-    }
     if (formData.partialDarCode === null) {
       DAR.postPartialDarRequest(formData).then(resp => {
         this.setShowDialogSave(false);

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -383,25 +383,21 @@ class DatasetRegistration extends Component {
           prev.disableOkBtn = true;
           return prev;
         });
-        DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-          formData.urlDAA = response.urlDAA;
-          formData.nameDAA = response.nameDAA;
-          if (formData.darCode !== undefined && formData.darCode !== null) {
-            DAR.updateDar(formData, formData.darCode).then(response => {
-              this.setState({ showDialogSubmit: false });
-              this.props.history.push('researcher_console');
-            });
-          } else {
-            DAR.postDataAccessRequest(formData).then(response => {
-              this.setState({ showDialogSubmit: false });
-              this.props.history.push('researcher_console');
-            }).catch(e =>
-              this.setState(prev => {
-                prev.problemSavingRequest = true;
-                return prev;
-              }));
-          }
-        });
+        if (formData.darCode !== undefined && formData.darCode !== null) {
+          DAR.updateDar(formData, formData.darCode).then(response => {
+            this.setState({ showDialogSubmit: false });
+            this.props.history.push('researcher_console');
+          });
+        } else {
+          DAR.postDataAccessRequest(formData).then(response => {
+            this.setState({ showDialogSubmit: false });
+            this.props.history.push('researcher_console');
+          }).catch(e =>
+            this.setState(prev => {
+              prev.problemSavingRequest = true;
+              return prev;
+            }));
+        }
       });
     } else {
       this.setState({ showDialogSubmit: false });
@@ -443,14 +439,7 @@ class DatasetRegistration extends Component {
   };
 
   savePartial() {
-
-    if (this.state.file !== undefined && this.state.file.name !== '') {
-      DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-        this.saveDAR(response);
-      });
-    } else {
-      this.saveDAR(null);
-    }
+    this.saveDAR(null);
   };
 
   saveDAR(response) {

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -70,8 +70,6 @@ class DatasetRegistration extends Component {
         havePi: '',
         profileName: '',
         piName: '',
-        urlDAA: '',
-        nameDAA: '',
         pubmedId: '',
         scientificUrl: ''
       },
@@ -148,8 +146,6 @@ class DatasetRegistration extends Component {
       formData.country = rpProperties.country != null ? rpProperties.country : '';
       formData.state = rpProperties.state != null ? rpProperties.state : '';
       formData.piName = rpProperties.piName !== null ? rpProperties.piName : '';
-      formData.nameDAA = rpProperties.nameDAA != null ? rpProperties.nameDAA : '';
-      formData.urlDAA = rpProperties.urlDAA != null ? rpProperties.urlDAA : '';
       formData.academicEmail = rpProperties.academicEmail != null ? rpProperties.academicEmail : '';
       formData.piEmail = rpProperties.piEmail != null ? rpProperties.piEmail : '';
       formData.isThePi = rpProperties.isThePI !== undefined ? rpProperties.isThePI : '';
@@ -172,9 +168,6 @@ class DatasetRegistration extends Component {
     this.setState(prev => {
       prev.completed = completed;
       prev.formData = formData;
-      if (formData.nameDAA !== '') {
-        prev.file.name = formData.nameDAA;
-      }
       return prev;
     });
 
@@ -444,10 +437,6 @@ class DatasetRegistration extends Component {
 
   saveDAR(response) {
     let formData = this.state.formData;
-    if (response !== null) {
-      formData.urlDAA = response.urlDAA;
-      formData.nameDAA = response.nameDAA;
-    }
     if (formData.partialDarCode === null) {
       DAR.postPartialDarRequest(formData).then(resp => {
         this.setShowDialogSave(false);

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -29,9 +29,6 @@ class DatasetRegistration extends Component {
       disableOkBtn: false,
       showValidationMessages: false,
       optionMessage: noOptionMessage,
-      file: {
-        name: ''
-      },
       showModal: false,
       completed: '',
       showDialogSubmit: false,

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -27,7 +27,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     this.saveProfile = this.saveProfile.bind(this);
     this.submit = this.submit.bind(this);
     this.saveUser = this.saveUser.bind(this);
-    this.handleFileChange = this.handleFileChange.bind(this);
   }
 
   async componentDidMount() {
@@ -50,9 +49,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       showDialogSubmit: false,
       showDialogSave: false,
       additionalEmail: '',
-      file: {
-        name: ''
-      },
       roles: [],
       profile: {
         checkNotifications: false,
@@ -159,15 +155,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         this.researcherFieldsValidation();
       }
     });
-  };
-
-  handleFileChange(event) {
-    if (event.target.files !== undefined && event.target.files[0]) {
-      let file = event.target.files[0];
-      this.setState({
-        file: file
-      });
-    }
   };
 
   researcherFieldsValidation() {
@@ -387,27 +374,9 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         profile = this.cleanObject(profile);
         profile.completed = true;
         if (this.state.profile.completed === undefined) {
-          if (this.state.file !== undefined && this.state.file.name !== '') {
-            DAR.postDAA(this.state.file.name, this.state.file, '').then(response => {
-              profile.urlDAA = response.urlDAA;
-              profile.nameDAA = response.nameDAA;
-              this.saveProperties(profile);
-            });
-          } else {
-            this.saveProperties(profile);
-          }
-
+          this.saveProperties(profile);
         } else {
-          if (this.state.file !== undefined && this.state.file.name !== '') {
-            const existentDAAUrl = _.isNil(profile.urlDAA) ? '' : profile.urlDAA;
-            DAR.postDAA(this.state.file.name, this.state.file, existentDAAUrl).then(response => {
-              profile.urlDAA = response.urlDAA;
-              profile.nameDAA = response.nameDAA;
-              this.updateResearcher(profile);
-            });
-          } else {
-            this.updateResearcher(profile);
-          }
+          this.updateResearcher(profile);
         }
       } else {
         this.saveUser().then(resp => {

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -7,7 +7,7 @@ import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { eRACommons } from '../components/eRACommons';
 import { PageHeading } from '../components/PageHeading';
 import { YesNoRadioGroup } from '../components/YesNoRadioGroup';
-import { DAR, Researcher, User } from '../libs/ajax';
+import { Researcher, User } from '../libs/ajax';
 import { Storage } from '../libs/storage';
 import { NotificationService } from '../libs/notificationService';
 import { Notification } from '../components/Notification';
@@ -73,9 +73,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         researcherGate: '',
         scientificURL: '',
         state: '',
-        zipcode: '',
-        urlDAA: '',
-        nameDAA: ''
+        zipcode: ''
       },
       showRequired: false,
       invalidFields: {

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { div, hr, label, form, textarea, a, span } from 'react-hyperscript-helpers';
+import { div, hr, label, form, textarea } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
-import { User, Researcher, Files } from "../libs/ajax";
+import { User, Researcher } from "../libs/ajax";
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 
 class ResearcherReview extends Component {
@@ -40,8 +40,7 @@ class ResearcherReview extends Component {
         pubmedID: '',
         scientificURL: '',
         state: '',
-        zipcode: '',
-        nameDAA: ''
+        zipcode: ''
       },
     };
   }
@@ -102,10 +101,6 @@ class ResearcherReview extends Component {
   confirmationHandlerOK = (answer) => (e) => {
     this.setState({ showConfirmationDialogOK: false });
     this.props.history.goBack();
-  };
-
-  downloadDAA() {
-    Files.getDAAFile(this.props.match.params.dacUserId, this.state.formData.nameDAA);
   };
 
   render() {
@@ -294,19 +289,6 @@ class ResearcherReview extends Component {
                   maxLength: "512",
                   readOnly: true
                 })
-              ])
-            ]),
-
-            div({isRendered: formData.nameDAA !== undefined, className: "row no-margin" }, [
-              div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                label({ className: "control-label default-color" }, ["Data Access Agreement signed by the organization's Signing Official"])
-              ]),
-
-              div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group" }, [
-                a({ id: "link_downloadAgreement", onClick: () => this.downloadDAA(), className: "col-lg-4 col-md-4 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color" }, [
-                  span({ className: "glyphicon glyphicon-download" }),
-                  "Download S.O. Signed Agreement"
-                ])
               ])
             ])
           ])


### PR DESCRIPTION
## Addresses
UI side of https://broadinstitute.atlassian.net/browse/DUOS-446
See also: https://github.com/DataBiosphere/consent/pull/753

## Changes
* Mostly code removal. We no longer upload or download a DAA for the user, that code has been removed from the UI for some time.
* Remove the download DAA link on researcher review page. This is technically no longer a valid function.
  * Have received Jonathan's 👍 on removing this feature

---- 

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
