### PR TITLE
DUOS-1287[risk=no]Remove usages of Deprecated UserFields from UI

### DIFF
--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -5,7 +5,7 @@ import {isNil, isEmpty} from 'lodash/fp';
 import { Theme } from '../libs/theme';
 import {Institution} from "../libs/ajax";
 import {useEffect, useState} from "react";
-import {findPropertyValue, UserProperties } from "../libs/utils";
+import {getPropertyValuesFromUser} from "../libs/utils";
 
 const styles = StyleSheet.create({
   page: {
@@ -155,17 +155,8 @@ export default function ApplicationDownloadLink(props) {
   const internalCollaborators = getCollaborators(darInfo, 'internalCollaborators');
   const externalCollaborators = getCollaborators(darInfo, 'externalCollaborators');
   const labCollaborators = getCollaborators(darInfo, 'labCollaborators');
-  const nihUsernameProp = findPropertyValue(UserProperties.NIH_USERNAME, researcherProfile);
-  const linkedInProp = findPropertyValue(UserProperties.LINKEDIN, researcherProfile);
-  const orcidProp = findPropertyValue(UserProperties.ORCID, researcherProfile);
-  const researcherGateProp = findPropertyValue(UserProperties.RESEARCHER_GATE, researcherProfile);
-  const isThePiProp = findPropertyValue(UserProperties.IS_THE_PI, researcherProfile);
-  const piNameProp = findPropertyValue(UserProperties.PI_NAME, researcherProfile);
-  const departmentProp = findPropertyValue(UserProperties.DEPARTMENT, researcherProfile);
-  const cityProp = findPropertyValue(UserProperties.CITY, researcherProfile);
-  const stateProp = findPropertyValue(UserProperties.STATE, researcherProfile);
-  const location = cityProp.concat(", ").concat(stateProp);
-  const emailProp = researcherProfile.email;
+  const researcherProps = getPropertyValuesFromUser(researcherProfile);
+  const location = (researcherProps.city).concat(", ").concat(researcherProps.state);
   // Use PDFViewer during development to see changes to the document immediately
   // return h(PDFViewer, {width: 1800, height: 800}, [
 
@@ -177,23 +168,23 @@ export default function ApplicationDownloadLink(props) {
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
             label: "NIH eRA Commons ID",
-            text: `${nihUsernameProp}`,
+            text: `${researcherProps.nihUsername}`,
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
             label: "LinkedIn Profile",
-            text: `${linkedInProp}`
+            text: `${researcherProps.linkedIn}`
           })
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
             label: "ORC ID",
-            text: `${orcidProp}`,
+            text: `${researcherProps.orcid}`,
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
             label: "ResearcherGate ID",
-            text: `${researcherGateProp}`
+            text: `${researcherProps.researcherGate}`
           }),
         ]),
         h(View, {style: styles.flexboxContainer}, [
@@ -203,15 +194,14 @@ export default function ApplicationDownloadLink(props) {
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
-            label: "Principal Investigator", text: `${isThePiProp ?
-              researcherProfile.displayName : piNameProp.propertyValue}`
+            label: "Principal Investigator", text: `${researcherProps.piName}`
           })
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {label: "Institution", text: `${institution}`, style: {marginRight: 30}}),
           h(SmallLabelTextComponent, {
             label: "Department",
-            text: `${departmentProp}`
+            text: `${researcherProps.department}`
           })
         ]),
         h(View, {style: styles.flexboxContainer}, [
@@ -221,7 +211,7 @@ export default function ApplicationDownloadLink(props) {
           }),
           h(SmallLabelTextComponent, {
             label: "Researcher Email",
-            text: `${emailProp}`
+            text: `${researcherProps.academicEmail}`
           }),
         ]),
         h(View, {style: styles.flexboxContainer}, [

--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -158,13 +158,14 @@ export default function ApplicationDownloadLink(props) {
   const nihUsernameProp = findPropertyValue(UserProperties.NIH_USERNAME, researcherProfile);
   const linkedInProp = findPropertyValue(UserProperties.LINKEDIN, researcherProfile);
   const orcidProp = findPropertyValue(UserProperties.ORCID, researcherProfile);
+  const researcherGateProp = findPropertyValue(UserProperties.RESEARCHER_GATE, researcherProfile);
   const isThePiProp = findPropertyValue(UserProperties.IS_THE_PI, researcherProfile);
   const piNameProp = findPropertyValue(UserProperties.PI_NAME, researcherProfile);
   const departmentProp = findPropertyValue(UserProperties.DEPARTMENT, researcherProfile);
   const cityProp = findPropertyValue(UserProperties.CITY, researcherProfile);
   const stateProp = findPropertyValue(UserProperties.STATE, researcherProfile);
   const location = cityProp.concat(", ").concat(stateProp);
-  const emailProp = findPropertyValue(UserProperties.EMAIL, researcherProfile);
+  const emailProp = researcherProfile.email;
   // Use PDFViewer during development to see changes to the document immediately
   // return h(PDFViewer, {width: 1800, height: 800}, [
 
@@ -192,7 +193,7 @@ export default function ApplicationDownloadLink(props) {
           }),
           h(SmallLabelTextComponent, {
             label: "ResearcherGate ID",
-            text: `${orcidProp}`
+            text: `${researcherGateProp}`
           }),
         ]),
         h(View, {style: styles.flexboxContainer}, [

--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -1,11 +1,11 @@
 import { Page, Document, StyleSheet, View, /*PDFViewer*/ PDFDownloadLink, Text} from '@react-pdf/renderer';
 import {h, span, i} from 'react-hyperscript-helpers';
 import {DataUseTranslation} from '../libs/dataUseTranslation';
-import {find, isEmpty} from 'lodash/fp';
+import {isNil, isEmpty} from 'lodash/fp';
 import { Theme } from '../libs/theme';
-import { isNil }from "lodash";
 import {Institution} from "../libs/ajax";
 import {useEffect, useState} from "react";
+import {findPropertyValue, UserProperties } from "../libs/utils";
 
 const styles = StyleSheet.create({
   page: {
@@ -155,20 +155,16 @@ export default function ApplicationDownloadLink(props) {
   const internalCollaborators = getCollaborators(darInfo, 'internalCollaborators');
   const externalCollaborators = getCollaborators(darInfo, 'externalCollaborators');
   const labCollaborators = getCollaborators(darInfo, 'labCollaborators');
-  const nihUsernameProp = find({propertyKey: 'nihUsername'})(researcherProfile.researcherProperties);
-  const linkedInProp = find({propertyKey: 'linkedIn'})(researcherProfile.researcherProperties);
-  const orcidProp = find({propertyKey: 'orcid'})(researcherProfile.researcherProperties);
-  const isThePiProp = find({propertyKey: 'isThePI'})(researcherProfile.researcherProperties);
-  const piNameProp = find({propertyKey: 'piName'})(researcherProfile.researcherProperties);
-  const departmentProp = find({propertyKey: 'department'})(researcherProfile.researcherProperties);
-  const cityProp = find({propertyKey: 'city'})(researcherProfile.researcherProperties);
-  const stateProp = find({propertyKey: 'state'})(researcherProfile.researcherProperties);
-  const location = () => {
-    const city = isNil(cityProp) ? "" : nihUsernameProp.propertyValue;
-    const state = isNil(stateProp) ? "" : nihUsernameProp.propertyValue;
-    return city.concat(", ").concat(state);
-  };
-  const emailProp = find({propertyKey: 'academicEmail'})(researcherProfile.researcherProperties);
+  const nihUsernameProp = findPropertyValue(UserProperties.NIH_USERNAME, researcherProfile);
+  const linkedInProp = findPropertyValue(UserProperties.LINKEDIN, researcherProfile);
+  const orcidProp = findPropertyValue(UserProperties.ORCID, researcherProfile);
+  const isThePiProp = findPropertyValue(UserProperties.IS_THE_PI, researcherProfile);
+  const piNameProp = findPropertyValue(UserProperties.PI_NAME, researcherProfile);
+  const departmentProp = findPropertyValue(UserProperties.DEPARTMENT, researcherProfile);
+  const cityProp = findPropertyValue(UserProperties.CITY, researcherProfile);
+  const stateProp = findPropertyValue(UserProperties.STATE, researcherProfile);
+  const location = cityProp.concat(", ").concat(stateProp);
+  const emailProp = findPropertyValue(UserProperties.EMAIL, researcherProfile);
   // Use PDFViewer during development to see changes to the document immediately
   // return h(PDFViewer, {width: 1800, height: 800}, [
 
@@ -180,23 +176,23 @@ export default function ApplicationDownloadLink(props) {
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
             label: "NIH eRA Commons ID",
-            text: `${isNil(nihUsernameProp) ? "" : nihUsernameProp.propertyValue}`,
+            text: `${nihUsernameProp}`,
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
             label: "LinkedIn Profile",
-            text: `${isNil(linkedInProp) ? "" : linkedInProp.propertyValue}`
+            text: `${linkedInProp}`
           })
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
             label: "ORC ID",
-            text: `${isNil(orcidProp) ? "" : orcidProp.propertyValue}`,
+            text: `${orcidProp}`,
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
             label: "ResearcherGate ID",
-            text: `${isNil(orcidProp) ? "" : orcidProp.propertyValue}`
+            text: `${orcidProp}`
           }),
         ]),
         h(View, {style: styles.flexboxContainer}, [
@@ -206,25 +202,25 @@ export default function ApplicationDownloadLink(props) {
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
-            label: "Principal Investigator", text: `${isNil(isThePiProp) ? "" : isThePiProp.propertyValue ?
-              researcherProfile.displayName : isNil(piNameProp) ? "" : piNameProp.propertyValue}`
+            label: "Principal Investigator", text: `${isThePiProp ?
+              researcherProfile.displayName : piNameProp.propertyValue}`
           })
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {label: "Institution", text: `${institution}`, style: {marginRight: 30}}),
           h(SmallLabelTextComponent, {
             label: "Department",
-            text: `${isNil(departmentProp) ? "" : departmentProp.propertyValue}`
+            text: `${departmentProp}`
           })
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
-            label: "Location", text: `${location()}`,
+            label: "Location", text: `${location}`,
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {
             label: "Researcher Email",
-            text: `${isNil(emailProp) ? "" : emailProp.propertyValue}`
+            text: `${emailProp}`
           }),
         ]),
         h(View, {style: styles.flexboxContainer}, [

--- a/src/components/modals/DarModal.js
+++ b/src/components/modals/DarModal.js
@@ -4,6 +4,8 @@ import {Styles} from '../../libs/theme';
 import Modal from 'react-modal';
 import {find, isEmpty, isNil} from 'lodash/fp';
 import CloseIconComponent from '../CloseIconComponent';
+import {Institution} from "../../libs/ajax";
+import {useEffect, useState} from "react";
 
 const ModalDetailRow = (props) => {
   return (
@@ -32,10 +34,6 @@ const returnPIName = (researcher) => {
   return returnName || researcher.displayName;
 };
 
-const returnInstitution = (researcher) => {
-  const institutionProp = find({propertyKey: "institution"})(researcher.researcherProperties);
-  return isNil(institutionProp) ? '- -' : institutionProp.propertyValue;
-};
 
 const processResearchTypes = (researchTypes) => {
   let researchStatements = '';
@@ -61,6 +59,22 @@ const requiresManualReview = (darDetails) => {
 const DarModal = (props) => {
   //NOTE: Modal should be simple (raw information should be passed in as props) in order to ensure plug and play use
   const {showModal, closeModal, darDetails, datasets, researcher} = props;
+  const [institution, setInstitution] = useState();
+
+  useEffect(() => {
+
+    const returnInstitution = async (researcher) => {
+      const institutionId = researcher.institutionId;
+      if (isNil(institutionId)) {
+        setInstitution('- -');
+      } else {
+        const institute = await Institution.getById(institutionId);
+        setInstitution(institute.name);
+      }
+    };
+    returnInstitution(researcher);
+  }, [researcher]);
+
   return h(Modal, {
     isOpen: showModal,
     onRequestClose: closeModal,
@@ -90,7 +104,7 @@ const DarModal = (props) => {
       }),
       h(ModalDetailRow, {
         label: 'Institution',
-        detail: returnInstitution(researcher)
+        detail: institution
       }),
       h(ModalDetailRow, {
         label: 'Dataset(s)',

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -214,7 +214,7 @@ export const DAR = {
     darInfo.researcherId = rawDar.userId;
     darInfo.darCode = rawDar.darCode;
     darInfo.projectTitle = rawDar.projectTitle;
-    darInfo.institution = rawDar.institutionName;
+    darInfo.institution = isNil(researcher.institutionId) ? "" : (await Institution.getById(researcher.institutionId)).name;
     darInfo.department = rawDar.department;
     darInfo.city = rawDar.city;
     darInfo.country = rawDar.country;
@@ -240,6 +240,7 @@ export const DAR = {
     darInfo.datasetIds = rawDar.datasetIds;
     darInfo.pi = rawDar.investigator;
     darInfo.havePI = rawDar.havePI || rawDar.isThePI;
+    //name from researcher bc name in props and on dar are not accurately populated
     darInfo.profileName = researcher.displayName;
     // dataUse from Models.dar has properties denoting what research the data will be used for.
     // Get these properties directly from the DAR.

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -9,16 +9,24 @@ import _ from 'lodash';
 import {User} from "./ajax";
 
 export const UserProperties = {
-  EMAIL: "academicEmail",
   NIH_USERNAME : "nihUsername",
   LINKEDIN : "linkedIn",
   ORCID: "orcid",
   IS_THE_PI: "isThePI",
+  HAVE_PI: "havePI",
+  PI_EMAIL: "piEmail",
   PI_NAME: "piName",
   DEPARTMENT: "department",
+  DIVISION: "division",
+  ADDRESS1: "address1",
+  ADDRESS2: "address2",
+  ZIPCODE: "zipcode",
   CITY: "city",
   STATE: "state",
-  COUNTRY: "country"
+  COUNTRY: "country",
+  RESEARCHER_GATE: "researcherGate",
+  PUBMED_ID: "pubmedID",
+  SCIENTIFIC_URL: "scientificURL"
 };
 
 export const findPropertyValue = (propName, researcher) => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -2,10 +2,11 @@ import Noty from 'noty';
 import 'noty/lib/noty.css';
 import 'noty/lib/themes/bootstrap-v3.css';
 import { forEach } from 'lodash';
-import { DAR, DataSet, Researcher } from "./ajax";
+import { DAR, DataSet } from "./ajax";
 import {Theme, Styles } from "./theme";
 import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes } from "lodash/fp";
 import _ from 'lodash';
+import {User} from "./ajax";
 
 export const applyHoverEffects = (e, style) => {
   forEach(style, (value, key) => {
@@ -200,7 +201,7 @@ export const getDarData = async (darId) => {
 
   try {
     darInfo = await DAR.getPartialDarRequest(darId);
-    const researcherPromise = await Researcher.getResearcherProfile(darInfo.userId);
+    const researcherPromise = await User.getById(darInfo.userId);
     const datasetsPromise = darInfo.datasetIds.map((id) => {
       return DataSet.getDataSetsByDatasetId(id);
     });

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -36,6 +36,32 @@ export const findPropertyValue = (propName, researcher) => {
   return isNil(prop) ? "" : prop.propertyValue;
 };
 
+export const getPropertyValuesFromUser = (user) => {
+  let researcherProps = {
+    academicEmail: user.email,
+    nihUsername: findPropertyValue(UserProperties.NIH_USERNAME, user),
+    linkedIn: findPropertyValue(UserProperties.LINKEDIN, user),
+    orcid: findPropertyValue(UserProperties.ORCID, user),
+    researcherGate: findPropertyValue(UserProperties.RESEARCHER_GATE, user),
+    department: findPropertyValue(UserProperties.DEPARTMENT, user),
+    division: findPropertyValue(UserProperties.DIVISION, user),
+    address1: findPropertyValue(UserProperties.ADDRESS1, user),
+    address2: findPropertyValue(UserProperties.ADDRESS2, user),
+    zipcode: findPropertyValue(UserProperties.ZIPCODE, user),
+    city: findPropertyValue(UserProperties.CITY, user),
+    state: findPropertyValue(UserProperties.STATE, user),
+    country: findPropertyValue(UserProperties.COUNTRY, user),
+    isThePI: findPropertyValue(UserProperties.IS_THE_PI, user),
+    havePI: findPropertyValue(UserProperties.HAVE_PI, user),
+    piName: findPropertyValue(UserProperties.IS_THE_PI, user) === "true" ? user.displayName : findPropertyValue(UserProperties.PI_NAME, user),
+    piEmail: findPropertyValue(UserProperties.IS_THE_PI, user) === "true" ? user.email : findPropertyValue(UserProperties.PI_EMAIL, user),
+    pubmedID: findPropertyValue(UserProperties.PUBMED_ID, user),
+    scientificURL: findPropertyValue(UserProperties.SCIENTIFIC_URL, user)
+  };
+
+  return researcherProps;
+};
+
 export const applyHoverEffects = (e, style) => {
   forEach(style, (value, key) => {
     e.target.style[key] = value;

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -8,6 +8,26 @@ import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes 
 import _ from 'lodash';
 import {User} from "./ajax";
 
+export const UserProperties = {
+  EMAIL: "academicEmail",
+  NIH_USERNAME : "nihUsername",
+  LINKEDIN : "linkedIn",
+  ORCID: "orcid",
+  IS_THE_PI: "isThePI",
+  PI_NAME: "piName",
+  DEPARTMENT: "department",
+  CITY: "city",
+  STATE: "state",
+  COUNTRY: "country"
+};
+
+export const findPropertyValue = (propName, researcher) => {
+  const prop = isNil(researcher.researcherProperties) ?
+    null
+    : find({ propertyKey: propName })(researcher.researcherProperties);
+  return isNil(prop) ? "" : prop.propertyValue;
+};
+
 export const applyHoverEffects = (e, style) => {
   forEach(style, (value, key) => {
     e.target.style[key] = value;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -9,7 +9,7 @@ import { TypeOfResearch } from './dar_application/TypeOfResearch';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Notification } from '../components/Notification';
 import { PageHeading } from '../components/PageHeading';
-import { DAR, Researcher, DataSet } from '../libs/ajax';
+import { DAR, Researcher, DataSet, User, Institution } from '../libs/ajax';
 import { NotificationService } from '../libs/notificationService';
 import { Storage } from '../libs/storage';
 import { Navigation } from "../libs/utils";
@@ -187,6 +187,11 @@ class DataAccessRequestApplication extends Component {
   async init() {
     const { dataRequestId } = this.props.match.params;
     let formData = {};
+    const researcher = await User.getMe();
+    this.setState(prev => {
+      prev.researcher = researcher;
+      return prev;
+    });
     if (!fp.isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
       // Same endpoint works for any dataRequestId, not just partials.
@@ -201,9 +206,9 @@ class DataAccessRequestApplication extends Component {
     let rpProperties = await Researcher.getPropertiesByResearcherId(currentUserId);
     formData.darCode = fp.isNil(formData.darCode) ? null : formData.darCode;
     formData.partialDarCode = fp.isNil(formData.partialDarCode) ? null : formData.partialDarCode;
-    formData.researcher = rpProperties.profileName != null ? rpProperties.profileName : '';
+    formData.researcher = isNil(researcher) ? "" : researcher.displayName;
     if (rpProperties.piName === undefined && rpProperties.isThePI === 'true') {
-      formData.investigator = rpProperties.profileName;
+      formData.investigator = formData.researcher;
     } else if (rpProperties.piName === undefined && rpProperties.isThePI === 'false') {
       formData.investigator = '';
     } else {
@@ -213,7 +218,7 @@ class DataAccessRequestApplication extends Component {
     formData.linkedIn = rpProperties.linkedIn !== undefined ? rpProperties.linkedIn : '';
     formData.researcherGate = rpProperties.researcherGate !== undefined ? rpProperties.researcherGate : '';
     formData.orcid = rpProperties.orcid !== undefined ? rpProperties.orcid : '';
-    formData.institution = rpProperties.institution != null ? rpProperties.institution : '';
+    formData.institution = isNil(researcher)  || isNil(researcher.institutionId)? "" : (await Institution.getById(researcher.institutionId)).name;
     formData.department = rpProperties.department != null ? rpProperties.department : '';
     formData.division = rpProperties.division != null ? rpProperties.division : '';
     formData.address1 = rpProperties.address1 != null ? rpProperties.address1 : '';

--- a/src/pages/DataAccessRequestRenewal.js
+++ b/src/pages/DataAccessRequestRenewal.js
@@ -18,7 +18,7 @@ import { LibraryCardAgreement } from '../components/LibraryCardAgreement';
 import DataProviderAgreement from '../assets/Data_Provider_Agreement.pdf';
 import addAccessIcon from '../images/icon_add_access.png';
 import './DataAccessRequestApplication.css';
-import {isNil} from "lodash";
+import {isNil} from "lodash/fp";
 
 
 const noOptionMessage = 'Start typing a Dataset Name, Sample Collection ID, or PI';

--- a/src/pages/DataAccessRequestRenewal.js
+++ b/src/pages/DataAccessRequestRenewal.js
@@ -9,7 +9,7 @@ import { eRACommons } from '../components/eRACommons';
 import { Notification } from '../components/Notification';
 import { PageHeading } from '../components/PageHeading';
 import { YesNoRadioGroup } from '../components/YesNoRadioGroup';
-import { DAR, Researcher } from '../libs/ajax';
+import { DAR, Researcher, Institution, User } from '../libs/ajax';
 import { NotificationService } from '../libs/notificationService';
 import { Storage } from '../libs/storage';
 import { TypeOfResearch } from './dar_application/TypeOfResearch';
@@ -18,6 +18,7 @@ import { LibraryCardAgreement } from '../components/LibraryCardAgreement';
 import DataProviderAgreement from '../assets/Data_Provider_Agreement.pdf';
 import addAccessIcon from '../images/icon_add_access.png';
 import './DataAccessRequestApplication.css';
+import {isNil} from "lodash";
 
 
 const noOptionMessage = 'Start typing a Dataset Name, Sample Collection ID, or PI';
@@ -137,13 +138,14 @@ class DataAccessRequestRenewal extends Component {
     }
     let currentUserId = Storage.getCurrentUser().dacUserId;
     let rpProperties = await Researcher.getPropertiesByResearcherId(currentUserId);
+    let researcher = isNil(formData.userId) ? null : await User.getById(formData.userId);
     formData.darCode = formData.darCode === undefined ? null : formData.darCode;
     formData.partialDarCode = formData.partialDarCode === undefined ? null : formData.partialDarCode;
-
-    formData.researcher = rpProperties.profileName != null ? rpProperties.profileName : '';
+    //bc the name in user properties is not accurate
+    formData.researcher = isNil(researcher) ? "" : researcher.displayName;
 
     if (rpProperties.piName === undefined && rpProperties.isThePI === 'true') {
-      formData.investigator = rpProperties.profileName;
+      formData.investigator = formData.researcher;
     } else if (rpProperties.piName === undefined && rpProperties.isThePI === 'false') {
       formData.investigator = '--';
     } else {
@@ -154,7 +156,8 @@ class DataAccessRequestRenewal extends Component {
       formData.linkedIn = rpProperties.linkedIn !== undefined ? rpProperties.linkedIn : '';
       formData.researcherGate = rpProperties.researcherGate !== undefined ? rpProperties.researcherGate : '';
       formData.orcid = rpProperties.orcid !== undefined ? rpProperties.orcid : '';
-      formData.institution = rpProperties.institution != null ? rpProperties.institution : '';
+      //bc the institution in user properties is not accurate
+      formData.institution = isNil(researcher)  || isNil(researcher.institutionId)? "" : (await Institution.getById(researcher.institutionId)).name;
       formData.department = rpProperties.department != null ? rpProperties.department : '';
       formData.division = rpProperties.division != null ? rpProperties.division : '';
       formData.address1 = rpProperties.address1 != null ? rpProperties.address1 : '';

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -4,8 +4,7 @@ import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
 import { User, Institution} from "../libs/ajax";
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
-import {findPropertyValue} from "../libs/utils";
-import {UserProperties} from "../libs/utils";
+import {getPropertyValuesFromUser} from "../libs/utils";
 
 class ResearcherReview extends Component {
 
@@ -54,30 +53,7 @@ class ResearcherReview extends Component {
   async findResearcherInfo() {
 
     const user = await User.getById(this.props.match.params.dacUserId);
-    let researcherProps = {
-      academicEmail: user.email,
-      nihUserName: findPropertyValue(UserProperties.NIH_USERNAME, user),
-      linkedIn: findPropertyValue(UserProperties.LINKEDIN, user),
-      orcid: findPropertyValue(UserProperties.ORCID, user),
-      researcherGate: findPropertyValue(UserProperties.RESEARCHER_GATE, user),
-      department: findPropertyValue(UserProperties.DEPARTMENT, user),
-      division: findPropertyValue(UserProperties.DIVISION, user),
-      address1: findPropertyValue(UserProperties.ADDRESS1, user),
-      address2: findPropertyValue(UserProperties.ADDRESS2, user),
-      zipcode: findPropertyValue(UserProperties.ZIPCODE, user),
-      city: findPropertyValue(UserProperties.CITY, user),
-      state: findPropertyValue(UserProperties.STATE, user),
-      country: findPropertyValue(UserProperties.COUNTRY, user),
-      isThePI: findPropertyValue(UserProperties.IS_THE_PI, user),
-      havePI: findPropertyValue(UserProperties.HAVE_PI, user),
-      piName: "",
-      piEmail: "",
-      pubmedID: findPropertyValue(UserProperties.PUBMED_ID, user),
-      scientificURL: findPropertyValue(UserProperties.SCIENTIFIC_URL, user)
-    };
-
-    researcherProps.piName = researcherProps.isThePI === true ? user.displayName : findPropertyValue(UserProperties.PI_NAME, user);
-    researcherProps.piEmail = researcherProps.isThePI === true ? user.email : findPropertyValue(UserProperties.PI_EMAIL, user);
+    let researcherProps = getPropertyValuesFromUser(user);
 
     let institution;
     if (user.institutionId !== undefined) {

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -4,6 +4,8 @@ import { PageHeading } from '../components/PageHeading';
 import { SubmitVoteBox } from '../components/SubmitVoteBox';
 import { User, Institution} from "../libs/ajax";
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
+import {findPropertyValue} from "../libs/utils";
+import {UserProperties} from "../libs/utils";
 
 class ResearcherReview extends Component {
 
@@ -32,12 +34,10 @@ class ResearcherReview extends Component {
         orcid: '',
         researcherGate: '',
         havePI: false,
-        havePIValue: '',
         institution: '',
         isThePI: false,
         piEmail: '',
         piName: '',
-        piValue: '',
         profileName: '',
         pubmedID: '',
         scientificURL: '',
@@ -54,17 +54,30 @@ class ResearcherReview extends Component {
   async findResearcherInfo() {
 
     const user = await User.getById(this.props.match.params.dacUserId);
-    let researcherProps = user.researcherProperties;
+    let researcherProps = {
+      academicEmail: user.email,
+      nihUserName: findPropertyValue(UserProperties.NIH_USERNAME, user),
+      linkedIn: findPropertyValue(UserProperties.LINKEDIN, user),
+      orcid: findPropertyValue(UserProperties.ORCID, user),
+      researcherGate: findPropertyValue(UserProperties.RESEARCHER_GATE, user),
+      department: findPropertyValue(UserProperties.DEPARTMENT, user),
+      division: findPropertyValue(UserProperties.DIVISION, user),
+      address1: findPropertyValue(UserProperties.ADDRESS1, user),
+      address2: findPropertyValue(UserProperties.ADDRESS2, user),
+      zipcode: findPropertyValue(UserProperties.ZIPCODE, user),
+      city: findPropertyValue(UserProperties.CITY, user),
+      state: findPropertyValue(UserProperties.STATE, user),
+      country: findPropertyValue(UserProperties.COUNTRY, user),
+      isThePI: findPropertyValue(UserProperties.IS_THE_PI, user),
+      havePI: findPropertyValue(UserProperties.HAVE_PI, user),
+      piName: "",
+      piEmail: "",
+      pubmedID: findPropertyValue(UserProperties.PUBMED_ID, user),
+      scientificURL: findPropertyValue(UserProperties.SCIENTIFIC_URL, user)
+    };
 
-    if (researcherProps.isThePI !== undefined) {
-      researcherProps.isThePI = JSON.parse(researcherProps.isThePI);
-      researcherProps.piValue = researcherProps.isThePI === true ? researcherProps.piValue = 'Yes' : researcherProps.piValue = 'No';
-    }
-
-    if (researcherProps.havePI !== undefined) {
-      researcherProps.havePI = JSON.parse(researcherProps.havePI);
-      researcherProps.havePIValue = researcherProps.havePI === true ? 'Yes' : researcherProps.havePIValue = 'No';
-    }
+    researcherProps.piName = researcherProps.isThePI === true ? user.displayName : findPropertyValue(UserProperties.PI_NAME, user);
+    researcherProps.piEmail = researcherProps.isThePI === true ? user.email : findPropertyValue(UserProperties.PI_EMAIL, user);
 
     let institution;
     if (user.institutionId !== undefined) {
@@ -236,13 +249,13 @@ class ResearcherReview extends Component {
             div({ className: "row margin-top-20" }, [
               div({ className: "col-xs-12 " + (formData.isThePI === true ? 'col-lg-12 col-md-12 col-sm-12' : 'col-lg-6 col-md-6 col-sm-6') }, [
                 label({ className: "control-label" }, ["Is this researcher the Principal Investigator?"]),
-                div({ id: "lbl_researcherIsPI", className: "control-data" }, [formData.piValue]),
+                div({ id: "lbl_researcherIsPI", className: "control-data" }, [formData.isThePI === true ? "Yes" : "No"]),
               ]),
 
               div({ isRendered: formData.isThePI === false }, [
                 div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12" }, [
                   label({ className: "control-label" }, ["Does the researcher have a Principal Investigator?"]),
-                  div({ id: "lbl_researcherhavePI", className: "control-data", readOnly: true}, [formData.havePIValue]),
+                  div({ id: "lbl_researcherhavePI", className: "control-data", readOnly: true}, [formData.havePI === true ? "Yes" : "No"]),
                 ])
               ])
             ]),
@@ -260,7 +273,8 @@ class ResearcherReview extends Component {
 
               div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
                 label({ className: "control-label" }, ["eRA Commons ID"]),
-                div({ id: "lbl_profileEraCommons", className: "control-data", name: "profileEraCommons", readOnly: true}, [formData.eRACommonsID]),
+                //eraCommonsID is currently being saved as nihUsername, this will change with DUOS-1095
+                div({ id: "lbl_profileEraCommons", className: "control-data", name: "profileEraCommons", readOnly: true}, [formData.nihUsername]),
               ]),
 
               div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { div, hh, span, h } from 'react-hyperscript-helpers';
+import { div, hh, h } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
 import { download } from '../../libs/utils';
 import { ApplicationSection } from './ApplicationSection';
@@ -7,7 +7,9 @@ import { StructuredDarRp } from '../../components/StructuredDarRp';
 import { ApplicantInfo } from './ApplicantInfo';
 import { DownloadLink } from '../../components/DownloadLink';
 import { DataUseTranslation } from '../../libs/dataUseTranslation';
-import isNil from "lodash/fp";
+import {isNil} from "lodash";
+import {find} from "lodash/fp";
+import {Institution} from "../../libs/ajax";
 
 const ROOT = {
   fontFamily: 'Arial',
@@ -36,9 +38,19 @@ export const AppSummary = hh(class AppSummary extends React.Component {
     super();
     this.state = {
       generateRestrictions: this.generateRestrictions.bind(this),
-      translatedRestrictions: []
+      translatedRestrictions: [],
+      institution: ""
     };
   }
+
+  getInstitutionFromProfile = async () => {
+    const institute = await Institution.getById(this.props.researcherProfile.institutionId);
+    this.setState(prev => {
+      prev.institution = institute.name;
+      return prev;
+    });
+  };
+
 
   generateRestrictions = async(dataUse) => {
     const translatedRestrictions = await DataUseTranslation.translateDataUseRestrictions(dataUse);
@@ -50,11 +62,23 @@ export const AppSummary = hh(class AppSummary extends React.Component {
 
   async componentDidMount() {
     await this.generateRestrictions(this.props.consent.dataUse);
+    if (!isNil(this.props.researcherProfile) && !isNil(this.props.researcherProfile.institutionId)) {
+      await this.getInstitutionFromProfile();
+    }
   }
 
   render() {
     const { darInfo, accessElection, consent, researcherProfile } = this.props;
-    const { piName, profileName, institution, department, city, country } = researcherProfile;
+    const isThePiProp = find({propertyKey: 'isThePI'})(researcherProfile.researcherProperties);
+    const piNameProp = find({propertyKey: 'piName'})(researcherProfile.researcherProperties);
+    const piName = isNil(isThePiProp) ? "- -" : isThePiProp.propertyValue ?
+      researcherProfile.displayName : isNil(piNameProp) ? "xx" : piNameProp.propertyValue;
+    const departmentProp = find({propertyKey: 'department'})(researcherProfile.researcherProperties);
+    const department = isNil(departmentProp) ? "" : departmentProp.propertyValue;
+    const cityProp = find({propertyKey: 'city'})(researcherProfile.researcherProperties);
+    const city = isNil(cityProp) ? "" : cityProp.propertyValue;
+    const countryProp = find({propertyKey: 'country'})(researcherProfile.researcherProperties);
+    const country = isNil(countryProp) ? "" : countryProp.propertyValue;
     const mrDAR = !isNil(accessElection) ? JSON.stringify(accessElection.useRestriction, null, 2) : null;
     const mrDUL = JSON.stringify(consent.useRestriction, null, 2);
     const translatedRestrictionsList = this.state.translatedRestrictions.map((restrictionObj, index) => {
@@ -118,9 +142,9 @@ export const AppSummary = hh(class AppSummary extends React.Component {
           [ApplicantInfo({
             researcherProfile: researcherProfile,
             content: {
-              principalInvestigator: researcherProfile.isThePI ? profileName : (piName || '- - -'),
-              researcher: profileName,
-              institution,
+              principalInvestigator: piName,
+              researcher: researcherProfile.displayName,
+              institution: this.state.institution,
               department,
               city,
               country

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -7,9 +7,10 @@ import { StructuredDarRp } from '../../components/StructuredDarRp';
 import { ApplicantInfo } from './ApplicantInfo';
 import { DownloadLink } from '../../components/DownloadLink';
 import { DataUseTranslation } from '../../libs/dataUseTranslation';
-import {isNil} from "lodash";
-import {find} from "lodash/fp";
+import {isNil} from "lodash/fp";
 import {Institution} from "../../libs/ajax";
+import {findPropertyValue} from "../../libs/utils";
+import {UserProperties} from "../../libs/utils";
 
 const ROOT = {
   fontFamily: 'Arial',
@@ -69,16 +70,13 @@ export const AppSummary = hh(class AppSummary extends React.Component {
 
   render() {
     const { darInfo, accessElection, consent, researcherProfile } = this.props;
-    const isThePiProp = find({propertyKey: 'isThePI'})(researcherProfile.researcherProperties);
-    const piNameProp = find({propertyKey: 'piName'})(researcherProfile.researcherProperties);
-    const piName = isNil(isThePiProp) ? "- -" : isThePiProp.propertyValue ?
-      researcherProfile.displayName : isNil(piNameProp) ? "xx" : piNameProp.propertyValue;
-    const departmentProp = find({propertyKey: 'department'})(researcherProfile.researcherProperties);
-    const department = isNil(departmentProp) ? "" : departmentProp.propertyValue;
-    const cityProp = find({propertyKey: 'city'})(researcherProfile.researcherProperties);
-    const city = isNil(cityProp) ? "" : cityProp.propertyValue;
-    const countryProp = find({propertyKey: 'country'})(researcherProfile.researcherProperties);
-    const country = isNil(countryProp) ? "" : countryProp.propertyValue;
+    const isThePi = findPropertyValue(UserProperties.IS_THE_PI, researcherProfile);
+    const piName = isThePi === true ?
+      researcherProfile.displayName
+      : findPropertyValue(UserProperties.PI_NAME, researcherProfile);
+    const department = findPropertyValue(UserProperties.DEPARTMENT, researcherProfile);
+    const city = findPropertyValue(UserProperties.CITY, researcherProfile);
+    const country = findPropertyValue(UserProperties.COUNTRY, researcherProfile);
     const mrDAR = !isNil(accessElection) ? JSON.stringify(accessElection.useRestriction, null, 2) : null;
     const mrDUL = JSON.stringify(consent.useRestriction, null, 2);
     const translatedRestrictionsList = this.state.translatedRestrictions.map((restrictionObj, index) => {


### PR DESCRIPTION
## SCOPE:
Replace all outdated references to profileName and Institution and replace with displayName and institutionId fields on the user
- update researcher query for reviewresults and accessreview, getResearcherProfile API does not have all the information we need, so instead use getUserById
- - update all appsummary user prop references bc new API call used
- - update all appdownloadlink user prop references bc new API call used
- update ResearcherReview.js references to user prop fields
- update DataAccessRequestRenewal.js references to user prop fields
- update DataAccessRequestApplication.js references to user prop fields
- update DarModal.js references to user prop field institution
- update institution reference in ajax method describedar that is used for memberconsole modals

## ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1287

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
