### PR TITLE
[DUOS-780][risk=no] Filter props that do not need to be sent on post

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -347,8 +347,9 @@ export const DAR = {
   },
 
   postDataAccessRequest: async dar => {
+    const filteredDar = fp.omit(['createDate', 'sortDate', 'data_access_request_id'])(dar);
     const url = `${await Config.getApiUrl()}/dar`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dar), { method: 'POST' }]));
+    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(filteredDar), { method: 'POST' }]));
     return await res;
   },
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-780
See also: https://github.com/DataBiosphere/consent/pull/754

## Changes
* Don't post certain fields to the endpoint that cause it to fail
* This gets us past the failure mode even without https://github.com/DataBiosphere/consent/pull/754

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
