### PR TITLE
DUOS=1428 [risk=no] Added isNil check to ResearcherProfile helper method

### DIFF
--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -363,7 +363,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   cleanObject = (obj) => {
     // Removes any zero length properties from a copy of the object
-    return omitBy(obj, (s) => { return trim(s.toString()).length === 0; });
+    return omitBy(obj, (s) => { return isNil(s) || trim(s.toString()).length === 0; });
   };
 
   saveProperties = async (profile) => {


### PR DESCRIPTION
Addresses [DUOS-1428](https://broadworkbench.atlassian.net/browse/DUOS-1428)

Code adds an isNil check on a helper method to prevent `ResearcherProfile` from erroring out on undefined attributes.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
