### PR TITLE
DUOS-1108[risk=no] Retrieve vote information for closed and canceled elections too (not just open)

### DIFF
--- a/src/pages/ReviewResults.js
+++ b/src/pages/ReviewResults.js
@@ -53,8 +53,7 @@ export default function ReviewResults(props) {
     try {
       accessElection = await Election.findElectionByDarId(darId);
     } catch (error) {
-      //access election is null, this is expected in the case of a closed, unreviewed, or canceled election status
-      //so for these cases there is currently no way to display the vote information
+      //access election is null
     }
     try {
       accessElectionReview = isNil(accessElection) ? null : await Election.findDataAccessElectionReview(accessElection.electionId, true);

--- a/src/pages/ReviewResults.js
+++ b/src/pages/ReviewResults.js
@@ -53,7 +53,8 @@ export default function ReviewResults(props) {
     try {
       accessElection = await Election.findElectionByDarId(darId);
     } catch (error) {
-      //access election is null
+      //access election is null, this is expected for a dar with an unreviewed election status
+      //so there is no vote information to display
     }
     try {
       accessElectionReview = isNil(accessElection) ? null : await Election.findDataAccessElectionReview(accessElection.electionId, true);


### PR DESCRIPTION
SCOPE:
- remove comment that is no longer true
- merge with DUOS-1108 in consent

Addresses:
- https://broadworkbench.atlassian.net/browse/DUOS-1108
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
