### PR TITLE
DUOS-1351[risk=no] Fixes on Createable dropdowns

### DIFF
--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -11,12 +11,12 @@ import { Theme } from '../../libs/theme';
 
 //modal component, used to render row on modal
 const FormFieldRow = (props) => {
-  const { card, dropdownOptions, updateInstitution, updateUser, modalType } = props;
+  const { card, dropdownOptions, updateInstitution, updateUser, modalType, setCard } = props;
   const [filteredDropdown, setFilteredDropdown] = useState(dropdownOptions);
   let template;
 
   //filter function for users dropdown
-  const userListFilter = (searchTerm) => {
+  const userListFilter = (searchTerm, card, setCard, action) => {
     let filteredCopy;
     if(isEmpty(searchTerm)) {
       filteredCopy = dropdownOptions;
@@ -29,6 +29,9 @@ const FormFieldRow = (props) => {
       });
     }
     setFilteredDropdown(filteredCopy);
+    if(action !== 'input-blur' && action !== `menu-close`) {
+      setCard(Object.assign({}, card, { email: searchTerm }));
+    }
   };
 
   if(!isNil(updateInstitution)) {
@@ -50,12 +53,15 @@ const FormFieldRow = (props) => {
       template = div({style: {marginBottom: '2%'}}, [
         label({}, ['Users']),
         h(Creatable, {
+          key: 'select-user',
           isClearable: true,
           onChange: updateUser,
-          onInputChange: userListFilter,
+          createOptionPosition: 'first',
+          onInputChange: (input, {action}) => userListFilter(input, card, setCard, action),
           getNewOptionData: (input) => { return {email: input}; },
           options: dropdownOptions,
           placeholder: 'Select or type a new user email',
+          isOptionSelected: () => false, //Workaround to prevent odd react-select behavior where all dropdown options are highlighted
           getOptionLabel: (option) => `${option.displayName || 'New User'} (${option.email || "No email provided"})` || option.email
         })
       ]);
@@ -136,6 +142,7 @@ export default function LibraryCardFormModal(props) {
           card,
           modalType,
           updateUser,
+          setCard,
           dropdownOptions: users,
         }),
         h(FormFieldRow, {

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -313,9 +313,15 @@ export default function ResearcherInfo(props) {
                 required: true,
                 isDisabled: !isNil(darCode),
                 placeholder: "Select from the list or type your SO's full name if it is not present. Clear selection with the Backspace key or the 'X' at the end of this input box",
-                onChange: (option) => { //this is react-async's onChange function, not React's. (Function definition is different, expects option rather than event)
+                onChange: (option) => {
                   const value = isNil(option) ? '' : formatSOString(option.displayName, option.email);
                   formFieldChange({name: 'signingOfficial', value});
+                },
+                onInputChange: (input, {action}) => {
+                  if(action !== 'input-blur' && action !== 'menu-close') {
+                    const value = isNil(input) ? '' : formatSOString(input, null);
+                    formFieldChange({name: 'signingOfficial', value});
+                  }
                 },
                 options: allSigningOfficials, //dropdown options
                 getOptionLabel: (option) => formatSOString(option.displayName, option.email), //formats labels on dropdown


### PR DESCRIPTION
Addresses [DUOS-1351](https://broadworkbench.atlassian.net/browse/DUOS-1351)

PR introduces bugfixes to the Createable dropdown on the DAR Application, allowing users to keep input when user tabs away or clicks away from the input. (This fix does not work on the LibraryCard variant so it isn't applied there).

PR introduces a bugfix on the Createable dropdown on the LibraryCardModal where all selections on the dropdown would be highlighted when a selection was made.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
