### PR TITLE
DUOS-873 [risk=no] Added disabled styling for Cloud Use Provider inputs

### DIFF
--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -92,7 +92,7 @@ export default function ResearcherInfo(props) {
 
   const cloudInputStyle = (input) => {
     return {
-      backgroundColor: showValidationMessages && isCloudProviderInvalid && isEmpty(input) ? "rgba(243, 73, 73, 0.19)" : 
+      backgroundColor: showValidationMessages && isCloudProviderInvalid && isEmpty(input) ? "rgba(243, 73, 73, 0.19)" :
         isEmpty(darCode) ? 'inherit' : '#eee'
     };
   };

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -90,6 +90,13 @@ export default function ResearcherInfo(props) {
     )
   ]);
 
+  const cloudInputStyle = (input) => {
+    return {
+      backgroundColor: showValidationMessages && isCloudProviderInvalid && isEmpty(input) ? "rgba(243, 73, 73, 0.19)" : 
+        isEmpty(darCode) ? 'inherit' : '#eee'
+    };
+  };
+
   return (
     div({ className: 'col-lg-10 col-lg-offset-1 col-md-12 col-sm-12 col-xs-12' }, [
       fieldset({ disabled: !isNil(darCode) }, [
@@ -388,24 +395,20 @@ export default function ResearcherInfo(props) {
               div({className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 rp-group"}, [
                 label({className: 'control-label'}, ['Name of Cloud Provider']),
                 input({
-                  style: {
-                    backgroundColor: showValidationMessages && isCloudProviderInvalid && isEmpty(cloudProvider) ? "rgba(243, 73, 73, 0.19)" : "inherit"
-                  },
+                  style: cloudInputStyle(cloudProvider),
                   type: 'text',
                   name: 'cloud-provider-name',
                   defaultValue: cloudProvider || '',
                   className: 'form-control',
                   required: true,
-                  disabled: !isNil(darCode),
+                  disabled: !isEmpty(darCode),
                   onBlur: (e) => formFieldChange({name: 'cloudProvider', value: e.target.value})
                 })
               ]),
               div({className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 rp-group"}, [
                 label({className: 'control-label'}, ['Type of Cloud Provider']),
                 input({
-                  style: {
-                    backgroundColor: showValidationMessages && isCloudProviderInvalid && isEmpty(cloudProviderType) ? "rgba(243, 73, 73, 0.19)" : "inherit"
-                  },
+                  style: cloudInputStyle(cloudProviderType),
                   type: 'text',
                   name: 'provider-type-name',
                   defaultValue: cloudProviderType || '',
@@ -420,11 +423,12 @@ export default function ResearcherInfo(props) {
               div({className: "col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group"}, [
                 textarea({
                   style: {
-                    backgroundColor: showValidationMessages && isCloudProviderInvalid && isEmpty(cloudProviderDescription) ? "rgba(243, 73, 73, 0.19)" : "inherit",
+                    backgroundColor: cloudInputStyle(cloudProviderDescription).backgroundColor,
                     width: '100%',
                     padding: '1rem'
                   },
                   defaultValue: cloudProviderDescription,
+                  disabled: !isNil(darCode),
                   onBlur: (e) => formFieldChange({name: 'cloudProviderDescription', value: e.target.value}),
                   name: 'cloudProviderDescription',
                   id: 'cloudProviderDescription',


### PR DESCRIPTION
Addresses [DUOS-873](https://broadinstitute.atlassian.net/browse/DUOS-873)

PR adds disabled styles for Cloud Use Provider inputs, as well as refactored logic for computing input style state based on whether the input has an error or if edits are even allowed in its current state (submitted DARs vs DAR drafts)

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
