### PR TITLE
[DUOS-1019][risk=no] Update DAR Modal Design

### DIFF
--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -28,8 +28,8 @@ const returnPIName = (researcher) => {
 };
 
 const returnInstitution = (researcher) => {
-  const piNameProp = find({propertyKey: "institution"})(researcher.researcherProperties);
-  return isNil(piNameProp) ? '- -' : piNameProp.propertyValue;
+  const institutionProp = find({propertyKey: "institution"})(researcher.researcherProperties);
+  return isNil(institutionProp) ? '- -' : institutionProp.propertyValue;
 };
 
 const processResearchTypes = (researchTypes) => {

--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -2,6 +2,7 @@ import { div, h } from 'react-hyperscript-helpers';
 import { Styles } from '../../libs/theme';
 import Modal from 'react-modal';
 import {isEmpty} from 'lodash/fp';
+import {Alert} from '../Alert';
 
 const ModalDetailRow = (props) => {
   return (
@@ -32,6 +33,15 @@ const processResearchTypes = (researchTypes) => {
   return researchStatements;
 };
 
+const requiresManualReview = (darDetails) => {
+  return darDetails.illegalBehavior ||
+    darDetails.poa ||
+    darDetails.psychiatricTraits ||
+    darDetails.sexualDiseases ||
+    darDetails.stigmatizedDiseases ||
+    darDetails.vulnerablePopulation;
+};
+
 const DarModal = (props) => {
   //NOTE: Modal should be simple (raw information should be passed in as props) in order to ensure plug and play use
   const {showModal, closeModal, darDetails} = props;
@@ -41,12 +51,19 @@ const DarModal = (props) => {
     onRequestClose: closeModal,
     shouldCloseOnOverlayClick: true,
     style: {
-      content: Styles.MODAL.CONTENT
+      content: {
+        ...Styles.MODAL.CONTENT,
+        ...{boxShadow: '3px 3px 0 #cccccc', borderRadius: "10px"}
+      }
     }
   }, [
     div({style: Styles.MODAL.CONTENT}, [
-      div({style: Styles.MODAL.DAR_SUBHEADER}, [`${darDetails.darCode}`]),
       div({style: Styles.MODAL.TITLE_HEADER}, [`${darDetails.projectTitle}`]),
+      div({style: { borderBottom: "1px solid #1F3B50" }}, []),
+      h(ModalDetailRow, {
+        label: 'Data Access Request Id',
+        detail: darDetails.darCode
+      }),
       h(ModalDetailRow, {
         label: 'Primary Investigator',
         detail: returnPIName(
@@ -71,7 +88,16 @@ const DarModal = (props) => {
       h(ModalDetailRow, {
         label: 'Type of Research',
         detail: processResearchTypes(darDetails.researchType)
-      })
+      }),
+      div({
+        isRendered: requiresManualReview(darDetails),
+        style: Styles.ALERT
+      }, [
+        Alert({
+          id: 'purposeStatementManualReview', type: 'danger',
+          title: 'This research involves studying a sensitive population and requires manual review.'
+        })
+      ])
     ])
   ]);
 };

--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -1,11 +1,8 @@
-import {div, h} from 'react-hyperscript-helpers';
+import { div, h } from 'react-hyperscript-helpers';
 import { Alert } from '../Alert';
-import { User } from '../../libs/ajax';
 import { Styles } from '../../libs/theme';
-import { Notifications } from '../../libs/utils';
 import Modal from 'react-modal';
-import {find, isEmpty, isNil} from 'lodash/fp';
-import {useEffect, useState} from 'react';
+import { find, isEmpty, isNil } from 'lodash/fp';
 
 const ModalDetailRow = (props) => {
   return (
@@ -30,6 +27,11 @@ const returnPIName = (researcher) => {
   return returnName || '- -';
 };
 
+const returnInstitution = (researcher) => {
+  const piNameProp = find({propertyKey: "institution"})(researcher.researcherProperties);
+  return isNil(piNameProp) ? '- -' : piNameProp.propertyValue;
+};
+
 const processResearchTypes = (researchTypes) => {
   let researchStatements = '';
   if(!isEmpty(researchTypes)) {
@@ -49,28 +51,9 @@ const requiresManualReview = (darDetails) => {
     darDetails.vulnerablePopulation;
 };
 
-const getResearcher = async (userId) => {
-  return await User.getById(userId);
-};
-
 const DarModal = (props) => {
   //NOTE: Modal should be simple (raw information should be passed in as props) in order to ensure plug and play use
-  const {showModal, closeModal, darDetails} = props;
-
-  const [researcher, setResearcher] = useState([]);
-  useEffect(() => {
-    const init = async() => {
-      try {
-        if (!isNil(darDetails.userId)) {
-          const researcher = await getResearcher(darDetails.userId);
-          setResearcher(researcher);
-        }
-      } catch(error) {
-        Notifications.showError({text: 'Error: Unable to retrieve researcher information'});
-      }
-    };
-    init();
-  }, []);
+  const {showModal, closeModal, darDetails, researcher} = props;
 
   return h(Modal, {
     isOpen: showModal,
@@ -100,7 +83,7 @@ const DarModal = (props) => {
       }),
       h(ModalDetailRow, {
         label: 'Institution',
-        detail: darDetails.institution || '- -'
+        detail: returnInstitution(researcher)
       }),
       h(ModalDetailRow, {
         label: 'Dataset(s)',

--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -36,7 +36,7 @@ const processResearchTypes = (researchTypes) => {
   let researchStatements = '';
   if(!isEmpty(researchTypes)) {
     researchStatements = researchTypes.map(type => {
-      return `${type.description} ${type.manualReview ? 'Requires manual review.' : ''}`;
+      return `${type.description}`;
     });
   }
   return researchStatements;
@@ -60,9 +60,9 @@ const DarModal = (props) => {
     onRequestClose: closeModal,
     shouldCloseOnOverlayClick: true,
     style: {
-      content: {
-        ...Styles.MODAL.CONTENT,
-        ...{boxShadow: '3px 3px 0 #cccccc', borderRadius: "10px"}
+      content: { ...Styles.MODAL.CONTENT },
+      overlay: {
+        backgroundColor: 'rgba(0, 0, 0, 0.5)'
       }
     }
   }, [

--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -1,4 +1,4 @@
-import { div, h } from 'react-hyperscript-helpers';
+import { div, h, span } from 'react-hyperscript-helpers';
 import { Alert } from '../Alert';
 import { Styles } from '../../libs/theme';
 import Modal from 'react-modal';
@@ -24,7 +24,7 @@ const returnPIName = (researcher) => {
     const piNameProp = find({propertyKey: "piName"})(properties);
     returnName = piNameProp.propertyValue;
   }
-  return returnName || '- -';
+  return returnName || researcher.displayName;
 };
 
 const returnInstitution = (researcher) => {
@@ -67,6 +67,10 @@ const DarModal = (props) => {
     }
   }, [
     div({style: Styles.MODAL.CONTENT}, [
+      span({
+        style: { float: 'right', cursor: 'pointer' },
+        onClick: closeModal,
+        className: "glyphicon glyphicon-remove default-color"}),
       div({style: Styles.MODAL.TITLE_HEADER}, [`${darDetails.projectTitle}`]),
       div({style: { borderBottom: "1px solid #1F3B50" }}, []),
       h(ModalDetailRow, {

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -238,15 +238,16 @@ export const Styles = {
       fontSize: '16px',
       fontWeight: Theme.font.weight.semibold,
       justifyContent: 'left',
-      color: "#777"
+      color: "#1F3B50"
     },
     TITLE_HEADER: {
       display: 'flex',
       fontFamily: 'Montserrat',
       fontSize: Theme.font.size.title,
-      fontWeight: Theme.font.weight.regular,
+      fontWeight: Theme.font.weight.semibold,
       justifyContent: 'left',
-      marginBottom: '4%'
+      marginBottom: '4%',
+      color: "#1F3B50"
     },
     DAR_DETAIL_ROW: {
       padding: '0 3%',
@@ -255,7 +256,7 @@ export const Styles = {
       justifyContent: 'space-between'
     },
     DAR_LABEL: {
-      color: "#777777",
+      color: "#1F3B50",
       fontSize: '14px',
       fontWeight: Theme.font.weight.semibold,
       width: "25%",
@@ -263,8 +264,12 @@ export const Styles = {
     },
     DAR_DETAIL: {
       fontSize: '16px',
-      fontWeight: Theme.font.weight.medium,
+      fontWeight: Theme.font.weight.regular,
       width: "70%"
     }
+  },
+  ALERT: {
+    fontSize: "15px",
+    textAlign: "center"
   }
 };

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -1,9 +1,9 @@
-import {isEmpty, isNil, includes, toLower, filter, cloneDeep} from 'lodash/fp';
-import { useState, useEffect, useRef} from 'react';
+import { isEmpty, isNil, includes, toLower, filter, cloneDeep } from 'lodash/fp';
+import { useState, useEffect, useRef } from 'react';
 import { div, h, img, input } from 'react-hyperscript-helpers';
-import { DAR} from '../libs/ajax';
+import { DAR, User } from '../libs/ajax';
 import { DataUseTranslation } from '../libs/dataUseTranslation';
-import {Notifications, formatDate} from '../libs/utils';
+import { Notifications, formatDate } from '../libs/utils';
 import { Styles} from '../libs/theme';
 import DarModal from '../components/modals/DarModal';
 import PaginationBar from '../components/PaginationBar';
@@ -70,6 +70,7 @@ const NewChairConsole = () => {
   const [filteredList, setFilteredList] = useState([]);
   const [tableSize, setTableSize] = useState();
   const [darDetails, setDarDetails] = useState({});
+  const [researcher, setResearcher] = useState({});
   const [currentPage, setCurrentPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
   const searchTerms = useRef('');
@@ -84,8 +85,8 @@ const NewChairConsole = () => {
         setFilteredList(pendingList);
         setPageCount(Math.ceil(pendingList.length / initTableSize));
       } catch(error) {
-        Notifications.showError({text: 'Error: Unable to retreive data requests from server'});
-      };
+        Notifications.showError({text: 'Error: Unable to retrieve data requests from server'});
+      }
     };
     init();
   }, []);
@@ -98,13 +99,15 @@ const NewChairConsole = () => {
 
   const openModal = async (darInfo) => {
     let darData = darInfo.data;
-    if(!isNil(darData)) {
+    if (!isNil(darData)) {
       setShowModal(true);
       darData.researchType = DataUseTranslation.generateResearchTypes(darData);
       if(!darData.datasetNames) {
         darData.datasetNames = getDatasetNames(darData.datasets);
       }
       setDarDetails(darData);
+      const researcher = await User.getById(darData.userId);
+      setResearcher(researcher);
     }
   };
 
@@ -196,7 +199,7 @@ const NewChairConsole = () => {
         h(Records, {isRendered: !isEmpty(filteredList), filteredList, openModal, currentPage, tableSize, applyTextHover, removeTextHover})
       ]),
       h(PaginationBar, {pageCount, currentPage, tableSize, goToPage, changeTableSize, Styles, applyTextHover, removeTextHover}),
-      h(DarModal, {showModal, closeModal, darDetails})
+      h(DarModal, {showModal, closeModal, darDetails, researcher})
     ])
   );
 };


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1019

This PR updates the style a little bit and re-arranges the elements in the modal to more closely align with the previous version. In addition, this pulls user information from the DAR create user instead of using the unreliable data in `darInfo`.

### New Modal UI:

<img width="1272" alt="Screen Shot 2021-02-08 at 3 48 54 PM" src="https://user-images.githubusercontent.com/116679/107279555-2f9bb580-6a25-11eb-8c69-a8fc51f75be1.png">

### Old Modal UI:

![Screen Shot 2021-02-08 at 3 47 11 PM](https://user-images.githubusercontent.com/116679/107279583-39251d80-6a25-11eb-8bfe-571560f45743.png)


----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
