### PR TITLE
DUOS-1238[risk=no]Add DAR view link to new DAC Chair Console 'unopened' DARs + text desc.

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -105,7 +105,7 @@ const Routes = (props) => (
       rolesAllowed={[USER_ROLES.chairperson, USER_ROLES.admin]} />
     <AuthenticatedRoute path="/reviewed_cases" component={ReviewedCases} props={props}
       rolesAllowed={[USER_ROLES.admin, USER_ROLES.alumni]} />
-    <AuthenticatedRoute path="/review_results/:referenceId" component={ReviewResults} props={props}
+    <AuthenticatedRoute path="/review_results/:referenceId/:status?" component={ReviewResults} props={props}
       rolesAllowed={[USER_ROLES.admin, USER_ROLES.alumni, USER_ROLES.chairperson]} />
     <Route path="*" component={NotFound} />
   </Switch>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -106,7 +106,7 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/reviewed_cases" component={ReviewedCases} props={props}
       rolesAllowed={[USER_ROLES.admin, USER_ROLES.alumni]} />
     <AuthenticatedRoute path="/review_results/:referenceId" component={ReviewResults} props={props}
-      rolesAllowed={[USER_ROLES.admin, USER_ROLES.alumni]} />
+      rolesAllowed={[USER_ROLES.admin, USER_ROLES.alumni, USER_ROLES.chairperson]} />
     <Route path="*" component={NotFound} />
   </Switch>
 );

--- a/src/components/dar_table/DarElectionRecords.js
+++ b/src/components/dar_table/DarElectionRecords.js
@@ -35,7 +35,7 @@ const electionStatusTemplate = (consoleType, dar, election, recordTextStyle, vot
       color: consoleType === consoleTypes.MANAGE_ACCESS ? Theme.palette.link : 'black' //color adjustment for manage console
     }),
     onClick: () => consoleType === consoleTypes.MANAGE_ACCESS && goToReviewResults(dar, history)
-  }, [election ? processElectionStatus(election, votes, showVotes) : '- -']);
+  }, [election ? processElectionStatus(election, votes, showVotes) : 'Unreviewed']);
 };
 
 export default function DarElectionRecords(props) {

--- a/src/components/dar_table/DarElectionRecords.js
+++ b/src/components/dar_table/DarElectionRecords.js
@@ -29,13 +29,16 @@ const goToReviewResults = (dar, history) => {
   }
 };
 const electionStatusTemplate = (consoleType, dar, election, recordTextStyle, votes, showVotes, history) =>{
-  const tag = consoleType === consoleTypes.MANAGE_ACCESS ? a : div;
+  const linkedStatuses = ['Unreviewed', 'Approved', 'Denied', 'Canceled'];
+  const status = election ? processElectionStatus(election, votes, showVotes) : 'Unreviewed';
+  const includeLink = (consoleType === consoleTypes.MANAGE_ACCESS || linkedStatuses.includes(status));
+  const tag = includeLink ? a : div;
   return tag({
     style: Object.assign({}, Styles.TABLE.ELECTION_STATUS_CELL, recordTextStyle, {
-      color: consoleType === consoleTypes.MANAGE_ACCESS ? Theme.palette.link : 'black' //color adjustment for manage console
+      color: includeLink ? Theme.palette.link : 'black' //color adjustment for manage console
     }),
-    onClick: () => consoleType === consoleTypes.MANAGE_ACCESS && goToReviewResults(dar, history)
-  }, [election ? processElectionStatus(election, votes, showVotes) : 'Unreviewed']);
+    onClick: () => includeLink && goToReviewResults(dar, history)
+  }, [status]);
 };
 
 export default function DarElectionRecords(props) {

--- a/src/components/dar_table/DarElectionRecords.js
+++ b/src/components/dar_table/DarElectionRecords.js
@@ -23,9 +23,13 @@ const calcVisibleWindow = (currentPage, tableSize, filteredList) => {
   }
 };
 
-const goToReviewResults = (dar, history) => {
+const goToReviewResults = (dar, history, status) => {
   if(dar && dar.referenceId) {
-    history.push(`review_results/${dar.referenceId}`);
+    if (status === 'Unreviewed') {
+      history.push(`review_results/${dar.referenceId}/${status}`);
+    } else {
+      history.push(`review_results/${dar.referenceId}`);
+    }
   }
 };
 const electionStatusTemplate = (consoleType, dar, election, recordTextStyle, votes, showVotes, history) =>{
@@ -37,7 +41,7 @@ const electionStatusTemplate = (consoleType, dar, election, recordTextStyle, vot
     style: Object.assign({}, Styles.TABLE.ELECTION_STATUS_CELL, recordTextStyle, {
       color: includeLink ? Theme.palette.link : 'black' //color adjustment for manage console
     }),
-    onClick: () => includeLink && goToReviewResults(dar, history)
+    onClick: () => includeLink && goToReviewResults(dar, history, status)
   }, [status]);
 };
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -261,7 +261,7 @@ export const processElectionStatus = (election, votes, showVotes) => {
   const electionStatus = election.status;
 
   if(!isEmpty(votes) && isNil(electionStatus)) {
-    output = '- -';
+    output = 'Unreviewed';
   } else if(electionStatus === 'Open') {
     //Null check since react doesn't necessarily perform prop updates immediately
     if(!isEmpty(votes) && !isNil(election)) {

--- a/src/pages/ReviewResults.js
+++ b/src/pages/ReviewResults.js
@@ -62,11 +62,13 @@ export default function ReviewResults(props) {
     //get the duos matching algorithm decision
     let matchData;
 
-    try {
-      matchData = await Match.findMatch(consent.consentId, accessElection.referenceId);
-      setMatchData(matchData);
-    } catch (e) {
-      Notifications.showError({ text: `Something went wrong trying to get match algorithm results. Error code: ${e.status}` });
+    if (!isNil(accessElection)) {
+      try {
+        matchData = await Match.findMatch(consent.consentId, accessElection.referenceId);
+        setMatchData(matchData);
+      } catch (e) {
+        Notifications.showError({text: `Something went wrong trying to get match algorithm results. Error code: ${e.status}`});
+      }
     }
   };
 

--- a/src/pages/ReviewResults.js
+++ b/src/pages/ReviewResults.js
@@ -13,6 +13,7 @@ const SECTION = {
 
 export default function ReviewResults(props) {
   const darId = props.match.params.referenceId;
+  const status = props.match.params.referenceId;
   const [datasets, setDatasets] = useState();
   const [darInfo, setDarInfo] = useState();
   const [consent, setConsent] = useState();
@@ -41,11 +42,14 @@ export default function ReviewResults(props) {
     let accessElectionReview;
     let rpElectionReview;
 
-    try {
-      accessElection = await Election.findElectionByDarId(darId);
-    } catch (error) {
-      //access election is null, this is expected for a dar with an unreviewed election status
-      //so there is no vote information to display
+    //dars with unreviewed status will not have an election
+    if (isNil(status)) {
+      try {
+        accessElection = await Election.findElectionByDarId(darId);
+      } catch (error) {
+        //access election is null, this is expected for a dar with an unreviewed election status
+        //so there is no vote information to display
+      }
     }
     try {
       accessElectionReview = isNil(accessElection) ? null : await Election.findDataAccessElectionReview(accessElection.electionId);

--- a/src/pages/ReviewResults.js
+++ b/src/pages/ReviewResults.js
@@ -13,7 +13,7 @@ const SECTION = {
 
 export default function ReviewResults(props) {
   const darId = props.match.params.referenceId;
-  const status = props.match.params.referenceId;
+  const status = props.match.params.status;
   const [datasets, setDatasets] = useState();
   const [darInfo, setDarInfo] = useState();
   const [consent, setConsent] = useState();
@@ -43,7 +43,7 @@ export default function ReviewResults(props) {
     let rpElectionReview;
 
     //dars with unreviewed status will not have an election
-    if (isNil(status)) {
+    if (status !== 'Unreviewed') {
       try {
         accessElection = await Election.findElectionByDarId(darId);
       } catch (error) {


### PR DESCRIPTION
SCOPE:
- Add links to review results page on non-open election statuses  (Unreviewed, Approved, Denied, Canceled) for the chair console
- Change -- to 'unreviewed' status for dars with no elections

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1238

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
