### PR TITLE
DUOS-876 [risk=no] Removed definition processing step for ontologies

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -254,7 +254,6 @@ class DataAccessRequestApplication extends Component {
         key: ontology.id || ontology.item.id,
         value: ontology.id || ontology.item.id,
         label: ontology.label || ontology.item.label,
-        definition: ontology.definition || ontology.item.definition,
         item: ontology.item
       };
     });
@@ -591,7 +590,6 @@ class DataAccessRequestApplication extends Component {
       const ontologies = fp.map(ontology => ({
         id: ontology.key,
         label: ontology.value,
-        definition: ontology.item.definition
       }))(this.state.formData.ontologies);
 
       if (ontologies.length > 0) {
@@ -663,7 +661,6 @@ class DataAccessRequestApplication extends Component {
       const ontologies = fp.map((o) => ({
         id: o.id || o.item.id,
         label: o.label || o.item.label,
-        definition: o.definition || o.item.definition,
         item: o.item
       }))(this.state.formData.ontologies);
       this.setState(prev => {

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -595,7 +595,6 @@ class DatasetRegistration extends Component {
         key: ontology.id || ontology.item.id,
         value: ontology.id || ontology.item.id,
         label: ontology.label || ontology.item.label,
-        definition: ontology.definition || ontology.item.definition,
         item: ontology || ontology.item
       };
     });


### PR DESCRIPTION
Addresses [DUOS-876](https://broadinstitute.atlassian.net/browse/DUOS-876)

PR removes processing step for definitions on ontologies as it is not guaranteed to be found, causing rendering errors on the front-end. Since definition is not required for disease label rendering, we can safely remove this step.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
