### PR TITLE
[DUOS-606][risk=no] Filter non-active datasets from the admin view

### DIFF
--- a/src/pages/manage_dac/AdminManageDac.js
+++ b/src/pages/manage_dac/AdminManageDac.js
@@ -8,7 +8,7 @@ import { PageHeading } from '../../components/PageHeading';
 import { PaginatorBar } from '../../components/PaginatorBar';
 import { SearchBox } from '../../components/SearchBox';
 import { DAC } from '../../libs/ajax';
-import * as ld from 'lodash';
+import * as fp from 'lodash/fp';
 
 
 const limit = 10;
@@ -43,9 +43,9 @@ class AdminManageDac extends Component {
     this._asyncRequest = DAC.list().then(
       dacs => {
         this._asyncRequest = null;
-        let sorted = ld.sortBy(dacs, 'name');
+        let sorted = fp.sortBy('name')(dacs);
         if (this.state.descendingOrder) {
-          sorted = ld.reverse(sorted);
+          sorted = fp.reverse(sorted);
         }
         this.setState(prev => {
           prev.currentPage = 1;
@@ -131,10 +131,11 @@ class AdminManageDac extends Component {
 
   viewDatasets = async (selectedDac) => {
     const datasets = await DAC.datasets(selectedDac.dacId);
+    const activeDatasets = fp.filter({ active: true })(datasets);
     this.setState(prev => {
       prev.showDatasetsModal = true;
       prev.selectedDac = selectedDac;
-      prev.selectedDatasets = datasets;
+      prev.selectedDatasets = activeDatasets;
       return prev;
     });
   };
@@ -161,9 +162,9 @@ class AdminManageDac extends Component {
   };
 
   sort = (sortField, descendingOrder = false) => (event) => {
-    let sorted = ld.sortBy(this.state.dacs, sortField);
+    let sorted = fp.sortBy(sortField)(this.state.dacs);
     if (descendingOrder) {
-      sorted = ld.reverse(sorted);
+      sorted = fp.reverse(sorted);
     }
     this.setState(prev => {
       prev.dacs = sorted;

--- a/src/pages/manage_dac/AdminManageDac.js
+++ b/src/pages/manage_dac/AdminManageDac.js
@@ -36,6 +36,7 @@ class AdminManageDac extends Component {
   }
 
   componentDidMount() {
+    // noinspection JSIgnoredPromiseFromCall
     this.fetchDacList();
   };
 
@@ -161,7 +162,7 @@ class AdminManageDac extends Component {
     return true;
   };
 
-  sort = (sortField, descendingOrder = false) => (event) => {
+  sort = (sortField, descendingOrder = false) => () => {
     let sorted = fp.sortBy(sortField)(this.state.dacs);
     if (descendingOrder) {
       sorted = fp.reverse(sorted);
@@ -218,7 +219,7 @@ class AdminManageDac extends Component {
 
           this.state.dacs.filter(this.searchTable(searchDacText))
             .slice((currentPage - 1) * limit, currentPage * this.state.limit)
-            .map((dac, eIndex) => {
+            .map(dac => {
               return (h(Fragment, { key: dac.dacId }, [
                 div({
                   id: dac.dacId,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-606

DACs are allowed to see their inactive datasets which account for the ones with no ID and appear to be duplicates. However, inactive datasets are not helpful in the view where Admins look at the datasets a DAC is managing. Filter those out.

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
