### PR TITLE
DUOS-1439[risk=no] Bugfix for OpenConfirmation function on Chair Console

### DIFF
--- a/src/components/dar_table/DarTable.js
+++ b/src/components/dar_table/DarTable.js
@@ -169,9 +169,10 @@ export default function DarTable(props) {
 
   const openConfirmation = useCallback((dar, index) => {
     const darData = dar.data;
+    const id = dar.referenceId;
     if (!isNil(darData)) {
       setShowConfirmation(true);
-      setCreateElectionInfo({id: darData.referenceId, name: darData.darCode, index});
+      setCreateElectionInfo({id, name: darData.darCode, index});
     } else {
       Notifications.showError({text:"Cannot open this election. Please contact us for support."});
     }


### PR DESCRIPTION
Addresses [DUOS-1439](https://broadworkbench.atlassian.net/browse/DUOS-1439)

PR changes referenceId value on `openConfirmation` so that it accesses the up to date value on the dar itself rather than the out-of-date value on `dar.data` (which would have the same value across multi-dataset DARs).

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
