### PR TITLE
DUOS-1106[risk=no]Require Library Cards for DAC Chairs to vote 'Yes' on Chair vote

### DIFF
--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -26,7 +26,7 @@ class AccessReview extends React.PureComponent {
 
   updateVote = () => {
     this.darReviewAccess();
-  }
+  };
 
   componentDidMount() {
     this.darReviewAccess();
@@ -70,6 +70,7 @@ class AccessReview extends React.PureComponent {
     const finalVotes = filter({ type: 'FINAL', dacUserId: currentUser.dacUserId })(allVotes);
     const agreementVotes = filter({ type: 'AGREEMENT', dacUserId: currentUser.dacUserId })(allVotes);
     const dacChairMessage = "DAC Chairs can optionally vote as a member.";
+    const libraryCards = isNil(researcherProfile) ? [] : researcherProfile.libraryCards;
 
     return div({ isRendered: darInfo != null, id: 'container', style: { margin: 'auto' } },
       [
@@ -88,7 +89,7 @@ class AccessReview extends React.PureComponent {
                 width: '30%',
               }
             },
-            [DacVotePanel({ history, memberVotes, chairVotes, finalVotes, agreementVotes, darId, accessElection, rpElection, consent, voteAsChair, selectChair: this.selectChair, updateVote: this.updateVote })]
+            [DacVotePanel({ history, memberVotes, chairVotes, finalVotes, agreementVotes, darId, accessElection, rpElection, consent, voteAsChair, selectChair: this.selectChair, updateVote: this.updateVote, libraryCards })]
           ),
           div(
             {

--- a/src/pages/access_review/DacVotePanel.js
+++ b/src/pages/access_review/DacVotePanel.js
@@ -321,7 +321,7 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
   };
 
   render() {
-    const { voteAsChair, selectChair, chairVotes } = this.props;
+    const { voteAsChair, selectChair, chairVotes, libraryCards } = this.props;
     const { alert, chairAccessVote, chairRpVote, memberAccessVote, memberRpVote, matchData, accessElectionOpen, rpElectionOpen } = this.state;
 
     // If we have an open election, theme the button based on the alert status.
@@ -376,7 +376,8 @@ export const DacVotePanel = hh(class DacVotePanel extends React.PureComponent {
               vote: chairAccessVote,
               rpVote: chairRpVote,
               accessElectionOpen: accessElectionOpen,
-              rpElectionOpen: rpElectionOpen
+              rpElectionOpen: rpElectionOpen,
+              libraryCards: libraryCards
             }),
             div({ style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center' } }, [
               this.showAlert(alert),

--- a/src/pages/access_review/VoteAsChair.js
+++ b/src/pages/access_review/VoteAsChair.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { div, a, span, hh } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
 import { VoteQuestion } from './VoteQuestion';
-import * as fp from 'lodash/fp';
+import {isNil, head, get, getOr} from 'lodash/fp';
 import * as moment from 'moment';
 
 const LINK = {
@@ -18,6 +18,14 @@ const LINK_SECTION = {
   alignItems: 'center',
 };
 
+const ERROR = {
+  fontSize: '12px',
+  fontWeight: '400',
+  textTransform: 'none',
+  margin: '12px 0',
+  color: 'red'
+};
+
 export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
 
   constructor(props) {
@@ -30,7 +38,7 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
   componentDidMount() {
     this.props.getVotes();
     this.props.getMatchData();
-  };
+  }
 
   toggleMatchData = () => {
     this.setState(prev => {
@@ -42,10 +50,10 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
   };
 
   formatMatchData = (matchData) => {
-    const failure = JSON.stringify(fp.getOr('false')('failed')(matchData)).toLowerCase() === 'true';
-    const vote = JSON.stringify(fp.getOr('false')('match')(matchData)).toLowerCase() === 'true';
+    const failure = JSON.stringify(getOr('false')('failed')(matchData)).toLowerCase() === 'true';
+    const vote = JSON.stringify(getOr('false')('match')(matchData)).toLowerCase() === 'true';
     const voteString = failure ? 'Unable to determine a system match' : vote ? 'Yes' : 'No';
-    const createDateString = moment(fp.get('createDate')(matchData)).format('YYYY-MM-DD');
+    const createDateString = moment(get('createDate')(matchData)).format('YYYY-MM-DD');
     const style = { marginLeft: '2rem', fontWeight: 'normal', textTransform: 'none' };
     return div({}, [
       div({},['DUOS Algorithm Decision:', span({style: style}, [voteString])]),
@@ -54,31 +62,34 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
   };
 
   render() {
-    const { vote, rpVote, onUpdate, matchData, accessElectionOpen, rpElectionOpen } = this.props;
-    const accessVoteQuestion = fp.isNil(vote) ?
+    const { vote, rpVote, onUpdate, matchData, accessElectionOpen, rpElectionOpen, libraryCards } = this.props;
+    const hasLibraryCard = !isNil(head(libraryCards));
+    const errorMessage = "The Researcher must have a Library Card before this DAR can be approved.";
+    const accessVoteQuestion = isNil(vote) ?
       div({}, []) :
       VoteQuestion({
         id: 'access-vote',
-        isRendered: !fp.isNil(vote),
+        isRendered: !isNil(vote),
         label: 'Question 1:',
         question: 'Should data access be granted to this applicant?',
         updateVote: (id, selectedOption, rationale) => onUpdate(id, selectedOption, rationale),
-        voteId: fp.isNil(vote) ? null : vote.voteId,
-        rationale: fp.isNil(vote.rationale) ? '' : vote.rationale,
-        selectedOption: fp.isNil(vote) ? null : vote.vote,
-        disabled: !accessElectionOpen
+        voteId: isNil(vote) ? null : vote.voteId,
+        rationale: isNil(vote.rationale) ? '' : vote.rationale,
+        selectedOption: isNil(vote) ? null : vote.vote,
+        disabled: !accessElectionOpen,
+        hasLibraryCard: hasLibraryCard
       });
-    const rpVoteQuestion = fp.isNil(rpVote) ?
+    const rpVoteQuestion = isNil(rpVote) ?
       div({}, []) :
       VoteQuestion({
         id: 'rp-vote',
-        isRendered: !fp.isNil(rpVote),
+        isRendered: !isNil(rpVote),
         label: 'Question 2:',
         question: 'Was the research purpose accurately converted to a structured format?',
         updateVote: (id, selectedOption, rationale) => onUpdate(id, selectedOption, rationale),
-        voteId: fp.isNil(rpVote) ? null : rpVote.voteId,
-        rationale: fp.isNil(rpVote.rationale) ? '' : rpVote.rationale,
-        selectedOption: fp.isNil(rpVote) ? null : rpVote.vote,
+        voteId: isNil(rpVote) ? null : rpVote.voteId,
+        rationale: isNil(rpVote.rationale) ? '' : rpVote.rationale,
+        selectedOption: isNil(rpVote) ? null : rpVote.vote,
         disabled: !rpElectionOpen
       });
     return div({ id: 'chair-vote' }, [
@@ -92,7 +103,8 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
       ]),
       div({ style: {color: this.state.viewMatchResults ? 'inherit' : 'transparent'} }, [
         this.formatMatchData(matchData)
-      ])
+      ]),
+      div({ style: ERROR, isRendered: hasLibraryCard === false}, [errorMessage])
     ]);
   }
 });

--- a/src/pages/access_review/VoteAsChair.js
+++ b/src/pages/access_review/VoteAsChair.js
@@ -20,7 +20,7 @@ const LINK_SECTION = {
 
 const ERROR = {
   fontSize: '12px',
-  fontWeight: '400',
+  fontWeight: '500',
   textTransform: 'none',
   margin: '12px 0',
   color: 'red'

--- a/src/pages/access_review/VoteQuestion.js
+++ b/src/pages/access_review/VoteQuestion.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { div, textarea, fieldset, h, input, hh } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
-import * as fp from 'lodash/fp';
+import {isNil} from 'lodash/fp';
 
 const HEADER = {
   fontSize: Theme.font.size.header,
@@ -37,7 +37,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
 
   setVote = (voteStatus, rationale) => {
     const { updateVote, voteId } = this.props;
-    if (fp.isNil(rationale)) {
+    if (isNil(rationale)) {
       rationale = '';
     }
     this.setState({
@@ -48,7 +48,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
   };
 
   render() {
-    const { label, question, id, rationale, selectedOption, disabled } = this.props;
+    const { label, question, id, rationale, selectedOption, disabled, hasLibraryCard } = this.props;
     const disabledProp = disabled ? { disabled: true } : {};
 
     return div({ style: { marginBottom: '24px' } },
@@ -61,6 +61,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
             ...disabledProp,
             type: 'radio',
             id: id + '-yes',
+            disabled: hasLibraryCard === false,
             onChange: () => this.setVote(true, this.state.rationale),
             checked: selectedOption === null ? false : selectedOption === true, // field will be checked if vote was previously submitted
           }),
@@ -87,7 +88,7 @@ export const VoteQuestion = hh(class VoteQuestion extends React.PureComponent {
           rows: '5',
           placeholder: 'OPTIONAL: Describe your rationale or add comments here',
           onChange: e => this.setVote(this.state.voteStatus, e.target.value),
-          value: fp.isNil(rationale) ? '' : rationale
+          value: isNil(rationale) ? '' : rationale
         })
       ]);
   }


### PR DESCRIPTION
## SCOPE
- in AccessReview: get library cards from researcher profile and pass the list to DacVotePanel
- in DacVotePanel: pass library cards to VoteAsChair
- inVoteAsChair: determine if the list is empty, if so display error. pass boolean hasLibraryCard to VoteQuestion
- inVoteQuestion if hasLibraryCard is false disable the yes button

## ADDRESSES
https://broadworkbench.atlassian.net/browse/DUOS-1106

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
