### PR TITLE
DUOS-912[risk=no]DAR Application Question 2.3.3 - Hide text box unless "Other" button is selected

### DIFF
--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -170,19 +170,19 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
             disabled: props.disabled,
           }),
 
-          props.other ?
-            textarea({
-              style: otherTextStyle,
-              value: props.otherText,
-              onChange: props.otherTextHandler,
-              name: 'otherText',
-              id: 'otherText',
-              maxLength: '512',
-              rows: '2',
-              required: props.other,
-              placeholder: 'Please specify if selected (max. 512 characters)',
-              enabled: true
-            }) : undefined
+          textarea({
+            isRendered: props.other,
+            style: otherTextStyle,
+            value: props.otherText,
+            onChange: props.otherTextHandler,
+            name: 'otherText',
+            id: 'otherText',
+            maxLength: '512',
+            rows: '2',
+            required: props.other,
+            placeholder: 'Please specify if selected (max. 512 characters)',
+            enabled: true
+          })
         ])
     );
   }

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -181,7 +181,7 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
             rows: '2',
             required: props.other,
             placeholder: 'Please specify if selected (max. 512 characters)',
-            enabled: true
+            disabled: props.disabled
           })
         ])
     );

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -170,19 +170,19 @@ export const TypeOfResearch = hh(class TypeOfResearch extends Component {
             disabled: props.disabled,
           }),
 
-          textarea({
-            style: otherTextStyle,
-            value: props.otherText,
-            onChange: props.otherTextHandler,
-            name: 'otherText',
-            id: 'otherText',
-            maxLength: '512',
-            rows: '2',
-            required: props.other,
-            placeholder: 'Please specify if selected (max. 512 characters)',
-            disabled: props.disabled || !props.other,
-          }),
-
+          props.other ?
+            textarea({
+              style: otherTextStyle,
+              value: props.otherText,
+              onChange: props.otherTextHandler,
+              name: 'otherText',
+              id: 'otherText',
+              maxLength: '512',
+              rows: '2',
+              required: props.other,
+              placeholder: 'Please specify if selected (max. 512 characters)',
+              enabled: true
+            }) : undefined
         ])
     );
   }


### PR DESCRIPTION

## Address
https://broadworkbench.atlassian.net/browse/DUOS-912?

## Scope of Changes
Check to make sure props.other is true before rendering the textbox
Set the textbox's enabled value to always be true

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
