### PR TITLE
DUOS-765 Pagination/Search added to New Chair Console

### DIFF
--- a/src/components/PaginationBar.js
+++ b/src/components/PaginationBar.js
@@ -1,6 +1,7 @@
 import { div, input, span } from 'react-hyperscript-helpers';
 import { useRef, useEffect } from 'react';
 import { toNumber } from 'lodash';
+import { Theme } from '../libs/theme';
 
 //NOTE: This is a new pagination made to fit with the updated table look
 //Component does not use third-party libraries for pagination, whereas the old version relies on 'react-pagination'
@@ -25,7 +26,7 @@ export default function PaginationBar(props) {
           span({
             onClick: (e) => goToPage(toNumber(currentPage.current.value) - 1),
             onMouseEnter: applyTextHover,
-            onMouseLeave: (e) => removeTextHover(e, '#1f3b50'),
+            onMouseLeave: (e) => removeTextHover(e, Theme.palette.primary),
           },['Prev']),
         ]),
         div({style: Styles.TABLE.CURRENT_PAGE}, [

--- a/src/components/PaginationBar.js
+++ b/src/components/PaginationBar.js
@@ -1,0 +1,66 @@
+import { div, input, span } from 'react-hyperscript-helpers';
+import { useRef, useEffect } from 'react';
+import { toNumber } from 'lodash';
+
+//NOTE: This is a new pagination made to fit with the updated table look
+//Component does not use third-party libraries for pagination, whereas the old version relies on 'react-pagination'
+//Style works with Current Dar Table, but allows for modification with styles passed as a prop
+export default function PaginationBar(props) {
+  const {pageCount, goToPage, changeTableSize, Styles, applyTextHover, removeTextHover} = props;
+  const currentPage = useRef(props.currentPage);
+  const tableSize = useRef(props.tableSize);
+
+  useEffect(() => {
+    currentPage.current.value = props.currentPage;
+    tableSize.current.value = props.tableSize;
+  }, [props.currentPage, props.tableSize]);
+
+  return (
+    div({style: Styles.TABLE.FOOTER}, [
+      div({style: Styles.TABLE.PAGINATION_SECTION_OFFSET}),
+      div({style: Styles.TABLE.PAGINATION_BUTTON_SECTION}, [
+        div({
+          style: Styles.TABLE.PAGINATION_BUTTON
+        }, [
+          span({
+            onClick: (e) => goToPage(toNumber(currentPage.current.value) - 1),
+            onMouseEnter: applyTextHover,
+            onMouseLeave: (e) => removeTextHover(e, '#1f3b50'),
+          },['Prev']),
+        ]),
+        div({style: Styles.TABLE.CURRENT_PAGE}, [
+          span({},['Page ']),
+          input({
+            onChange: (e) => goToPage(toNumber(currentPage.current.value)),
+            type: 'text',
+            pattern: '[0-9]+',
+            ref: currentPage,
+            defaultvalue: props.currentPage,
+            style: Styles.TABLE.PAGINATION_INPUT
+          }),
+          span({}, [` of ${pageCount}`])
+        ]),
+        div({
+          style: Styles.TABLE.PAGINATION_BUTTON
+        }, [
+          span({
+            onClick: (e) => goToPage(toNumber(currentPage.current.value) + 1),
+            onMouseEnter: applyTextHover,
+            onMouseLeave: (e) => removeTextHover(e, '#1f3b50')
+          }, ['Next'])
+        ]),
+      ]),
+      div({style: Styles.TABLE.PAGINATION_TABLE_SIZE_SECTION}, [
+        span({style: {}}, ['Rows per page: ']),
+        input({
+          onChange: (e) => changeTableSize(tableSize.current.value),
+          type: 'text',
+          pattern: '[0-9]+',
+          ref: tableSize,
+          defaultvalue: props.tableSize,
+          style: Styles.TABLE.PAGINATION_INPUT
+        })
+      ])
+    ])
+  );
+};

--- a/src/components/PaginationBar.js
+++ b/src/components/PaginationBar.js
@@ -4,7 +4,7 @@ import { toNumber } from 'lodash';
 
 //NOTE: This is a new pagination made to fit with the updated table look
 //Component does not use third-party libraries for pagination, whereas the old version relies on 'react-pagination'
-//Style works with Current Dar Table, but allows for modification with styles passed as a prop
+//Style works with Current Dar Table, but allows for modification with styles passed as a prop (though I expect to do some more fine-tuning with future implementations)
 export default function PaginationBar(props) {
   const {pageCount, goToPage, changeTableSize, Styles, applyTextHover, removeTextHover} = props;
   const currentPage = useRef(props.currentPage);
@@ -33,7 +33,6 @@ export default function PaginationBar(props) {
           input({
             onChange: (e) => goToPage(toNumber(currentPage.current.value)),
             type: 'text',
-            pattern: '[0-9]+',
             ref: currentPage,
             defaultvalue: props.currentPage,
             style: Styles.TABLE.PAGINATION_INPUT
@@ -51,11 +50,10 @@ export default function PaginationBar(props) {
         ]),
       ]),
       div({style: Styles.TABLE.PAGINATION_TABLE_SIZE_SECTION}, [
-        span({style: {}}, ['Rows per page: ']),
+        span({style: {marginRight: '2%'}}, ['Rows per page: ']),
         input({
           onChange: (e) => changeTableSize(tableSize.current.value),
           type: 'text',
-          pattern: '[0-9]+',
           ref: tableSize,
           defaultvalue: props.tableSize,
           style: Styles.TABLE.PAGINATION_INPUT

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -92,7 +92,8 @@ export const Styles = {
   },
   RIGHT_HEADER_SECTION: {
     display: 'flex',
-    alignItems: 'flex-end'
+    alignItems: 'flex-end',
+    width: '25%',
   },
   LEFT_HEADER_SECTION: {
     display: 'flex',
@@ -127,6 +128,9 @@ export const Styles = {
     DAR_TEXT_HOVER: {
       cursor: 'pointer',
       color: '#0cabc5d9'
+    },
+    RECORD_ROW_HOVER: {
+      backgroundColor: '#e2eef9'
     },
     DATA_REQUEST_TEXT: {
       color: "#00609F",
@@ -188,7 +192,34 @@ export const Styles = {
       width: "100%",
       display: 'flex',
       justifyContent: 'center'
-    }
+    },
+    PAGINATION_SECTION_OFFSET: {
+      flex: 1
+    },
+    PAGINATION_BUTTON_SECTION: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      flex: 1
+    },
+    PAGINATION_BUTTON: {
+      margin: '2%',
+      flex: 1
+    },
+    PAGINATION_CURRENT_PAGE: {
+      margin: '2% 0',
+      flex: 2
+    },
+    PAGINATION_INPUT: {
+      textAlign: 'center',
+      width: '20%'
+    },
+    PAGINATION_TABLE_SIZE_SECTION: {
+      display: 'flex',
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'flex-end'
+    },
   },
   MODAL: {
     CONTENT: {
@@ -233,12 +264,6 @@ export const Styles = {
       fontSize: '16px',
       fontWeight: Theme.font.weight.medium,
       width: "70%"
-    }
-  },
-  PAGINATION_BAR: {
-    OPTION: {
-      flex: 1,
-      margin: "2%"
     }
   }
 };

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -174,6 +174,17 @@ export const Styles = {
       display: "flex",
       justifyContent: "left",
       alignItems: "center",
+    },
+    FOOTER: {
+      display: 'flex',
+      color: "#00243C",
+      fontSize: '14px'
+    },
+    END_FOOTER_SECTION: {
+      width: "20%"
+    },
+    MIDDLE_FOOTER_SECTION: {
+      width: "25%"
     }
   },
   MODAL: {

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -212,7 +212,8 @@ export const Styles = {
     },
     PAGINATION_INPUT: {
       textAlign: 'center',
-      width: '20%'
+      width: '20%',
+      fontFamily: 'Montserrat'
     },
     PAGINATION_TABLE_SIZE_SECTION: {
       display: 'flex',

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -176,15 +176,18 @@ export const Styles = {
       alignItems: "center",
     },
     FOOTER: {
+      backgroundColor: "#f3f6f7",
+      fontSize: '14px',
+      fontFamily: "Montserrat",
       display: 'flex',
-      color: "#00243C",
-      fontSize: '14px'
+      padding: '0 1%',
+      justifyContent: 'flex-end',
+      height: '51px'
     },
-    END_FOOTER_SECTION: {
-      width: "20%"
-    },
-    MIDDLE_FOOTER_SECTION: {
-      width: "25%"
+    FOOTER_SECTION: {
+      width: "100%",
+      display: 'flex',
+      justifyContent: 'center'
     }
   },
   MODAL: {
@@ -230,6 +233,12 @@ export const Styles = {
       fontSize: '16px',
       fontWeight: Theme.font.weight.medium,
       width: "70%"
+    }
+  },
+  PAGINATION_BAR: {
+    OPTION: {
+      flex: 1,
+      margin: "2%"
     }
   }
 };

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -26,6 +26,16 @@ const removeTextHover = (e, color) => {
   e.target.style.color = color;
 };
 
+const getElectionDate = (election) => {
+  let formattedString = '- -';
+  if(election) {
+    //NOTE: some elections have a createDate attribute but not a lastUpdate attributes
+    const targetDate = election.lastUpdate || election.createDate;
+    formattedString = formatDate(targetDate);
+  }
+  return formattedString;
+}
+
 const Records = (props) => {
   //NOTE: currentPage is not zero-indexed
   const {openModal, currentPage, tableSize, applyTextHover, removeTextHover} = props;
@@ -46,7 +56,7 @@ const Records = (props) => {
         onMouseLeave: (e) => removeTextHover(e, Styles.TABLE.DATA_REQUEST_TEXT.color)
       }, [dar && dar.data ? dar.data.darCode : '- -']),
       div({style: Object.assign({}, Styles.TABLE.TITLE_CELL, recordTextStyle)}, [dar && dar.data ? dar.data.projectTitle : '- -']),
-      div({style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL, recordTextStyle)}, [election ? formatDate(election.lastUpdate) : '- -']),
+      div({style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL, recordTextStyle)}, [getElectionDate(election)]),
       div({style: Object.assign({}, Styles.TABLE.DAC_CELL, recordTextStyle)}, [dac ? dac.name : '- -']),
       div({style: Object.assign({}, Styles.TABLE.ELECTION_STATUS_CELL, recordTextStyle)}, [election ? election.status : '- -']),
       div({style: Object.assign({}, Styles.TABLE.ELECTION_ACTIONS_CELL, recordTextStyle)}, ['Placeholder for buttons. (font style is placeholder as well)'])
@@ -117,7 +127,7 @@ const NewChairConsole = () => {
             const dar = electionData.dar ? electionData.dar.data : undefined;
             const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode)]) : [];
             const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
-            const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(election.status), formatDate(election.lastUpdate)]) : [];
+            const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(election.status), getElectionDate(election)]) : [];
             return includes(term, targetDarAttrs) || includes(term, targetDacAttrs) || includes(term, targetElectionAttrs);
           }, newFilteredList);
         }
@@ -158,13 +168,16 @@ const NewChairConsole = () => {
           input({
             type: 'text',
             placeholder: 'Enter search terms',
-            style: { //Styling seems to only work when defined here, variable reference doesn't work
+            //Styling seems to only work when defined here, variable reference doesn't work
+            //Odds are there's a competing style, need to figure out where it's coming from
+            style: {
               width: '100%',
               border: '1px solid #cecece',
-              backgroundColor: 'aliceblue',
+              backgroundColor: '#f3f6f7',
               borderRadius: '5px',
-              height: '3rem',
-              paddingLeft: '2%'
+              height: '4rem',
+              paddingLeft: '2%',
+              fontFamily: 'Montserrat'
             },
             onChange:(e) => handleSearchChange(searchTerms.current),
             ref: searchTerms
@@ -175,7 +188,7 @@ const NewChairConsole = () => {
         div({style: Styles.TABLE.HEADER_ROW}, [
           div({style: Styles.TABLE.DATA_ID_CELL}, ["Data Request ID"]),
           div({style: Styles.TABLE.TITLE_CELL}, ["Project title"]),
-          div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Submission date"]),
+          div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Last Updated"]),
           div({style: Styles.TABLE.DAC_CELL}, ["DAC"]),
           div({style: Styles.TABLE.ELECTION_STATUS_CELL}, ["Election status"]),
           div({style: Styles.TABLE.ELECTION_ACTIONS_CELL}, ["Election actions"])

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -34,7 +34,7 @@ const getElectionDate = (election) => {
     formattedString = formatDate(targetDate);
   }
   return formattedString;
-}
+};
 
 const Records = (props) => {
   //NOTE: currentPage is not zero-indexed
@@ -114,7 +114,7 @@ const NewChairConsole = () => {
 
   const handleSearchChange = () => {
     setCurrentPage(1);
-    const searchTermValues = toLower(searchTerms.current.value).split(/\s|\,/);
+    const searchTermValues = toLower(searchTerms.current.value).split(/\s|,/);
     if(isEmpty(searchTermValues)) {
       setFilteredList(electionList);
     } else {

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -1,4 +1,4 @@
-import {isEmpty, isNil, includes, toLower, filter} from 'lodash/fp';
+import {isEmpty, isNil, includes, toLower, filter, cloneDeep} from 'lodash/fp';
 import { useState, useEffect, useRef} from 'react';
 import { div, h, img, input } from 'react-hyperscript-helpers';
 import { DAR} from '../libs/ajax';
@@ -6,6 +6,7 @@ import { DataUseTranslation } from '../libs/dataUseTranslation';
 import {Notifications, formatDate} from '../libs/utils';
 import { Styles} from '../libs/theme';
 import DarModal from '../components/modals/DarModal';
+import { toNumber } from 'lodash';
 
 const getDatasetNames = (datasets) => {
   if(!datasets){return '';}
@@ -15,7 +16,34 @@ const getDatasetNames = (datasets) => {
   return datasetNames.join('\n');
 };
 
+const PaginationBar = (props) => {
+  const {pageCount, goToPage} = props;
+  const currentPage = useRef(props.currentPage);
+
+  useEffect(() => {
+    currentPage.current.value = props.currentPage;
+  }, [props.currentPage]);
+
+  return (
+    div({}, [
+      div({onClick: (e) => goToPage(toNumber(currentPage.current.value) - 1)}, ['Prev']),
+      div({}, [//insert middle style
+        'Page ',
+        input({
+          onChange: (e) => goToPage(toNumber(currentPage.current.value)),
+          type: 'text',
+          ref: currentPage,
+          defaultvalue: props.currentPage
+        }),
+        `of ${pageCount}`
+      ]),
+      div({onClick: (e) => goToPage(toNumber(currentPage.current.value) + 1)}, ['Next'])
+    ])
+  );
+};
+
 const Records = (props) => {
+  //NOTE: currentPage is not zero-indexed
   const {openModal, currentPage, tableSize} = props;
   const startIndex = (currentPage - 1) * tableSize;
   const endIndex = currentPage * tableSize; //NOTE: endIndex is exclusive, not inclusive
@@ -35,7 +63,7 @@ const Records = (props) => {
   return visibleWindow.map((electionInfo, index) => {
     const {dar, dac, election} = electionInfo;
     const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};
-    return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${dar.data.darCode}`}, [
+    return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${dar.data.referenceId}`}, [
       div({
         style: Object.assign({}, Styles.TABLE.DATA_ID_CELL, dataIDTextStyle),
         onClick: (e) => openModal(dar),
@@ -55,10 +83,11 @@ const NewChairConsole = () => {
   const [showModal, setShowModal] = useState(false);
   const [electionList, setElectionList] = useState([]);
   const [filteredList, setFilteredList] = useState([]);
-  const [tableSize, setTableSize] = useState(15);
+  const [tableSize, setTableSize] = useState();
   const [darDetails, setDarDetails] = useState({});
   const [currentPage, setCurrentPage] = useState(1);
-  const searchTerms = useRef();
+  const [pageCount, setPageCount] = useState(1);
+  const searchTerms = useRef('');
 
   useEffect(() => {
     const init = async() => {
@@ -66,6 +95,8 @@ const NewChairConsole = () => {
         const pendingList = await DAR.getDataAccessManageV2();
         setElectionList(pendingList);
         setFilteredList(pendingList);
+        setTableSize(15);
+        setPageCount(Math.ceil(pendingList.length / 15));
       } catch(error) {
         Notifications.showError({text: 'Error: Unable to retreive data requests from server'});
       };
@@ -90,19 +121,33 @@ const NewChairConsole = () => {
   };
 
   const handleSearchChange = () => {
-    const searchTermValue = toLower(searchTerms.current.value);
-    if(isEmpty(searchTermValue)) {
+    setCurrentPage(1);
+    const searchTermValues = toLower(searchTerms.current.value).split(/\s|\,/);
+    if(isEmpty(searchTermValues)) {
       setFilteredList(electionList);
     } else {
-      const newFilteredList = filter(electionData => {
-        const { election, dac} = electionData;
-        const dar = electionData.dar ? election.dar.data : undefined;
-        const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode)]) : [];
-        const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
-        const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(election.status), election.lastUpdate]) : [];
-        return includes(searchTermValue, targetDarAttrs) || includes(searchTermValue, targetDacAttrs) || includes(searchTermValue, targetElectionAttrs);
-      }, electionList);
+      let newFilteredList = cloneDeep(electionList);
+      searchTermValues.forEach((splitTerm) => {
+        const term = splitTerm.trim();
+        if(!isEmpty(term)) {
+          newFilteredList = filter(electionData => {
+            const { election, dac} = electionData;
+            const dar = electionData.dar ? electionData.dar.data : undefined;
+            const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode)]) : [];
+            const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
+            const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(election.status), formatDate(election.lastUpdate)]) : [];
+            return includes(term, targetDarAttrs) || includes(term, targetDacAttrs) || includes(term, targetElectionAttrs);
+          }, newFilteredList);
+        }
+      });
       setFilteredList(newFilteredList);
+    }
+  };
+
+  //NOTE: send this function to Pagination component to update currentPage on ChairConsole
+  const goToPage = (currentPage) => {
+    if(currentPage > 0 && currentPage < pageCount + 1) {
+      setCurrentPage(currentPage);
     }
   };
 
@@ -122,11 +167,12 @@ const NewChairConsole = () => {
             div({style: Styles.SMALL}, ["Select and manage Data Access Requests for DAC review"])
           ])
         ]),
+        //NOTE: genericize this component, it can be reused
         div({className: "right-header-section", style: Styles.RIGHT_HEADER_SECTION}, [
           input({
             type: 'text',
             placeholder: 'Enter search terms',
-            onChange: handleSearchChange,
+            onChange:(e) => handleSearchChange(searchTerms.current),
             ref: searchTerms
           })
         ])
@@ -142,6 +188,18 @@ const NewChairConsole = () => {
         ]),
         //NOTE: for now table is rendering electionList (the full list), will implement controlled view as part of pagination PR
         h(Records, {isRendered: !isEmpty(filteredList), filteredList, openModal, currentPage, tableSize})
+      ]),
+      div({style: Styles.TABLE.FOOTER}, [
+        div({style: Styles.TABLE.END_FOOTER_SECTION}, [
+
+        ]),
+        //NOTE: genericize this component, it can be reused
+        div({style: Styles.TABLE.MIDDLE_FOOTER_SECTION}, [
+          h(PaginationBar, {pageCount, currentPage, tableSize, goToPage})
+        ]),
+        div({styles: Styles.TABLE.END_FOOTER_SECTION}, [
+
+        ])
       ]),
       //NOTE: TODO -> continue working/styling out modal
       h(DarModal, {showModal, closeModal, darDetails})


### PR DESCRIPTION
Addresses [DUOS-765](https://broadworkbench.atlassian.net/browse/DUOS-765)

PR adds Pagination and search to New Chair Console. New Pagination component was made to remove dependency on `react-pagination` library. Search has been slightly modified to allow for a drill-down search on space or comma separated terms (search will split the list of terms and reduce the list iteratively).

NOTE: Noticed an issue on dev where multiple DARs with the same content (referenceID was identical) were being returned from the endpoint, which is why certain DARs will look to be repeated. From the UI's point of view these DARs are unique, so it'll render all of them. Choosing a specific DAR from the list of duplicates was not implemented since that would have to be a standard that must be applied to all UI elements (since you're effectively designating a specific election as the de-facto choice). Will hold off on implementing such a filter until further details are hashed out.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
