### PR TITLE
DUOS-905 Fix for Obscure SRP display [risk=no]

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -16,7 +16,7 @@ const srpTranslations = {
   },
   poa: {
     code: 'POA',
-    desciption: 'The dataset will be used for the study of Population Origins/Migration patterns.',
+    description: 'The dataset will be used for the study of Population Origins/Migration patterns.',
     manualReview: true
   },
   diseases: (diseases) => {


### PR DESCRIPTION
Addresses ![DUOS-905](https://broadworkbench.atlassian.net/browse/DUOS-905)

Obscure display was the result of a key typo. Correction of said typo provides proper key referencing for display.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
