### PR TITLE
DUOS-788 [risk="no] Take DAC Chair to 'Vote as Chair' tab when clicking 'Log Final Vote'

### DIFF
--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -113,7 +113,7 @@ export const ChairConsole = hh(class ChairConsole extends Component {
     this.props.history.push(`dul_collect/${consentId}`);
   };
 
-  openFinalAccessReview = (referenceId, electionId, rpElectionId,) => (e) => {
+  openFinalAccessReview = (referenceId, electionId, rpElectionId) => (e) => {
     this.props.history.push(`${'final_access_review'}/${referenceId}/${electionId}`);
   };
 

--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -113,16 +113,26 @@ export const ChairConsole = hh(class ChairConsole extends Component {
     this.props.history.push(`dul_collect/${consentId}`);
   };
 
-  openFinalAccessReview = (referenceId, electionId, rpElectionId) => (e) => {
+  openFinalAccessReview = (referenceId, electionId, rpElectionId,) => (e) => {
     this.props.history.push(`${'final_access_review'}/${referenceId}/${electionId}`);
   };
 
-  openAccessReview = (referenceId, voteId, rpVoteId) => async (e) => {
+  openAccessReview = (referenceId, voteId, rpVoteId, alreadyVoted) => async (e) => {
     const pathStart = await NavigationUtils.accessReviewPath();
+    let chairFinal = false;
+    if(this.state.currentUser && alreadyVoted) {
+      chairFinal = this.state.currentUser.isChairPerson;
+    }
     if (rpVoteId !== null) {
-      this.props.history.push(`${pathStart}/${referenceId}/${voteId}/${rpVoteId}`);
+      this.props.history.push(
+        `${pathStart}/${referenceId}/${voteId}/${rpVoteId}`,
+        {chairFinal}
+      );
     } else {
-      this.props.history.push(`${pathStart}/${referenceId}/${voteId}`);
+      this.props.history.push(
+        `${pathStart}/${referenceId}/${voteId}`,
+        {chairFinal}
+      );
     }
   };
 
@@ -325,7 +335,7 @@ export const ChairConsole = hh(class ChairConsole extends Component {
                       button({
                         id: pendingCase.frontEndId + '_btnVote',
                         name: 'btn_voteAccess',
-                        onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId, pendingCase.rpVoteId),
+                        onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId, pendingCase.rpVoteId, pendingCase.alreadyVoted),
                         className: 'cell-button cancel-color'
                       }, [
                         span({ isRendered: (pendingCase.alreadyVoted === false) && (pendingCase.electionStatus !== 'Final') }, ['Vote']),

--- a/src/pages/access_review/AccessReviewV2.js
+++ b/src/pages/access_review/AccessReviewV2.js
@@ -14,12 +14,8 @@ const SECTION = {
 class AccessReviewV2 extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = this.initialState();
-  }
-
-  initialState() {
-    return {
-      voteAsChair: false,
+    this.state = {
+      voteAsChair: props.location.state.chairFinal
     };
   }
 


### PR DESCRIPTION
Addresses [DUOS-788](https://broadinstitute.atlassian.net/browse/DUOS-788)

PR is simple: it initializes state for access review v2 based on a boolean that is only true when a chairperson logs final vote. The history object used to perform the redirect is given a state variable that is accessible in the access review v2 for use in initialization. The value itself is determined on the parent component (ChairConsole) via two state variables: currentUser.isChairPerson and pendingCases.alreadyVoted

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
