### PR TITLE
DUOS-1149[risk=low]DAC Member (who is also a chair) can close/reopen election not in their DAC in the chair console

### DIFF
--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -97,24 +97,20 @@ const Records = (props) => {
             const targetTypes = (v.type === 'Chairperson' || v.type === 'DAC');
             return belongsToUser && targetTypes;
           })(electionInfo.votes);
-          const voteButton = h(TableTextButton, {
-            key: `vote-button-${e.referenceId}`,
-            onClick: () => props.history.push(`access_review/${dar.referenceId}`),
-            label: 'Vote',
-            disabled: isEmpty(votes)
-          });
-          if (chairDacIds.includes(dacId)) {
-            return [
-              voteButton,
-              h(TableIconButton, {
-                icon: Block,
-                key: `cancel-button-${e.referenceId}`,
-                onClick: () => cancelElectionHandler(electionInfo, dar.referenceId, index)
-              })
-            ];
-          } else {
-            return [voteButton];
-          }
+          return [
+            h(TableTextButton, {
+              key: `vote-button-${e.referenceId}`,
+              onClick: () => props.history.push(`access_review/${dar.referenceId}`),
+              label: 'Vote',
+              disabled: isEmpty(votes)
+            }),
+            h(TableIconButton, {
+              isRendered: chairDacIds.includes(dacId),
+              icon: Block,
+              key: `cancel-button-${e.referenceId}`,
+              onClick: () => cancelElectionHandler(electionInfo, dar.referenceId, index)
+            })
+          ];
         }
         default :
           return h(TableTextButton, {

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -1,4 +1,4 @@
-import { isEmpty, isNil, includes, toLower, filter, cloneDeep, find } from 'lodash/fp';
+import { isEmpty, isNil, includes, map, toLower, filter, cloneDeep, find } from 'lodash/fp';
 import { useState, useEffect, useRef } from 'react';
 import { div, h, img, input } from 'react-hyperscript-helpers';
 import { DAR, Election, User, Votes } from '../libs/ajax';
@@ -85,7 +85,10 @@ const Records = (props) => {
   const createActionButtons = (electionInfo, index) => {
     const e = electionInfo.election;
     const dar = electionInfo.dar;
-    const currentUserId = Storage.getCurrentUser().dacUserId;
+    const dacId = electionInfo.dac.dacId;
+    const currentUser = Storage.getCurrentUser();
+    const chairDacIds = map((role) => {return role.dacId;})(filter({roleId: 2})(currentUser.roles));
+    const currentUserId = currentUser.dacUserId;
     if (!isNil(e)) {
       switch (e.status) {
         case 'Open' : {
@@ -94,32 +97,39 @@ const Records = (props) => {
             const targetTypes = (v.type === 'Chairperson' || v.type === 'DAC');
             return belongsToUser && targetTypes;
           })(electionInfo.votes);
-          return [
-            h(TableTextButton, {
-              key: `vote-button-${e.referenceId}`,
-              onClick: () => props.history.push(`access_review/${dar.referenceId}`),
-              label: 'Vote',
-              disabled: isEmpty(votes)
-            }),
-            h(TableIconButton, {
-              icon: Block,
-              key: `cancel-button-${e.referenceId}`,
-              onClick: () => cancelElectionHandler(electionInfo, dar.referenceId, index)
-            })
-          ];
+          const voteButton = h(TableTextButton, {
+            key: `vote-button-${e.referenceId}`,
+            onClick: () => props.history.push(`access_review/${dar.referenceId}`),
+            label: 'Vote',
+            disabled: isEmpty(votes)
+          });
+          if (chairDacIds.includes(dacId)) {
+            return [
+              voteButton,
+              h(TableIconButton, {
+                icon: Block,
+                key: `cancel-button-${e.referenceId}`,
+                onClick: () => cancelElectionHandler(electionInfo, dar.referenceId, index)
+              })
+            ];
+          } else {
+            return [voteButton];
+          }
         }
         default :
           return h(TableTextButton, {
             key: `reopen-button-${e.referenceId}`,
             onClick: () => openConfirmation(dar, index),
-            label: 'Re-Open'
+            label: 'Re-Open',
+            disabled: !chairDacIds.includes(dacId)
           });
       }
     }
     return h(TableTextButton, {
       onClick: () => openConfirmation(dar, index),
       key: `open-election-dar-${dar.referenceId}`,
-      label: 'Open Election'
+      label: 'Open Election',
+      disabled: !chairDacIds.includes(dacId)
     });
   };
 
@@ -207,7 +217,7 @@ export default function NewChairConsole(props) {
 
   const closeConfirmation = () => {
     setShowConfirmation(false);
-  }
+  };
 
   const updateLists = (updatedElection, darId, index, successText, votes = undefined) => {
     const i = index + ((currentPage - 1) * tableSize);

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -89,6 +89,7 @@ const Records = (props) => {
     const currentUser = Storage.getCurrentUser();
     const chairDacIds = map((role) => {return role.dacId;})(filter({roleId: 2})(currentUser.roles));
     const currentUserId = currentUser.dacUserId;
+    const isChair = chairDacIds.includes(dacId);
     if (!isNil(e)) {
       switch (e.status) {
         case 'Open' : {
@@ -105,7 +106,7 @@ const Records = (props) => {
               disabled: isEmpty(votes)
             }),
             h(TableIconButton, {
-              isRendered: chairDacIds.includes(dacId),
+              isRendered: isChair,
               icon: Block,
               key: `cancel-button-${e.referenceId}`,
               onClick: () => cancelElectionHandler(electionInfo, dar.referenceId, index)
@@ -117,7 +118,7 @@ const Records = (props) => {
             key: `reopen-button-${e.referenceId}`,
             onClick: () => openConfirmation(dar, index),
             label: 'Re-Open',
-            disabled: !chairDacIds.includes(dacId)
+            disabled: !isChair
           });
       }
     }
@@ -125,7 +126,7 @@ const Records = (props) => {
       onClick: () => openConfirmation(dar, index),
       key: `open-election-dar-${dar.referenceId}`,
       label: 'Open Election',
-      disabled: !chairDacIds.includes(dacId)
+      disabled: !isChair
     });
   };
 

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -89,7 +89,7 @@ const Records = (props) => {
     const currentUser = Storage.getCurrentUser();
     const chairDacIds = map((role) => {return role.dacId;})(filter({roleId: 2})(currentUser.roles));
     const currentUserId = currentUser.dacUserId;
-    const isChair = chairDacIds.includes(dacId);
+    const isChairForThisDAC = chairDacIds.includes(dacId);
     if (!isNil(e)) {
       switch (e.status) {
         case 'Open' : {
@@ -106,7 +106,7 @@ const Records = (props) => {
               disabled: isEmpty(votes)
             }),
             h(TableIconButton, {
-              isRendered: isChair,
+              isRendered: isChairForThisDAC,
               icon: Block,
               key: `cancel-button-${e.referenceId}`,
               onClick: () => cancelElectionHandler(electionInfo, dar.referenceId, index)
@@ -118,7 +118,7 @@ const Records = (props) => {
             key: `reopen-button-${e.referenceId}`,
             onClick: () => openConfirmation(dar, index),
             label: 'Re-Open',
-            disabled: !isChair
+            isRendered: isChairForThisDAC
           });
       }
     }
@@ -126,7 +126,7 @@ const Records = (props) => {
       onClick: () => openConfirmation(dar, index),
       key: `open-election-dar-${dar.referenceId}`,
       label: 'Open Election',
-      disabled: !isChair
+      isRendered: isChairForThisDAC
     });
   };
 


### PR DESCRIPTION
SCOPE
- gather a list of dacIds that the current user is a chairperson in
- check to see if the dacId for the current row/dar is in that list
- if the user is not a chairperson on the dac for that row, then disable the open and re-open buttons and don't show the cancel election button

ADDRESSES
https://broadworkbench.atlassian.net/browse/DUOS-1149

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
