### PR TITLE
DUOS-1154[risk=no] Fix DAC Summary Visual Not Displaying

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -514,8 +514,8 @@ export const Election = {
 
   findElectionByDarId: async (requestId) => {
     const url = `${await Config.getApiUrl()}/dataRequest/${requestId}/election`;
-    const res = await fetchOk(url, Config.authOpts());
-    return res.json();
+    const res = await axios.get(url, Config.authOpts());
+    return res.data;
   },
 
   downloadDatasetVotesForDARElection: async (requestId) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -514,8 +514,8 @@ export const Election = {
 
   findElectionByDarId: async (requestId) => {
     const url = `${await Config.getApiUrl()}/dataRequest/${requestId}/election`;
-    const res = await axios.get(url, Config.authOpts());
-    return res.data;
+    const res = await fetchOk(url, Config.authOpts());
+    return await res.json();
   },
 
   downloadDatasetVotesForDARElection: async (requestId) => {

--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -38,7 +38,9 @@ class AccessReview extends React.PureComponent {
     // Access Election Information
     const getElectionInformation = async(darId) => {
       try{
+        // const accessVote = await Votes.getDarVote(darId, voteId);
         const accessElection = await Election.findElectionByDarId(darId);
+        const accessElectionReview = await Election.findDataAccessElectionReview(accessElection.electionId, false);
         const rpElectionReview = isNil(accessElection) ? null : await Election.findRPElectionReview(accessElection.electionId, false);
         const rpElection = isNil(rpElectionReview) ? null : rpElectionReview.election;
         return {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection};
@@ -48,12 +50,12 @@ class AccessReview extends React.PureComponent {
       }
     };
 
-    const [electionData, darData, allVotes] = await Promise.all([
-      getElectionInformation(darId),
+    const [darData, allVotes] = await Promise.all([
       getDarData(darId),
       //Vote information
       Votes.getDarVotes(darId),
     ]);
+    const electionData = await getElectionInformation(darData.darInfo.referenceId);
     const {datasets, darInfo, consent, researcherProfile} = darData;
     const {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection} = electionData;
 

--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -49,12 +49,12 @@ class AccessReview extends React.PureComponent {
       }
     };
 
-    const [darData, allVotes] = await Promise.all([
+    const [darData, allVotes, electionData] = await Promise.all([
       getDarData(darId),
       //Vote information
       Votes.getDarVotes(darId),
+      getElectionInformation(darId)
     ]);
-    const electionData = await getElectionInformation(darData.darInfo.referenceId);
     const {datasets, darInfo, consent, researcherProfile} = darData;
     const {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection} = electionData;
 

--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -38,7 +38,6 @@ class AccessReview extends React.PureComponent {
     // Access Election Information
     const getElectionInformation = async(darId) => {
       try{
-        // const accessVote = await Votes.getDarVote(darId, voteId);
         const accessElection = await Election.findElectionByDarId(darId);
         const accessElectionReview = await Election.findDataAccessElectionReview(accessElection.electionId, false);
         const rpElectionReview = isNil(accessElection) ? null : await Election.findRPElectionReview(accessElection.electionId, false);


### PR DESCRIPTION
Addresses [DUOS-1154](https://broadworkbench.atlassian.net/browse/DUOS-1154)

PR addresses disrupted election initialization within ```AccessReview``` as a result of a previous PR. It removed functional calls with outdated/deprecated voteId argument, but also inadvertently removed the accessElectionReview assignment that was needed for downstream DOM elements. This PR restores that function call and adds missing await keyword to ```Election.findElectionByDarId```

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
