### PR TITLE
[DUOS-753][risk=no] Add a spinner/loading icon over the sign in button while it is loading

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -130,7 +130,7 @@ export const SignIn = hh(class SignIn extends Component {
     let googleLoginButton;
 
     if (this.state.clientId === '') {
-      googleLoginButton = div({ style: { 'position': 'relative', 'marginTop': '20px', 'marginLeft': '45px', 'zIndex': '10000' } }, [
+      googleLoginButton = div({ style: { 'position': 'absolute', 'top': '45px', 'right': '45px', 'zIndex': '10000' } }, [
         img({ src: '/images/loading-indicator.svg', alt: 'spinner' })
       ]);
     } else {
@@ -140,6 +140,7 @@ export const SignIn = hh(class SignIn extends Component {
           clientId: this.state.clientId,
           onSuccess: this.responseGoogle,
           onFailure: this.forbidden,
+          disabledStyle: { 'opacity': '25%', 'cursor': 'not-allowed', 'pointer-events': 'none' }
         }
       );
     }

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { Component } from 'react';
 import GoogleLogin from 'react-google-login';
-import { div, h, hh, img, span, button } from 'react-hyperscript-helpers';
+import { div, h, hh, img, span } from 'react-hyperscript-helpers';
 import { Alert } from '../components/Alert';
 import { User } from '../libs/ajax';
 import { Config } from '../libs/config';

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import { Component } from 'react';
 import GoogleLogin from 'react-google-login';
-import { div, h, hh, img, span } from 'react-hyperscript-helpers';
+import { div, h, hh, img, span, button } from 'react-hyperscript-helpers';
 import { Alert } from '../components/Alert';
 import { User } from '../libs/ajax';
 import { Config } from '../libs/config';
@@ -125,6 +125,21 @@ export const SignIn = hh(class SignIn extends Component {
     return user;
   };
 
+  renderSpinnerIfDisabled = (disabled) => {
+    return disabled ?
+      div({ style: { 'position': 'absolute', 'top': '45px', 'right': '45px', 'zIndex': '10000' } }, [
+        img({ src: '/images/loading-indicator.svg', alt: 'spinner' })
+      ]) :
+      h(GoogleLogin, {
+        scope: 'openid email profile',
+        theme: 'dark',
+        clientId: this.state.clientId,
+        onSuccess: this.responseGoogle,
+        onFailure: this.forbidden,
+        disabledStyle: { 'opacity': '25%', 'cursor': 'not-allowed' },
+      });
+  };
+
   render() {
 
     let googleLoginButton;
@@ -135,12 +150,11 @@ export const SignIn = hh(class SignIn extends Component {
       ]);
     } else {
       googleLoginButton = h(GoogleLogin, {
-          scope: 'openid email profile',
-          theme: 'dark',
-          clientId: this.state.clientId,
-          onSuccess: this.responseGoogle,
-          onFailure: this.forbidden,
-          disabledStyle: { 'opacity': '25%', 'cursor': 'not-allowed' },
+        scope: 'openid email profile',
+        clientId: this.state.clientId,
+        onSuccess: this.responseGoogle,
+        onFailure: this.forbidden,
+        render: ({disabled}) => this.renderSpinnerIfDisabled(disabled)
         }
       );
     }

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -127,7 +127,7 @@ export const SignIn = hh(class SignIn extends Component {
 
   renderSpinnerIfDisabled = (disabled) => {
     return disabled ?
-      div({ style: { 'position': 'absolute', 'top': '45px', 'right': '45px', 'zIndex': '10000' } }, [
+      div({ style: { textAlign: 'center', height: '44px', width: '180px' } }, [
         img({ src: '/images/loading-indicator.svg', alt: 'spinner' })
       ]) :
       h(GoogleLogin, {
@@ -145,7 +145,7 @@ export const SignIn = hh(class SignIn extends Component {
     let googleLoginButton;
 
     if (this.state.clientId === '') {
-      googleLoginButton = div({ style: { 'position': 'absolute', 'top': '45px', 'right': '45px', 'zIndex': '10000' } }, [
+      googleLoginButton = div({ style: { textAlign: 'center', height: '44px', width: '180px' } }, [
         img({ src: '/images/loading-indicator.svg', alt: 'spinner' })
       ]);
     } else {

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -140,7 +140,7 @@ export const SignIn = hh(class SignIn extends Component {
           clientId: this.state.clientId,
           onSuccess: this.responseGoogle,
           onFailure: this.forbidden,
-          disabledStyle: { 'opacity': '25%', 'cursor': 'not-allowed', 'pointer-events': 'none' }
+          disabledStyle: { 'opacity': '25%', 'cursor': 'not-allowed' },
         }
       );
     }


### PR DESCRIPTION
<img width="490" alt="Screen Shot 2020-10-07 at 12 46 46 PM" src="https://user-images.githubusercontent.com/43456581/95361785-2c3bc600-089b-11eb-9411-a1d3025e8a06.png">

Users were confused by the greyed out log in button appearing before being usable. We had some spinner logic for when we fetch the client id on our side, but the default 3rd party login component had an additional loading step (greyed out button) that temporarily disables the button and prevents login. These changes capture when the component is disabled and displays the spinner instead until the login component is fully ready for use.


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
