### PR TITLE
DUOS-1090[risk=no] Cancel Election correction

### DIFF
--- a/src/components/TableIconButton.js
+++ b/src/components/TableIconButton.js
@@ -36,10 +36,9 @@ export default function TableIconButton(props) {
   //NOTE: span wrapper is needed for svg child elements due to flaky behavior onMouseEnter and onMouseLeave
   // https://github.com/facebook/react/issues/4492 --> NOTE: though the issue is from the React repo, the bug is tied to browser specs, NOT React
   return (
-    span({style, onMouseEnter, onMouseLeave}, [
+    span({style, onMouseEnter, onMouseLeave, onClick}, [
       h(Icon, {
         isRendered: isRendered && !isNil(Icon),
-        onClick,
         className: classes.root
       })
     ])

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -106,7 +106,7 @@ const Records = (props) => {
     if (!isNil(e)) {
       switch (e.status) {
         case 'Open' : {
-          const votes = filter({type: 'DAC', dacUserId: currentUserId})(electionInfo.votes);
+          const votes = filter({type: 'DAC', dacUserId: currentUserId, electionId: e.electionId})(electionInfo.votes);
           const isFinal = !isEmpty(votes.find((voteData) => !isNil(voteData.vote)));
           return [
             h(TableTextButton, {


### PR DESCRIPTION
Addresses [DUOS-1090](https://broadworkbench.atlassian.net/browse/DUOS-1090)

PR fixes Cancel Election bug by moving onClick handler from material-ui's Icon component to the span wrapper within TableButtonIcon.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
