### PR TITLE
DUOS-1172[risk=no]UI: State Unselectable with no message explaining why

### DIFF
--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -721,7 +721,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                 div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
                   div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
                     div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
-                      label({ id: 'lbl_profileCity', className: 'control-label' }, ['City* ']),
+                      label({ id: 'lbl_profileCity', className: 'control-label' }, ['City*']),
                       input({
                         id: 'profileCity',
                         name: 'city',

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -1,6 +1,6 @@
 import {omit, cloneDeep, isEmpty, isNil, get, trim, omitBy } from 'lodash';
 import { Component } from 'react';
-import {button, div, form, hh, hr, input, label, option, select, span, textarea} from 'react-hyperscript-helpers';
+import {button, div, form, h, hh, hr, input, label, option, select, span, textarea} from 'react-hyperscript-helpers';
 import { LibraryCards } from '../components/LibraryCards';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { eRACommons } from '../components/eRACommons';
@@ -12,6 +12,7 @@ import { NotificationService } from '../libs/notificationService';
 import { Notification } from '../components/Notification';
 import { USER_ROLES, setUserRoleStatuses } from '../libs/utils';
 import {getNames} from "country-list";
+import ReactTooltip from "react-tooltip";
 
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
@@ -50,7 +51,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         address2: '',
         city: '',
         completed: undefined,
-        country: undefined,
+        country: '',
         department: '',
         division: '',
         eRACommonsID: '',
@@ -140,6 +141,20 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
         this.researcherFieldsValidation();
       }
     });
+    //clear out state field if the user selects
+    //another country or clears out the country field
+    if (field === "country") {
+      if (value !== "United States of America") {
+        this.setState(prev => {
+          prev.profile.state = "";
+          return prev;
+        }, () => {
+          if (this.state.validateFields) {
+            this.researcherFieldsValidation();
+          }
+        });
+      }
+    }
   };
 
   researcherFieldsValidation() {
@@ -254,8 +269,8 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
   }
 
   isValidState(value) {
-    const stateSelected = (!isNil(value) || !isEmpty(value)) && (value !== "N/A");
-    const inUS = (this.state.profile.country === "United States of America");
+    const stateSelected = (!isNil(value) || !isEmpty(value));
+    const inUS = (this.state.profile.country === "United States of America" || this.state.profile.country === "");
     if (inUS && stateSelected) {
       return true;
     }
@@ -723,7 +738,14 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                     ]),
 
                     div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
-                      label({ id: 'lbl_profileState', className: 'control-label'}, ['State*']),
+                      label({ id: 'lbl_profileState', className: 'control-label'}, ['State*',
+                        span({
+                          isRendered: !(this.state.profile.country == "" || this.state.profile.country == "United States of America"),
+                          className: 'glyphicon glyphicon-question-sign tooltip-icon',
+                          "data-tip": "State cannot be selected if a non-US Country is selected.",
+                          'data-for': 'tip_profilestate',
+                        })
+                      ]),
                       select({
                         id: 'profileState',
                         name: 'state',
@@ -731,7 +753,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                         value: this.state.profile.state,
                         className: (this.state.invalidFields.state && showValidationMessages) ? 'form-control required-field-error' : 'form-control',
                         required: true,
-                        disabled: (this.state.profile.country !== "United States of America")
+                        disabled: (this.state.profile.country !== "" && this.state.profile.country !== "United States of America")
                       }, stateNames ),
                       span({
                         className: 'cancel-color required-field-error-span',
@@ -957,6 +979,20 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                       ['Are you sure you want to leave this page? Please remember that you need to submit your Profile information to be able to create a Data Access Request.'])
                   ]
                   ),
+                  h(ReactTooltip, {
+                    id: "tip_profilestate",
+                    place: 'left',
+                    effect: 'solid',
+                    multiline: true,
+                    className: 'tooltip-wrapper'
+                  }),
+                  h(ReactTooltip, {
+                    id: "tip_isthePI",
+                    place: 'left',
+                    effect: 'solid',
+                    multiline: true,
+                    className: 'tooltip-wrapper'
+                  })
                 ])
               ])
             ])

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -269,7 +269,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
   }
 
   isValidState(value) {
-    const stateSelected = (!isNil(value) || !isEmpty(value));
+    const stateSelected = (!isNil(value) && !isEmpty(value));
     const inUS = (this.state.profile.country === "United States of America" || this.state.profile.country === "");
     if (inUS && stateSelected) {
       return true;

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -721,7 +721,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                 div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding' }, [
                   div({ className: 'row fsi-row-lg-level fsi-row-md-level no-margin' }, [
                     div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
-                      label({ id: 'lbl_profileCity', className: 'control-label' }, ['City*']),
+                      label({ id: 'lbl_profileCity', className: 'control-label' }, ['City* ']),
                       input({
                         id: 'profileCity',
                         name: 'city',
@@ -738,12 +738,11 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                     ]),
 
                     div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
-                      label({ id: 'lbl_profileState', className: 'control-label'}, ['State*',
+                      label({ id: 'lbl_profileState', className: 'control-label'}, ['State* ',
                         span({
-                          isRendered: !(this.state.profile.country == "" || this.state.profile.country == "United States of America"),
                           className: 'glyphicon glyphicon-question-sign tooltip-icon',
                           "data-tip": "State cannot be selected if a non-US Country is selected.",
-                          'data-for': 'tip_profilestate',
+                          'data-for': 'tip_profileState',
                         })
                       ]),
                       select({
@@ -815,7 +814,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                     span({
                       className: 'glyphicon glyphicon-question-sign tooltip-icon',
                       'data-tip': 'This information is required in order to classify users as bonafide researchers as part of the process of Data Access approvals.',
-                      'data-for': 'tip_isthePI'
+                      'data-for': 'tip_isThePI'
                     })
                   ])
                 ]),
@@ -977,17 +976,16 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                   }, [
                     div({ className: 'dialog-description' },
                       ['Are you sure you want to leave this page? Please remember that you need to submit your Profile information to be able to create a Data Access Request.'])
-                  ]
-                  ),
+                  ]),
                   h(ReactTooltip, {
-                    id: "tip_profilestate",
+                    id: "tip_profileState",
                     place: 'left',
                     effect: 'solid',
                     multiline: true,
                     className: 'tooltip-wrapper'
                   }),
                   h(ReactTooltip, {
-                    id: "tip_isthePI",
+                    id: "tip_isThePI",
                     place: 'left',
                     effect: 'solid',
                     multiline: true,


### PR DESCRIPTION
SCOPE:
- updated state validation check 
- leave state box enabled when no country is selected, only disable when a non US country is selected
- fix tooltip for isPi
- add tooltip for state

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1172

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
