### PR TITLE
DUOS-1146[risk=no]Reformat radio buttons on Dataset Registration Page

### DIFF
--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -1070,7 +1070,7 @@ class DatasetRegistration extends Component {
                     [
                       span({className: 'control-label rp-title-question dataset-color'}, [
                         '2.1 Primary Data Use Terms* ',
-                        span({},
+                        span({style: {marginBottom:'1.5rem'}},
                           ['Please select one of the following data use permissions for your dataset.']),
                         div({
                           style: {'marginLeft': '15px'},
@@ -1089,10 +1089,6 @@ class DatasetRegistration extends Component {
                           {className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'},
                           [
                             RadioButton({
-                              style: {
-                                marginBottom: '2rem',
-                                color: '#777',
-                              },
                               id: 'checkGeneral',
                               name: 'checkPrimary',
                               value: 'general',
@@ -1104,10 +1100,6 @@ class DatasetRegistration extends Component {
                             }),
 
                             RadioButton({
-                              style: {
-                                marginBottom: '2rem',
-                                color: '#777',
-                              },
                               id: 'checkHmb',
                               name: 'checkPrimary',
                               value: 'hmb',
@@ -1119,10 +1111,6 @@ class DatasetRegistration extends Component {
                             }),
 
                             RadioButton({
-                              style: {
-                                marginBottom: '2rem',
-                                color: '#777',
-                              },
                               id: 'checkDisease',
                               name: 'checkPrimary',
                               value: 'diseases',
@@ -1134,6 +1122,7 @@ class DatasetRegistration extends Component {
                             }),
                             div({
                               style: {
+                                marginTop: '1rem',
                                 marginBottom: '2rem',
                                 color: '#777',
                                 cursor: diseases ? 'pointer' : 'not-allowed',
@@ -1152,10 +1141,6 @@ class DatasetRegistration extends Component {
                             ]),
 
                             RadioButton({
-                              style: {
-                                marginBottom: '2rem',
-                                color: '#777',
-                              },
                               id: 'checkOther',
                               name: 'checkPrimary',
                               value: 'other',
@@ -1167,6 +1152,7 @@ class DatasetRegistration extends Component {
                             }),
 
                             textarea({
+                              style: {margin: '1rem 0'},
                               className: 'form-control',
                               defaultValue: primaryOtherText,
                               onBlur: (e) => this.setOtherText(e, 'primary'),
@@ -1467,37 +1453,32 @@ class DatasetRegistration extends Component {
                     ]),
                   ]),
 
-                  div({ className: 'row no-margin' }, [
+                  div({ className: 'row no-margin'}, [
                     div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
                       label({ style: controlLabelStyle, className: 'default-color' },
                         ['Do you want to make this dataset publicly available in the DUOS dataset catalog and able to receive data access requests under the assigned DAC above?']),
 
-                      RadioButton({
-                        style: {
-                          marginBottom: '2rem',
-                          marginLeft: '2rem',
-                          color: '#777',
-                        },
-                        id: 'checkNeedsApproval_yes',
-                        name: 'checkNeedsApproval',
-                        value: 'yes',
-                        defaultChecked: !needsApproval,
-                        onClick: () => this.setNeedsApproval(false),
-                        label: 'Yes'
-                      }),
+                      div({style: {display: 'flex'}}, [
+                        RadioButton({
+                          id: 'checkNeedsApproval_yes',
+                          name: 'checkNeedsApproval',
+                          value: 'yes',
+                          defaultChecked: !needsApproval,
+                          onClick: () => this.setNeedsApproval(false),
+                          label: 'Yes'
+                        }),
 
-                      RadioButton({
-                        style: {
-                          margin: '2rem',
-                          color: '#777',
-                        },
-                        id: 'checkNeedsApproval_no',
-                        name: 'checkNeedsApproval',
-                        value: 'no',
-                        defaultChecked: needsApproval,
-                        onClick: () => this.setNeedsApproval(true),
-                        label: 'No'
-                      }),
+                        div({style: {width: '10%'}}),
+
+                        RadioButton({
+                          id: 'checkNeedsApproval_no',
+                          name: 'checkNeedsApproval',
+                          value: 'no',
+                          defaultChecked: needsApproval,
+                          onClick: () => this.setNeedsApproval(true),
+                          label: 'No'
+                        }),
+                      ]),
                     ]),
                   ]),
 


### PR DESCRIPTION
## Scope:
- remove custom style objects from radio button so it uses default styling
- adjust the margins surrounding the buttons
- put the yes or no buttons side by side because I thought they looked weird in a column, but I could change this back if I'm the only one thinking that

## Addresses:
https://broadworkbench.atlassian.net/browse/DUOS-1146

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
