### PR TITLE
DUOS-1211[risk=no]Remove broken 'Add a Data Access Committee' button/modal from the Admin Console

### DIFF
--- a/src/pages/AdminConsole.js
+++ b/src/pages/AdminConsole.js
@@ -2,7 +2,6 @@ import { Component } from 'react';
 import { div, hr } from 'react-hyperscript-helpers';
 import { AdminConsoleBox } from '../components/AdminConsoleBox';
 import { PageHeading } from '../components/PageHeading';
-import { AddDacModal } from './manage_dac/AddDacModal';
 import { AddUserModal } from '../components/modals/AddUserModal';
 import { ElectionTimeoutModal } from '../components/modals/ElectionTimeoutModal';
 import { Election, ElectionTimeout, PendingCases } from '../libs/ajax';
@@ -18,7 +17,6 @@ class AdminConsole extends Component {
     this.state = {
       currentUser: currentUser,
       showModal: false,
-      showAddDacModal: false,
       showAddUserModal: false,
       showElectionTimeoutModal: false,
       dulUnreviewedCases: 0,
@@ -57,21 +55,14 @@ class AdminConsole extends Component {
     );
   }
 
-  addDac = (e) => {
-    this.setState(prev => {
-      prev.showAddDacModal = true;
-      return prev;
-    });
-  };
-
-  addUser = (e) => {
+  addUser = () => {
     this.setState(prev => {
       prev.showAddUserModal = true;
       return prev;
     });
   };
 
-  async electionTimeout(e) {
+  async electionTimeout() {
     const timeOut = await ElectionTimeout.findApprovalExpirationTime();
     const isDataSetElection = await Election.isDataSetElectionOpen();
 
@@ -90,10 +81,6 @@ class AdminConsole extends Component {
         this.setState({showAddUserModal: false});
         this.props.history.push(`admin_manage_users`);
         break;
-      case 'addDac':
-        this.setState({showAddDacModal: false});
-        this.props.history.push(`manage_dac`);
-        break;
       case 'electionTimeout': this.setState({ showElectionTimeoutModal: false }); break;
       default: break;
     }
@@ -101,7 +88,6 @@ class AdminConsole extends Component {
 
   closeModal = (name) => {
     switch (name) {
-      case 'addDac': this.setState({ showAddDacModal: false }); break;
       case 'addUser': this.setState({ showAddUserModal: false }); break;
       case 'electionTimeout': this.setState({ showElectionTimeoutModal: false }); break;
       default: break;
@@ -110,7 +96,6 @@ class AdminConsole extends Component {
 
   afterModalOpen = (name) => {
     switch (name) {
-      case 'addDac': this.setState(prev => { prev.showAddDacModal = false; return prev; }); break;
       case 'addUser': this.setState(prev => { prev.showAddUserModal = false; return prev; }); break;
       case 'electionTimeout': this.setState(prev => { prev.showElectionTimeoutModal = false; return prev; }); break;
       default: break;
@@ -214,25 +199,7 @@ class AdminConsole extends Component {
                   iconSize: 'large',
                 })
               ]),
-
-              div({ className: "col-lg-6 col-md-6 col-sm-12 col-xs-12 admin-box" }, [
-                AdminConsoleBox({
-                  id: 'btn_addDAC',
-                  clickHandler: this.addDac,
-                  color: 'common',
-                  title: 'Add Data Access Committee',
-                  description: 'Create a new Data Access Committee in the system',
-                  iconName: 'add-dac',
-                  iconSize: 'large',
-                }),
-                AddDacModal({
-                  showModal: this.state.showAddDacModal,
-                  isEditMode: false,
-                  onOKRequest: this.okModal,
-                  onCloseRequest: this.closeModal,
-                  onAfterOpen: this.afterModalOpen
-                })
-              ])
+              consoleBoxPlaceholder
             ]),
 
             div({ className: "row fsi-row-lg-level fsi-row-md-level no-margin" }, [


### PR DESCRIPTION
SCOPE:
On admin console, remove add dac button and add dac modal

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1211


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
