### PR TITLE
DUOS-882[risk=no] Read Researcher information from ResearcherProfile rather than darInfo

### DIFF
--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -140,7 +140,7 @@ export const AppSummary = hh(class AppSummary extends React.Component {
           [ApplicantInfo({
             researcherProfile: researcherProfile,
             content: {
-              principalInvestigator: piName,
+              principalInvestigator: researcherProfile.isThePI ? profileName : (piName || '- - -'),
               researcher: profileName,
               institution,
               department,

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -73,7 +73,7 @@ export const AppSummary = hh(class AppSummary extends React.Component {
 
   render() {
     const { darInfo, accessElection, consent, researcherProfile } = this.props;
-    const { pi, profileName, institution, department, city, country } = darInfo;
+    const { piName, profileName, institution, department, city, country } = researcherProfile;
     const mrDAR = JSON.stringify(accessElection.useRestriction, null, 2);
     const mrDUL = JSON.stringify(consent.useRestriction, null, 2);
     const translatedRestrictionsList = this.state.translatedRestrictions.map((restrictionObj) => {
@@ -140,7 +140,7 @@ export const AppSummary = hh(class AppSummary extends React.Component {
           [ApplicantInfo({
             researcherProfile: researcherProfile,
             content: {
-              principalInvestigator: pi,
+              principalInvestigator: piName,
               researcher: profileName,
               institution,
               department,


### PR DESCRIPTION
Addresses [DUOS-882](https://broadinstitute.atlassian.net/browse/DUOS-882)

PR updates logic on the AppSummary component so that it operates under the v2 DAR API expectations rather than the v1 expectations it was originally built on. This means reading Researcher information from the ResearcherProfile object rather than darInfo.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
