### PR TITLE
[DUOS-906][risk=no] Remove unnecessary npm install

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -7,15 +7,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-
-      - name: Update and install node
-        run: |
-          sudo apt update
-          sudo apt install -f nodejs-dev node-gyp libssl1.0-dev
-          sudo apt install -f nodejs npm
-      - name: Build an image from Dockerfile
-        run: |
-          docker build -f Dockerfile -t docker.io/broadinstitute/duos:${{ github.sha }} .
+      - name: Build Dockerfile
+        run: docker build -f Dockerfile -t docker.io/broadinstitute/duos:${{ github.sha }} .
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-906

npm install is not necessary since the docker build does it internally.

---

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
