### PR TITLE
DUOS-1333[risk=no]LC display in eRACommons component is broken

### DIFF
--- a/src/components/LibraryCards.js
+++ b/src/components/LibraryCards.js
@@ -13,9 +13,9 @@ export const LibraryCards = hh(class LibraryCards extends PureComponent {
           span({ className: 'library-label' }, 'None')
         ]) :
         ld.map(ld.uniq(libraryCards), card => {
-          return div({ key: card, style: { margin: 1 }, className: 'library-flag flag-enabled' }, [
+          return div({ key: card.id, style: { margin: 1 }, className: 'library-flag flag-enabled' }, [
             div({ className: 'library-icon' }),
-            span({ className: 'library-label' }, card)
+            span({ className: 'library-label' }, card.name)
           ]);
         })
     ]);

--- a/src/index.css
+++ b/src/index.css
@@ -1232,7 +1232,6 @@ a .editable:hover, a .enabled:hover {
 
 .library-flag {
   height: 34px;
-  width: 145px;
   border-radius: 2px;
   padding: 7px 12px 0 12px;
   color: white;

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -14,6 +14,7 @@ import { USER_ROLES, setUserRoleStatuses } from '../libs/utils';
 import {getNames} from "country-list";
 import ReactTooltip from "react-tooltip";
 import { SearchSelect } from '../components/SearchSelect';
+import { filter } from 'lodash/fp';
 
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
@@ -39,7 +40,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
   initialState() {
     return {
       loading: true,
-      hasLibraryCard: false,
       fieldStatus: {},
       showDialogSubmit: false,
       showDialogSave: false,
@@ -483,6 +483,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     let completed = this.state.profile.completed;
     const { researcherProfile, showValidationMessages } = this.state;
     const libraryCards = get(researcherProfile, 'libraryCards', []);
+    const lcInstitutions = filter((institution) => libraryCards.includes(institution.id))(this.state.institutionList);
 
     return (
 
@@ -592,7 +593,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                       LibraryCards({
                         style: { display: 'flex', flexFlow: 'row wrap' },
                         isRendered: !isNil(researcherProfile),
-                        libraryCards: libraryCards
+                        libraryCards: lcInstitutions
                       })
                     ])
                   ])


### PR DESCRIPTION
SCOPE:
 - pass institutions to Library Card component so the name can be displayed
 - remove width constraint so entire institution name can be displayed
 
ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1333
----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
