### PR TITLE
DUOS-1107 Update processElectionStatus in NewChairConsole so that it checks on 'Closed' rather than 'Final'

### DIFF
--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -40,7 +40,9 @@ const processElectionStatus = (election, votes) => {
       const completedVotes = (filter(wasVoteSubmitted)(dacVotes)).length;
       output = `Open (${completedVotes} / ${dacVotes.length} votes)`;
     }
-  } else if (electionStatus === 'Final') {
+    //some databases have Closed set as electionStatus, some have Final
+    //they effectively mean the same thing, however string check needs to be done on both
+  } else if (electionStatus === 'Final' || electionStatus === 'Closed') {
     const finalVote = find(wasFinalVoteTrue)(votes);
     output = finalVote ? 'Accepted' : 'Closed';
   } else {
@@ -85,7 +87,7 @@ const Records = (props) => {
   const createActionButtons = (electionInfo, index) => {
     const e = electionInfo.election;
     const dar = electionInfo.dar;
-    const dacId = electionInfo.dac.dacId;
+    const dacId = isNil(electionInfo.dac) ? null: electionInfo.dac.dacId;
     const currentUser = Storage.getCurrentUser();
     const chairDacIds = map((role) => {return role.dacId;})(filter({roleId: 2})(currentUser.roles));
     const currentUserId = currentUser.dacUserId;
@@ -136,7 +138,7 @@ const Records = (props) => {
     return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${dar.data.referenceId}-${index}`}, [
       div({
         style: Object.assign({}, Styles.TABLE.DATA_ID_CELL, dataIDTextStyle),
-        onClick: (e) => openModal(dar),
+        onClick: () => openModal(dar),
         onMouseEnter: applyTextHover,
         onMouseLeave: (e) => removeTextHover(e, Styles.TABLE.DATA_REQUEST_TEXT.color)
       }, [dar && dar.data ? dar.data.darCode : '- -']),
@@ -318,7 +320,7 @@ export default function NewChairConsole(props) {
               paddingLeft: '2%',
               fontFamily: 'Montserrat'
             },
-            onChange:(e) => handleSearchChange(searchTerms.current),
+            onChange:() => handleSearchChange(searchTerms.current),
             ref: searchTerms
           })
         ])


### PR DESCRIPTION
Addresses [DUOS-1107](https://broadworkbench.atlassian.net/browse/DUOS-1107)

PR checks for both ```Closed``` and ```Final``` values when processing closed ```Elections``` on ```NewChairConsole```. Though the string values are distinct, they both represent a closed ```Election```, so checking on both ensures that no election slips through the cracks. 

PR also adds null check on ```DACs``` before assigning ```dacId``` values to variables in ```NewChairConsole```. Check is needed for elections that are not tied to a ```DAC```.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
