### PR TITLE
DUOS-1246[risk=no]List Institutes should also return create user information

### DIFF
--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -86,13 +86,13 @@ export default function InstitutionTable(props) {
             ]),
             div({
               style: Object.assign({}, Styles.TABLE.DATA_ID_CELL)
-            }, [inst.createUser]),
+            }, [inst.createUser.displayName]),
             div({
               style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL)
             }, [inst.createDate]),
             div({
               style: Object.assign({}, Styles.TABLE.DATA_ID_CELL)
-            }, [inst.updateUser ? inst.updateUser : '']),
+            }, [inst.updateUser ? inst.updateUser.displayName : '']),
             div({
               style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL)
             }, [inst.updateDate]),

--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -86,7 +86,7 @@ export default function InstitutionTable(props) {
             ]),
             div({
               style: Object.assign({}, Styles.TABLE.DATA_ID_CELL)
-            }, [inst.createUser.displayName]),
+            }, [inst.createUser ? inst.createUser.displayName : '']),
             div({
               style: Object.assign({}, Styles.TABLE.SUBMISSION_DATE_CELL)
             }, [inst.createDate]),


### PR DESCRIPTION
SCOPE:
Merge after DUOS-1246 in Consent
- retrieve the display name from the create user and update user objects

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1246

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
