### PR TITLE
DUOS-1239[risk=no] Correctly read json response from findMatch()

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -705,12 +705,7 @@ export const Match = {
   findMatch: async (consentId, purposeId) => {
     const url = `${await Config.getApiUrl()}/match/${consentId}/${purposeId}`;
     const res = await fetchOk(url, Config.authOpts());
-    try {
-      const answer = await res;
-      return answer;
-    } catch (error) {
-      return {};
-    }
+    return res.json();
   }
 };
 


### PR DESCRIPTION
Addresses [DUOS-1239](https://broadworkbench.atlassian.net/browse/DUOS-1239)

PR updates ```Match.findMatch()``` to remove odd try...catch block as well as to return ```res.json``` instead of ```res```. Improper return resulted in evaluated ```NO``` result

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
