### PR TITLE
DUOS-1197[risk=no] Researcher View: Don't allow cancel when there are open/approved/denied elections for a DAR

### DIFF
--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -194,7 +194,7 @@ class ResearcherConsole extends Component {
                       span({ isRendered: dar.electionStatus === 'Closed' && dar.electionVote === false }, ["Denied"]),
                       span({ isRendered: dar.electionStatus === 'Closed' && dar.electionVote === true }, ["Approved"]),
                     ]),
-                    div({ className: "col-xs-1 cell-body f-center", disabled: dar.isCanceled }, [
+                    div({ className: "col-xs-1 cell-body f-center", disabled: dar.electionStatus !== 'un-reviewed'}, [
                       button({
                         id: dar.frontEndId + "_btnCancel", name: "btn_cancel", isRendered: !dar.isCanceled, className: "cell-button cancel-color",
                         onClick: this.cancelDar, value: dar.dataRequestId


### PR DESCRIPTION
Addresses [DUOS-1197](https://broadworkbench.atlassian.net/browse/DUOS-1197)

PR changes disable conditional on Cancel button within ```Researcher Console``` so that the button is only active on an ```un-reviewed``` status. 

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
