### PR TITLE
DUOS-1270[risk=no]Add 'Return to Console' link in upper right corner of DAR Review UI

### DIFF
--- a/src/pages/ReviewResults.js
+++ b/src/pages/ReviewResults.js
@@ -80,7 +80,7 @@ export default function ReviewResults(props) {
     (!isNil(darInfo)) ?
       div({id: 'container', style: {margin: '2rem'}}, [
         div({id: 'header', style: {...SECTION, padding: '1rem 0'}}, [
-          AccessReviewHeader({})
+          AccessReviewHeader({history: props.history})
         ]),
         div({id: 'body', style: SECTION}, [
           DarApplication({

--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -87,7 +87,7 @@ class AccessReview extends React.PureComponent {
           {
             id: 'header', style: SECTION
           },
-          [AccessReviewHeader({ match, message: dacChairMessage })]
+          [AccessReviewHeader({ match, message: dacChairMessage, history })]
         ),
         div({ id: 'body', style: { display: 'flex' } }, [
           div(

--- a/src/pages/access_review/AccessReviewHeader.js
+++ b/src/pages/access_review/AccessReviewHeader.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import { div, img, hh } from 'react-hyperscript-helpers';
+import { div, img, h, hh, a, span } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
 import lockIcon from '../../images/lock-icon.png';
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { isNil } from 'lodash/fp';
+import {Navigation} from "../../libs/utils";
+import {Storage} from "../../libs/storage";
 
 const TITLE = {
   fontWeight: Theme.font.weight.semibold,
@@ -11,24 +14,20 @@ const TITLE = {
   marginBottom: '5px',
 };
 
-const SMALL = {
-  fontSize: Theme.font.size.small,
-  lineHeight: Theme.font.leading.dense,
-};
-
 const SUBHEADER = {
   fontSize: Theme.font.size.subheader,
   lineHeight: Theme.font.leading.dense
-}
+};
 
 export const AccessReviewHeader = hh(class AccessReviewHeader extends React.PureComponent {
 
   render() {
+    const message = this.props.message;
+
     return div(
       {
         style: {
           justifyContent: 'space-between',
-          alignItems: 'center',
           display: 'flex',
           fontFamily: 'Arial',
           color: Theme.palette.primary,
@@ -57,11 +56,16 @@ export const AccessReviewHeader = hh(class AccessReviewHeader extends React.Pure
               div({ style: SUBHEADER },
                 "Review the Application Summary and Data Use Limitations to determine if the researcher should be granted access to the data."
               ),
-              div({ isRendered: !isNil(this.props.message), style: SUBHEADER }, this.props.message )
+              div({ isRendered: !isNil(message), style: SUBHEADER }, message )
             ])
           ]
-        )
-      ]
-    );
+        ),
+        div({ style: {marginRight: '10px', anchor: 'right' }}, [
+          a({onClick: () => {Navigation.back(Storage.getCurrentUser(), this.props.history);}, style: {fontSize: '22px'}}, [
+            h(ArrowBackIcon, {style: {marginRight: '8px', marginBottom: '-4px', fontSize: '22px'}}),
+            span('Return to Console')
+          ])
+        ])
+      ]);
   }
 });


### PR DESCRIPTION
SCOPE:
On access review (for open elections) and review results (for approved, denied, and unreviewed elections) page, pass the history prop to the header

In the accessReviewHeader, add a back button that navigates to the correct console depending on the current user
Now all chairs, members, and admin have a clear way to navigate back from all Dar review pages

I added it to both pages for consistency of appearance when a DAC Chair clicks an open election vs a non-open election

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1270

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
