### PR TITLE
DUOS-1189/DUOS-1194[risk=no]Add 'Dataset Name' column to DAC Chair,  and Admin Consoles

### DIFF
--- a/src/components/dar_table/DarElectionRecords.js
+++ b/src/components/dar_table/DarElectionRecords.js
@@ -1,6 +1,12 @@
 import { isEmpty } from 'lodash/fp';
 import { div, h, a } from 'react-hyperscript-helpers';
-import { applyTextHover, removeTextHover, getElectionDate, processElectionStatus } from '../../libs/utils';
+import {
+  applyTextHover,
+  removeTextHover,
+  getElectionDate,
+  processElectionStatus,
+  getNameOfDatasetForThisDAR
+} from '../../libs/utils';
 import { Styles } from '../../libs/theme';
 import DarTableActions from './DarTableActions';
 import { Theme } from '../../libs/theme';
@@ -50,6 +56,7 @@ export default function DarElectionRecords(props) {
         onMouseLeave: (e) => removeTextHover(e, Styles.TABLE.DATA_REQUEST_TEXT.color)
       }, [dar && dar.data ? dar.data.darCode : '- -']),
       div({style: Object.assign({}, Styles.TABLE.TITLE_CELL, recordTextStyle)}, [dar && dar.data ? dar.data.projectTitle : '- -']),
+      div({style: Object.assign({}, Styles.TABLE.TITLE_CELL, recordTextStyle)}, [dar && dar.data ? getNameOfDatasetForThisDAR(dar.data.datasets, dar.data.datasetIds) : '- -']),
       div({style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL, recordTextStyle)}, [getElectionDate(election)]),
       div({style: Object.assign({}, Styles.TABLE.DAC_CELL, recordTextStyle)}, [dac ? dac.name : '- -']),
       electionStatusTemplate(consoleType, dar, election, recordTextStyle, votes, showVotes, history),

--- a/src/components/dar_table/DarTable.js
+++ b/src/components/dar_table/DarTable.js
@@ -17,6 +17,7 @@ import ReactTooltip from 'react-tooltip';
 export const tableHeaderTemplate = [
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Data Request ID"]),
   div({style: Styles.TABLE.TITLE_CELL}, ["Project title"]),
+  div({style: Styles.TABLE.TITLE_CELL}, ["Dataset"]),
   div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Last Updated"]),
   div({style: Styles.TABLE.DAC_CELL}, ["DAC"]),
   div({style: Styles.TABLE.ELECTION_STATUS_CELL}, ["Election status"]),
@@ -26,6 +27,7 @@ const loadingMarginOverwrite = {margin: '1rem 2%'};
 
 export const tableRowLoadingTemplate = [
   div({style: assign(Styles.TABLE.DATA_ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
+  div({style: assign(Styles.TABLE.TITLE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.TITLE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.SUBMISSION_DATE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.DAC_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),

--- a/src/components/dar_table/DarTable.js
+++ b/src/components/dar_table/DarTable.js
@@ -17,7 +17,7 @@ import ReactTooltip from 'react-tooltip';
 export const tableHeaderTemplate = [
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Data Request ID"]),
   div({style: Styles.TABLE.TITLE_CELL}, ["Project Title"]),
-  div({style: Styles.TABLE.TITLE_CELL}, ["Dataset Name"]),
+  div({style: Styles.TABLE.DATASET_CELL}, ["Dataset Name"]),
   div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Last Updated"]),
   div({style: Styles.TABLE.DAC_CELL}, ["DAC"]),
   div({style: Styles.TABLE.ELECTION_STATUS_CELL}, ["Election Status"]),
@@ -28,7 +28,7 @@ const loadingMarginOverwrite = {margin: '1rem 2%'};
 export const tableRowLoadingTemplate = [
   div({style: assign(Styles.TABLE.DATA_ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.TITLE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
-  div({style: assign(Styles.TABLE.TITLE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
+  div({style: assign(Styles.TABLE.DATASET_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.SUBMISSION_DATE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.DAC_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.ELECTION_STATUS_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),

--- a/src/components/dar_table/DarTable.js
+++ b/src/components/dar_table/DarTable.js
@@ -16,12 +16,12 @@ import ReactTooltip from 'react-tooltip';
 ////////////////////
 export const tableHeaderTemplate = [
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Data Request ID"]),
-  div({style: Styles.TABLE.TITLE_CELL}, ["Project title"]),
-  div({style: Styles.TABLE.TITLE_CELL}, ["Dataset"]),
+  div({style: Styles.TABLE.TITLE_CELL}, ["Project Title"]),
+  div({style: Styles.TABLE.TITLE_CELL}, ["Dataset Name"]),
   div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Last Updated"]),
   div({style: Styles.TABLE.DAC_CELL}, ["DAC"]),
-  div({style: Styles.TABLE.ELECTION_STATUS_CELL}, ["Election status"]),
-  div({style: Styles.TABLE.ELECTION_ACTIONS_CELL}, ["Election actions"])
+  div({style: Styles.TABLE.ELECTION_STATUS_CELL}, ["Election Status"]),
+  div({style: Styles.TABLE.ELECTION_ACTIONS_CELL}, ["Election Actions"])
 ];
 const loadingMarginOverwrite = {margin: '1rem 2%'};
 

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -165,39 +165,46 @@ export const Styles = {
       justifyContent: "left",
       alignItems: "center",
       wordBreak: 'break-word',
-      margin: "0 2%"
+      margin: "0 1%"
+    },
+    DATASET_CELL: {
+      width: "18%",
+      margin: "0 1%",
+      display: "flex",
+      justifyContent: "left",
+      alignItems: "center"
     },
     DATA_ID_CELL: {
-      width: "10%",
-      margin: "0 2%",
+      width: "14%",
+      margin: "0 1%",
       display: "flex",
       justifyContent: "left",
       alignItems: "center"
     },
     SUBMISSION_DATE_CELL: {
-      width: "10%",
-      margin: "0 2%",
+      width: "12%",
+      margin: "0 1%",
       display: "flex",
       justifyContent: "left",
       alignItems: "center",
     },
     DAC_CELL: {
-      width: "10%",
-      margin: "0 2%",
+      width: "8%",
+      margin: "0 1%",
       display: "flex",
       justifyContent: "left",
       alignItems: "center",
     },
     ELECTION_STATUS_CELL: {
-      width: "10%",
-      margin: "0 2%",
+      width: "12%",
+      margin: "0 1%",
       display: "flex",
       justifyContent: "left",
       alignItems: "center",
     },
     ELECTION_ACTIONS_CELL: {
-      width: "23%",
-      margin: "0 2%",
+      width: "16%",
+      margin: "0 1%",
       display: "flex",
       justifyContent: "left",
       alignItems: "center",

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -5,7 +5,7 @@ import {Config} from './config';
 import {forEach} from 'lodash';
 import {DAR, DataSet, Researcher} from "./ajax";
 import {Styles} from "./theme";
-import { find, map, isEmpty, filter, cloneDeep, isNil, toLower, includes } from "lodash/fp";
+import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes } from "lodash/fp";
 
 export const applyHoverEffects = (e, style) => {
   forEach(style, (value, key) => {
@@ -16,8 +16,7 @@ export const applyHoverEffects = (e, style) => {
 //currently, dars contain a list of datasets (any length) and a list of length 1 of a datasetId
 //go through the list of datasets and get the name of the dataset whose id is in the datasetId list
 export const getNameOfDatasetForThisDAR = (datasets, datasetId) => {
-  let id = datasetId[0].toString();
-  let data = find({"value" : id})(datasets);
+  const data = !isNil(datasetId) && !isEmpty(datasetId) ? find({"value" : first(datasetId).toString()})(datasets) : null;
   return isNil(data) ? '- -' : getDatasetNames([data]);
 };
 
@@ -321,7 +320,8 @@ export const darSearchHandler = (electionList, setFilteredList, setCurrentPage) 
           newFilteredList = filter(electionData => {
             const { election, dac, votes} = electionData;
             const dar = electionData.dar ? electionData.dar.data : undefined;
-            const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode)]) : [];
+            console.log(dar);
+            const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode), toLower(getNameOfDatasetForThisDAR(dar.datasets, dar.datasetIds))]) : [];
             const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
             const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(processElectionStatus(election, votes)), getElectionDate(election)]) : [];
             return includes(term, targetDarAttrs) || includes(term, targetDacAttrs) || includes(term, targetElectionAttrs);

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -18,7 +18,7 @@ export const applyHoverEffects = (e, style) => {
 export const getNameOfDatasetForThisDAR = (datasets, datasetId) => {
   let id = datasetId[0].toString();
   let data = find({"value" : id})(datasets);
-  return isNil(data) ? "--" : getDatasetNames([data]);
+  return isNil(data) ? '- -' : getDatasetNames([data]);
 };
 
 export const formatDate = (dateval) => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -320,7 +320,6 @@ export const darSearchHandler = (electionList, setFilteredList, setCurrentPage) 
           newFilteredList = filter(electionData => {
             const { election, dac, votes} = electionData;
             const dar = electionData.dar ? electionData.dar.data : undefined;
-            console.log(dar);
             const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode), toLower(getNameOfDatasetForThisDAR(dar.datasets, dar.datasetIds))]) : [];
             const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
             const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(processElectionStatus(election, votes)), getElectionDate(election)]) : [];

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -13,6 +13,14 @@ export const applyHoverEffects = (e, style) => {
   });
 };
 
+//currently, dars contain a list of datasets (any length) and a list of length 1 of a datasetId
+//go through the list of datasets and get the name of the dataset whose id is in the datasetId list
+export const getNameOfDatasetForThisDAR = (datasets, datasetId) => {
+  let id = datasetId[0].toString();
+  let data = find({"value" : id})(datasets);
+  return isNil(data) ? "--" : getDatasetNames([data]);
+};
+
 export const formatDate = (dateval) => {
   if (dateval === null || dateval === undefined) {
     return '---';

--- a/src/pages/MemberConsole.js
+++ b/src/pages/MemberConsole.js
@@ -81,7 +81,7 @@ class MemberConsole extends Component {
 
   }
 
-  openAccessReview = (referenceId) => async (e) => {
+  openAccessReview = (referenceId) => async () => {
     const pathStart = NavigationUtils.accessReviewPath();
     this.props.history.push(`${pathStart}/${referenceId}`);
   };


### PR DESCRIPTION
SCOPE:
-NOTE: this PR does not implement the additional column in the member console, like the ticket requests. This is because the member console is getting its data from the v1 endpoint that does not contain datasets or dataset id. We could implement this column without changing the api call if we query for the dar off of the access election and then query again for the dataset based off of the datasetid included in the dar. This would be two extra api calls for every row, which would slow things down quite a bit. I think it makes more sense to convert the member console over to the v2 api call and reuse the components used for the new chair and admin access pages. But that is out of the scope of this PR. Additionally, in the meantime, the datasets are already accessible from this page by clicking on the dar modal. Thoughts?
-implement Dataset column on new chair and new admin manage access

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1189
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
