### PR TITLE
DUOS-1011[risk=no]Fix redirect bug for Chair Users

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -59,8 +59,8 @@ export const setUserRoleStatuses = (user, Storage) => {
 };
 
 export const Navigation = {
-  back: (user, history) => {
-    const page = user.isChairPerson ? NavigationUtils.dacChairConsolePath()
+  back: async (user, history) => {
+    const page = user.isChairPerson ? await NavigationUtils.dacChairConsolePath()
       : user.isMember ? '/member_console'
         : user.isAdmin ? '/admin_console'
           : user.isResearcher ? '/dataset_catalog'
@@ -69,8 +69,8 @@ export const Navigation = {
                 : '/';
     history.push(page);
   },
-  console: (user, history) => {
-    const page = user.isChairPerson ? NavigationUtils.dacChairConsolePath()
+  console: async (user, history) => {
+    const page = user.isChairPerson ? await NavigationUtils.dacChairConsolePath()
       : user.isMember ? '/member_console'
         : user.isAdmin ? '/admin_console'
           : user.isResearcher ? '/researcher_console'


### PR DESCRIPTION
Addresses [DUOS-1101](https://broadworkbench.atlassian.net/browse/DUOS-1101)

PR fixes redirect bug for Chair users by adding async/await flow to the Navigation utility helpers. Recent addition of the asynchronous function ```darChairConsolePath``` requires the use of async/await to control ternary evaluation flow (otherwise the evaluation will call the function and move on without waiting for the result).

**NOTE**: There may be similar navigation bugs in backlog (Vote redirect) that most likely stem from this issue.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
