### PR TITLE
DUOS-1086[risk=no]Redo reverted changes: Refactor the vote page on New Chair Console

### DIFF
--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -107,11 +107,10 @@ const Records = (props) => {
         case 'Open' :
           const votes = filter({type: 'DAC', dacUserId: currentUserId})(electionInfo.votes);
           const isFinal = !isEmpty(votes.find((voteData) => !isNil(voteData.vote)));
-          const vote = head(votes);
           return [
             h(TableTextButton, {
               key: `vote-button-${e.referenceId}`,
-              onClick: () => props.history.push(`access_review/${dar.referenceId}/${vote.voteId}`),
+              onClick: () => props.history.push(`access_review/${dar.referenceId}`),
               label: isFinal ? 'Final' : 'Vote'
             }),
             h(TableIconButton, {


### PR DESCRIPTION
Scope:
- remove vote from access review link, leave votes and isFinal as is for the label

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-1086

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
