### PR TITLE
DUOS-881[risk=no]Hyperlink 'Signing Official' to eRA Commons definition page

### DIFF
--- a/src/pages/dar_application/DataUseAgreements.js
+++ b/src/pages/dar_application/DataUseAgreements.js
@@ -80,11 +80,16 @@ export default function DataUseAgreements(props) {
 
             div({ className: 'row no-margin' }, [
               div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
-                label({ className: 'control-label default-color' },
-                  ['Important: Your Signing Official must sign and send a Library Card Agreement authorizing your use prior to accesssing to data.']),
-                a({ href: '/home_signing_official', target: '_blank' }, '(Click here for detailed instructions for your Signing Official)'),
+                label({ className: 'control-label default-color' }, [
+                  'Important: Your ',
+                    a({ href: 'https://era.nih.gov/erahelp/commons/#Commons/roles/SO.htm%3FTocPath%3DUser%2520Roles%7C_____9', target: '_blank'}, 'Signing Official' ),
+                    ' must sign and send a Library Card Agreement authorizing your use prior to accesssing to data.'
+                ])
               ]),
 
+              div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
+                a({ href: '/home_signing_official', target: '_blank' }, '(Click here for detailed instructions for your Signing Official)')
+              ]),
 
               div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                 a({

--- a/src/pages/dar_application/DataUseAgreements.js
+++ b/src/pages/dar_application/DataUseAgreements.js
@@ -82,8 +82,8 @@ export default function DataUseAgreements(props) {
               div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                 label({ className: 'control-label default-color' }, [
                   'Important: Your ',
-                    a({ href: 'https://era.nih.gov/erahelp/commons/#Commons/roles/SO.htm%3FTocPath%3DUser%2520Roles%7C_____9', target: '_blank'}, 'Signing Official' ),
-                    ' must sign and send a Library Card Agreement authorizing your use prior to accesssing to data.'
+                  a({ href: 'https://era.nih.gov/erahelp/commons/#Commons/roles/SO.htm%3FTocPath%3DUser%2520Roles%7C_____9', target: '_blank'}, 'Signing Official' ),
+                  ' must sign and send a Library Card Agreement authorizing your use prior to accesssing to data.'
                 ])
               ]),
 


### PR DESCRIPTION
## Address
https://broadworkbench.atlassian.net/browse/DUOS-881?

## Scope of Changes
added link (from Jira story) to text "Signing Official"
moved following line of linked text to new division


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
