### PR TITLE
DUOS-1237[risk=no] Updates to Dynamic Question Conditionals on DAR Application

### DIFF
--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -129,8 +129,8 @@ export default function DataAccessRequest(props) {
                   //process DS attributes seperately due to unique attributes
                   calculateDSTally(value, ontologyTally);
                 } else {
-                  //otherwise mark question as true
-                  updatedDULQuestions[key] = isNil(value) ? true : value;
+                  //otherwise check value. If true, update with value, otherwise defer to current status on updatedDULQuestions
+                  updatedDULQuestions[key] = value || updatedDULQuestions[key];
                 }
               }
             })(dataUse);

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -130,7 +130,7 @@ export default function DataAccessRequest(props) {
                   calculateDSTally(value, ontologyTally);
                 } else {
                   //otherwise mark question as true
-                  updatedDULQuestions[key] = true;
+                  updatedDULQuestions[key] = isNil(value) ? true : value;
                 }
               }
             })(dataUse);

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -117,7 +117,6 @@ export default function DataAccessRequest(props) {
       const targetDULKeys = ['ethicsApprovalRequired', 'collaboratorRequired', 'publicationResults', 'diseaseRestrictions', 'geneticStudiesOnly'];
       let updatedDULQuestions = {};
       let ontologyTally = {};
-
       if (!isNil(datasetCollection)) {
         const collectionLength = datasetCollection.length;
         datasetCollection.forEach(dataset => {
@@ -192,7 +191,7 @@ export default function DataAccessRequest(props) {
   }, [datasets, initializeDatasets, activeDULQuestions, formFieldChange, darCode]);
 
   const renderDULQuestions = (darCode) => {
-    let renderBool = !(isNil(activeDULQuestions) && isEmpty(activeDULQuestions)) && !every(value => value === false)(activeDULQuestions);
+    let renderBool = !(isNil(activeDULQuestions) && isEmpty(activeDULQuestions)) && !every(value => value !== true)(activeDULQuestions);
 
     if(!isEmpty(darCode)) {
       //for submitted dars dsAcknowledgement is not processed properly due to dataset split, therefore you need to check dsAcknowledgement directly

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -7,6 +7,7 @@ import includes from 'lodash/fp/includes';
 import cloneDeep from 'lodash/fp/cloneDeep';
 import isEqual from 'lodash/fp/isEqual';
 import every from 'lodash/fp/every';
+import any from 'lodash/fp/some';
 import { DAR } from '../../libs/ajax';
 import AsyncSelect from 'react-select/async';
 import UploadLabelButton from '../../components/UploadLabelButton';
@@ -191,7 +192,7 @@ export default function DataAccessRequest(props) {
   }, [datasets, initializeDatasets, activeDULQuestions, formFieldChange, darCode]);
 
   const renderDULQuestions = (darCode) => {
-    let renderBool = !(isNil(activeDULQuestions) && isEmpty(activeDULQuestions)) && !every(value => value !== true)(activeDULQuestions);
+    let renderBool = !(isNil(activeDULQuestions) && isEmpty(activeDULQuestions)) && any(value => value === true)(activeDULQuestions);
 
     if(!isEmpty(darCode)) {
       //for submitted dars dsAcknowledgement is not processed properly due to dataset split, therefore you need to check dsAcknowledgement directly


### PR DESCRIPTION
Addresses [DUOS-1237](https://broadworkbench.atlassian.net/browse/DUOS-1237)

Old logic behind calculating DUL questions operated under the assumption that dataUse only contained keys that were marked true (non-relevant keys were never included in return). Logic has been updated to expect all keys to be present with   true/false evaluations.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
