### PR TITLE
[DUOS-821][risk=no] Remove user id param

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -326,8 +326,8 @@ export const DAR = {
     return await res;
   },
 
-  getPartialDarRequestList: async userId => {
-    const url = `${await Config.getApiUrl()}/dar/partials/manage?userId=${userId}`;
+  getPartialDarRequestList: async () => {
+    const url = `${await Config.getApiUrl()}/dar/partials/manage`;
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -117,7 +117,7 @@ class ResearcherConsole extends Component {
       }
     );
 
-    DAR.getPartialDarRequestList(currentUser.dacUserId).then(
+    DAR.getPartialDarRequestList().then(
       pdars => {
         this.setState({
           partialDars: pdars,


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-821
Requires https://github.com/DataBiosphere/consent/pull/817

NOTE: DO NOT MERGE unless https://github.com/DataBiosphere/consent/pull/817 will be on production before this moves to production.

## Changes
Remove unnecessary user id param from researcher's get partial dars endpoint

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
