### PR TITLE
DUOS-1098[risk=no] Standardized Close Icon as own component

### DIFF
--- a/src/components/BaseModal.js
+++ b/src/components/BaseModal.js
@@ -3,6 +3,7 @@ import { button, div, h, span, hh } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import './BaseModal.css';
 import { PageSubHeading } from '../components/PageSubHeading';
+import CloseIconComponent from '../components/CloseIconComponent';
 
 const customStyles = {
   overlay: {
@@ -40,7 +41,6 @@ export const BaseModal = hh(class BaseModal extends Component {
 
     return (
       div({}, [
-
         h(Modal, {
           isOpen: this.props.showModal,
           onAfterOpen: this.props.afterOpen,
@@ -49,9 +49,7 @@ export const BaseModal = hh(class BaseModal extends Component {
           contentLabel: "Modal"
         }, [
           div({ className: "modal-header" }, [
-            button({ type: "button", className: "modal-close-btn close", onClick: this.props.onRequestClose }, [
-              span({ className: "glyphicon glyphicon-remove default-color" }),
-            ]),
+            h(CloseIconComponent, {closeFn: this.props.onRequestClose}),
             PageSubHeading({ id: this.props.id, imgSrc: this.props.imgSrc, color: this.props.color, iconSize: this.props.iconSize, title: this.props.title, description: this.props.description }),
           ]),
 
@@ -60,7 +58,6 @@ export const BaseModal = hh(class BaseModal extends Component {
           ]),
 
           div({ className: "modal-footer" }, [
-            // disabled: "consentForm.$invalid || disableButton",
             button({ id: "btn_action", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn " + this.props.color + "-background",
               onClick: this.props.action.handler, disabled: disableOkBtn }, [this.props.action.label]),
             button({ isRendered: this.props.type !== "informative", id: "btn_cancel", className: "col-lg-3 col-md-3 col-sm-4 col-xs-6 btn dismiss-background", onClick: this.props.onRequestClose }, ["Cancel"]),

--- a/src/components/CloseIconComponent.js
+++ b/src/components/CloseIconComponent.js
@@ -7,6 +7,6 @@ export default function CloseIconComponent(props) {
     className: 'modal-close-btn close',
     onClick: closeFn
   }, [
-    span({ className: ' glyphicon glyphicon-remove default-color'})
+    span({ className: 'glyphicon glyphicon-remove default-color'})
   ]);
 }

--- a/src/components/CloseIconComponent.js
+++ b/src/components/CloseIconComponent.js
@@ -1,0 +1,12 @@
+import { button, span } from 'react-hyperscript-helpers';
+
+export default function CloseIconComponent(props) {
+  const { closeFn } = props;
+  return button({
+    type: 'button',
+    className: 'modal-close-btn close',
+    onClick: closeFn
+  }, [
+    span({ className: ' glyphicon glyphicon-remove default-color'})
+  ]);
+}

--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp';
 import { Component } from 'react';
-import { button, div, h, h2, span, hh } from 'react-hyperscript-helpers';
+import { button, div, h, h2, hh } from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import { Alert } from '../components/Alert';
+import CloseIconComponent from '../components/CloseIconComponent';
 import './ConfirmationDialog.css';
-
 
 const customStyles = {
   overlay: {
@@ -60,9 +60,7 @@ export const ConfirmationDialog = hh(class ConfirmationDialog extends Component 
         contentLabel: "Modal"
       }, [
         div({ className: "dialog-header" }, [
-          button({ id: "btn_dialogClose", type: "button", className: "dialog-close-btn close", onClick: this.props.action.handler(false) }, [
-            span({ className: "glyphicon glyphicon-remove default-color" }),
-          ]),
+          h(CloseIconComponent, {closeFn: this.props.action.handler(false)}),
           h2({ id: "lbl_dialogTitle", className: "dialog-title " + this.props.color + "-color" }, [this.props.title]),
         ]),
 

--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -2,9 +2,11 @@ import {button, div, h} from "react-hyperscript-helpers";
 import {Styles} from "../../libs/theme";
 import Modal from "react-modal";
 import {isNil} from "lodash";
+import CloseIconComponent from '../CloseIconComponent';
 
 const ConfirmationModal = (props) => {
   const {showConfirmation, closeConfirmation, title, message, header, onConfirm, id, index} = props;
+  const closeFn = () => closeConfirmation();
 
   //id and index are optional parameters to onConfirm
   //can use an onConfirm with no parameters
@@ -23,12 +25,13 @@ const ConfirmationModal = (props) => {
     }
   }, [
     div({style: Styles.MODAL.CONFIRMATION}, [
+      h(CloseIconComponent, {closeFn}),
       div({style: Styles.MODAL.DAR_SUBHEADER}, [`${header}`]),
       div({style: Styles.MODAL.TITLE_HEADER}, [`${title}`]),
       div({style: Styles.MODAL.DAR_DETAIL}, [`${message}`]),
       div({style: {width: "40%", float: "right"}}, [
         div({style: {width: "45%", float: "left"}}, [
-          button({className: "cell-button cancel-color", onClick: () => closeConfirmation() }, ["Cancel"])
+          button({className: "cell-button cancel-color", onClick: closeFn }, ["Cancel"])
         ]),
         div({style: {width: "45%", float: "right"}}, [
           confirmButton

--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -1,8 +1,9 @@
-import {div, h, span} from 'react-hyperscript-helpers';
+import {div, h} from 'react-hyperscript-helpers';
 import {Alert} from '../Alert';
 import {Styles} from '../../libs/theme';
 import Modal from 'react-modal';
 import {find, isEmpty, isNil} from 'lodash/fp';
+import CloseIconComponent from '../CloseIconComponent';
 
 const ModalDetailRow = (props) => {
   return (
@@ -72,11 +73,7 @@ const DarModal = (props) => {
     }
   }, [
     div({style: Styles.MODAL.CONTENT}, [
-      span({
-        style: {float: 'right', cursor: 'pointer'},
-        onClick: closeModal,
-        className: "glyphicon glyphicon-remove default-color"
-      }),
+      h(CloseIconComponent, {closeFn: closeModal}),
       div({style: Styles.MODAL.TITLE_HEADER}, [`${darDetails.projectTitle}`]),
       div({style: {borderBottom: "1px solid #1F3B50"}}, []),
       h(ModalDetailRow, {


### PR DESCRIPTION
Addresses [DUOS-1098](https://broadworkbench.atlassian.net/browse/DUOS-1098)

PR standardizes close button by transforming it into an importable component.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] PR is labeled with a Jira ticket number and includes a link to the ticket
- [x] PR is labeled with a security risk modifier [no, low, medium, high] 
- [x] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
