### PR TITLE
DUOS-886[risk=no] Dataset Catalog: Remove link from datasets w/o dbgap links

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -64,9 +64,9 @@ class DatasetCatalog extends Component {
           find(
             row.properties,
             p => {
-              return p.propertyName == 'dbGAP';
+              return p.propertyName === 'dbGAP';
             },
-        ), 'propertyValue', '') ;
+          ), 'propertyValue', '') ;
     });
     this.setState({
       dataSetList: { catalog: catalog },
@@ -514,16 +514,16 @@ class DatasetCatalog extends Component {
                             get(find(dacs, dac => { return dac.id === dataSet.dacId; }), 'name', '')
                           ]),
 
-                            td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') },
-                              [ dataSet.dbGapLink !== '' ?
-                                  a({
-                                  id: trIndex + '_linkdbGap',
-                                  name: 'link_dbGap',
-                                  href: dataSet.dbGapLink,
-                                  target: '_blank',
-                                  className: 'enabled'
-                                }, ['Link']) : ''
-                              ]),
+                          td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') },
+                            [dataSet.dbGapLink !== '' ?
+                              a({
+                                id: trIndex + '_linkdbGap',
+                                name: 'link_dbGap',
+                                href: dataSet.dbGapLink,
+                                target: '_blank',
+                                className: 'enabled'
+                              }, ['Link']) : '--'
+                            ]),
 
                           td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') }, [
                             a({

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -59,6 +59,7 @@ class DatasetCatalog extends Component {
     catalog.forEach((row, index) => {
       row.checked = false;
       row.ix = index;
+      row.dbGapLinked = true;
     });
     this.setState({
       dataSetList: { catalog: catalog },

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -1,7 +1,5 @@
 import find from 'lodash/find';
 import get from 'lodash/get';
-import first from 'lodash/first';
-import isNil from 'lodash/isNil';
 import { Component, Fragment } from 'react';
 import { a, button, div, form, h, input, label, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import ReactTooltip from 'react-tooltip';

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -1,5 +1,7 @@
 import find from 'lodash/find';
 import get from 'lodash/get';
+import first from 'lodash/first';
+import isNil from 'lodash/isNil';
 import { Component, Fragment } from 'react';
 import { a, button, div, form, h, input, label, span, table, tbody, td, th, thead, tr } from 'react-hyperscript-helpers';
 import ReactTooltip from 'react-tooltip';
@@ -59,7 +61,14 @@ class DatasetCatalog extends Component {
     catalog.forEach((row, index) => {
       row.checked = false;
       row.ix = index;
-      row.dbGapLinked = true;
+      row.dbGapLink =
+        get (
+          find(
+            row.properties,
+            p => {
+              return p.propertyName == 'dbGAP';
+            },
+        ), 'propertyValue', '') ;
     });
     this.setState({
       dataSetList: { catalog: catalog },
@@ -507,17 +516,16 @@ class DatasetCatalog extends Component {
                             get(find(dacs, dac => { return dac.id === dataSet.dacId; }), 'name', '')
                           ]),
 
-                          td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') }, [
-                            a({
-                              id: trIndex + '_linkdbGap',
-                              name: 'link_dbGap',
-                              href: get(find(dataSet.properties, p => { return p.propertyName === 'dbGAP'; }), 'propertyValue', ''),
-                              target: '_blank',
-                              className: (get(find(dataSet.properties, p => { return p.propertyName === 'dbGAP'; }), 'propertyValue', '').length > 0 ?
-                                'enabled' :
-                                'disabled')
-                            }, ['Link'])
-                          ]),
+                            td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') },
+                              [ dataSet.dbGapLink !== '' ?
+                                  a({
+                                  id: trIndex + '_linkdbGap',
+                                  name: 'link_dbGap',
+                                  href: dataSet.dbGapLink,
+                                  target: '_blank',
+                                  className: 'enabled'
+                                }, ['Link']) : ''
+                              ]),
 
                           td({ className: 'table-items cell-size ' + (!dataSet.active ? 'dataset-disabled' : '') }, [
                             a({


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-886

## Scope of Changes
Added dataSet.gbGapLink 
Check to make sure the link is not empty before creating the link association in render

## Testing
Use a researcher role and visit the Dataset Catalog page. Datasets without links should not show a link nor be clickable.

--- 
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
