### PR TITLE
[DUOS-789][risk=no] Disable voting on non-open elections

### DIFF
--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -6,6 +6,7 @@ export const Theme = {
     link: '#216fb4',
     error: '#DB3214',
     success: '#00928A',
+    disabled: '#cccccc',
     background: {
       secondary: 'rgba(0, 96, 159, 0.1)',
       highlighted: 'rgba(193,107,12, 0.1)',

--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -345,13 +345,11 @@ export const ChairConsole = hh(class ChairConsole extends Component {
                     div({
                       isRendered: this.isAccessCollectEnabled(pendingCase),
                       className: twoColumnClass + ' cell-body f-center'
-                    }, [
-                    ]),
+                    }, []),
                     div({
                       isRendered: (pendingCase.alreadyVoted === true) && (pendingCase.electionStatus === 'Final'),
                       className: twoColumnClass + ' cell-body f-center'
-                    }, [
-                    ]),
+                    }, []),
                     div({
                       isRendered: (!pendingCase.alreadyVoted) && (pendingCase.electionStatus !== 'Final'),
                       className: twoColumnClass + ' cell-body text f-center empty'

--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -86,7 +86,9 @@ export const ChairConsole = hh(class ChairConsole extends Component {
     PendingCases.findDataRequestPendingCasesByUser(currentUser.dacUserId).then(
       dars => {
         this.setState(prev => {
-          prev.electionsList.access = dars.access;
+          // Filter elections. See https://broadinstitute.atlassian.net/browse/DUOS-789
+          // for more work related to ensuring closed elections aren't displayed here.
+          prev.electionsList.access = _.filter(dars.access, { electionStatus: 'Open' });
           prev.totalAccessPendingVotes = dars.totalAccessPendingVotes;
           return prev;
         });

--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -326,10 +326,10 @@ export const ChairConsole = hh(class ChairConsole extends Component {
                         id: pendingCase.frontEndId + '_btnVote',
                         name: 'btn_voteAccess',
                         onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId, pendingCase.rpVoteId),
-                        className: 'cell-button ' + (pendingCase.alreadyVoted === true ? 'default-color' : 'cancel-color')
+                        className: 'cell-button cancel-color'
                       }, [
                         span({ isRendered: (pendingCase.alreadyVoted === false) && (pendingCase.electionStatus !== 'Final') }, ['Vote']),
-                        span({ isRendered: pendingCase.alreadyVoted === true }, ['Log Final Vote'])
+                        span({ isRendered: pendingCase.alreadyVoted === true }, ['Update Vote'])
                       ])
                     ]),
                     div({

--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -86,9 +86,9 @@ export const ChairConsole = hh(class ChairConsole extends Component {
     PendingCases.findDataRequestPendingCasesByUser(currentUser.dacUserId).then(
       dars => {
         this.setState(prev => {
-          // Filter elections. See https://broadinstitute.atlassian.net/browse/DUOS-789
+          // Filter vote-able elections. See https://broadinstitute.atlassian.net/browse/DUOS-789
           // for more work related to ensuring closed elections aren't displayed here.
-          prev.electionsList.access = _.filter(dars.access, { electionStatus: 'Open' });
+          prev.electionsList.access = _.filter(dars.access, (e) => { return e.electionStatus !== 'Closed'; });
           prev.totalAccessPendingVotes = dars.totalAccessPendingVotes;
           return prev;
         });

--- a/src/pages/MemberConsole.js
+++ b/src/pages/MemberConsole.js
@@ -90,7 +90,9 @@ class MemberConsole extends Component {
       prev.totalDulPendingVotes = duls.totalDulPendingVotes;
       prev.electionsList.dul = duls.dul;
       prev.totalAccessPendingVotes = dars.totalAccessPendingVotes;
-      prev.electionsList.access = dars.access;
+      // Filter vote-able elections. See https://broadinstitute.atlassian.net/browse/DUOS-789
+      // for more work related to ensuring closed elections aren't displayed here.
+      prev.electionsList.access = _.filter(dars.access, (e) => { return e.electionStatus !== 'Closed'; });
       return prev;
     });
 

--- a/src/pages/access_review/DacVotePanel.js
+++ b/src/pages/access_review/DacVotePanel.js
@@ -319,6 +319,18 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
     const { voteAsChair, selectChair, chairVotes } = this.props;
     const { alert, chairAccessVote, chairRpVote, memberAccessVote, memberRpVote, matchData, accessElectionOpen, rpElectionOpen } = this.state;
 
+    // If we have an open election, theme the button based on the alert status.
+    // If we do not, set it to disabled state.
+    const voteButtonStyle = (accessElectionOpen || rpElectionOpen) ?
+      (alert === 'success') ? { backgroundColor: Theme.palette.success } : {} :
+      { backgroundColor: Theme.palette.disabled, cursor: 'not-allowed'};
+
+    // If we have an open election, we can submit votes as either a chair or member.
+    // If we do not, we cannot submit any votes.
+    const voteButtonAction = (accessElectionOpen || rpElectionOpen) ?
+      (!fp.isEmpty(chairVotes) && voteAsChair) ? this.submitChairVote : this.submitMemberVote :
+      () => {};
+
     return div({ style: ROOT },
       [
         div({ id: 'tabs', style: { display: 'flex' } }, [
@@ -366,8 +378,8 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
               button({
                 id: 'vote',
                 className: 'button-contained',
-                style: alert === 'success' ? { backgroundColor: Theme.palette.success } : {},
-                onClick: (!fp.isEmpty(chairVotes) && voteAsChair) ? this.submitChairVote : this.submitMemberVote,
+                style: voteButtonStyle,
+                onClick: voteButtonAction,
               },
               ['Vote',
                 alert === 'success' && span({ className: 'glyphicon glyphicon-ok', style: { marginLeft: '8px' } })

--- a/src/pages/access_review/DacVotePanel.js
+++ b/src/pages/access_review/DacVotePanel.js
@@ -71,8 +71,8 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
     const chairFinalVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(finalVotes);
     const chairAccessVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(chairVotes);
     const chairRpVote = fp.isNil(rpElection) ? null : fp.find({ electionId: rpElection.electionId })(chairVotes);
-    const accessElectionOpen = fp.isNil(accessElection) ? false : fp.isEqual(accessElection.status)('Open');
-    const rpElectionOpen = fp.isNil(rpElection) ? false : fp.isEqual(rpElection.status)('Open');
+    const accessElectionOpen = fp.isNil(accessElection) ? false : !fp.isEqual(accessElection.status)('Closed');
+    const rpElectionOpen = fp.isNil(rpElection) ? false : !fp.isEqual(rpElection.status)('Closed');
     this.setState({
       alert: '',
       chairAgreementVote: chairAgreementVote,

--- a/src/pages/access_review/DacVotePanel.js
+++ b/src/pages/access_review/DacVotePanel.js
@@ -107,8 +107,8 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
     const chairAccessVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(chairVotes);
     const memberAccessVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(memberVotes);
     const memberRpVote = fp.isNil(rpElection) ? null : fp.find({ electionId: rpElection.electionId })(memberVotes);
-    const accessElectionOpen = fp.isNil(accessElection) ? false : fp.isEqual(accessElection.status)('Open');
-    const rpElectionOpen = fp.isNil(rpElection) ? false : fp.isEqual(rpElection.status)('Open');
+    const accessElectionOpen = fp.isNil(accessElection) ? false : !fp.isEqual(accessElection.status)('Closed');
+    const rpElectionOpen = fp.isNil(rpElection) ? false : !fp.isEqual(rpElection.status)('Closed');
     this.setState({
       alert: '',
       chairAccessVote: chairAccessVote,

--- a/src/pages/access_review/DacVotePanel.js
+++ b/src/pages/access_review/DacVotePanel.js
@@ -55,7 +55,9 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
       chairFinalVote: null,
       chairAgreementVote: null,
       memberAccessVote: null,
-      memberRpVote: null
+      memberRpVote: null,
+      accessElectionOpen: false,
+      rpElectionOpen: false
     };
   };
 
@@ -69,12 +71,16 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
     const chairFinalVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(finalVotes);
     const chairAccessVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(chairVotes);
     const chairRpVote = fp.isNil(rpElection) ? null : fp.find({ electionId: rpElection.electionId })(chairVotes);
+    const accessElectionOpen = fp.isNil(accessElection) ? false : fp.isEqual(accessElection.status)('Open');
+    const rpElectionOpen = fp.isNil(rpElection) ? false : fp.isEqual(rpElection.status)('Open');
     this.setState({
       alert: '',
       chairAgreementVote: chairAgreementVote,
       chairFinalVote: chairFinalVote,
       chairAccessVote: chairAccessVote,
       chairRpVote: chairRpVote,
+      accessElectionOpen: accessElectionOpen,
+      rpElectionOpen: rpElectionOpen
     });
   };
 
@@ -101,11 +107,15 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
     const chairAccessVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(chairVotes);
     const memberAccessVote = fp.isNil(accessElection) ? null : fp.find({ electionId: accessElection.electionId })(memberVotes);
     const memberRpVote = fp.isNil(rpElection) ? null : fp.find({ electionId: rpElection.electionId })(memberVotes);
+    const accessElectionOpen = fp.isNil(accessElection) ? false : fp.isEqual(accessElection.status)('Open');
+    const rpElectionOpen = fp.isNil(rpElection) ? false : fp.isEqual(rpElection.status)('Open');
     this.setState({
       alert: '',
       chairAccessVote: chairAccessVote,
       memberAccessVote: memberAccessVote,
-      memberRpVote: memberRpVote
+      memberRpVote: memberRpVote,
+      accessElectionOpen: accessElectionOpen,
+      rpElectionOpen: rpElectionOpen
     });
   };
 
@@ -254,7 +264,6 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
 
   // posts the supplied vote for this DAR
   submitVote = async (vote) => {
-    console.log(JSON.stringify(vote));
     const { darId } = this.props;
     try {
       if (vote.type === 'FINAL') {
@@ -308,7 +317,7 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
 
   render() {
     const { voteAsChair, selectChair, chairVotes } = this.props;
-    const { alert, chairAccessVote, chairRpVote, memberAccessVote, memberRpVote, matchData } = this.state;
+    const { alert, chairAccessVote, chairRpVote, memberAccessVote, memberRpVote, matchData, accessElectionOpen, rpElectionOpen } = this.state;
 
     return div({ style: ROOT },
       [
@@ -338,6 +347,8 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
               onUpdate: this.updateMemberVote,
               vote: memberAccessVote,
               rpVote: memberRpVote,
+              accessElectionOpen: accessElectionOpen,
+              rpElectionOpen: rpElectionOpen
             }),
             VoteAsChair({
               isRendered: voteAsChair,
@@ -346,7 +357,9 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
               onUpdate: this.updateChairVotes,
               matchData: matchData,
               vote: chairAccessVote,
-              rpVote: chairRpVote
+              rpVote: chairRpVote,
+              accessElectionOpen: accessElectionOpen,
+              rpElectionOpen: rpElectionOpen
             }),
             div({ style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' } }, [
               this.showAlert(alert),

--- a/src/pages/access_review/VoteAsChair.js
+++ b/src/pages/access_review/VoteAsChair.js
@@ -54,7 +54,7 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
   };
 
   render() {
-    const { vote, rpVote, onUpdate, matchData} = this.props;
+    const { vote, rpVote, onUpdate, matchData, accessElectionOpen, rpElectionOpen } = this.props;
     const accessVoteQuestion = fp.isNil(vote) ?
       div({}, []) :
       VoteQuestion({
@@ -66,6 +66,7 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
         voteId: fp.isNil(vote) ? null : vote.voteId,
         rationale: fp.isNil(vote.rationale) ? '' : vote.rationale,
         selectedOption: fp.isNil(vote) ? null : vote.vote,
+        disabled: !accessElectionOpen
       });
     const rpVoteQuestion = fp.isNil(rpVote) ?
       div({}, []) :
@@ -78,6 +79,7 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
         voteId: fp.isNil(rpVote) ? null : rpVote.voteId,
         rationale: fp.isNil(rpVote.rationale) ? '' : rpVote.rationale,
         selectedOption: fp.isNil(rpVote) ? null : rpVote.vote,
+        disabled: !rpElectionOpen
       });
     return div({ id: 'chair-vote' }, [
       accessVoteQuestion,

--- a/src/pages/access_review/VoteAsMember.js
+++ b/src/pages/access_review/VoteAsMember.js
@@ -10,7 +10,7 @@ export const VoteAsMember = hh(class VoteAsMember extends React.PureComponent {
   };
 
   render() {
-    const { onUpdate, vote, rpVote } = this.props;
+    const { onUpdate, vote, rpVote, accessElectionOpen, rpElectionOpen } = this.props;
     return div({ id: 'member-vote' }, [
       VoteQuestion({
         id: 'access-vote',
@@ -21,6 +21,7 @@ export const VoteAsMember = hh(class VoteAsMember extends React.PureComponent {
         voteId: fp.isNil(vote) ? null : vote.voteId,
         rationale: fp.isNil(vote) ? '' : vote.rationale,
         selectedOption:fp.isNil(vote) ? null : vote.vote,
+        disabled: !accessElectionOpen
       }),
       VoteQuestion({
         id: 'rp-vote',
@@ -31,6 +32,7 @@ export const VoteAsMember = hh(class VoteAsMember extends React.PureComponent {
         voteId: fp.isNil(rpVote) ? null : rpVote.voteId,
         rationale: fp.isNil(rpVote) ? '' : rpVote.rationale,
         selectedOption: fp.isNil(rpVote) ? null : rpVote.vote,
+        disabled: !rpElectionOpen
       }),
     ]);
   }

--- a/src/pages/access_review/VoteQuestion.js
+++ b/src/pages/access_review/VoteQuestion.js
@@ -48,7 +48,8 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
   };
 
   render() {
-    const { label, question, id, rationale, selectedOption } = this.props;
+    const { label, question, id, rationale, selectedOption, disabled } = this.props;
+    const inputProps = disabled ? { disabled: true } : {};
 
     return div({ style: { marginBottom: '24px' } },
       [
@@ -57,6 +58,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
         div({ style: FADED }, 'Your vote*'),
         fieldset([
           input({
+            ...inputProps,
             type: 'radio',
             id: id + '-yes',
             onChange: () => this.setVote(true, this.state.rationale),
@@ -67,6 +69,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
             style: { margin: '8px' },
           }, 'Yes'),
           input({
+            ...inputProps,
             type: 'radio',
             id: id + '-no',
             onChange: () => this.setVote(false, this.state.rationale),
@@ -79,6 +82,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
         ]),
         div({ style: FADED }, 'Rationale'),
         textarea({
+          ...inputProps,
           style: INPUT,
           rows: '5',
           placeholder: 'OPTIONAL: Describe your rationale or add comments here',

--- a/src/pages/access_review/VoteQuestion.js
+++ b/src/pages/access_review/VoteQuestion.js
@@ -49,7 +49,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
 
   render() {
     const { label, question, id, rationale, selectedOption, disabled } = this.props;
-    const inputProps = disabled ? { disabled: true } : {};
+    const disabledProp = disabled ? { disabled: true } : {};
 
     return div({ style: { marginBottom: '24px' } },
       [
@@ -58,7 +58,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
         div({ style: FADED }, 'Your vote*'),
         fieldset([
           input({
-            ...inputProps,
+            ...disabledProp,
             type: 'radio',
             id: id + '-yes',
             onChange: () => this.setVote(true, this.state.rationale),
@@ -69,7 +69,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
             style: { margin: '8px' },
           }, 'Yes'),
           input({
-            ...inputProps,
+            ...disabledProp,
             type: 'radio',
             id: id + '-no',
             onChange: () => this.setVote(false, this.state.rationale),
@@ -82,7 +82,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
         ]),
         div({ style: FADED }, 'Rationale'),
         textarea({
-          ...inputProps,
+          ...disabledProp,
           style: INPUT,
           rows: '5',
           placeholder: 'OPTIONAL: Describe your rationale or add comments here',


### PR DESCRIPTION
## Addresses
Partially addresses https://broadinstitute.atlassian.net/browse/DUOS-789
See also: https://github.com/DataBiosphere/consent/pull/768

## Changes
This PR:
1. Filters closed data access elections from the chair/member manage DAR pages
2. Disables vote submission on non-open elections, effectively making a read-only view of the voting page
    - This does not provide any navigation to a read only-view
3. Minor language changes to the manage dar console to more accurately reflect the button actions
    - `Log Final Vote` is now `Update Vote` which is what it really does.

## TODO:
In separate PRs:
~1. Update pending case API so it does not return closed elections~ See https://github.com/DataBiosphere/consent/pull/768

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
