### PR TITLE
[DUOS-901][risk=no] Disable Apply Access Button when disabled datasets selected

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -1,5 +1,6 @@
 import find from 'lodash/find';
 import get from 'lodash/get';
+import some from 'lodash/some';
 import { Component, Fragment } from 'react';
 import { a, button, div, form, h, input, label, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import ReactTooltip from 'react-tooltip';
@@ -33,6 +34,7 @@ class DatasetCatalog extends Component {
       },
       dacs: [],
       disableOkButton: false,
+      disableApplyAccessButton: true,
       translatedUseRestrictionModal: {},
       isAdmin: null,
       isResearcher: null,
@@ -316,10 +318,13 @@ class DatasetCatalog extends Component {
 
   selectAll = (e) => {
     const checked = e.target.checked;
-    const checkedCatalog = this.state.dataSetList.catalog.map(row => { row.checked = checked; return row; });
+    const catalog = this.state.dataSetList.catalog;
+    const checkedCatalog = catalog.map(row => { row.checked = checked; return row; });
+    const disabledChecked = some(catalog, {'checked': true, 'active': false});
     this.setState(prev => {
       prev.allChecked = checked;
       prev.dataSetList.catalog = checkedCatalog;
+      prev.disableApplyAccessButton = disabledChecked;
       return prev;
     });
   };
@@ -335,8 +340,11 @@ class DatasetCatalog extends Component {
       ...catalog.slice(index + 1)
     ];
 
+    const disabledChecked = some(catalog, {'checked': true, 'active': false});
+
     this.setState(prev => {
       prev.dataSetList.catalog = catalog;
+      prev.disableApplyAccessButton = disabledChecked;
       return prev;
     });
   };
@@ -624,7 +632,7 @@ class DatasetCatalog extends Component {
             button({
               id: 'btn_applyAccess',
               isRendered: this.state.isResearcher,
-              disabled: this.state.dataSetList.catalog.filter(row => row.checked).length === 0,
+              disabled: (this.state.dataSetList.catalog.filter(row => row.checked).length === 0) || this.state.disableApplyAccessButton,
               onClick: () => this.exportToRequest(),
               className: 'btn-primary dataset-background search-wrapper',
               'data-tip': 'Request Access for selected Datasets', 'data-for': 'tip_requestAccess'


### PR DESCRIPTION
Addresses: https://broadworkbench.atlassian.net/browse/DUOS-901

Adds a check for selected disabled (inactive) datasets. If any disabled datasets are selected, disable the Apply Access button that leads to DAR creation. Leaves the Download Dataset button enabled.

<img width="1534" alt="Screen Shot 2021-01-07 at 4 11 57 PM" src="https://user-images.githubusercontent.com/43456581/103945375-1ee4e080-5103-11eb-8fb2-8c0e7f7a6be7.png">


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
