### PR TITLE
DUOS-1330[risk=no]Researcher Review: institution.name can throw an error when none exist

### DIFF
--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -5,6 +5,7 @@ import { SubmitVoteBox } from '../components/SubmitVoteBox';
 import { User, Institution} from "../libs/ajax";
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import {getPropertyValuesFromUser} from "../libs/utils";
+import {isNil} from "lodash/fp";
 
 class ResearcherReview extends Component {
 
@@ -174,7 +175,7 @@ class ResearcherReview extends Component {
             div({ className: "row margin-top-20" }, [
               div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
                 label({ className: "control-label" }, ["Institution Name"]),
-                div({ id: "lbl_profileInstitution", className: "control-data", name: "profileInstitution", readOnly: true}, [institution.name]),
+                div({ id: "lbl_profileInstitution", className: "control-data", name: "profileInstitution", readOnly: true}, [isNil(institution) ? '' : institution.name]),
               ])
             ]),
 


### PR DESCRIPTION
SCOPE:
- add null check before getting institution name

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1330

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
