### PR TITLE
DUOS-1231[risk=no] Remove scrollbar from Modal Windows

### DIFF
--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -12,7 +12,7 @@ const customStyles = {
     right: '0',
     bottom: '0',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    overflowY: 'scroll',
+    overflowY: 'auto',
   },
 
   content: {
@@ -23,7 +23,7 @@ const customStyles = {
     maxWidth: '60%',
     border: '1px solid rgb(204, 204, 204)',
     background: 'rgb(255, 255, 255)',
-    overflow: 'scroll',
+    overflow: 'auto',
     borderRadius: '4px',
     outline: 'none',
     padding: '10px 20px 20px 20px',

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -23,7 +23,7 @@ const customStyles = {
     margin: '0 auto',
     maxWidth: '50%',
     background: 'rgb(255, 255, 255)',
-    overflow: 'scroll',
+    overflow: 'auto',
     outline: 'none',
     padding: '20px 20px 20px 20px',
   }


### PR DESCRIPTION
Addresses [DUOS-1231](https://broadworkbench.atlassian.net/browse/DUOS-1231)

PR aims to remove scrollbars from appearing on modal windows if it is not needed.

NOTE: cannot reproduce the screenshot scrollbars on my personal laptop (Mac OS X), however the modal does have an ```overflow: scroll``` style, as do other modals, so it made sense to switch it over to ```overflow: auto```. I appreciate any assistance in making sure the styling works across different OS.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [x] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [x] Get PO sign-off for all non-trivial UI or workflow changes
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
