### PR TITLE
[DUOS-1095][risk=no] Standardize on User's eraCommonsId 

### DIFF
--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -168,7 +168,7 @@ export default function ApplicationDownloadLink(props) {
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
             label: "NIH eRA Commons ID",
-            text: `${researcherProps.nihUsername}`,
+            text: `${researcherProps.eraCommonsId}`,
             style: {marginRight: 30}
           }),
           h(SmallLabelTextComponent, {

--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -12,7 +12,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
   state = {
     isAuthorized: false,
     expirationCount: 0,
-    nihUsername: '',
+    eraCommonsId: '',
     nihError: false,
     isHovered: false
   };
@@ -63,12 +63,12 @@ export const eRACommons = hh(class eRACommons extends React.Component {
       const isAuthorized = isNil(authProp) ? false : getOr(false,'propertyValue')(authProp);
       const expirationCount = isNil(expProp) ? 0 : AuthenticateNIH.expirationCount(getOr(0,'propertyValue')(expProp));
       const nihValid = isAuthorized && expirationCount > 0;
-      const nihUsernameProp = find({'propertyKey':'nihUsername'})(props);
+      const eraCommonsId = response.eraCommonsId;
       this.props.onNihStatusUpdate(nihValid);
       this.setState(prev => {
         prev.isAuthorized = isAuthorized;
         prev.expirationCount = expirationCount;
-        prev.nihUsername = isNil(nihUsernameProp) ? '' : getOr('', 'propertyValue')(nihUsernameProp);
+        prev.eraCommonsId = isNil(eraCommonsId) ? '' : eraCommonsId;
         return prev;
       });
     });
@@ -185,7 +185,7 @@ export const eRACommons = hh(class eRACommons extends React.Component {
                 display: 'inline',
                 paddingTop: 5
               }
-            }, [this.state.nihUsername]),
+            }, [this.state.eraCommonsId]),
             button({
               style: {
                 float: 'left',

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -9,7 +9,6 @@ import _ from 'lodash';
 import {User} from "./ajax";
 
 export const UserProperties = {
-  NIH_USERNAME : "nihUsername",
   LINKEDIN : "linkedIn",
   ORCID: "orcid",
   IS_THE_PI: "isThePI",
@@ -39,7 +38,7 @@ export const findPropertyValue = (propName, researcher) => {
 export const getPropertyValuesFromUser = (user) => {
   let researcherProps = {
     academicEmail: user.email,
-    nihUsername: findPropertyValue(UserProperties.NIH_USERNAME, user),
+    eraCommonsId: user.eraCommonsId,
     linkedIn: findPropertyValue(UserProperties.LINKEDIN, user),
     orcid: findPropertyValue(UserProperties.ORCID, user),
     researcherGate: findPropertyValue(UserProperties.RESEARCHER_GATE, user),

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -29,7 +29,7 @@ class ResearcherReview extends Component {
         department: '',
         division: '',
         eRACommonsID: '',
-        nihUsername: '',
+        eraCommonsId: '',
         linkedIn: '',
         orcid: '',
         researcherGate: '',
@@ -152,7 +152,7 @@ class ResearcherReview extends Component {
             div({ className: "row no-margin" }, [
               div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12" }, [
                 label({ className: "control-label" }, ["NIH User Name"]),
-                div({ id: "lbl_profileNihUsername", className: "control-data", name: "profileNihUsername",  readOnly: true}, [formData.nihUsername]),
+                div({ id: "lbl_profileeraCommonsId", className: "control-data", name: "profileeraCommonsId",  readOnly: true}, [formData.eraCommonsId]),
               ]),
 
               div({ className: "col-lg-6 col-md-6 col-sm-6 col-xs-12" }, [
@@ -250,8 +250,7 @@ class ResearcherReview extends Component {
 
               div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [
                 label({ className: "control-label" }, ["eRA Commons ID"]),
-                //eraCommonsID is currently being saved as nihUsername, this will change with DUOS-1095
-                div({ id: "lbl_profileEraCommons", className: "control-data", name: "profileEraCommons", readOnly: true}, [formData.nihUsername]),
+                div({ id: "lbl_profileEraCommons", className: "control-data", name: "profileEraCommons", readOnly: true}, [formData.eraCommonsId]),
               ]),
 
               div({ className: "col-lg-12 col-md-12 col-sm-12 col-xs-12" }, [


### PR DESCRIPTION
## Scope
This PR updates references to nihUsername in researcher properties to instead reference eraCommonsId on the user. 
This need to be merged at the same time as https://github.com/DataBiosphere/consent/pull/1157

## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1095

## Depends On:
https://github.com/DataBiosphere/consent/pull/1157

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
