### PR TITLE
[DUOS-1236][risk=no] Update builder image and readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:14.17.4 AS builder
+FROM node:16.6.2-slim AS builder
 LABEL maintainer="grushton@broadinstitute.org"
 
 # set working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# base image
+# builder image
 FROM node:16.6.2-slim AS builder
 LABEL maintainer="grushton@broadinstitute.org"
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The Data Use Oversight system ensures that researchers using genomics data honor
 
 Deployments are currently run in CircleCI.
 
-1. We use node@15 On Darwin with Homebrew:
+1. We use node@16 On Darwin with Homebrew:
 
 ```
-brew install node@15
+brew install node@16
 ```
 2. Update npm:
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1236

Tested locally by building and running locally against dev configs 👍🏽 
```
docker build . -t duos
docker run -v ${PWD}/public/config.json:/usr/share/nginx/html/config.json:ro -p 80:8080 duos:latest
```

Double checking the new image:
```
➜  duos-ui git:(DUOS-1236) ✗ docker images
REPOSITORY                                TAG                 IMAGE ID       CREATED          SIZE
duos                                      latest              f7494733d1f3   6 seconds ago    49MB
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
