### PR TITLE
DUOS-971 [risk=no] Updated primary and secondary translations within dataUseTranslation

### DIFF
--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -6,11 +6,14 @@ import { StructuredDarRp } from './StructuredDarRp';
 import {Theme} from '../libs/theme';
 import * as Utils from '../libs/utils';
 import * as ld from 'lodash';
+import {DataUseTranslation} from '../libs/dataUseTranslation';
 
 export const ApplicationSummary = hh(class ApplicationSummary extends PureComponent {
 
   render() {
-    const { hasUseRestriction, mrDAR, darInfo, downloadDAR, researcherProfile } = this.props;
+    let {darInfo} = this.props;
+    const { hasUseRestriction, mrDAR, downloadDAR, researcherProfile } = this.props;
+    darInfo.purposeStatements = DataUseTranslation.generatePurposeStatement(darInfo);
     const libraryCards = ld.get(researcherProfile, 'libraryCards', []);
     return div({className: 'col-lg-8 col-md-8 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
       div({ className: 'panel-heading cm-boxhead access-color' }, [

--- a/src/components/YesNoRadioGroup.js
+++ b/src/components/YesNoRadioGroup.js
@@ -24,7 +24,7 @@ export const YesNoRadioGroup = (props) => {
             id: "lbl_" + props.id + "_" + ix,
             htmlFor: "rad_" + id + "_" + ix,
             className: "radio-wrapper",
-            style: props.disabled ? {opacity: 0.6, cursor: "not-allowed"} : {}
+            style: disabled ? {opacity: 0.6, cursor: "not-allowed"} : {}
           }, [
             input({
               type: "radio",

--- a/src/components/YesNoRadioGroup.js
+++ b/src/components/YesNoRadioGroup.js
@@ -1,4 +1,5 @@
 import { div, input, label, span } from 'react-hyperscript-helpers';
+import isNil from 'lodash/fp/isNil';
 import './RadioGroups.css';
 
 export const YesNoRadioGroup = (props) => {
@@ -8,35 +9,35 @@ export const YesNoRadioGroup = (props) => {
     props.onChange(e, props.name, value);
   };
 
-  const { id, name, optionValues = ['true', 'false'], optionLabels = ['Yes', 'No'], value } = props;
+  const { id, name, optionValues = ['true', 'false'], optionLabels = ['Yes', 'No'], value, disabled } = props;
   const normValue = (value === 'true' || value === true || value === '1') ? 'true' :
     (value === 'false' || value === false || value === '0') ? 'false' : null;
 
   return (
-
     div({ className: 'radio-inline' }, [
       optionLabels.map((option, ix) => {
         return (
 
           label({
             key: id + ix,
-            onClick: (e) => selectOption(e, optionValues[ix]),
+            onClick: (e) => !isNil(props.onChange) && selectOption(e, optionValues[ix]),
             id: "lbl_" + props.id + "_" + ix,
             htmlFor: "rad_" + id + "_" + ix,
-            className: "radio-wrapper"
+            className: "radio-wrapper",
+            style: props.disabled ? {opacity: 0.6, cursor: "not-allowed"} : {}
           }, [
-              input({
-                type: "radio",
-                id: "rad_" + id + "_" + ix,
-                name: name,
-                value: optionValues[ix],
-                checked: normValue === optionValues[ix],
-                onChange: () => { }
-              }),
-              span({ className: "radio-check" }),
-              span({ className: "radio-label" }, [optionLabels[ix]])
-            ])
-         );
+            input({
+              type: "radio",
+              id: "rad_" + id + "_" + ix,
+              name: name,
+              value: optionValues[ix],
+              checked: normValue === optionValues[ix],
+              onChange: () => { }
+            }),
+            span({ className: "radio-check" }),
+            span({ className: "radio-label" }, [optionLabels[ix]])
+          ])
+        );
       })
     ])
   );

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -328,10 +328,6 @@ export const DataUseTranslation = {
     if (darInfo.stigmatizedDiseases) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.stigmatizedDiseases);
     }
-    if(darInfo.population) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.population);
-    }
-
     if (darInfo.vulnerablePopulation) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.vulnerablePopulation);
     }

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -95,6 +95,11 @@ const srpTranslations = {
     description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).',
     manualReview: true
   },
+  populationMigration: {
+    code: 'OTHER',
+    description: 'The dataset will be used for a study or population origins and/or migration patterns',
+    manualReview: true
+  },
   psychiatricTraits: {
     code: 'OTHER',
     description: 'The dataset will be used for the study of psychological traits, including intelligence, attention, emotion.',
@@ -241,7 +246,7 @@ export const DataUseTranslation = {
       statementArray = concat(statementArray)(srpTranslations.controls);
     }
 
-    if(darInfo.population || darInfo.poa) {
+    if(darInfo.poa) {
       statementArray = concat(statementArray)(srpTranslations.poa);
     }
 
@@ -278,11 +283,11 @@ export const DataUseTranslation = {
      *
      * Tracing this through to Ontology, both refer to http://purl.obolibrary.org/obo/DUO_0000011 which is POA
      */
-    if (darInfo.poa || darInfo.population || darInfo.populationMigration) {
+    if (darInfo.poa) {
       dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.poa);
     }
-    if (darInfo.diseases && !isEmpty(darInfo.diseases)) {
-      const diseaseTranslation = srpTranslations.diseases(clone(darInfo.diseases));
+    if (darInfo.diseases && !isEmpty(darInfo.ontologies)) {
+      const diseaseTranslation = srpTranslations.diseases(clone(darInfo.ontologies));
       dataUseSummary.primary = uniq(concat(dataUseSummary.primary)(diseaseTranslation));
     }
     if (darInfo.other) {
@@ -290,7 +295,6 @@ export const DataUseTranslation = {
     }
 
     // Secondary Codes
-
     if (darInfo.methods) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.methods);
     }
@@ -323,6 +327,9 @@ export const DataUseTranslation = {
     }
     if (darInfo.vulnerablePopulation) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.vulnerablePopulation);
+    }
+    if(darInfo.populationMigration) {
+      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.populationMigration);
     }
     if (darInfo.psychiatricTraits) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.psychiatricTraits);

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -95,9 +95,9 @@ const srpTranslations = {
     description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).',
     manualReview: true
   },
-  populationMigration: {
+  population: {
     code: 'OTHER',
-    description: 'The dataset will be used for a study or population origins and/or migration patterns',
+    description: 'The dataset will be used to study variations within the general population (e.g., general substructure of a population).',
     manualReview: true
   },
   psychiatricTraits: {
@@ -246,7 +246,7 @@ export const DataUseTranslation = {
       statementArray = concat(statementArray)(srpTranslations.controls);
     }
 
-    if(darInfo.poa) {
+    if(darInfo.poa || darInfo.populationMigration) {
       statementArray = concat(statementArray)(srpTranslations.poa);
     }
 
@@ -283,9 +283,12 @@ export const DataUseTranslation = {
      *
      * Tracing this through to Ontology, both refer to http://purl.obolibrary.org/obo/DUO_0000011 which is POA
      */
-    if (darInfo.poa) {
+
+    //NOTE: additional check on hmb, diseases, and other are needed for older DARs where populationMigration - poa link was not established
+    if ((darInfo.poa || darInfo.populationMigration) && (!darInfo.hmb && !darInfo.diseases && !darInfo.other)) {
       dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.poa);
     }
+
     if (darInfo.diseases && !isEmpty(darInfo.ontologies)) {
       const diseaseTranslation = srpTranslations.diseases(clone(darInfo.ontologies));
       dataUseSummary.primary = uniq(concat(dataUseSummary.primary)(diseaseTranslation));
@@ -325,11 +328,15 @@ export const DataUseTranslation = {
     if (darInfo.stigmatizedDiseases) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.stigmatizedDiseases);
     }
+    if(darInfo.population) {
+      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.population);
+    }
+
     if (darInfo.vulnerablePopulation) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.vulnerablePopulation);
     }
-    if(darInfo.populationMigration) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.populationMigration);
+    if(darInfo.population) {
+      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.population);
     }
     if (darInfo.psychiatricTraits) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.psychiatricTraits);

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -775,6 +775,7 @@ class DataAccessRequestApplication extends Component {
     this.setState(prev => {
       prev.formData.hmb = true;
       prev.formData.poa = false;
+      prev.formData.populationMigration = false;
       prev.formData.diseases = false;
       prev.formData.other = false;
       prev.formData.otherText = '';
@@ -787,6 +788,12 @@ class DataAccessRequestApplication extends Component {
     this.setState(prev => {
       prev.formData.hmb = false;
       prev.formData.poa = true;
+      //populationMigration's value is the same as poa since they're the same question
+      //however business context requires the two questions to exist on both step 2 and 3
+      //therefore both keys needed to distinguish position in application
+      //therefore populationMigration (step 3 question) will have it's value set by poa
+      //ui element for populationMigration will be disables on step 3
+      prev.formData.populationMigration = true;
       prev.formData.diseases = false;
       prev.formData.other = false;
       prev.formData.otherText = '';
@@ -798,6 +805,7 @@ class DataAccessRequestApplication extends Component {
   setDiseases = (e) => {
     let applyToState = {
       poa: false,
+      populationMigration: false,
       other: false,
       otherText: ''
     };
@@ -826,6 +834,7 @@ class DataAccessRequestApplication extends Component {
     this.setState(prev => {
       prev.formData.hmb = false;
       prev.formData.poa = false;
+      prev.formData.populationMigration = false;
       prev.formData.diseases = false;
       prev.formData.other = true;
       prev.formData.ontologies = [];
@@ -899,6 +908,7 @@ class DataAccessRequestApplication extends Component {
       hmb: hmb,
       hmbHandler: this.setHmb,
       poa: poa,
+      populationMigration: this.state.formData.populationMigration,
       poaHandler: this.setPoa,
       diseases: diseases,
       diseasesHandler: this.setDiseases,
@@ -1092,7 +1102,14 @@ class DataAccessRequestApplication extends Component {
                 oneGender: this.state.formData.oneGender,
                 partialSave: this.partialSave,
                 pediatric: this.state.formData.pediatric,
-                populationMigration: this.state.formData.populationMigration,
+                /*
+                  NOTE: Assignment below is intentional. populationMigration and POA will have the same value with
+                  poa as the determinant variable. populationMigration will exists as an indicator of its presence on step 3.
+                  Values for both poa and populationMigration will be updated on selection handlers for step 2.
+                  Display value for step 3 need to be based off of poa since older DARs were not created under this standard
+                  Standard decision made on 01/28/2021, will add implementation date later
+                */
+                populationMigration: this.state.formData.poa,
                 prevPage: this.prevPage,
                 psychiatricTraits: this.state.formData.psychiatricTraits,
                 sexualDiseases: this.state.formData.sexualDiseases,

--- a/src/pages/dar_application/ResearchPurposeStatement.js
+++ b/src/pages/dar_application/ResearchPurposeStatement.js
@@ -269,6 +269,9 @@ export default function ResearchPurposeStatement(props) {
             ]),
           ]),
 
+          //NOTE: Question should be disabled since answer is based on whether or not poa is selected
+          //Question will reamain here since Executive Board made conscious decision to leave step 3 questions as is
+          //Value equivalency is explained on DataAccessRequestApplication comments (in the middle of props assignment for this component)
           div({
             className: 'radio-question-container row no-margin', style: {
               backgroundColor: showValidationMessages && populationMigration.toString().length === 0 ? alertBackgroundColor : 'inherit'
@@ -278,19 +281,20 @@ export default function ResearchPurposeStatement(props) {
               className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'
             }, [
               label({
-                className: 'control-label rp-choice-questions'
+                className: 'control-label rp-choice-questions',
               },
-              ['3.1.9 Does the research aim involve the study of Population Origins/Migration patterns?'])
+              ['3.1.9 Does the research aim involve the study of Population Origins/Migration patterns? (Answer is pre-determined based on selections made in Step 2)',
+              ])
             ]),
             div({
               className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'
             }, [
               YesNoRadioGroup({
                 value: populationMigration,
-                onChange: handleRadioChange,
                 id: 'populationMigration',
                 name: 'populationMigration',
-                required: true
+                required: true,
+                disabled: true
               })
             ]),
           ]),


### PR DESCRIPTION
Addresses [DUOS-971](https://broadworkbench.atlassian.net/browse/DUOS-971)

Code makes adjustments to the primary and secondary statements within the dataUseTranslation utility file. PR separates POA from populationMigration by evaluating them in their proper categories (poa in primary, popMigration in secondary). Code also corrects disease statement analysis by correcting the reference to ontologies.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
