### PR TITLE
DUOS-1137[risk=no] Added Researcher/Library Card Table to SO Console

### DIFF
--- a/src/components/SimpleButton.js
+++ b/src/components/SimpleButton.js
@@ -1,4 +1,4 @@
-import { div } from 'react-hyperscript-helpers';
+import { button } from 'react-hyperscript-helpers';
 import { useState, useEffect } from 'react';
 
 export default function SimpleButton(props) {
@@ -43,5 +43,5 @@ export default function SimpleButton(props) {
     return baseAttributes;
   };
 
-  return div(getDivAttributes(disabled), [label]);
+  return button(getDivAttributes(disabled), [label]);
 }

--- a/src/components/SimpleButton.js
+++ b/src/components/SimpleButton.js
@@ -2,7 +2,7 @@ import { button } from 'react-hyperscript-helpers';
 import { useState, useEffect } from 'react';
 
 export default function SimpleButton(props) {
-  const { onClick, label, disabled, baseColor, additionalStyle } = props;
+  const { onClick, label, disabled, baseColor, additionalStyle, keyProp } = props;
 
   const updateStyle = (backgroundColor, baseColor, additionalStyle = {}, pointerBool, disabled) => {
     const baseStyle = {
@@ -18,7 +18,7 @@ export default function SimpleButton(props) {
       cursor: pointerBool ? 'pointer' : 'default'
     };
 
-    const newStyle = Object.assign({}, additionalStyle, baseStyle);
+    const newStyle = Object.assign({}, baseStyle, additionalStyle);
     if (disabled) {
       newStyle.opacity = '0.5';
     }
@@ -34,6 +34,7 @@ export default function SimpleButton(props) {
   const getDivAttributes = (disabled) => {
     const baseAttributes = {
       style,
+      key: keyProp || `${label}-button`,
       onClick: () => !disabled && onClick(),
       onMouseEnter: () =>
         !disabled && updateStyle(baseColor, 'white', additionalStyle, true, disabled),

--- a/src/components/SimpleTable.js
+++ b/src/components/SimpleTable.js
@@ -24,15 +24,15 @@ const SkeletonLoader = ({columnRow, columnHeaders, baseStyle, tableSize}) => {
 };
 
 //Simple cell text display
-const SimpleTextCell = ({ text, style }) => {
+const SimpleTextCell = ({ text, style, keyProp }) => {
   text = isNil(text) ? '- -' : text;
-  return div({ style, role: 'cell' }, [text]);
+  return div({ style, role: 'cell', key: keyProp }, [text]);
 };
 
 //Simple cell text that carries onClick functionality
-const OnClickTextCell = ({ text, style, onClick }) => {
+const OnClickTextCell = ({ text, style, onClick, keyProp }) => {
   text = isNil(text) ? '- -' : text;
-  return div({ style, onClick, role: 'cell' }, [text]);
+  return div({ style, onClick, role: 'cell', key: keyProp }, [text]);
 };
 
 //Column component that renders the column row based on column headers
@@ -63,10 +63,10 @@ const DataRows = ({rowData, baseStyle, columnHeaders}) => {
           output = div({style: columnWidthStyle, key: `${!isNil(data) && !isNil(data.key) ? data.key : 'component-' + index + '-' + cellIndex}-container`}, [data]);
         //if there is no onClick function, render as simple cell
         } else if (isNil(onClick)) {
-          output = h(SimpleTextCell, { text: data, style: appliedStyle, key: `filtered-list-${id}-${label}`, cellIndex });
+          output = h(SimpleTextCell, { text: data, style: appliedStyle, keyProp: `filtered-list-${id}-${label}`, cellIndex });
         } else {
           //otherwise render as on click cell
-          output = h(OnClickTextCell, { text: data, style: appliedStyle, onClick: () => onClick(index), key: `filtered-list-${id}-${label}`, cellIndex });
+          output = h(OnClickTextCell, { text: data, style: appliedStyle, onClick: () => onClick(index), keyProp: `filtered-list-${id}-${label}`, cellIndex });
         }
         return output;
       }));

--- a/src/components/SimpleTable.js
+++ b/src/components/SimpleTable.js
@@ -26,19 +26,19 @@ const SkeletonLoader = ({columnRow, columnHeaders, baseStyle, tableSize}) => {
 //Simple cell text display
 const SimpleTextCell = ({ text, style }) => {
   text = isNil(text) ? '- -' : text;
-  return div({ style }, [text]);
+  return div({ style, role: 'cell' }, [text]);
 };
 
 //Simple cell text that carries onClick functionality
 const OnClickTextCell = ({ text, style, onClick }) => {
   text = isNil(text) ? '- -' : text;
-  return div({ style, onClick }, [text]);
+  return div({ style, onClick, role: 'cell' }, [text]);
 };
 
 //Column component that renders the column row based on column headers
 const ColumnRow = ({columnHeaders, baseStyle, columnStyle}) => {
   const rowStyle = Object.assign({}, baseStyle, columnStyle);
-  return div({style: rowStyle, key: `column-row-container`}, columnHeaders.map((header) => {
+  return div({style: rowStyle, key: `column-row-container`, role:'row'}, columnHeaders.map((header) => {
     const {cellStyle, label} = header;
     //style here pertains to styling for individual cells
     //should be used to set dimensions of specific columns
@@ -50,7 +50,7 @@ const ColumnRow = ({columnHeaders, baseStyle, columnStyle}) => {
 const DataRows = ({rowData, baseStyle, columnHeaders}) => {
   const rows = rowData.map((row, index) => {
     const id = rowData[index][0].id;
-    return div({style: Object.assign({border: '1px solid #f3f6f7'}, baseStyle), key: `row-data-${id}`},
+    return div({style: Object.assign({border: '1px solid #f3f6f7'}, baseStyle), key: `row-data-${id}`, role: 'row'},
       row.map(({data, style, onClick, isComponent, id, label}, cellIndex) => {
         let output;
         //columnHeaders determine width of the columns,
@@ -99,5 +99,5 @@ export default function SimpleTable(props) {
   const tableTemplate = [columnRow, h(DataRows, {rowData, baseStyle, columnHeaders})];
   const output = isLoading ? h(SkeletonLoader, {columnRow, columnHeaders, baseStyle, tableSize}) : tableTemplate;
 
-  return div({className: 'table-data', style: Styles.TABLE.CONTAINER}, [output, paginationBar]);
+  return div({className: 'table-data', style: Styles.TABLE.CONTAINER, role: 'table'}, [output, paginationBar]);
 }

--- a/src/components/SimpleTable.js
+++ b/src/components/SimpleTable.js
@@ -19,7 +19,6 @@ const SkeletonLoader = ({columnRow, columnHeaders, baseStyle, tableSize}) => {
     }
     return rowsSkeleton;
   };
-
   return rowTemplateArray(columnRow, columnHeaders);
 };
 
@@ -98,6 +97,5 @@ export default function SimpleTable(props) {
   const columnRow = h(ColumnRow, {key: 'column-row-container', columnHeaders, baseStyle, columnStyle});
   const tableTemplate = [columnRow, h(DataRows, {rowData, baseStyle, columnHeaders})];
   const output = isLoading ? h(SkeletonLoader, {columnRow, columnHeaders, baseStyle, tableSize}) : tableTemplate;
-
   return div({className: 'table-data', style: Styles.TABLE.CONTAINER, role: 'table'}, [output, paginationBar]);
 }

--- a/src/components/SimpleTable.js
+++ b/src/components/SimpleTable.js
@@ -60,7 +60,7 @@ const DataRows = ({rowData, baseStyle, columnHeaders}) => {
         //assume component is in hyperscript format
         //wrap component in dive with columnWidth applied
         if (isComponent) {
-          output = div({style: columnWidthStyle, key: `${!isNil(data) ? data.key : 'component-' + index + '-' + cellIndex}-container`}, [data]);
+          output = div({style: columnWidthStyle, key: `${!isNil(data) && !isNil(data.key) ? data.key : 'component-' + index + '-' + cellIndex}-container`}, [data]);
         //if there is no onClick function, render as simple cell
         } else if (isNil(onClick)) {
           output = h(SimpleTextCell, { text: data, style: appliedStyle, key: `filtered-list-${id}-${label}`, cellIndex });

--- a/src/components/library_card_table/LibraryCardTable.js
+++ b/src/components/library_card_table/LibraryCardTable.js
@@ -195,6 +195,7 @@ export default function LibraryCardTable(props) {
   ];
 
   //hook to recalculate visible table records when listed dependencies update
+  //NOTE: function moved to util, update implementation here
   useEffect(() => {
     const init = async () => {
       try {

--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -7,10 +7,7 @@ const ConfirmationModal = (props) => {
   const {showConfirmation, closeConfirmation, title, message, header, onConfirm} = props;
   const closeFn = () => closeConfirmation();
 
-  //id and index are optional parameters to onConfirm
-  //can use an onConfirm with no parameters
-  let confirmButton;
-  confirmButton = button({className: "cell-button hover-color", onClick: onConfirm}, ["Confirm"]);
+  const confirmButton = button({className: "cell-button hover-color", onClick: onConfirm}, ["Confirm"]);
 
   return h(Modal, {
     isOpen: showConfirmation,
@@ -21,9 +18,9 @@ const ConfirmationModal = (props) => {
   }, [
     div({style: Styles.MODAL.CONFIRMATION}, [
       h(CloseIconComponent, {closeFn}),
-      div({style: Styles.MODAL.DAR_SUBHEADER}, [`${header}`]),
-      div({style: Styles.MODAL.TITLE_HEADER}, [`${title}`]),
-      div({style: Styles.MODAL.DAR_DETAIL}, [`${message}`]),
+      div({style: Styles.MODAL.DAR_SUBHEADER}, [header]),
+      div({style: Styles.MODAL.TITLE_HEADER}, [title]),
+      div({style: Styles.MODAL.DAR_DETAIL}, [message]),
       div({style: {width: "40%", float: "right"}}, [
         div({style: {width: "45%", float: "left"}}, [
           button({className: "cell-button cancel-color", onClick: closeFn }, ["Cancel"])

--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -9,15 +9,9 @@ import Creatable from 'react-select/creatable';
 import SimpleButton from '../SimpleButton';
 import { Theme } from '../../libs/theme';
 
-//modal component, used to render row on modal
 const FormFieldRow = (props) => {
   const { card, dropdownOptions, updateInstitution, updateUser, modalType, setCard } = props;
-  // signing officials shouldn't be able to pick and choose from solutions
-  // front-end can hide the input by limiting dropdown options to less than two choices
-  // (as a way to impose conditional rendering without adding more prop variables)
-  // however back-end still needs to filter out institutionId
 
-  //NOTE: check if this works as expected
   const cardlessOptions = dropdownOptions.filter((option) => {
     const libraryCards = option.libraryCards || [];
     const savedCard = libraryCards.find(({institutionId}) => institutionId === card.institutionId);
@@ -87,7 +81,6 @@ const FormFieldRow = (props) => {
 
 export default function LibraryCardFormModal(props) {
   //NOTE: dropdown options need to be passed down from parent component
-  //fetch for all institutions needs to happen on component init
   const { showModal, updateOnClick, createOnClick, closeModal, institutions, users, modalType} = props;
 
   const [card, setCard] = useState(props.card);

--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -12,6 +12,10 @@ import { Theme } from '../../libs/theme';
 //modal component, used to render row on modal
 const FormFieldRow = (props) => {
   const { card, dropdownOptions, updateInstitution, updateUser, modalType } = props;
+  // signing officials shouldn't be able to pick and choose from solutions
+  // front-end can hide the input by limiting dropdown options to less than two choices
+  // (as a way to impose conditional rendering without adding more prop variables)
+  // however back-end still needs to filter out institutionId
   const [filteredDropdown, setFilteredDropdown] = useState(dropdownOptions);
   let template;
 
@@ -132,13 +136,16 @@ export default function LibraryCardFormModal(props) {
           modalType == 'add' ? 'Add Library Card' : 'Update Library Card',
         ]),
         div({ style: { borderBottom: '1px solid #1FB50' } }, []),
+        //users dropdown
         h(FormFieldRow, {
           card,
           modalType,
           updateUser,
           dropdownOptions: users,
         }),
+        //institution dropdown
         h(FormFieldRow, {
+          isRendered: institutions.length > 1,
           card,
           modalType,
           updateInstitution,

--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -16,7 +16,13 @@ const FormFieldRow = (props) => {
   // front-end can hide the input by limiting dropdown options to less than two choices
   // (as a way to impose conditional rendering without adding more prop variables)
   // however back-end still needs to filter out institutionId
-  const [filteredDropdown, setFilteredDropdown] = useState(dropdownOptions);
+
+  //NOTE: check if this works as expected
+  const cardlessOptions = dropdownOptions.filter(({libraryCards}) => {
+    const savedCard = libraryCards.find(({institutionId}) => institutionId === card.institutionId);
+    return isNil(savedCard);
+  });
+  const [filteredDropdown, setFilteredDropdown] = useState(cardlessOptions);
   let template;
 
   //filter function for users dropdown
@@ -82,6 +88,7 @@ export default function LibraryCardFormModal(props) {
   useEffect(() => {
     setCard(props.card);
   }, [props.card]);
+
 
   //onClick function, updates associated instituion on dropdown select
   const updateInstitution = (value) => {

--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -18,7 +18,8 @@ const FormFieldRow = (props) => {
   // however back-end still needs to filter out institutionId
 
   //NOTE: check if this works as expected
-  const cardlessOptions = dropdownOptions.filter(({libraryCards}) => {
+  const cardlessOptions = dropdownOptions.filter((option) => {
+    const libraryCards = option.libraryCards || [];
     const savedCard = libraryCards.find(({institutionId}) => institutionId === card.institutionId);
     return isNil(savedCard);
   });

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -115,7 +115,6 @@ const LibraryCardCell = ({
   return {
     isComponent: true,
     id,
-    style: {}, //need to figure out a base style
     label: 'lc-button',
     data: div(
       {
@@ -181,7 +180,6 @@ export default function SigningOfficialTable(props) {
   const [pageCount, setPageCount] = useState(1);
   const [filteredResearchers, setFilteredResearchers] = useState([]);
   const [visibleResearchers, setVisibleResearchers] = useState([]);
-  // const [signingOfficial, setSigningOfficial] = useState({});
   const [selectedCard, setSelectedCard] = useState({});
   const [showModal, setShowModal] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
@@ -290,7 +288,6 @@ export default function SigningOfficialTable(props) {
     setShowModal(true);
   };
 
-  //NOTE: make sure callback methods works as expected
   const issueLibraryCard = async (selectedCard, researchers) => {
     let messageName;
     try {
@@ -300,7 +297,7 @@ export default function SigningOfficialTable(props) {
       const {userEmail, userName, userId} = newLibraryCard;
       let targetIndex = findIndex((researcher) => userId === researcher.dacUserId)(listCopy);
       //library cards array should only have one card MAX (officials should not be able to see cards from other institutions)
-      if(targetIndex === -1) { //if card is not found, push new user to end of list
+      if(targetIndex === -1) { //if card is not found, push new user to top of list
         const targetUnregisteredResearcher = find((researcher) => userId === researcher.dacUserId)(props.unregisteredResearchers);
         const attributes = {
           email: userEmail,
@@ -326,7 +323,6 @@ export default function SigningOfficialTable(props) {
     }
   };
 
-  //NOTE: other callback method, make sure it works as expected
   const deactivateLibraryCard = async (selectedCard, researchers) => {
     const {id, userName, userEmail, userId} = selectedCard;
     const listCopy = cloneDeep(researchers);

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -313,7 +313,7 @@ export default function SigningOfficialTable(props) {
       const targetIndex = findIndex((researcher) => userId === researcher.dacUserId)(listCopy);
       //library cards array should only have one card MAX (officials should not be able to see cards from other institutions)
       if(targetIndex === -1) { //if card is not found, push new user to end of list
-        listCopy.unshift({userEmail, libraryCards: [newLibraryCard], roles: []});
+        listCopy.unshift({email: userEmail, libraryCards: [newLibraryCard], roles: []});
         messageName = userEmail;
       } else {
         listCopy[targetIndex].libraryCards = [newLibraryCard];

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -1,0 +1,66 @@
+import { useState, useEffect } from "react";
+import { cloneDeep, findIndex } from "lodash/fp";
+import { Notifications, USER_ROLES } from "../../libs/utils";
+import { User, LibraryCard } from "../../libs/ajax";
+import { Storage } from "../../libs/storage";
+
+export default function SigningOfficialTable(props) {
+  const [researchers, setResearchers] = useState([]);
+  const [signingOffiical, setSigningOfficial] = useState({});
+
+  //NOTE: for now mock out ajax calls so I can develop the console.
+  //The back-end code needs to be updated in a separate PR
+
+  useEffect(() => {
+    const init = async() => {
+      try {
+        //NOTE: for now mock this ajax call so that I can design the front-end
+        const researchers = await User.list(USER_ROLES.signingOfficial);
+        const signingOfficial = Storage.getCurrentUser();
+        setResearchers(researchers);
+        setSigningOfficial(signingOfficial);
+      } catch(error) {
+        Notifications.showError({text: 'Failed to initialie Signing Table Console'});
+      }
+    };
+    init();
+  }, []);
+
+  const issueNewLibraryCard = async (targetResearcher, researcherList) => {
+    const { eraCommonsId, dacUserId, displayName, email } = targetResearcher;
+    const { institutionId } = signingOffiical;
+    try {
+      const listCopy = cloneDeep(researcherList);
+      const newLibraryCard = LibraryCard.createLibraryCard({
+        institutionId,
+        eraCommonsId,
+        email,
+        userId: dacUserId,
+        userName: displayName
+      });
+
+      const targetIndex = findIndex((researcher) => targetResearcher.dacUserId === researcher.dacUserId)(researcherList);
+      //library cards array should only have one card MAX, SO should not be able to see LCs from other institutions
+      listCopy[targetIndex].libraryCards = [newLibraryCard];
+      setResearchers(listCopy);
+      Notifications.showSuccess({text: `Issued new library card to ${displayName}`});
+    } catch(error) {
+      Notifications.showError({text: `Error issuing library card to ${displayName}`});
+    }
+  };
+
+  const deleteLibraryCard = async (id, displayName, dacUserId, researcherList) => {
+    const listCopy = cloneDeep(researcherList);
+    try {
+      await LibraryCard.deleteLibraryCard(id);
+      const targetIndex = findIndex((researcher) => dacUserId === researcher.dacUserId)(researcherList);
+      listCopy[targetIndex].libraryCards = [];
+      setResearchers(listCopy);
+      Notifications.showSuccess({text: `Removed library card issued to ${displayName}`});
+    } catch(error) {
+      Notifications.showError({text: `Error deleting library card issued to ${displayName}`});
+    }
+  };
+
+  
+}

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -265,7 +265,7 @@ export default function SigningOfficialTable(props) {
 
   const processResearcherRowData = (researchers = []) => {
     return researchers.map(researcher => {
-      const {displayName, count = 0, roles, libraryCards} = researcher;
+      const {displayName, /*count = 0,*/ roles, libraryCards} = researcher;
       const libraryCard = !isEmpty(libraryCards) ? libraryCards[0] : {};
       const email = researcher.email || libraryCard.userEmail;
       const id = researcher.dacUserId;

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -1,8 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, Fragment } from "react";
 import { Styles } from "../../libs/theme";
-import { h, div, button } from "react-hyperscript-helpers";
+import { h, div, button, img } from "react-hyperscript-helpers";
+import lockIcon from '../../images/lock-icon.png';
 import { cloneDeep, findIndex, concat } from "lodash/fp";
+import SimpleTable from "../SimpleTable";
 import PaginationBar from "../PaginationBar";
+import SearchBar from "../SearchBar";
 import {
   Notifications,
   USER_ROLES,
@@ -147,6 +150,7 @@ export default function SigningOfficialTable(props) {
   const [newCard, setNewCard] = useState({});
   const [showModal, setShowModal] = useState(false);
   const searchRef = useRef('');
+  const [isLoading, setIsLoading] = useState(true);
 
   //NOTE: for now mock out ajax calls so I can develop the console.
   //The back-end code needs to be updated in a separate PR
@@ -159,10 +163,12 @@ export default function SigningOfficialTable(props) {
   }, [props.researchers, researchers]);
 
   useEffect(() => {
+    setIsLoading(true);
     recalculateVisibleTable(
       tableSize, pageCount, filteredResearchers, currentPage,
       setPageCount, setCurrentPage, setVisibleResearchers
     );
+    setIsLoading(false);
   }, [tableSize, pageCount, filteredResearchers, currentPage]);
 
   const paginationBar = h(PaginationBar, {
@@ -245,4 +251,34 @@ export default function SigningOfficialTable(props) {
       Notifications.showError({text: `Error deleting library card issued to ${displayName}`});
     }
   }, [researchers]);
+
+  return (
+    h(Fragment, {}, [
+      div({style: {display: 'flex', justifyContent: 'space-between'}}, [
+        div(
+          {className: 'left-header-section', style: Styles.LEFT_HEADER_SECTION},
+          [
+            div({style: Styles.ICON_CONTAINER}, [
+              img({
+                id: 'lock-icon',
+                src: lockIcon,
+                style: Styles.HEADER_IMG
+              }),
+            ]),
+            div({ style: Styles.HEADER_CONTAINER}, [
+              div({ style: Styles.TITLE}, ['Manage Researchers']),
+              div(
+                {style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '18px'})},
+                ["Manage your institution's researchers"]
+              )
+            ])
+          ]
+        ),
+        h(SearchBar, {handleSearchChange, searchRef}),
+      ]),
+      h(SimpleTable, {
+
+      })
+    ])
+  );
 }

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, Fragment } from "react";
 import { Styles, Theme } from "../../libs/theme";
 import { h, div, button } from "react-hyperscript-helpers";
-import { cloneDeep, findIndex, concat } from "lodash/fp";
+import { cloneDeep, findIndex, join, map, sortedUniq, sortBy, isEmpty, isNil, flow } from "lodash/fp";
 import SimpleTable from "../SimpleTable";
 import SimpleButton from "../SimpleButton";
 import PaginationBar from "../PaginationBar";
@@ -15,7 +15,6 @@ import {
 import LibraryCardFormModal from "../modals/LibraryCardFormModal";
 import ConfirmationModal from "../modals/ConfirmationModal";
 import { LibraryCard } from "../../libs/ajax";
-import { isEmpty, isNil } from "lodash";
 
 //Styles specific to this table
 const styles = {
@@ -123,8 +122,14 @@ const LibraryCardCell = ({
 };
 
 const roleCell = (roles, id) => {
-  const roleNames = roles.map(role => role.name);
-  const roleString = concat(roleNames);
+
+  const roleString = flow(
+    map(role => role.name),
+    sortBy((name) => name),
+    sortedUniq,
+    join(', ')
+  )(roles);
+
   return {
     data: roleString || '- -',
     id,

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -191,7 +191,7 @@ export default function SigningOfficialTable(props) {
   const [confirmationTitle, setConfirmationTitle] = useState('');
   const [confirmType, setConfirmType] = useState('delete');
 
-  const { signingOfficial } = props;
+  const { signingOfficial, unregisteredResearchers } = props;
 
   //Search function for SearchBar component, function defined in utils
   const handleSearchChange = tableSearchHandler(
@@ -396,7 +396,7 @@ export default function SigningOfficialTable(props) {
       createOnClick: (card) => issueLibraryCard(card, researchers),
       closeModal: () => setShowModal(false),
       card: selectedCard,
-      users: props.researchers,
+      users: unregisteredResearchers,
       institutions: [], //pass in empty array to force modal to hide institution dropdown
       modalType: 'add',
     }),

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -268,7 +268,7 @@ export default function SigningOfficialTable(props) {
       const {displayName, /*count = 0,*/ roles, libraryCards} = researcher;
       const libraryCard = !isEmpty(libraryCards) ? libraryCards[0] : {};
       const email = researcher.email || libraryCard.userEmail;
-      const id = researcher.dacUserId;
+      const id = researcher.dacUserId || email;
       return [
         displayNameCell(displayName, id),
         emailCell(email, id),

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -186,12 +186,10 @@ export default function SigningOfficialTable(props) {
   const [showModal, setShowModal] = useState(false);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const searchRef = useRef('');
-  const [isLoading, setIsLoading] = useState(true);
   const [confirmationModalMsg, setConfirmationModalMsg] = useState('');
   const [confirmationTitle, setConfirmationTitle] = useState('');
   const [confirmType, setConfirmType] = useState('delete');
-
-  const { signingOfficial, unregisteredResearchers } = props;
+  const { signingOfficial, unregisteredResearchers, isLoading } = props;
 
   //Search function for SearchBar component, function defined in utils
   const handleSearchChange = tableSearchHandler(
@@ -213,9 +211,7 @@ export default function SigningOfficialTable(props) {
   useEffect(() => {
     const init = async() => {
       try{
-        setIsLoading(true);
         setResearchers(props.researchers);
-        setIsLoading(false);
       } catch(error) {
         Notifications.showError({text: 'Failed to initialize researcher table'});
       }
@@ -231,7 +227,6 @@ export default function SigningOfficialTable(props) {
   }, [researchers]);
 
   useEffect(() => {
-    setIsLoading(true);
     recalculateVisibleTable({
       tableSize, pageCount,
       filteredList: filteredResearchers,
@@ -240,7 +235,6 @@ export default function SigningOfficialTable(props) {
       setCurrentPage,
       setVisibleList: setVisibleResearchers
     });
-    setIsLoading(false);
   }, [tableSize, pageCount, filteredResearchers, currentPage]);
 
   const goToPage = useCallback((value) => {
@@ -339,7 +333,7 @@ export default function SigningOfficialTable(props) {
         const card = researcher.libraryCards[0];
         return !isNil(card) && id === card.id;
       })(researchers);
-      if(isNil(userId)) {
+      if(isNil(userId) || researchers[targetIndex].institutionId !== signingOfficial.institutionId) {
         listCopy.splice(targetIndex, 1);
       } else {
         listCopy[targetIndex].libraryCards = [];

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -52,12 +52,17 @@ const DeactivateLibraryCardButton = (props) => {
   const {card = {}, showConfirmationModal} = props;
   const message = 'Are you sure you want to deactivate this library card?';
   const title = 'Deactivate Library Card';
-  return button({
-    key: `deactivate-card-${card.id}`,
-    role: 'button',
-    style: {}, //figure this out},
+  return h(SimpleButton, {
+    keyProp: `deactivate-card-${card.id}`,
+    label: 'Deactivate',
+    baseColor: Theme.palette.error,
+    additionalStyle: {
+      width: '30%',
+      padding: '2%',
+      fontSize: '1.45rem'
+    },
     onClick: () => showConfirmationModal({card, message, title, confirmType: 'delete'})
-  }, ['Deactivate']);
+  });
 };
 
 const IssueLibraryCardButton = (props) => {
@@ -67,11 +72,17 @@ const IssueLibraryCardButton = (props) => {
   const {card, showConfirmationModal} = props;
   const message = 'Are you sure you want to issue this library card?';
   const title = 'Issue Library Card';
-  return button({
-    role: 'button',
-    style: {},
-    onClick: () => showConfirmationModal({card, message, title, confirmType: 'issue'})
-  }, ['Issue']);
+  return h(SimpleButton, {
+    keyProp: `issue-card-${card.userEmail}`,
+    label: 'Issue',
+    baseColor: Theme.palette.secondary,
+    additionalStyle: {
+      width: '30%',
+      padding: '2%',
+      fontSize: '1.45rem',
+    },
+    onClick: () => showConfirmationModal({ card, message, title, confirmType: 'issue' }),
+  });
 };
 
 const researcherFilterFunction = getSearchFilterFunctions().signingOfficialResearchers;

--- a/src/components/signing_official_table/SigningOffiicalTable.js
+++ b/src/components/signing_official_table/SigningOffiicalTable.js
@@ -1,71 +1,237 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Styles } from "../../libs/theme";
 import { h, div, button } from "react-hyperscript-helpers";
-import { cloneDeep, findIndex } from "lodash/fp";
-import { Notifications, USER_ROLES } from "../../libs/utils";
+import { cloneDeep, findIndex, concat } from "lodash/fp";
+import PaginationBar from "../PaginationBar";
+import {
+  Notifications,
+  USER_ROLES,
+  tableSearchHandler,
+  recalculateVisibleTable,
+  getSearchFilterFunctions,
+  searchOnFilteredList,
+  goToPage,
+  changeTableSize
+} from "../../libs/utils";
 import { User, LibraryCard } from "../../libs/ajax";
-import { Storage } from "../../libs/storage";
-import { button } from "noty";
+import { isEmpty, isNil } from "lodash";
 
-const deactivateLibraryCard = (props) => {
-  const {deactivateLibraryCard} = props;
+//Styles specific to this table
+const styles = {
+  baseStyle: {
+    fontFamily: 'Arial',
+    fontSize: '14px',
+    fontWeight: 400,
+    display: 'flex',
+    padding: '1rem 2%',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  columnStyle: Object.assign({}, Styles.TABLE.HEADER_ROW, {
+    justifyContent: 'space-between',
+  }),
+  cellWidths: {
+    email: '25%',
+    name: '20%',
+    libraryCard: '25%',
+    role: '20%',
+    activeDARs: '10%'
+  },
+};
+
+//column header format for table
+const columnHeaderFormat = {
+  email: {label: 'Email', cellStyle: {width: styles.cellWidths.email}},
+  name: {label: 'Name', cellStyle: {width: styles.cellWidths.name}},
+  libraryCard: {label: 'Library Card', cellStyle: {width: styles.cellWidths.libraryCard}},
+  role: {label: 'Role', cellStyle: {width: styles.cellWidths.libraryCard}},
+  activeDARs: {label: 'Active DARs', cellStyle: {width: styles.cellWidths.activeDARs}}
+};
+
+const DeactivateLibraryCardButton = (props) => {
+  const {deactivateLibraryCard, id} = props;
   return button({
+    role: 'button',
     style: {}, //figure this out},
-    onClick: () => deactivateLibraryCard()
+    onClick: () => deactivateLibraryCard(id)
   }, ['Deactivate']);
-}
+};
+
+const IssueLibraryCardButton = (props) => {
+  //SO should be able to add library cards to users that are not yet in the system, so userEmail needs to be a possible value to send back
+  //username can be confirmed on back-end -> if userId exists pull data from db, otherwise only save email
+  //institution id should be determined from the logged in SO account on the back-end
+  const {issueLibraryCard, targetResearcher} = props;
+  return button({
+    role: 'button',
+    style: {},
+    onClick: () => issueLibraryCard(targetResearcher)
+  }, ['Issue']);
+};
+
+const researcherFilterFunction = getSearchFilterFunctions().signingOfficialResearchers;
 
 const LibraryCardCell = (props) => {
-  const {issueNewLibraryCard, deleteLibraryCard, card} = props;
-  return { 
-    
-  }
+  const {issueLibraryCard, deactivateLibraryCard, targetResearcher, card} = props;
+  const {id, userId} = card;
 
+  const button = !isNil(card) ? DeactivateLibraryCardButton({
+    deactivateLibraryCard,
+    id
+  }) : IssueLibraryCardButton({
+    issueLibraryCard,
+    targetResearcher
+  });
+
+  return {
+    isComponent: true,
+    id: userId,
+    style: {},//figure it out,
+    label: 'lc-button',
+    data: div({
+      style: {
+        display: 'flex',
+        justifyContent: 'left'
+      },
+      key: `lc-action-cell-${userId}`
+    }, [button])
+  };
+};
+
+const roleCell = (roles, id) => {
+  const roleNames = roles.map(role => role.name);
+  const roleString = concat(roleNames);
+  return {
+    data: roleString || '- -',
+    id,
+    style: {},
+    label: 'user-role'
+  };
+};
+
+const emailCell = (email, id) => {
+  return {
+    data: email || '- -',
+    id,
+    style: {},
+    label: 'user-email'
+  };
+};
+
+const displayNameCell = (displayName, id) => {
+  return {
+    data: displayName || '- -',
+    id,
+    style: {},
+    label: 'display-name'
+  };
+};
+
+const activeDarCountCell = (count, id) => {
+  return {
+    data: count || 0,
+    id,
+    style: {},
+    label: 'active-dar-count'
+  };
 };
 
 export default function SigningOfficialTable(props) {
   const [researchers, setResearchers] = useState([]);
+  const [tableSize, setTableSize] = useState(10);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
+  const [filteredResearchers, setFilteredResearchers] = useState([]);
+  const [visibleResearchers, setVisibleResearchers] = useState([]);
   const [signingOfficial, setSigningOfficial] = useState({});
+  const [newCard, setNewCard] = useState({});
+  const [showModal, setShowModal] = useState(false);
+  const searchRef = useRef('');
 
   //NOTE: for now mock out ajax calls so I can develop the console.
   //The back-end code needs to be updated in a separate PR
 
   useEffect(() => {
-    const init = async() => {
-      try {
-        //NOTE: for now mock this ajax call so that I can design the front-end
-        const researchers = await User.list(USER_ROLES.signingOfficial);
-        const signingOfficial = Storage.getCurrentUser();
-        setResearchers(researchers);
-        setSigningOfficial(signingOfficial);
-      } catch(error) {
-        Notifications.showError({text: 'Failed to initialie Signing Table Console'});
-      }
-    };
-    init();
-  }, []);
+    searchOnFilteredList(
+      searchRef.current.value, researchers,
+      researcherFilterFunction, setFilteredResearchers
+    );
+  }, [props.researchers, researchers]);
 
-  const issueNewLibraryCard = useCallback(async (targetResearcher) => {
-    const { eraCommonsId, dacUserId, displayName, email } = targetResearcher;
-    const { institutionId } = signingOfficial;
+  useEffect(() => {
+    recalculateVisibleTable(
+      tableSize, pageCount, filteredResearchers, currentPage,
+      setPageCount, setCurrentPage, setVisibleResearchers
+    );
+  }, [tableSize, pageCount, filteredResearchers, currentPage]);
+
+  const paginationBar = h(PaginationBar, {
+    pageCount,
+    currentPage,
+    tableSize,
+    goToPage,
+    changeTableSize
+  });
+
+  const processResearcherRowData = (researchers = []) => {
+    return researchers.map(researcher => {
+      const {id, email, displayName, count = 0, roles, libraryCards} = researcher;
+      return [
+        emailCell(email, id),
+        displayNameCell(displayName, id),
+        h(LibraryCardCell, {
+          issueLibraryCard,
+          deactivateLibraryCard,
+          targetResearcher: researcher,
+          card: isEmpty(libraryCards) ? {} : libraryCards[0]
+        }),
+        roleCell(roles, id),
+        activeDarCountCell(count, id)
+      ];
+    });
+  };
+
+  //Search function for SearchBar component, function defined in utils
+  const handleSearchChange = tableSearchHandler(
+    researchers,
+    setFilteredResearchers,
+    setCurrentPage,
+    'signingOfficialResearchers'
+  );
+
+  const showModalOnClick = () => {
+    setShowModal(true);
+  };
+
+  const issueLibraryCard = useCallback(async (targetResearcher) => {
+    const { dacUserId } = targetResearcher;
+    let { email, displayName } = targetResearcher;
+    let messageName;
     try {
       const listCopy = cloneDeep(researchers);
-      const newLibraryCard = LibraryCard.createLibraryCard({
-        institutionId,
-        eraCommonsId,
-        email,
-        userId: dacUserId,
-        userName: displayName
+      //NOTE: institution_id and userName can be supplied by the back-end
+      const newLibraryCard = await LibraryCard.createLibraryCard({
+        userEmail: email,
+        userId: dacUserId
       });
+      displayName = newLibraryCard.displayName;
+      email = newLibraryCard.email;
 
       const targetIndex = findIndex((researcher) => targetResearcher.dacUserId === researcher.dacUserId)(listCopy);
       //library cards array should only have one card MAX, SO should not be able to see LCs from other institutions
-      listCopy[targetIndex].libraryCards = [newLibraryCard];
+      if(targetIndex === -1) { //if card is not found, push new card to end of list
+        listCopy.push({email, libraryCards: [newLibraryCard]});
+        messageName = email;
+      } else {
+        listCopy[targetIndex].libraryCards = [newLibraryCard];
+        messageName = displayName;
+      }
       setResearchers(listCopy);
-      Notifications.showSuccess({text: `Issued new library card to ${displayName}`});
+      Notifications.showSuccess({text: `Issued new library card to ${messageName}`});
     } catch(error) {
-      Notifications.showError({text: `Error issuing library card to ${displayName}`});
+      Notifications.showError({text: `Error issuing library card to ${messageName}`});
     }
-  }, [signingOfficial, researchers]);
+  }, [researchers]);
 
   const deactivateLibraryCard = useCallback(async (id, displayName, dacUserId) => {
     const listCopy = cloneDeep(researchers);

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -926,6 +926,11 @@ export const User = {
     const url = `${await Config.getApiUrl()}/api/user/signing-officials`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'GET' }]));
     return res.json();
+  },
+  getUnassignedUsers: async () => {
+    const url = `${await Config.getApiUrl()}/api/user/institution/unassigned`;
+    const res = await axios.get(url, Config.authOpts());
+    return res.data;
   }
 
 };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -428,9 +428,9 @@ export const getSearchFilterFunctions = () => {
         includes(term, toLower(eraCommonsId));
     }, targetList),
     signingOfficialResearchers: (term, targetList) => filter(researcher => {
-      const { displayName, eraCommonsId, email, roles } = researcher;
+      const { displayName, eraCommonsId, email } = researcher;
+      const roles = researcher.roles || [];
       const baseAttributes = [displayName, eraCommonsId, email];
-
       const includesRoles = roles.reduce((memo, current) => {
         const roleName = current.name;
         return memo || includes(term, toLower(roleName));

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -583,15 +583,19 @@ export const searchOnFilteredList = (searchTerms, originalList, filterFn, setFil
   setFilteredList(filteredList);
 };
 
-const goToPage = (value, setCurrentPage, pageCount) => {
-  if(value >= 1 && value <= pageCount) {
-    setCurrentPage(value);
-  }
+export const goToPageCallback = (setCurrentPage, pageCount) => {
+  return (value) => {
+    if(value >= 1 && value <= pageCount) {
+      setCurrentPage(value);
+    }
+  };
 };
 
-const changeTableSize = (value, setTableSize) => {
-  if (value > 0 && !isNaN(parseInt(value))) {
-    setTableSize(value);
-  }
+export const changeTableSize = (setTableSize) => {
+  return (value) => {
+    if (value > 0 && !isNaN(parseInt(value))) {
+      setTableSize(value);
+    }
+  };
 };
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -430,10 +430,16 @@ export const getSearchFilterFunctions = () => {
     signingOfficialResearchers: (term, targetList) => filter(researcher => {
       const { userName, createDate, updateDate, eraCommonsId, userEmail, roles } = researcher;
       const baseAttributes = [userName, createDate, updateDate, eraCommonsId, userEmail];
-      const reduceCallback = (memo, current) => memo || includes(toLower(current), term);
 
-      const includesRoles = reduce(reduceCallback)(roles);
-      const includesBaseAttributes = reduce(reduceCallback)(baseAttributes);
+      const includesRoles = reduce((memo, current) => {
+        const roleName = current.name;
+        return memo || includes(toLower(roleName), term);
+      })(roles);
+
+      const includesBaseAttributes = reduce((memo, current) =>
+        memo || includes(toLower(current), term)
+      )(baseAttributes);
+
       return includesRoles || includesBaseAttributes;
     })(targetList)
   };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -556,3 +556,42 @@ export const getColumnSort = (getList, callback) => {
     callback(sortedData, descendantOrder);
   };
 };
+
+//Functions that are commonly used between tables//
+export const recalculateVisibleTable = async (tableSize, pageCount, filteredList, currentPage, setPageCount, setCurrentPage, setVisibleList ) => {
+  try {
+    setPageCount(calcTablePageCount(tableSize, filteredList));
+    if (currentPage > pageCount) {
+      setCurrentPage(pageCount);
+    }
+    const visibleList = calcVisibleWindow(
+      currentPage,
+      tableSize,
+      filteredList
+    );
+    setVisibleList(visibleList);
+  } catch (error) {
+    Notifications.showError({ text: 'Error updating Library Card table' });
+  }
+};
+
+export const searchOnFilteredList = (searchTerms, originalList, filterFn, setFilteredList) => {
+  let filteredList = originalList;
+  if(!isEmpty(searchTerms)) {
+    filteredList = filterFn(searchTerms, originalList);
+  }
+  setFilteredList(filteredList);
+};
+
+const goToPage = (value, setCurrentPage, pageCount) => {
+  if(value >= 1 && value <= pageCount) {
+    setCurrentPage(value);
+  }
+};
+
+const changeTableSize = (value, setTableSize) => {
+  if (value > 0 && !isNaN(parseInt(value))) {
+    setTableSize(value);
+  }
+};
+

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -558,7 +558,9 @@ export const getColumnSort = (getList, callback) => {
 };
 
 //Functions that are commonly used between tables//
-export const recalculateVisibleTable = async (tableSize, pageCount, filteredList, currentPage, setPageCount, setCurrentPage, setVisibleList ) => {
+export const recalculateVisibleTable = async ({
+  tableSize, pageCount, filteredList, currentPage, setPageCount, setCurrentPage, setVisibleList
+}) => {
   try {
     setPageCount(calcTablePageCount(tableSize, filteredList));
     if (currentPage > pageCount) {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -4,7 +4,7 @@ import 'noty/lib/themes/bootstrap-v3.css';
 import { forEach } from 'lodash';
 import { DAR, DataSet } from "./ajax";
 import {Theme, Styles } from "./theme";
-import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq } from "lodash/fp";
+import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq, reduce } from "lodash/fp";
 import _ from 'lodash';
 import {User} from "./ajax";
 
@@ -426,7 +426,16 @@ export const getSearchFilterFunctions = () => {
         includes(term, formatDate(updateDate)) ||
         includes(term, toLower(userEmail)) ||
         includes(term, toLower(eraCommonsId));
-    }, targetList)
+    }, targetList),
+    signingOfficialResearchers: (term, targetList) => filter(researcher => {
+      const { userName, createDate, updateDate, eraCommonsId, userEmail, roles } = researcher;
+      const baseAttributes = [userName, createDate, updateDate, eraCommonsId, userEmail];
+      const reduceCallback = (memo, current) => memo || includes(toLower(current), term);
+
+      const includesRoles = reduce(reduceCallback)(roles);
+      const includesBaseAttributes = reduce(reduceCallback)(baseAttributes);
+      return includesRoles || includesBaseAttributes;
+    })(targetList)
   };
 };
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -583,19 +583,3 @@ export const searchOnFilteredList = (searchTerms, originalList, filterFn, setFil
   setFilteredList(filteredList);
 };
 
-export const goToPageCallback = (setCurrentPage, pageCount) => {
-  return (value) => {
-    if(value >= 1 && value <= pageCount) {
-      setCurrentPage(value);
-    }
-  };
-};
-
-export const changeTableSize = (setTableSize) => {
-  return (value) => {
-    if (value > 0 && !isNaN(parseInt(value))) {
-      setTableSize(value);
-    }
-  };
-};
-

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -4,7 +4,7 @@ import 'noty/lib/themes/bootstrap-v3.css';
 import { forEach } from 'lodash';
 import { DAR, DataSet } from "./ajax";
 import {Theme, Styles } from "./theme";
-import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq, reduce } from "lodash/fp";
+import { find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq} from "lodash/fp";
 import _ from 'lodash';
 import {User} from "./ajax";
 
@@ -428,17 +428,18 @@ export const getSearchFilterFunctions = () => {
         includes(term, toLower(eraCommonsId));
     }, targetList),
     signingOfficialResearchers: (term, targetList) => filter(researcher => {
-      const { userName, createDate, updateDate, eraCommonsId, userEmail, roles } = researcher;
-      const baseAttributes = [userName, createDate, updateDate, eraCommonsId, userEmail];
+      const { displayName, eraCommonsId, email, roles } = researcher;
+      const baseAttributes = [displayName, eraCommonsId, email];
 
-      const includesRoles = reduce((memo, current) => {
+      const includesRoles = roles.reduce((memo, current) => {
         const roleName = current.name;
-        return memo || includes(toLower(roleName), term);
-      })(roles);
+        return memo || includes(term, toLower(roleName));
+      }, false);
 
-      const includesBaseAttributes = reduce((memo, current) =>
-        memo || includes(toLower(current), term)
-      )(baseAttributes);
+      const includesBaseAttributes = baseAttributes.reduce(
+        (memo, current) => {
+          return memo || includes(term, toLower(current));
+        }, false);
 
       return includesRoles || includesBaseAttributes;
     })(targetList)

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -3,6 +3,7 @@ import {useEffect} from "react";
 import {Notifications} from "../libs/utils";
 import {div, a, h} from "react-hyperscript-helpers";
 import {Styles} from "../libs/theme";
+import SigningOfficialTable from "../components/signing_official_table/SigningOffiicalTable";
 import DarTableSkeletonLoader from "../components/TableSkeletonLoader";
 import {tableHeaderTemplate} from "../components/dar_table/DarTable";
 import {tableRowLoadingTemplate} from "../components/dar_table/DarTable";
@@ -31,36 +32,6 @@ export default function SigningOfficialConsole() {
   //could benefit in moving this to utils or a shared component so it can be used for the adminManageUsers page
   const widerColumnStyle = assign(Styles.TABLE.DATASET_CELL, {margin: '1rem 2%'});
   const regWidthColumnStyle = assign(Styles.TABLE.SUBMISSION_DATE_CELL, {margin: '1rem 2%'});
-  const userTableHeaderTemplate = [
-    div({style: widerColumnStyle, className: 'cell-sort'}, [
-      "Name",
-      span({ className: 'glyphicon sort-icon glyphicon-sort' })
-    ]),
-    div({style: widerColumnStyle, className: 'cell-sort'}, [
-      "Email",
-      span({ className: 'glyphicon sort-icon glyphicon-sort' })
-    ]),
-    div({style: widerColumnStyle, className: 'cell-sort'}, [
-      "Library Card",
-      span({ className: 'glyphicon sort-icon glyphicon-sort' })
-    ]),
-    div({style: regWidthColumnStyle, className: 'cell-sort'}, [
-      "Role",
-      span({ className: 'glyphicon sort-icon glyphicon-sort' })
-    ]),
-    div({style: regWidthColumnStyle, className: 'cell-sort'}, [
-      "Active DARs",
-      span({ className: 'glyphicon sort-icon glyphicon-sort' })
-    ])
-  ];
-
-  const userTableRowLoadingTemplate = [
-    div({style: widerColumnStyle, className: 'text-placeholder'}),
-    div({style: widerColumnStyle, className: 'text-placeholder'}),
-    div({style: widerColumnStyle, className: 'text-placeholder'}),
-    div({style: regWidthColumnStyle, className: 'text-placeholder'}),
-    div({style: regWidthColumnStyle, className: 'text-placeholder'})
-  ];
 
   useEffect(() => {
     const init = async() => {
@@ -121,8 +92,7 @@ export default function SigningOfficialConsole() {
         }, ["Add Researcher(s)"]),
       ]),
       //researcher table goes here
-      h(DarTableSkeletonLoader, {isRendered: isLoading, tableHeaderTemplate: userTableHeaderTemplate, tableRowLoadingTemplate: userTableRowLoadingTemplate}),
-
+      h(SigningOfficialTable, {}, []),
       div({style: {display: 'flex', justifyContent: "space-between"}}, [
         div({className: "left-header-section", style: Styles.LEFT_HEADER_SECTION}, [
           div({style: Styles.ICON_CONTAINER}, [

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -10,10 +10,8 @@ import {tableRowLoadingTemplate} from "../components/dar_table/DarTable";
 import {User} from "../libs/ajax";
 import {img} from "react-hyperscript-helpers";
 import lockIcon from "../images/lock-icon.png";
-import userIcon from "../images/icon_manage_users.png";
 import SearchBar from "../components/SearchBar";
 import {darSearchHandler} from "../libs/utils";
-import {userSearchHandler} from "../libs/utils";
 import { USER_ROLES } from "../libs/utils";
 
 export default function SigningOfficialConsole() {
@@ -23,10 +21,8 @@ export default function SigningOfficialConsole() {
   const [darList,] = useState();
   const [setFilteredDarList] = useState();
   const [setCurrentDarPage] = useState();
+  const [unregisteredResearchers, setUnregisteredResearchers] = useState();
   //states to be added and used for manage researcher component
-  const [userList,] = useState();
-  const [setFilteredUserList] = useState();
-  const [setCurrentUserPage] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -35,6 +31,8 @@ export default function SigningOfficialConsole() {
         setIsLoading(true);
         const soUser = await User.getMe();
         const researcherList = await User.list(USER_ROLES.signingOfficial);
+        const unregisteredResearchers = await User.getUnassignedUsers();
+        setUnregisteredResearchers(unregisteredResearchers);
         setResearchers(researcherList);
         setSiginingOfficial(soUser);
         setIsLoading(false);
@@ -47,7 +45,6 @@ export default function SigningOfficialConsole() {
   }, []);
 
   const handleSearchChangeDars = darSearchHandler(darList, setFilteredDarList, setCurrentDarPage);
-  const handleSearchChangeUsers = userSearchHandler(userList, setFilteredUserList, setCurrentUserPage);
 
   return (
     div({style: Styles.PAGE}, [
@@ -67,7 +64,7 @@ export default function SigningOfficialConsole() {
       ]),
       div({style: {borderTop: '1px solid #BABEC1', height: 0}}, []),
       //researcher table goes here
-      h(SigningOfficialTable, {researchers, signingOfficial}, []),
+      h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers}, []),
       div({style: {display: 'flex', justifyContent: "space-between"}}, [
         div({className: "left-header-section", style: Styles.LEFT_HEADER_SECTION}, [
           div({style: Styles.ICON_CONTAINER}, [

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -30,8 +30,12 @@ export default function SigningOfficialConsole() {
       try {
         setIsLoading(true);
         const soUser = await User.getMe();
-        const researcherList = await User.list(USER_ROLES.signingOfficial);
-        const unregisteredResearchers = await User.getUnassignedUsers();
+        const soPromises = await Promise.all([
+          User.list(USER_ROLES.signingOfficial),
+          User.getUnassignedUsers()
+        ]);
+        const researcherList = soPromises[0];
+        const unregisteredResearchers = soPromises[1];
         setUnregisteredResearchers(unregisteredResearchers);
         setResearchers(researcherList);
         setSiginingOfficial(soUser);
@@ -64,7 +68,7 @@ export default function SigningOfficialConsole() {
       ]),
       div({style: {borderTop: '1px solid #BABEC1', height: 0}}, []),
       //researcher table goes here
-      h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers}, []),
+      h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
       div({style: {display: 'flex', justifyContent: "space-between"}}, [
         div({className: "left-header-section", style: Styles.LEFT_HEADER_SECTION}, [
           div({style: Styles.ICON_CONTAINER}, [

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -14,11 +14,11 @@ import userIcon from "../images/icon_manage_users.png";
 import SearchBar from "../components/SearchBar";
 import {darSearchHandler} from "../libs/utils";
 import {userSearchHandler} from "../libs/utils";
-import {assign} from "lodash/fp";
-import {span} from "react-hyperscript-helpers";
+import { USER_ROLES } from "../libs/utils";
 
 export default function SigningOfficialConsole() {
-  const [signingOfficial, setSiginingOfficial] = useState();
+  const [signingOfficial, setSiginingOfficial] = useState({});
+  const [researchers, setResearchers] = useState([]);
   //states to be added and used for the manage dar component
   const [darList,] = useState();
   const [setFilteredDarList] = useState();
@@ -29,16 +29,14 @@ export default function SigningOfficialConsole() {
   const [setCurrentUserPage] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
-  //could benefit in moving this to utils or a shared component so it can be used for the adminManageUsers page
-  const widerColumnStyle = assign(Styles.TABLE.DATASET_CELL, {margin: '1rem 2%'});
-  const regWidthColumnStyle = assign(Styles.TABLE.SUBMISSION_DATE_CELL, {margin: '1rem 2%'});
-
   useEffect(() => {
     const init = async() => {
       try {
         setIsLoading(true);
         const soUser = await User.getMe();
-        setSiginingOfficial(soUser.displayName);
+        const researcherList = await User.list(USER_ROLES.signingOfficial);
+        setResearchers(researcherList);
+        setSiginingOfficial(soUser);
         setIsLoading(false);
       } catch(error) {
         Notifications.showError({text: 'Error: Unable to retrieve current user from server'});
@@ -55,7 +53,7 @@ export default function SigningOfficialConsole() {
     div({style: Styles.PAGE}, [
       div({ isRendered: !isLoading, style: {display: "flex"}}, [
         div({style: {...Styles.HEADER_CONTAINER, paddingTop: "3rem", paddingBottom: "2rem"}}, [
-          div({style: Styles.TITLE}, ["Welcome " +signingOfficial+ "!"]),
+          div({style: Styles.TITLE}, ["Welcome " +signingOfficial.displayName+ "!"]),
           div({style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '18px'})}, [
             "Your researchers and their submitted Data Access requests are below. ",
             a({
@@ -92,7 +90,7 @@ export default function SigningOfficialConsole() {
         }, ["Add Researcher(s)"]),
       ]),
       //researcher table goes here
-      h(SigningOfficialTable, {}, []),
+      h(SigningOfficialTable, {researchers, signingOfficial}, []),
       div({style: {display: 'flex', justifyContent: "space-between"}}, [
         div({className: "left-header-section", style: Styles.LEFT_HEADER_SECTION}, [
           div({style: Styles.ICON_CONTAINER}, [

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -66,29 +66,6 @@ export default function SigningOfficialConsole() {
         ])
       ]),
       div({style: {borderTop: '1px solid #BABEC1', height: 0}}, []),
-      div({style: {display: 'flex',justifyContent: "space-between"}}, [
-        div({ style: Styles.LEFT_HEADER_SECTION}, [
-          div({style: {... Styles.ICON_CONTAINER, textAlign: "center"}}, [
-            img({
-              id: 'user-icon',
-              src: userIcon
-            })
-          ]),
-          div({style: Styles.HEADER_CONTAINER}, [
-            div({style: {...Styles.SUB_HEADER, marginTop: '0'}}, ["Researchers"]),
-            div({style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '16px'})}, [
-              "My Institution's Researchers. Issue or Remove Researcher privileges below.",
-            ])
-          ])
-        ]),
-        h(SearchBar, {handleSearchChange: handleSearchChangeUsers}),
-        a({
-          id: 'btn_addUser',
-          className: "btn-primary btn-add common-background",
-          style: {marginTop: '4.75rem'}
-          //onClick: this.addUser
-        }, ["Add Researcher(s)"]),
-      ]),
       //researcher table goes here
       h(SigningOfficialTable, {researchers, signingOfficial}, []),
       div({style: {display: 'flex', justifyContent: "space-between"}}, [


### PR DESCRIPTION
Front-end portion of [DUOS-1137](https://broadworkbench.atlassian.net/browse/DUOS-1137)

PR adds the researcher table to the SO console, allowing SO to create and deactivate library cards for users (or yet to join users) within an institution.

**NOTE:** Certain features are missing and/or not functional due to necessary changes on the back-end, which will be made as a separate PR on Consent. Some of these changes include alterations to how Library Cards are created and destroyed, the alteration of SO User list fetch so that it returns partially empty User models for library cards that are tied to yet-to-join users, and a query that can calculate a User's Active DAR count. 

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
