### PR TITLE
DUOS-830 [risk=no] Added options to question 2.3 to increase user selection specificity

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -616,14 +616,15 @@ class DataAccessRequestApplication extends Component {
 
   setDiseases = (e) => {
     let applyToState = {
-      hmb: false,
       poa: false,
       other: false,
       otherText: ''
     };
     if(!fp.isEmpty(e.target.value)) {
+      applyToState.hmb = false;
       applyToState.diseases = true;
     } else {
+      applyToState.hmb = true;
       applyToState.diseases = false;
       applyToState.ontologies = [];
     }

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -614,13 +614,21 @@ class DataAccessRequestApplication extends Component {
     });
   };
 
-  setDiseases = () => {
+  setDiseases = (e) => {
+    let applyToState = {
+      hmb: false,
+      poa: false,
+      other: false,
+      otherText: ''
+    };
+    if(!fp.isEmpty(e.target.value)) {
+      applyToState.diseases = true;
+    } else {
+      applyToState.diseases = false;
+      applyToState.ontologies = [];
+    }
     this.setState(prev => {
-      prev.formData.hmb = false;
-      prev.formData.poa = false;
-      prev.formData.diseases = true;
-      prev.formData.other = false;
-      prev.formData.otherText = '';
+      prev.formData = fp.assign(prev.formData, applyToState);
       return prev;
     });
   };

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -10,6 +10,13 @@ const radioButtonStyle = {
   color: '#777',
 };
 
+const diseaseLabel = {
+    fontWeight: 800,
+    color: '#777777',
+    float: 'left',
+    marginLeft: '2rem'
+  }
+
 export const TypeOfResearch = hh(class TypeOfResearch extends Component {
 
   searchOntologies = (query, callback) => {
@@ -89,12 +96,14 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
           },[
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12', style: {marginBottom: '1.5rem'}}, [
               span({className: 'control-label rp-choice-questions'}, [
-                div({style: {marginLeft: '2rem'}}, 'Are you studying any specific disease(s)?'),
+                div({style: {marginLeft: '2rem', color: 'rgb(96, 59, 155)'}}, 'Are you studying any specific disease(s)?'),
                 fp.map.convert({cap: false})((boolVal, option) => {
                   return label({
                     key: `check-diseases-option-${option}`, 
-                    className: 'control-label rp-choice-questions',
-                    style: {marginLeft: '2rem'}
+                    className: 'control-label',
+                    //!important is needed since rp-choice-questions has an !important tag
+                    //NOTE: try to review css and see if !important can be removed. Inline style eliminates the need for it
+                    style: diseaseLabel
                   }, [
                     input({
                       type: 'radio',

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -11,11 +11,11 @@ const radioButtonStyle = {
 };
 
 const diseaseLabel = {
-    fontWeight: 800,
-    color: '#777777',
-    float: 'left',
-    marginLeft: '2rem'
-  }
+  fontWeight: 800,
+  color: '#777777',
+  float: 'left',
+  marginLeft: '2rem'
+};
 
 export const TypeOfResearch = hh(class TypeOfResearch extends Component {
 
@@ -41,7 +41,7 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
 
   render() {
     const props = this.props;
-    const hmb = props.diseases ? true : this.props.hmb; 
+    const hmb = props.diseases ? true : this.props.hmb;
     const ontologies = props.ontologies.map(ontology => {
       //minor processing step to ensure id and key are on ontology so that AsyncSelect does not break
       //done as a preventative measure for previously saved ontologies (prior to DUOS-718 PR)
@@ -99,7 +99,7 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
                 div({style: {marginLeft: '2rem', color: 'rgb(96, 59, 155)'}}, 'Are you studying any specific disease(s)?'),
                 fp.map.convert({cap: false})((boolVal, option) => {
                   return label({
-                    key: `check-diseases-option-${option}`, 
+                    key: `check-diseases-option-${option}`,
                     className: 'control-label',
                     //!important is needed since rp-choice-questions has an !important tag
                     //NOTE: try to review css and see if !important can be removed. Inline style eliminates the need for it

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -1,9 +1,14 @@
-import {div, h, hh, textarea} from 'react-hyperscript-helpers';
+import {div, h, hh, textarea, label, input, span} from 'react-hyperscript-helpers';
 import {RadioButton} from '../../components/RadioButton';
 import {Component} from 'react';
 import AsyncSelect from 'react-select/async/dist/react-select.esm';
 import {DAR} from '../../libs/ajax';
 import * as fp from 'lodash/fp';
+
+const radioButtonStyle = {
+  marginBottom: '2rem',
+  color: '#777',
+};
 
 export const TypeOfResearch = hh(class TypeOfResearch extends Component {
 
@@ -23,8 +28,13 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
       });
   };
 
+  optionEventHandler = (e, optionHandler) => {
+    optionHandler(e);
+  }
+
   render() {
     const props = this.props;
+    const hmb = props.diseases ? true : this.props.hmb; 
     const ontologies = props.ontologies.map(ontology => {
       //minor processing step to ensure id and key are on ontology so that AsyncSelect does not break
       //done as a preventative measure for previously saved ontologies (prior to DUOS-718 PR)
@@ -38,7 +48,7 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
       border: '1px solid #999',
       backgroundColor: '#eee',
       padding: '6px 12px',
-      width: '100%',
+      width: '100%'
     };
     if (props.other) {
       otherTextStyle = fp.merge(otherTextStyle, {backgroundColor: '#fff'});
@@ -59,28 +69,73 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
     }
 
     return (
-      div({},
+      div({className: 'radio-questions-container'},
         [
           RadioButton({
-            style: {
-              marginBottom: '2rem',
-              color: '#777',
-            },
+            style: fp.merge(radioButtonStyle, {marginBottom: 0}),
             id: 'checkHmb',
             name: 'checkPrimary',
             value: 'hmb',
-            defaultChecked: props.hmb,
+            defaultChecked: (hmb || this.props.diseases),
             onClick: props.hmbHandler,
             label: '2.3.1 Health/medical/biomedical research: ',
             description: 'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.',
             disabled: props.disabled,
           }),
 
+          div({
+            isRendered: hmb,
+            className: 'row no-margin'
+          },[
+            div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12', style: {marginBottom: '1.5rem'}}, [
+              span({className: 'control-label rp-choice-questions'}, [
+                div({style: {marginLeft: '2rem'}}, 'Are you studying any specific disease(s)?'),
+                fp.map.convert({cap: false})((boolVal, option) => {
+                  return label({
+                    key: `check-diseases-option-${option}`, 
+                    className: 'control-label rp-choice-questions',
+                    style: {marginLeft: '2rem'}
+                  }, [
+                    input({
+                      type: 'radio',
+                      id: 'checkDiseases',
+                      value: boolVal ? boolVal : undefined, //value on inputs is always a string, need to ensure booleans from props are processed correctly
+                      name: 'diseases',
+                      checked: props.diseases === !!boolVal,
+                      onChange: props.diseasesHandler,
+                      disabled: props.disabled,
+                      style: {marginRight: '1rem'}
+                    }),
+                    option
+                  ]);
+                })({'Yes': true, 'No': false})
+              ])
+            ]),
+
+            div({
+              className: 'col-lg-12 col-md-12 col-sm-12 col-sx-12 ',
+              isRendered: props.diseases,
+              style: {
+                marginLeft: '2rem',
+                marginBottom: '2rem'
+              }
+            }, [
+              h(AsyncSelect, {
+                styles: ontologySelectionStyle,
+                id: 'sel_diseases',
+                isDisabled: !props.diseases,
+                isMulti: true,
+                loadOptions: (query, callback) => this.searchOntologies(query, callback),
+                onChange: (option) => props.ontologiesHandler(option),
+                value: ontologies,
+                placeholder: 'Please enter one or more diseases',
+                classNamePrefix: 'select'
+              })
+            ])
+          ]),
+
           RadioButton({
-            style: {
-              marginBottom: '2rem',
-              color: '#777',
-            },
+            style: radioButtonStyle,
             id: 'checkPoa',
             name: 'checkPrimary',
             value: 'poa',
@@ -90,49 +145,6 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
             description: 'The outcome of this study is expected to provide new knowledge about the origins of a certain population or its ancestry.',
             disabled: props.disabled,
           }),
-
-          RadioButton({
-            style: {
-              marginBottom: '2rem',
-              color: '#777',
-            },
-            id: 'checkDisease',
-            name: 'checkPrimary',
-            value: 'poa',
-            defaultChecked: props.diseases,
-            onClick: props.diseasesHandler,
-            label: '2.3.3 Disease-related studies: ',
-            description: 'The primary purpose of the research is to learn more about a particular disease or disorder (e.g., type 2 diabetes), a trait (e.g., blood pressure), or a set of related conditions (e.g., autoimmune diseases, psychiatric disorders).',
-            disabled: props.disabled,
-          }),
-
-          div({
-            style: {
-              marginBottom: '2rem',
-              color: '#777',
-            },
-          },
-          ['If you selected Disease-related Studies, please select the disease area(s) this study focuses on in the box below.']),
-
-          div({
-            style: {
-              marginBottom: '2rem',
-              color: '#777',
-              cursor: props.diseases ? 'pointer' : 'not-allowed',
-            },
-          }, [
-            h(AsyncSelect, {
-              styles: ontologySelectionStyle,
-              id: 'sel_diseases',
-              isDisabled: !props.diseases,
-              isMulti: true,
-              loadOptions: (query, callback) => this.searchOntologies(query, callback),
-              onChange: (option) => props.ontologiesHandler(option),
-              value: ontologies,
-              placeholder: 'Please enter one or more diseases',
-              classNamePrefix: 'select',
-            }),
-          ]),
 
           RadioButton({
             style: {


### PR DESCRIPTION
Addresses [DUOS-830](https://broadinstitute.atlassian.net/browse/DUOS-830)

PR moves diseases as a sub-question to HMB in an attempt to guide the user select diseases as an option is applicable rather than just selecting HMB because its broad enough to meet their definition of their project.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
