### PR TITLE
DUOS-1326[risk=no]Update Manage Institution page "next" button styling

### DIFF
--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -7,8 +7,8 @@ import PaginationBar from '../PaginationBar';
 import AddInstitutionModal from '../modals/AddInstitutionModal';
 
 export const tableHeaderTemplate = [
-  div({style: Styles.TABLE.DATA_ID_CELL}, ["ID"]),
-  div({style: Styles.TABLE.TITLE_CELL}, ["Institution"]),
+  div({style: Styles.TABLE.ID_CELL}, ["ID"]),
+  div({style: Styles.TABLE.INSTITUTION_CELL}, ["Institution"]),
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Create User"]),
   div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Create Date"]),
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Update User"]),
@@ -18,8 +18,8 @@ export const tableHeaderTemplate = [
 const loadingMarginOverwrite = {margin: '1rem 2%'};
 
 export const tableRowLoadingTemplate = [
-  div({style: assign(Styles.TABLE.DATA_ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
-  div({style: assign(Styles.TABLE.TITLE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
+  div({style: assign(Styles.TABLE.ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
+  div({style: assign(Styles.TABLE.INSTITUTION_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.DATA_ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.SUBMISSION_DATE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.DATA_ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
@@ -75,13 +75,16 @@ export default function InstitutionTable(props) {
           const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};
           return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${inst.id}-${index}`}, [
             div({
-              style: Object.assign({}, Styles.TABLE.DATA_ID_CELL),
+              style: Object.assign({}, Styles.TABLE.ID_CELL),
             }, [inst.id]),
             div({
-              style: Object.assign({}, Styles.TABLE.TITLE_CELL)
+              style: Object.assign({}, Styles.TABLE.INSTITUTION_CELL)
             }, [
-              a({
-                onClick: () => { openUpdateModal(inst.id); }
+              a({ style: {
+                overflow: "hidden",
+                whiteSpace: "nowrap",
+                textOverflow: "ellipsis"},
+              onClick: () => { openUpdateModal(inst.id); }
               }, [inst.name])
             ]),
             div({

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -266,6 +266,21 @@ export const Styles = {
       justifyContent: "left",
       alignItems: "center",
     },
+    ID_CELL: {
+      width: "5%",
+      margin: "0 1%",
+      display: "flex",
+      justifyContent: "left",
+      alignItems: "center",
+    },
+    INSTITUTION_CELL: {
+      maxWidth: "35%",
+      minWidth: "35%",
+      margin: "0 1%",
+      display: "flex",
+      justifyContent: "left",
+      alignItems: "center",
+    },
     FOOTER: {
       backgroundColor: "#f3f6f7",
       fontSize: '14px',


### PR DESCRIPTION
SCOPE:
- Make the institution name column much wider so the likelihood of text overflow decreases
- Hide text overflow and show ellipsis instead of letting text go to second line

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1326
----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
