### PR TITLE
[DUOS-1219][risk=no] Handle the dataset name validation correctly

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -467,7 +467,11 @@ export const DataSet = {
   validateDatasetName: async (name) => {
     const url = `${await Config.getApiUrl()}/dataset/validate?name=${name}`;
     try {
-      const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), {method: 'GET'}]));
+      // We expect a 404 in the case where the dataset name does not exist
+      const res = await fetchAny(url, fp.mergeAll([Config.authOpts(), {method: 'GET'}]));
+      if (res.status === 404) {
+        return -1
+      }
       return await res.json();
     }
     catch (err) {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1219

As of https://github.com/DataBiosphere/duos-ui/pull/1023, we handle the `fetchOK` method slightly differently which caused an infinite spinner in the `404` case on the dataset registration page. We really shouldn't be using `fetchOK` since the successful case is actually an HTTP error code so using `fetchAny` is more appropriate.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
