### PR TITLE
DUOS-1336[risk=no]UI: Consolidate Console Design

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -230,6 +230,29 @@ class DuosHeader extends Component {
       isSigningOfficial = currentUser.isSigningOfficial;
     }
 
+    const hasTwoOrMoreRoles = () => {
+      let roles = 0;
+      if (isAdmin) {
+        roles += 1;
+      }
+      if (isResearcher) {
+        roles += 1;
+      }
+      if (isMember) {
+        roles += 1;
+      }
+      if (isChairPerson) {
+        roles += 1;
+      }
+      if (isDataOwner) {
+        roles += 1;
+      }
+      if (isSigningOfficial) {
+        roles += 1;
+      }
+      return roles >= 2;
+    };
+
     const dropdownLinks = {
       statistics: {
         'Votes Statistics': {
@@ -304,6 +327,70 @@ class DuosHeader extends Component {
       url: this.props.location.pathname
     });
 
+    const adminLink = (inDropDown) => li({ isRendered: inDropDown ? isAdmin : isAdmin && !hasTwoOrMoreRoles()}, [
+      h(Link, { id: 'link_adminConsole', to: '/admin_console' }, [
+        'Admin Console',
+      ]),
+    ]);
+
+    const signingOfficialLink = (inDropDown)  => li({ isRendered:  inDropDown ? isSigningOfficial : isSigningOfficial && !hasTwoOrMoreRoles()}, [
+      h(Link, { id: 'link_so_console', to: '/signing_official_console' }, ['Signing Official Console'])
+    ]);
+
+    const chairpersonLink = (inDropDown)  => li({ className: 'dropdown', isRendered: inDropDown ? isChairPerson : isChairPerson && !hasTwoOrMoreRoles()}, [
+      a(
+        {
+          role: 'button',
+          className: 'dropdown-toggle',
+          'data-toggle': 'dropdown',
+        },
+        [
+          div({}, [
+            'DAC Chair Console',
+            span({ className: 'caret caret-margin' }, []),
+          ]),
+        ]
+      ),
+      ul({ className: 'dropdown-menu user-dropdown', role: 'menu' }, [
+        li({}, [
+          h(
+            Link,
+            { id: 'link_chairConsole', to: this.state.dacChairPath },
+            ['Manage DARs']
+          ),
+        ]),
+        hr({ style: hrStyle }),
+        li({}, [
+          h(Link, { id: 'link_manageDac', to: '/manage_dac' }, [
+            'Manage DACs',
+          ]),
+        ]),
+      ]),
+    ]);
+
+    const memberLink = (inDropDown) =>
+      li({ isRendered: inDropDown ? isMember : isMember && !hasTwoOrMoreRoles() }, [
+        h(Link, { id: 'link_memberConsole', to: '/member_console' }, [
+          'DAC Member Console',
+        ]),
+      ]);
+
+    const researcherLink = (inDropDown) => li({ isRendered: inDropDown ? isResearcher : isResearcher && !hasTwoOrMoreRoles() }, [
+      h(
+        Link,
+        { id: 'link_researcherConsole', to: '/researcher_console' },
+        ['Researcher Console']
+      ),
+    ]);
+
+    const dataOwnerLink = (inDropDown) => li({ isRendered: inDropDown ? isDataOwner :  isDataOwner && !hasTwoOrMoreRoles() }, [
+      h(
+        Link,
+        { id: 'link_dataOwnerConsole', to: '/data_owner_console' },
+        ['Data Owner Console']
+      ),
+    ]);
+
     return nav({ className: 'navbar-duos', role: 'navigation' }, [
       h(Hidden, { mdDown: true }, [
         this.makeNotifications(),
@@ -343,15 +430,7 @@ class DuosHeader extends Component {
                   ]),
                 ]),
               ]),
-              li({ isRendered: isAdmin }, [
-                h(Link, { id: 'link_adminConsole', to: '/admin_console' }, [
-                  'Admin Console',
-                ]),
-              ]),
-              li({ isRendered: isSigningOfficial }, [
-                h(Link, { id: 'link_so_console', to: '/signing_official_console' }, ['Signing Official Console'])
-              ]),
-              li({ className: 'dropdown', isRendered: isChairPerson }, [
+              li({ className: 'dropdown', isRendered: hasTwoOrMoreRoles() }, [
                 a(
                   {
                     role: 'button',
@@ -360,49 +439,27 @@ class DuosHeader extends Component {
                   },
                   [
                     div({}, [
-                      'DAC Chair Console',
+                      'Your Consoles',
                       span({ className: 'caret caret-margin' }, []),
                     ]),
                   ]
                 ),
                 ul({ className: 'dropdown-menu user-dropdown', role: 'menu' }, [
-                  li({}, [
-                    h(
-                      Link,
-                      { id: 'link_chairConsole', to: this.state.dacChairPath },
-                      ['Manage DARs']
-                    ),
-                  ]),
-                  hr({ style: hrStyle }),
-                  li({}, [
-                    h(Link, { id: 'link_manageDac', to: '/manage_dac' }, [
-                      'Manage DACs',
-                    ]),
-                  ]),
+                  adminLink(true),
+                  signingOfficialLink(true),
+                  chairpersonLink(true),
+                  memberLink(true),
+                  researcherLink(true),
+                  dataOwnerLink(true)
                 ]),
               ]),
 
-              li({ isRendered: isMember }, [
-                h(Link, { id: 'link_memberConsole', to: '/member_console' }, [
-                  'DAC Member Console',
-                ]),
-              ]),
-
-              li({ isRendered: isResearcher }, [
-                h(
-                  Link,
-                  { id: 'link_researcherConsole', to: '/researcher_console' },
-                  ['Researcher Console']
-                ),
-              ]),
-
-              li({ isRendered: isDataOwner }, [
-                h(
-                  Link,
-                  { id: 'link_dataOwnerConsole', to: '/data_owner_console' },
-                  ['Data Owner Console']
-                ),
-              ]),
+              adminLink(false),
+              signingOfficialLink(false),
+              chairpersonLink(false),
+              memberLink(false),
+              researcherLink(false),
+              dataOwnerLink(false),
 
               li({ isRendered: isResearcher }, [
                 h(

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -15,7 +15,7 @@ import { Styles } from '../libs/theme';
 import DuosLogo from '../images/duos-network-logo.svg';
 import contactUsHover from '../images/navbar_icon_contact_us_hover.svg';
 import contactUsStandard from '../images/navbar_icon_contact_us.svg';
-import { isNil } from 'lodash';
+import { isNil, map, uniq } from 'lodash/fp';
 
 const styles = {
   drawerPaper: {
@@ -231,26 +231,8 @@ class DuosHeader extends Component {
     }
 
     const hasTwoOrMoreRoles = () => {
-      let roles = 0;
-      if (isAdmin) {
-        roles += 1;
-      }
-      if (isResearcher) {
-        roles += 1;
-      }
-      if (isMember) {
-        roles += 1;
-      }
-      if (isChairPerson) {
-        roles += 1;
-      }
-      if (isDataOwner) {
-        roles += 1;
-      }
-      if (isSigningOfficial) {
-        roles += 1;
-      }
-      return roles >= 2;
+      const roleNames = uniq(map("name")(currentUser.roles));
+      return roleNames.length >= 2;
     };
 
     const dropdownLinks = {
@@ -370,7 +352,7 @@ class DuosHeader extends Component {
 
     const chairSubHeader =
       li({ isRendered: isChairPerson, style: {marginTop: '10px', marginBottom: '5px'} }, [
-        span({style: { color: '#00609f', fontSize: '12px', fontWeight: '500', padding: '10px 15px'}}, ['DAC Chair Console'])
+        span({style: { fontSize: '12px', fontWeight: '600', padding: '10px 15px'}}, ['DAC Chair Console'])
       ]);
 
     const chairManageDACsLink =

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -370,7 +370,7 @@ class DuosHeader extends Component {
 
     const chairSubHeader =
       li({ isRendered: isChairPerson, style: {marginTop: '10px', marginBottom: '5px'} }, [
-        span({style: { color: '#00609f', fontSize: '12px', padding: '10px 15px'}}, ['DAC Chair Console'])
+        span({style: { color: '#00609f', fontSize: '12px', fontWeight: '500', padding: '10px 15px'}}, ['DAC Chair Console'])
       ]);
 
     const chairManageDACsLink =

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -337,7 +337,7 @@ class DuosHeader extends Component {
       h(Link, { id: 'link_so_console', to: '/signing_official_console' }, ['Signing Official Console'])
     ]);
 
-    const chairpersonLink = (inDropDown)  => li({ className: 'dropdown', isRendered: inDropDown ? isChairPerson : isChairPerson && !hasTwoOrMoreRoles()}, [
+    const chairpersonDropDown = li({ className: 'dropdown', isRendered: isChairPerson && !hasTwoOrMoreRoles()}, [
       a(
         {
           role: 'button',
@@ -367,6 +367,24 @@ class DuosHeader extends Component {
         ]),
       ]),
     ]);
+
+    const chairSubHeader =
+      li({ isRendered: isChairPerson, style: {marginTop: '10px', marginBottom: '5px'} }, [
+        span({style: { color: '#00609f', fontSize: '12px', padding: '10px 15px'}}, ['DAC Chair Console'])
+      ]);
+
+    const chairManageDACsLink =
+      li({ isRendered: isChairPerson, style: {marginLeft: '10px', paddingBottom: '0 !important'} }, [
+        h(Link, { id: 'link_manageDac', to: '/manage_dac' }, [
+          'Manage DACs',
+        ]),
+      ]);
+    const chairManageDARsLink =
+      li({ isRendered: isChairPerson, style: {marginLeft: '10px'} }, [
+        h( Link, { id: 'link_chairConsole', to: this.state.dacChairPath },
+          ['Manage DARs']
+        ),
+      ]);
 
     const memberLink = (inDropDown) =>
       li({ isRendered: inDropDown ? isMember : isMember && !hasTwoOrMoreRoles() }, [
@@ -448,7 +466,9 @@ class DuosHeader extends Component {
                 ul({ className: 'dropdown-menu user-dropdown', role: 'menu' }, [
                   adminLink(true),
                   signingOfficialLink(true),
-                  chairpersonLink(true),
+                  chairSubHeader,
+                  chairManageDARsLink,
+                  chairManageDACsLink,
                   memberLink(true),
                   researcherLink(true),
                   dataOwnerLink(true)
@@ -457,7 +477,7 @@ class DuosHeader extends Component {
 
               adminLink(false),
               signingOfficialLink(false),
-              chairpersonLink(false),
+              chairpersonDropDown,
               memberLink(false),
               researcherLink(false),
               dataOwnerLink(false),

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -430,6 +430,7 @@ class DuosHeader extends Component {
                   ]),
                 ]),
               ]),
+
               li({ className: 'dropdown', isRendered: hasTwoOrMoreRoles() }, [
                 a(
                   {


### PR DESCRIPTION
SCOPE: 
- create dropdown menu of consoles
- make links into reusable constants, and add logic for when to render
- remove sublist (manage Dars and manae Dacs) when in the 'your consoles' dropdown  and render them in the main list, slightly indented

ADDRESSES:
- https://broadworkbench.atlassian.net/browse/DUOS-1336

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
