### PR TITLE
DUOS-1171[risk=no] Adjusted Positioning and Sizing of Legacy Modals

### DIFF
--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -13,15 +13,12 @@ const customStyles = {
     bottom: '0',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     overflowY: 'scroll',
-
   },
 
   content: {
     position: 'relative',
     top: '20%',
-    // bottom: '35%',
     maxHeight: '60%',
-    // left: '20%',
     margin: '0 auto',
     maxWidth: '60%',
     border: '1px solid rgb(204, 204, 204)',

--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -3,9 +3,38 @@ import { button, div, h, span, hh } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import './BaseModal.css';
 import { PageSubHeading } from '../components/PageSubHeading';
-import {Styles} from '../libs/theme';
+
+const customStyles = {
+  overlay: {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    right: '0',
+    bottom: '0',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    overflowY: 'scroll',
+
+  },
+
+  content: {
+    position: 'relative',
+    top: '20%',
+    // bottom: '35%',
+    maxHeight: '60%',
+    // left: '20%',
+    margin: '0 auto',
+    maxWidth: '60%',
+    border: '1px solid rgb(204, 204, 204)',
+    background: 'rgb(255, 255, 255)',
+    overflow: 'scroll',
+    borderRadius: '4px',
+    outline: 'none',
+    padding: '10px 20px 20px 20px',
+  }
+};
 
 Modal.setAppElement('#root');
+
 export const BaseModal = hh(class BaseModal extends Component {
 
   render() {
@@ -19,7 +48,7 @@ export const BaseModal = hh(class BaseModal extends Component {
           isOpen: this.props.showModal,
           onAfterOpen: this.props.afterOpen,
           onRequestClose: this.props.onRequestClose,
-          style: Styles.MODAL.CONTENT,
+          style: customStyles,
           contentLabel: "Modal"
         }, [
           div({ className: "modal-header" }, [

--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -3,38 +3,9 @@ import { button, div, h, span, hh } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import './BaseModal.css';
 import { PageSubHeading } from '../components/PageSubHeading';
-
-const customStyles = {
-  overlay: {
-    position: 'fixed',
-    top: '0',
-    left: '0',
-    right: '0',
-    bottom: '0',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    overflowY: 'scroll',
-
-  },
-
-  content: {
-    position: 'relative',
-    top: '0',
-    right: '0',
-    bottom: '0',
-    left: '0',
-    width: '750px',
-    margin: '12vh auto 50px auto',
-    border: '1px solid rgb(204, 204, 204)',
-    background: 'rgb(255, 255, 255)',
-    overflow: 'hidden',
-    borderRadius: '4px',
-    outline: 'none',
-    padding: '10px 20px 20px 20px',
-  }
-};
+import {Styles} from '../libs/theme';
 
 Modal.setAppElement('#root');
-
 export const BaseModal = hh(class BaseModal extends Component {
 
   render() {
@@ -48,30 +19,27 @@ export const BaseModal = hh(class BaseModal extends Component {
           isOpen: this.props.showModal,
           onAfterOpen: this.props.afterOpen,
           onRequestClose: this.props.onRequestClose,
-          style: customStyles,
+          style: Styles.MODAL.CONTENT,
           contentLabel: "Modal"
         }, [
-
-            div({ className: "modal-header" }, [
-              button({ type: "button", className: "modal-close-btn close", onClick: this.props.onRequestClose }, [
-                span({ className: "glyphicon glyphicon-remove default-color" }),
-              ]),
-              PageSubHeading({ id: this.props.id, imgSrc: this.props.imgSrc, color: this.props.color, iconSize: this.props.iconSize, title: this.props.title, description: this.props.description }),
+          div({ className: "modal-header" }, [
+            button({ type: "button", className: "modal-close-btn close", onClick: this.props.onRequestClose }, [
+              span({ className: "glyphicon glyphicon-remove default-color" }),
             ]),
+            PageSubHeading({ id: this.props.id, imgSrc: this.props.imgSrc, color: this.props.color, iconSize: this.props.iconSize, title: this.props.title, description: this.props.description }),
+          ]),
 
-            div({ className: "modal-content" }, [
-              this.props.children
-            ]),
+          div({ className: "modal-content" }, [
+            this.props.children
+          ]),
 
-            div({ className: "modal-footer" }, [
-              // disabled: "consentForm.$invalid || disableButton",
-              button({ id: "btn_action", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn " + this.props.color + "-background",
-                onClick: this.props.action.handler, disabled: disableOkBtn }, [this.props.action.label]),
-              button({ isRendered: this.props.type !== "informative", id: "btn_cancel", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn dismiss-background", onClick: this.props.onRequestClose }, ["Cancel"]),
-            ]),
-
-          ])
-
+          div({ className: "modal-footer" }, [
+            // disabled: "consentForm.$invalid || disableButton",
+            button({ id: "btn_action", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn " + this.props.color + "-background",
+              onClick: this.props.action.handler, disabled: disableOkBtn }, [this.props.action.label]),
+            button({ isRendered: this.props.type !== "informative", id: "btn_cancel", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn dismiss-background", onClick: this.props.onRequestClose }, ["Cancel"]),
+          ]),
+        ])
       ])
     );
   }

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -20,12 +20,10 @@ const customStyles = {
     position: 'relative',
     maxHeight: '300px',
     top: '30%',
-    // right: '32%',
-    // bottom: '30%',
     margin: '0 auto',
     maxWidth: '50%',
     background: 'rgb(255, 255, 255)',
-    overflow: 'auto',
+    overflow: 'scroll',
     outline: 'none',
     padding: '20px 20px 20px 20px',
   }

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -17,17 +17,14 @@ const customStyles = {
   },
 
   content: {
-    position: 'relative',
-    top: '0',
-    right: '0',
-    bottom: '0',
-    left: '0',
-    width: '600px',
-    margin: '12vh auto auto auto',
-    border: '1px solid rgb(204, 204, 204)',
+    maxHeight: '171px',
+    top: '30%',
+    right: '32%',
+    bottom: '30%',
+    left: '32%',
+    width: '36%',
     background: 'rgb(255, 255, 255)',
     overflow: 'auto',
-    borderRadius: '4px',
     outline: 'none',
     padding: '10px 20px 20px 20px',
   }
@@ -45,7 +42,7 @@ export const ConfirmationDialog = hh(class ConfirmationDialog extends Component 
     };
   }
 
-  static getDerivedStateFromProps(nextProps, prevState) {
+  static getDerivedStateFromProps(nextProps) {
     return {
       alertMessage: nextProps.alertMessage,
       alertTitle: nextProps.alertTitle
@@ -56,34 +53,30 @@ export const ConfirmationDialog = hh(class ConfirmationDialog extends Component 
     const { disableOkBtn = false, disableNoBtn = false } = this.props;
 
     return (
-
-      div({}, [
-
-        h(Modal, {
-          isOpen: this.props.showModal,
-          onAfterOpen: this.props.afterOpenModal,
-          onRequestClose: this.props.onRequestClose,
-          style: _.mergeAll([customStyles, this.props.style]),
-          contentLabel: "Modal"
-        }, [
-          div({ className: "dialog-header" }, [
-            button({ id: "btn_dialogClose", type: "button", className: "dialog-close-btn close", onClick: this.props.action.handler(false) }, [
-              span({ className: "glyphicon glyphicon-remove default-color" }),
-            ]),
-            h2({ id: "lbl_dialogTitle", className: "dialog-title " + this.props.color + "-color" }, [this.props.title]),
+      h(Modal, {
+        isOpen: this.props.showModal,
+        onAfterOpen: this.props.afterOpenModal,
+        onRequestClose: this.props.onRequestClose,
+        style: _.mergeAll([customStyles, this.props.style]),
+        contentLabel: "Modal"
+      }, [
+        div({ className: "dialog-header" }, [
+          button({ id: "btn_dialogClose", type: "button", className: "dialog-close-btn close", onClick: this.props.action.handler(false) }, [
+            span({ className: "glyphicon glyphicon-remove default-color" }),
           ]),
+          h2({ id: "lbl_dialogTitle", className: "dialog-title " + this.props.color + "-color" }, [this.props.title]),
+        ]),
 
-          div({ id: "lbl_dialogContent", className: "dialog-content" }, [
-            this.props.children,
-            div({ isRendered: this.state.alertTitle !== undefined, className: "dialog-alert" }, [
-              Alert({ id: "dialog", type: "danger", title: this.state.alertTitle, description: this.state.alertMessage })
-            ])
-          ]),
-
-          div({ className: "dialog-footer" }, [
-            button({ isRendered: this.props.type !== "informative", id: "btn_cancel", className: "col-lg-3 col-lg-offset-3 col-md-3 col-md-offset-3 col-sm-4 col-sm-offset-2 col-xs-6 btn dismiss-background", onClick: this.props.action.handler(false), disabled: disableNoBtn }, ["No"]),
-            button({ id: "btn_action", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn " + this.props.color + "-background " + (this.props.type === "informative" ? "f-right" : ""), onClick: this.props.action.handler(true), disabled: disableOkBtn }, [this.props.action.label]),
+        div({ id: "lbl_dialogContent", className: "dialog-content" }, [
+          this.props.children,
+          div({ isRendered: this.state.alertTitle !== undefined, className: "dialog-alert" }, [
+            Alert({ id: "dialog", type: "danger", title: this.state.alertTitle, description: this.state.alertMessage })
           ])
+        ]),
+
+        div({ className: "dialog-footer row no-margin" }, [
+          button({ isRendered: this.props.type !== "informative", id: "btn_cancel", className: "col-lg-3 col-lg-offset-3 col-md-3 col-md-offset-3 col-sm-4 col-sm-offset-2 col-xs-6 btn dismiss-background", onClick: this.props.action.handler(false), disabled: disableNoBtn }, ["No"]),
+          button({ id: "btn_action", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn " + this.props.color + "-background " + (this.props.type === "informative" ? "f-right" : ""), onClick: this.props.action.handler(true), disabled: disableOkBtn }, [this.props.action.label]),
         ])
       ])
     );

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -17,16 +17,17 @@ const customStyles = {
   },
 
   content: {
-    maxHeight: '171px',
+    position: 'relative',
+    maxHeight: '300px',
     top: '30%',
-    right: '32%',
-    bottom: '30%',
-    left: '32%',
-    width: '36%',
+    // right: '32%',
+    // bottom: '30%',
+    margin: '0 auto',
+    maxWidth: '50%',
     background: 'rgb(255, 255, 255)',
     overflow: 'auto',
     outline: 'none',
-    padding: '10px 20px 20px 20px',
+    padding: '20px 20px 20px 20px',
   }
 };
 

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -200,13 +200,13 @@ class AdminManageUsers extends Component {
                       id: user.dacUserId + "_btnResearcherReview", name: "btn_researcherReview", onClick: () => this.openResearcherReview(user.dacUserId),
                       isRendered: user.researcher !== false && user.completed === true, className: "admin-manage-buttons col-lg-10 col-md-10 col-sm-10 col-xs-9"
                     }, [
-                        div({
-                          className:
+                      div({
+                        className:
                             ((user.researcher === true && user.completed === true && user.status === 'pending') || user.status === null) ? 'enabled'
                               : user.researcher === true && user.completed === true && user.status !== 'pending' ? 'editable'
                                 : user.researcher === false || !user.completed ? 'disabled' : ''
-                        }, ["Review"]),
-                      ]),
+                      }, ["Review"]),
+                    ]),
 
                     a({ isRendered: user.researcher === "false" || !user.completed, className: "admin-manage-buttons col-lg-10 col-md-10 col-sm-10 col-xs-9" }, [
                       div({ className: "disabled" }, ["Review"]),

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -144,7 +144,7 @@ class DatasetCatalog extends Component {
     const formData = await DAR.postDarDraft(darBody);
     const referenceId = formData.referenceId;
     this.props.history.push({ pathname: 'dar_application/' + referenceId });
-  };
+  }
 
   openConnectDataset(dataset) {
     this.setState(prev => {
@@ -190,41 +190,41 @@ class DatasetCatalog extends Component {
     });
   }
 
-  openDelete = (datasetId) => (e) => {
+  openDelete = (datasetId) => () => {
     this.setState({
       showDialogDelete: true,
       datasetId: datasetId
     });
   };
 
-  openEdit = (datasetId) => (e) => {
+  openEdit = (datasetId) => () => {
     this.setState({
       showDialogEdit: true,
       datasetId: datasetId
     });
-  }
+  };
 
-  openEnable = (datasetId) => (e) => {
+  openEnable = (datasetId) => () => {
     this.setState({
       showDialogEnable: true,
       datasetId: datasetId
     });
   };
 
-  openDisable = (datasetId) => (e) => {
+  openDisable = (datasetId) => () => {
     this.setState({
       showDialogDisable: true,
       datasetId: datasetId
     });
   };
 
-  dialogHandlerDelete = (answer) => (e) => {
+  dialogHandlerDelete = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
-      DataSet.deleteDataset(this.state.datasetId).then(resp => {
+      DataSet.deleteDataset(this.state.datasetId).then(() => {
         this.getDatasets();
         this.setState({ showDialogDelete: false, disableOkButton: false });
-      }).catch(error => {
+      }).catch(() => {
         this.setState(prev => {
           prev.showDialogDelete = true;
           prev.alertMessage = 'Please try again later.';
@@ -237,13 +237,13 @@ class DatasetCatalog extends Component {
     }
   };
 
-  dialogHandlerEnable = (answer) => (e) => {
+  dialogHandlerEnable = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
-      DataSet.disableDataset(this.state.datasetId, true).then(resp => {
+      DataSet.disableDataset(this.state.datasetId, true).then(() => {
         this.getDatasets();
         this.setState({ showDialogEnable: false, disableOkButton: false });
-      }).catch(error => {
+      }).catch(() => {
         this.setState(prev => {
           prev.showDialogEnable = true;
           prev.alertMessage = 'Please try again later.';
@@ -257,13 +257,13 @@ class DatasetCatalog extends Component {
 
   };
 
-  dialogHandlerDisable = (answer) => (e) => {
+  dialogHandlerDisable = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
-      DataSet.disableDataset(this.state.datasetId, false).then(resp => {
+      DataSet.disableDataset(this.state.datasetId, false).then(() => {
         this.getDatasets();
         this.setState({ showDialogDisable: false, disableOkButton: false });
-      }).catch(error => {
+      }).catch(() => {
         this.setState(prev => {
           prev.alertMessage = 'Please try again later.';
           prev.alertTitle = 'Something went wrong';
@@ -276,7 +276,7 @@ class DatasetCatalog extends Component {
     }
   };
 
-  dialogHandlerEdit = (answer) => (e) => {
+  dialogHandlerEdit = (answer) => () => {
     this.setState({ disableOkButton: true });
     if (answer) {
       this.setState(prev => {
@@ -362,7 +362,7 @@ class DatasetCatalog extends Component {
   defaultString(str, defaultStr) {
     if (str.length === 0) { return defaultStr; }
     return str;
-  };
+  }
 
   render() {
 
@@ -530,15 +530,15 @@ class DatasetCatalog extends Component {
                           td({
                             className: 'cell-size ' + (!dataSet.active ? 'dataset-disabled' : ''),
                             style: Theme.textTableBody },
-                            [dataSet.dbGapLink !== '' ?
-                              a({
-                                id: trIndex + '_linkdbGap',
-                                name: 'link_dbGap',
-                                href: dataSet.dbGapLink,
-                                target: '_blank',
-                                className: 'enabled'
-                              }, ['Link']) : '--'
-                            ]),
+                          [dataSet.dbGapLink !== '' ?
+                            a({
+                              id: trIndex + '_linkdbGap',
+                              name: 'link_dbGap',
+                              href: dataSet.dbGapLink,
+                              target: '_blank',
+                              className: 'enabled'
+                            }, ['Link']) : '--'
+                          ]),
 
                           td({
                             className: 'cell-size ' + (!dataSet.active ? 'dataset-disabled' : ''),
@@ -712,8 +712,7 @@ class DatasetCatalog extends Component {
             showModal: this.state.showDialogEdit,
             disableOkBtn: this.state.disableOkButton,
             action: { label: 'Yes', handler: this.dialogHandlerEdit }
-          }, [div({ className: 'dialog-description' }, ['Are you sure you want to edit this Dataset?']),]),
-
+          }, [div({ className: 'dialog-description' }, ['Are you sure you want to edit this Dataset?'])]),
           ConnectDatasetModal({
             isRendered: this.state.showConnectDatasetModal,
             showModal: this.state.showConnectDatasetModal,


### PR DESCRIPTION
Addresses [DUOS-1171](https://broadworkbench.atlassian.net/browse/DUOS-1171)

PR addresses Modal sliding under navbar by adjusting its top positioning to be 20% or 30%, ensuring that it stands clear of the navbar, as well as setting max-width, max-height, and scroll attributes to ensure that the modal fits on the center of the screen and does continue to grow past the window's borders. 

Styling with the newer modals is not advised as the older modals depend on bootstrap classes while the newer styles rely on flexbox (and have an overall theme that differs from the older styles that the modal/parent page still use).

PR also includes additional syntax corrections as pointed out by eslint.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
