### PR TITLE
DUOS-1200[risk=no]DAC Member's vote "Date" does not appear on DAC Chair Vote page

### DIFF
--- a/src/pages/access_review/VoteSummary.js
+++ b/src/pages/access_review/VoteSummary.js
@@ -113,7 +113,7 @@ export const VoteSummary = hh(
 
     memberVote = (vote) => {
       const voteString = fp.isNil(vote.vote.vote) ? 'Pending' : vote.vote.vote ? 'Yes' : 'No';
-      const createDateString = fp.isNil(vote.vote.createDate) ? '' : moment(vote.vote.createDate).format('MM/DD/YY');
+      const updateDateString = fp.isNil(vote.vote.updateDate) ? '' : moment(vote.vote.updateDate).format('MM/DD/YY');
       return div({
         key: vote.vote.voteId,
         style: {
@@ -138,7 +138,7 @@ export const VoteSummary = hh(
           ]),
           div({style: {display: 'flex', flexWrap: 'wrap'}}, [
             div({style:{padding: '0 1rem 1rem 0'}}, ['DATE: ']),
-            div({style:{fontWeight: Theme.font.weight.regular}}, [createDateString]),
+            div({style:{fontWeight: Theme.font.weight.regular}}, [updateDateString]),
           ]),
           div({style: {}}, [
             div({style: {flex: '1 0 auto', padding: '0 1rem 1rem 0'}}, ['RATIONALE: ']),

--- a/src/pages/access_review/VoteSummary.js
+++ b/src/pages/access_review/VoteSummary.js
@@ -113,7 +113,11 @@ export const VoteSummary = hh(
 
     memberVote = (vote) => {
       const voteString = fp.isNil(vote.vote.vote) ? 'Pending' : vote.vote.vote ? 'Yes' : 'No';
-      const updateDateString = fp.isNil(vote.vote.updateDate) ? '' : moment(vote.vote.updateDate).format('MM/DD/YY');
+      const updateDateString = !fp.isNil(vote.vote.updateDate) ?
+        moment(vote.vote.updateDate).format('MM/DD/YY')
+        : !fp.isNil(vote.vote.createDate) ?
+          moment(vote.vote.createDate).format('MM/DD/YY')
+          : '';
       return div({
         key: vote.vote.voteId,
         style: {


### PR DESCRIPTION
SCOPE:
The field that is populated when a vote has been cast is updateDate instead of createDate.
Bug fix on access review and review results pages for non-pending votes

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1200

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
