### PR TITLE
[DUOS-1216][risk=no] Update branch image tagging

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
         ENVIRONMENT_TAG=""
         if ${{ github.event_name == 'pull_request'}}; then
-          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${SHA_TAG}_pull_request"
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${SHA_TAG}"
         elif ${{github.event_name == 'push' }}; then
           ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
         fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
   tag-build-push:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code 
+    - name: Checkout code
       uses: actions/checkout@v2
     - name: Get Short Sha
       id: short-sha
@@ -39,12 +39,7 @@ jobs:
       id: construct-tags
       run: |
         SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
-        ENVIRONMENT_TAG=""
-        if ${{ github.event_name == 'pull_request'}}; then
-          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ github.event.pull_request.head.ref }}"
-        elif ${{github.event_name == 'push' }}; then
-          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
-        fi
+        ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
         echo ::set-output name=sha-tag::$SHA_TAG
         echo ::set-output name=environment-tag::$ENVIRONMENT_TAG
     - name: Build Image

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,11 +7,6 @@ on:
     paths-ignore:
     - 'README.md'
     - '.github/**'
-  pull_request:
-    branches:
-    - develop
-    paths-ignore:
-    - 'README.md'
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
   VAULT_PATH_GCR: secret/devops/ci/gcp-sa/broad-dsp-gcr-public/gcr-publish-key

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
         SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
         ENVIRONMENT_TAG=""
         if ${{ github.event_name == 'pull_request'}}; then
-          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${SHA_TAG}"
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${{ steps.short-sha.outputs.sha }}"
         elif ${{github.event_name == 'push' }}; then
           ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
         fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,11 @@ on:
     paths-ignore:
     - 'README.md'
     - '.github/**'
+  pull_request:
+    branches:
+    - develop
+    paths-ignore:
+    - 'README.md'
 env:
   VAULT_ADDR: https://clotho.broadinstitute.org:8200
   VAULT_PATH_GCR: secret/devops/ci/gcp-sa/broad-dsp-gcr-public/gcr-publish-key
@@ -34,7 +39,12 @@ jobs:
       id: construct-tags
       run: |
         SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
-        ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
+        ENVIRONMENT_TAG=""
+        if ${{ github.event_name == 'pull_request'}}; then
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${SHA_TAG}_pull_request"
+        elif ${{github.event_name == 'push' }}; then
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
+        fi
         echo ::set-output name=sha-tag::$SHA_TAG
         echo ::set-output name=environment-tag::$ENVIRONMENT_TAG
     - name: Build Image


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1216

Dependabot branch names can cause docker builds to fail since we try to tag them with branch names which are usually invalid when dependabot creates them.

For example, see [this failing check](https://github.com/DataBiosphere/duos-ui/pull/1021/checks?check_run_id=2363452063)
```
docker build \
  -t gcr.io/broad-dsp-gcr-public/duos-ui:fa8e11db1bd6 \
  -t gcr.io/broad-dsp-gcr-public/duos-ui:dependabot/docker/develop/nginxinc/nginx-unprivileged-1.19.10-alpine .
...
invalid argument "gcr.io/broad-dsp-gcr-public/duos-ui:dependabot/docker/develop/nginxinc/nginx-unprivileged-1.19.10-alpine" for "-t, --tag" flag: invalid reference format
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
