### PR TITLE
[DUOS-1332][risk=no] Update LC display

### DIFF
--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -40,14 +40,14 @@ export const AppSummary = hh(class AppSummary extends React.Component {
     this.state = {
       generateRestrictions: this.generateRestrictions.bind(this),
       translatedRestrictions: [],
-      institution: ""
+      institution: {},
     };
   }
 
   getInstitutionFromProfile = async () => {
-    const institute = await Institution.getById(this.props.researcherProfile.institutionId);
+    const institution = await Institution.getById(this.props.researcherProfile.institutionId);
     this.setState(prev => {
-      prev.institution = institute.name;
+      prev.institution = institution;
       return prev;
     });
   };
@@ -139,10 +139,10 @@ export const AppSummary = hh(class AppSummary extends React.Component {
           },
           [ApplicantInfo({
             researcherProfile: researcherProfile,
+            institution: this.state.institution,
             content: {
               principalInvestigator: piName,
               researcher: researcherProfile.displayName,
-              institution: this.state.institution,
               department,
               city,
               country

--- a/src/pages/access_review/ApplicantInfo.js
+++ b/src/pages/access_review/ApplicantInfo.js
@@ -52,7 +52,8 @@ export const ApplicantInfo = hh(
                 borderRadius: 3,
                 textAlign: 'center',
                 paddingLeft: 3,
-                paddingRight: 3
+                paddingRight: 3,
+                maxWidth: 150
               },
             },
             [institution.name]),

--- a/src/pages/access_review/ApplicantInfo.js
+++ b/src/pages/access_review/ApplicantInfo.js
@@ -32,9 +32,12 @@ export const ApplicantInfo = hh(
         ]);
       });
     };
-    formatLibraryCard = cards => {
+    formatLibraryCard = (cards, institution) => {
       return ld.map(cards, (card) => {
-        return div({ style: { margin: 3 } }, [
+        if (card.institutionId !== institution.id) {
+          return div({});
+        }
+        return div({ style: { margin: 3, textAlign: 'center' } }, [
           img({
             id: 'card_' + card,
             src: cardImg,
@@ -48,15 +51,17 @@ export const ApplicantInfo = hh(
                 backgroundColor: '#00928A',
                 borderRadius: 3,
                 textAlign: 'center',
+                paddingLeft: 3,
+                paddingRight: 3
               },
             },
-            [card]),
+            [institution.name]),
         ]);
       });
     };
 
     render() {
-      const { content, researcherProfile } = this.props;
+      const { content, researcherProfile, institution } = this.props;
       const libraryCards = ld.get(researcherProfile, 'libraryCards', []);
       return div(
         { style: { fontFamily: 'Arial', color: Theme.palette.primary } }, [
@@ -67,7 +72,7 @@ export const ApplicantInfo = hh(
             [
               div({ style: {...HEADER, margin: '20px 0'} }, 'Library Cards'),
               div({ style: { display: 'flex', flexFlow: 'row wrap' } },
-                this.formatLibraryCard(libraryCards)),
+                this.formatLibraryCard(libraryCards, institution)),
             ]),
         ]);
     }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1332

Note to reviewer, suggest hiding whitespace changes.

## Changes
* With the update to the library card model, the display for users that had LCs threw an error. This PR fixes that error.
* Minor update to `ReviewResults` `useEffect` to remove a console warning about unused dependencies.

As a complication of this, we now have slightly different functionality. We only display the LC for the institution the user is a member of. If there are multiple LCs with different institutions for a single user, we will ignore them. Logically, this makes sense since we now associate users to a signing official based on their institution, and LCs are issued by signing officials, so in practice, a user will not have more than one. If they do, they are not relevant as they are associated to an institution the user is not a member of.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
