### PR TITLE
[DUOS-899][risk=no] Dataset Update Error on Datasets with Primary Disease Restrictions

### DIFF
--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -654,7 +654,8 @@ class DatasetRegistration extends Component {
       result.hmbResearch = data.hmb;
     }
     if (data.diseases) {
-      result.diseaseRestrictions = data.ontologies;
+      let ids = data.ontologies.map(ontology => ontology.id);
+      result.diseaseRestrictions = ids;
     }
     if (data.other) {
       result.otherRestrictions = data.other;

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -103,8 +103,10 @@ class DatasetRegistration extends Component {
     if (!fp.isEmpty(this.state.updateDataset)) {
       this.prefillDatasetFields(this.state.updateDataset);
       const ontologies = await this.getOntologies(this.state.formData.diseases);
+      const formattedOntologies = this.formatOntologyItems(ontologies);
       this.setState(prev => {
-        prev.formData.ontologies = ontologies;
+        prev.formData.ontologies = formattedOntologies;
+        prev.formData.diseases = !fp.isEmpty(ontologies);
         return prev;
       });
     }
@@ -280,7 +282,7 @@ class DatasetRegistration extends Component {
       this.isValid(formData.phenotype) &&
       this.isValid(formData.nrParticipants) &&
       this.isValid(formData.description) &&
-      !this.isTypeOfResearchInvalid();
+      (!fp.isEmpty(this.state.updateDataset) || !this.isTypeOfResearchInvalid());
   };
 
   validateDatasetName(name) {
@@ -617,7 +619,7 @@ class DatasetRegistration extends Component {
     result.isAssociatedToDataOwners = true;
     result.updateAssociationToDataOwnerAllowed = true;
     result.properties = this.createProperties();
-    result.dataUse = this.formatDataUse(this.state.formData);
+    result.dataUse = fp.isEmpty(this.state.updateDataset) ? this.formatDataUse(this.state.formData) : this.state.updateDataset.dataUse;
     return result;
   };
 
@@ -711,7 +713,7 @@ class DatasetRegistration extends Component {
       methods = false,
       generalUse = false,
     } = this.state.formData;
-    const ontologies = this.formatOntologyItems(this.state.formData.ontologies);
+    const { ontologies } = this.state.formData;
     const { needsApproval = false } = this.state.datasetData;
     const { problemSavingRequest, problemLoadingUpdateDataset, showValidationMessages, submissionSuccess } = this.state;
     const isTypeOfResearchInvalid = this.isTypeOfResearchInvalid();


### PR DESCRIPTION
Addresses: https://broadinstitute.atlassian.net/browse/DUOS-899

Jonathan noticed a bug while testing the update dataset v2 feature, where datasets with disease restrictions were not able to be updated. Other types of datasets appeared to be updating properly, and creation was working.

- Moved reformatting of ontology into select-able items to ComponentDidMount so it doesn't happen multiple times during re-render
- Set diseases = true if there are diseaseRestrictions for a given update dataset case
- Don't validate primary data use if this is an update dataset case
- Don't generate a new data use object if this is an update dataset case (since we shouldn't be able to edit that anyhow)

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
