### PR TITLE
DUOS-1102 [risk=no] Researcher Console: Submitted DAR shows in my temporary DAR table

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -615,7 +615,7 @@ class DataAccessRequestApplication extends Component {
         //actual fix would involve generating a blank draft record that is saved on console button click
         //however that would fall outside the scope of this pr, which is already large enough due to refactored code
         let referenceId = formattedFormData.referenceId;
-        let darPartialResponse = this.updateDraftResponse(formattedFormData, referenceId);
+        let darPartialResponse = await this.updateDraftResponse(formattedFormData, referenceId);
         referenceId = darPartialResponse.referenceId;
 
         //execute saveDARDocuments method only if documents are required for the DAR


### PR DESCRIPTION
Addresses [DUOS-1102](https://broadworkbench.atlassian.net/browse/DUOS-1102)

Bug in question regard submitting DAR applications with multiple datasets. Upon submission the draft should be processed and translated to a normal DAR, with any additional datasets outside of the first being tied to newly generated DARs. The functionality that occurs is that the draft remains while new records are generated for all datasets on the submitted form.

The bug is the result of a race condition that occurs due to a missing ```await``` keyword on one of the asynchronous function calls. Fix is to add the keyword back in.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
