### PR TITLE
[DUOS-493][risk=no] Use commit tagged image in deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ commands:
       sa_key_name:
         type: string
         default: 'GCLOUD_DUOS_DEV'
-      env:
-        type: string
-        default: 'dev'
       application_name:
         type: string
         default: 'duos'
@@ -34,7 +31,6 @@ commands:
           name: Export env vars for substitution. $BASH_ENV is sourced before each step
           command: |
             echo 'export COMMIT="`git rev-parse --short=12 HEAD`"' >> $BASH_ENV
-            echo 'export ENV="<< parameters.env >>"' >> $BASH_ENV
             echo 'export APPLICATION_NAME="<< parameters.application_name >>"' >> $BASH_ENV
             echo 'export GOOGLE_PROJECT="<< parameters.google_project >>"' >> $BASH_ENV
             source $BASH_ENV
@@ -54,7 +50,6 @@ commands:
             docker tag ${APPLICATION_NAME} gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT}
             gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://gcr.io
             docker push gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT}
-            gcloud container images add-tag gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT} gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT}-${ENV} -q
             gcloud container images add-tag gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT} gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:latest -q
   deploy-env:
     description: "Deploy commit to GCR"
@@ -62,9 +57,6 @@ commands:
       sa_key_name:
         type: string
         default: 'GCLOUD_DUOS_DEV'
-      env:
-        type: string
-        default: 'dev'
       namespace:
         type: string
         default: 'duos'
@@ -160,12 +152,10 @@ jobs:
           at: .
       - push-env:
           sa_key_name: 'GCLOUD_DUOS_DEV'
-          env: 'dev'
           application_name: 'duos'
           google_project: 'broad-duos-dev'
       - deploy-env:
           sa_key_name: 'GCLOUD_DUOS_DEV'
-          env: 'dev'
           namespace: 'duos'
           application_name: 'duos'
           google_project: 'broad-duos-dev'
@@ -183,12 +173,10 @@ jobs:
           at: .
       - push-env:
           sa_key_name: 'GCLOUD_DUOS_DEV'
-          env: 'staging'
           application_name: 'duos'
           google_project: 'broad-duos-dev'
       - deploy-env:
           sa_key_name: 'GCLOUD_DUOS_DEV'
-          env: 'staging'
           namespace: 'duos'
           application_name: 'duos'
           google_project: 'broad-duos-dev'

--- a/conf/k8s.yml
+++ b/conf/k8s.yml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: ${APPLICATION_NAME}
-          image: gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT}-${ENV}
+          image: gcr.io/${GOOGLE_PROJECT}/${APPLICATION_NAME}:${COMMIT}
           imagePullPolicy: Always
           volumeMounts:
             - name: configs


### PR DESCRIPTION
## Addresses
Cleanup associated to https://broadinstitute.atlassian.net/browse/DUOS-493

## Changes
Now that we're deploying an image that doesn't have env-specific configs, we can point the deployment yaml to the image tagged with just the commit hash. This PR removes the `env` parameter and environment variable that was previously necessary in the deployment to distinguish the difference between a dev/staging/prod image.

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
