### PR TITLE
[DUOS-900][risk=no] Update the UI to validate dataset name more efficiently

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -530,6 +530,17 @@ export const DataSet = {
     const url = `${await Config.getApiUrl()}/dataset/${datasetId}`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataSetObject), { method: 'PUT' }]));
     return await res.json();
+  },
+
+  validateDatasetName: async (name) => {
+    const url = `${await Config.getApiUrl()}/dataset/validate?name=${name}`;
+    try {
+      const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), {method: 'GET'}]));
+      return await res.json();
+    }
+    catch (err) {
+      return -1;
+    }
   }
 };
 

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -300,7 +300,6 @@ class DatasetRegistration extends Component {
       (!fp.isEmpty(this.state.updateDataset) || !this.isTypeOfResearchInvalid());
   };
 
-  // call the new ajax function and save it to the state?
   async validateDatasetName(name) {
     return DataSet.validateDatasetName(name).then(datasetId => {
       const isValid = (datasetId < 0);

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -245,10 +245,10 @@ class DatasetRegistration extends Component {
   };
 
   // same as handleChange, but adds call to validate dataset name and only affects state if a change has been made
-  handleDatasetNameChange = (e) => {
+  handleDatasetNameChange = async (e) => {
     const value = e.target.value;
     if (this.state.datasetData.datasetName !== value) {
-      this.validateDatasetName(value);
+      await this.validateDatasetName(value);
       this.setState(prev => {
         prev.datasetData.datasetName = value;
         prev.disableOkBtn = false;

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -244,6 +244,21 @@ class DatasetRegistration extends Component {
     });
   };
 
+  // same as handleChange, but adds call to validate dataset name and only affects state if a change has been made
+  handleDatasetNameChange = (e) => {
+    const value = e.target.value;
+    if (this.state.datasetData.datasetName !== value) {
+      this.validateDatasetName(value);
+      this.setState(prev => {
+        prev.datasetData.datasetName = value;
+        prev.disableOkBtn = false;
+        prev.problemSavingRequest = false;
+        prev.submissionSuccess = false;
+        return prev;
+      });
+    }
+  };
+
   handlePositiveIntegerOnly = (e) => {
     const field = e.target.name;
     const value = e.target.value.replace(/[^\d]/,'');
@@ -274,7 +289,7 @@ class DatasetRegistration extends Component {
   validateRequiredFields(formData) {
     return this.isValid(formData.researcher) &&
       this.isValid(formData.principalInvestigator) &&
-      this.validateDatasetName((formData.datasetName)) &&
+      this.state.validName &&
       this.isValid(formData.datasetName) &&
       this.isValid(formData.datasetRepoUrl) &&
       this.isValid(formData.dataType) &&
@@ -285,22 +300,19 @@ class DatasetRegistration extends Component {
       (!fp.isEmpty(this.state.updateDataset) || !this.isTypeOfResearchInvalid());
   };
 
-  validateDatasetName(name) {
-    let oldDataset = this.state.updateDataset;
-    let datasets = this.state.allDatasetNames;
-    // create dataset case
-    if (fp.isEmpty(oldDataset)) {
-      return !fp.contains(name, datasets);
-    }
-    // update dataset case (include old dataset name as valid)
-    else {
-      let updateDatasetName = fp.find(p => p.propertyName === "Dataset Name", this.state.updateDataset.properties).propertyValue;
-
-      return (name === updateDatasetName || !fp.contains(name, datasets));
-    }
+  // call the new ajax function and save it to the state?
+  async validateDatasetName(name) {
+    return DataSet.validateDatasetName(name).then(datasetId => {
+      const isValid = (datasetId < 0);
+      this.setState(prev => {
+        prev.validName = isValid;
+        return prev;
+      });
+    });
   };
 
-  showDatasetNameErrors(name, showValidationMessages) {
+  // generates the css classnames based on what's in the dataset name field and if we have tried to submit
+  showDatasetNameErrorHighlight(name, showValidationMessages) {
     if (fp.isEmpty(name)) {
       return showValidationMessages ? 'form-control required-field-error' : 'form-control';
     }
@@ -312,12 +324,12 @@ class DatasetRegistration extends Component {
       }
       // if the old dataset name has been edited
       else {
-        return this.validateDatasetName(name) ? 'form-control' : 'form-control required-field-error';
+        return this.state.validName ? 'form-control' : 'form-control required-field-error';
       }
     }
     // if a new dataset name is being edited
     else {
-      return this.validateDatasetName(name) ? 'form-control' : 'form-control required-field-error';
+      return this.state.validName ? 'form-control' : 'form-control required-field-error';
     }
   };
 
@@ -823,15 +835,15 @@ class DatasetRegistration extends Component {
                           id: 'inputName',
                           maxLength: '256',
                           defaultValue: this.state.datasetData.datasetName,
-                          onBlur: this.handleChange,
-                          className: this.showDatasetNameErrors(this.state.datasetData.datasetName, showValidationMessages),
+                          onBlur: this.handleDatasetNameChange,
+                          className: this.showDatasetNameErrorHighlight(this.state.datasetData.datasetName, showValidationMessages),
                           required: true,
                         }),
                         span({
                           className: 'cancel-color required-field-error-span',
-                          isRendered: fp.includes('required-field-error', this.showDatasetNameErrors(this.state.datasetData.datasetName, showValidationMessages))
+                          isRendered: fp.includes('required-field-error', this.showDatasetNameErrorHighlight(this.state.datasetData.datasetName, showValidationMessages))
                         },
-                        [this.validateDatasetName(this.state.datasetData.datasetName) ? 'Required field' : 'Dataset Name already in use']),
+                        [this.state.validName ? 'Required field' : 'Dataset Name already in use']),
                       ])
                   ]),
 


### PR DESCRIPTION
Addresses: https://broadworkbench.atlassian.net/browse/DUOS-900
Implements the validate dataset name endpoint on the dataset registration field, verifying if the given name is available or not, right after it's typed.

### Scope of Changes
---
- Validate dataset name availability on blur (after exiting the dataset name input field), IF the input value is different than what it was last
- Renamed `showDatasetNameErrors` to the slightly more descriptive `showDatasetNameErrorHighlight` and added a note for what it does

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
