### PR TITLE
[DUOS-1057][risk=no] All DARs always have use restrictions

### DIFF
--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -12,7 +12,7 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
 
   render() {
     let {darInfo} = this.props;
-    const { hasUseRestriction, mrDAR, downloadDAR, researcherProfile } = this.props;
+    const { mrDAR, downloadDAR, researcherProfile } = this.props;
     darInfo.purposeStatements = DataUseTranslation.generatePurposeStatement(darInfo);
     const libraryCards = ld.get(researcherProfile, 'libraryCards', []);
     return div({className: 'col-lg-8 col-md-8 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
@@ -102,7 +102,7 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
             ])
           ]),
 
-          div({ isRendered: hasUseRestriction, className: 'row dar-summary' }, [
+          div({ className: 'row dar-summary' }, [
             div({ className: 'control-label access-color' }, ['Structured Research Purpose']),
             div({ className: 'response-label translated-restriction'}, [
               StructuredDarRp({

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -358,12 +358,6 @@ export const DAR = {
     return await res.json();
   },
 
-  hasUseRestriction: async (referenceId) => {
-    const url = `${await Config.getApiUrl()}/dar/hasUseRestriction/${referenceId}`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
-  },
-
   requiresManualReview: (object) => {
     var manualReview = false;
     object.forEach(function (element) {

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -17,7 +17,7 @@ class AccessPreview extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      hasUseRestriction: false,
+      hasUseRestriction: true,
       consentName: '',
       isQ1Expanded: true,
       isQ2Expanded: false,
@@ -49,16 +49,6 @@ class AccessPreview extends Component {
           prev.dataUse = consent.dataUse;
           prev.consentName = consent.name;
         });
-      }
-    );
-
-    DAR.hasUseRestriction(referenceId).then(
-      useRestriction => {
-        if (useRestriction.hasUseRestriction === true) {
-          this.setState(prev => {
-            prev.hasUseRestriction = true;
-          });
-        }
       }
     );
 

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -17,7 +17,6 @@ class AccessPreview extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      hasUseRestriction: true,
       consentName: '',
       isQ1Expanded: true,
       isQ2Expanded: false,
@@ -112,8 +111,7 @@ class AccessPreview extends Component {
             id: 'accessCollectVotes',
             onClick: this.toggleQ1,
             color: 'access',
-            title: this.state.hasUseRestriction ? 'Q1. Should data access be granted to this applicant?'
-              : 'Should data access be granted to this applicant?',
+            title: 'Q1. Should data access be granted to this applicant?',
             expanded: this.state.isQ1Expanded
           }, [
 
@@ -122,7 +120,6 @@ class AccessPreview extends Component {
               ApplicationSummary({
                 isRendered: !ld.isNil(this.state.darInfo) && !ld.isNil(this.state.researcherProfile),
                 mrDAR: null,
-                hasUseRestriction: this.state.hasUseRestriction,
                 darInfo: this.state.darInfo,
                 downloadDAR: this.downloadDAR,
                 researcherProfile: this.state.researcherProfile }),
@@ -139,7 +136,6 @@ class AccessPreview extends Component {
 
         div({ className: 'row no-margin' }, [
           CollapsiblePanel({
-            isRendered: this.state.hasUseRestriction,
             id: 'rpCollectVotes',
             onClick: this.toggleQ1,
             color: 'access',


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1057
See also: https://github.com/DataBiosphere/consent/pull/951

## Changes
All DARs have a minimum number of questions that satisfy the requirements for a "Use Restriction". This PR does away with the server side call to make that determination.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
