### PR TITLE
DUOS-718 [risk=no] Bugfix for disease picker

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -159,7 +159,6 @@ class DataAccessRequestApplication extends Component {
     let rpProperties = await Researcher.getPropertiesByResearcherId(currentUserId);
     formData.darCode = fp.isNil(formData.darCode) ? null : formData.darCode;
     formData.partialDarCode = fp.isNil(formData.partialDarCode) ? null : formData.partialDarCode;
-    formData.ontologies = this.formatOntologyItems(formData);
     formData.researcher = rpProperties.profileName != null ? rpProperties.profileName : '';
     if (rpProperties.piName === undefined && rpProperties.isThePI === 'true') {
       formData.investigator = rpProperties.profileName;
@@ -204,20 +203,18 @@ class DataAccessRequestApplication extends Component {
 
   };
 
-  formatOntologyItems = (formData) => {
-    let ontologyItems = [];
+  formatOntologyItems = (ontologies) => {
     // Filter null values. TODO: Possible bug in saving partial dars
-    let formDataOntologies = fp.pickBy(fp.identity)(formData.ontologies);
-    if (!fp.isNil(formDataOntologies) && !fp.isEmpty(formDataOntologies)) {
-      ontologyItems = fp.map((item) => {
-        return {
-          key: item.id,
-          value: item.id,
-          label: item.label,
-          item: item
-        };
-      })(formDataOntologies);
-    }
+    const ontologyItems = ontologies.map((ontology) => {
+      return {
+        id: ontology.id || ontology.item.id,
+        key: ontology.id || ontology.item.id,
+        value: ontology.id || ontology.item.id,
+        label: ontology.label || ontology.item.label,
+        definition: ontology.definition || ontology.item.definition,
+        item: ontology.item
+      };
+    });
     return ontologyItems;
   };
 
@@ -539,9 +536,10 @@ class DataAccessRequestApplication extends Component {
       const datasetIds = fp.map('value')(this.state.formData.datasets);
       // DAR ontologies needs to be a list of id/labels.
       const ontologies = fp.map((o) => ({
-        id: o.key,
-        label: o.value,
-        definition: o.item.definition
+        id: o.id || o.item.id,
+        label: o.label || o.item.label,
+        definition: o.definition || o.item.definition,
+        item: o.item
       }))(this.state.formData.ontologies);
       this.setState(prev => {
         prev.formData.datasetIds = datasetIds;
@@ -630,7 +628,7 @@ class DataAccessRequestApplication extends Component {
 
   onOntologiesChange = (data) => {
     this.setState(prev => {
-      prev.formData.ontologies = data;
+      prev.formData.ontologies = data || [];
       return prev;
     });
   };
@@ -678,7 +676,6 @@ class DataAccessRequestApplication extends Component {
       labCollaborators,
       internalCollaborators,
       externalCollaborators,
-      ontologies = [],
       signingOfficial = '',
       itDirector = '',
       cloudUse = false,
@@ -686,20 +683,21 @@ class DataAccessRequestApplication extends Component {
       anvilUse = false,
       cloudProvider = '',
       cloudProviderType = '',
-      cloudProviderDescription = ''
+      cloudProviderDescription = '',
     } = this.state.formData;
 
     const { dataRequestId } = this.props.match.params;
     const eRACommonsDestination = fp.isNil(dataRequestId) ? 'dar_application' : ('dar_application/' + dataRequestId);
     const { problemSavingRequest, showValidationMessages,  step1 } = this.state;
     const isTypeOfResearchInvalid = this.isTypeOfResearchInvalid();
-
+    const ontologies = this.formatOntologyItems(this.state.formData.ontologies);
     const step1Invalid = this.step1InvalidResult(this.step1InvalidChecks());
     const step2Invalid = this.verifyStep2();
     const step3Invalid = this.step3InvalidResult();
 
     //NOTE: component is only here temporarily until component conversion has been complete
     //ideally this, along with the other variable initialization should be done with a useEffect hook
+
     const TORComponent = TypeOfResearch({
       hmb: hmb,
       hmbHandler: this.setHmb,

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -204,7 +204,6 @@ class DataAccessRequestApplication extends Component {
   };
 
   formatOntologyItems = (ontologies) => {
-    // Filter null values. TODO: Possible bug in saving partial dars
     const ontologyItems = ontologies.map((ontology) => {
       return {
         id: ontology.id || ontology.item.id,

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -25,6 +25,11 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
 
   render() {
     const props = this.props;
+    const ontologies = props.ontologies.map(ontology => {
+      ontology.id = ontology.id || ontology.item.id;
+      ontology.key = ontology.id;
+      return ontology;
+    });
     let otherTextStyle = {
       borderRadius: 4,
       boxShadow: 'inset 0 1px 1px rgba(0,0,0,.075)',
@@ -121,7 +126,7 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
               isMulti: true,
               loadOptions: (query, callback) => this.searchOntologies(query, callback),
               onChange: (option) => props.ontologiesHandler(option),
-              value: props.ontologies,
+              value: ontologies,
               placeholder: 'Please enter one or more diseases',
               classNamePrefix: 'select',
             }),

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -26,6 +26,8 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
   render() {
     const props = this.props;
     const ontologies = props.ontologies.map(ontology => {
+      //minor processing step to ensure id and key are on ontology so that AsyncSelect does not break
+      //done as a preventative measure for previously saved ontologies (prior to DUOS-718 PR)
       ontology.id = ontology.id || ontology.item.id;
       ontology.key = ontology.id;
       return ontology;


### PR DESCRIPTION
Addresses [DUOS-718](https://broadinstitute.atlassian.net/browse/DUOS-718)

PR provides fix to ontology picker on DAR by setting the key, id, and item values on each ontology item within the TypeOfResearch component on prop update to ensure that the React-Select component (AsyncSelect) will not break. It also adds the definition (now being checked on the back-end) as well as change the labelling so that it displays the name of the disease rather than the ontology definition link. Branch may end up with merge conflicts as a result of DUOS-681

There may be one issue with regards to previously saved ontologies in that their labels will show the ontology links since...
1) they lack a saved reference to item
2) their label value is set to equal the ontology link.

Otherwise these elements are still saved and can be removed as usual.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
