### PR TITLE
DUOS-631[risk=no]textarea bug

### DIFF
--- a/src/pages/access_review/VoteQuestion.js
+++ b/src/pages/access_review/VoteQuestion.js
@@ -38,7 +38,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
   setVote = (voteStatus, rationale) => {
     const { updateVote, voteId } = this.props;
     if (fp.isNil(rationale)) {
-      rationale = null;
+      rationale = '';
     }
     this.setState({
       voteStatus: voteStatus,


### PR DESCRIPTION
Scope:
-make rationale empty string instead of null

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-631

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
