### PR TITLE
[DUOS-665][risk=no] Display the use restriction from consent instead of election

### DIFF
--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -477,7 +477,7 @@ class AccessResultRecords extends Component {
     );
   }
 
-  showDarData(electionReview) {
+  async showDarData(electionReview) {
     let electionAccess = electionReview.election;
     if (electionReview.election.finalRationale === null) {
       electionAccess.finalRationale = '';
@@ -488,7 +488,7 @@ class AccessResultRecords extends Component {
     const voteAgreement = electionReview.voteAgreement;
 
     // this data is used to construct structured_ files
-    const mrDAR = JSON.stringify(electionReview.election.useRestriction, null, 2);
+    const mrDAR = JSON.stringify(electionReview.consent.useRestriction, null, 2);
 
     return {
       electionAccess: electionAccess,
@@ -512,7 +512,7 @@ class AccessResultRecords extends Component {
       status: electionReview.election.status,
       voteList: this.chunk(electionReview.reviewVote, 2),
       chartDataDUL: this.getGraphData(electionReview.reviewVote),
-      mrDUL: JSON.stringify(electionReview.election.useRestriction, null, 2)
+      mrDUL: JSON.stringify(electionReview.consent.useRestriction, null, 2)
     };
   };
 
@@ -570,7 +570,7 @@ class AccessResultRecords extends Component {
     };
 
     const dataAccessElectionReview = await Election.findDataAccessElectionReview(electionId, false);
-    const darData = this.showDarData(dataAccessElectionReview);
+    const darData = await this.showDarData(dataAccessElectionReview);
     const electionReview = await Election.findElectionReviewById(dataAccessElectionReview.associatedConsent.electionId, dataAccessElectionReview.associatedConsent.consentId);
     const showDULDataPromise = await this.showDULData(electionReview);
     const vaultVotePromise = await this.vaultVote(electionReview.consent.consentId, darData.electionAccess.referenceId);

--- a/src/pages/AccessReview.js
+++ b/src/pages/AccessReview.js
@@ -180,7 +180,7 @@ class AccessReview extends Component {
       prev.dataUse = consent.dataUse;
       prev.election = election;
       prev.rpVote = rpVote;
-      if (!ld.isNil(election) && !ld.isNil(election.useRestriction) && !ld.isNil(rpVote)) {
+      if (!ld.isNil(consent.useRestriction) && !ld.isNil(rpVote)) {
         prev.hasUseRestriction = true;
       } else {
         prev.hasUseRestriction = false;

--- a/src/pages/FinalAccessReview.js
+++ b/src/pages/FinalAccessReview.js
@@ -410,8 +410,11 @@ class FinalAccessReview extends Component {
       election: electionReview.election
     };
 
+    if (!isNil(electionReview.consent)) {
+      applyToState.mrDUL = JSON.stringify(electionReview.consent.useRestriction, null, 2);
+    }
+
     if(!isNil(electionReview.election)) {
-      applyToState.mrDUL = JSON.stringify(electionReview.election.useRestriction, null, 2);
       applyToState.dulName = electionReview.election.dulName;
       applyToState.status = electionReview.election.status;
       applyToState.finalRationale = electionReview.election.finalRationale || '';


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/DUOS-665
See also https://github.com/DataBiosphere/consent/pull/838

## Changes
* Refer to the consent's use restriction instead of the election's use restriction
* These are all legacy pages and are slated for deprecation

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
