### PR TITLE
DUOS-672 [risk=no] Replaced translatedUseRestriction render with consent translation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3718,9 +3718,9 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "requires": {
         "readable-stream": "^2.3.5",
@@ -10535,9 +10535,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -13753,11 +13753,11 @@
       "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo="
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -41,7 +41,7 @@ export async function GenerateUseRestrictionStatements(dataUse) {
   });
 };
 
-//component generation for non AccessReviewV2 components 
+//component generation for non AccessReviewV2 components
 //template structure is different between DAR and DUL due to differing grid organization in previous template, making it hard to convert
 //task is not impossible, just requires additional time
 export default function TranslatedDULComponent(props) {

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -5,11 +5,24 @@ import isEmpty from 'lodash/fp/isEmpty';
 import * as Utils from '../libs/utils';
 import isNil from 'lodash/fp/isNil';
 
-//NOTE: li partial can be used in components that only need the list
 const liStyle = {
   padding: '0.6rem'
 };
 
+const DULPanel = {
+  margin: '0.5rem',
+  flex: 1,
+  boxShadow: 'rgba(0, 0, 0, 0.14) 3px 3px 3px 1px',
+  border: '1px solid #f5f5f5',
+  borderRadius: '5px'
+};
+
+const DULContainer = {
+  display: 'flex',
+  padding: '0 1.1rem'
+};
+
+//NOTE: li partial can be used in components that only need the list
 export async function GenerateUseRestrictionStatements(dataUse) {
   if (!dataUse || isEmpty(dataUse)) {
     return [li({
@@ -28,7 +41,7 @@ export async function GenerateUseRestrictionStatements(dataUse) {
   });
 };
 
-//component generation for non AccessReviewV2 components
+//component generation for non AccessReviewV2 components 
 //template structure is different between DAR and DUL due to differing grid organization in previous template, making it hard to convert
 //task is not impossible, just requires additional time
 export default function TranslatedDULComponent(props) {
@@ -58,14 +71,34 @@ export default function TranslatedDULComponent(props) {
     onClick: () => props.downloadDUL()
   }, ["Download Data Use Letter"]) : a({className: 'italic hover-color'}, [' No Data Use Letter Present']);
 
-  const template = div({ className: "data-use-container" }, [
+  //panel formats differ depending on whether or not its used in DAR vs DUL
+  const DARTemplate = div({ className: "data-use-container" }, [
     div({ className: "panel-heading cm-boxhead dul-color" }, [
       h4({}, ["Data Use Limitations"]),
     ]),
     ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
-    div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
-    div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
+    div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL) && !isEmpty(props.downloadDUL)}, [dataUseLetterLink]),
+    div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL && !isEmpty(props.mrDUL))},[machineReadableLink])
   ]);
 
-  return template;
+  const DULTemplate =
+    div({style: DULContainer}, [
+      div({ className: "data-use-panel", style: DULPanel }, [
+        div({ className: "panel-heading cm-boxhead dul-color" }, [
+          h4({}, ["Data Use Limitations"]),
+        ]),
+        ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
+      ]),
+      div({className: "data-use-panel", style: DULPanel}, [
+        div({ className: "panel-heading cm-boxhead dul-color" }, [
+          h4({}, ["Data Use Limitations"]),
+        ]),
+        div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL) && !isEmpty(props.downloadDUL)}, [dataUseLetterLink]),
+        div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL && !isEmpty(props.mrDUL))},[machineReadableLink])
+      ])
+    ]);
+
+  const output = props.isDUL ? DULTemplate : DARTemplate;
+
+  return output;
 }

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -1,4 +1,4 @@
-import { div, ul, li, h4, button } from 'react-hyperscript-helpers';
+import { div, ul, li, h4, a, button } from 'react-hyperscript-helpers';
 import {DataUseTranslation} from '../libs/dataUseTranslation';
 import isEmpty from 'lodash/fp/isEmpty';
 import * as Utils from '../libs/utils';
@@ -22,12 +22,12 @@ export const generateUseRestrictionStatements = (dataUse) => {
 };
 
 export default function TranslatedDULComponent(props) {
-  const machineReadableButton = !isNil(props.mrDUL) ? button({
+  const machineReadableLink = !isNil(props.mrDUL) ? a({
     id: 'btn_downloadSDul',
     onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
     filename: 'machine-readable-DUL.json',
     value: props.mrDUL,
-    className: 'btn-secondary btn-download-pdf hover-color'
+    className: 'italic hover-color'
   }, ['Download DUL machine-readable format']) : '';
 
   const translatedDULStatements = generateUseRestrictionStatements(props.restrictions);
@@ -52,7 +52,7 @@ export default function TranslatedDULComponent(props) {
         div({ className: 'row dar-summary' }, [
           div({ className: 'control-label dul-color' }, ['Structured Limitations']),
           ul({className: 'response-label translated-restriction'}, [translatedDULStatements]),
-          machineReadableButton
+          machineReadableLink
         ])
       ])
     ])

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -21,19 +21,20 @@ export const generateUseRestrictionStatements = (dataUse) => {
     });
 };
 
-export default function TranslatedDULComponent(props) {
-  const machineReadableLink = !isNil(props.mrDUL) ? a({
-    id: 'btn_downloadSDul',
-    onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
-    filename: 'machine-readable-DUL.json',
-    value: props.mrDUL,
-    className: 'italic hover-color'
-  }, ['Download DUL machine-readable format']) : '';
-
+export default function translatedDULComponent(props) {
+  let template;
   const translatedDULStatements = generateUseRestrictionStatements(props.restrictions);
 
-  return (
-    div({className: 'translated-dul-component-container'}, [
+  if(props.mrDUL) {
+    const machineReadableLink = !isNil(props.mrDUL) ? a({
+      id: 'btn_downloadSDul',
+      onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
+      filename: 'machine-readable-DUL.json',
+      value: props.mrDUL,
+      className: 'italic hover-color'
+    }, ['Download DUL machine-readable format']) : '';
+
+    template = div({className: 'translated-dul-component-container'}, [
       div({ className: 'panel-heading cm-boxhead dul-color' }, [
         h4({}, ['Data Use Limitations'])
       ]),
@@ -55,6 +56,33 @@ export default function TranslatedDULComponent(props) {
           machineReadableLink
         ])
       ])
-    ])
-  );
+    ]);
+  } else if(props.downloadDUL) {
+    template = div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
+      div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
+        div({ className: "panel-heading cm-boxhead dul-color" }, [
+          h4({}, ["Data Use Limitations"]),
+        ]),
+        div({
+          id: "panel_dul",
+          className: "panel-body cm-boxbody"
+        }, [
+          button({
+            id: "btn_downloadDataUseLetter",
+            className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color",
+            onClick: () => props.downloadDUL()
+          }, ["Download Data Use Letter"]),
+        ])
+      ]),
+
+      div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
+        div({ className: "panel-heading cm-boxhead dul-color" }, [
+          h4({}, ["Structured Limitations"]),
+        ]),
+        div({ id: "panel_structuredDul", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements])
+      ]),
+    ]);
+  }
+
+  return template;
 }

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from 'react';
+import {useEffect, useState} from 'react';
 import { div, li, h4, a, ul} from 'react-hyperscript-helpers';
 import {DataUseTranslation} from '../libs/dataUseTranslation';
 import isEmpty from 'lodash/fp/isEmpty';
@@ -6,7 +6,6 @@ import * as Utils from '../libs/utils';
 import isNil from 'lodash/fp/isNil';
 
 //NOTE: li partial can be used in components that only need the list
-
 const liStyle = {
   padding: '0.6rem'
 };
@@ -33,14 +32,15 @@ export async function GenerateUseRestrictionStatements(dataUse) {
 //template structure is different between DAR and DUL due to differing grid organization in previous template, making it hard to convert
 //task is not impossible, just requires additional time
 export default function TranslatedDULComponent(props) {
-  const translatedDULStatements = useRef();
+  const [translatedDULStatements, setTranslatedDULStatements] = useState([]);
 
   useEffect(() => {
     const generatedRestrictions = async (restrictions) => {
-      translatedDULStatements.current = await GenerateUseRestrictionStatements(restrictions);
+      const updatedStatements = await GenerateUseRestrictionStatements(restrictions);
+      setTranslatedDULStatements(updatedStatements);
     };
     generatedRestrictions(props.restrictions);
-  }, [props.restrictions]);
+  }, [props.restrictions, setTranslatedDULStatements]);
 
   const machineReadableLink = !isNil(props.mrDUL) && !isEmpty(props.mrDUL) ? a({
     id: 'btn_downloadSDul',
@@ -63,7 +63,7 @@ export default function TranslatedDULComponent(props) {
     div({ className: "panel-heading cm-boxhead dul-color" }, [
       h4({}, ["Data Use Limitations"]),
     ]),
-    ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements.current]),
+    ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
     div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
     div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
   ]);

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -22,7 +22,7 @@ export const generateUseRestrictionStatements = (dataUse) => {
 };
 
 export default function TranslatedDULComponent(props) {
-  const mrDULPartial = !isNil(props.mrDUL) ? button({
+  const machineReadableButton = !isNil(props.mrDUL) ? button({
     id: 'btn_downloadSDul',
     onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
     filename: 'machine-readable-DUL.json',
@@ -30,19 +30,29 @@ export default function TranslatedDULComponent(props) {
     className: 'btn-secondary btn-download-pdf hover-color'
   }, ['Download DUL machine-readable format']) : '';
 
-
-  const translatedDULStatements = generateUseRestrictionStatements(props.restrictions, props.mDUL);
+  const translatedDULStatements = generateUseRestrictionStatements(props.restrictions);
 
   return (
     div({className: 'translated-dul-component-container'}, [
       div({ className: 'panel-heading cm-boxhead dul-color' }, [
         h4({}, ['Data Use Limitations'])
       ]),
+      div({
+        id: "panel_dul",
+        className: "panel-body cm-boxbody",
+        isRendered: !isNil(props.downloadDUL) && !isEmpty(props.downloadDUL)
+      }, [
+        button({
+          id: "btn_downloadDataUseLetter",
+          className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color",
+          onClick: props.downloadDUL
+        }, ["Download Data Use Letter"]),
+      ]),
       div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
         div({ className: 'row dar-summary' }, [
           div({ className: 'control-label dul-color' }, ['Structured Limitations']),
           ul({className: 'response-label translated-restriction'}, [translatedDULStatements]),
-          mrDULPartial
+          machineReadableButton
         ])
       ])
     ])

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -58,7 +58,6 @@ export default function TranslatedDULComponent(props) {
     onClick: () => props.downloadDUL()
   }, ["Download Data Use Letter"]) : a({className: 'italic hover-color'}, [' No Data Use Letter Present']);
 
-
   const template = div({ className: "data-use-container" }, [
     div({ className: "panel-heading cm-boxhead dul-color" }, [
       h4({}, ["Data Use Limitations"]),

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -55,46 +55,47 @@ export default function TranslatedDULComponent(props) {
     generatedRestrictions(props.restrictions);
   }, [props.restrictions, setTranslatedDULStatements]);
 
-  const machineReadableLink = !isNil(props.mrDUL) && !isEmpty(props.mrDUL) ? a({
+  const machineReadableLink = a({
     id: 'btn_downloadSDul',
     onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
     filename: 'machine-readable-DUL.json',
     value: props.mrDUL,
     className: 'italic hover-color response-label',
-  }, ['Download DUL machine-readable format']) : a({className: 'italic hover-color'}, ['No machine readable download DUL present']);
+  }, ['Download DUL machine-readable format']);
 
-  const dataUseLetterLink = !isNil(props.downloadDUL) && !isEmpty(props.downloadDUL) ? a({
+  const dataUseLetterLink = a({
     id: "btn_downloadDataUseLetter",
     className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 italic hover-color",
     fileName: props.downloadDUL,
     value: props.downloadDUL,
     onClick: () => props.downloadDUL()
-  }, ["Download Data Use Letter"]) : a({className: 'italic hover-color'}, [' No Data Use Letter Present']);
+  }, ["Download Data Use Letter"]);
 
   //panel formats differ depending on whether or not its used in DAR vs DUL
+
   const DARTemplate = div({ className: "data-use-container" }, [
     div({ className: "panel-heading cm-boxhead dul-color" }, [
       h4({}, ["Data Use Limitations"]),
     ]),
     ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
-    div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL) && !isEmpty(props.downloadDUL)}, [dataUseLetterLink]),
-    div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL && !isEmpty(props.mrDUL))},[machineReadableLink])
+    div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
+    div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
   ]);
 
   const DULTemplate =
     div({style: DULContainer}, [
+      div({className: "data-use-panel", style: DULPanel}, [
+        div({ className: "panel-heading cm-boxhead dul-color" }, [
+          h4({}, ["Data Use Limitations"]),
+        ]),
+        div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
+        div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
+      ]),
       div({ className: "data-use-panel", style: DULPanel }, [
         div({ className: "panel-heading cm-boxhead dul-color" }, [
           h4({}, ["Structured Limitations"]),
         ]),
         ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
-      ]),
-      div({className: "data-use-panel", style: DULPanel}, [
-        div({ className: "panel-heading cm-boxhead dul-color" }, [
-          h4({}, ["Data Use Limitations"]),
-        ]),
-        div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL) && !isEmpty(props.downloadDUL)}, [dataUseLetterLink]),
-        div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL && !isEmpty(props.mrDUL))},[machineReadableLink])
       ])
     ]);
 

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -85,7 +85,7 @@ export default function TranslatedDULComponent(props) {
     div({style: DULContainer}, [
       div({ className: "data-use-panel", style: DULPanel }, [
         div({ className: "panel-heading cm-boxhead dul-color" }, [
-          h4({}, ["Data Use Limitations"]),
+          h4({}, ["Structured Limitations"]),
         ]),
         ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
       ]),

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -1,6 +1,8 @@
-import { div, ul, li, h4 } from 'react-hyperscript-helpers';
+import { div, ul, li, h4, button } from 'react-hyperscript-helpers';
 import {DataUseTranslation} from '../libs/dataUseTranslation';
 import isEmpty from 'lodash/fp/isEmpty';
+import * as Utils from '../libs/utils';
+import isNil from 'lodash/fp/isNil';
 
 //NOTE: li partial can be used in components that only need the list
 export const generateUseRestrictionStatements = (dataUse) => {
@@ -20,7 +22,17 @@ export const generateUseRestrictionStatements = (dataUse) => {
 };
 
 export default function TranslatedDULComponent(props) {
-  const translatedDULStatements = generateUseRestrictionStatements(props.restrictions);
+  const mrDULPartial = !isNil(props.mrDUL) ? button({
+    id: 'btn_downloadSDul',
+    onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
+    filename: 'machine-readable-DUL.json',
+    value: props.mrDUL,
+    className: 'btn-secondary btn-download-pdf hover-color'
+  }, ['Download DUL machine-readable format']) : '';
+
+
+  const translatedDULStatements = generateUseRestrictionStatements(props.restrictions, props.mDUL);
+
   return (
     div({className: 'translated-dul-component-container'}, [
       div({ className: 'panel-heading cm-boxhead dul-color' }, [
@@ -29,7 +41,8 @@ export default function TranslatedDULComponent(props) {
       div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
         div({ className: 'row dar-summary' }, [
           div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-          ul({className: 'response-label translated-restriction'}, [translatedDULStatements])
+          ul({className: 'response-label translated-restriction'}, [translatedDULStatements]),
+          mrDULPartial
         ])
       ])
     ])

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -5,10 +5,6 @@ import isEmpty from 'lodash/fp/isEmpty';
 import * as Utils from '../libs/utils';
 import isNil from 'lodash/fp/isNil';
 
-const liStyle = {
-  padding: '0.6rem'
-};
-
 const DULPanel = {
   margin: '0.5rem',
   flex: 1,
@@ -27,8 +23,7 @@ export async function GenerateUseRestrictionStatements(dataUse) {
   if (!dataUse || isEmpty(dataUse)) {
     return [li({
       className: 'translated restriction',
-      key: 'restriction-none',
-      style: liStyle
+      key: 'restriction-none'
     }, ['None'])];
   }
   const translations = await DataUseTranslation.translateDataUseRestrictions(dataUse);
@@ -36,7 +31,6 @@ export async function GenerateUseRestrictionStatements(dataUse) {
     return li({
       className: 'translated-restriction',
       key: `${restriction.code}-statement`,
-      style: liStyle
     }, [restriction.description]);
   });
 };
@@ -60,7 +54,7 @@ export default function TranslatedDULComponent(props) {
     onClick: () => Utils.download('machine-readable-DUL.json', props.mrDUL),
     filename: 'machine-readable-DUL.json',
     value: props.mrDUL,
-    className: 'italic hover-color response-label',
+    className: 'italic hover-color',
   }, ['Download DUL machine-readable format']);
 
   const dataUseLetterLink = a({
@@ -77,7 +71,7 @@ export default function TranslatedDULComponent(props) {
     div({ className: "panel-heading cm-boxhead dul-color" }, [
       h4({}, ["Data Use Limitations"]),
     ]),
-    ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none'}}, [translatedDULStatements]),
+    ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none', marginTop: '0.8rem'}}, [translatedDULStatements]),
     div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
     div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
   ]);

--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -1,0 +1,37 @@
+import { div, ul, li, h4 } from 'react-hyperscript-helpers';
+import {DataUseTranslation} from '../libs/dataUseTranslation';
+import isEmpty from 'lodash/fp/isEmpty';
+
+//NOTE: li partial can be used in components that only need the list
+export const generateUseRestrictionStatements = (dataUse) => {
+  if (!dataUse || isEmpty(dataUse)) {
+    return [li({
+      className: 'response-label translated restriction',
+      key: 'restriction-none'
+    }, ['None'])];
+  }
+  return DataUseTranslation.translateDataUseRestrictions(dataUse)
+    .map((restriction) => {
+      return li({
+        className: 'response-label translated-restriction',
+        key: `${restriction.code}-statement`
+      }, [restriction.description]);
+    });
+};
+
+export default function TranslatedDULComponent(props) {
+  const translatedDULStatements = generateUseRestrictionStatements(props.restrictions);
+  return (
+    div({className: 'translated-dul-component-container'}, [
+      div({ className: 'panel-heading cm-boxhead dul-color' }, [
+        h4({}, ['Data Use Limitations'])
+      ]),
+      div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
+        div({ className: 'row dar-summary' }, [
+          div({ className: 'control-label dul-color' }, ['Structured Limitations']),
+          ul({className: 'response-label translated-restriction'}, [translatedDULStatements])
+        ])
+      ])
+    ])
+  );
+}

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -5,7 +5,7 @@ import { Component } from 'react';
 import { a, div, hh, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import { ReadMore } from '../ReadMore';
-import { DataUseTranslation } from '../../libs/dataUseTranslation'
+import { DataUseTranslation } from '../../libs/dataUseTranslation';
 
 export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
 

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -5,9 +5,27 @@ import { Component } from 'react';
 import { a, div, hh, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import { ReadMore } from '../ReadMore';
-
+import { DataUseTranslation } from '../../libs/dataUseTranslation'
 
 export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
+
+  constructor(props) {
+    super();
+    this.state = {
+      translatedDatasetRestrictions: [],
+      getStructuredUseRestrictionLink: this.getStructuredUseRestrictionLink.bind(this)
+    };
+  }
+
+  async componentDidMount() {
+    let translationPromises = this.props.datasets.map((dataset) =>
+      DataUseTranslation.translateDataUseRestrictions(dataset.dataUse));
+    const datasetTranslations = await Promise.all(translationPromises);
+    this.setState(prev => {
+      prev.translatedDatasetRestrictions = datasetTranslations;
+      return prev;
+    });
+  }
 
   getProperty = (properties, propName) => {
     return find(properties, p => { return p.propertyName.toLowerCase() === propName.toLowerCase(); });
@@ -26,75 +44,77 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
       span({ name: 'link_dbGap', className: 'disabled' }, ['---']);
   };
 
-  getStructuredUseRestrictionLink = (dataset) => {
-    const trimmedContent = dataset.translatedUseRestriction.trim();
-    if (isEmpty(trimmedContent)) {
-      return span({ className: 'disabled' }, ['---']);
+  getStructuredUseRestrictionLink = (index) => {
+    if(this.state.translatedDatasetRestrictions && this.state.translatedDatasetRestrictions[index]) {
+      const translatedUseRestrictions = this.state.translatedDatasetRestrictions[index]
+        .map((translations) => translations.description)
+        .join('\n');
+      if (isEmpty(translatedUseRestrictions)) {
+        return span({ className: 'disabled' }, ['---']);
+      }
+      return ReadMore({
+        content: translatedUseRestrictions,
+        className: 'row no-margin',
+        style: { whiteSpace: 'pre-line' },
+        charLimit: 30,
+        inline: true
+      });
     }
-    return ReadMore({
-      content: trimmedContent,
-      className: 'row no-margin',
-      style: { whiteSpace: 'pre-line' },
-      charLimit: 30,
-      inline: true
-    });
   };
 
   render() {
     return (BaseModal({
-          id: 'dacDatasetsModal',
-          showModal: this.props.showModal,
-          onRequestClose: this.props.onCloseRequest,
-          color: 'common',
-          type: 'informative',
-          iconSize: 'none',
-          customStyles: { width: '80%' },
-          title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
-          action: { label: 'Close', handler: this.props.onCloseRequest }
-        },
-        [
-          div({ className: 'table-scroll', style: { margin: 0 } }, [
-            table({ className: 'table' }, [
-              thead({}, [
-                tr({}, [
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Id']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Name']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['dbGap']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Structured Data Use Limitations']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Data Type']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Phenotype/Indication']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Principal Investigator(PI)']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['# of participants']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Description']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Species']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Data Depositor']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['Consent ID']),
-                  th({ className: 'table-titles dataset-color cell-size' }, ['SC-ID'])
-                ])
-              ]),
-              tbody({}, [
-                this.props.datasets.map((dataset) => {
-                  return tr({ key: dataset.alias }, [
-                    td({ className: 'table-items cell-size', style: { position: 'relative' } }, [dataset.alias]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
-                    td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(dataset)]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, '# of participants', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Description', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Species', '---')]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Depositor', '---')]),
-                    td({ className: 'table-items cell-size' }, [dataset.consentId]),
-                    td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Sample Collection ID', '---')])
-                  ]);
-                })
-              ])
+      id: 'dacDatasetsModal',
+      showModal: this.props.showModal,
+      onRequestClose: this.props.onCloseRequest,
+      color: 'common',
+      type: 'informative',
+      iconSize: 'none',
+      customStyles: { width: '80%' },
+      title: 'DAC Datasets associated with DAC: ' + this.props.dac.name,
+      action: { label: 'Close', handler: this.props.onCloseRequest }
+    },
+    [
+      div({ className: 'table-scroll', style: { margin: 0 } }, [
+        table({ className: 'table' }, [
+          thead({}, [
+            tr({}, [
+              th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Id']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Dataset Name']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['dbGap']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Structured Data Use Limitations']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Data Type']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Phenotype/Indication']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Principal Investigator(PI)']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['# of participants']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Description']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Species']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Data Depositor']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['Consent ID']),
+              th({ className: 'table-titles dataset-color cell-size' }, ['SC-ID'])
             ])
+          ]),
+          tbody({}, [
+            this.props.datasets.map((dataset, index) => {
+              return tr({ key: dataset.alias }, [
+                td({ className: 'table-items cell-size', style: { position: 'relative' } }, [dataset.alias]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
+                td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(index)]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, '# of participants', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Description', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Species', '---')]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Depositor', '---')]),
+                td({ className: 'table-items cell-size' }, [dataset.consentId]),
+                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Sample Collection ID', '---')])
+              ]);
+            })
           ])
         ])
-    );
+      ])
+    ]));
   }
-
 });

--- a/src/components/modals/DatasetSummaryModal.js
+++ b/src/components/modals/DatasetSummaryModal.js
@@ -2,6 +2,7 @@ import { Component } from 'react';
 import { div, hr, label, hh } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import { DataSet, Consent } from '../../libs/ajax';
+import TranslatedDULComponent from '../TranslatedDULComponent';
 
 export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Component {
 
@@ -19,7 +20,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
       dataDepositor: '',
       pi: '',
       consentName: '',
-      translatedUseRestriction: '',
+      dataUse: {}
     };
 
     this.closeHandler = this.closeHandler.bind(this);
@@ -45,7 +46,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
       property.dataDepositor = dataSet.properties[8].propertyValue;
       property.pi = dataSet.properties[9].propertyValue;
       property.consentName = consent.name;
-      property.translatedUseRestriction = dataSet.translatedUseRestriction;
+      property.dataUse = consent.dataUse;
       property.loading = false;
       return property;
     });
@@ -151,9 +152,10 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
             div({ id: "txt_consentId", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.consentName]),
           ]),
 
+          //NOTE: test dataOwner view for this div
           div({ className: "row" }, [
             label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
-            div({ id: "txt_structured", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label translated-restriction", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, []),
+            TranslatedDULComponent({restrictions: this.state.dataUse})
           ])
         ])
       ])

--- a/src/components/modals/DatasetSummaryModal.js
+++ b/src/components/modals/DatasetSummaryModal.js
@@ -95,68 +95,68 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
         description: 'Requested Dataset Information',
         action: { label: "Close", handler: this.OKHandler }
       },
-        [
-          div({ className: "summary" }, [
-            div({ className: "row" }, [
-              label({ id: "lbl_datasetId", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Dataset ID"]),
-              div({ id: "txt_datasetId", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.datasetId]),
-            ]),
+      [
+        div({ className: "summary" }, [
+          div({ className: "row" }, [
+            label({ id: "lbl_datasetId", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Dataset ID"]),
+            div({ id: "txt_datasetId", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.datasetId]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_datasetName", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Dataset Name"]),
-              div({ id: "txt_datasetName", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.datasetName]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_datasetName", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Dataset Name"]),
+            div({ id: "txt_datasetName", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.datasetName]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_description", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Description"]),
-              div({ id: "txt_description", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.description]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_description", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Description"]),
+            div({ id: "txt_description", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.description]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_dataType", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Data Type"]),
-              div({ id: "txt_dataType", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.dataType]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_dataType", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Data Type"]),
+            div({ id: "txt_dataType", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.dataType]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_phenotype", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Phenotype/Indication"]),
-              div({ id: "txt_phenotype", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.phenotype]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_phenotype", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Phenotype/Indication"]),
+            div({ id: "txt_phenotype", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.phenotype]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_species", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Species"]),
-              div({ id: "txt_species", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.species]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_species", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Species"]),
+            div({ id: "txt_species", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.species]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_participants", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["# of Participants"]),
-              div({ id: "txt_participants", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.nrParticipants]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_participants", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["# of Participants"]),
+            div({ id: "txt_participants", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.nrParticipants]),
+          ]),
 
-            hr({}),
+          hr({}),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_depositor", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Data Depositor"]),
-              div({ id: "txt_depositor", className: "col-lg-3 col-md-3 col-sm-9 col-xs-8 response-label" }, [this.state.dataDepositor]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_depositor", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Data Depositor"]),
+            div({ id: "txt_depositor", className: "col-lg-3 col-md-3 col-sm-9 col-xs-8 response-label" }, [this.state.dataDepositor]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_PI", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Principal Investigator"]),
-              div({ id: "txt_PI", className: "col-lg-3 col-md-3 col-sm-9 col-xs-8 response-label" }, [this.state.pi]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_PI", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Principal Investigator"]),
+            div({ id: "txt_PI", className: "col-lg-3 col-md-3 col-sm-9 col-xs-8 response-label" }, [this.state.pi]),
+          ]),
 
-            hr({}),
+          hr({}),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_consentId", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Consent ID"]),
-              div({ id: "txt_consentId", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.consentName]),
-            ]),
+          div({ className: "row" }, [
+            label({ id: "lbl_consentId", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Consent ID"]),
+            div({ id: "txt_consentId", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.consentName]),
+          ]),
 
-            div({ className: "row" }, [
-              label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
-              div({ id: "txt_structured", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label translated-restriction", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, []),
-            ])
+          div({ className: "row" }, [
+            label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
+            div({ id: "txt_structured", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label translated-restriction", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, []),
           ])
         ])
+      ])
     );
   }
 });

--- a/src/components/modals/DatasetSummaryModal.js
+++ b/src/components/modals/DatasetSummaryModal.js
@@ -35,7 +35,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
   async getSummaryInfo() {
     const dataSet = await DataSet.getDataSetsByDatasetId(this.props.dataSetId);
     const consent = await Consent.findConsentById(dataSet.consentId);
-    const translatedDULStatements = GenerateUseRestrictionStatements(consent.dataUse);
+    const translatedDULStatements = await GenerateUseRestrictionStatements(consent.dataUse);
 
     this.setState(property => {
       property.datasetName = dataSet.properties[0].propertyValue;
@@ -157,7 +157,9 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
 
           div({ className: "row" }, [
             label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
-            ul({style: {listStyle: 'none'}}, this.state.translatedDULStatements)
+            div({className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label"}, [
+               ul({style: {listStyleType: 'none', padding: 0, margin: 0}, }, this.state.translatedDULStatements)
+            ])
           ])
         ])
       ])

--- a/src/components/modals/DatasetSummaryModal.js
+++ b/src/components/modals/DatasetSummaryModal.js
@@ -1,8 +1,8 @@
 import { Component } from 'react';
-import { div, hr, label, hh, h } from 'react-hyperscript-helpers';
+import { div, hr, label, hh, ul } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import { DataSet, Consent } from '../../libs/ajax';
-import TranslatedDULComponent from '../TranslatedDULComponent';
+import { GenerateUseRestrictionStatements } from '../TranslatedDULComponent';
 
 export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Component {
 
@@ -20,7 +20,8 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
       dataDepositor: '',
       pi: '',
       consentName: '',
-      dataUse: {}
+      dataUse: {},
+      translatedDULStatements: []
     };
 
     this.closeHandler = this.closeHandler.bind(this);
@@ -34,6 +35,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
   async getSummaryInfo() {
     const dataSet = await DataSet.getDataSetsByDatasetId(this.props.dataSetId);
     const consent = await Consent.findConsentById(dataSet.consentId);
+    const translatedDULStatements = GenerateUseRestrictionStatements(consent.dataUse);
 
     this.setState(property => {
       property.datasetName = dataSet.properties[0].propertyValue;
@@ -48,6 +50,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
       property.consentName = consent.name;
       property.dataUse = consent.dataUse;
       property.loading = false;
+      property.translatedDULStatements = translatedDULStatements;
       return property;
     });
   }
@@ -152,10 +155,9 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
             div({ id: "txt_consentId", className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label" }, [this.state.consentName]),
           ]),
 
-          //NOTE: test dataOwner view for this div
           div({ className: "row" }, [
             label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
-            h(TranslatedDULComponent,{restrictions: this.state.dataUse})
+            ul({style: {listStyle: 'none'}}, this.state.translatedDULStatements)
           ])
         ])
       ])

--- a/src/components/modals/DatasetSummaryModal.js
+++ b/src/components/modals/DatasetSummaryModal.js
@@ -158,7 +158,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
           div({ className: "row" }, [
             label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
             div({className: "col-lg-9 col-md-9 col-sm-9 col-xs-8 response-label"}, [
-               ul({style: {listStyleType: 'none', padding: 0, margin: 0}, }, this.state.translatedDULStatements)
+              ul({style: {listStyleType: 'none', padding: 0, margin: 0}, }, this.state.translatedDULStatements)
             ])
           ])
         ])

--- a/src/components/modals/DatasetSummaryModal.js
+++ b/src/components/modals/DatasetSummaryModal.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { div, hr, label, hh } from 'react-hyperscript-helpers';
+import { div, hr, label, hh, h } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import { DataSet, Consent } from '../../libs/ajax';
 import TranslatedDULComponent from '../TranslatedDULComponent';
@@ -155,7 +155,7 @@ export const DatasetSummaryModal = hh(class DatasetSummaryModal extends Componen
           //NOTE: test dataOwner view for this div
           div({ className: "row" }, [
             label({ id: "lbl_structured", className: "col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label dataset-color" }, ["Structured Limitations"]),
-            TranslatedDULComponent({restrictions: this.state.dataUse})
+            h(TranslatedDULComponent,{restrictions: this.state.dataUse})
           ])
         ])
       ])

--- a/src/components/modals/TranslatedDulModal.js
+++ b/src/components/modals/TranslatedDulModal.js
@@ -37,9 +37,9 @@ export const TranslatedDulModal = hh(class TranslatedDulModal extends Component 
         description: 'Translated Use Restriction',
         action: { label: "Close", handler: this.OKHandler }
       },
-        [
-          div({ id: "txt_translatedRestrictions", className: "row no-margin translated-restriction", dangerouslySetInnerHTML: {__html:this.props.useRestriction }}, []),
-        ])
+      [
+        div({ id: "txt_translatedRestrictions", className: "row no-margin translated-restriction", dangerouslySetInnerHTML: {__html:this.props.useRestriction }}, []),
+      ])
     );
   }
 });

--- a/src/components/modals/TranslatedDulModal.js
+++ b/src/components/modals/TranslatedDulModal.js
@@ -1,45 +1,39 @@
-import { Component } from 'react';
-import { div, hh } from 'react-hyperscript-helpers';
+import { ul } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
+import {generateUseRestrictionStatements} from '../TranslatedDULComponent';
 // import { DataSet } from '../../libs/ajax'
 
 const MODAL_ID = 'translatedDul';
 
-export const TranslatedDulModal = hh(class TranslatedDulModal extends Component {
+const listStyle = {
+  listStyle: 'none'
+};
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      translatedUseRestriction: this.props.translatedUseRestriction
-    };
+export default function TranslatedDulModal(props) {
+  const OKHandler = (e) => {
+    props.onOKRequest(MODAL_ID);
   };
 
-  OKHandler = (e) => {
-    this.props.onOKRequest(MODAL_ID);
+  const closeHandler = (e) => {
+    props.onCloseRequest(MODAL_ID);
   };
 
-  closeHandler = (e) => {
-    this.props.onCloseRequest(MODAL_ID);
-  };
+  const translatedDULList = generateUseRestrictionStatements(props.dataUse || {});
 
-  render() {
-    return (
-
-      BaseModal({
-        id: "translatedDulModal",
-        showModal: this.props.showModal,
-        onRequestClose: this.closeHandler,
-        onAfterOpen: this.afterOpenHandler,
-        color: "dataset",
-        type: "informative",
-        iconSize: 'none',
-        title: "More information",
-        description: 'Translated Use Restriction',
-        action: { label: "Close", handler: this.OKHandler }
-      },
-      [
-        div({ id: "txt_translatedRestrictions", className: "row no-margin translated-restriction", dangerouslySetInnerHTML: {__html:this.props.useRestriction }}, []),
-      ])
-    );
-  }
-});
+  return (
+    BaseModal({
+      id: "translatedDulModal",
+      showModal: props.showModal,
+      onRequestClose: closeHandler,
+      color: "dataset",
+      type: "informative",
+      iconSize: 'none',
+      title: "More information",
+      description: 'Translated Use Restriction',
+      action: { label: "Close", handler: OKHandler }
+    },
+    [
+      ul({style: listStyle, id: "txt_translatedRestrictions", className: "row no-margin translated-restriction"}, [translatedDULList]),
+    ])
+  );
+};

--- a/src/components/modals/TranslatedDulModal.js
+++ b/src/components/modals/TranslatedDulModal.js
@@ -1,6 +1,6 @@
 import { ul } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
-import {generateUseRestrictionStatements} from '../TranslatedDULComponent';
+import {GenerateUseRestrictionStatements} from '../TranslatedDULComponent';
 // import { DataSet } from '../../libs/ajax'
 
 const MODAL_ID = 'translatedDul';
@@ -18,7 +18,7 @@ export default function TranslatedDulModal(props) {
     props.onCloseRequest(MODAL_ID);
   };
 
-  const translatedDULList = generateUseRestrictionStatements(props.dataUse || {});
+  const translatedDULList = GenerateUseRestrictionStatements(props.dataUse || {});
 
   return (
     BaseModal({

--- a/src/components/modals/TranslatedDulModal.js
+++ b/src/components/modals/TranslatedDulModal.js
@@ -1,7 +1,7 @@
 import { ul } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import {GenerateUseRestrictionStatements} from '../TranslatedDULComponent';
-// import { DataSet } from '../../libs/ajax'
+import { useState, useEffect } from 'react';
 
 const MODAL_ID = 'translatedDul';
 
@@ -18,7 +18,16 @@ export default function TranslatedDulModal(props) {
     props.onCloseRequest(MODAL_ID);
   };
 
-  const translatedDULList = GenerateUseRestrictionStatements(props.dataUse || {});
+  const [translatedDULList, setTranslatedDULList] = useState(GenerateUseRestrictionStatements(props.dataUse || []));
+
+  useEffect(() => {
+    const getTranslatedDULList = async() => {
+      const list = await GenerateUseRestrictionStatements(props.dataUse || []);
+      setTranslatedDULList(list);
+    };
+
+    getTranslatedDULList();
+  }, [props.dataUse]);
 
   return (
     BaseModal({
@@ -33,7 +42,7 @@ export default function TranslatedDulModal(props) {
       action: { label: "Close", handler: OKHandler }
     },
     [
-      ul({style: listStyle, id: "txt_translatedRestrictions", className: "row no-margin translated-restriction"}, [translatedDULList]),
+      ul({style: listStyle, id: "txt_translatedRestrictions", className: "row no-margin translated-restriction"}, translatedDULList),
     ])
   );
 };

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -262,6 +262,7 @@ export const DAR = {
     darInfo.city = rawDar.city;
     darInfo.country = rawDar.country;
     darInfo.status = rawDar.status;
+    darInfo.restrictions = rawDar.restrictions;
 
     darInfo.hasAdminComment = researcher.rationale != null;
     darInfo.adminComment = researcher.rationale;

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -6,8 +6,6 @@ import join from 'lodash/fp/join';
 import concat from 'lodash/fp/concat';
 import clone from 'lodash/fp/clone';
 import uniq from 'lodash/fp/uniq';
-import { Consent } from '../libs/ajax';
-import { Config } from '../libs/config';
 import { searchOntology } from '../libs/ontologyService';
 
 const srpTranslations = {

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -348,7 +348,6 @@ export const DataUseTranslation = {
             resolvedLabels = await Promise.all(ontologyPromises);
           } catch (error) {
             Notifications.showError({text: 'Ontology API Request Error'});
-            console.log(error);
           }
           resp = consentTranslations.diseaseRestrictions(resolvedLabels);
         } else {

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,4 +1,3 @@
-import forEach from 'lodash/fp/forEach';
 import isNil from 'lodash/fp/isNil';
 import isEmpty from 'lodash/fp/isEmpty';
 import filter from 'lodash/fp/filter';
@@ -7,6 +6,7 @@ import concat from 'lodash/fp/concat';
 import clone from 'lodash/fp/clone';
 import uniq from 'lodash/fp/uniq';
 import { searchOntology } from '../libs/ontologyService';
+import { Notifications } from '../libs/utils';
 
 const srpTranslations = {
   hmb: {
@@ -347,6 +347,7 @@ export const DataUseTranslation = {
             });
             resolvedLabels = await Promise.all(ontologyPromises);
           } catch (error) {
+            Notifications.showError({text: 'Ontology API Request Error'});
             console.log(error);
           }
           resp = consentTranslations.diseaseRestrictions(resolvedLabels);

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,5 +1,6 @@
 import * as fp from 'lodash/fp';
 
+//NOTE: need to incorporate the generic core statements and the prefixes into this data struct for universal use
 const translations = {
   hmb: {
     code: "HMB",
@@ -269,4 +270,108 @@ export const DataUseTranslation = {
     return dataUseSummary;
   },
 
+};
+
+export const translatedUseStatements = function(darInfo, type) {
+  //singlePhrases will contain the core message that is shared by both sRP and DULs
+  //pronouns can be prefixed to these central definitions
+  const singlePhrases = {
+    nres: 'any purpose without restrictions.',
+    gru: 'any research purpose.',
+    hmb: 'a health, medical, or biomedical research purpose.',
+    ds: 'for reasearch on the specified disease(s).',
+    poa: 'population, origin, or ancestry research.',
+    mds: 'methods development research (e.g., development of software or algorithms).',
+    nmds: 'methods development research (e.g., development of software or algorithms) only within the bounds of other use limitations.',
+    gso: 'genetic studies only.',
+    npu: 'not-for-profit and non-commercial.',
+    pub: 'make results of studies using the data available to the larger scientific community.',
+    col: 'collaborate with the primary study investigators',
+    irb: 'provide documentation of local IRB/ERB approval',
+    gs: 'within a certain geographic area',
+    mor: 'withold from publishing until the specified date',
+    rt: 'return derived/enriched data to the database/resource'
+  };
+
+  const prefixPhrases = {
+    nres: {
+      srp: null,
+      dul: 'Use is permited for '
+    },
+    gru: {
+      srp: null,
+      dul: 'Use is permitted for '
+    },
+    hmb: {
+      srp: 'The primary aim of this research is ',
+      dul: 'Use is permitted for '
+    },
+    ds: {
+      srp: 'The primary aim of this research is ',
+      dul: 'Use is permitted for '
+    },
+    poa: {
+      srp: 'The primary aim of this research is ',
+      dul: 'Use is limited to '
+    },
+    mds: {
+      dul: null,
+      srp: 'This research includes '
+    },
+    nmds: {
+      dul: 'Use for ',
+      srp: null
+    },
+    gso: {
+      dul: 'Use is limited to ',
+      srp: 'This research includes '
+    },
+    npu: {
+      dul: 'Use is limited to ',
+      srp: 'This research is '
+    },
+    pub: {
+      dul: 'Use requires user to ',
+      srp: 'The researcher will '
+    },
+    col: {
+      dul: 'Use requires users to ',
+      srp: 'The reseracher will '
+    },
+    irb: {
+      dul: 'Use requires users to ',
+      srp: 'The researcher will '
+    },
+    gs: {
+      dul: 'Use is limited to ',
+      srp: 'The research is '
+    },
+    mor: {
+      dul: 'Use requires users to ',
+      srp: 'The researcher will '
+    },
+    rt: {
+      dul: 'Use requires users to ',
+      srp: 'The researcher will '
+    }
+  };
+
+  const generateStatements = function (darInfo, type) {
+    if(!type || !darInfo) {return [];}
+
+    const keys = Object.keys(singlePhrases);
+    let returnStatements = [];
+    keys.forEach(key => {
+      if(prefixPhrases[key][type] && darInfo[key]) {
+        returnStatements.push({
+          description: prefixPhrases[key][type] + singlePhrases[key],
+          key: key
+        });
+      }
+    });
+
+    return returnStatements;
+  };
+
+  return generateStatements(darInfo, type);
 };

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,31 +1,70 @@
 import * as fp from 'lodash/fp';
 
 //NOTE: need to incorporate the generic core statements and the prefixes into this data struct for universal use
+//NOTE: need to encapsulate values in true/false keys since there may be variations on what is expected for each attribute
+//NOTE: values that have no expected value for true or valse should have it be set to null for exclusion in processing
+const processedDiseaseString = (prefix, diseases) => {
+  const diseaseArray = diseases.sort().map(disease => disease.label);
+  const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : diseaseArray[0];
+  return {
+    description: prefix + diseaseString,
+    manualReview: false
+  };
+};
+
+//NOTE: will need to create a mapper or key check to point the equivalent keys across all references to the same front-end definition
+//Examples - forProfit, male, female, pediatric (and possible even more)
+//NOTE: need to understand the differences between NMDS and MDS and NCTRL and CTRL for categorization sake
+//NOTE: most likely will need to rewrite dependent components to use new interface
 const translations = {
   hmb: {
     code: "HMB",
-    description: 'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.',
+    srp: {
+      description: 'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.'
+    },
+    dul: {
+      true: {
+        description: 'Use is permitted for a health, medical, or biomedical research purpose'
+      },
+      false: null
+    },
     manualReview: false
   },
   poa: {
     code: 'POA',
-    desciption: 'The dataset will be used for the study of Population Origins/Migration patterns.',
+    srp: {
+      description: 'The primary aim of this research is for population, origin, or ancestry research',
+    },
+    dul: {
+      true: {
+        description: 'Use is limited to population, origin, or ancestry research'
+      },
+      false: null
+    },
     manualReview: true
   },
   diseases: (diseases) => {
-    const diseaseArray = diseases.sort().map(disease => disease.label);
-    const diseaseString = diseaseArray.length > 1 ? fp.join('; ')(diseaseArray) : diseaseArray[0];
     return {
       code: 'DS',
-      description: 'Disease-related studies: ' + diseaseString,
+      srp: {
+        description: processedDiseaseString('The primary aim of this research is for ', diseases)
+      },
+      dul: {
+        true: {
+          description: processedDiseaseString('Use is permitted for '),
+        },
+        false: null
+      },
       manualReview: false
     };
   },
+  //NOTE: figure out if this needs to be removed or not 
   researchTypeDisease: {
     code: 'DS',
     description: 'The primary purpose of the research is to learn more about a particular disease or disorder, a trait, or a set of related conditions.',
     manualReview: false
   },
+  //NOTE: need to know how to format this string for srp and dul
   other: (otherText) => {
     return {
       code: 'OTHER',
@@ -33,70 +72,195 @@ const translations = {
       manualReview: true
     };
   },
+  //srp only
   methods: {
     code: 'MDS',
-    description: 'The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data. Data will be used for developing and/or validating new methods.',
+    srp: {
+      description: 'The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data. Data will be used for developing and/or validating new methods.',
+    },
+    dul: null,
     manualReview: false
   },
+  //srp only
   controls: {
     code: 'CTRL',
-    description: 'The reason for this request is to increase the number of controls available for a comparison group.',
+    srp: {
+      description: 'The reason for this request is to increase the number of controls available for a comparison group.'
+    },
+    dul: null,
     manualReview: false
   },
   forProfit: {
     code: 'NCU',
-    description: 'The dataset will be used in a study related to a commercial purpose.',
+    srp:{
+      description: 'This research is not-for-profit and non-commercial.'
+    },
+    dul: {
+      true: {
+        description: 'Use is limited to not-for-profit and non-commercial.'
+      },
+      false: {
+        description: 'Use is not limited to not-for-profit and non-commercial.'
+      }
+    },
     manualReview: false
   },
   genderFemale: {
     code: 'POP-F',
-    description: 'The dataset will be used for the study of females.',
+    srp: {
+      description: 'This research is limited to studies about females.',
+    },
+    dul: {
+      true: {
+        description: 'Use is limited to studies about females.'
+      },
+      false: null
+    },
     manualReview: false
   },
   genderMale: {
     code: 'POP-M',
-    description: 'The dataset will be used for the study of males.',
+    srp: {
+      description: 'The dataset will be used for studies about males.'
+    },
+    dul: {
+      true: {
+        description: 'Use is limited to studies about males.'
+      },
+      false: null
+    },
     manualReview: false
   },
   pediatric: {
     code: 'POP-P',
-    description: 'The dataset will be used for the study of children.',
+    srp: {description: 'The dataset will be used for the study of children.'},
+    dul: {
+      true: {
+        description: 'The dataset will be used for pediatric research.'
+      },
+      false: null
+    },
     manualReview: false
   },
+  //srp only?
   illegalBehavior: {
     code: 'OTHER',
-    description: 'The dataset will be used for the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization).',
+    srp: {description: 'The dataset will be used for the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization).'},
+    dul: null,
     manualReview: true
   },
+  //srp only?
   addiction: {
     code: 'OTHER',
-    description: 'The dataset will be used for the study of alcohol or drug abuse, or abuse of other addictive products.',
+    srp: {description: 'The dataset will be used for the study of alcohol or drug abuse, or abuse of other addictive products.'},
+    dul: null,
     manualReview: true
   },
+  //srp only?
   sexualDiseases: {
     code: 'OTHER',
-    description: 'The dataset will be used for the study of sexual preferences or sexually transmitted diseases.',
+    srp: {description: 'The dataset will be used for the study of sexual preferences or sexually transmitted diseases.'},
+    dul: null,
     manualReview: true
   },
+  //srp only?
   stigmatizedDiseases: {
     code: 'OTHER',
-    description: 'The dataset will be used for the study of stigmatizing illnesses.',
+    srp: {description: 'The dataset will be used for the study of stigmatizing illnesses.'},
+    dul: null,
     manualReview: true
   },
+  //srp only?
   vulnerablePopulation: {
     code: 'OTHER',
-    description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).',
+    srp: {description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).'},
+    dul: null,
     manualReview: true
   },
+  //srp only?
   psychiatricTraits: {
     code: 'OTHER',
-    description: 'The dataset will be used for the study of psychological traits, including intelligence, attention, emotion.',
+    srp: {description: 'The dataset will be used for the study of psychological traits, including intelligence, attention, emotion.'},
+    dul: null,
     manualReview: true
   },
+  //srp only?
   notHealth: {
     code: 'OTHER',
-    description: 'The dataset will be used for the research that correlates ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.',
+    srp: {description: 'The dataset will be used for the research that correlates ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.'},
+    dul: null,
     manualReview: true
+  },
+  //dul only?
+  geneticStudiesOnly: {
+    code: 'GSO',
+    srp: {
+      description: 'This research includes genetic studies only.'
+    },
+    dul: {
+      true: {
+        description: 'Use is limited to genetic studies only'
+      },
+      false: null
+    },
+    //what is this value?
+    manualReview: false
+  },
+  publicationResults: {
+    code: 'PUB',
+    srp: {
+      description: 'The researcher will make results of studies using the data available to the larger scientific community'
+    },
+    dul: {
+      true: {
+        description: 'Use requires users to make results of studies using the data availbale to the larger scientific community.'
+      },
+      false: null
+    },
+    //what should this value be?
+    manualReview: false
+  },
+  collaboratorRequired: {
+    code: 'COL',
+    srp: {
+      description: 'The researcher will collaborate with the primary study investigators.'
+    },
+    dul: {
+      true: {
+        description: 'Use requires users to collaborate with the primary study investigators.'
+      },
+      false: null
+    },
+    //What should this value be?
+    manualReview: false
+  },
+  ethicsApprovalRequired: {
+    code: 'IRB',
+    srp: {
+      description: 'The researcher will provide documentation of local IRB/ERB approval.'
+    },
+    dul: {
+      true: {
+        description: 'Use requires users to provide documentation of local IRB/ERB approval.'
+      },
+      false: null
+    },
+    //what should this value be?
+    manualReview: false
+  },
+  geographicalRestriction: {
+    code: 'GS',
+    srp: {
+      description: 'The research is within a certain gepgraphic area'
+    },
+    dul: {
+      true: {
+        description: 'Use is limited to within a certain geographic area'
+      },
+      false: null
+    },
+    //what should this value be?
+    manualReview: false
   }
 };
 

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -335,9 +335,9 @@ export const DataUseTranslation = {
       const value = dataUse[key];
       if(!isNil(value) && value) {
         if(key === 'diseaseRestrictions') {
-          restrictionStatements.push({key, description: consentTranslations.diseaseRestrictions(value)});
+          restrictionStatements.push(consentTranslations.diseaseRestrictions(value));
         } else {
-          restrictionStatements.push({key, description: consentTranslations[key]});
+          restrictionStatements.push(consentTranslations[key]);
         }
       }
     })(targetKeys);

--- a/src/libs/ontologyService.js
+++ b/src/libs/ontologyService.js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { Config } from '../libs/config';
+
+
+export async function searchOntology(obolibraryURL) {
+  const baseURL = await Config.getOntologyApiUrl();
+  const params = {id: obolibraryURL};
+  try{
+    let resp = await axios.get(`${baseURL}search`, {params});
+    return resp.data[0];
+  } catch(error) {
+    console.log(error);
+  }
+}
+
+export default {searchOntology};

--- a/src/libs/ontologyService.js
+++ b/src/libs/ontologyService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { Config } from '../libs/config';
-
+import { Notifications } from '../libs/utils';
 
 export async function searchOntology(obolibraryURL) {
   const baseURL = await Config.getOntologyApiUrl();
@@ -9,8 +9,8 @@ export async function searchOntology(obolibraryURL) {
     let resp = await axios.get(`${baseURL}search`, {params});
     return resp.data[0];
   } catch(error) {
-    console.log(error);
+    Notifications.showError('Error: Ontology Search Request failed');
   }
 }
 
-export default {searchOntology};
+export default { searchOntology };

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -15,6 +15,7 @@ import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import { Theme } from '../libs/theme';
+import { translatedUseStatements } from '../libs/dataUseTranslation';
 
 class AccessCollect extends Component {
 
@@ -30,6 +31,14 @@ class AccessCollect extends Component {
 
   async componentDidMount() {
     await this.loadData();
+  }
+
+  generateDULStatements() {
+    const restrictions = translatedUseStatements(this.state.darInfo, 'dul');
+    return restrictions.map((restriction) => {
+      debugger;
+      return div({className: 'response-label translated-restriction', key: restriction.key}, [restriction.description]);
+    });
   }
 
   initialState() {
@@ -235,7 +244,6 @@ class AccessCollect extends Component {
   async findDataAccessElectionReview() {
     let electionReview = await Election.findDataAccessElectionReview(this.props.match.params.electionId, false);
     this.getRPGraphData('access', electionReview.reviewVote);
-
     this.setState(prev => {
       prev.isQ1Expanded = true;
       prev.isQ2Expanded = false;
@@ -251,6 +259,7 @@ class AccessCollect extends Component {
       prev.dulName = electionReview.consent.dulName;
       prev.status = electionReview.election.status;
       prev.accessAlreadyVote = electionReview.election.finalVote !== null ? true : false;
+      //NOTE: What's with this logic? the variable isn't even used
       prev.userestriction = electionReview.election.translatedUseRestriction === null ?
         'This includes sensitive research objectives that requires manual review.' :
         electionReview.election.translatedUseRestriction;
@@ -360,7 +369,7 @@ class AccessCollect extends Component {
 
   render() {
 
-    const { translatedUseRestriction } = this.state;
+    const translatedDULComponent = this.generateDULStatements();
 
     return (
       div({ className: 'container container-wide' }, [
@@ -414,7 +423,7 @@ class AccessCollect extends Component {
                 div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
                   div({ className: 'row dar-summary' }, [
                     div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-                    div({ className: 'response-label translated-restriction', dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
+                    div({ className: 'response-label translated-restriction'}, [translatedDULComponent])
                   ])
                 ])
               ])

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -15,7 +15,7 @@ import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import { Theme } from '../libs/theme';
-import { DataUseTranslation } from '../libs/dataUseTranslation';
+import translatedDULComponent from '../components/TranslatedDULComponent';
 
 class AccessCollect extends Component {
 
@@ -31,14 +31,6 @@ class AccessCollect extends Component {
 
   async componentDidMount() {
     await this.loadData();
-  }
-
-  generateUseRestrictionStatements(dataUse) {
-    if(!dataUse) { return []; }
-    return DataUseTranslation.translateDataUseRestrictions(dataUse)
-      .map((restriction) => {
-        return div({className: 'response-label translated-restriction', key: restriction.key}, [restriction.description]);
-      });
   }
 
   initialState() {
@@ -74,6 +66,7 @@ class AccessCollect extends Component {
         ]
       },
       translatedUseRestriction: '',
+      dataUse: {},
       voteStatus: '',
       createDate: '',
       hasUseRestriction: false,
@@ -258,7 +251,6 @@ class AccessCollect extends Component {
       prev.isQ2Expanded = false;
       prev.consentName = electionReview.associatedConsent.name;
       prev.consentId = electionReview.consent.consentId;
-      prev.translatedUseRestriction = electionReview.consent.translatedUseRestriction;
       prev.electionType = 'access';
       prev.election = electionReview.election;
       prev.darOriginalFinalVote = electionReview.election.finalVote;
@@ -269,9 +261,9 @@ class AccessCollect extends Component {
       prev.status = electionReview.election.status;
       prev.accessAlreadyVote = electionReview.election.finalVote !== null ? true : false;
       //NOTE: What's with this logic? the variable isn't even used
-      prev.userestriction = electionReview.election.translatedUseRestriction === null ?
-        'This includes sensitive research objectives that requires manual review.' :
-        electionReview.election.translatedUseRestriction;
+      // prev.userestriction = electionReview.election.translatedUseRestriction === null ?
+      //   'This includes sensitive research objectives that requires manual review.' :
+        // electionReview.election.translatedUseRestriction;
       prev.voteAccessList = this.chunk(electionReview.reviewVote, 2);
       return prev;
     });
@@ -377,7 +369,6 @@ class AccessCollect extends Component {
   }
 
   render() {
-    const translatedDULComponent = this.generateUseRestrictionStatements(this.state.dataUse);
     return (
       div({ className: 'container container-wide' }, [
         div({ className: 'row no-margin' }, [
@@ -424,15 +415,7 @@ class AccessCollect extends Component {
                 researcherProfile: this.state.researcherProfile }),
 
               div({ className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
-                div({ className: 'panel-heading cm-boxhead dul-color' }, [
-                  h4({}, ['Data Use Limitations'])
-                ]),
-                div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
-                  div({ className: 'row dar-summary' }, [
-                    div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-                    div({ className: 'response-label translated-restriction'}, [translatedDULComponent])
-                  ])
-                ])
+                translatedDULComponent({restrictions: this.state.dataUse})
               ])
             ]),
 

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -15,7 +15,7 @@ import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import { Theme } from '../libs/theme';
-import translatedDULComponent from '../components/TranslatedDULComponent';
+import TranslatedDULComponent from '../components/TranslatedDULComponent';
 
 class AccessCollect extends Component {
 
@@ -65,7 +65,6 @@ class AccessCollect extends Component {
           ['Pending', 0]
         ]
       },
-      translatedUseRestriction: '',
       dataUse: {},
       voteStatus: '',
       createDate: '',
@@ -260,10 +259,6 @@ class AccessCollect extends Component {
       prev.dulName = electionReview.consent.dulName;
       prev.status = electionReview.election.status;
       prev.accessAlreadyVote = electionReview.election.finalVote !== null ? true : false;
-      //NOTE: What's with this logic? the variable isn't even used
-      // prev.userestriction = electionReview.election.translatedUseRestriction === null ?
-      //   'This includes sensitive research objectives that requires manual review.' :
-        // electionReview.election.translatedUseRestriction;
       prev.voteAccessList = this.chunk(electionReview.reviewVote, 2);
       return prev;
     });
@@ -414,8 +409,11 @@ class AccessCollect extends Component {
                 downloadDAR: this.downloadDAR,
                 researcherProfile: this.state.researcherProfile }),
 
-              div({ className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
-                translatedDULComponent({restrictions: this.state.dataUse})
+              div({
+                className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes',
+                isRendered: !ld.isEmpty(this.state.dataUse)
+              }, [
+                TranslatedDULComponent({restrictions: this.state.dataUse})
               ])
             ]),
 

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -413,7 +413,7 @@ class AccessCollect extends Component {
                 className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes',
                 isRendered: !ld.isEmpty(this.state.dataUse)
               }, [
-                TranslatedDULComponent({restrictions: this.state.dataUse})
+                h(TranslatedDULComponent,{restrictions: this.state.dataUse})
               ])
             ]),
 

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -15,7 +15,7 @@ import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import { Theme } from '../libs/theme';
-import { translatedUseStatements } from '../libs/dataUseTranslation';
+import { DataUseTranslation } from '../libs/dataUseTranslation';
 
 class AccessCollect extends Component {
 
@@ -33,12 +33,11 @@ class AccessCollect extends Component {
     await this.loadData();
   }
 
-  generateDULStatements() {
-    const restrictions = translatedUseStatements(this.state.darInfo, 'dul');
-    return restrictions.map((restriction) => {
-      debugger;
-      return div({className: 'response-label translated-restriction', key: restriction.key}, [restriction.description]);
-    });
+  generateUseRestrictionStatements(dataUse) {
+    return DataUseTranslation.translateDataUseRestrictions(dataUse)
+      .map((restriction) => {
+        return div({className: 'response-label translated-restriction', key: restriction.key}, [restriction.description]);
+      });
   }
 
   initialState() {
@@ -368,8 +367,7 @@ class AccessCollect extends Component {
   }
 
   render() {
-
-    const translatedDULComponent = this.generateDULStatements();
+    const translatedDULComponent = this.generateUseRestrictionStatements();
 
     return (
       div({ className: 'container container-wide' }, [

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -10,7 +10,7 @@ import { PageHeading } from '../components/PageHeading';
 import { SingleResultBox } from '../components/SingleResultBox';
 import { StructuredDarRp } from '../components/StructuredDarRp';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
-import { DAR, Election, Email, Files, Researcher } from '../libs/ajax';
+import { DAR, Election, Email, Files, Researcher, DataSet } from '../libs/ajax';
 import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
@@ -34,6 +34,7 @@ class AccessCollect extends Component {
   }
 
   generateUseRestrictionStatements(dataUse) {
+    if(!dataUse) { return []; }
     return DataUseTranslation.translateDataUseRestrictions(dataUse)
       .map((restriction) => {
         return div({className: 'response-label translated-restriction', key: restriction.key}, [restriction.description]);
@@ -238,6 +239,15 @@ class AccessCollect extends Component {
     await this.findDataAccessElectionReview();
     await this.findRPElectionReview();
     await this.findDar();
+    await this.getDataset(this.state.election.dataSetId);
+  }
+
+  async getDataset(id) {
+    const dataset = await DataSet.getDataSetsByDatasetId(id);
+    this.setState((prev) => {
+      prev.dataUse = dataset.dataUse;
+      return prev;
+    });
   }
 
   async findDataAccessElectionReview() {
@@ -367,8 +377,7 @@ class AccessCollect extends Component {
   }
 
   render() {
-    const translatedDULComponent = this.generateUseRestrictionStatements();
-
+    const translatedDULComponent = this.generateUseRestrictionStatements(this.state.dataUse);
     return (
       div({ className: 'container container-wide' }, [
         div({ className: 'row no-margin' }, [

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { Component } from 'react';
-import { a, button, div, h4, i } from 'react-hyperscript-helpers';
+import { a, button, div, h4, i, h } from 'react-hyperscript-helpers';
 import { ApplicationSummary } from '../components/ApplicationSummary';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { DataAccessRequest } from '../components/DataAccessRequest';
@@ -141,7 +141,7 @@ class AccessPreview extends Component {
                 className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes',
                 isRendered: !ld.isEmpty(this.state.dataUse)
               }, [
-                TranslatedDULComponent({restrictions: this.state.dataUse})
+                h(TranslatedDULComponent,{restrictions: this.state.dataUse})
               ])
             ])
           ])

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -21,9 +21,6 @@ class AccessPreview extends Component {
       consentName: '',
       isQ1Expanded: true,
       isQ2Expanded: false,
-      consent: {
-        translatedUseRestriction: ''
-      },
       dataUse: {},
       darInfo: Models.dar,
       researcherProfile: null
@@ -49,7 +46,6 @@ class AccessPreview extends Component {
     DAR.getDarConsent(referenceId).then(
       consent => {
         this.setState(prev => {
-          prev.consent = consent;
           prev.dataUse = consent.dataUse;
           prev.consentName = consent.name;
         });
@@ -141,7 +137,7 @@ class AccessPreview extends Component {
                 downloadDAR: this.downloadDAR,
                 researcherProfile: this.state.researcherProfile }),
 
-              div({ 
+              div({
                 className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes',
                 isRendered: !ld.isEmpty(this.state.dataUse)
               }, [

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -10,7 +10,7 @@ import { DAR, Files, Researcher } from '../libs/ajax';
 import { Models } from '../libs/models';
 import { Theme } from '../libs/theme';
 import * as ld from 'lodash';
-
+import TranslatedDULComponent from '../components/TranslatedDULComponent';
 
 class AccessPreview extends Component {
 
@@ -24,6 +24,7 @@ class AccessPreview extends Component {
       consent: {
         translatedUseRestriction: ''
       },
+      dataUse: {},
       darInfo: Models.dar,
       researcherProfile: null
     };
@@ -49,6 +50,7 @@ class AccessPreview extends Component {
       consent => {
         this.setState(prev => {
           prev.consent = consent;
+          prev.dataUse = consent.dataUse;
           prev.consentName = consent.name;
         });
       }
@@ -98,11 +100,7 @@ class AccessPreview extends Component {
   };
 
   render() {
-
-    const { translatedUseRestriction } = this.state.consent;
-
     return (
-
       div({ className: 'container container-wide' }, [
         div({ className: 'row no-margin' }, [
           div({ className: 'col-lg-10 col-md-9 col-sm-9 col-xs-12 no-padding' }, [
@@ -143,16 +141,11 @@ class AccessPreview extends Component {
                 downloadDAR: this.downloadDAR,
                 researcherProfile: this.state.researcherProfile }),
 
-              div({ className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
-                div({ className: 'panel-heading cm-boxhead dul-color' }, [
-                  h4({}, ['Data Use Limitations'])
-                ]),
-                div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
-                  div({ className: 'row dar-summary' }, [
-                    div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-                    div({ className: 'response-label translated-restriction', dangerouslySetInnerHTML: { __html: translatedUseRestriction } }, [])
-                  ])
-                ])
+              div({ 
+                className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes',
+                isRendered: !ld.isEmpty(this.state.dataUse)
+              }, [
+                TranslatedDULComponent({restrictions: this.state.dataUse})
               ])
             ])
           ])

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -356,28 +356,6 @@ class AccessResultRecords extends Component {
     );
   }
 
-  // renderDataUseLimitation(sDUL, mrDUL) {
-
-  //   return (
-  //     div({className: 'col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
-
-  //       div({ className: 'panel-heading cm-boxhead dul-color' }, [
-  //         h4({}, ['Data Use Limitations'])
-  //       ]),
-  //       div({ id: 'dul', className: 'panel-body cm-boxbody' }, [
-  //         div({ className: 'row dar-summary' }, [
-  //           div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-  //           div({ className: 'response-label translated-restriction', dangerouslySetInnerHTML: { __html: sDUL } }, []),
-  //           a({
-  //             id: 'btn_downloadSDul', onClick: () => Utils.download('machine-readable-DUL.json', mrDUL),
-  //             filename: 'machine-readable-DUL.json', value: mrDUL, className: 'italic hover-color'
-  //           }, ['Download DUL machine-readable format'])
-  //         ])
-  //       ])
-  //     ])
-  //   );
-  // }
-
   renderCollectResultBox1(hasUseRestriction, finalDACVote) {
 
     if (finalDACVote === null || finalDACVote === undefined) {

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -129,7 +129,7 @@ class AccessResultRecords extends Component {
 
   render() {
 
-    const { darInfo, hasUseRestriction, mrDAR, sDUL, mrDUL, showRPaccordion, researcherProfile } = this.state;
+    const { darInfo, hasUseRestriction, mrDAR, showRPaccordion, researcherProfile } = this.state;
 
     const backButton = div({ className: 'col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding' }, [
       a({ id: 'btn_back', onClick: this.goBack, className: 'btn-primary btn-back' }, [
@@ -173,7 +173,7 @@ class AccessResultRecords extends Component {
             hasUseRestriction: hasUseRestriction,
             darInfo: darInfo,
             downloadDAR: this.downloadDAR,
-            researcherProfile: researcherProfile 
+            researcherProfile: researcherProfile
           }),
 
           div({ className: 'col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
@@ -355,27 +355,27 @@ class AccessResultRecords extends Component {
     );
   }
 
-  renderDataUseLimitation(sDUL, mrDUL) {
+  // renderDataUseLimitation(sDUL, mrDUL) {
 
-    return (
-      div({className: 'col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
+  //   return (
+  //     div({className: 'col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
 
-        div({ className: 'panel-heading cm-boxhead dul-color' }, [
-          h4({}, ['Data Use Limitations'])
-        ]),
-        div({ id: 'dul', className: 'panel-body cm-boxbody' }, [
-          div({ className: 'row dar-summary' }, [
-            div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-            div({ className: 'response-label translated-restriction', dangerouslySetInnerHTML: { __html: sDUL } }, []),
-            a({
-              id: 'btn_downloadSDul', onClick: () => Utils.download('machine-readable-DUL.json', mrDUL),
-              filename: 'machine-readable-DUL.json', value: mrDUL, className: 'italic hover-color'
-            }, ['Download DUL machine-readable format'])
-          ])
-        ])
-      ])
-    );
-  }
+  //       div({ className: 'panel-heading cm-boxhead dul-color' }, [
+  //         h4({}, ['Data Use Limitations'])
+  //       ]),
+  //       div({ id: 'dul', className: 'panel-body cm-boxbody' }, [
+  //         div({ className: 'row dar-summary' }, [
+  //           div({ className: 'control-label dul-color' }, ['Structured Limitations']),
+  //           div({ className: 'response-label translated-restriction', dangerouslySetInnerHTML: { __html: sDUL } }, []),
+  //           a({
+  //             id: 'btn_downloadSDul', onClick: () => Utils.download('machine-readable-DUL.json', mrDUL),
+  //             filename: 'machine-readable-DUL.json', value: mrDUL, className: 'italic hover-color'
+  //           }, ['Download DUL machine-readable format'])
+  //         ])
+  //       ])
+  //     ])
+  //   );
+  // }
 
   renderCollectResultBox1(hasUseRestriction, finalDACVote) {
 

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -1,7 +1,6 @@
 import * as ld from 'lodash';
 import isNil from 'lodash/fp/isNil';
 import isEmpty from 'lodash/fp/isEmpty';
-import assign from 'lodash/fp/assign';
 import { Component, Fragment } from 'react';
 import { a, div, h, h3, h4, hr, i, label, span } from 'react-hyperscript-helpers';
 import { ApplicationSummary } from '../components/ApplicationSummary';

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -661,9 +661,6 @@ class AccessResultRecords extends Component {
     //Contextually the difference between each of these elections are not clear (TYPE is different, but what that entails is not obvious)
     //Similar questions with the various votes (rpVotes, finalDACVote).
 
-    //The various consent objects seem to have the same data, they only really differ in timestamps, ids, and type
-    //Need to do a more thorough analysis of the above (larger sample size)
-
     //NOTE: the component currently uses hasRestrictions, which I found out to simply be a check on the restrictions attribute on a DAR
     //Basically all it does is check if a value exists and returns the bool value
     //So all I've done is simply check that value myself from the describeDar return value rather than use the endpoint
@@ -701,10 +698,6 @@ class AccessResultRecords extends Component {
       state = Object.assign({}, state, assignToState);
       return state;
     });
-
-    //From here process results and assign them to state variable
-    //NOTE: need to make sure functions have been refactored/organized correctly
-    //NOTE: see if there's a way to simplify the election/vote requests and processing steps
   }
 }
 

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -534,8 +534,7 @@ class AccessResultRecords extends Component {
       status: electionReview.election.status,
       voteList: this.chunk(electionReview.reviewVote, 2),
       chartDataDUL: this.getGraphData(electionReview.reviewVote),
-      mrDUL: JSON.stringify(electionReview.election.useRestriction, null, 2), //could this be calculated on the front-end?
-      sDUL: electionReview.election.translatedUseRestriction //target for removal since it'll be processed on the front=end
+      mrDUL: JSON.stringify(electionReview.election.useRestriction, null, 2)
     };
   };
 

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -13,6 +13,7 @@ import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import { Theme } from '../libs/theme';
 import { Navigation } from '../libs/utils';
+import TranslatedDULComponent from '../components/TranslatedDULComponent';
 
 
 class AccessReview extends Component {
@@ -176,6 +177,7 @@ class AccessReview extends Component {
     this.setState(prev => {
       prev.consentName = consent.name;
       prev.consentId = consent.consentId;
+      prev.dataUse = consent.dataUse;
       prev.election = election;
       prev.rpVote = rpVote;
       if (!ld.isNil(election) && !ld.isNil(election.useRestriction) && !ld.isNil(rpVote)) {
@@ -191,13 +193,11 @@ class AccessReview extends Component {
     Election.findConsentElectionByDarElection(vote.electionId).then(data => {
       if (data.dulName !== null && data.dulElection !== null) {
         this.setState({
-          dulName: data.dulName,
-          translatedUseRestriction: data.translatedUseRestriction
+          dulName: data.dulName
         });
       } else {
         this.setState({
-          dulName: consent.dulName,
-          translatedUseRestriction: consent.translatedUseRestriction
+          dulName: consent.dulName
         });
       }
     });
@@ -222,8 +222,8 @@ class AccessReview extends Component {
       hasLibraryCard: false,
       consentName: '',
       consentId: '',
+      dataUse: {},
       dulName: '',
-      translatedUseRestriction: '',
       isQ1Expanded: true,
       disableQ1Btn: false,
       isQ2Expanded: false,
@@ -323,14 +323,7 @@ class AccessReview extends Component {
                 div({ className: 'panel-heading cm-boxhead dul-color' }, [
                   h4({}, ['Data Use Limitations'])
                 ]),
-                div({ id: 'panel_dul', className: 'panel-body cm-boxbody' }, [
-                  div({ className: 'row dar-summary' }, [
-                    div({ className: 'control-label dul-color' }, ['Structured Limitations']),
-                    div({
-                      className: 'response-label translated-restriction', dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction }
-                    }, [])
-                  ])
-                ])
+                TranslatedDULComponent({restrictions: this.state.dataUse})
               ])
             ]),
 

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -1,6 +1,6 @@
 import * as ld from 'lodash';
 import { Component } from 'react';
-import { a, button, div, h4, hr, i } from 'react-hyperscript-helpers';
+import { a, button, div, h4, hr, i, h } from 'react-hyperscript-helpers';
 import { ApplicationSummary } from '../components/ApplicationSummary';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
@@ -320,10 +320,7 @@ class AccessReview extends Component {
                 researcherProfile: researcherProfile }),
 
               div({ className: 'col-lg-4 col-md-4 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
-                div({ className: 'panel-heading cm-boxhead dul-color' }, [
-                  h4({}, ['Data Use Limitations'])
-                ]),
-                TranslatedDULComponent({restrictions: this.state.dataUse})
+                h(TranslatedDULComponent,{restrictions: this.state.dataUse})
               ])
             ]),
 

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -14,9 +14,7 @@ import { NotificationService } from '../libs/notificationService';
 import { Storage } from '../libs/storage';
 import { Navigation } from "../libs/utils";
 import * as fp from 'lodash/fp';
-
 import './DataAccessRequestApplication.css';
-import { isEmpty } from 'lodash';
 
 class DataAccessRequestApplication extends Component {
 

--- a/src/pages/DataOwnerReview.js
+++ b/src/pages/DataOwnerReview.js
@@ -46,7 +46,6 @@ class DataOwnerReview extends Component {
       alertMessage: '',
     };
 
-    this.myHandler = this.myHandler.bind(this);
     this.handleOpenApplicationModal = this.handleOpenApplicationModal.bind(this);
     this.handleCloseApplicationModal = this.handleCloseApplicationModal.bind(this);
     this.handleOpenDatasetModal = this.handleOpenDatasetModal.bind(this);
@@ -116,10 +115,6 @@ class DataOwnerReview extends Component {
         return prev;
       });
     }
-  }
-
-  myHandler(event) {
-    // TBD
   }
 
   handleOpenApplicationModal() {

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -473,7 +473,7 @@ class DatasetCatalog extends Component {
                           td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') }, [
                             a({
                               id: trIndex + '_linkTranslatedDul', name: 'link_translatedDul',
-                              onClick: (e) => this.openTranslatedDUL(dataSet.dataUse),
+                              onClick: () => this.openTranslatedDUL(dataSet.dataUse),
                               className: (!dataSet.active ? 'dataset-disabled' : 'enabled')
                             }, ['Translated Use Restriction'])
                           ]),

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -11,7 +11,6 @@ import { PaginatorBar } from '../components/PaginatorBar';
 import { SearchBox } from '../components/SearchBox';
 import { DAR, DataSet, Files } from '../libs/ajax';
 import { Storage } from '../libs/storage';
-import { dataUseTranslaton } from '../libs/storage';
 
 class DatasetCatalog extends Component {
 

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -5,12 +5,13 @@ import { a, button, div, form, h, input, label, span, table, tbody, td, th, thea
 import ReactTooltip from 'react-tooltip';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { ConnectDatasetModal } from '../components/modals/ConnectDatasetModal';
-import { TranslatedDulModal } from '../components/modals/TranslatedDulModal';
+import TranslatedDulModal from '../components/modals/TranslatedDulModal';
 import { PageHeading } from '../components/PageHeading';
 import { PaginatorBar } from '../components/PaginatorBar';
 import { SearchBox } from '../components/SearchBox';
 import { DAR, DataSet, Files } from '../libs/ajax';
 import { Storage } from '../libs/storage';
+import { dataUseTranslaton } from '../libs/storage';
 
 class DatasetCatalog extends Component {
 
@@ -121,10 +122,6 @@ class DatasetCatalog extends Component {
     this.props.history.push({ pathname: 'dar_application/' + referenceId });
   };
 
-  associate() {
-
-  }
-
   openConnectDataset(dataset) {
     this.setState(prev => {
       prev.datasetConnect = dataset;
@@ -147,9 +144,9 @@ class DatasetCatalog extends Component {
     }, () => this.getDatasets());
   }
 
-  openTranslatedDUL = (translatedUseRestriction) => () => {
+  openTranslatedDUL = (dataUse) => {
     this.setState(prev => {
-      prev.translatedUseRestrictionModal = translatedUseRestriction;
+      prev.dataUse = dataUse;
       prev.showTranslatedDULModal = true;
       return prev;
     });
@@ -477,7 +474,7 @@ class DatasetCatalog extends Component {
                           td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') }, [
                             a({
                               id: trIndex + '_linkTranslatedDul', name: 'link_translatedDul',
-                              onClick: this.openTranslatedDUL(dataSet.translatedUseRestriction),
+                              onClick: (e) => this.openTranslatedDUL(dataSet.dataUse),
                               className: (!dataSet.active ? 'dataset-disabled' : 'enabled')
                             }, ['Translated Use Restriction'])
                           ]),
@@ -574,10 +571,10 @@ class DatasetCatalog extends Component {
               "data-tip": "Request Access for selected Datasets", "data-for": "tip_requestAccess"
             }, ["Apply for Access"])
           ]),
-          TranslatedDulModal({
+          h(TranslatedDulModal,{
             isRendered: this.state.showTranslatedDULModal,
             showModal: this.state.showTranslatedDULModal,
-            useRestriction: this.state.translatedUseRestrictionModal,
+            dataUse: this.state.dataUse,
             onOKRequest: this.okTranslatedDULModal,
             onCloseRequest: this.closeTranslatedDULModal
           }),

--- a/src/pages/DulCollect.js
+++ b/src/pages/DulCollect.js
@@ -7,6 +7,7 @@ import { CollectResultBox } from '../components/CollectResultBox';
 import { Election, Files, Email } from '../libs/ajax';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Storage } from '../libs/storage';
+import TranslatedDULComponent from '../components/TranslatedDULComponent';
 
 class DulCollect extends Component {
 
@@ -30,7 +31,6 @@ class DulCollect extends Component {
       prev.consentGroupName = election.consent.groupName;
       prev.consentName = election.consent.name;
       prev.dulName = election.consent.dulName;
-      prev.translatedUseRestriction = election.election.translatedUseRestriction;
       prev.projectTitle = election.election.projectTitle;
       prev.finalVote = election.election.finalVote;
       prev.finalRationale = election.election.finalRationale;
@@ -61,7 +61,6 @@ class DulCollect extends Component {
       hasUseRestriction: Boolean,
       projectTitle: '',
       consentName: '',
-      translatedUseRestriction: '',
       consentGroupName: null,
       finalVote: '',
       finalRationale: '',
@@ -176,6 +175,8 @@ class DulCollect extends Component {
       this.state.consentName
     ]);
 
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.election.consent.dataUse});
+
     return (
 
       div({ className: "container container-wide" }, [
@@ -193,11 +194,11 @@ class DulCollect extends Component {
         ConfirmationDialog({
           title: this.state.dialogTitle, color: 'dul', showModal: this.state.showDialogReminder, type: "informative", action: { label: "Ok", handler: this.dialogHandlerReminder }
         }, [
-            div({ className: "dialog-description" }, [
-              span({ isRendered: this.state.isReminderSent === true }, ["The reminder was successfully sent."]),
-              span({ isRendered: this.state.isReminderSent === false }, ["The reminder couldn't be sent. Please contact Support."]),
-            ]),
+          div({ className: "dialog-description" }, [
+            span({ isRendered: this.state.isReminderSent === true }, ["The reminder was successfully sent."]),
+            span({ isRendered: this.state.isReminderSent === false }, ["The reminder couldn't be sent. Please contact Support."]),
           ]),
+        ]),
         div({ className: "accordion-title dul-color" }, ["Were the data use limitations in the Data Use Letter accurately converted to structured limitations?"]),
 
         hr({ className: "section-separator", style: { 'marginTop': '0' } }),
@@ -214,10 +215,7 @@ class DulCollect extends Component {
           ]),
 
           div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            div({ className: "panel-heading cm-boxhead dul-color" }, [
-              h4({}, ["Structured Limitations"]),
-            ]),
-            div({ id: "panel_structuredDul", className: "panel-body cm-boxbody translated-restriction", dangerouslySetInnerHTML: { __html: this.state.translatedUseRestriction } }, [])
+            translatedDULStatements
           ]),
         ]),
 

--- a/src/pages/DulCollect.js
+++ b/src/pages/DulCollect.js
@@ -177,7 +177,7 @@ class DulCollect extends Component {
       b({ isRendered: this.state.consentGroupName, className: "pipe", dangerouslySetInnerHTML: { __html: this.state.consentGroupName } }, []),
       this.state.consentName
     ]);
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.dataUse, downloadDUL: this.downloadDUL});
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.dataUse, downloadDUL: this.downloadDUL, isDUL: true});
 
     return (
 

--- a/src/pages/DulCollect.js
+++ b/src/pages/DulCollect.js
@@ -27,6 +27,9 @@ class DulCollect extends Component {
     let election = await Election.electionReviewResource(consentId, 'TranslateDUL');
     this.setGraphData(election.reviewVote);
     this.setState(prev => {
+      if(election.consent) {
+        prev.dataUse = election.consent.dataUse;
+      }
       prev.dulVoteList = this.chunk(election.reviewVote, 2);
       prev.consentGroupName = election.consent.groupName;
       prev.consentName = election.consent.name;
@@ -174,8 +177,7 @@ class DulCollect extends Component {
       b({ isRendered: this.state.consentGroupName, className: "pipe", dangerouslySetInnerHTML: { __html: this.state.consentGroupName } }, []),
       this.state.consentName
     ]);
-
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.election.consent.dataUse, downloadDUL: this.downloadDUL});
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.dataUse, downloadDUL: this.downloadDUL});
 
     return (
 
@@ -203,11 +205,7 @@ class DulCollect extends Component {
 
         hr({ className: "section-separator", style: { 'marginTop': '0' } }),
         h4({ className: "hint" }, ["Please review the Data Use Letter, Structured Limitations, and DAC votes to determine if the Data Use Limitations were appropriately converted to Structured Limitations"]),
-
-        div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [translatedDULStatements])
-        ]),
-
+        translatedDULStatements,
         div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
           CollectResultBox({
             id: "dulCollectResult",
@@ -234,10 +232,10 @@ class DulCollect extends Component {
             title: "Post Final Vote?", color: 'dul', showModal: this.state.showConfirmationDialogOK,
             action: { label: "Yes", handler: this.confirmationHandlerOK }
           }, [
-              div({ className: "dialog-description" }, [
-                span({}, ["If you post this vote the Election will be closed with current results."]),
-              ]),
+            div({ className: "dialog-description" }, [
+              span({}, ["If you post this vote the Election will be closed with current results."]),
             ]),
+          ]),
         ]),
 
         h3({ className: "cm-subtitle" }, ["Data Access Committee Votes"]),

--- a/src/pages/DulCollect.js
+++ b/src/pages/DulCollect.js
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'react';
-import { div, button, i, span, b, a, hr, h4, h3, h } from 'react-hyperscript-helpers';
+import { div, i, span, b, a, hr, h4, h3, h } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
 import { SingleResultBox } from '../components/SingleResultBox';
@@ -175,7 +175,7 @@ class DulCollect extends Component {
       this.state.consentName
     ]);
 
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.election.consent.dataUse});
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.election.consent.dataUse, downloadDUL: this.downloadDUL});
 
     return (
 
@@ -205,18 +205,7 @@ class DulCollect extends Component {
         h4({ className: "hint" }, ["Please review the Data Use Letter, Structured Limitations, and DAC votes to determine if the Data Use Limitations were appropriately converted to Structured Limitations"]),
 
         div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            div({ className: "panel-heading cm-boxhead dul-color" }, [
-              h4({}, ["Data Use Limitations"]),
-            ]),
-            div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
-              button({ id: "btn_downloadDataUseLetter", className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: this.downloadDUL }, ["Download Data Use Letter"]),
-            ])
-          ]),
-
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            translatedDULStatements
-          ]),
+          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [translatedDULStatements])
         ]),
 
         div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -1,6 +1,5 @@
-import { isNil } from 'lodash';
 import { Component } from 'react';
-import { div, button, i, span, b, a, h4, hr, h} from 'react-hyperscript-helpers';
+import { div, i, span, b, a, hr, h} from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { Consent, Election, Files } from '../libs/ajax';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -54,7 +54,7 @@ class DulPreview extends Component {
       this.state.consentPreview.name
     ]);
 
-    const translatedDULStatements = h(TranslatedDULComponent,{restrictions: this.state.consentPreview.dataUse, isDUL: true});
+    const translatedDULStatements = h(TranslatedDULComponent,{restrictions: this.state.consentPreview.dataUse, isDUL: true, downloadDUL: this.downloadDUL});
 
     return (
 

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -30,7 +30,7 @@ class DulPreview extends Component {
       consent = await Consent.findConsentById(consentId);
     }
 
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: consent, downloadDUL: this.downloadDUL});
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: consent, downloadDUL: this.downloadDUL, isDUL: true});
 
     this.setState(state => {
       state.consentPreview = consent;

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -83,10 +83,7 @@ class DulPreview extends Component {
         div({ className: "accordion-title dul-color" },
           ["Were the data use limitations in the Data Use Letter accurately converted to structured limitations?"]),
         hr({ className: "section-separator" }),
-
-        div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [this.state.translatedDULStatements])
-        ]),
+        this.state.translatedDULStatements
       ])
     );
   }

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -30,7 +30,7 @@ class DulPreview extends Component {
       consent = await Consent.findConsentById(consentId);
     }
 
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: consent});
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: consent, downloadDUL: this.downloadDUL});
 
     this.setState(state => {
       state.consentPreview = consent;
@@ -85,25 +85,7 @@ class DulPreview extends Component {
         hr({ className: "section-separator" }),
 
         div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            div({ className: "panel-heading cm-boxhead dul-color" }, [
-              h4({}, ["Data Use Limitations"]),
-            ]),
-            div({
-              id: "panel_dul",
-              className: "panel-body cm-boxbody"
-            }, [
-              button({
-                id: "btn_downloadDataUseLetter",
-                className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color",
-                onClick: () => this.downloadDUL()
-              }, ["Download Data Use Letter"]),
-            ])
-          ]),
-
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes"},
-            [this.state.translatedDULStatements]
-          ),
+          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [this.state.translatedDULStatements])
         ]),
       ])
     );

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -24,19 +24,18 @@ class DulPreview extends Component {
 
   async electionReview() {
     const consentId = this.props.match.params.consentId;
-    let consent = (await Election.electionReviewResource(consentId, 'TranslateDUL')).consent;
-
-    if(isNil(consent.election)) {
-      consent = await Consent.findConsentById(consentId);
+    let consent = await Election.electionReviewResource(consentId, 'TranslateDUL');
+    if (consent.election !== undefined) {
+      this.setState({
+        consentPreview: consent.consent
+      });
+    } else {
+      Consent.findConsentById(consentId).then(resp => {
+        this.setState({
+          consentPreview: resp
+        });
+      });
     }
-
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: consent, downloadDUL: this.downloadDUL, isDUL: true});
-
-    this.setState(state => {
-      state.consentPreview = consent;
-      state.translatedDULStatements = translatedDULStatements;
-      return state;
-    });
   }
 
   componentDidMount() {
@@ -54,6 +53,8 @@ class DulPreview extends Component {
       b({ className: "pipe", isRendered: this.state.consentPreview.groupName }, [this.state.consentPreview.groupName]),
       this.state.consentPreview.name
     ]);
+
+    const translatedDULStatements = h(TranslatedDULComponent,{restrictions: this.state.consentPreview.dataUse, isDUL: true});
 
     return (
 
@@ -83,7 +84,7 @@ class DulPreview extends Component {
         div({ className: "accordion-title dul-color" },
           ["Were the data use limitations in the Data Use Letter accurately converted to structured limitations?"]),
         hr({ className: "section-separator" }),
-        this.state.translatedDULStatements
+        translatedDULStatements
       ])
     );
   }

--- a/src/pages/DulResultRecords.js
+++ b/src/pages/DulResultRecords.js
@@ -1,5 +1,5 @@
 import { Component, Fragment } from 'react';
-import { div, button, i, span, b, a, hr, h4, h } from 'react-hyperscript-helpers';
+import { div, i, span, b, a, hr, h } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { SingleResultBox } from '../components/SingleResultBox';

--- a/src/pages/DulResultRecords.js
+++ b/src/pages/DulResultRecords.js
@@ -41,23 +41,31 @@ class DulResultRecords extends Component {
 
   async voteInfo() {
     let electionReview = await Election.findReviewedElections(this.state.electionId);
+    let dataUse;
+
     if (typeof electionReview === 'undefined') {
       this.props.history.push('/reviewd_cases');
     }
 
-    if (electionReview.election.finalRationale === 'null') {
-      electionReview.election.finalRationale = '';
+    if(electionReview.election) {
+      if (electionReview.election.finalRationale === 'null') {
+        electionReview.election.finalRationale = '';
+      }
     }
+
+    if (electionReview.consent) {
+      dataUse = electionReview.consent.dataUse;
+    };
 
     this.setState({
       electionReview: electionReview,
       consentName: electionReview.consent.name,
       election: electionReview.election,
+      dataUse,
       dul: electionReview.election.dataUseLetter,
       downloadUrl: await Config.getApiUrl() + 'consent/' + electionReview.consent.consentId + '/dul',
       dulName: electionReview.election.dulName,
       finalRationale: electionReview.election.finalRationale,
-
       status: electionReview.election.status,
       finalVote: electionReview.election.finalVote,
       dulVoteList: this.chunk(electionReview.reviewVote, 2),
@@ -100,7 +108,6 @@ class DulResultRecords extends Component {
       hasUseRestriction: true,
       projectTitle: '',
       consentName: '',
-      // translatedUseStatements: '',
       dulElection: {
         finalVote: '',
         finalRationale: '',
@@ -149,28 +156,11 @@ class DulResultRecords extends Component {
 
         hr({ className: "section-separator", style: { 'marginTop': '0' } }),
 
-        div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          h(TranslatedDULComponent, {
-            restrictions: this.electionReview.consent,
-            downloadDUL: this.downloadDUL
-          })
-          // div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-          //   div({ className: "panel-heading cm-boxhead dul-color" }, [
-          //     h4({}, ["Data Use Limitations"]),
-          //   ]),
-          //   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
-          //     button({ id: "btn_downloadDataUseLetter", className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: this.downloadDUL }, ["Download Data Use Letter"]),
-          //   ])
-          // ]),
-
-          // div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-          //   div({ className: "panel-heading cm-boxhead dul-color" }, [
-          //     h4({}, ["Structured Limitations"]),
-          //   ]),
-          //   div({ id: "panel_structuredDul", className: "panel-body cm-boxbody translated-restriction", dangerouslySetInnerHTML: { __html: this.state.sDul } }, [])
-          // ]),
-
-        ]),
+        h(TranslatedDULComponent, {
+          restrictions: this.state.dataUse,
+          downloadDUL: this.downloadDUL,
+          isDUL: true
+        }),
 
         div({ className: "row no-margin" }, [
           div({ className: "col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-12 col-xs-12" }, [

--- a/src/pages/DulResultRecords.js
+++ b/src/pages/DulResultRecords.js
@@ -7,6 +7,7 @@ import { CollectResultBox } from '../components/CollectResultBox';
 import { Election, Files } from '../libs/ajax';
 import { Storage } from '../libs/storage';
 import { Config } from '../libs/config';
+import TranslatedDULComponent from '../components/TranslatedDULComponent';
 
 class DulResultRecords extends Component {
 
@@ -55,7 +56,6 @@ class DulResultRecords extends Component {
       dul: electionReview.election.dataUseLetter,
       downloadUrl: await Config.getApiUrl() + 'consent/' + electionReview.consent.consentId + '/dul',
       dulName: electionReview.election.dulName,
-      sDul: electionReview.election.translatedUseRestriction,
       finalRationale: electionReview.election.finalRationale,
 
       status: electionReview.election.status,
@@ -100,7 +100,7 @@ class DulResultRecords extends Component {
       hasUseRestriction: true,
       projectTitle: '',
       consentName: '',
-      sDul: '',
+      // translatedUseStatements: '',
       dulElection: {
         finalVote: '',
         finalRationale: '',
@@ -150,21 +150,26 @@ class DulResultRecords extends Component {
         hr({ className: "section-separator", style: { 'marginTop': '0' } }),
 
         div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            div({ className: "panel-heading cm-boxhead dul-color" }, [
-              h4({}, ["Data Use Limitations"]),
-            ]),
-            div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
-              button({ id: "btn_downloadDataUseLetter", className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: this.downloadDUL }, ["Download Data Use Letter"]),
-            ])
-          ]),
+          h(TranslatedDULComponent, {
+            restrictions: this.electionReview.consent,
+            downloadDUL: this.downloadDUL
+          })
+          // div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
+          //   div({ className: "panel-heading cm-boxhead dul-color" }, [
+          //     h4({}, ["Data Use Limitations"]),
+          //   ]),
+          //   div({ id: "panel_dul", className: "panel-body cm-boxbody" }, [
+          //     button({ id: "btn_downloadDataUseLetter", className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color", onClick: this.downloadDUL }, ["Download Data Use Letter"]),
+          //   ])
+          // ]),
 
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            div({ className: "panel-heading cm-boxhead dul-color" }, [
-              h4({}, ["Structured Limitations"]),
-            ]),
-            div({ id: "panel_structuredDul", className: "panel-body cm-boxbody translated-restriction", dangerouslySetInnerHTML: { __html: this.state.sDul } }, [])
-          ]),
+          // div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
+          //   div({ className: "panel-heading cm-boxhead dul-color" }, [
+          //     h4({}, ["Structured Limitations"]),
+          //   ]),
+          //   div({ id: "panel_structuredDul", className: "panel-body cm-boxbody translated-restriction", dangerouslySetInnerHTML: { __html: this.state.sDul } }, [])
+          // ]),
+
         ]),
 
         div({ className: "row no-margin" }, [
@@ -191,22 +196,22 @@ class DulResultRecords extends Component {
             title: "Data Access Committee Votes",
             expanded: this.state.isQ1Expanded
           }, [
-              this.state.dulVoteList.map((row, rIndex) => {
-                return h(Fragment, { key: rIndex }, [
-                  div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-                    row.map((vm, vIndex) => {
-                      return h(Fragment, { key: vIndex }, [
-                        SingleResultBox({
-                          id: "dulSingleResult_" + vIndex,
-                          color: "dul",
-                          data: vm
-                        })
-                      ]);
-                    })
-                  ]),
-                ]);
-              })
-            ]),
+            this.state.dulVoteList.map((row, rIndex) => {
+              return h(Fragment, { key: rIndex }, [
+                div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
+                  row.map((vm, vIndex) => {
+                    return h(Fragment, { key: vIndex }, [
+                      SingleResultBox({
+                        id: "dulSingleResult_" + vIndex,
+                        color: "dul",
+                        data: vm
+                      })
+                    ]);
+                  })
+                ]),
+              ]);
+            })
+          ]),
         ]),
       ])
     );

--- a/src/pages/DulReview.js
+++ b/src/pages/DulReview.js
@@ -127,7 +127,7 @@ class DulReview extends Component {
         div({ className: "accordion-title dul-color" }, ["Were the data use limitations in the Data Use Letter accurately converted to structured limitations?"]),
         hr({ className: "section-separator" }),
         h4({ className: "hint" }, ["Please review the Data Use Letter and determine if the Data Use Limitations were accurately converted to Structured Limitations"]),
-        h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL}),
+        h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL, isDUL: true}),
         div({ className: "col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-12 col-xs-12" }, [
           div({ className: "jumbotron box-vote dul-background-lighter" }, [
             SubmitVoteBox({

--- a/src/pages/DulReview.js
+++ b/src/pages/DulReview.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import { div, b, span, a, h4, hr, i, button } from 'react-hyperscript-helpers';
+import { div, b, span, a, h4, hr, i, h } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
 import { Votes, Election, Consent, Files } from '../libs/ajax';
@@ -34,7 +34,7 @@ class DulReview extends Component {
     this.setEnableVoteButton = this.setEnableVoteButton.bind(this);
   }
 
-  voteInfo() {
+  voteInfo = async () => {
     const voteId = this.props.match.params.voteId;
     const consentId = this.props.match.params.consentId;
 
@@ -42,23 +42,15 @@ class DulReview extends Component {
     const electionPromise = Election.findElectionByVoteId(voteId);
     const consentPromise = Consent.findConsentById(consentId);
 
-    Promise.all(votesPromise, electionPromise, consentPromise)
-      .then((promiseResults) => {
-        const votes = promiseResults[0];
-        const elections = promiseResults[1];
-        const consent = promiseResults[2];
+    const [votes, elections, consent] = await Promise.all(votesPromise, electionPromise, consentPromise);
 
-        this.setState( prev => {
-          prev.votes = votes;
-          prev.elections = elections;
-          prev.consent = consent;
-          prev.consentName = consent.dulName;
-          return prev;
-        });
-
-      }).catch((error) => {
-        console.log(error);
-      });
+    this.setState( prev => {
+      prev.votes = votes;
+      prev.elections = elections;
+      prev.consent = consent;
+      prev.consentName = consent.dulName;
+      return prev;
+    });
   };
 
   setEnableVoteButton() {
@@ -137,7 +129,8 @@ class DulReview extends Component {
 
         div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
           div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            h(TranslatedDULComponent({restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL}))
+            h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL})
+          ])
         ]),
 
         div({ className: "col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-12 col-xs-12" }, [

--- a/src/pages/DulReview.js
+++ b/src/pages/DulReview.js
@@ -34,7 +34,7 @@ class DulReview extends Component {
     this.setEnableVoteButton = this.setEnableVoteButton.bind(this);
   }
 
-  voteInfo = async () => {
+  async voteInfo() {
     const voteId = this.props.match.params.voteId;
     const consentId = this.props.match.params.consentId;
 
@@ -42,7 +42,7 @@ class DulReview extends Component {
     const electionPromise = Election.findElectionByVoteId(voteId);
     const consentPromise = Consent.findConsentById(consentId);
 
-    const [votes, elections, consent] = await Promise.all(votesPromise, electionPromise, consentPromise);
+    const [votes, elections, consent] = await Promise.all([votesPromise, electionPromise, consentPromise]);
 
     this.setState( prev => {
       prev.votes = votes;
@@ -126,13 +126,7 @@ class DulReview extends Component {
         div({ className: "accordion-title dul-color" }, ["Were the data use limitations in the Data Use Letter accurately converted to structured limitations?"]),
         hr({ className: "section-separator" }),
         h4({ className: "hint" }, ["Please review the Data Use Letter and determine if the Data Use Limitations were accurately converted to Structured Limitations"]),
-
-        div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [
-          div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes" }, [
-            h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL})
-          ])
-        ]),
-
+        h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL}),
         div({ className: "col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-12 col-xs-12" }, [
           div({ className: "jumbotron box-vote dul-background-lighter" }, [
             SubmitVoteBox({

--- a/src/pages/DulReview.js
+++ b/src/pages/DulReview.js
@@ -13,6 +13,7 @@ class DulReview extends Component {
   constructor(props) {
     super(props);
     this.state = this.initialState();
+    this.voteInfo = this.voteInfo.bind(this);
   }
 
   initialState() {
@@ -28,8 +29,8 @@ class DulReview extends Component {
     };
   }
 
-  componentDidMount() {
-    this.voteInfo();
+  async componentDidMount() {
+    await this.voteInfo();
     this.logVote = this.logVote.bind(this);
     this.setEnableVoteButton = this.setEnableVoteButton.bind(this);
   }

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -1,7 +1,7 @@
 import * as ld from 'lodash';
-import { apply, assign, isNil } from 'lodash/fp';
+import { assign, isNil } from 'lodash/fp';
 import { Component, Fragment } from 'react';
-import { a, b, br, div, h, h3, h4, hr, i, label, span } from 'react-hyperscript-helpers';
+import { b, br, div, h, h3, h4, hr, i, label, span } from 'react-hyperscript-helpers';
 import { Link } from 'react-router-dom';
 import { ApplicationSummary } from '../components/ApplicationSummary';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
@@ -480,7 +480,7 @@ class FinalAccessReview extends Component {
       applyToState = {
         electionRP: election,
         statusRP: election.status,
-        rpVoteAccessList: this.chunk(rpElectionReview.reviewVote, 2), 
+        rpVoteAccessList: this.chunk(rpElectionReview.reviewVote, 2),
         chartRP: this.getGraphData(rpElectionReview.reviewVote),
         showRPaccordion: true
       };

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -419,7 +419,10 @@ class FinalAccessReview extends Component {
 
     if(!isNil(electionReview.consent)) {
       applyToState.downloadUrl = await Config.getApiUrl() + 'consent/' + electionReview.consent.consentId + '/dul';
-      applyToState.TranslatedDULComponent = h(TranslatedDULComponent, {restrictions: electionReview.consent.dataUse, mrDUL: applyToState.mrDUL});
+      applyToState.TranslatedDULComponent = h(TranslatedDULComponent, {
+        restrictions: electionReview.consent.dataUse,
+        mrDUL: applyToState.mrDUL
+      });
     }
 
     applyToState.voteList = this.chunk(electionReview.reviewVote, 2);
@@ -611,8 +614,9 @@ class FinalAccessReview extends Component {
             downloadDAR: this.downloadDAR,
             researcherProfile: this.state.researcherProfile }),
 
-          div({ className: 'col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
-            applyToState.TranslatedDULComponent
+          div({ className: 'col-lg-6 col-md-6 col-sm-12 col-xs-12 panel panel-primary cm-boxes'}, [
+            this.state.TranslatedDULComponent
+          ])
         ]),
 
         hr({ className: 'section-separator' }),

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -485,7 +485,6 @@ class FinalAccessReview extends Component {
         showRPaccordion: false
       };
     }
-    //NOTE: should this be moved outside of this method's flow control?
     applyToState.loading = false;
     return applyToState;
   }

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { div, hh } from 'react-hyperscript-helpers';
+import { div, hh, span } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
 import { Files } from '../../libs/ajax';
 import { download } from '../../libs/utils';
 import { ApplicationSection } from './ApplicationSection';
 import { StructuredDarRp } from '../../components/StructuredDarRp';
-import { StructuredLimitations } from './StructuredLimitations';
 import { ApplicantInfo } from './ApplicantInfo';
 import { DownloadLink } from '../../components/DownloadLink';
+import { DataUseTranslation } from '../../libs/dataUseTranslation';
 
 const SUBHEADER = {
   margin: '32px 0px',
@@ -20,7 +20,54 @@ const SUBHEADER = {
   fontFamily: 'Montserrat',
 };
 
-export const AppSummary = hh(class AppSummary extends React.PureComponent {
+const ROOT = {
+  fontFamily: 'Montserrat',
+  color: Theme.palette.primary,
+  whiteSpace: 'pre-line'
+};
+
+const HEADER = {
+  marginBottom: '5px',
+  fontSize: Theme.font.size.header,
+  lineHeight: Theme.font.leading.regular,
+  fontWeight: Theme.font.weight.semibold,
+  color: Theme.palette.highlighted,
+};
+
+const TEXT = {
+  fontSize: Theme.font.size.small,
+  lineHeight: Theme.font.leading.regular,
+  fontWeight: Theme.font.weight.regular,
+  display: 'inline-block'
+};
+
+const BOLD = {
+  ...TEXT,
+  fontWeight: Theme.font.weight.semibold,
+};
+
+export const AppSummary = hh(class AppSummary extends React.Component {
+
+  constructor(props) {
+    super();
+    this.state = {
+      generateRestrictions: this.generateRestrictions.bind(this),
+      translatedRestrictions: []
+    };
+  }
+
+  generateRestrictions = async(dataUse) => {
+    const translatedRestrictions = await DataUseTranslation.translateDataUseRestrictions(dataUse);
+    this.setState(prev => {
+      prev.translatedRestrictions = translatedRestrictions;
+      return prev;
+    });
+  }
+
+  async componentDidMount() {
+    await this.generateRestrictions(this.props.consent.dataUse);
+  }
+
   /**
    * downloads the data use letter for this dataset
    */
@@ -34,6 +81,21 @@ export const AppSummary = hh(class AppSummary extends React.PureComponent {
     const { pi, profileName, institution, department, city, country } = darInfo;
     const mrDAR = JSON.stringify(accessElection.useRestriction, null, 2);
     const mrDUL = JSON.stringify(consent.useRestriction, null, 2);
+    const translatedRestrictionsList = this.state.translatedRestrictions.map((restrictionObj) => {
+      return span({style: TEXT}, restrictionObj.description);
+    });
+    const StructuredLimitations = div({ style: ROOT}, [
+      div({style: HEADER}, 'Data Use Structured Limitations'),
+      div({style: TEXT}, [translatedRestrictionsList]),
+      div(DownloadLink({
+        label: 'DUL machine-readable format',
+        onDownload: () => download('machine-readable-DUL.json', mrDUL)
+      })),
+      div(DownloadLink({
+        label: 'Data Use Letter',
+        onDownload: this.downloadDUL
+      }))
+    ]);
 
     return div({ id: 'app-summary' },
       [
@@ -64,11 +126,7 @@ export const AppSummary = hh(class AppSummary extends React.PureComponent {
                 borderRadius: '9px',
               }
             },
-            [StructuredLimitations({
-              content: darInfo.translatedDataUse,
-              labels: ['DUL machine-readable format', 'Data Use Letter'],
-              functions: [() => download('machine-readable-DUL.json', mrDUL), this.downloadDUL]
-            })]
+            [StructuredLimitations]
           )
         ]),
         div(

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { div, hh, span } from 'react-hyperscript-helpers';
+import { div, hh, span, h } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
 import { Files } from '../../libs/ajax';
 import { download } from '../../libs/utils';
@@ -82,14 +82,16 @@ export const AppSummary = hh(class AppSummary extends React.Component {
     const StructuredLimitations = div({ style: ROOT}, [
       div({style: HEADER}, 'Data Use Structured Limitations'),
       div({style: TEXT}, [translatedRestrictionsList]),
-      div(DownloadLink({
-        label: 'DUL machine-readable format',
-        onDownload: () => download('machine-readable-DUL.json', mrDUL)
-      })),
-      div(DownloadLink({
-        label: 'Data Use Letter',
-        onDownload: this.downloadDUL
-      }))
+      div({style: {marginTop: '0.8rem'}}, [
+        h(DownloadLink,{
+          label: 'DUL machine-readable format',
+          onDownload: () => download('machine-readable-DUL.json', mrDUL)
+        }),
+        h(DownloadLink,{
+          label: 'Data Use Letter',
+          onDownload: this.downloadDUL
+        })
+      ])
     ]);
 
     return div({ id: 'app-summary' },

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -41,11 +41,6 @@ const TEXT = {
   display: 'inline-block'
 };
 
-const BOLD = {
-  ...TEXT,
-  fontWeight: Theme.font.weight.semibold,
-};
-
 export const AppSummary = hh(class AppSummary extends React.Component {
 
   constructor(props) {


### PR DESCRIPTION
Addresses [DUOS-644](https://broadinstitute.atlassian.net/browse/DUOS-644), [DUOS-672](https://broadinstitute.atlassian.net/browse/DUOS-672)

PR replaces instances where components render pre-translated Data Use Limitations with updated code/definitions defined on the front-end and processed via consent object reference.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
