### PR TITLE
[DUOS-296][risk=no] Stop building/deploying to deprecated cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,28 +101,6 @@ commands:
             kubectl rollout status deployment/${APPLICATION_NAME}
 
 jobs:
-  build-dev:
-    executor: cypress
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - cache-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
-      - run: cp config/base_config.json public/config.json
-      - run: npm install --silent
-      - run: npm install react-scripts --silent
-      - run:
-          name: build
-          command: CI=false npm run build
-          environment:
-            NODE_OPTIONS: --max-old-space-size=5120
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .gcloudignore
-            - build
-            - config
-            - Dockerfile
   build-staging:
     executor: cypress
     steps:
@@ -146,27 +124,6 @@ jobs:
             - config
             - Dockerfile
 
-  deploy-dev:
-    executor: cloud-sdk
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - cache-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}-{{ arch }}
-      - attach_workspace:
-          at: .
-      - push-env:
-          sa_key_name: 'GCLOUD_DUOS_DEV'
-          application_name: 'duos'
-          google_project: 'broad-duos-dev'
-      - deploy-env:
-          sa_key_name: 'GCLOUD_DUOS_DEV'
-          namespace: 'duos'
-          application_name: 'duos'
-          google_project: 'broad-duos-dev'
-          google_zone: 'us-central1-a'
-          google_cluster: 'duos-ui-dev-cluster'
-          commit: ${COMMIT}
   deploy-staging:
     executor: cloud-sdk
     steps:
@@ -202,16 +159,6 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build-dev:
-          filters:
-            branches:
-              only: /.*/
-      - deploy-dev:
-          requires:
-            - build-dev
-          filters:
-            branches:
-              only: develop
       - build-staging:
           filters:
             tags:


### PR DESCRIPTION
## Addresses

Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-296

We're migrating from the current dev cluster to a terra dev cluster. This PR turns off the build/deploy to the cluster in the older project so we can be focused on the new one.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
