### PR TITLE
DUOS-1074[risk=no] Swapped out height for padding on Table Row Styling

### DIFF
--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -127,7 +127,7 @@ export const Styles = {
       fontSize: "14px",
       display: "flex",
       justifyContent: "center",
-      height: "48px",
+      padding: '0.8rem 0'
     },
     RECORD_TEXT: {
       color: "#00243C"


### PR DESCRIPTION
Addresses [DUOS-1074](https://broadworkbench.atlassian.net/browse/DUOS-1074)

Simple PR, swaps out height attribute for padding to allow for more flexible row heights. Problem can be seen in staging where Datasets have much larger names than those on dev. Styling update will cause variable row height, however consistent top and bottom padding will ensure consistent spacing between records.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
