### PR TITLE
DUOS-1202[risk=no]  DUOS-1202  "Other Secondary Data Use Terms" free text not displaying in Dataset Catalog or DAR Review UI

### DIFF
--- a/src/components/TranslatedDULComponent.js
+++ b/src/components/TranslatedDULComponent.js
@@ -33,7 +33,7 @@ export async function GenerateUseRestrictionStatements(dataUse) {
       key: `${restriction.code}-statement`,
     }, [restriction.description]);
   });
-};
+}
 
 //component generation for non AccessReviewV2 components
 //template structure is different between DAR and DUL due to differing grid organization in previous template, making it hard to convert

--- a/src/components/modals/TranslatedDulModal.js
+++ b/src/components/modals/TranslatedDulModal.js
@@ -10,11 +10,11 @@ const listStyle = {
 };
 
 export default function TranslatedDulModal(props) {
-  const OKHandler = (e) => {
+  const OKHandler = () => {
     props.onOKRequest(MODAL_ID);
   };
 
-  const closeHandler = (e) => {
+  const closeHandler = () => {
     props.onCloseRequest(MODAL_ID);
   };
 
@@ -45,4 +45,4 @@ export default function TranslatedDulModal(props) {
       ul({style: listStyle, id: "txt_translatedRestrictions", className: "row no-margin translated-restriction"}, translatedDULList),
     ])
   );
-};
+}

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -6,8 +6,8 @@ import concat from 'lodash/fp/concat';
 import clone from 'lodash/fp/clone';
 import uniq from 'lodash/fp/uniq';
 import head from 'lodash/fp/head';
-import { searchOntology } from '../libs/ontologyService';
-import { Notifications } from '../libs/utils';
+import { searchOntology } from './ontologyService';
+import { Notifications } from './utils';
 
 const srpTranslations = {
   hmb: {
@@ -403,6 +403,14 @@ export const DataUseTranslation = {
     });
     restrictionStatements = await Promise.all(processingPromises);
     restrictionStatements = filter((statement) => !isNil(statement))(restrictionStatements);
+    if (!isNil(dataUse.other)) {
+      restrictionStatements = restrictionStatements.concat(
+        { code: "OTH", description: dataUse.other });
+    }
+    if (!isNil(dataUse.secondaryOther)) {
+      restrictionStatements = restrictionStatements.concat(
+        { code: "OTH2", description: dataUse.secondaryOther });
+    }
     return restrictionStatements;
   }
 };

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -144,7 +144,7 @@ class DatasetCatalog extends Component {
     const formData = await DAR.postDarDraft(darBody);
     const referenceId = formData.referenceId;
     this.props.history.push({ pathname: 'dar_application/' + referenceId });
-  };
+  }
 
   openConnectDataset(dataset) {
     this.setState(prev => {
@@ -190,41 +190,41 @@ class DatasetCatalog extends Component {
     });
   }
 
-  openDelete = (datasetId) => (e) => {
+  openDelete = (datasetId) => () => {
     this.setState({
       showDialogDelete: true,
       datasetId: datasetId
     });
   };
 
-  openEdit = (datasetId) => (e) => {
+  openEdit = (datasetId) => () => {
     this.setState({
       showDialogEdit: true,
       datasetId: datasetId
     });
-  }
+  };
 
-  openEnable = (datasetId) => (e) => {
+  openEnable = (datasetId) => () => {
     this.setState({
       showDialogEnable: true,
       datasetId: datasetId
     });
   };
 
-  openDisable = (datasetId) => (e) => {
+  openDisable = (datasetId) => () => {
     this.setState({
       showDialogDisable: true,
       datasetId: datasetId
     });
   };
 
-  dialogHandlerDelete = (answer) => (e) => {
+  dialogHandlerDelete = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
-      DataSet.deleteDataset(this.state.datasetId).then(resp => {
+      DataSet.deleteDataset(this.state.datasetId).then(() => {
         this.getDatasets();
         this.setState({ showDialogDelete: false, disableOkButton: false });
-      }).catch(error => {
+      }).catch(() => {
         this.setState(prev => {
           prev.showDialogDelete = true;
           prev.alertMessage = 'Please try again later.';
@@ -237,13 +237,13 @@ class DatasetCatalog extends Component {
     }
   };
 
-  dialogHandlerEnable = (answer) => (e) => {
+  dialogHandlerEnable = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
-      DataSet.disableDataset(this.state.datasetId, true).then(resp => {
+      DataSet.disableDataset(this.state.datasetId, true).then(() => {
         this.getDatasets();
         this.setState({ showDialogEnable: false, disableOkButton: false });
-      }).catch(error => {
+      }).catch(() => {
         this.setState(prev => {
           prev.showDialogEnable = true;
           prev.alertMessage = 'Please try again later.';
@@ -257,13 +257,13 @@ class DatasetCatalog extends Component {
 
   };
 
-  dialogHandlerDisable = (answer) => (e) => {
+  dialogHandlerDisable = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
-      DataSet.disableDataset(this.state.datasetId, false).then(resp => {
+      DataSet.disableDataset(this.state.datasetId, false).then(() => {
         this.getDatasets();
         this.setState({ showDialogDisable: false, disableOkButton: false });
-      }).catch(error => {
+      }).catch(() => {
         this.setState(prev => {
           prev.alertMessage = 'Please try again later.';
           prev.alertTitle = 'Something went wrong';
@@ -276,7 +276,7 @@ class DatasetCatalog extends Component {
     }
   };
 
-  dialogHandlerEdit = (answer) => (e) => {
+  dialogHandlerEdit = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
       this.setState(prev => {
@@ -362,7 +362,7 @@ class DatasetCatalog extends Component {
   defaultString(str, defaultStr) {
     if (str.length === 0) { return defaultStr; }
     return str;
-  };
+  }
 
   render() {
 
@@ -530,15 +530,15 @@ class DatasetCatalog extends Component {
                           td({
                             className: 'cell-size ' + (!dataSet.active ? 'dataset-disabled' : ''),
                             style: Theme.textTableBody },
-                            [dataSet.dbGapLink !== '' ?
-                              a({
-                                id: trIndex + '_linkdbGap',
-                                name: 'link_dbGap',
-                                href: dataSet.dbGapLink,
-                                target: '_blank',
-                                className: 'enabled'
-                              }, ['Link']) : '--'
-                            ]),
+                          [dataSet.dbGapLink !== '' ?
+                            a({
+                              id: trIndex + '_linkdbGap',
+                              name: 'link_dbGap',
+                              href: dataSet.dbGapLink,
+                              target: '_blank',
+                              className: 'enabled'
+                            }, ['Link']) : '--'
+                          ]),
 
                           td({
                             className: 'cell-size ' + (!dataSet.active ? 'dataset-disabled' : ''),


### PR DESCRIPTION
SCOPE:
- fixed eslint warnings that I encountered on the way
- add a check for other and secondary other on the dataUse object and include the text from those fields in the result of translateDataUseRestrictions

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
