### PR TITLE
DUOS-883[risk=no] Added additional validation and rendering logic for uploaded documents on DAR application

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -614,7 +614,13 @@ class DataAccessRequestApplication extends Component {
         let referenceId = formattedFormData.referenceId;
         let darPartialResponse = this.updateDraftResponse(formattedFormData, referenceId);
         referenceId = darPartialResponse.referenceId;
-        darPartialResponse = this.saveDARDocuments(uploadedIrbDocument, uploadedCollaborationLetter, referenceId);
+
+        //execute saveDARDocuments method only if documents are required for the DAR
+        //value can be determined from activeDULQuestions, which is populated on Step 2 where document upload occurs
+        const {activeDULQuestions} = this.state.formData;
+        if(activeDULQuestions.ethicsApprovalRequired || activeDULQuestions.collaboratorRequired) {
+          darPartialResponse = await this.saveDARDocuments(uploadedIrbDocument, uploadedCollaborationLetter, referenceId);
+        }
         let updatedFormData = assign({}, formattedFormData, darPartialResponse);
         await DAR.postDar(updatedFormData);
         this.setState({
@@ -690,7 +696,12 @@ class DataAccessRequestApplication extends Component {
       if(fp.isNil(dataRequestId)) {
         this.props.history.replace('/dar_application/' + referenceId);
       }
-      darPartialResponse = await this.saveDARDocuments(uploadedIrbDocument, uploadedCollaborationLetter, referenceId);
+      //execute saveDARDocuments method only if documents are required for the DAR
+      //value can be determined from activeDULQuestions, which is populated on Step 2 where document upload occurs
+      const {activeDULQuestions} = this.state.formData;
+      if(activeDULQuestions.ethicsApprovalRequired || activeDULQuestions.collaboratorRequired) {
+        darPartialResponse = await this.saveDARDocuments(uploadedIrbDocument, uploadedCollaborationLetter, referenceId);
+      }
       this.setState(prev => {
         prev.formData = assign({}, prev.formData, darPartialResponse);
         prev.showDialogSave = false;

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -154,10 +154,23 @@ export default function DataAccessRequest(props) {
 
       if(!isEqual(updatedDULQuestions, activeDULQuestions)) {
         setActiveDULQuestions(updatedDULQuestions);
-        //maintain dsAcknowledgement integrity when question is no longer active
-        if(!updatedDULQuestions['diseaseRestrictions'] && isEmpty(darCode)) {
-          setDSAcknowledgement(false);
-          formFieldChange({name: 'dsAcknowledgement', value: false});
+        //integrity checks/actions only occur on drafts
+        if(isEmpty(darCode)) {
+          //maintain dsAcknowledgement integrity when question is no longer active
+          if(!updatedDULQuestions['diseaseRestrictions']) {
+            setDSAcknowledgement(false);
+            formFieldChange({name: 'dsAcknowledgement', value: false});
+          }
+          //clear document files if associated question is inactive
+          //active clearing allows submitted DAR to control document rendering confidently when referencing these variables
+          if(!updatedDULQuestions['ethicsApprovalRequired']) {
+            formFieldChange({name: 'irbDocumentName', value: ''});
+            formFieldChange({name: 'irbDocumentLocation', value: ''});
+          }
+          if(!updatedDULQuestions['collaboratorRequired']) {
+            formFieldChange({name: 'collaborationLetterName', value: ''});
+            formFieldChange({name: 'collaborationLetterLocation', value: ''});
+          }
         }
         //State update is asynchronous, send updatedDULQuestions for parent component
         formFieldChange({name: 'activeDULQuestions', value: updatedDULQuestions});
@@ -550,7 +563,8 @@ export default function DataAccessRequest(props) {
 
         div({
           className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12',
-          isRendered: activeDULQuestions['ethicsApprovalRequired'] === true,
+          //isRendered conditions => 1st condition: submitted DARs, 2nd condition: DAR drafts
+          isRendered: (!isEmpty(darCode) && !isEmpty(irbDocumentLocation)) || activeDULQuestions['ethicsApprovalRequired'] === true,
           style: uploadFileDiv(showValidationMessages, uploadedIrbDocument, irbDocumentLocation)
         }, [
           div({className: 'row no-margin'}, [
@@ -580,7 +594,8 @@ export default function DataAccessRequest(props) {
 
         div({
           className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12',
-          isRendered: activeDULQuestions['collaboratorRequired'] === true,
+          //isRendered conditions => 1st condition: submitted DARs, 2nd condition: DAR drafts
+          isRendered: (!isEmpty(darCode) && !isEmpty(collaborationLetterLocation)) || activeDULQuestions['collaboratorRequired'] === true,
           style: uploadFileDiv(showValidationMessages, uploadedCollaborationLetter, collaborationLetterLocation)
         }, [
           div({className: 'row no-margin'}, [


### PR DESCRIPTION
Addresses [DUOS-883](https://broadinstitute.atlassian.net/browse/DUOS-883)

PR adds data validation and rendering logic to ensure that submitted DARs will render uploaded documents based on the presence of the documents, regardless of whether or not the dataset requires uploaded documents. Feature is done to keep documentation visible and consistent across the different DARs generated from the initial application.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
