### PR TITLE
DUOS-871 [risk=no] Added disabled button styling for Add Collaborator Button

### DIFF
--- a/src/pages/dar_application/CollaboratorList.js
+++ b/src/pages/dar_application/CollaboratorList.js
@@ -208,10 +208,11 @@ export default function CollaboratorList(props) {
       div({className: 'row no-margin'}, [
         div({className: 'col-lg-12 col-md-12 col-sm-12-col-xs-12', style: {marginTop: "1rem"}}, [
           a({
-            id: 'add-collaborator-btn',
-            onClick: addCollaborator,
+            id: 'add-collaborator-btn access-background',
+            onClick: () => !props.disabled && addCollaborator(),
             className: 'btn-primary f-right access-background',
-            role: "button"
+            role: "button",
+            disabled: props.disabled
           },[
             span({ className: 'glyphicon glyphicon-plus', 'aria-hidden': 'true'}),
             'Add Collaborator'

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -243,6 +243,7 @@ export default function ResearcherInfo(props) {
                 collaboratorKey: 'labCollaborators',
                 collaboratorLabel: 'Internal Lab Member',
                 showApproval: true,
+                disabled: !isEmpty(darCode),
                 deleteBoolArray: (new Array(labCollaborators.length).fill(false))
               })
             ])
@@ -265,6 +266,7 @@ export default function ResearcherInfo(props) {
             ]),
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
               h(CollaboratorList, {
+                disabled: !isEmpty(darCode),
                 formFieldChange,
                 collaborators: internalCollaborators,
                 collaboratorKey: 'internalCollaborators',
@@ -456,6 +458,7 @@ export default function ResearcherInfo(props) {
             ]),
             div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
               h(CollaboratorList, {
+                disabled: !isEmpty(darCode),
                 formFieldChange,
                 collaborators: externalCollaborators,
                 collaboratorKey: 'externalCollaborators',


### PR DESCRIPTION
Addresses [DUOS-871](https://broadinstitute.atlassian.net/browse/DUOS-871)

PR adds disabled styling and disabled status checks for Add Collaborator button on submitted DARs. 

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
