### PR TITLE
DUOS-1051[risk=no] Add null/empty check for ontologies array within srpTranslations

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -20,13 +20,17 @@ const srpTranslations = {
     manualReview: true
   },
   diseases: (diseases) => {
-    const diseaseArray = diseases.sort().map(disease => disease.label);
-    const diseaseString = diseaseArray.length > 1 ? join('; ')(diseaseArray) : diseaseArray[0];
-    return {
+    let outputStruct = {
       code: 'DS',
-      description: 'The dataset will be used for disease related studies' + (!isEmpty(diseaseString) ? ` (${diseaseString})` : ''),
+      description: 'The dataset will be used for disease related studies',
       manualReview: false
     };
+    if(!isEmpty(diseases)) {
+      const diseaseArray = diseases.sort().map((disease) => disease.label);
+      const diseaseString = diseaseArray.length > 1 ? join('; ')(diseaseArray) : diseaseArray[0];
+      outputStruct.description = outputStruct.description + ` (${diseaseString})`;
+    }
+    return outputStruct;
   },
   researchTypeDisease: {
     code: 'DS',

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -126,7 +126,7 @@ const consentTranslations = {
     description: 'Use is permitted for a health, medical, or biomedical research purpose'
   },
   diseaseRestrictions: (restrictions) => {
-    if (restrictions.length < 1) { return 'Use is permitted for the specified disease(s): Not specified'; }
+    if (isEmpty(restrictions)) { return 'Use is permitted for the specified disease(s): Not specified'; }
     const restrictionList = restrictions.join(', ');
     return {
       code: 'DS',


### PR DESCRIPTION
Addresses [DUOS-1051](https://broadworkbench.atlassian.net/browse/DUOS-1051)

PR adds a null/empty check to ```ontologies``` array within ```srpTranslations.diseases``` in dataUseTranslations. Check is now needed since empty ```ontologies``` are no longer checked as part of ```disease``` validation in the DAR. PR also adds an ```isEmpty``` check for ```diseaseRestrictions``` within ```consentTranslations``` as well for similar reasons.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
