### PR TITLE
DUOS-838 [risk=no] Added definition attribute to ontology items in DAR form

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -214,7 +214,7 @@ class DataAccessRequestApplication extends Component {
           key: item.id,
           value: item.id,
           label: item.label,
-          item: { id: item.id, label: item.label }
+          item: item
         };
       })(formDataOntologies);
     }
@@ -483,10 +483,11 @@ class DataAccessRequestApplication extends Component {
 
   dialogHandlerSubmit = (answer) => (e) => {
     if (answer === true) {
-      let ontologies = [];
-      for (let ontology of this.state.formData.ontologies) {
-        ontologies.push(ontology.item);
-      }
+      let ontologies = fp.map(ontology => ({
+        id: ontology.key,
+        label: ontology.value,
+        definition: ontology.item.definition
+      }))(this.state.formData.ontologies);
       this.setState(prev => {
         if (ontologies.length > 0) {
           prev.formData.ontologies = ontologies;
@@ -537,10 +538,11 @@ class DataAccessRequestApplication extends Component {
       // DAR datasetIds needs to be a list of ids
       const datasetIds = fp.map('value')(this.state.formData.datasets);
       // DAR ontologies needs to be a list of id/labels.
-      const ontologies = fp.map((o) => {return {
+      const ontologies = fp.map((o) => ({
         id: o.key,
-        label: o.value
-      };})(this.state.formData.ontologies);
+        label: o.value,
+        definition: o.item.definition
+      }))(this.state.formData.ontologies);
       this.setState(prev => {
         prev.formData.datasetIds = datasetIds;
         prev.formData.ontologies = ontologies;


### PR DESCRIPTION
Addresses [DUOS-838](https://broadinstitute.atlassian.net/browse/DUOS-838)

PR aims to add definition attribute to ontology list items since it is not being validated against on the back-end. Null/undefined values for description resulted in ontology list items failing to save at all. Adding the attribute will rectify the situation.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
