### PR TITLE
[DUOS-1435][risk=no] Delay Dependabot PRs

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,6 +6,20 @@ jobs:
     steps:
       - name: Log Actor
         run: echo "${{ github.actor }}"
+
+      # For all dependabot PRs, add a sleep time from 0-9 minutes to reduce
+      # the contention on pulling repo secrets from multiple, simultaneous PRs
+      - name: Calculate Sleep if Dependabot
+        id: sleep
+        if: github.actor == 'dependabot[bot]'
+        shell: bash
+        run: echo "::set-output name=minutes::$(($GITHUB_RUN_NUMBER % 10))"
+      - name: Sleep if Dependabot
+        if: github.actor == 'dependabot[bot]'
+        uses: whatnick/wait-action@master
+        with:
+          time: '${{ steps.sleep.outputs.minutes }}m'
+
       - name: Checkout
         uses: actions/checkout@v2
       - name: NPM Install


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1435

Add a sleep to the automation tests for Dependabot PRs so they don't fail when pulling secrets.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
