### PR TITLE
DUOS-1265[risk=no]DAR Console Search needs to be able to filter on election status

### DIFF
--- a/src/components/dar_table/DarElectionRecords.js
+++ b/src/components/dar_table/DarElectionRecords.js
@@ -34,7 +34,7 @@ const goToReviewResults = (dar, history, status) => {
 };
 const electionStatusTemplate = (consoleType, dar, election, recordTextStyle, votes, showVotes, history) =>{
   const linkedStatuses = ['Unreviewed', 'Approved', 'Denied', 'Canceled'];
-  const status = election ? processElectionStatus(election, votes, showVotes) : 'Unreviewed';
+  const status = processElectionStatus(election, votes, showVotes);
   const includeLink = (consoleType === consoleTypes.MANAGE_ACCESS || linkedStatuses.includes(status));
   const tag = includeLink ? a : div;
   return tag({

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -258,9 +258,8 @@ export const wasFinalVoteTrue = (voteData) => {
 
 export const processElectionStatus = (election, votes, showVotes) => {
   let output;
-  const electionStatus = election.status;
-
-  if(!isEmpty(votes) && isNil(electionStatus)) {
+  const electionStatus = election ? election.status : null;
+  if (isNil(electionStatus)) {
     output = 'Unreviewed';
   } else if(electionStatus === 'Open') {
     //Null check since react doesn't necessarily perform prop updates immediately
@@ -322,7 +321,7 @@ export const darSearchHandler = (electionList, setFilteredList, setCurrentPage) 
             const dar = electionData.dar ? electionData.dar.data : undefined;
             const targetDarAttrs = !isNil(dar) ? JSON.stringify([toLower(dar.projectTitle), toLower(dar.darCode), toLower(getNameOfDatasetForThisDAR(dar.datasets, dar.datasetIds))]) : [];
             const targetDacAttrs = !isNil(dac) ? JSON.stringify([toLower(dac.name)]) : [];
-            const targetElectionAttrs = !isNil(election) ? JSON.stringify([toLower(processElectionStatus(election, votes)), getElectionDate(election)]) : [];
+            const targetElectionAttrs = JSON.stringify([toLower(processElectionStatus(election, votes)), getElectionDate(election)]);
             return includes(term, targetDarAttrs) || includes(term, targetDacAttrs) || includes(term, targetElectionAttrs);
           }, newFilteredList);
         }


### PR DESCRIPTION
SCOPE:
Add null check for elections in processElectionStatus, marking null elections as unreviewed
Remove null check for elections before calling processElectionStatus from the darSearchHandler, this way it returns [unreviewed, date] instead of []
Remove null check for elections before calling processElectionStatus from the electionStatusTemplate because it is no longer necessary

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1265

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
