### PR TITLE
[DUOS-1015][risk=no] Refactor

### DIFF
--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -3,10 +3,10 @@ import { div, hh, span, h, h4, label, button, ul, li, b, a } from 'react-hypersc
 import { Alert } from './Alert';
 import { LibraryCards } from './LibraryCards';
 import { StructuredDarRp } from './StructuredDarRp';
-import {Theme} from '../libs/theme';
+import { Theme } from '../libs/theme';
 import * as Utils from '../libs/utils';
 import * as ld from 'lodash';
-import {DataUseTranslation} from '../libs/dataUseTranslation';
+import { DataUseTranslation } from '../libs/dataUseTranslation';
 import ApplicationDownloadLink from './ApplicationDownloadLink';
 
 export const ApplicationSummary = hh(class ApplicationSummary extends PureComponent {

--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -7,12 +7,13 @@ import {Theme} from '../libs/theme';
 import * as Utils from '../libs/utils';
 import * as ld from 'lodash';
 import {DataUseTranslation} from '../libs/dataUseTranslation';
+import ApplicationDownloadLink from './ApplicationDownloadLink';
 
 export const ApplicationSummary = hh(class ApplicationSummary extends PureComponent {
 
   render() {
     let {darInfo} = this.props;
-    const { mrDAR, downloadDAR, researcherProfile } = this.props;
+    const { mrDAR, researcherProfile, datasets } = this.props;
     darInfo.purposeStatements = DataUseTranslation.generatePurposeStatement(darInfo);
     const libraryCards = ld.get(researcherProfile, 'libraryCards', []);
     return div({className: 'col-lg-8 col-md-8 col-sm-12 col-xs-12 panel panel-primary cm-boxes' }, [
@@ -23,14 +24,14 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
       div({ id: 'panel_applicationSummary', className: 'panel-body row' }, [
         div({ className: 'col-lg-4 col-md-5 col-sm-5 col-xs-12' }, [
 
-          div({ isRendered: darInfo.havePI, className: 'row no-margin' }, [
+          div({ isRendered: (researcherProfile.havePI === "true"), className: 'row no-margin' }, [
             label({ className: 'control-label access-color' }, ['PI: ']),
             span({ id: 'lbl_principalInvestigator', className: 'response-label', style: { 'paddingLeft': '5px' } },
               [darInfo.pi])
           ]),
           div({ className: 'row no-margin' }, [
             label({ className: 'control-label access-color' }, ['Researcher: ']),
-            span({ id: 'lbl_researcher', className: 'response-label', style: { 'paddingLeft': '5px' } }, [darInfo.profileName])
+            span({ id: 'lbl_researcher', className: 'response-label', style: { 'paddingLeft': '5px' } }, [researcherProfile.profileName])
           ]),
           div({ className: 'row no-margin' }, [
             label({ className: 'control-label no-padding' }, ['Status: ']),
@@ -52,24 +53,24 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
           ]),
           div({ className: 'row no-margin' }, [
             label({ className: 'control-label access-color' }, ['Institution: ']),
-            span({ id: 'lbl_institution', className: 'response-label', style: { 'paddingLeft': '5px' } }, [darInfo.institution])
+            span({ id: 'lbl_institution', className: 'response-label', style: { 'paddingLeft': '5px' } }, [researcherProfile.institution])
           ]),
           div({ className: 'row no-margin' }, [
             label({ className: 'control-label access-color' }, ['Department: ']),
-            span({ id: 'lbl_department', className: 'response-label', style: { 'paddingLeft': '5px' } }, [darInfo.department])
+            span({ id: 'lbl_department', className: 'response-label', style: { 'paddingLeft': '5px' } }, [researcherProfile.department])
           ]),
           div({ className: 'row no-margin' }, [
             label({ className: 'control-label access-color' }, ['City: ']),
-            span({ id: 'lbl_state', className: 'response-label', style: { 'paddingLeft': '5px' } }, [darInfo.city])
+            span({ id: 'lbl_state', className: 'response-label', style: { 'paddingLeft': '5px' } }, [researcherProfile.city])
           ]),
           div({ className: 'row no-margin' }, [
             label({ className: 'control-label access-color' }, ['Country: ']),
-            span({ id: 'lbl_country', className: 'response-label', style: { 'paddingLeft': '5px' } }, [darInfo.country])
+            span({ id: 'lbl_country', className: 'response-label', style: { 'paddingLeft': '5px' } }, [researcherProfile.country])
           ]),
           button({
             id: 'btn_downloadFullApplication',
-            className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 btn-secondary btn-download-pdf hover-color', onClick: downloadDAR
-          }, ['Download Full Application'])
+            className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 btn-secondary btn-download-pdf hover-color'
+          }, [h(ApplicationDownloadLink, {darInfo, researcherProfile, datasets})])
         ]),
 
         div({ className: 'col-lg-8 col-md-7 col-sm-7 col-xs-12' }, [

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -399,6 +399,15 @@ export const DataSet = {
     return await res.json();
   },
 
+  getDarDatasets: async (datasetIds) => {
+    let datasets;
+    const datasetsPromise = datasetIds.map((id) => {
+      return DataSet.getDataSetsByDatasetId(id);
+    });
+    datasets = await Promise.all(datasetsPromise);
+    return datasets;
+  },
+
   getDataSetsByDatasetId: async dataSetId => {
     const url = `${await Config.getApiUrl()}/dataset/${dataSetId}`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -628,11 +628,6 @@ export const Files = {
   getApprovedUsersFile: async (fileName, dataSetId) => {
     const url = `${await Config.getApiUrl()}/dataset/${dataSetId}/approved/users`;
     return getFile(url, fileName);
-  },
-
-  getDARFile: async (darId) => {
-    const url = `${await Config.getApiUrl()}/dataRequest/${darId}/pdf`;
-    return await getFile(url, null);
   }
 };
 

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -18,7 +18,6 @@ import { Theme } from '../libs/theme';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
 import accessIcon from '../images/icon_access.png';
 import ApplicationDownloadLink from '../components/ApplicationDownloadLink';
-import { Notifications } from '../libs/utils';
 
 class AccessCollect extends Component {
 
@@ -305,7 +304,7 @@ class AccessCollect extends Component {
   async findDar() {
     await DAR.describeDar(this.props.match.params.referenceId).then(
       darInfo => {
-        this.getDarDatasets(darInfo).then((datasets) => {
+        DataSet.getDarDatasets(darInfo.datasetIds).then((datasets) => {
           this.setState({datasets: datasets});
           Researcher.getResearcherProfile(darInfo.researcherId).then(
             researcherProfile => {
@@ -319,20 +318,6 @@ class AccessCollect extends Component {
       }
     );
   }
-
-  getDarDatasets = async (darInfo) => {
-    let datasets;
-    try {
-      const datasetsPromise = darInfo.datasetIds.map((id) => {
-        return DataSet.getDataSetsByDatasetId(id);
-      });
-      datasets = await Promise.all(datasetsPromise);
-    } catch(error) {
-      Notifications.showError({text: 'Error initializing DAR Datasets'});
-      return Promise.reject(error);
-    }
-    return datasets;
-  };
 
   getRPGraphData(type, reviewVote) {
     var yes = 0, no = 0, empty = 0;

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -1,6 +1,6 @@
 import * as ld from 'lodash';
 import { Component, Fragment } from 'react';
-import {a, button, div, h, h3, h4, hr, i, span,} from 'react-hyperscript-helpers';
+import { a, button, div, h, h3, h4, hr, i, span } from 'react-hyperscript-helpers';
 import { ApplicationSummary } from '../components/ApplicationSummary';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { CollectResultBox } from '../components/CollectResultBox';

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -18,7 +18,7 @@ import { Theme } from '../libs/theme';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
 import accessIcon from '../images/icon_access.png';
 import ApplicationDownloadLink from '../components/ApplicationDownloadLink';
-import {Notifications} from '../libs/utils';
+import { Notifications } from '../libs/utils';
 
 class AccessCollect extends Component {
 

--- a/src/pages/AccessCollect.js
+++ b/src/pages/AccessCollect.js
@@ -1,6 +1,6 @@
 import * as ld from 'lodash';
 import { Component, Fragment } from 'react';
-import { a, div, h, h3, h4, hr, i, span } from 'react-hyperscript-helpers';
+import {a, button, div, h, h3, h4, hr, i, span,} from 'react-hyperscript-helpers';
 import { ApplicationSummary } from '../components/ApplicationSummary';
 import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import { CollectResultBox } from '../components/CollectResultBox';
@@ -305,7 +305,7 @@ class AccessCollect extends Component {
   async findDar() {
     await DAR.describeDar(this.props.match.params.referenceId).then(
       darInfo => {
-        this.getDarData(darInfo).then((datasets) => {
+        this.getDarDatasets(darInfo).then((datasets) => {
           this.setState({datasets: datasets});
           Researcher.getResearcherProfile(darInfo.researcherId).then(
             researcherProfile => {
@@ -320,7 +320,7 @@ class AccessCollect extends Component {
     );
   }
 
-  getDarData = async (darInfo) => {
+  getDarDatasets = async (darInfo) => {
     let datasets;
     try {
       const datasetsPromise = darInfo.datasetIds.map((id) => {
@@ -533,9 +533,9 @@ class AccessCollect extends Component {
                 ]),
                 div({ id: 'panel_researchPurpose', className: 'panel-body cm-boxbody' }, [
                   div({ style: { 'marginBottom': '10px' } }, [darInfo.rus]),
-                  div({isRendered: !ld.isNil(darInfo) && !ld.isNil(researcherProfile)}, [
-                    h(ApplicationDownloadLink, {darInfo, researcherProfile, datasets})
-                  ])
+                  button({ isRendered: !ld.isNil(darInfo) && !ld.isNil(researcherProfile),
+                    className: 'col-lg-6 col-md-6 col-sm-6 col-xs-12 btn-secondary btn-download-pdf hover-color'},
+                  [h(ApplicationDownloadLink, {darInfo, researcherProfile, datasets})])
                 ])
               ]),
 

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -6,14 +6,14 @@ import { CollapsiblePanel } from '../components/CollapsiblePanel';
 import DataAccessRequestHeader from '../components/DataAccessRequestHeader';
 import { PageHeading } from '../components/PageHeading';
 import { StructuredDarRp } from '../components/StructuredDarRp';
-import {DAR, DataSet, Researcher} from '../libs/ajax';
+import { DAR, DataSet, Researcher } from '../libs/ajax';
 import { Models } from '../libs/models';
 import { Theme } from '../libs/theme';
 import * as ld from 'lodash';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
 import accessIcon from '../images/icon_access.png';
 import ApplicationDownloadLink from '../components/ApplicationDownloadLink';
-import {Notifications} from '../libs/utils';
+import { Notifications } from '../libs/utils';
 
 class AccessPreview extends Component {
 

--- a/src/pages/AccessPreview.js
+++ b/src/pages/AccessPreview.js
@@ -13,7 +13,6 @@ import * as ld from 'lodash';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
 import accessIcon from '../images/icon_access.png';
 import ApplicationDownloadLink from '../components/ApplicationDownloadLink';
-import { Notifications } from '../libs/utils';
 
 class AccessPreview extends Component {
 
@@ -57,7 +56,7 @@ class AccessPreview extends Component {
 
     DAR.describeDar(referenceId).then(
       darInfo => {
-        this.getDarDatasets(darInfo).then((datasets) => {
+        DataSet.getDarDatasets(darInfo.datasetIds).then((datasets) => {
           this.setState({datasets: datasets});
         }).then(() => {
           Researcher.getResearcherProfile(darInfo.researcherId).then(
@@ -72,20 +71,6 @@ class AccessPreview extends Component {
       }
     );
   }
-
-  getDarDatasets = async (darInfo) => {
-    let datasets;
-    try {
-      const datasetsPromise = darInfo.datasetIds.map((id) => {
-        return DataSet.getDataSetsByDatasetId(id);
-      });
-      datasets = await Promise.all(datasetsPromise);
-    } catch(error) {
-      Notifications.showError({text: 'Error initializing DAR Datasets'});
-      return Promise.reject(error);
-    }
-    return datasets;
-  };
 
   toggleQ1 = (e) => {
     this.setState(prev => {

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -15,7 +15,7 @@ import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import * as Utils from '../libs/utils';
 import accessIcon from '../images/icon_access.png';
-import {Notifications} from '../libs/utils';
+import { Notifications } from '../libs/utils';
 
 
 class AccessResultRecords extends Component {

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -15,7 +15,6 @@ import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';
 import * as Utils from '../libs/utils';
 import accessIcon from '../images/icon_access.png';
-import { Notifications } from '../libs/utils';
 
 
 class AccessResultRecords extends Component {
@@ -548,20 +547,6 @@ class AccessResultRecords extends Component {
     };
   }
 
-  async getDarDatasets (darInfo) {
-    let datasets;
-    try {
-      const datasetsPromise = darInfo.datasetIds.map((id) => {
-        return DataSet.getDataSetsByDatasetId(id);
-      });
-      datasets = await Promise.all(datasetsPromise);
-    } catch(error) {
-      Notifications.showError({text: 'Error initializing DAR Datasets'});
-      return Promise.reject(error);
-    }
-    return datasets;
-  }
-
   //returns the most recent final vote
   async getFinalDACVote(electionId) {
     const finalDACVote = await Votes.getDarFinalAccessVote(electionId);
@@ -630,7 +615,7 @@ class AccessResultRecords extends Component {
       this.electionRPCall(electionId, false) //Election.findRPElectionReview(electionId, false (finalStatus))
     ]);
 
-    const datasets = await this.getDarDatasets(darAPIResults.darInfo);
+    const datasets = await DataSet.getDarDatasets(darAPIResults.darInfo.datasetIds);
     const {darData, electionReview, showDULData, vaultVote} = electionReviewResults;
     const consent = electionReview.consent;
 

--- a/src/pages/AccessResultRecords.js
+++ b/src/pages/AccessResultRecords.js
@@ -9,7 +9,7 @@ import DataAccessRequestHeader from '../components/DataAccessRequestHeader';
 import { PageHeading } from '../components/PageHeading';
 import { SingleResultBox } from '../components/SingleResultBox';
 import TranslatedDULComponent from '../components/TranslatedDULComponent';
-import {DAR, DataSet, Election, Match, Researcher, Votes} from '../libs/ajax';
+import { DAR, DataSet, Election, Match, Researcher, Votes } from '../libs/ajax';
 import { Config } from '../libs/config';
 import { Models } from '../libs/models';
 import { Storage } from '../libs/storage';

--- a/src/pages/access_review/DarApplication.js
+++ b/src/pages/access_review/DarApplication.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { div, span, hh, h } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
-import { Files } from '../../libs/ajax';
 import { AppSummary } from './AppSummary';
 import { VoteSummary } from './VoteSummary';
 import ApplicationDownloadLink from '../../components/ApplicationDownloadLink';
@@ -25,11 +24,6 @@ const HEADER_BOLD = {
 };
 
 export const DarApplication = hh(class DarApplication extends React.PureComponent {
-
-  downloadDAR = () => {
-    const { darId } = this.props;
-    Files.getDARFile(darId);
-  };
 
   render() {
     const { voteAsChair, darInfo, accessElection, consent, accessElectionReview, rpElectionReview, researcherProfile, datasets } = this.props;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1015

## Changes
Updated the following pages so that they use the `ApplicationDownloadLink` to download a DAR's PDF file instead of making an API call to consent.
* Access Collect (admin view for existing DAR election)
* Access Preview (admin view for a new DAR election)
* Access Results Record (admin view for Statistics -> Reviewed Cases Record -> Record)

Updated the common component, `ApplicationSummary` with some bug fixes where we were not looking at the correct researcher properties for display.

Discovered a bug where we were showing the wrong machine readable DAR content. Filed in [DUOS-1089](https://broadworkbench.atlassian.net/browse/DUOS-1089)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
