### PR TITLE
[DUOS-898][risk=no] Dataset Catalog table columns separated

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -393,8 +393,8 @@ class DatasetCatalog extends Component {
               table({ className: 'table' }, [
                 thead({}, [
                   tr({}, [
-                    th({ isRendered: this.state.isAdmin, className: 'cell-size', style: { textAlign: 'center' } }, ['Actions']),
-                    th({}),
+                    th(),
+                    th({ isRendered: this.state.isAdmin, className: 'cell-size', style: { minWidth: '14rem' }}, ['Actions']),
                     th({ className: 'cell-size' }, ['Dataset ID']),
                     th({ className: 'cell-size' }, ['Dataset Name']),
                     th({ className: 'cell-size' }, ['Data Access Committee']),


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-898

- Realigned the table row setup for checkbox + actions columns

<img width="1235" alt="Screen Shot 2020-12-18 at 1 53 02 PM" src="https://user-images.githubusercontent.com/43456581/102650192-7f05e980-4138-11eb-91f8-05523d988e06.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
