### PR TITLE
[DUOS-910][risk=no] Use auth user to retrieve datasets

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -481,8 +481,8 @@ export const DataSet = {
     return await res.json();
   },
 
-  findDataSets: async dacUserId => {
-    const url = `${await Config.getApiUrl()}/dataset?dacUserId=${dacUserId}`;
+  getDatasets: async () => {
+    const url = `${await Config.getApiUrl()}/dataset`;
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -55,7 +55,7 @@ class DatasetCatalog extends Component {
   }
 
   async getDatasets() {
-    let catalog = await DataSet.findDataSets(this.currentUser.dacUserId);
+    let catalog = await DataSet.getDatasets();
     catalog.forEach((row, index) => {
       row.checked = false;
       row.ix = index;

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -86,7 +86,7 @@ class DatasetRegistration extends Component {
     await this.init();
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     const currentUser = await Storage.getCurrentUser();
-    const allDatasets =  await DataSet.findDataSets(currentUser.dacUserId);
+    const allDatasets =  await DataSet.getDatasets();
     const allDatasetNames = allDatasets.map(d => {
       let name = d.properties.find(p => p.propertyName === "Dataset Name");
       return name.propertyValue;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-910

Removes security hole where a user can query datasets under a different user's id
Requires: https://github.com/DataBiosphere/consent/pull/874

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
