### PR TITLE
[DUOS-1220][risk=no] Add CSP Headers

### DIFF
--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -11,6 +11,7 @@ map $sent_http_content_type $expires {
 server {
   listen 8080;
   expires $expires;
+  add_header Content-Security-Policy "default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com www.google-analytics.com www.gstatic.com; connect-src 'self' *.broadinstitute.org storage.googleapis.com; img-src 'self' data:; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com;";
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1220
Also addresses https://broadworkbench.atlassian.net/browse/DUOS-848

This PR adds CSP headers to the nginx config file. This could also be done in the proxy by updating the helm charts, but updating nginx locally is easier to test and just as functional as the headers should be passed through the proxy.

## Testing
To test, build and run locally. Images, fonts, scripts, etc., should all run normally.

```
docker build . -t duos
docker compose up 
```

If you wish to test out additional changes to `default.conf`, update your local compose file before running `docker compose up` so it overwrites the version in the build image:
```
version: '3.8'
services:
  app:
    image: duos:latest
    container_name: duos
    ports:
      - 3000:8080
    volumes:
      - ./config/dev.json:/usr/share/nginx/html/config.json
      - ./conf/conf.d/default.conf:/etc/nginx/conf.d/default.conf
    command: ["nginx", "-g", "daemon off;"]
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
