### PR TITLE
DUOS-1166[risk=no]Profile updates cannot be submitted on staging

### DIFF
--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -418,6 +418,9 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   async saveUser() {
     const currentUserUpdate = Storage.getCurrentUser();
+    //temporarily, include the email in the payload passed to consent
+    //bc this is causing failures on staging without the backend changes that go with it
+    // this change will be reverted in DUOS-1167 once the next monolith release occurs
     //delete currentUserUpdate.email;
     currentUserUpdate.displayName = this.state.profile.profileName;
     currentUserUpdate.additionalEmail = this.state.additionalEmail;

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -418,7 +418,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   async saveUser() {
     const currentUserUpdate = Storage.getCurrentUser();
-    delete currentUserUpdate.email;
+    //delete currentUserUpdate.email;
     currentUserUpdate.displayName = this.state.profile.profileName;
     currentUserUpdate.additionalEmail = this.state.additionalEmail;
     currentUserUpdate.roles = this.state.roles;


### PR DESCRIPTION
SCOPE:
- temporarily, include the email in the payload passed to consent 
- this change can be undone once the next monolith release occurs (I filed DUOS-1167 ticket for this)

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1166

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
