### PR TITLE
DUOS-1205[risk-no]Remove Data Use Letter button on all DAR Review pages

### DIFF
--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -47,7 +47,7 @@ export const AppSummary = hh(class AppSummary extends React.Component {
       prev.translatedRestrictions = translatedRestrictions;
       return prev;
     });
-  }
+  };
 
   async componentDidMount() {
     await this.generateRestrictions(this.props.consent.dataUse);
@@ -76,10 +76,6 @@ export const AppSummary = hh(class AppSummary extends React.Component {
         h(DownloadLink,{
           label: 'DUL machine-readable format',
           onDownload: () => download('machine-readable-DUL.json', mrDUL)
-        }),
-        h(DownloadLink,{
-          label: 'Data Use Letter',
-          onDownload: this.downloadDUL
         })
       ])
     ]);

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { div, hh, span, h } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
-import { Files } from '../../libs/ajax';
 import { download } from '../../libs/utils';
 import { ApplicationSection } from './ApplicationSection';
 import { StructuredDarRp } from '../../components/StructuredDarRp';
@@ -52,14 +51,6 @@ export const AppSummary = hh(class AppSummary extends React.Component {
   async componentDidMount() {
     await this.generateRestrictions(this.props.consent.dataUse);
   }
-
-  /**
-   * downloads the data use letter for this dataset
-   */
-  downloadDUL = () => {
-    const { consentId, dulName } = this.props.consent;
-    Files.getDulFile(consentId, dulName);
-  };
 
   render() {
     const { darInfo, accessElection, consent, researcherProfile } = this.props;


### PR DESCRIPTION
SCOPE:
- remove DUL link from AppSummary 
- App Summary is used on the AccessReview and ReviewResults pages

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1205

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
