### PR TITLE
[DUOS-1242][risk=no] - Add shibboleth to the content security policy

### DIFF
--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -11,7 +11,7 @@ map $sent_http_content_type $expires {
 server {
   listen 8080;
   expires $expires;
-  add_header Content-Security-Policy "default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.broadinstitute.org storage.googleapis.com *.google-analytics.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com;";
+  add_header Content-Security-Policy "default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.broadinstitute.org storage.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com;";
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;


### PR DESCRIPTION
**Addresses**
https://broadworkbench.atlassian.net/browse/DUOS-1242

**Changes**
- Adds shibboleth url to the content security policy

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
