### PR TITLE
DUOS-1335[risk=no] Show all library cards on Access Review

### DIFF
--- a/src/pages/access_review/ApplicantInfo.js
+++ b/src/pages/access_review/ApplicantInfo.js
@@ -3,6 +3,7 @@ import * as ld from 'lodash';
 import { div, hh, img } from 'react-hyperscript-helpers';
 import { Theme } from '../../libs/theme';
 import cardImg from '../../images/card.png';
+import { isEmpty } from 'lodash';
 
 const HEADER = {
   margin: '10px 0px',
@@ -32,11 +33,12 @@ export const ApplicantInfo = hh(
         ]);
       });
     };
-    formatLibraryCard = (cards, institution) => {
+    formatLibraryCard = (cards) => {
       return ld.map(cards, (card) => {
-        if (card.institutionId !== institution.id) {
+        if (isEmpty(card) || isEmpty(card.institution)) {
           return div({});
         }
+        const { institution } = card;
         return div({ style: { margin: 3, textAlign: 'center' } }, [
           img({
             id: 'card_' + card,


### PR DESCRIPTION
UI portion of [DUOS-1335](https://broadworkbench.atlassian.net/browse/DUOS-1335)

PR adjusts the `AccessReview` component to list all library cards rather than just the researcher's institution. 

NOTE: No adjustments were needed for the user profile page since it already expects an array of library cards.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
