### PR TITLE
[DUOS-854][risk=no] Submit consent data use info alongside dataset registration

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -75,8 +75,8 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/profile" component={ResearcherProfile} props={props} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/admin_manage_access" component={AdminManageAccess} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/signing_official_console" component={SigningOfficialConsole} props={props} rolesAllowed={[USER_ROLES.admin]} />
-    <AuthenticatedRoute path="/dataset_registration/:datasetId" component={DatasetRegistration} props={props} rolesAllowed={[USER_ROLES.admin]} />
-    <AuthenticatedRoute path="/dataset_registration" component={DatasetRegistration} props={props} rolesAllowed={[USER_ROLES.admin]} />
+    <AuthenticatedRoute path="/dataset_registration/:datasetId" component={DatasetRegistration} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson]} />
+    <AuthenticatedRoute path="/dataset_registration" component={DatasetRegistration} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/dar_renewal" component={DataAccessRequestRenewal} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_dul" component={AdminManageDul} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/dataset_catalog" component={DatasetCatalog} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -365,10 +365,12 @@ class DatasetCatalog extends Component {
                 description: "Search and select datasets then click 'Apply for Access' to request access"
               }),
             ]),
-            div({ className: 'f-right' }, [
+            div({ className: 'f-right', isRendered: (this.state.isAdmin || this.state.isChairPerson) }, [
+              div({ className: 'col-lg-7 col-md-7 col-sm-7 col-xs-7 search-wrapper' }, [
+                h(SearchBox, { id: 'datasetCatalog', searchHandler: this.handleSearchDul, pageHandler: this.handlePageChange, color: 'dataset' })
+              ]),
               button({
                 id: 'btn_addDataset',
-                isRendered: this.state.isResearcher,
                 onClick: () => this.props.history.push({ pathname: 'dataset_registration' }),
                 className: 'btn-primary dataset-background search-wrapper',
                 'data-tip': 'Add a new Dataset', 'data-for': 'tip_addDataset'
@@ -606,9 +608,6 @@ class DatasetCatalog extends Component {
           ]),
 
           div({ className: 'col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding' }, [
-            div({ className: 'col-lg-7 col-md-7 col-sm-7 col-xs-7' }, [
-              h(SearchBox, { id: 'datasetCatalog', searchHandler: this.handleSearchDul, pageHandler: this.handlePageChange, color: 'dataset' })
-            ]),
             button({
               id: 'btn_downloadSelection',
               download: '',

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -52,7 +52,7 @@ class DatasetRegistration extends Component {
         datasetName: '',
         researcher: '',
         collectionId: '',
-        pi: '',
+        principalInvestigator: '',
         datasetRepoUrl: '',
         dataType: '',
         species: '',
@@ -158,7 +158,7 @@ class DatasetRegistration extends Component {
       prev.datasetData.description = description ? description.propertyValue : '';
       prev.datasetData.datasetRepoUrl = datasetRepoUrl ? datasetRepoUrl.propertyValue : '';
       prev.datasetData.researcher = researcher ? researcher.propertyValue : '';
-      prev.datasetData.pi = pi ? pi.propertyValue : '';
+      prev.datasetData.principalInvestigator = pi ? pi.propertyValue : '';
       prev.datasetData.needsApproval = needsApproval;
       prev.selectedDac = dac;
 
@@ -271,6 +271,7 @@ class DatasetRegistration extends Component {
 
   validateRequiredFields(formData) {
     return this.isValid(formData.researcher) &&
+      this.isValid(formData.principalInvestigator) &&
       this.validateDatasetName((formData.datasetName)) &&
       this.isValid(formData.datasetName) &&
       this.isValid(formData.datasetRepoUrl) &&
@@ -566,8 +567,8 @@ class DatasetRegistration extends Component {
     if (formData.researcher) {
       properties.push({"propertyName": "Data Depositor", "propertyValue": formData.researcher});
     }
-    if (formData.pi) {
-      properties.push({"propertyName": "Principal Investigator(PI)", "propertyValue": formData.pi});
+    if (formData.principalInvestigator) {
+      properties.push({"propertyName": "Principal Investigator(PI)", "propertyValue": formData.principalInvestigator});
     }
 
     return properties;
@@ -682,7 +683,8 @@ class DatasetRegistration extends Component {
 
     const controlLabelStyle = {
       fontWeight: 500,
-      marginBottom: 0
+      marginTop: '1rem',
+      marginBottom: '1rem'
     };
 
     const {
@@ -772,12 +774,32 @@ class DatasetRegistration extends Component {
                     ])
                   ]),
 
+                  div({ className: 'form-group' }, [
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      label({ className: 'control-label rp-title-question dataset-color' }, ['1.2 Principal Investigator (PI)*'])
+                    ]),
+
+                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                      input({
+                        type: 'text',
+                        name: 'principalInvestigator',
+                        id: 'inputPrincipalInvestigator',
+                        value: this.state.datasetData.principalInvestigator,
+                        className: (fp.isEmpty(this.state.datasetData.principalInvestigator) && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
+                        required: true
+                      }),
+                      span({
+                        isRendered: (fp.isEmpty(this.state.datasetData.principalInvestigator) && showValidationMessages), className: 'cancel-color required-field-error-span'
+                      }, ['Required field'])
+                    ])
+                  ]),
+
                   div({className: 'form-group'}, [
                     div(
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.2 Dataset Name* ',
+                          '1.3 Dataset Name* ',
                           span({},
                             ['Please provide a publicly displayable name for the dataset']),
                         ]),
@@ -808,7 +830,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.3 Dataset Repository URL* ',
+                          '1.4 Dataset Repository URL* ',
                           span({},
                             ['Please provide the URL at which approved requestors can access the data']),
                         ]),
@@ -842,7 +864,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.4 Data Type* ',
+                          '1.5 Data Type* ',
                         ]),
                       ]),
                     div(
@@ -873,7 +895,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.5 Species* ',
+                          '1.6 Species* ',
                         ]),
                       ]),
                     div(
@@ -904,7 +926,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.6 Phenotype/Indication* ',
+                          '1.7 Phenotype/Indication* ',
                         ]),
                       ]),
                     div(
@@ -935,7 +957,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.7 # of Participants* ',
+                          '1.8 # of Participants* ',
                         ]),
                       ]),
                     div(
@@ -967,7 +989,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.8 Dataset Description* ',
+                          '1.9 Dataset Description* ',
                         ]),
                       ]),
                     div(
@@ -998,7 +1020,7 @@ class DatasetRegistration extends Component {
                       {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                       [
                         label({className: 'control-label rp-title-question dataset-color'}, [
-                          '1.9 Data Access Committee* ',
+                          '1.10 Data Access Committee* ',
                         ]),
                       ]),
                     div(

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -3,7 +3,6 @@ import { RadioButton } from '../components/RadioButton';
 import { a, br, div, fieldset, form, h, h3, hr, input, label, span, textarea } from 'react-hyperscript-helpers';
 import { Link } from 'react-router-dom';
 import Select from 'react-select';
-import ReactTooltip from 'react-tooltip';
 import { Alert } from '../components/Alert';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Notification } from '../components/Notification';
@@ -124,7 +123,6 @@ class DatasetRegistration extends Component {
             prev.problemLoadingUpdateDataset = true;
           });
           this.props.history.push('/dataset_registration');
-          ReactTooltip.rebuild();
         }
         else {
           this.setState(prev => {
@@ -376,7 +374,6 @@ class DatasetRegistration extends Component {
           if (fp.isEmpty(this.state.updateDataset)) {
             DataSet.postDatasetForm(ds).then(resp => {
               this.setState({ showDialogSubmit: false, submissionSuccess: true });
-              ReactTooltip.rebuild();
             }).catch(e => {
               let errorMessage = (e.status === 409) ?
                 'Dataset with this name already exists: ' + this.state.datasetData.datasetName
@@ -394,7 +391,6 @@ class DatasetRegistration extends Component {
             const { datasetId } = this.props.match.params;
             DataSet.updateDataset(datasetId, ds).then(resp => {
               this.setState({ showDialogSubmit: false, submissionSuccess: true });
-              ReactTooltip.rebuild();
             }).catch(e => {
               let errorMessage = 'Some errors occurred, the Dataset was not updated.';
               this.setState(prev => {
@@ -1508,7 +1504,6 @@ class DatasetRegistration extends Component {
                           title: 'Dataset Registration Confirmation', disableOkBtn: this.state.disableOkBtn,
                           color: 'dataset', showModal: this.state.showDialogSubmit, action: { label: 'Yes', handler: this.dialogHandlerSubmit }
                         }, [div({ className: 'dialog-description' }, ['Are you sure you want to submit this Dataset Registration?'])]),
-                        h(ReactTooltip, { id: 'tip_clearNihAccount', place: 'right', effect: 'solid', multiline: true, className: 'tooltip-wrapper' }),
 
                       ])
                     ])

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -107,7 +107,7 @@ class DatasetRegistration extends Component {
         prev.formData.ontologies = ontologies;
         return prev;
       });
-    };
+    }
   };
 
   async init() {
@@ -452,6 +452,8 @@ class DatasetRegistration extends Component {
       prev.formData.hmb = false;
       prev.formData.diseases = false;
       prev.formData.ontologies = [];
+      prev.formData.other = false;
+      prev.formData.primaryOtherText = '';
       prev.disableOkBtn = false;
       prev.problemSavingRequest = false;
       prev.submissionSuccess = false;
@@ -466,6 +468,8 @@ class DatasetRegistration extends Component {
       prev.formData.diseases = false;
       prev.formData.ontologies = [];
       prev.formData.npoa = false;
+      prev.formData.other = false;
+      prev.formData.primaryOtherText = '';
       prev.disableOkBtn = false;
       prev.problemSavingRequest = false;
       prev.submissionSuccess = false;
@@ -479,6 +483,8 @@ class DatasetRegistration extends Component {
       prev.formData.hmb = false;
       prev.formData.diseases = true;
       prev.formData.npoa = false;
+      prev.formData.other = false;
+      prev.formData.primaryOtherText = '';
       prev.disableOkBtn = false;
       prev.problemSavingRequest = false;
       prev.submissionSuccess = false;
@@ -764,7 +770,7 @@ class DatasetRegistration extends Component {
                         name: 'researcher',
                         id: 'inputResearcher',
                         value: this.state.datasetData.researcher,
-                        disabled: true,
+                        disabled: !isUpdateDataset,
                         className: (fp.isEmpty(this.state.datasetData.researcher) && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         required: true
                       }),
@@ -1475,8 +1481,7 @@ class DatasetRegistration extends Component {
                         value: 'yes',
                         defaultChecked: !needsApproval,
                         onClick: () => this.setNeedsApproval(false),
-                        label: 'Yes',
-                        disabled: isUpdateDataset,
+                        label: 'Yes'
                       }),
 
                       RadioButton({
@@ -1489,8 +1494,7 @@ class DatasetRegistration extends Component {
                         value: 'no',
                         defaultChecked: needsApproval,
                         onClick: () => this.setNeedsApproval(true),
-                        label: 'No',
-                        disabled: isUpdateDataset,
+                        label: 'No'
                       }),
                     ]),
                   ]),

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -516,7 +516,7 @@ class DatasetRegistration extends Component {
 
   setOtherText = (e, level) => {
     const value = e.target.value;
-    (level === "primary") ?
+    (level === 'primary') ?
       this.setState(prev => {
         prev.formData.other = true;
         prev.formData.primaryOtherText = value;
@@ -636,7 +636,7 @@ class DatasetRegistration extends Component {
       result.ethicsApprovalRequired = data.ethics;
     }
     if (data.geographic) {
-      result.geographicalRestrictions = "Yes";
+      result.geographicalRestrictions = 'Yes';
     }
     if (data.moratorium) {
       result.publicationMoratorium = data.moratorium;
@@ -1143,7 +1143,7 @@ class DatasetRegistration extends Component {
                             textarea({
                               className: 'form-control',
                               value: primaryOtherText,
-                              onChange: (e) => this.setOtherText(e, "primary"),
+                              onChange: (e) => this.setOtherText(e, 'primary'),
                               name: 'primaryOtherText',
                               id: 'primaryOtherText',
                               maxLength: '512',
@@ -1400,7 +1400,7 @@ class DatasetRegistration extends Component {
                           [
                             textarea({
                               value: secondaryOtherText,
-                              onChange: (e) => this.setOtherText(e, "secondary"),
+                              onChange: (e) => this.setOtherText(e, 'secondary'),
                               name: 'secondaryOtherText',
                               id: 'inputSecondaryOtherText',
                               className: 'form-control',


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-854
- Check for consent validity before allowing form submission
- Reformats the form submission responses specific to DataUse before POSTing (aka renaming the variables). 
- Adds in the two new fields publicationMoratorium and secondaryOther
- Minor refactoring of the two sets of "other"s to distinguish between primary and secondary
- Removes the POA primary use option and hides the NPOA secondary use option UNLESS "General Use" is selected in primary use, or legacy dataset is loaded in with npoa = true
<img width="665" alt="Screen Shot 2020-12-04 at 2 33 45 PM" src="https://user-images.githubusercontent.com/43456581/101207085-1732a780-363e-11eb-8c75-60160df50303.png">
<img width="545" alt="Screen Shot 2020-12-04 at 2 33 54 PM" src="https://user-images.githubusercontent.com/43456581/101207087-18fc6b00-363e-11eb-93eb-264ac93f6bc4.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
