### PR TITLE
DUOS-1093[risk=no]Update DAR to use Researcher's SO

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -954,7 +954,7 @@ export const User = {
   },
 
   getSOsForCurrentUser: async () => {
-    const url = `${await Config.getApiUrl()}/api/user/SigningOfficials`;
+    const url = `${await Config.getApiUrl()}/api/user/signing-officials`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'GET' }]));
     return res.json();
   }

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -951,6 +951,12 @@ export const User = {
     const url = `${await Config.getApiUrl()}/api/dacuser/status/${userId}`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(userRoleStatus), { method: 'PUT' }]));
     return res.json();
+  },
+
+  getSOsForCurrentUser: async () => {
+    const url = `${await Config.getApiUrl()}/api/user/SigningOfficials`;
+    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'GET' }]));
+    return res.json();
   }
 
 };

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -34,7 +34,6 @@ class DataAccessRequestApplication extends Component {
       showDialogSubmit: false,
       showDialogSave: false,
       step: 1,
-      allSigningOfficials: [],
       formData: {
         datasets: [],
         darCode: null,

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -188,7 +188,7 @@ class DataAccessRequestApplication extends Component {
   async getSOs()  {
     const allSOs = await User.getSOsForCurrentUser();
     const allSOsOptions = map((user) =>  {
-      return {value: user.displayName, label: user.displayName};
+      return {value: user.userId, label: user.displayName};
     })(allSOs);
     return allSOsOptions;
   }

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -18,6 +18,7 @@ import { isEmpty, isNil, assign } from 'lodash';
 import { isFileEmpty } from '../libs/utils';
 import './DataAccessRequestApplication.css';
 import headingIcon from '../images/icon_add_access.png';
+import {map} from "lodash/fp";
 
 class DataAccessRequestApplication extends Component {
   constructor(props) {
@@ -33,6 +34,7 @@ class DataAccessRequestApplication extends Component {
       showDialogSubmit: false,
       showDialogSave: false,
       step: 1,
+      allSigningOfficials: [],
       formData: {
         datasets: [],
         darCode: null,
@@ -184,12 +186,22 @@ class DataAccessRequestApplication extends Component {
     return datasets;
   }
 
+  async getSOs()  {
+    const allSOs = await User.getSOsForCurrentUser();
+    const allSOsOptions = map((user) =>  {
+      return {value: user.displayName, label: user.displayName};
+    })(allSOs);
+    return allSOsOptions;
+  }
+
   async init() {
     const { dataRequestId } = this.props.match.params;
     let formData = {};
     const researcher = await User.getMe();
+    const signingOfficials = await this.getSOs();
     this.setState(prev => {
       prev.researcher = researcher;
+      prev.allSigningOfficials = signingOfficials;
       return prev;
     });
     if (!fp.isNil(dataRequestId)) {
@@ -1040,6 +1052,7 @@ class DataAccessRequestApplication extends Component {
                 researcherGate: researcherGate,
                 showValidationMessages: showValidationMessages,
                 nextPage: this.nextPage,
+                allSigningOfficials: this.state.allSigningOfficials,
                 signingOfficial,
                 itDirector,
                 anvilUse,

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -4,7 +4,7 @@ import { Alert } from '../../components/Alert';
 import { Link } from 'react-router-dom';
 import { a, div, fieldset, h, h3, input, label, span, textarea} from 'react-hyperscript-helpers';
 import { eRACommons } from '../../components/eRACommons';
-import {isNil} from 'lodash/fp';
+import {isNil, find} from 'lodash/fp';
 import CollaboratorList from './CollaboratorList';
 import { isEmpty } from 'lodash';
 import Creatable from 'react-select/creatable';
@@ -56,7 +56,6 @@ export default function ResearcherInfo(props) {
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
   const [signingOfficial, setSigningOfficial] = useState();
-  const [soUserId, setSoUserId] = useState();
   const [itDirector, setITDirector] = useState(props.itDirector || '');
   const [anvilUse, setAnvilUse] = useState(props.anvilUse || '');
   const [cloudUse, setCloudUse] = useState(props.cloudUse || '');
@@ -78,8 +77,15 @@ export default function ResearcherInfo(props) {
     allSigningOfficials.push(newOption);
     setAllSigningOfficials(allSigningOfficials);
     setSigningOfficial(e);
-    setSoUserId(null);
     formFieldChange({ name: "signingOfficial", value: e });
+  };
+
+  const getSOValue = () => {
+    if (isNil(signingOfficial)) {
+      return null;
+    } else {
+      return find((option) => option.value === signingOfficial)(allSigningOfficials);
+    }
   };
 
   const cloudRadioGroup = div({
@@ -317,17 +323,14 @@ export default function ResearcherInfo(props) {
                 required={true}
                 disabled={!isNil(darCode)}
                 placeholder="Select from the list or type your SO's full name if it is not present"
-                onChange={(e) =>  {
-                  //if this was a user created option there is no ID to save
-                  formFieldChange({name: 'signingOfficial', value: e.label});
-                  (e.value === e.label) ? setSoUserId(null) : setSoUserId(e.value);
+                onChange={(e) => {
+                  formFieldChange({name: 'signingOfficial', value: e.value});
+                  setSigningOfficial(e.value);
                 }}
                 onCreateOption={(e) => updateSOList(e)}
                 options={allSigningOfficials}
                 styles={soDropDownStyle}
-                value={isNil(signingOfficial) || isEmpty(signingOfficial) ?
-                  //if this was a user created option there is no ID so use the name for both value and label
-                  null : {value: isNil(soUserId) ? signingOfficial : soUserId, label: signingOfficial}}
+                value={getSOValue()}
               />,
               span({
                 isRendered: showValidationMessages && isEmpty(signingOfficial),

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -4,10 +4,9 @@ import { Alert } from '../../components/Alert';
 import { Link } from 'react-router-dom';
 import { a, div, fieldset, h, h3, input, label, span, textarea} from 'react-hyperscript-helpers';
 import { eRACommons } from '../../components/eRACommons';
-import {isNil, map} from 'lodash/fp';
+import {isNil} from 'lodash/fp';
 import CollaboratorList from './CollaboratorList';
 import { isEmpty } from 'lodash';
-import {User} from "../../libs/ajax";
 import Creatable from 'react-select/creatable';
 
 const profileLink = h(Link, {to:'/profile', className:'hover-color'}, ['Your Profile']);
@@ -57,6 +56,7 @@ export default function ResearcherInfo(props) {
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
   const [signingOfficial, setSigningOfficial] = useState();
+  const [soUserId, setSoUserId] = useState();
   const [itDirector, setITDirector] = useState(props.itDirector || '');
   const [anvilUse, setAnvilUse] = useState(props.anvilUse || '');
   const [cloudUse, setCloudUse] = useState(props.cloudUse || '');
@@ -78,6 +78,7 @@ export default function ResearcherInfo(props) {
     allSigningOfficials.push(newOption);
     setAllSigningOfficials(allSigningOfficials);
     setSigningOfficial(e);
+    setSoUserId(null);
     formFieldChange({ name: "signingOfficial", value: e });
   };
 
@@ -316,11 +317,15 @@ export default function ResearcherInfo(props) {
                 required={true}
                 disabled={!isNil(darCode)}
                 placeholder="Select from the list or type your SO's full name if it is not present"
-                onChange={(e) => formFieldChange({name: 'signingOfficial', value: e.label})}
+                onChange={(e) =>  {
+                  formFieldChange({name: 'signingOfficial', value: e.label});
+                  (e.value === e.label) ? setSoUserId(null) : setSoUserId(e.value);
+                }}
                 onCreateOption={(e) => updateSOList(e)}
                 options={allSigningOfficials}
                 styles={soDropDownStyle}
-                value={isNil(signingOfficial) || isEmpty(signingOfficial) ? null : {value: signingOfficial, label: signingOfficial}}
+                value={isNil(signingOfficial) || isEmpty(signingOfficial) ?
+                  null : {value: isNil(soUserId) ? signingOfficial : soUserId, label: signingOfficial}}
               />,
               span({
                 isRendered: showValidationMessages && isEmpty(signingOfficial),

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -318,6 +318,7 @@ export default function ResearcherInfo(props) {
                 disabled={!isNil(darCode)}
                 placeholder="Select from the list or type your SO's full name if it is not present"
                 onChange={(e) =>  {
+                  //if this was a user created option there is no ID to save
                   formFieldChange({name: 'signingOfficial', value: e.label});
                   (e.value === e.label) ? setSoUserId(null) : setSoUserId(e.value);
                 }}
@@ -325,6 +326,7 @@ export default function ResearcherInfo(props) {
                 options={allSigningOfficials}
                 styles={soDropDownStyle}
                 value={isNil(signingOfficial) || isEmpty(signingOfficial) ?
+                  //if this was a user created option there is no ID so use the name for both value and label
                   null : {value: isNil(soUserId) ? signingOfficial : soUserId, label: signingOfficial}}
               />,
               span({

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -48,6 +48,12 @@ export default function ResearcherInfo(props) {
     marginTop: '5rem'
   };
 
+  const soDropDownStyle = {
+    control: styles => ({ ...styles,
+      backgroundColor: !isNil(darCode) ? '#efefef' : 'white',
+      borderColor: showValidationMessages && isEmpty(signingOfficial) ? '#D13B07' : '#999999' }),
+  };
+
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
   const [signingOfficial, setSigningOfficial] = useState();
@@ -318,10 +324,13 @@ export default function ResearcherInfo(props) {
             div({className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group'}, [
               <Creatable
                 key={"selectSO"}
+                required={true}
+                disabled={!isNil(darCode)}
                 placeholder="Select from the list or type your SO's full name if it is not present"
                 onChange={(e) => formFieldChange({name: 'signingOfficial', value: e.value})}
                 onCreateOption={(e) => updateSOList(e)}
                 options={allSigningOfficials}
+                styles={soDropDownStyle}
                 value={isNil(signingOfficial) || isEmpty(signingOfficial) ? null : {value: signingOfficial, label: signingOfficial}}
               />,
               span({

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -61,7 +61,7 @@ export default function ResearcherInfo(props) {
   const [anvilUse, setAnvilUse] = useState(props.anvilUse || '');
   const [cloudUse, setCloudUse] = useState(props.cloudUse || '');
   const [localUse, setLocalUse] = useState(props.localUse || '');
-  const [allSigningOfficials, setAllSigningOfficials] = useState(props.allSigningOfficials || []);
+  const [allSigningOfficials, setAllSigningOfficials] = useState(props.allSigningOfficials);
 
   useEffect(() => {
     setSigningOfficial(props.signingOfficial);
@@ -70,14 +70,15 @@ export default function ResearcherInfo(props) {
     setAnvilUse(props.anvilUse);
     setCloudUse(props.cloudUse);
     setLocalUse(props.localUse);
-  }, [props.signingOfficial, props.checkCollaborator, props.itDirector, props.anvilUse, props.cloudUse, props.localUse]);
+    setAllSigningOfficials(props.allSigningOfficials);
+  }, [props.signingOfficial, props.allSigningOfficials, props.checkCollaborator, props.itDirector, props.anvilUse, props.cloudUse, props.localUse]);
 
   const updateSOList = (e) => {
     const newOption = {value: e, label: e};
     allSigningOfficials.push(newOption);
     setAllSigningOfficials(allSigningOfficials);
     setSigningOfficial(e);
-    formFieldChange("signingOfficial", e);
+    formFieldChange({ name: "signingOfficial", value: e });
   };
 
   const cloudRadioGroup = div({

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -50,7 +50,7 @@ export default function ResearcherInfo(props) {
 
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
-  const [signingOfficial, setSigningOfficial] = useState(props.signingOfficial || null);
+  const [signingOfficial, setSigningOfficial] = useState();
   const [itDirector, setITDirector] = useState(props.itDirector || '');
   const [anvilUse, setAnvilUse] = useState(props.anvilUse || '');
   const [cloudUse, setCloudUse] = useState(props.cloudUse || '');

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -316,7 +316,7 @@ export default function ResearcherInfo(props) {
                 required={true}
                 disabled={!isNil(darCode)}
                 placeholder="Select from the list or type your SO's full name if it is not present"
-                onChange={(e) => formFieldChange({name: 'signingOfficial', value: e.value})}
+                onChange={(e) => formFieldChange({name: 'signingOfficial', value: e.label})}
                 onCreateOption={(e) => updateSOList(e)}
                 options={allSigningOfficials}
                 styles={soDropDownStyle}

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -61,27 +61,15 @@ export default function ResearcherInfo(props) {
   const [anvilUse, setAnvilUse] = useState(props.anvilUse || '');
   const [cloudUse, setCloudUse] = useState(props.cloudUse || '');
   const [localUse, setLocalUse] = useState(props.localUse || '');
-  const [allSigningOfficials, setAllSigningOfficials] = useState([]);
-  const [calledOnce, setCalledOnce] = useState(false);
+  const [allSigningOfficials, setAllSigningOfficials] = useState(props.allSigningOfficials || []);
 
   useEffect(() => {
-    const getSOs = async ()  => {
-      const allSOs = await User.getSOsForCurrentUser();
-      const allSOsOptions = map((user) =>  {
-        return {value: user.displayName, label: user.displayName};
-      })(allSOs);
-      setAllSigningOfficials(allSOsOptions);
-    };
-    if (!calledOnce) {
-      getSOs();
-    }
     setSigningOfficial(props.signingOfficial);
     setCheckCollaborator(props.checkCollaborator);
     setITDirector(props.itDirector);
     setAnvilUse(props.anvilUse);
     setCloudUse(props.cloudUse);
     setLocalUse(props.localUse);
-    setCalledOnce(true);
   }, [props.signingOfficial, props.checkCollaborator, props.itDirector, props.anvilUse, props.cloudUse, props.localUse]);
 
   const updateSOList = (e) => {


### PR DESCRIPTION
SCOPE:
This PR adds a 'creatable' drop down menu that users can select their SO from and add their SO to if their SO is not on the list. This PR uses the API created in DUOS-1093 in consent and therefore must be merged after that PR. Since  DUOS-1093 in consent is not merged yet, this PR currently requires that local consent is running on branch DUOS-1093 in order to be tested.

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1093

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
