### PR TITLE
DUOS-1011[risk=no]Expose Download 'Approved Requestors' to all users in Dataset Catalog

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -427,7 +427,7 @@ class DatasetCatalog extends Component {
                     th({ className: 'cell-size' }, ['Data Custodian']),
                     th({ className: 'cell-size' }, ['Consent ID']),
                     th({ className: 'cell-size' }, ['SC-ID']),
-                    th({ isRendered: this.state.isAdmin, className: 'cell-size' }, ['Approved Requestors'])
+                    th({ className: 'cell-size' }, ['Approved Requestors'])
                   ])
                 ]),
 
@@ -621,7 +621,7 @@ class DatasetCatalog extends Component {
                               '---')
                           ]),
 
-                          td({ isRendered: this.state.isAdmin, className: 'cell-size', style: Theme.textTableBody }, [
+                          td({ className: 'cell-size', style: Theme.textTableBody }, [
                             a({
                               id: trIndex + '_linkDownloadList', name: 'link_downloadList', onClick: () => this.downloadList(dataSet),
                               className: 'enabled'


### PR DESCRIPTION
SCOPE:
- remove "rendered: state.isadmin" check so the column is always rendered

ADDRESSES:
- https://broadworkbench.atlassian.net/browse/DUOS-1011

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
