### PR TITLE
DUOS-1314[risk=no]UI: Replace ajax methods that use deprecated APIs

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -275,6 +275,7 @@ export const DAR = {
     return await res;
   },
 
+  //v2 get draft dars
   getDraftDarRequestList: async () => {
     const url = `${await Config.getApiUrl()}/api/dar/v2/draft/manage`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -907,6 +907,12 @@ export const User = {
     const url = `${await Config.getApiUrl()}/api/user`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'POST' }]));
     return res.json();
+  },
+
+  registerStatus: async (userRoleStatus, userId) => {
+    const url = `${await Config.getApiUrl()}/api/dacuser/status/${userId}`;
+    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(userRoleStatus), { method: 'PUT' }]));
+    return res.json();
   }
 
 };

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -175,13 +175,6 @@ export const DAC = {
 
 export const DAR = {
 
-  describeDarWithConsent: async (darId) => {
-    const darInfo = await DAR.describeDar(darId);
-    const consent = await DAR.getDarConsent(darId);
-    darInfo.translatedDataUse = await DAR.translateDataUse(consent.dataUse);
-    return { darInfo, consent };
-  },
-
   //v2 get for DARs
   describeDar: async (darId) => {
     const apiUrl = await Config.getApiUrl();
@@ -254,12 +247,6 @@ export const DAR = {
     return darInfo;
   },
 
-  translateDataUse: async dataUse => {
-    const url = `${await Config.getOntologyApiUrl()}translate/summary`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataUse), { method: 'POST' }]));
-    return await res.json();
-  },
-
   //v2 get for DARs
   getPartialDarRequest: async darId => {
     const url = `${await Config.getApiUrl()}/api/dar/v2/${darId}`;
@@ -288,23 +275,14 @@ export const DAR = {
     return await res;
   },
 
-  getPartialDarRequestList: async () => {
-    const url = `${await Config.getApiUrl()}/api/dar/partials/manage`;
+  getDraftDarRequestList: async () => {
+    const url = `${await Config.getApiUrl()}/api/dar/v2/draft/manage`;
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },
 
   getDarConsent: async id => {
     const url = `${await Config.getApiUrl()}/api/dar/find/${id}/consent`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
-  },
-
-  getDarFields: async (id, fields) => {
-    let url = `${await Config.getApiUrl()}/api/dar/find/${id}`;
-    if (fields !== null) {
-      url = url + `?fields=${fields}`;
-    }
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },
@@ -346,7 +324,7 @@ export const DAR = {
     return res.data;
   },
 
-  //endpoint to be deprecated
+  //endpoint to be deprecated once V2 endpoint is updated to account for reasearchers
   getDataAccessManage: async() => {
     const url = `${await Config.getApiUrl()}/api/dar/manage`;
     const res = await fetchOk(url, Config.authOpts());
@@ -517,11 +495,6 @@ export const Election = {
     return res.json();
   },
 
-  findElectionById: async (electionId) => {
-    const url = `${await Config.getApiUrl()}/api/election/${electionId}`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
-  },
   findElectionByVoteId: async (voteId) => {
     const url = `${await Config.getApiUrl()}/api/election/vote/${voteId}`;
     const res = await fetchOk(url, Config.authOpts());
@@ -615,18 +588,6 @@ export const Election = {
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },
-
-  findElectionReviewById: async (electionId, referenceId) => {
-    if (electionId !== undefined) {
-      const url = `${await Config.getApiUrl()}/api/electionReview/${electionId}`;
-      const res = await fetchOk(url, Config.authOpts());
-      return await res.json();
-    } else {
-      const url = `${await Config.getApiUrl()}/api/electionReview/last/${referenceId}`;
-      const res = await fetchOk(url, Config.authOpts());
-      return await res.json();
-    }
-  }
 
 };
 
@@ -945,12 +906,6 @@ export const User = {
     const url = `${await Config.getApiUrl()}/api/user`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'POST' }]));
     return res.json();
-  },
-
-  registerStatus: async (userRoleStatus, userId) => {
-    const url = `${await Config.getApiUrl()}/api/dacuser/status/${userId}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(userRoleStatus), { method: 'PUT' }]));
-    return res.json();
   }
 
 };
@@ -985,12 +940,6 @@ export const Votes = {
 
   getDarVote: async (requestId, voteId) => {
     const url = `${await Config.getApiUrl()}/api/dataRequest/${requestId}/vote/${voteId}`;
-    const res = await fetchOk(url, Config.authOpts());
-    return res.json();
-  },
-
-  getDarFinalAccessVote: async (requestId) => {
-    const url = `${await Config.getApiUrl()}/api/dataRequest/${requestId}/vote/final`;
     const res = await fetchOk(url, Config.authOpts());
     return res.json();
   },

--- a/src/pages/DataOwnerReview.js
+++ b/src/pages/DataOwnerReview.js
@@ -74,9 +74,8 @@ class DataOwnerReview extends Component {
 
   async getDarInfo() {
     const dar = await DAR.describeDar(this.props.match.params.referenceId);
-    const darRus = dar.rus;
     this.setState(prev => {
-      prev.darFields.rus = darRus.rus;
+      prev.darFields.rus = dar.rus;
       prev.pendingCase.voteId = this.props.match.params.voteId;
       prev.pendingCase.referenceId = this.props.match.params.referenceId;
       prev.pendingCase.dataSetId = this.props.match.params.dataSetId;

--- a/src/pages/DataOwnerReview.js
+++ b/src/pages/DataOwnerReview.js
@@ -73,7 +73,8 @@ class DataOwnerReview extends Component {
   }
 
   async getDarInfo() {
-    const darRus = await DAR.getDarFields(this.props.match.params.referenceId, 'rus');
+    const dar = await DAR.describeDar(this.props.match.params.referenceId);
+    const darRus = dar.rus;
     this.setState(prev => {
       prev.darFields.rus = darRus.rus;
       prev.pendingCase.voteId = this.props.match.params.voteId;

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -135,7 +135,7 @@ class ResearcherConsole extends Component {
       }
     );
 
-    DAR.getPartialDarRequestList().then(
+    DAR.getDraftDarRequestList().then(
       pdars => {
         this.setState({
           partialDars: pdars,
@@ -297,28 +297,29 @@ class ResearcherConsole extends Component {
                 hr({ className: "table-head-separator" }),
 
                 this.state.partialDars.slice((currentPartialDarPage - 1) * partialDarLimit, currentPartialDarPage * partialDarLimit).map((pdar, idx) => {
-                  return h(Fragment, { key: pdar.partialDarCode + '_' + idx }, [
-                    div({ key: pdar.partialDarCode, id: pdar.partialDarCode, className: "row no-margin tableRowPartial" }, [
+                  return h(Fragment, { key: pdar.dar.data.partialDarCode + '_' + idx }, [
+                    div({ key: pdar.dar.data.partialDarCode, id: pdar.dar.data.partialDarCode, className: "row no-margin tableRowPartial" }, [
                       a({
-                        id: pdar.partialDarCode + "_btnDelete",
+                        id: pdar.dar.data.partialDarCode + "_btnDelete",
                         name: "btn_delete",
                         className: "col-xs-1 cell-body delete-dar default-color",
-                        onClick: this.deletePartialDar, value: pdar.dataRequestId
+                        onClick: this.deletePartialDar,
+                        value: pdar.dar.referenceId
                       }, [
-                        span({ className: "cm-icon-button glyphicon glyphicon-trash caret-margin", "aria-hidden": "true", value: pdar.dataRequestId }),
+                        span({ className: "cm-icon-button glyphicon glyphicon-trash caret-margin", "aria-hidden": "true", value: pdar.dar.referenceId }),
                       ]),
 
-                      div({ style: Theme.textTableBody, id: pdar.partialDarCode + "_partialId", name: "partialId", className: "col-xs-2" }, [pdar.partialDarCode]),
-                      div({ style: Theme.textTableBody, id: pdar.partialDarCode + "_partialTitle", name: "partialTitle", className: "col-xs-5" }, [pdar.projectTitle]),
-                      div({ style: Theme.textTableBody, id: pdar.partialDarCode + "_partialDate", name: "partialDate", className: "col-xs-2" }, [Utils.formatDate(pdar.createDate)]),
+                      div({ style: Theme.textTableBody, id: pdar.dar.data.partialDarCode + "_partialId", name: "partialId", className: "col-xs-2" }, [pdar.dar.data.partialDarCode]),
+                      div({ style: Theme.textTableBody, id: pdar.dar.data.partialDarCode + "_partialTitle", name: "partialTitle", className: "col-xs-5" }, [pdar.dar.data.projectTitle]),
+                      div({ style: Theme.textTableBody, id: pdar.dar.data.partialDarCode + "_partialDate", name: "partialDate", className: "col-xs-2" }, [Utils.formatDate(pdar.dar.createDate)]),
                       div({className: "col-xs-2 cell-body f-center" }, [
                         button({
-                          id: pdar.partialDarCode + '_btnResume',
+                          id: pdar.dar.data.partialDarCode + '_btnResume',
                           name: 'btn_resume',
                           className: 'cell-button hover-color',
                         }, [
                           h(Link, {
-                            to: 'dar_application/' + pdar.dataRequestId,
+                            to: 'dar_application/' + pdar.dar.data.referenceId,
                           }, ['Resume'])],
                         ),
                       ]),

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -85,8 +85,11 @@ class ResearcherReview extends Component {
     } else if (voteStatus === "false") {
       status = "rejected";
     }
-    let userStatus = { status: status, rationale: rationale, roleId: 5 };
-    User.registerStatus(userStatus, this.props.match.params.dacUserId).then(
+    let updatedUser = this.state.user;
+    updatedUser.status = status;
+    updatedUser.rationale = rationale;
+    const payload = { updatedUser: updatedUser };
+    User.update(payload, this.props.match.params.dacUserId).then(
       () => {
         this.setState({ showConfirmationDialogOK: true });
       }
@@ -103,7 +106,6 @@ class ResearcherReview extends Component {
   render() {
 
     const { formData, rationale, voteStatus, user, institution } = this.state;
-
     return (
       div({ className: "container " }, [
         div({ className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12" }, [

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -103,6 +103,7 @@ class ResearcherReview extends Component {
   render() {
 
     const { formData, rationale, voteStatus, user, institution } = this.state;
+
     return (
       div({ className: "container " }, [
         div({ className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12" }, [

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -85,11 +85,8 @@ class ResearcherReview extends Component {
     } else if (voteStatus === "false") {
       status = "rejected";
     }
-    let updatedUser = this.state.user;
-    updatedUser.status = status;
-    updatedUser.rationale = rationale;
-    const payload = { updatedUser: updatedUser };
-    User.update(payload, this.props.match.params.dacUserId).then(
+    let userStatus = { status: status, rationale: rationale, roleId: 5 };
+    User.registerStatus(userStatus, this.props.match.params.dacUserId).then(
       () => {
         this.setState({ showConfirmationDialogOK: true });
       }


### PR DESCRIPTION
SCOPE:
- Remove unused methods from ajax
- Remove and replace usages of ajax methods that call deprecated APIs 
- - replace  getPartialDarRequestList with getDraftDarRequestList on researcher console
- -  replace getDarFields with describeDar on DataOwnerReview
- - replace registerStatus with Update on researcher review

UPDATE: Justin's comments are addressed in DUOS-1329. That PR must be merged first in order for the functionality on the researcherReview page to remain intact.

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1314

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
