### PR TITLE
DUOS-1276[risk=no] Refactored updateFinalAccessDarVote to include electionId in vote payload

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1008,19 +1008,10 @@ export const Votes = {
   },
 
   updateFinalAccessDarVote: async (requestId, vote) => {
-    var postObject = {};
-    postObject.vote = vote.vote;
-    postObject.dacUserId = vote.dacUserId;
-    postObject.rationale = vote.rationale;
-    if (vote.type === 'FINAL') {
-      postObject.type = 'FINAL';
-    }
     const url = `${await Config.getApiUrl()}/dataRequest/${requestId}/vote/${vote.voteId}/final`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(postObject), { method: 'POST' }]));
+    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(vote), { method: 'POST' }]));
     return await res.json();
-
   }
-
 };
 
 export const AuthenticateNIH = {


### PR DESCRIPTION
Addresses [DUOS-1276](https://broadworkbench.atlassian.net/browse/DUOS-1276)

PR simplifies `updateFinalAccessDarVote` to just use the vote payload rather than just filtering out attributes. The filtered attributes were outdated, causing `electionId` to never be included in the vote object. As a result the final vote would always error out with a `404 Vote could not be logged` (since the election could not be found). Since front-end components are already managing the vote payload and the back-end has to validate any incoming payload, it makes sense to simplify the ajax method.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] PR is labeled with a Jira ticket number and includes a link to the ticket
- [ ] PR is labeled with a security risk modifier [no, low, medium, high] 
- [ ] PR describes scope of changes

In all cases:

- [ ] Get a minimum of one thumbs worth of review, preferably 2 if enough team members are available
- [ ] Get PO sign-off for all non-trivial UI or workflow changes
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this
- [ ] Test this change deployed correctly and works on dev environment after deployment
