### PR TITLE
DUOS-1359[risk=no]Send Reminder link visible in Approved DARs, Review Results

### DIFF
--- a/src/pages/access_review/DarApplication.js
+++ b/src/pages/access_review/DarApplication.js
@@ -107,7 +107,7 @@ export const DarApplication = hh(class DarApplication extends React.PureComponen
           questionNumber: '1',
           votes: accessVotes,
           isAdmin: isAdmin,
-          finalDecision
+          accessElection
         }),
         VoteSummary({
           isRendered: voteAsChair && !isNil(rpVotes),
@@ -115,7 +115,7 @@ export const DarApplication = hh(class DarApplication extends React.PureComponen
           questionNumber: '2',
           votes: rpVotes,
           isAdmin: isAdmin,
-          finalDecision
+          accessElection
         }),
         AppSummary({darInfo, accessElection, consent, researcherProfile})
       ])

--- a/src/pages/access_review/DarApplication.js
+++ b/src/pages/access_review/DarApplication.js
@@ -106,14 +106,16 @@ export const DarApplication = hh(class DarApplication extends React.PureComponen
           question: 'Should data access be granted to this application?',
           questionNumber: '1',
           votes: accessVotes,
-          isAdmin: isAdmin
+          isAdmin: isAdmin,
+          finalDecision
         }),
         VoteSummary({
           isRendered: voteAsChair && !isNil(rpVotes),
           question: 'Was the research purpose accurately converted to a structured format?',
           questionNumber: '2',
           votes: rpVotes,
-          isAdmin: isAdmin
+          isAdmin: isAdmin,
+          finalDecision
         }),
         AppSummary({darInfo, accessElection, consent, researcherProfile})
       ])

--- a/src/pages/access_review/VoteSummary.js
+++ b/src/pages/access_review/VoteSummary.js
@@ -155,7 +155,8 @@ export const VoteSummary = hh(
           padding: '1rem',
           textAlign: 'right',
           flexShrink: '0',
-          fontWeight: Theme.font.weight.regular}
+          fontWeight: Theme.font.weight.regular},
+        isRendered: this.props.finalDecision === "No decision"
         }, [a({onClick: () => this.sendReminder(vote)}, ['Send Reminder'])])
       ]);
     };

--- a/src/pages/access_review/VoteSummary.js
+++ b/src/pages/access_review/VoteSummary.js
@@ -156,7 +156,7 @@ export const VoteSummary = hh(
           textAlign: 'right',
           flexShrink: '0',
           fontWeight: Theme.font.weight.regular},
-        isRendered: this.props.finalDecision === "No decision"
+        isRendered: isNil(this.props.accessElection) ? false : this.props.accessElection.status === "Open"
         }, [a({onClick: () => this.sendReminder(vote)}, ['Send Reminder'])])
       ]);
     };


### PR DESCRIPTION
SCOPE:
- in DarApplication (used by both AccessReview page and ReviewResults page), pass in finalDecision variable (already defined) to VoteSummary component
- in VoteSummary, only render the send reminder link if the finalDescision is "no decision", it can be one of: "no", "yes" or "no decision"

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1359

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
