### PR TITLE
[DUOS-1222][risk=no] Turn off dependabot pushes to GCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,10 +54,10 @@ jobs:
         -t ${{ steps.construct-tags.outputs.environment-tag }} \
         .
     - name: Log Testing
-      if: ${{ github.github_actor != 'rushtong' }}
-      run: echo "${{ github.github_actor }}"
+      if: github.actor != 'dependabot'
+      run: echo "${{ github.actor }}"
     - name: Push Image to GCR
-      if: ${{ github.github_actor != 'dependabot' }}
+      if: github.actor != 'dependabot'
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,8 +53,7 @@ jobs:
         -t ${{ steps.construct-tags.outputs.sha-tag }} \
         -t ${{ steps.construct-tags.outputs.environment-tag }} \
         .
-    - name: Log Testing
-      if: github.actor != 'dependabot'
+    - name: Log Github Actor
       run: echo "${{ github.actor }}"
     - name: Push Image to GCR
       if: github.actor != 'dependabot'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,11 @@ jobs:
         -t ${{ steps.construct-tags.outputs.sha-tag }} \
         -t ${{ steps.construct-tags.outputs.environment-tag }} \
         .
+    - name: Log Testing
+      if: ${{ github.github_actor != 'rushtong' }}
+      run: echo "${{ github.github_actor }}"
     - name: Push Image to GCR
+      if: ${{ github.github_actor != 'dependabot' }}
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,7 @@ jobs:
     - name: Log Github Actor
       run: echo "${{ github.actor }}"
     - name: Push Image to GCR
-      if: github.actor != 'dependabot'
+      if: github.actor != 'dependabot[bot]'
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1222

## Changes
* Log the github actor name for reference. We may need to adjust the conditional in a future PR.
* Disable pushes to GCR for dependabot-generated PRs

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
