### PR TITLE
DUOS-867[risk=no] Added check on chairFinal value on location for AccessReviewV2

### DIFF
--- a/src/pages/access_review/AccessReviewV2.js
+++ b/src/pages/access_review/AccessReviewV2.js
@@ -15,7 +15,7 @@ class AccessReviewV2 extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      voteAsChair: props.location.state.chairFinal
+      voteAsChair: (props.location && props.location.state ? props.location.state.chairFinal : false)
     };
   }
 


### PR DESCRIPTION
Addresses [DUOS-867](https://broadinstitute.atlassian.net/browse/DUOS-867)

PR adds an explicit check on props.location and props.location.state before checking for props.location.state.chairFinal. If value not present, value will default to false. This fix is necessary to correct attribute checks on non-existent attributes which are causing blank page renders for DAC members.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
