### PR TITLE
DUOS-938 [risk=no] Removed ReactTooltip from DAR Application and ResearcherProfile

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -1,6 +1,5 @@
 import { Component } from 'react';
 import { a, div, form, h, hr, i, small, span} from 'react-hyperscript-helpers';
-import ReactTooltip from 'react-tooltip';
 import ResearcherInfo from './dar_application/ResearcherInfo';
 import DataAccessRequest from './dar_application/DataAccessRequest';
 import ResearchPurposeStatement from './dar_application/ResearchPurposeStatement';
@@ -165,7 +164,6 @@ class DataAccessRequestApplication extends Component {
 
   async componentDidMount() {
     await this.init();
-    ReactTooltip.rebuild();
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     this.setState(prev => {
       prev.notificationData = notificationData;

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import { Component } from 'react';
 import {button, div, form, h, hh, hr, input, label, span, textarea } from 'react-hyperscript-helpers';
-import ReactTooltip from 'react-tooltip';
 import { LibraryCards } from '../components/LibraryCards';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { eRACommons } from '../components/eRACommons';
@@ -31,7 +30,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   async componentDidMount() {
     this.getResearcherProfile();
-    ReactTooltip.rebuild();
     this.props.history.push('profile');
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     this.setState(prev => {
@@ -137,7 +135,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
           return prev;
         });
       }
-      ReactTooltip.rebuild();
     });
   }
 
@@ -940,28 +937,15 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                   }, ['Continue later']),
 
                   ConfirmationDialog({
-                      title: 'Continue later',
-                      color: 'common',
-                      showModal: this.state.showDialogSave,
-                      action: { label: 'Yes', handler: this.dialogHandlerSave }
-                    }, [
-                      div({ className: 'dialog-description' },
-                        ['Are you sure you want to leave this page? Please remember that you need to submit your Profile information to be able to create a Data Access Request.'])
-                    ]
+                    title: 'Continue later',
+                    color: 'common',
+                    showModal: this.state.showDialogSave,
+                    action: { label: 'Yes', handler: this.dialogHandlerSave }
+                  }, [
+                    div({ className: 'dialog-description' },
+                      ['Are you sure you want to leave this page? Please remember that you need to submit your Profile information to be able to create a Data Access Request.'])
+                  ]
                   ),
-                  h(ReactTooltip, {
-                    id: 'tip_clearNihAccount',
-                    place: 'right',
-                    effect: 'solid',
-                    multiline: true,
-                    className: 'tooltip-wrapper'
-                  }),
-                  h(ReactTooltip, {
-                    id: 'tip_isthePI',
-                    effect: 'solid',
-                    multiline: true,
-                    className: 'tooltip-wrapper'
-                  })
                 ])
               ])
             ])

--- a/src/pages/dar_application/DataUseAgreements.js
+++ b/src/pages/dar_application/DataUseAgreements.js
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { a, div, fieldset, h, h3, label, li, ol, ul, p, span} from 'react-hyperscript-helpers';
 import isNil from 'lodash/fp/isNil';
 import { Alert } from '../../components/Alert';
-import ReactTooltip from 'react-tooltip';
 
 const StepAlertTemplate = (props) => {
   const ulLinkStyle = {
@@ -139,7 +138,6 @@ export default function DataUseAgreements(props) {
             className: 'f-right btn-primary access-background bold'
           }, ['Attest and Send']),
           ConfirmationDialogComponent,
-          h(ReactTooltip, { id: 'tip_clearNihAccount', place: 'right', effect: 'solid', multiline: true, className: 'tooltip-wrapper' }),
           a({
             id: 'btn_save', isRendered: isNil(darCode), onClick: partialSave,
             className: 'f-right btn-secondary access-color'


### PR DESCRIPTION
Addresses [DUOS-938](https://broadworkbench.atlassian.net/browse/DUOS-938)

Code removes ReactTooltip components from DAR Application and Researcher Profile. This component caused stray black borders to be rendered on the bottom of the associated pages. Seeing that the component wasn't being utilized, removing the component altogether is the fastest way to address the issue

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
