### PR TITLE
DUOS-1022[risk=no]UI: Move 'Already Registered?" above 'Sign in with Google' button

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -103,7 +103,7 @@ class Home extends Component {
     };
 
     const registerPositionStyle = {
-      padding: '1em',
+      padding: "1em",
       position: 'absolute',
       top: '6rem',
       right: "3rem",

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -119,11 +119,11 @@ class Home extends Component {
           div({ className: 'row', style: { backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}, [
             img({ style: { height: 'inherit', minWidth: '100%' }, src: '/images/home_header_background.png'}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
-              span({style: {color: '#FFFFFF', position: 'relative', margin: 'auto 0'}}, ['Already registered?']),
-              SignIn({props: this.props, onSignIn: () => onSignIn(), history: history, style: {position: 'relative'}}),
+              span({ style: {color: '#FFFFFF', position: 'relative' }}, ['Already registered?']),
+              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history, style: { position: 'relative'}})
             ]),
             div({isRendered: !isLogged, style: registerPositionStyle}, [
-              span({style: {color: '#FFFFFF', padding: '10px'}}, ['If not, ',
+              span({ style: { color: '#FFFFFF' }}, ['If not, ',
                 a({
                   href: 'https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup',
                 }, ['register here'])

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -119,7 +119,7 @@ class Home extends Component {
           div({ className: 'row', style: { backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}, [
             img({ style: { height: 'inherit', minWidth: '100%' }, src: '/images/home_header_background.png'}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
-              span({ style: {color: '#FFFFFF' }}, ['Already registered?']),
+              span({ style: {color: "#FFFFFF" }}, ['Already registered?']),
               SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history })
             ]),
             div({isRendered: !isLogged, style: registerPositionStyle}, [

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -106,7 +106,7 @@ class Home extends Component {
       padding: '1em',
       position: 'absolute',
       top: '6rem',
-      right: '3rem',
+      right: "3rem",
       zIndex: 1000,
       margin: '3px'
     };

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -99,7 +99,18 @@ class Home extends Component {
       alignItems: 'center',
       position: 'absolute',
       top: '0',
-      right: '1rem'};
+      right: '1rem',
+    };
+
+    const registerPositionStyle = {
+      padding: '1em 1em',
+      position: 'absolute',
+      top: '6rem',
+      right: '2rem',
+      zIndex: 1000,
+      margin: '3px'
+    };
+
 
     return (
 
@@ -108,9 +119,11 @@ class Home extends Component {
           div({ className: 'row', style: { backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}, [
             img({ style: { height: 'inherit', minWidth: '100%' }, src: '/images/home_header_background.png'}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
-              span({ style: { color: '#FFFFFF', position: 'relative', margin: 'auto 0'}}, ['Already registered?']),
-              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history, style: { position: 'relative'}}),
-              span( {style: { color: '#FFFFFF', margin: 'auto 1rem auto 4rem'} }, ['If not, ',
+              span({style: {color: '#FFFFFF', position: 'relative', margin: 'auto 0'}}, ['Already registered?']),
+              SignIn({props: this.props, onSignIn: () => onSignIn(), history: history, style: {position: 'relative'}}),
+            ]),
+            div({isRendered: !isLogged, style: registerPositionStyle}, [
+              span({style: {color: '#FFFFFF', padding: '10px'}}, ['If not, ',
                 a({
                   href: 'https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup',
                 }, ['register here'])

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -103,10 +103,10 @@ class Home extends Component {
     };
 
     const registerPositionStyle = {
-      padding: '1em 1em',
+      padding: '1em',
       position: 'absolute',
       top: '6rem',
-      right: '2rem',
+      right: '3rem',
       zIndex: 1000,
       margin: '3px'
     };
@@ -119,8 +119,8 @@ class Home extends Component {
           div({ className: 'row', style: { backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}, [
             img({ style: { height: 'inherit', minWidth: '100%' }, src: '/images/home_header_background.png'}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
-              span({ style: {color: '#FFFFFF', position: 'relative' }}, ['Already registered?']),
-              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history, style: { position: 'relative'}})
+              span({ style: {color: '#FFFFFF' }}, ['Already registered?']),
+              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history })
             ]),
             div({isRendered: !isLogged, style: registerPositionStyle}, [
               span({ style: { color: '#FFFFFF' }}, ['If not, ',

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -98,7 +98,7 @@ class Home extends Component {
       padding: '1em 1em 0 0',
       alignItems: 'center',
       position: 'absolute',
-      top: '0',
+      top: "0",
       right: '1rem',
     };
 

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -120,7 +120,7 @@ class Home extends Component {
             img({ style: { height: 'inherit', minWidth: '100%' }, src: '/images/home_header_background.png'}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
               span({ style: {color: "#FFFFFF" }}, ['Already registered?']),
-              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history })
+              SignIn({ props: this.props, onSignIn: () => onSignIn(), history })
             ]),
             div({isRendered: !isLogged, style: registerPositionStyle}, [
               span({ style: { color: '#FFFFFF' }}, ['If not, ',

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -98,7 +98,7 @@ class Home extends Component {
       padding: '1em 1em 0 0',
       alignItems: 'center',
       position: 'absolute',
-      top: '1rem',
+      top: '0',
       right: '1rem'};
 
     return (

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -105,7 +105,7 @@ class Home extends Component {
     const registerPositionStyle = {
       padding: "1em",
       position: 'absolute',
-      top: '6rem',
+      top: "6rem",
       right: "3rem",
       zIndex: 1000,
       margin: "3px"

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -96,7 +96,6 @@ class Home extends Component {
 
     const signInPositionStyle = {
       padding: '1em 1em 0 0',
-      display: 'flex',
       alignItems: 'center',
       position: 'absolute',
       top: '1rem',
@@ -109,11 +108,9 @@ class Home extends Component {
           div({ className: 'row', style: { backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}, [
             img({ style: { height: 'inherit', minWidth: '100%' }, src: '/images/home_header_background.png'}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
-              span({ style: { color: '#FFFFFF', position: 'relative', float: 'left', margin: 'auto 1rem'}}, ['Already registered?']),
-              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history, style: { position: 'relative', float: 'right'}})
-            ]),
-            div({isRendered: !isLogged, style: { ...signInPositionStyle, padding: '1em 2em 0 0', top: '6rem', zIndex: 1000 }}, [
-              span( {style: { color: '#FFFFFF', float: 'right', margin: 'auto 1rem'} }, ['If not, ',
+              span({ style: { color: '#FFFFFF', position: 'relative', margin: 'auto 0'}}, ['Already registered?']),
+              SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history, style: { position: 'relative'}}),
+              span( {style: { color: '#FFFFFF', margin: 'auto 1rem auto 4rem'} }, ['If not, ',
                 a({
                   href: 'https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup',
                 }, ['register here'])

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -108,7 +108,7 @@ class Home extends Component {
       top: '6rem',
       right: "3rem",
       zIndex: 1000,
-      margin: '3px'
+      margin: "3px"
     };
 
 


### PR DESCRIPTION
Scope:
Move Already Registered above signin button
fix formatting to accommodate for changes

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-1022

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
