### PR TITLE
DUOS-1156[risk=no]Researcher Profile: Academic Email field not being pre-populated

### DIFF
--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -31,7 +31,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     super(props);
     this.state = this.initialState();
 
-    this.getResearcherProfile = this.getResearcherProfile.bind(this);
     this.clearNotRelatedPIFields = this.clearNotRelatedPIFields.bind(this);
     this.clearCommonsFields = this.clearCommonsFields.bind(this);
     this.clearNoHasPIFields = this.clearNoHasPIFields.bind(this);
@@ -42,7 +41,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   async componentDidMount() {
     const currentUser = Storage.getCurrentUser();
-    await this.getResearcherProfile();
+    await this.getResearcherProfile(currentUser);
     this.props.history.push('profile');
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     this.setState(prev => {
@@ -109,8 +108,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     };
   }
 
-  async getResearcherProfile() {
-    const currentUser = Storage.getCurrentUser();
+  getResearcherProfile = async (currentUser) => {
     let rp = {};
     let profile = await Researcher.getResearcherProfile(currentUser.dacUserId);
     const user = await User.getByEmail(currentUser.email);

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -50,6 +50,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       prev.notificationData = notificationData;
       prev.profile.academicEmail = currentUser.email;
       prev.currentUser = currentUser;
+      prev.isResearcher = currentUser.isResearcher;
       return prev;
     });
   }
@@ -57,7 +58,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
   initialState() {
     return {
       loading: true,
-      isResearcher: Storage.getCurrentUser().isResearcher,
       hasLibraryCard: false,
       fieldStatus: {},
       showDialogSubmit: false,

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -25,7 +25,6 @@ const UsaStates = require('usa-states').UsaStates;
 const stateNames = (new UsaStates().arrayOf("names")).map((name) => option({value: name}, [name]));
 stateNames.splice(0, 0, empty);
 
-
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   constructor(props) {


### PR DESCRIPTION
SCOPE:
- set email value in componentDidMount from Storage.getcurrentUser().email, this will be the login email that is authorized
- remove currentUser constant from top of file, this wasn't updating as frequently as it needed to because it was outside of Researcher Profile, causing issues so I set the current user as a state in componentDidMount as well
- I also moved setting isResearcher from the constructor to componentdidMount so we don't need to Storage.getCurrentUser again there

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1156
https://broadworkbench.atlassian.net/browse/DUOS-1158


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
