### PR TITLE
[DUOS-890][risk=no] Can't edit Data Custodian/PI fields on dataset registration form

### DIFF
--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -769,6 +769,7 @@ class DatasetRegistration extends Component {
                         name: 'researcher',
                         id: 'inputResearcher',
                         value: this.state.datasetData.researcher,
+                        onChange: this.handleChange,
                         disabled: !isUpdateDataset,
                         className: (fp.isEmpty(this.state.datasetData.researcher) && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         required: true
@@ -790,6 +791,7 @@ class DatasetRegistration extends Component {
                         name: 'principalInvestigator',
                         id: 'inputPrincipalInvestigator',
                         value: this.state.datasetData.principalInvestigator,
+                        onChange: this.handleChange,
                         className: (fp.isEmpty(this.state.datasetData.principalInvestigator) && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         required: true
                       }),

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -1143,7 +1143,7 @@ class DatasetRegistration extends Component {
                                 isDisabled: isUpdateDataset || !diseases,
                                 isMulti: true,
                                 loadOptions: (query, callback) => this.searchOntologies(query, callback),
-                                onBlur: (option) => this.onOntologiesChange(option),
+                                onChange: (option) => this.onOntologiesChange(option),
                                 value: ontologies,
                                 placeholder: 'Please enter one or more diseases',
                                 classNamePrefix: 'select',

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -768,8 +768,8 @@ class DatasetRegistration extends Component {
                         type: 'text',
                         name: 'researcher',
                         id: 'inputResearcher',
-                        value: this.state.datasetData.researcher,
-                        onChange: this.handleChange,
+                        defaultValue: this.state.datasetData.researcher,
+                        onBlur: this.handleChange,
                         disabled: !isUpdateDataset,
                         className: (fp.isEmpty(this.state.datasetData.researcher) && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         required: true
@@ -790,8 +790,8 @@ class DatasetRegistration extends Component {
                         type: 'text',
                         name: 'principalInvestigator',
                         id: 'inputPrincipalInvestigator',
-                        value: this.state.datasetData.principalInvestigator,
-                        onChange: this.handleChange,
+                        defaultValue: this.state.datasetData.principalInvestigator,
+                        onBlur: this.handleChange,
                         className: (fp.isEmpty(this.state.datasetData.principalInvestigator) && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         required: true
                       }),
@@ -819,8 +819,8 @@ class DatasetRegistration extends Component {
                           name: 'datasetName',
                           id: 'inputName',
                           maxLength: '256',
-                          value: this.state.datasetData.datasetName,
-                          onChange: this.handleChange,
+                          defaultValue: this.state.datasetData.datasetName,
+                          onBlur: this.handleChange,
                           className: this.showDatasetNameErrors(this.state.datasetData.datasetName, showValidationMessages),
                           required: true,
                         }),
@@ -851,8 +851,8 @@ class DatasetRegistration extends Component {
                           id: 'inputRepoUrl',
                           maxLength: '256',
                           placeholder: 'http://...',
-                          value: this.state.datasetData.datasetRepoUrl,
-                          onChange: this.handleChange,
+                          defaultValue: this.state.datasetData.datasetRepoUrl,
+                          onBlur: this.handleChange,
                           className: (fp.isEmpty(this.state.datasetData.datasetRepoUrl) && showValidationMessages) ?
                             'form-control required-field-error' :
                             'form-control',
@@ -882,8 +882,8 @@ class DatasetRegistration extends Component {
                           name: 'dataType',
                           id: 'inputDataType',
                           maxLength: '256',
-                          value: this.state.datasetData.dataType,
-                          onChange: this.handleChange,
+                          defaultValue: this.state.datasetData.dataType,
+                          onBlur: this.handleChange,
                           className: (fp.isEmpty(this.state.datasetData.dataType) && showValidationMessages) ?
                             'form-control required-field-error' :
                             'form-control',
@@ -913,8 +913,8 @@ class DatasetRegistration extends Component {
                           name: 'species',
                           id: 'inputSpecies',
                           maxLength: '256',
-                          value: this.state.datasetData.species,
-                          onChange: this.handleChange,
+                          defaultValue: this.state.datasetData.species,
+                          onBlur: this.handleChange,
                           className: (fp.isEmpty(this.state.datasetData.species) && showValidationMessages) ?
                             'form-control required-field-error' :
                             'form-control',
@@ -944,8 +944,8 @@ class DatasetRegistration extends Component {
                           name: 'phenotype',
                           id: 'inputPhenotype',
                           maxLength: '256',
-                          value: this.state.datasetData.phenotype,
-                          onChange: this.handleChange,
+                          defaultValue: this.state.datasetData.phenotype,
+                          onBlur: this.handleChange,
                           className: (fp.isEmpty(this.state.datasetData.phenotype) && showValidationMessages) ?
                             'form-control required-field-error' :
                             'form-control',
@@ -976,8 +976,8 @@ class DatasetRegistration extends Component {
                           id: 'inputParticipants',
                           maxLength: '256',
                           min: '0',
-                          value: this.state.datasetData.nrParticipants,
-                          onChange: this.handlePositiveIntegerOnly,
+                          defaultValue: this.state.datasetData.nrParticipants,
+                          onBlur: this.handlePositiveIntegerOnly,
                           className: (fp.isEmpty(this.state.datasetData.nrParticipants) && showValidationMessages) ?
                             'form-control required-field-error' :
                             'form-control',
@@ -1007,8 +1007,8 @@ class DatasetRegistration extends Component {
                           name: 'description',
                           id: 'inputDescription',
                           maxLength: '256',
-                          value: this.state.datasetData.description,
-                          onChange: this.handleChange,
+                          defaultValue: this.state.datasetData.description,
+                          onBlur: this.handleChange,
                           className: (fp.isEmpty(this.state.datasetData.description) && showValidationMessages) ?
                             'form-control required-field-error' :
                             'form-control',
@@ -1143,7 +1143,7 @@ class DatasetRegistration extends Component {
                                 isDisabled: isUpdateDataset || !diseases,
                                 isMulti: true,
                                 loadOptions: (query, callback) => this.searchOntologies(query, callback),
-                                onChange: (option) => this.onOntologiesChange(option),
+                                onBlur: (option) => this.onOntologiesChange(option),
                                 value: ontologies,
                                 placeholder: 'Please enter one or more diseases',
                                 classNamePrefix: 'select',
@@ -1167,8 +1167,8 @@ class DatasetRegistration extends Component {
 
                             textarea({
                               className: 'form-control',
-                              value: primaryOtherText,
-                              onChange: (e) => this.setOtherText(e, 'primary'),
+                              defaultValue: primaryOtherText,
+                              onBlur: (e) => this.setOtherText(e, 'primary'),
                               name: 'primaryOtherText',
                               id: 'primaryOtherText',
                               maxLength: '512',
@@ -1424,8 +1424,8 @@ class DatasetRegistration extends Component {
                           {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                           [
                             textarea({
-                              value: secondaryOtherText,
-                              onChange: (e) => this.setOtherText(e, 'secondary'),
+                              defaultValue: secondaryOtherText,
+                              onBlur: (e) => this.setOtherText(e, 'secondary'),
                               name: 'secondaryOtherText',
                               id: 'inputSecondaryOtherText',
                               className: 'form-control',


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-890
Added missing onChange handler to the affected fields so that they are editable.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
