### PR TITLE
DUOS-1324[risk=no] Remove investigator name from dataset metrics API and display

### DIFF
--- a/src/pages/DatasetStatistics.js
+++ b/src/pages/DatasetStatistics.js
@@ -134,10 +134,6 @@ export default function DatasetStatistics(props) {
                 moreContent: [
                   div({style: {display: 'flex', backgroundColor: "white"}}, [
                     div({style: {display: 'flex', paddingRight: '2rem'}}, [
-                      div({style: Styles.SMALL_BOLD}, ["Principal Investigator: "]),
-                      div({style: Styles.SMALL_BOLD}, [dar.investigator]),
-                    ]),
-                    div({style: {display: 'flex', paddingRight: '2rem'}}, [
                       div({style: Styles.SMALL_BOLD}, ["Last Updated: "]),
                       div({style: Styles.SMALL_BOLD}, [formatDate(dar.updateDate)]),
                     ]),


### PR DESCRIPTION
SCOPE:
- remove PI name from dataset statistics page

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1324

 ----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
