### PR TITLE
DUOS-1139[risk=no]Admin Manage Access Cancel Election electionId undefined

### DIFF
--- a/src/pages/AdminManageAccess.js
+++ b/src/pages/AdminManageAccess.js
@@ -87,6 +87,7 @@ class AdminManageAccess extends Component {
   }
 
   dialogHandlerCancel = async (dar) => {
+    console.log(dar);
     const dataRequestId = dar.dataRequestId;
     const electionId = dar.election ? dar.election.electionId : dar.electionId;
     const CANCEL = "Canceled";
@@ -263,7 +264,7 @@ class AdminManageAccess extends Component {
                       isRendered: (dar.electionStatus === 'Open') || (dar.electionStatus === 'Final'),
                     }, [button({
                       style: {margin: "0 15px 5px 0"},
-                      onClick: () => this.dialogHandlerCancel(dar.dataRequestId, dar.electionId),
+                      onClick: () => this.dialogHandlerCancel(dar),
                       className: "cell-button cancel-color"
                     }, ["Cancel"]),
                     ]),

--- a/src/pages/AdminManageAccess.js
+++ b/src/pages/AdminManageAccess.js
@@ -87,7 +87,6 @@ class AdminManageAccess extends Component {
   }
 
   dialogHandlerCancel = async (dar) => {
-    console.log(dar);
     const dataRequestId = dar.dataRequestId;
     const electionId = dar.election ? dar.election.electionId : dar.electionId;
     const CANCEL = "Canceled";


### PR DESCRIPTION
SCOPE:
this bug was already addressed in DUOS-1125 but the solution was partially reverted leading to this bug, fix by passing in the expected argument to dialogHandleCancel

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1139

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
