### PR TITLE
[DUOS-1367][risk=no] Turn off background signin on staging

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -53,7 +53,7 @@ const Routes = (props) => (
     <Route exact path="/backgroundsignin" render={
       (routeProps) =>
         props.env
-          ? props.env !== 'prod'
+          ? (props.env !== 'prod' && props.env !== 'staging')
             ? <BackgroundSignIn {...routeProps} />
             : <NotFound />
           : <div />


### PR DESCRIPTION
## Addresses
Turn off background signin on staging: https://broadworkbench.atlassian.net/browse/DUOS-1367

When config.env is set to `staging`, the background url is no longer visible

![Screen Shot 2021-07-23 at 3 40 39 PM](https://user-images.githubusercontent.com/116679/126833184-567f4d2e-3ac8-4cb5-862e-9f5bfc2cb100.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
