### PR TITLE
DUOS-1217[risk=no] Changed Font in DAR Review to Arial

### DIFF
--- a/src/components/StructuredDarRp.js
+++ b/src/components/StructuredDarRp.js
@@ -5,7 +5,7 @@ import { DataUseTranslation } from '../libs/dataUseTranslation';
 import { Theme } from '../libs/theme';
 
 const ROOT = {
-  fontFamily: 'Montserrat',
+  fontFamily: 'Arial',
   color: Theme.palette.primary,
   whiteSpace: 'pre-line'
 };

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -21,9 +21,9 @@ export const Theme = {
     size: {
       title: '28px',
       superheader: '24px',
-      header: '18px',
+      header: '1.7rem',
       subheader: '16px',
-      small: '14px'
+      small: '1.6rem'
     },
     leading: {
       regular: '22px',

--- a/src/pages/access_review/AccessReviewHeader.js
+++ b/src/pages/access_review/AccessReviewHeader.js
@@ -12,7 +12,7 @@ const TITLE = {
 };
 
 const SMALL = {
-  fontSize: Theme.font.size.small,
+  fontSize: '15px',
   lineHeight: Theme.font.leading.dense,
 };
 
@@ -25,7 +25,7 @@ export const AccessReviewHeader = hh(class AccessReviewHeader extends React.Pure
           justifyContent: 'space-between',
           alignItems: 'center',
           display: 'flex',
-          fontFamily: 'Montserrat',
+          fontFamily: 'Arial',
           color: Theme.palette.primary,
         }
       },

--- a/src/pages/access_review/AccessReviewHeader.js
+++ b/src/pages/access_review/AccessReviewHeader.js
@@ -12,7 +12,7 @@ const TITLE = {
 };
 
 const SMALL = {
-  fontSize: '15px',
+  fontSize: Theme.font.size.small,
   lineHeight: Theme.font.leading.dense,
 };
 

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -10,7 +10,7 @@ import { DataUseTranslation } from '../../libs/dataUseTranslation';
 import isNil from "lodash/fp";
 
 const ROOT = {
-  fontFamily: 'Montserrat',
+  fontFamily: 'Arial',
   color: Theme.palette.primary,
   whiteSpace: 'pre-line'
 };

--- a/src/pages/access_review/ApplicantInfo.js
+++ b/src/pages/access_review/ApplicantInfo.js
@@ -59,7 +59,7 @@ export const ApplicantInfo = hh(
       const { content, researcherProfile } = this.props;
       const libraryCards = ld.get(researcherProfile, 'libraryCards', []);
       return div(
-        { style: { fontFamily: 'Montserrat', color: Theme.palette.primary } }, [
+        { style: { fontFamily: 'Arial', color: Theme.palette.primary } }, [
           div({ style: HEADER }, 'Applicant Information'),
           div({ style: { display: 'flex', justifyContent: 'space-between' }},
             this.formatResearcherInfo(content)),

--- a/src/pages/access_review/ApplicationSection.js
+++ b/src/pages/access_review/ApplicationSection.js
@@ -10,7 +10,7 @@ const TEXT = {
 export const ApplicationSection = hh(class ApplicationSection extends React.PureComponent {
   render() {
     const { header, content, headerColor } = this.props;
-    return div({ style: { fontFamily: 'Montserrat', color: Theme.palette.primary } }, [
+    return div({ style: { fontFamily: 'Arial', color: Theme.palette.primary } }, [
       div({
         style: {
           marginBottom: '5px',

--- a/src/pages/access_review/DacVotePanel.js
+++ b/src/pages/access_review/DacVotePanel.js
@@ -11,7 +11,7 @@ import { VoteAsChair } from './VoteAsChair';
 
 const ROOT = {
   height: '100%',
-  fontFamily: 'Montserrat',
+  fontFamily: 'Arial',
   fontSize: Theme.font.size.small,
   lineHeight: Theme.font.leading.dense,
   fontWeight: Theme.font.weight.semibold,

--- a/src/pages/access_review/DarApplication.js
+++ b/src/pages/access_review/DarApplication.js
@@ -7,7 +7,7 @@ import ApplicationDownloadLink from '../../components/ApplicationDownloadLink';
 import { isNil, get, find } from 'lodash/fp';
 
 const SECTION = {
-  fontFamily: 'Montserrat',
+  fontFamily: 'Arial',
   margin: '1rem 0',
   color: Theme.palette.primary,
   display: 'flex',

--- a/src/pages/access_review/StructuredLimitations.js
+++ b/src/pages/access_review/StructuredLimitations.js
@@ -5,7 +5,7 @@ import { Theme } from '../../libs/theme';
 import { DownloadLink } from '../../components/DownloadLink';
 
 const ROOT = {
-  fontFamily: 'Montserrat',
+  fontFamily: 'Arial',
   color: Theme.palette.primary,
   whiteSpace: 'pre-line'
 };

--- a/src/pages/access_review/VoteQuestion.js
+++ b/src/pages/access_review/VoteQuestion.js
@@ -17,7 +17,7 @@ const FADED = {
 
 const INPUT = {
   backgroundColor: '#ffffff',
-  fontSize: '12px',
+  fontSize: '1.35rem',
   fontWeight: Theme.font.weight.regular,
   border: 'none',
   padding: '8px',

--- a/src/pages/access_review/VoteSummary.js
+++ b/src/pages/access_review/VoteSummary.js
@@ -12,7 +12,7 @@ const STYLE = {
   fontSize: Theme.font.size.small,
   lineHeight: Theme.font.leading.dense,
   fontWeight: Theme.font.weight.semibold,
-  fontFamily: 'Montserrat',
+  fontFamily: 'Arial',
   backgroundColor: Theme.palette.background.secondary,
   padding: 16,
   borderRadius: '9px',


### PR DESCRIPTION
Addresses [DUOS-1217](https://broadworkbench.atlassian.net/browse/DUOS-1217)

PR changes the font used on the DAR Review page from Montserrat to Arial and a font size update to the DAR Review sub-header section.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
