### PR TITLE
DUOS-1389[risk=no]Remove unnecessary API call from Dar Application page

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -800,6 +800,7 @@ export const PendingCases = {
 
 export const Researcher = {
 
+  //unused
   getPropertiesByResearcherId: async (userId) => {
     const url = `${await Config.getApiUrl()}/api/researcher/${userId}`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -800,7 +800,7 @@ export const PendingCases = {
 
 export const Researcher = {
 
-  //unused
+  //unused do we want to deprecate this API
   getPropertiesByResearcherId: async (userId) => {
     const url = `${await Config.getApiUrl()}/api/researcher/${userId}`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -800,13 +800,6 @@ export const PendingCases = {
 
 export const Researcher = {
 
-  //unused do we want to deprecate this API
-  getPropertiesByResearcherId: async (userId) => {
-    const url = `${await Config.getApiUrl()}/api/researcher/${userId}`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
-  },
-
   createProperties: async (researcherProperties) => {
     const url = `${await Config.getApiUrl()}/api/researcher`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(researcherProperties), { method: 'POST' }]));

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -25,7 +25,8 @@ export const UserProperties = {
   COUNTRY: "country",
   RESEARCHER_GATE: "researcherGate",
   PUBMED_ID: "pubmedID",
-  SCIENTIFIC_URL: "scientificURL"
+  SCIENTIFIC_URL: "scientificURL",
+  COMPLETED: "completed"
 };
 
 export const findPropertyValue = (propName, researcher) => {
@@ -55,7 +56,8 @@ export const getPropertyValuesFromUser = (user) => {
     piName: findPropertyValue(UserProperties.IS_THE_PI, user) === "true" ? user.displayName : findPropertyValue(UserProperties.PI_NAME, user),
     piEmail: findPropertyValue(UserProperties.IS_THE_PI, user) === "true" ? user.email : findPropertyValue(UserProperties.PI_EMAIL, user),
     pubmedID: findPropertyValue(UserProperties.PUBMED_ID, user),
-    scientificURL: findPropertyValue(UserProperties.SCIENTIFIC_URL, user)
+    scientificURL: findPropertyValue(UserProperties.SCIENTIFIC_URL, user),
+    completed: findPropertyValue(UserProperties.COMPLETED, user)
   };
 
   return researcherProps;

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -233,8 +233,8 @@ class DataAccessRequestApplication extends Component {
     let completed = false;
     if (!fp.isNil(formData.darCode)) {
       completed = '';
-    } else if (rpProperties.completed !== '') {
-      completed = JSON.parse(rpProperties.completed);
+    } else if (isNil(rpProperties.completed) && rpProperties.completed !== '') {
+      completed = rpProperties.completed;
     }
     this.setState(prev => {
       prev.completed = completed;
@@ -1011,7 +1011,7 @@ class DataAccessRequestApplication extends Component {
               div({ className: 'dialog-description' },
                 ['Are you sure you want to save this Data Access Request? Previous changes will be overwritten.'])
             ]),
-            div({ isRendered: this.state.step === 1 }, [
+            div({ isRendered: this.state.step === 1 && (this.state.formData.researcher !== '') }, [ 
               h(ResearcherInfo, ({
                 checkCollaborator: checkCollaborator,
                 completed: this.state.completed,

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -233,7 +233,7 @@ class DataAccessRequestApplication extends Component {
     let completed = false;
     if (!fp.isNil(formData.darCode)) {
       completed = '';
-    } else if (!isNil(rpProperties.completed) && rpProperties.completed !== '') {
+    } else if (rpProperties.completed !== '') {
       completed = rpProperties.completed;
     }
     this.setState(prev => {

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -233,7 +233,7 @@ class DataAccessRequestApplication extends Component {
     let completed = false;
     if (!fp.isNil(formData.darCode)) {
       completed = '';
-    } else if (isNil(rpProperties.completed) && rpProperties.completed !== '') {
+    } else if (!isNil(rpProperties.completed) && rpProperties.completed !== '') {
       completed = rpProperties.completed;
     }
     this.setState(prev => {

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -1011,7 +1011,7 @@ class DataAccessRequestApplication extends Component {
               div({ className: 'dialog-description' },
                 ['Are you sure you want to save this Data Access Request? Previous changes will be overwritten.'])
             ]),
-            div({ isRendered: this.state.step === 1 && (this.state.formData.researcher !== '') }, [ 
+            div({ isRendered: this.state.step === 1 && (this.state.formData.researcher !== '') }, [
               h(ResearcherInfo, ({
                 checkCollaborator: checkCollaborator,
                 completed: this.state.completed,

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -509,7 +509,7 @@ class DataAccessRequestApplication extends Component {
             //if question is a checkbox acknowledgement and the question is active, check to see if box was left unchecked using translated key
           } else if((formDataKey === 'dsAcknowledgement' || formDataKey === 'gsoAcknowledgement' || formDataKey === 'pubAcknowledgement')) {
             return !this.state.formData[formDataKey];
-            //else check input directly
+          //else check input directly
           } else {
             return !input;
           }


### PR DESCRIPTION
## SCOPE:
- Remove getPropertiesByResearcherId call and instead use the properties on the already retrieved user from the getMe call

ADDRESSES:
https://broadworkbench.atlassian.net/browse/DUOS-1389

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
