### PR TITLE
DUOS-864 [risk="no"] refactored login flow to allow for UI template update

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -6,9 +6,7 @@ import { Alert } from '../components/Alert';
 import { User } from '../libs/ajax';
 import { Config } from '../libs/config';
 import { Storage } from '../libs/storage';
-import { USER_ROLES } from '../libs/utils';
-
-
+import { setUserRoleStatuses, USER_ROLES } from '../libs/utils';
 export const SignIn = hh(class SignIn extends Component {
 
   constructor(props) {
@@ -34,48 +32,50 @@ export const SignIn = hh(class SignIn extends Component {
 
   responseGoogle = async (response) => {
     Storage.setGoogleData(response);
-    this.getUser().then(
-      user => {
-        user = Object.assign(user, this.setUserRoleStatuses(user));
-        this.redirect(user);
-      },
-      error => {
-        User.registerUser().then(
-          user => {
-            this.setUserRoleStatuses(user);
-            this.props.history.push('/profile');
-            this.props.onSignIn();
-          },
-          error => {
-            const status = error.status;
-            switch (status) {
-              case 400:
-                this.setState(prev => {
-                  prev.error = { show: true, title: 'Error', msg: JSON.stringify(error) };
-                  return prev;
-                });
-                break;
-              case 409:
-                // If the user exists, just log them in.
-                this.getUser().then(
-                  user => {
-                    user = Object.assign(user, this.setUserRoleStatuses(user));
-                    this.redirect(user);
-                  },
-                  error => {
-                    Storage.clearStorage();
-                  });
-                break;
-              default:
-                this.setState(prev => {
-                  prev.error = { show: true, title: 'Error', msg: 'Unexpected error, please try again' };
-                  return prev;
-                });
-                break;
-            }
+    try{
+      const userRes = await this.getUser();
+      const user = Object.assign(userRes, setUserRoleStatuses(userRes, Storage));
+      this.redirect(user);
+    } catch(error) {
+      try {
+        let registeredUser = await User.registerUser();
+        this.setUserRoleStatuses(registeredUser, Storage);
+        this.props.onSignIn(); //is this async?
+        this.props.history.push('/profile');
+      } catch(error) {
+        try{
+          const status = error.status;
+          switch(status) {
+            case 400:
+              this.setState(prev => {
+                prev.error = {show: true, title: 'Error', msg: JSON.stringify(error)};
+                return prev;
+              });
+              break;
+            case 409:
+              try {
+                let user = await this.getUser();
+                user = Object.assign({}, user, setUserRoleStatuses(user, Storage));
+                this.redirect(user);
+              } catch(error) {
+                Storage.clearStorage();
+              }
+              break;
+            default:
+              this.setState(prev => {
+                prev.error = { show: true, title: 'Error', msg: 'Unexpected error, please try again'};
+                return prev;
+              });
+              break;
           }
-        );
-      });
+        } catch(error) {
+          this.setState(prev => {
+            prev.error = {show: true, title: 'Error', msg: JSON.stringify(error)};
+            return prev;
+          });
+        }
+      }
+    }
   };
 
   forbidden = (response) => {
@@ -155,7 +155,7 @@ export const SignIn = hh(class SignIn extends Component {
         onSuccess: this.responseGoogle,
         onFailure: this.forbidden,
         render: ({disabled}) => this.renderSpinnerIfDisabled(disabled)
-        }
+      }
       );
     }
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -38,6 +38,18 @@ export const sleep = (milliseconds) => {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
 };
 
+export const setUserRoleStatuses = (user, Storage) => {
+  const currentUserRoles = user.roles.map(roles => roles.name);
+  user.isChairPerson = currentUserRoles.indexOf(USER_ROLES.chairperson) > -1;
+  user.isMember = currentUserRoles.indexOf(USER_ROLES.member) > -1;
+  user.isAdmin = currentUserRoles.indexOf(USER_ROLES.admin) > -1;
+  user.isResearcher = currentUserRoles.indexOf(USER_ROLES.researcher) > -1;
+  user.isDataOwner = currentUserRoles.indexOf(USER_ROLES.dataOwner) > -1;
+  user.isAlumni = currentUserRoles.indexOf(USER_ROLES.alumni) > -1;
+  Storage.setCurrentUser(user);
+  return user;
+};
+
 export const Navigation = {
   back: (user, history) => {
     const page = user.isChairPerson ? '/chair_console'

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -12,7 +12,7 @@ import { Storage } from '../libs/storage';
 import { NotificationService } from '../libs/notificationService';
 import { Notification } from '../components/Notification';
 import * as ld from 'lodash';
-import {USER_ROLES, setUserRoleStatuses, Navigation } from '../libs/utils';
+import { USER_ROLES, setUserRoleStatuses } from '../libs/utils';
 
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
@@ -379,8 +379,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       } else {
         this.saveUser().then(resp => {
           this.setState({ isResearcher: resp.isResearcher, showDialogSubmit: false });
-          //Should the code redirect the user to the Researcher console or should it redirect to the expanded profile on account creation
-          //QUESTION: Is there a reason why the expanded profile page isn't the default view?
         });
       }
 

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -12,7 +12,7 @@ import { Storage } from '../libs/storage';
 import { NotificationService } from '../libs/notificationService';
 import { Notification } from '../components/Notification';
 import * as ld from 'lodash';
-import {USER_ROLES} from '../libs/utils';
+import {USER_ROLES, setUserRoleStatuses, Navigation } from '../libs/utils';
 
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
@@ -378,8 +378,9 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         }
       } else {
         this.saveUser().then(resp => {
-          this.setState({ showDialogSubmit: false });
-          this.props.history.goBack();
+          this.setState({ isResearcher: resp.isResearcher, showDialogSubmit: false });
+          //Should the code redirect the user to the Researcher console or should it redirect to the expanded profile on account creation
+          //QUESTION: Is there a reason why the expanded profile page isn't the default view?
         });
       }
 
@@ -387,7 +388,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       this.setState({ showDialogSubmit: false });
     }
   };
-
 
   updateResearcher(profile) {
     const profileClone = this.cloneProfile(profile);
@@ -405,7 +405,9 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     currentUser.additionalEmail = this.state.additionalEmail;
     currentUser.roles = this.state.roles;
     const payload = { updatedUser: currentUser };
-    await User.update(payload, currentUser.dacUserId);
+    let updatedUser = await User.update(payload, currentUser.dacUserId);
+    updatedUser = Object.assign({}, updatedUser, setUserRoleStatuses(updatedUser, Storage));
+    return updatedUser;
   };
 
   handleCheckboxChange = (e) => {


### PR DESCRIPTION
Addresses [DUOS-864](https://broadinstitute.atlassian.net/browse/DUOS-864)

PR addresses missing UI updates on new user profile submission to provide feedback that information has been submitted successfully. Currently the view updates from the basic profile view to the expanded view, though there is room for discussion on whether this is the optimal corse of action. (Other possibilities: Should we show the expanded profile view on default?Should the basic profile submission redirect to the Dataset Catalog?)

Code has also been refactored to implement established logic (User info assignment) across multiple components.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
