### PR TITLE
DUOS-1229[risk=no]Restore Vote Statistics Download functions

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -668,9 +668,14 @@ export const Files = {
 };
 
 export const Summary = {
-  getFile: async (URI, nameFile) => {
+  getFile: async (fileName) => {
+    const URI = `/consent/cases/summary/file?fileType=${fileName}`;
     const url = `${await Config.getApiUrl()}${URI}`;
-    return await getFile(url, nameFile);
+    if (fileName === 'TranslateDUL') {
+      return await getFile(url, 'DUL_summary.tsv');
+    } else {
+      return await getFile(url, 'DAR_summary.tsv');
+    }
   }
 };
 

--- a/src/pages/SummaryVotes.js
+++ b/src/pages/SummaryVotes.js
@@ -138,7 +138,7 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
           button({
             id: "btn_downloadStatsDul",
             className: "col-lg-2 col-md-3 col-sm-4 col-xs-12 search-wrapper btn-primary dul-background",
-            onClick: () => this.getFile("TranslateDUL"),
+            onClick: () => Summary.getFile("TranslateDUL"),
             isRendered: this.isAuthedToDownload()
           }, [
             span({}, ["Download stats"]),
@@ -178,7 +178,7 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
           button({
             id: "btn_downloadStatsAccess",
             className: "col-lg-2 col-md-3 col-sm-4 col-xs-12 search-wrapper btn-primary access-background",
-            onClick: () => this.getFile("DataAccess"),
+            onClick: () => Summary.getFile("DataAccess"),
             isRendered: this.isAuthedToDownload()
           }, [
             span({}, ["Download stats"]),
@@ -262,15 +262,6 @@ export const SummaryVotes = hh(class SummaryVotes extends Component {
         ])
       ])
     );
-  }
-
-  getFile(fileName) {
-    const URI = `/consent/cases/summary/file?fileType=${fileName}`;
-    if (fileName === 'TranslateDUL') {
-      Summary.getFile(URI, 'DUL_summary.tsv');
-    } else {
-      Summary.getFile(URI, 'DAR_summary.tsv');
-    }
   }
 
   getDarReport(fileType, fileName) {


### PR DESCRIPTION
SCOPE:
- Refactor getFile so the URI is created in the ajax file rather than on the summary votes page
- Tested with the DUOS-1229 PR in Consent and the Download Stats button does cause a file to download when clicked

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1229

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
