### PR TITLE
DUOS-1044[risk=no] Fix label assignment for ontologies on DAR submission

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -256,6 +256,7 @@ class DataAccessRequestApplication extends Component {
   formatOntologyItems = (ontologies) => {
     const ontologyItems = ontologies.map((ontology) => {
       return {
+        //item being referenced as a way to backfill older ontologies that don't have a proper label attributes
         id: ontology.id || ontology.item.id,
         key: ontology.id || ontology.item.id,
         value: ontology.id || ontology.item.id,
@@ -593,10 +594,7 @@ class DataAccessRequestApplication extends Component {
       const userId = Storage.getCurrentUser().dacUserId;
       const {uploadedIrbDocument, uploadedCollaborationLetter} = this.state.step2;
       let formattedFormData = fp.cloneDeep(this.state.formData);
-      const ontologies = fp.map(ontology => ({
-        id: ontology.key,
-        label: ontology.value,
-      }))(this.state.formData.ontologies);
+      const ontologies = this.formatOntologyItems(this.state.formData.ontologies);
 
       if (ontologies.length > 0) {
         formattedFormData.ontologies = ontologies;
@@ -670,11 +668,7 @@ class DataAccessRequestApplication extends Component {
       // DAR datasetIds needs to be a list of ids
       const datasetIds = fp.map('value')(this.state.formData.datasets);
       // DAR ontologies needs to be a list of id/labels.
-      const ontologies = fp.map((o) => ({
-        id: o.id || o.item.id,
-        label: o.label || o.item.label,
-        item: o.item
-      }))(this.state.formData.ontologies);
+      const ontologies = this.formatOntologyItems(this.state.formData.ontologies);
       this.setState(prev => {
         prev.formData.datasetIds = datasetIds;
         prev.formData.ontologies = ontologies;


### PR DESCRIPTION
Addresses [DUOS-1044](https://broadworkbench.atlassian.net/browse/DUOS-1044)

PR aims to fix label assignment on ontologies on DAR submission so that the disease name is saved under label rather than the DOID link. PR also includes minor code cleanup regarding ontology attribute assignment.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
