### PR TITLE
DUOS-1348[risk=no] Added Zendesk FAQ redirect to navbar link

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -19,7 +19,6 @@ import DulPreview from './pages/DulPreview';
 import DulResultRecords from './pages/DulResultRecords';
 import DulReview from './pages/DulReview';
 import Election404 from './pages/Election404';
-import FAQs from './pages/FAQs';
 import Home from './pages/Home';
 import HomeAbout from './pages/HomeAbout';
 import HomeSigningOfficial from './pages/HomeSigningOfficial';
@@ -58,7 +57,6 @@ const Routes = (props) => (
             : <NotFound />
           : <div />
     } />
-    <Route path="/FAQs" component={FAQs} />
     <Route path="/home_about" component={HomeAbout} />
     <Route path="/home_signing_official" component={HomeSigningOfficial} />
     <Route path="/home_dac_info" component={HomeDacInfo} />

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -458,7 +458,13 @@ class DuosHeader extends Component {
                   ['Dataset Catalog']
                 ),
               ]),
-              li({}, [h(Link, { id: 'link_help', to: '/FAQs' }, ['FAQs'])]),
+              li({}, [
+                a({
+                  id: 'link_help',
+                  href: 'https://broad-duos.zendesk.com/hc/en-us/articles/360059957092-Frequently-Asked-Questions-FAQs-',
+                  target: '_blank'
+                }, ['FAQs']),
+              ]),
               contactUsButton,
               supportrequestModal,
             ]),


### PR DESCRIPTION
Addresses [DUOS-1348](https://broadworkbench.atlassian.net/browse/DUOS-1348)

PR adds the Zendesk FAQ blog post as the href value to the navbar link. PR also removes imports of FAQs.js and routing to that component.

Not sure if FAQs page should be deleted altogether. The import removal is enough to keep the file out of the webpack bundle and the file could be a good fallback if there are technical difficulties with the Zendesk blog.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
