### PR TITLE
DUOS-1328[risk=no]Use new getUsers by RoleName API for Admins on UI

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -911,8 +911,8 @@ export const User = {
     return res.data;
   },
 
-  list: async () => {
-    const url = `${await Config.getApiUrl()}/api/dacuser`;
+  list: async roleName => {
+    const url = `${await Config.getApiUrl()}/api/user/role/${roleName}`;
     const res = await fetchOk(url, Config.authOpts());
     return res.json();
   },

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -8,6 +8,7 @@ import { PaginatorBar } from '../components/PaginatorBar';
 import { SearchBox } from '../components/SearchBox';
 import { User } from '../libs/ajax';
 import manageUsersIcon from "../images/icon_manage_users.png";
+import {USER_ROLES} from "../libs/utils";
 
 class AdminManageUsers extends Component {
 
@@ -29,7 +30,7 @@ class AdminManageUsers extends Component {
   }
 
   async getUsers() {
-    const users = await User.list("Admin");
+    const users = await User.list(USER_ROLES.admin);
     let userList = users.map(user => {
       user.researcher = false;
       user.roles.forEach(role => {

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -29,7 +29,7 @@ class AdminManageUsers extends Component {
   }
 
   async getUsers() {
-    const users = await User.list();
+    const users = await User.list("Admin");
     let userList = users.map(user => {
       user.researcher = false;
       user.roles.forEach(role => {


### PR DESCRIPTION
SCOPE: 
- update user.list ajax method to point towards new UserResource API created in DUOS-1260 so that must be merged first
- this method is only used on the AdminManageUsers page currently, so add the "Admin" role param there

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1328

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
