### PR TITLE
[DUOS-904][risk=no] Handle no dac selected on Dataset Registration Edit

### DIFF
--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -1041,7 +1041,7 @@ class DatasetRegistration extends Component {
                           id: 'inputDac',
                           onChange: (option) => this.onDacChange(option),
                           blurInputOnSelect: true,
-                          value: fp.filter((dac) => this.state.selectedDac.dacId === dac.value, dacOptions),
+                          value: fp.filter((dac) => this.state.selectedDac?.dacId === dac.value, dacOptions),
                           openMenuOnFocus: true,
                           isDisabled: false,
                           isClearable: true,


### PR DESCRIPTION
Addresses: https://broadworkbench.atlassian.net/browse/DUOS-904

Quick fix to only access dacId if there is an existing selectedDac.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
