### PR TITLE
DUOS-1071[risk=no] Fix DS loading bug

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -735,7 +735,7 @@ class DataAccessRequestApplication extends Component {
 
     let dataUseArray = await Promise.all(datasetPromises);
     dataUseArray.forEach((datasetRecord, index) => {
-      currentDatasets[index].dataUse = datasetRecord.dataUse;
+      currentDatasets[index].dataUse = datasetRecord.dataUse || {};
     });
     return currentDatasets;
   }

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -189,7 +189,7 @@ export default function DataAccessRequest(props) {
     };
 
     updateDatasetsAndDULQuestions(datasets);
-  }, [datasets, initializeDatasets, activeDULQuestions, formFieldChange, darCode]);
+  }, [props.datasets, initializeDatasets, activeDULQuestions, formFieldChange, darCode]);
 
   const renderDULQuestions = (darCode) => {
     let renderBool = !(isNil(activeDULQuestions) && isEmpty(activeDULQuestions)) && !every(value => value === false)(activeDULQuestions);

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -189,7 +189,7 @@ export default function DataAccessRequest(props) {
     };
 
     updateDatasetsAndDULQuestions(datasets);
-  }, [props.datasets, initializeDatasets, activeDULQuestions, formFieldChange, darCode]);
+  }, [datasets, initializeDatasets, activeDULQuestions, formFieldChange, darCode]);
 
   const renderDULQuestions = (darCode) => {
     let renderBool = !(isNil(activeDULQuestions) && isEmpty(activeDULQuestions)) && !every(value => value === false)(activeDULQuestions);


### PR DESCRIPTION
Addresses [DUOS-1071](https://broadworkbench.atlassian.net/browse/DUOS-1071)

PR addresses infinite spinner and fetches caused by null assignment on dataUse attribute for specific datasets. The assumption was that a dataUse object was guaranteed, with two calls, one through AsyncSelect, and another with prop update should the AsyncSelect component fail. However, datasets with no restrictions return a null value rather than an empty object. Since the code executes the fetch under the empty object assumption, the code enters an endless cycle of reading a null, fetching, assigning returned value (which is null), repeat. Solution is to simply assign an empty object as a default value if a null is returned.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
