### PR TITLE
[DUOS-773][risk=no] Remove download DUL links

### DIFF
--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -57,14 +57,6 @@ export default function TranslatedDULComponent(props) {
     className: 'italic hover-color',
   }, ['Download DUL machine-readable format']);
 
-  const dataUseLetterLink = a({
-    id: "btn_downloadDataUseLetter",
-    className: "col-lg-6 col-md-6 col-sm-6 col-xs-12 italic hover-color",
-    fileName: props.downloadDUL,
-    value: props.downloadDUL,
-    onClick: () => props.downloadDUL()
-  }, ["Download Data Use Letter"]);
-
   //panel formats differ depending on whether or not its used in DAR vs DUL
 
   const DARTemplate = div({ className: "data-use-container" }, [
@@ -72,7 +64,6 @@ export default function TranslatedDULComponent(props) {
       h4({}, ["Data Use Limitations"]),
     ]),
     ul({ id: "panel_dataUseLimitations", className: "panel-body cm-boxbody translated-restriction", style: {listStyle: 'none', marginTop: '0.8rem'}}, [translatedDULStatements]),
-    div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
     div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
   ]);
 
@@ -82,7 +73,6 @@ export default function TranslatedDULComponent(props) {
         div({ className: "panel-heading cm-boxhead dul-color" }, [
           h4({}, ["Data Use Limitations"]),
         ]),
-        div({id: "panel_dulLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.downloadDUL)}, [dataUseLetterLink]),
         div({id: "panel_mrlLink panel-body", className: "panel-body cm-boxbody translated-restriction", isRendered: !isNil(props.mrDUL)},[machineReadableLink])
       ]),
       div({ className: "data-use-panel", style: DULPanel }, [

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -720,18 +720,6 @@ export const Email = {
 
 export const Files = {
 
-  // Get DUL File requires another field for fileName to be downloaded
-  // this field is required in the component
-  getDulFile: async (consentId, fileName) => {
-    const url = `${await Config.getApiUrl()}/consent/${consentId}/dul`;
-    return getFile(url, fileName);
-  },
-
-  getDulFileByElectionId: async (consentId, electionId, fileName) => {
-    const url = `${await Config.getApiUrl()}/consent/${consentId}/dul?electionId=${electionId}`;
-    return getFile(url, fileName);
-  },
-
   getApprovedUsersFile: async (fileName, dataSetId) => {
     const url = `${await Config.getApiUrl()}/dataset/${dataSetId}/approved/users`;
     return getFile(url, fileName);

--- a/src/pages/DataOwnerReview.js
+++ b/src/pages/DataOwnerReview.js
@@ -1,10 +1,10 @@
 import { Component } from 'react';
-import { div, button, hr, h4, a, span } from 'react-hyperscript-helpers';
+import { div, hr, h4, a, span } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { SubmitTriVoteBox } from '../components/SubmitTriVoteBox';
 import { ApplicationSummaryModal } from '../components/modals/ApplicationSummaryModal';
 import { DatasetSummaryModal } from '../components/modals/DatasetSummaryModal';
-import { DAR, Files, DataSet, Consent, Votes } from '../libs/ajax';
+import { DAR, DataSet, Consent, Votes } from '../libs/ajax';
 import { ConfirmationDialog } from "../components/ConfirmationDialog";
 
 const APPROVE = "1";
@@ -61,7 +61,6 @@ class DataOwnerReview extends Component {
     this.submitVote = this.submitVote.bind(this);
     this.getDarInfo = this.getDarInfo.bind(this);
     this.getConsentInfo = this.getConsentInfo.bind(this);
-    this.downloadDUL = this.downloadDUL.bind(this);
     this.getVote = this.getVote.bind(this);
   }
 
@@ -183,10 +182,6 @@ class DataOwnerReview extends Component {
     this.props.history.goBack();
   };
 
-  downloadDUL = () => (e) => {
-    Files.getDulFile(this.state.consent.id, this.state.consent.data.dulName);
-  };
-
   async submitVote(answer, rationale) {
     let updatedVote = {};
 
@@ -297,15 +292,9 @@ class DataOwnerReview extends Component {
                 showModal: this.state.showDatasetSummaryModal,
                 onOKRequest: this.okDatasetSummaryModal,
                 onCloseRequest: this.closeDatasetSummaryModal
-              }),
-            ]),
-            div({ id: "dul", className: "panel-body cm-boxbody" }, [
-              button({
-                className: "col-lg-6 col-md-6 col-sm-8 col-xs-12 btn-secondary btn-reminder hover-color",
-                onClick: this.downloadDUL()
-              }, ["Download Data Use Letter"]),
+              })
             ])
-          ]),
+          ])
         ]),
 
         div({ className: "col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-12 col-xs-12" }, [

--- a/src/pages/DulCollect.js
+++ b/src/pages/DulCollect.js
@@ -4,7 +4,7 @@ import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
 import { SingleResultBox } from '../components/SingleResultBox';
 import { CollectResultBox } from '../components/CollectResultBox';
-import { Election, Files, Email } from '../libs/ajax';
+import { Election, Email } from '../libs/ajax';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Storage } from '../libs/storage';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
@@ -77,12 +77,6 @@ class DulCollect extends Component {
       ]
     };
   };
-
-
-  downloadDUL = (e) => {
-    Files.getDulFile(this.props.match.params.consentId, this.state.dulName);
-  };
-
 
   handlerReminder = (e) => (voteId) => {
     this.setState(prev => {
@@ -177,7 +171,7 @@ class DulCollect extends Component {
       b({ isRendered: this.state.consentGroupName, className: "pipe", dangerouslySetInnerHTML: { __html: this.state.consentGroupName } }, []),
       this.state.consentName
     ]);
-    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.dataUse, downloadDUL: this.downloadDUL, isDUL: true});
+    const translatedDULStatements = h(TranslatedDULComponent, {restrictions: this.state.dataUse, isDUL: true});
 
     return (
 

--- a/src/pages/DulPreview.js
+++ b/src/pages/DulPreview.js
@@ -1,7 +1,7 @@
 import { Component } from 'react';
 import { div, i, span, b, a, hr, h} from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
-import { Consent, Election, Files } from '../libs/ajax';
+import { Consent, Election } from '../libs/ajax';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
 
 class DulPreview extends Component {
@@ -14,7 +14,6 @@ class DulPreview extends Component {
 
     this.back = this.back.bind(this);
     this.electionReview = this.electionReview.bind(this);
-    this.downloadDUL = this.downloadDUL.bind(this);
   }
 
   back() {
@@ -41,10 +40,6 @@ class DulPreview extends Component {
     this.electionReview();
   }
 
-  downloadDUL = () => {
-    Files.getDulFile(this.props.match.params.consentId, this.state.consentPreview.dulName);
-  };
-
 
   render() {
 
@@ -53,7 +48,7 @@ class DulPreview extends Component {
       this.state.consentPreview.name
     ]);
 
-    const translatedDULStatements = h(TranslatedDULComponent,{restrictions: this.state.consentPreview.dataUse, isDUL: true, downloadDUL: this.downloadDUL});
+    const translatedDULStatements = h(TranslatedDULComponent,{restrictions: this.state.consentPreview.dataUse, isDUL: true});
 
     return (
 

--- a/src/pages/DulResultRecords.js
+++ b/src/pages/DulResultRecords.js
@@ -4,7 +4,7 @@ import { PageHeading } from '../components/PageHeading';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { SingleResultBox } from '../components/SingleResultBox';
 import { CollectResultBox } from '../components/CollectResultBox';
-import { Election, Files } from '../libs/ajax';
+import { Election } from '../libs/ajax';
 import { Storage } from '../libs/storage';
 import { Config } from '../libs/config';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
@@ -125,10 +125,6 @@ class DulResultRecords extends Component {
     };
   }
 
-  downloadDUL = (e) => {
-    Files.getDulFileByElectionId(this.state.electionReview.election.referenceId, this.state.electionReview.election.electionId, this.state.electionReview.election.dulName);
-  };
-
   render() {
 
     const { chartData = {} } = this.state;
@@ -158,7 +154,6 @@ class DulResultRecords extends Component {
 
         h(TranslatedDULComponent, {
           restrictions: this.state.dataUse,
-          downloadDUL: this.downloadDUL,
           isDUL: true
         }),
 

--- a/src/pages/DulReview.js
+++ b/src/pages/DulReview.js
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import { div, b, span, a, h4, hr, i, h } from 'react-hyperscript-helpers';
 import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
-import { Votes, Election, Consent, Files } from '../libs/ajax';
+import { Votes, Election, Consent } from '../libs/ajax';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Storage } from "../libs/storage";
 import { Navigation } from "../libs/utils";
@@ -89,10 +89,6 @@ class DulReview extends Component {
     }
   };
 
-  downloadDUL = (e) => {
-    Files.getDulFile(this.props.match.params.consentId, this.state.election.dulName);
-  };
-
   confirmationHandlerOK = (answer) => (e) => {
     this.setState({ showConfirmationDialog: false });
     Navigation.back(this.state.currentUser, this.props.history);
@@ -127,7 +123,7 @@ class DulReview extends Component {
         div({ className: "accordion-title dul-color" }, ["Were the data use limitations in the Data Use Letter accurately converted to structured limitations?"]),
         hr({ className: "section-separator" }),
         h4({ className: "hint" }, ["Please review the Data Use Letter and determine if the Data Use Limitations were accurately converted to Structured Limitations"]),
-        h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, downloadDUL: this.downloadDUL, isDUL: true}),
+        h(TranslatedDULComponent, {restrictions: this.state.consent.dataUse, isDUL: true}),
         div({ className: "col-lg-8 col-lg-offset-2 col-md-8 col-md-offset-2 col-sm-12 col-xs-12" }, [
           div({ className: "jumbotron box-vote dul-background-lighter" }, [
             SubmitVoteBox({


### PR DESCRIPTION
Addresses: https://broadworkbench.atlassian.net/browse/DUOS-773

Removes the Download DUL link from these pages:
- DUL_Results_Record
- DUL_Collect
- DUL_Preview
- DUL_Review
- Data_Owner_Review

Note: the pages and/or `TranslatedDULComponent` might need additional clean up as some of them are purposed for users voting on whether or not the DUL was properly translated.

<img width="1110" alt="Screen Shot 2021-01-05 at 9 42 05 AM" src="https://user-images.githubusercontent.com/43456581/103659654-a9c6af00-4f3a-11eb-91dc-3034668fdae0.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
