### PR TITLE
DUOS-1159[risk=no] Template Updates/Corrections for DatasetRegistration

### DIFF
--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -1095,7 +1095,7 @@ class DatasetRegistration extends Component {
                               defaultChecked: generalUse,
                               onClick: this.setGeneralUse,
                               label: 'General Research Use: ',
-                              description: 'use is permitted for any research purpose',
+                              description: 'Use is permitted for any research purpose',
                               disabled: isUpdateDataset,
                             }),
 
@@ -1106,7 +1106,7 @@ class DatasetRegistration extends Component {
                               defaultChecked: hmb,
                               onClick: this.setHmb,
                               label: 'Health/Medical/Biomedical Use: ',
-                              description: 'use is permitted for any health, medical, or biomedical purpose',
+                              description: 'Use is permitted for any health, medical, or biomedical purpose',
                               disabled: isUpdateDataset,
                             }),
 
@@ -1117,7 +1117,7 @@ class DatasetRegistration extends Component {
                               defaultChecked: diseases,
                               onClick: this.setDiseases,
                               label: 'Disease-related studies: ',
-                              description: 'use is permitted for research on the specified disease',
+                              description: 'Use is permitted for research on the specified disease',
                               disabled: isUpdateDataset,
                             }),
                             div({
@@ -1147,15 +1147,15 @@ class DatasetRegistration extends Component {
                               defaultChecked: other,
                               onClick: this.setOther,
                               label: 'Other Use:',
-                              description: 'permitted research use is defined as follows: ',
+                              description: 'Permitted research use is defined as follows: ',
                               disabled: isUpdateDataset,
                             }),
 
                             textarea({
                               style: {margin: '1rem 0'},
                               className: 'form-control',
-                              defaultValue: primaryOtherText,
-                              onBlur: (e) => this.setOtherText(e, 'primary'),
+                              value: primaryOtherText,
+                              onChange: (e) => this.setOtherText(e, 'primary'),
                               name: 'primaryOtherText',
                               id: 'primaryOtherText',
                               maxLength: '512',


### PR DESCRIPTION
Addresses [DUOS-1159](https://broadworkbench.atlassian.net/browse/DUOS-1159)

PR fixes validation errors caused by an uncontrolled textarea and its associated state variable ```primaryOtherText```. PR also includes capitalization adjustments to radio button subtexts.

To recreate the bug, fill in data as expected with ```Other``` as the selected primary use and fill in the text. Then switch to any other primary use value, and then switch back to ```Other```. Finally, submit the form to hit the failed validation.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
