### PR TITLE
DUOS-851[risk=no] Add processing logic for General Use, HMB, DS, and POA

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -342,7 +342,7 @@ export const DataUseTranslation = {
       const isGeneralUseActive = dataUse.generalUse && !isHMBActive;
       const isPOAActive = !isGeneralUseActive && ! isHMBActive && isEmpty(dataUse.diseaseRestrictions);
       let statement;
-      
+
       if(
         !targetKeys.includes(key) ||
         (key === 'hmbResearch' && isHMBActive) ||

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -336,8 +336,27 @@ export const DataUseTranslation = {
 
   translateDataUseRestrictions: async (dataUse) => {
 
-    const processRestrictionStatements = async(key, value) => {
-      let resp;
+    const processDefinedLimitations = (key, dataUse, consentTranslations) => {
+      const targetKeys = ['hmbResearch', 'populationOriginsAncestry', 'generalUse'];
+      const isHMBActive = dataUse.hmbResearch && isEmpty(dataUse.diseaseRestrictions);
+      const isGeneralUseActive = dataUse.generalUse && !isHMBActive;
+      const isPOAActive = !isGeneralUseActive && ! isHMBActive && isEmpty[dataUse.diseaseRestrictions]
+      let statement;
+      
+      if(
+        !targetKeys.includes(key) ||
+        (key === 'hmbResearch' && isHMBActive) ||
+        (key === 'populationOriginsAncestry' && isPOAActive) ||
+        (key === 'generalUse' && !isHMBActive)
+      ) {
+        statement = consentTranslations[key];
+      }
+      return statement;
+    }
+
+    const processRestrictionStatements = async(key, dataUse) => {
+      let resp;   
+      const value = dataUse[key];
       if (!isNil(value) && value) {
         if (key === 'diseaseRestrictions') {
           let resolvedLabels = [];
@@ -351,7 +370,7 @@ export const DataUseTranslation = {
           }
           resp = consentTranslations.diseaseRestrictions(resolvedLabels);
         } else {
-          resp = consentTranslations[key];
+          resp = processDefinedLimitations(key, dataUse, consentTranslations);
         }
       }
       return resp;
@@ -361,8 +380,7 @@ export const DataUseTranslation = {
     let restrictionStatements = [];
     let targetKeys = Object.keys(consentTranslations);
     const processingPromises = targetKeys.map((key) => {
-      const value = dataUse[key];
-      return processRestrictionStatements(key, value);
+      return processRestrictionStatements(key, dataUse);
     });
 
     restrictionStatements = await Promise.all(processingPromises);

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -340,7 +340,7 @@ export const DataUseTranslation = {
       const targetKeys = ['hmbResearch', 'populationOriginsAncestry', 'generalUse'];
       const isHMBActive = dataUse.hmbResearch && isEmpty(dataUse.diseaseRestrictions);
       const isGeneralUseActive = dataUse.generalUse && !isHMBActive;
-      const isPOAActive = !isGeneralUseActive && ! isHMBActive && isEmpty[dataUse.diseaseRestrictions]
+      const isPOAActive = !isGeneralUseActive && ! isHMBActive && isEmpty(dataUse.diseaseRestrictions);
       let statement;
       
       if(
@@ -352,10 +352,10 @@ export const DataUseTranslation = {
         statement = consentTranslations[key];
       }
       return statement;
-    }
+    };
 
     const processRestrictionStatements = async(key, dataUse) => {
-      let resp;   
+      let resp;
       const value = dataUse[key];
       if (!isNil(value) && value) {
         if (key === 'diseaseRestrictions') {


### PR DESCRIPTION
Addresses [DUOS-851](https://broadinstitute.atlassian.net/browse/DUOS-851)

PR adds processing logic for defined limitations such that only one is rendered out to the UI based on contextual hierarchy of attributes (Ex: if POA is true and HMB is true, only HMB should be rendered based on attribute hierarchy). Results can be seen on DatasetCatalog summary modal.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
