### PR TITLE
[DUOS-1018][risk=no] Remove rpVoteId for populating the voting page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -95,7 +95,7 @@ const Routes = (props) => (
       rolesAllowed={[USER_ROLES.admin, USER_ROLES.alumni]} />
     <AuthenticatedRoute path="/dul_results_record/:electionId" component={DulResultRecords} props={props}
       rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson, USER_ROLES.member, USER_ROLES.alumni]} />
-    <AuthenticatedRoute path="/access_review/:darId/:voteId/:rpVoteId?" component={AccessReview} props={props}
+    <AuthenticatedRoute path="/access_review/:darId/:voteId" component={AccessReview} props={props}
       rolesAllowed={[USER_ROLES.member, USER_ROLES.chairperson]}/>
     <AuthenticatedRoute path="/access_preview/:referenceId?/:electionId?" component={AccessPreview} props={props}
       rolesAllowed={[USER_ROLES.admin]} />

--- a/src/pages/ChairConsole.js
+++ b/src/pages/ChairConsole.js
@@ -113,23 +113,16 @@ export const ChairConsole = hh(class ChairConsole extends Component {
     this.props.history.push(`dul_collect/${consentId}`);
   };
 
-  openAccessReview = (referenceId, voteId, rpVoteId, alreadyVoted) => async (e) => {
+  openAccessReview = (referenceId, voteId, alreadyVoted) => async (e) => {
     const pathStart = NavigationUtils.accessReviewPath();
     let chairFinal = false;
     if(this.state.currentUser && alreadyVoted) {
       chairFinal = this.state.currentUser.isChairPerson;
     }
-    if (rpVoteId !== null) {
-      this.props.history.push(
-        `${pathStart}/${referenceId}/${voteId}/${rpVoteId}`,
-        {chairFinal}
-      );
-    } else {
-      this.props.history.push(
-        `${pathStart}/${referenceId}/${voteId}`,
-        {chairFinal}
-      );
-    }
+    this.props.history.push(
+      `${pathStart}/${referenceId}/${voteId}`,
+      {chairFinal}
+    );
   };
 
   isAccessCollectEnabled = (pendingCase) => {
@@ -331,7 +324,7 @@ export const ChairConsole = hh(class ChairConsole extends Component {
                       button({
                         id: pendingCase.frontEndId + '_btnVote',
                         name: 'btn_voteAccess',
-                        onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId, pendingCase.rpVoteId, pendingCase.alreadyVoted),
+                        onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId, pendingCase.alreadyVoted),
                         className: 'cell-button cancel-color'
                       }, [
                         span({ isRendered: (pendingCase.alreadyVoted === false) && (pendingCase.electionStatus !== 'Final') }, ['Vote']),

--- a/src/pages/MemberConsole.js
+++ b/src/pages/MemberConsole.js
@@ -98,13 +98,9 @@ class MemberConsole extends Component {
 
   }
 
-  openAccessReview = (referenceId, voteId, rpVoteId) => async (e) => {
+  openAccessReview = (referenceId, voteId) => async (e) => {
     const pathStart = NavigationUtils.accessReviewPath();
-    if (rpVoteId !== null) {
-      this.props.history.push(`${pathStart}/${referenceId}/${voteId}/${rpVoteId}`);
-    } else {
-      this.props.history.push(`${pathStart}/${referenceId}/${voteId}`);
-    }
+    this.props.history.push(`${pathStart}/${referenceId}/${voteId}`);
   };
 
   openDULReview = (consentId, voteId) => (e) => {
@@ -284,7 +280,7 @@ class MemberConsole extends Component {
                       className: oneColumnClass + ' cell-body text f-center'
                     }, [pendingCase.logged]),
                     div({
-                      onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId, pendingCase.rpVoteId),
+                      onClick: this.openAccessReview(pendingCase.referenceId, pendingCase.voteId),
                       className: twoColumnClass + ' cell-body f-center'
                     }, [
                       button({

--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -41,7 +41,7 @@ class AccessReview extends React.PureComponent {
         const accessVote = await Votes.getDarVote(darId, voteId);
         const accessElectionReview = await Election.findDataAccessElectionReview(accessVote.electionId, false);
         const accessElection = fp.isNil(accessElectionReview) ? null : accessElectionReview.election;
-        const rpElectionReview = await Election.findRPElectionReview(accessElection.electionId, false);
+        const rpElectionReview = fp.isNil(accessElection) ? null : await Election.findRPElectionReview(accessElection.electionId, false);
         const rpElection = fp.isNil(rpElectionReview) ? null : rpElectionReview.election;
         return {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection};
       } catch(error) {

--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -33,7 +33,7 @@ class AccessReview extends React.PureComponent {
   }
 
   async darReviewAccess() {
-    const { darId, voteId, rpVoteId } = this.props.match.params;
+    const { darId, voteId } = this.props.match.params;
 
     // Access Election Information
     const getElectionInformaion = async(darId, voteId) => {
@@ -41,7 +41,7 @@ class AccessReview extends React.PureComponent {
         const accessVote = await Votes.getDarVote(darId, voteId);
         const accessElectionReview = await Election.findDataAccessElectionReview(accessVote.electionId, false);
         const accessElection = fp.isNil(accessElectionReview) ? null : accessElectionReview.election;
-        const rpElectionReview = fp.isNil(rpVoteId) ? null : await Election.findRPElectionReview(accessElection.electionId, false);
+        const rpElectionReview = await Election.findRPElectionReview(accessElection.electionId, false);
         const rpElection = fp.isNil(rpElectionReview) ? null : rpElectionReview.election;
         return {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection};
       } catch(error) {

--- a/src/pages/access_review/AccessReviewHeader.js
+++ b/src/pages/access_review/AccessReviewHeader.js
@@ -1,8 +1,6 @@
 import React from 'react';
-import { div, button, img, hh } from 'react-hyperscript-helpers';
+import { div, img, hh } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
-import { Storage } from '../../libs/storage';
-import { Navigation } from '../../libs/utils';
 
 const TITLE = {
   fontWeight: Theme.font.weight.semibold,
@@ -16,26 +14,13 @@ const SMALL = {
   lineHeight: Theme.font.leading.dense,
 };
 
-const BUTTON = {
-  ...SMALL,
-  fontWeight: Theme.font.weight.semibold,
-  color: Theme.palette.secondary,
-};
-
 export const AccessReviewHeader = hh(class AccessReviewHeader extends React.PureComponent {
 
-  openAccessReview = (referenceId, voteId, rpVoteId) => {
-    if (rpVoteId !== null) {
-      this.props.history.push(`/access_review/${referenceId}/${voteId}/${rpVoteId}`);
-    } else {
-      this.props.history.push(`/access_review/${referenceId}/${voteId}`);
-    }
+  openAccessReview = (referenceId, voteId) => {
+    this.props.history.push(`/access_review/${referenceId}/${voteId}`);
   };
 
   render() {
-    const currentUser = Storage.getCurrentUser();
-    const { history } = this.props;
-    const { darId, voteId, rpVoteId } = this.props.match.params;
     return div(
       {
         style: {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1018

It turns out that we don't need to pass in a research purpose vote id for the user to populate the member/chair voting page. This PR removes it from the paths and button calls and looks up the RP election directly from the access election.

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
