### PR TITLE
DUOS-1327[risk=no]Update Researcher Console to Manage V2 endpoint

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -346,8 +346,11 @@ export const DAR = {
   },
 
   //new manage endpoint, should be renamed once v1 variant is removed from use
-  getDataAccessManageV2: async() => {
-    const url = `${await Config.getApiUrl()}/api/dar/manage/v2`;
+  getDataAccessManageV2: async(roleName) => {
+    let url = `${await Config.getApiUrl()}/api/dar/manage/v2`;
+    if (!isNil(roleName)) {
+      url = `${await Config.getApiUrl()}/api/dar/manage/v2/?roleName=${roleName}`;
+    } 
     const res = await axios.get(url, Config.authOpts());
     return res.data;
   },

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -325,26 +325,6 @@ export const DAR = {
     return res.data;
   },
 
-  //endpoint to be deprecated once V2 endpoint is updated to account for reasearchers
-  getDataAccessManage: async() => {
-    const url = `${await Config.getApiUrl()}/api/dar/manage`;
-    const res = await fetchOk(url, Config.authOpts());
-    let dars = await res.json();
-    dars.map(dar => {
-      if (!fp.isNil(dar.ownerUser) && !fp.isNil(dar.ownerUser.roles)) {
-        dar.ownerUser.roles.map(role => {
-          if (role.name === 'Researcher') {
-            dar.status = dar.ownerUser.status;
-            return dar;
-          }
-          return dar;
-        });
-      }
-      return dar;
-    });
-    return dars;
-  },
-
   //new manage endpoint, should be renamed once v1 variant is removed from use
   getDataAccessManageV2: async(roleName) => {
     let url = `${await Config.getApiUrl()}/api/dar/manage/v2`;

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -330,7 +330,7 @@ export const DAR = {
     let url = `${await Config.getApiUrl()}/api/dar/manage/v2`;
     if (!isNil(roleName)) {
       url = `${await Config.getApiUrl()}/api/dar/manage/v2/?roleName=${roleName}`;
-    } 
+    }
     const res = await axios.get(url, Config.authOpts());
     return res.data;
   },

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -229,7 +229,7 @@ class ResearcherConsole extends Component {
                       span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === false }, ["Denied"]),
                       span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === true }, ["Approved"]),
                     ]),
-                    div({ className: "col-xs-1 cell-body f-center", disabled: darInfo.electionStatus !== 'un-reviewed'}, [
+                    div({ className: "col-xs-1 cell-body f-center" }, [
                       button({
                         id: darInfo.dar.data.darCode + "_btnCancel", name: "btn_cancel", isRendered: isNil(darInfo.election), className: "cell-button cancel-color",
                         onClick: this.cancelDar, value: darInfo.dar.referenceId

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -11,6 +11,7 @@ import { Link } from 'react-router-dom';
 import { Theme } from '../libs/theme';
 import accessIcon from "../images/icon_access.png";
 import { isNil } from 'lodash/fp'
+import {USER_ROLES} from "../libs/utils";
 
 class ResearcherConsole extends Component {
 
@@ -124,7 +125,7 @@ class ResearcherConsole extends Component {
 
   init() {
 
-    DAR.getDataAccessManageV2("Researcher").then(
+    DAR.getDataAccessManageV2(USER_ROLES.researcher).then(
       dars => {
         this.setState({
           dars: dars,

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -210,13 +210,7 @@ class ResearcherConsole extends Component {
                   "Date",
                   span({ className: 'glyphicon sort-icon glyphicon-sort' })
                 ]),
-                div({ style: Theme.textTableHead, className: "col-xs-2 cell-sort f-center access-color", onClick: this.sortDars({
-                  sortKey: 'electionStatus',
-                  descendantOrder: this.state.darDescOrder
-                }) }, [
-                  "Status",
-                  span({ className: 'glyphicon sort-icon glyphicon-sort' })
-                ]),
+                div({ style: Theme.textTableHead, className: "col-xs-2 cell-sort f-center access-color"}, [ "Status" ]),
                 div({ style: Theme.textTableHead, className: "col-xs-1 f-center access-color" }, ["Cancel"]),
                 div({ style: Theme.textTableHead, className: "col-xs-1 f-center access-color" }, ["Review"]),
               ]),
@@ -230,17 +224,17 @@ class ResearcherConsole extends Component {
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_createDate", name: "createDate", className: "col-xs-2" }, [Utils.formatDate(darInfo.dar.createDate)]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_electionStatus", name: "electionStatus", className: "col-xs-2 bold f-center" }, [
                       span({ isRendered: isNil(darInfo.election) }, ["Submitted"]),
-                      span({ isRendered: darInfo.election.status === 'Open' || darInfo.electionStatus === 'Final' || darInfo.electionStatus === 'PendingApproval' }, ["In review"]),
-                      span({ isRendered: darInfo.election.status === 'Canceled' }, ["Canceled"]),
-                      span({ isRendered: darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === false }, ["Denied"]),
-                      span({ isRendered: darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === true }, ["Approved"]),
+                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Open' || darInfo.electionStatus === 'Final' || darInfo.electionStatus === 'PendingApproval' }, ["In review"]),
+                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Canceled' }, ["Canceled"]),
+                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === false }, ["Denied"]),
+                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === true }, ["Approved"]),
                     ]),
                     div({ className: "col-xs-1 cell-body f-center", disabled: darInfo.electionStatus !== 'un-reviewed'}, [
                       button({
-                        id: darInfo.dar.data.darCode + "_btnCancel", name: "btn_cancel", isRendered: !darInfo.isCanceled, className: "cell-button cancel-color",
+                        id: darInfo.dar.data.darCode + "_btnCancel", name: "btn_cancel", isRendered: isNil(darInfo.election), className: "cell-button cancel-color",
                         onClick: this.cancelDar, value: darInfo.dar.referenceId
                       }, ["Cancel"]),
-                      button({ isRendered: darInfo.isCanceled, className: "disabled" }, ["Canceled"]),
+                      button({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Canceled' , className: "disabled" }, ["Canceled"]),
                     ]),
                     div({ className: "col-xs-1 cell-body f-center" }, [
                       button({

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -217,17 +217,26 @@ class ResearcherConsole extends Component {
               hr({ className: "table-head-separator" }),
 
               this.state.dars.slice((currentDarPage - 1) * darLimit, currentDarPage * darLimit).map(darInfo => {
+                const opened = !isNil(darInfo.election);
+                //if the dar was canceled by an admin or chair the canceled status will be on the election
+                //if the researcher canceled the dar the canceled status will be on the dar data
+                const canceled = 
+                !isNil(darInfo.dar.data.status) ? 
+                  darInfo.dar.data.status === 'Canceled'
+                  : opened ?
+                    darInfo.election.status === 'Canceled'
+                    : false;
                 return h(Fragment, { key: darInfo.dar.darCode }, [
                   div({ key: darInfo.dar.data.darCode, id: darInfo.dar.data.darCode, className: "row no-margin tableRow" }, [
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_darId", name: "darId", className: "col-xs-2" }, [darInfo.dar.data.darCode]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_projectTitle", name: "projectTitle", className: "col-xs-4" }, [darInfo.dar.data.projectTitle]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_createDate", name: "createDate", className: "col-xs-2" }, [Utils.formatDate(darInfo.dar.createDate)]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_electionStatus", name: "electionStatus", className: "col-xs-2 bold f-center" }, [
-                      span({ isRendered: isNil(darInfo.election) }, ["Submitted"]),
-                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Open' || darInfo.electionStatus === 'Final' || darInfo.electionStatus === 'PendingApproval' }, ["In review"]),
-                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Canceled' }, ["Canceled"]),
-                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === false }, ["Denied"]),
-                      span({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === true }, ["Approved"]),
+                      span({ isRendered: !opened && !canceled}, ["Submitted"]),
+                      span({ isRendered: opened && !canceled ? darInfo.election.status === 'Open' || darInfo.election.status === 'Final' || darInfo.election.status === 'PendingApproval' : false}, ["In review"]),
+                      span({ isRendered: canceled }, ["Canceled"]),
+                      span({ isRendered: opened ? darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === false : false}, ["Denied"]),
+                      span({ isRendered: opened ? darInfo.election.status === 'Closed' && darInfo.election.finalAccessVote === true : false}, ["Approved"]),
                     ]),
                     div({ className: "col-xs-1 cell-body f-center" }, [
                       button({

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -10,7 +10,7 @@ import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Link } from 'react-router-dom';
 import { Theme } from '../libs/theme';
 import accessIcon from "../images/icon_access.png";
-import { isNil } from 'lodash/fp'
+import { isNil } from 'lodash/fp';
 import {USER_ROLES} from "../libs/utils";
 
 class ResearcherConsole extends Component {
@@ -211,23 +211,23 @@ class ResearcherConsole extends Component {
                   "Date",
                   span({ className: 'glyphicon sort-icon glyphicon-sort' })
                 ]),
-                div({ style: Theme.textTableHead, className: "col-xs-2 cell-sort f-center access-color"}, [ "Status" ]),
+                div({ style: Theme.textTableHead, className: "col-xs-2 cell-sort f-center access-color"}, ["Status"]),
                 div({ style: Theme.textTableHead, className: "col-xs-1 f-center access-color" }, ["Cancel"]),
                 div({ style: Theme.textTableHead, className: "col-xs-1 f-center access-color" }, ["Review"]),
               ]),
               hr({ className: "table-head-separator" }),
 
-              this.state.dars.slice((currentDarPage - 1) * darLimit, currentDarPage * darLimit).map(darInfo => {
+              this.state.dars.slice((currentDarPage - 1) * darLimit, currentDarPage * darLimit).map((darInfo, idx) => {
                 const opened = !isNil(darInfo.election);
                 //if the dar was canceled by an admin or chair the canceled status will be on the election
                 //if the researcher canceled the dar the canceled status will be on the dar data
-                const canceled = 
-                !isNil(darInfo.dar.data.status) ? 
+                const canceled =
+                !isNil(darInfo.dar.data.status) ?
                   darInfo.dar.data.status === 'Canceled'
                   : opened ?
                     darInfo.election.status === 'Canceled'
                     : false;
-                return h(Fragment, { key: darInfo.dar.darCode }, [
+                return h(Fragment, { key: darInfo.dar.darCode + '_' + idx}, [
                   div({ key: darInfo.dar.data.darCode, id: darInfo.dar.data.darCode, className: "row no-margin tableRow" }, [
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_darId", name: "darId", className: "col-xs-2" }, [darInfo.dar.data.darCode]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + "_projectTitle", name: "projectTitle", className: "col-xs-4" }, [darInfo.dar.data.projectTitle]),


### PR DESCRIPTION
SCOPE:
- Remove usage of /manage endpoint on Researcher Console
- Replace with /manage/v2 endpoint
- Refactor usages of data to account for the new data structure
- - remove sorting on election status (sorting on election status does not exist on the member, chair ,or admin consoles which use the same manage/v2/endpoint bc not all dars have an election)
- - update cancel button to only show when there is no election instead of being disabled for all other cases
- - update the way in which status is calculated

ADDRESSES:
partially https://broadworkbench.atlassian.net/browse/DUOS-1327

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
