### PR TITLE
DUOS-1360[risk=no]Manage Institutes: Add SOs to page

### DIFF
--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -74,14 +74,13 @@ export default function InstitutionTable(props) {
       div({style: Styles.TABLE.CONTAINER}, [
         div({style: Styles.TABLE.HEADER_ROW}, [tableHeaderTemplate]),
         filteredList.slice((currentPage - 1) * tableSize, (currentPage * tableSize)).map((inst, index) => {
-          let signingOfficials = '';
-          isNil(inst.signingOfficials) ? signingOfficials = '' : inst.signingOfficials.forEach((user, i) => {
-            signingOfficials = signingOfficials.concat(user.displayName, ' (', user.email, ')');
-            //if there are multiple SOs in the list and this is not the last one, add comma
-            if (inst.signingOfficials.length > 1 && i < (inst.signingOfficials.length - 1)) {
-              signingOfficials = signingOfficials.concat(', ');
-            }
-          });
+          let signingOfficialsList = [];
+          if (!isNil(inst.signingOfficials)) {
+            inst.signingOfficials.forEach((user, i) => {
+              signingOfficialsList.push(user.displayName.concat(' (', user.email, ')'));
+            });
+          }
+          const signingOfficialsText = signingOfficialsList.join(', ');
           const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};
           return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${inst.id}-${index}`}, [
             div({
@@ -99,7 +98,7 @@ export default function InstitutionTable(props) {
             ]),
             div({
               style: Object.assign({}, Styles.TABLE.INSTITUTION_CELL)
-            }, [span(signingOfficials)]),
+            }, [span(signingOfficialsText)]),
             div({
               style: Object.assign({}, Styles.TABLE.DATA_ID_CELL)
             }, [inst.createUser ? inst.createUser.displayName : '']),

--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -76,11 +76,10 @@ export default function InstitutionTable(props) {
         filteredList.slice((currentPage - 1) * tableSize, (currentPage * tableSize)).map((inst, index) => {
           let signingOfficialsList = [];
           if (!isNil(inst.signingOfficials)) {
-            inst.signingOfficials.forEach((user, i) => {
-              signingOfficialsList.push(`${user.displayName} (${user.email})`);
+            inst.signingOfficials.forEach((user) => {
+              signingOfficialsList.push(span({style: {display: 'block'}}, `${user.displayName} (${user.email})`));
             });
           }
-          const signingOfficialsText = signingOfficialsList.join(', ');
           const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};
           return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${inst.id}-${index}`}, [
             div({
@@ -97,8 +96,8 @@ export default function InstitutionTable(props) {
               }, [inst.name])
             ]),
             div({
-              style: Object.assign({}, Styles.TABLE.INSTITUTION_CELL)
-            }, [span(signingOfficialsText)]),
+              style: Object.assign({}, {...Styles.TABLE.INSTITUTION_CELL, display: 'block'})
+            }, signingOfficialsList),
             div({
               style: Object.assign({}, Styles.TABLE.DATA_ID_CELL)
             }, [inst.createUser ? inst.createUser.displayName : '']),

--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -1,6 +1,6 @@
-import { isEmpty, assign } from 'lodash/fp';
+import { isEmpty, isNil, assign } from 'lodash/fp';
 import { useState, useEffect } from 'react';
-import { div, h, a } from 'react-hyperscript-helpers';
+import { div, h, a , span } from 'react-hyperscript-helpers';
 import { Styles } from '../../libs/theme';
 import ReactTooltip from 'react-tooltip';
 import PaginationBar from '../PaginationBar';
@@ -9,6 +9,7 @@ import AddInstitutionModal from '../modals/AddInstitutionModal';
 export const tableHeaderTemplate = [
   div({style: Styles.TABLE.ID_CELL}, ["ID"]),
   div({style: Styles.TABLE.INSTITUTION_CELL}, ["Institution"]),
+  div({style: Styles.TABLE.INSTITUTION_CELL}, ["Signing Officials"]),
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Create User"]),
   div({style: Styles.TABLE.SUBMISSION_DATE_CELL}, ["Create Date"]),
   div({style: Styles.TABLE.DATA_ID_CELL}, ["Update User"]),
@@ -19,6 +20,7 @@ const loadingMarginOverwrite = {margin: '1rem 2%'};
 
 export const tableRowLoadingTemplate = [
   div({style: assign(Styles.TABLE.ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
+  div({style: assign(Styles.TABLE.INSTITUTION_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.INSTITUTION_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.DATA_ID_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
   div({style: assign(Styles.TABLE.SUBMISSION_DATE_CELL, loadingMarginOverwrite), className: 'text-placeholder'}),
@@ -72,6 +74,14 @@ export default function InstitutionTable(props) {
       div({style: Styles.TABLE.CONTAINER}, [
         div({style: Styles.TABLE.HEADER_ROW}, [tableHeaderTemplate]),
         filteredList.slice((currentPage - 1) * tableSize, (currentPage * tableSize)).map((inst, index) => {
+          let signingOfficials = '';
+          isNil(inst.signingOfficials) ? signingOfficials = '' : inst.signingOfficials.forEach((user, i) => {
+            signingOfficials = signingOfficials.concat(user.displayName, ' (', user.email, ')');
+            //if there are multiple SOs in the list and this is not the last one, add line break
+            if (inst.signingOfficials.length > 1 && i < (inst.signingOfficials.length - 1)) {
+              signingOfficials = signingOfficials.concat('\n');
+            }
+          });
           const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};
           return div({style: Object.assign({}, borderStyle, Styles.TABLE.RECORD_ROW), key: `${inst.id}-${index}`}, [
             div({
@@ -81,12 +91,14 @@ export default function InstitutionTable(props) {
               style: Object.assign({}, Styles.TABLE.INSTITUTION_CELL)
             }, [
               a({ style: {
-                overflow: "hidden",
                 whiteSpace: "nowrap",
                 textOverflow: "ellipsis"},
               onClick: () => { openUpdateModal(inst.id); }
               }, [inst.name])
             ]),
+            div({
+              style: Object.assign({}, Styles.TABLE.INSTITUTION_CELL)
+            }, [span(signingOfficials)]),
             div({
               style: Object.assign({}, Styles.TABLE.DATA_ID_CELL)
             }, [inst.createUser ? inst.createUser.displayName : '']),

--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -77,9 +77,9 @@ export default function InstitutionTable(props) {
           let signingOfficials = '';
           isNil(inst.signingOfficials) ? signingOfficials = '' : inst.signingOfficials.forEach((user, i) => {
             signingOfficials = signingOfficials.concat(user.displayName, ' (', user.email, ')');
-            //if there are multiple SOs in the list and this is not the last one, add line break
+            //if there are multiple SOs in the list and this is not the last one, add comma
             if (inst.signingOfficials.length > 1 && i < (inst.signingOfficials.length - 1)) {
-              signingOfficials = signingOfficials.concat('\n');
+              signingOfficials = signingOfficials.concat(', ');
             }
           });
           const borderStyle = index > 0 ? {borderTop: "1px solid rgba(109,110,112,0.2)"} : {};

--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -91,6 +91,7 @@ export default function InstitutionTable(props) {
               style: Object.assign({}, Styles.TABLE.INSTITUTION_CELL)
             }, [
               a({ style: {
+                overflow: "hidden",
                 whiteSpace: "nowrap",
                 textOverflow: "ellipsis"},
               onClick: () => { openUpdateModal(inst.id); }

--- a/src/components/institution_table/InstitutionTable.js
+++ b/src/components/institution_table/InstitutionTable.js
@@ -77,7 +77,7 @@ export default function InstitutionTable(props) {
           let signingOfficialsList = [];
           if (!isNil(inst.signingOfficials)) {
             inst.signingOfficials.forEach((user, i) => {
-              signingOfficialsList.push(user.displayName.concat(' (', user.email, ')'));
+              signingOfficialsList.push(`${user.displayName} (${user.email})`);
             });
           }
           const signingOfficialsText = signingOfficialsList.join(', ');

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -268,15 +268,15 @@ export const Styles = {
       alignItems: "center",
     },
     ID_CELL: {
-      width: "5%",
+      width: "2%",
       margin: "0 1%",
       display: "flex",
       justifyContent: "left",
       alignItems: "center",
     },
     INSTITUTION_CELL: {
-      maxWidth: "35%",
-      minWidth: "35%",
+      maxWidth: "25%",
+      minWidth: "25%",
       margin: "0 1%",
       display: "flex",
       justifyContent: "left",


### PR DESCRIPTION
SCOPE:
- This PR adds a column for SOs to the admin manage institutions page, displays their name and email.
- This PR uses the updated DAO call from DUOS-1360 in Consent so it needs to be tested with that branch
<img width="1592" alt="Screen Shot 2021-07-29 at 5 03 20 PM" src="https://user-images.githubusercontent.com/77015255/127675118-25399d06-9ca7-4d85-9492-b2f23db9589a.png">

ADDRESSES:
- https://broadworkbench.atlassian.net/browse/DUOS-1360

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
