### PR TITLE
DUOS-1032 [risk=no] Removed empty ontology conditional for disease sRP statement

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -24,7 +24,7 @@ const srpTranslations = {
     const diseaseString = diseaseArray.length > 1 ? join('; ')(diseaseArray) : diseaseArray[0];
     return {
       code: 'DS',
-      description: 'Disease-related studies: ' + diseaseString,
+      description: 'The dataset will be used for disease related studies' + (!isEmpty(diseaseString) ? ` (${diseaseString})` : ''),
       manualReview: false
     };
   },
@@ -289,7 +289,7 @@ export const DataUseTranslation = {
       dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.poa);
     }
 
-    if (darInfo.diseases && !isEmpty(darInfo.ontologies)) {
+    if (darInfo.diseases) {
       const diseaseTranslation = srpTranslations.diseases(clone(darInfo.ontologies));
       dataUseSummary.primary = uniq(concat(dataUseSummary.primary)(diseaseTranslation));
     }


### PR DESCRIPTION
Addresses [DUOS-1032](https://broadworkbench.atlassian.net/browse/DUOS-1032)

PR removes empty ontology array check so that DS purpose statement will render if selected. This means that statement is solely dependent on the disease boolean value within DAR json. Disease purpose statement has been updated to be flexible with possible empty ontology list.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
