### PR TITLE
DUOS-1131[risk=no]Remove email updates from user APIs

### DIFF
--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -77,6 +77,11 @@ export const AddUserModal = hh(class AddUserModal extends Component {
   }
 
   OKHandler = async (event) => {
+    let user = {
+      displayName: this.state.displayName,
+      emailPreference: this.state.emailPreference,
+      roles: this.state.updatedRoles
+    };
     event.persist();
     this.setState({
       submitted: true
@@ -85,14 +90,9 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     if (validForm === false) {
       return;
     }
-    let user = {
-      displayName: this.state.displayName,
-      email: this.state.email,
-      emailPreference: this.state.emailPreference,
-      roles: this.state.updatedRoles
-    };
     switch (this.state.mode) {
       case 'Add': {
+        user.email = this.state.email;
         const createdUser = await User.create(user);
         this.setState({ emailValid: createdUser });
         break;

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -77,11 +77,6 @@ export const AddUserModal = hh(class AddUserModal extends Component {
   }
 
   OKHandler = async (event) => {
-    let user = {
-      displayName: this.state.displayName,
-      emailPreference: this.state.emailPreference,
-      roles: this.state.updatedRoles
-    };
     event.persist();
     this.setState({
       submitted: true
@@ -90,6 +85,11 @@ export const AddUserModal = hh(class AddUserModal extends Component {
     if (validForm === false) {
       return;
     }
+    let user = {
+      displayName: this.state.displayName,
+      emailPreference: this.state.emailPreference,
+      roles: this.state.updatedRoles
+    };
     switch (this.state.mode) {
       case 'Add': {
         user.email = this.state.email;


### PR DESCRIPTION
SCOPE:
remove email field from User.update calls
on Researcher Profile disable ability to change emails as it would only cause inconsistencies between front and back end, instead pre-populate that field from info in Storage
address compilation warnings and get rid of unnecessary Storage.getCurrentUser calls by making a constant
NOTE: Merge after DUOS-1131 in consent as this currently crashes without the backend changes

Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-1131

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
