### PR TITLE
DUOS-1042 Added Election Status Output Processing to NewChairConsole

### DIFF
--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -20,10 +20,8 @@ const processElectionStatus = (election, votes) => {
   const electionStatus = election.status;
 
   if(!isEmpty(votes) && isNil(electionStatus)) {
-    return '- -';
-  }
-
-  if(electionStatus === 'Open') {
+    output = '- -';
+  } else if(electionStatus === 'Open') {
     const completedVotes = (filter(wasVoteSubmitted)(votes)).length;
     output = `Open (${completedVotes} / ${votes.length} votes)`;
   } else if (electionStatus === 'Final') {

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -1,4 +1,4 @@
-import { head, isEmpty, isNil, includes, toLower, filter, cloneDeep } from 'lodash/fp';
+import { head, isEmpty, isNil, includes, toLower, filter, cloneDeep, find } from 'lodash/fp';
 import { useState, useEffect, useRef } from 'react';
 import { div, h, img, input, button } from 'react-hyperscript-helpers';
 import { DAR, Election, User } from '../libs/ajax';
@@ -9,6 +9,30 @@ import DarModal from '../components/modals/DarModal';
 import PaginationBar from '../components/PaginationBar';
 import {Storage} from "../libs/storage";
 import ConfirmationModal from "../components/modals/ConfirmationModal";
+
+const wasVoteSubmitted = (vote) => {
+  const targetDate = vote.createDate || vote.updateDate || vote.lastUpdate || vote.lastUpdateDate;
+  return !isNil(targetDate);
+};
+
+const processElectionStatus = (election, votes) => {
+  const electionStatus = election.status;
+  if(!isEmpty(votes) && isNil(electionStatus)) {
+    return '- -';
+  }
+
+  let output;
+  if(electionStatus === 'Open') {
+    const completedVotes = (filter(wasVoteSubmitted)(votes)).length;
+    output = `${completedVotes} / ${votes.length}`;
+  } else if (electionStatus === 'Final') {
+    const finalVote = find((vote) => vote.type === 'Final' && !isNil(vote))(votes);
+    output = finalVote ? 'Accepted' : 'Denied';
+  } else {
+    output = electionStatus;
+  }
+  return output;
+};
 
 const getDatasetNames = (datasets) => {
   if(!datasets){return '';}
@@ -73,7 +97,7 @@ const Records = (props) => {
   };
 
   return visibleWindow.map((electionInfo, index) => {
-    const {dar, dac, election} = electionInfo;
+    const {dar, dac, election, votes} = electionInfo;
     const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};
     return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${dar.data.referenceId}-${index}`}, [
       div({
@@ -85,7 +109,7 @@ const Records = (props) => {
       div({style: Object.assign({}, Styles.TABLE.TITLE_CELL, recordTextStyle)}, [dar && dar.data ? dar.data.projectTitle : '- -']),
       div({style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL, recordTextStyle)}, [getElectionDate(election)]),
       div({style: Object.assign({}, Styles.TABLE.DAC_CELL, recordTextStyle)}, [dac ? dac.name : '- -']),
-      div({style: Object.assign({}, Styles.TABLE.ELECTION_STATUS_CELL, recordTextStyle)}, [election ? election.status : '- -']),
+      div({style: Object.assign({}, Styles.TABLE.ELECTION_STATUS_CELL, recordTextStyle)}, [election ? processElectionStatus(election, votes) : '- -']),
       div({style: Object.assign({}, Styles.TABLE.ELECTION_ACTIONS_CELL, recordTextStyle)}, [createActionButton(electionInfo, index)]),
     ]);
   });
@@ -165,11 +189,11 @@ const NewChairConsole = (props) => {
         const term = splitTerm.trim();
         if(!isEmpty(term)) {
           newFilteredList = filter(electionData => {
-            const { election, dac} = electionData;
+            const { election, dac, votes} = electionData;
             const dar = electionData.dar ? electionData.dar.data : undefined;
             const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode)]) : [];
             const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
-            const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(election.status), getElectionDate(election)]) : [];
+            const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(processElectionStatus(election, votes)), getElectionDate(election)]) : [];
             return includes(term, targetDarAttrs) || includes(term, targetDacAttrs) || includes(term, targetElectionAttrs);
           }, newFilteredList);
         }

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -28,6 +28,7 @@ const processElectionStatus = (election, votes) => {
   if(!isEmpty(votes) && isNil(electionStatus)) {
     output = '- -';
   } else if(electionStatus === 'Open') {
+    //React doesn't necessarily perform state updates quickly, if check will ensure data is present
     if(!isEmpty(votes) && !isNil(election)) {
       const completedVotes = (filter(wasVoteSubmitted)(votes)).length;
       output = `Open (${completedVotes} / ${votes.length} votes)`;

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -16,17 +16,18 @@ const wasVoteSubmitted = (vote) => {
 };
 
 const processElectionStatus = (election, votes) => {
+  let output;
   const electionStatus = election.status;
+
   if(!isEmpty(votes) && isNil(electionStatus)) {
     return '- -';
   }
 
-  let output;
   if(electionStatus === 'Open') {
     const completedVotes = (filter(wasVoteSubmitted)(votes)).length;
     output = `Open (${completedVotes} / ${votes.length} votes)`;
   } else if (electionStatus === 'Final') {
-    const finalVote = find((vote) => vote.type === 'Final' && !isNil(vote))(votes);
+    const finalVote = find((voteData) => voteData.type === 'Final' && !isNil(voteData.vote))(votes);
     output = finalVote ? 'Accepted' : 'Denied';
   } else {
     output = electionStatus;

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -15,6 +15,12 @@ const wasVoteSubmitted = (vote) => {
   return !isNil(targetDate);
 };
 
+const wasFinalVoteSubmitted = (voteData) => {
+  const {type, vote} = voteData;
+  //vote status capitalizes final, election status does not
+  return type === 'FINAL' && !isNil(vote);
+};
+
 const processElectionStatus = (election, votes) => {
   let output;
   const electionStatus = election.status;
@@ -25,7 +31,7 @@ const processElectionStatus = (election, votes) => {
     const completedVotes = (filter(wasVoteSubmitted)(votes)).length;
     output = `Open (${completedVotes} / ${votes.length} votes)`;
   } else if (electionStatus === 'Final') {
-    const finalVote = find((voteData) => voteData.type === 'Final' && !isNil(voteData.vote))(votes);
+    const finalVote = find(wasFinalVoteSubmitted)(votes);
     output = finalVote ? 'Accepted' : 'Denied';
   } else {
     output = electionStatus;

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -24,7 +24,7 @@ const processElectionStatus = (election, votes) => {
   let output;
   if(electionStatus === 'Open') {
     const completedVotes = (filter(wasVoteSubmitted)(votes)).length;
-    output = `${completedVotes} / ${votes.length}`;
+    output = `Open (${completedVotes} / ${votes.length} votes)`;
   } else if (electionStatus === 'Final') {
     const finalVote = find((vote) => vote.type === 'Final' && !isNil(vote))(votes);
     output = finalVote ? 'Accepted' : 'Denied';


### PR DESCRIPTION
Addresses [DUOS-1042](https://broadworkbench.atlassian.net/browse/DUOS-1042)

PR adds processing for election status so that ```Open``` and ```Final``` statuses can have customized outputs. ```Open``` will show ```votes submitted / votes expected``` whereas ```Final``` will display ```Accepted``` or ```Denied``` based on the final vote itself. Helpers have been implemented on search to reflect visible data. 

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
