### PR TITLE
DUOS-1438[risk=no] Add Demoable Data Custodian Subsection to SO Console

### DIFF
--- a/src/components/SelectableText.js
+++ b/src/components/SelectableText.js
@@ -1,0 +1,51 @@
+import { useState, useEffect, useMemo } from "react";
+import { div } from "react-hyperscript-helpers";
+
+const getSelectedTabStyle = (style) => {
+  const { color } = style;
+  return Object.assign({}, style, {
+    borderBottom: `3px solid ${color}`,
+    fontWeight: 400,
+  });
+};
+
+export default function SelectableText(props) {
+  const { label, color, componentType, setSelected, selectedType, fontSize } = props;
+  const baseStyle = useMemo(() => {
+    return {
+      fontSize,
+      fontWeight: 400,
+      borderBottom: '0px',
+      marginRight: '2rem',
+      color,
+    };
+  }, [color, fontSize]);
+
+
+  const [style, setStyle] = useState(baseStyle);
+
+  useEffect(() => {
+    selectedType === componentType ? setStyle(getSelectedTabStyle(baseStyle)) : setStyle(baseStyle);
+  }, [baseStyle, componentType, selectedType]);
+
+  const addHoverEffect = () => {
+    const hoverStyle = { fontWeight: 600, cursor: 'pointer' };
+    const updatedStyle = Object.assign({}, style, hoverStyle);
+    setStyle(updatedStyle);
+  };;
+
+  const removeHoverEffect = () => {
+    const standardStyle = { fontWeight: 400, cursor: 'default' };
+    const updatedStyle = Object.assign({}, style, standardStyle);
+    setStyle(updatedStyle);
+  };
+
+  return(
+    div({
+      style,
+      onMouseEnter: addHoverEffect,
+      onMouseLeave: removeHoverEffect,
+      onClick: () => setSelected(componentType)
+    }, [label])
+  );
+}

--- a/src/components/SelectableText.js
+++ b/src/components/SelectableText.js
@@ -32,7 +32,7 @@ export default function SelectableText(props) {
     const hoverStyle = { fontWeight: 600, cursor: 'pointer' };
     const updatedStyle = Object.assign({}, style, hoverStyle);
     setStyle(updatedStyle);
-  };;
+  };
 
   const removeHoverEffect = () => {
     const standardStyle = { fontWeight: 400, cursor: 'default' };

--- a/src/components/data_custodian_table/DataCustodianTable.js
+++ b/src/components/data_custodian_table/DataCustodianTable.js
@@ -1,0 +1,427 @@
+import { useState, useEffect, useCallback, useRef, Fragment } from "react";
+import { Styles, Theme } from "../../libs/theme";
+import { h, div, img } from "react-hyperscript-helpers";
+import userIcon from '../../images/icon_manage_users.png';
+import { cloneDeep, find, findIndex, join, map, sortedUniq, sortBy, isEmpty, isNil, flow } from "lodash/fp";
+import SimpleTable from "../SimpleTable";
+import SimpleButton from "../SimpleButton";
+import PaginationBar from "../PaginationBar";
+import SearchBar from "../SearchBar";
+import {
+  Notifications,
+  tableSearchHandler,
+  recalculateVisibleTable,
+  getSearchFilterFunctions,
+  searchOnFilteredList
+} from "../../libs/utils";
+import LibraryCardFormModal from "../modals/LibraryCardFormModal";
+import ConfirmationModal from "../modals/ConfirmationModal";
+
+//NOTE: make sure the new 'custodian' model works 
+
+//Styles specific to this table
+const styles = {
+  baseStyle: {
+    fontFamily: 'Arial',
+    fontSize: '14px',
+    fontWeight: 400,
+    display: 'flex',
+    padding: '1rem 2%',
+    justifyContent: 'space-between',
+    alignItems: 'center'
+  },
+  columnStyle: Object.assign({}, Styles.TABLE.HEADER_ROW, {
+    justifyContent: 'space-between',
+  }),
+  cellWidths: {
+    email: '25%',
+    name: '20%',
+    libraryCard: '25%',
+    institution: '20%',
+    // activeDARs: '10%'
+  },
+};
+
+//column header format for table
+const columnHeaderFormat = {
+  email: {label: 'Email', cellStyle: {width: styles.cellWidths.email}},
+  name: {label: 'Name', cellStyle: {width: styles.cellWidths.name}},
+  role: {label: 'Role', cellStyle: {width: styles.cellWidths.libraryCard}},
+  institution: {label: 'Institution', cellStyle: {width: styles.cellWidths.institution}}
+};
+
+const RemoveDataCustodianButton = (props) => {
+  const { custodian = {}, showConfirmationModal } = props;
+  const message = 'Are you sure you want to remove this data custodian?';
+  const title = 'Remove Data Custodian';
+  return h(SimpleButton, {
+    keyProp: `remove-custodian-${custodian.id}`,
+    label: 'Remove',
+    baseColor: Theme.palette.error,
+    additionalStyle: {
+      width: '30%',
+      padding: '2%',
+      fontSize: '1.45rem',
+    },
+    onClick: () =>
+      showConfirmationModal({ custodian, message, title, confirmType: 'delete' }),
+  });
+};
+
+const IssueDataCustodianButton = (props) => {
+  const { custodian, showConfirmationModal } = props;
+  const message = 'Are you sure you want to make this persone a Data Custodian?';
+  const title = 'Issue Data Custodian';
+  return h(SimpleButton, {
+    keyProp: `issue-card-${custodian.userEmail}`,
+    label: 'Issue',
+    baseColor: Theme.palette.secondary,
+    additionalStyle: {
+      width: '30%',
+      padding: '2%',
+      fontSize: '1.45rem',
+    },
+    onClick: () =>
+      showConfirmationModal({ custodian, message, title, confirmType: 'issue' }),
+  });
+};
+
+const researcherFilterFunction = getSearchFilterFunctions().signingOfficialResearchers;
+
+const CustodianCell = ({
+  custodian,
+  showConfirmationModal,
+  institutionId
+}) => {
+  const id = custodian.dacUserId || custodian.email;
+  const button = !isNil(custodian)
+    ? RemoveDataCustodianButton({
+      custodian,
+      showConfirmationModal,
+    })
+    : IssueDataCustodianButton({
+      custodian: {
+        userId: custodian.dacUserId,
+        userEmail: custodian.email,
+        institutionId: institutionId
+      },
+      showConfirmationModal
+    });
+  return {
+    isComponent: true,
+    id,
+    label: 'lc-button',
+    data: div(
+      {
+        style: {
+          display: 'flex',
+          justifyContent: 'left',
+        },
+        key: `lc-action-cell-${id}`,
+      },
+      [button]
+    ),
+  };
+};
+
+const roleCell = (roles, id) => {
+  const roleString = flow(
+    map((role) => role.name),
+    sortBy((name) => name),
+    sortedUniq,
+    join(', ')
+  )(roles);
+
+  return {
+    data: roleString || '- -',
+    id,
+    style: {},
+    label: 'user-role',
+  };
+};
+
+const emailCell = (email, id) => {
+  return {
+    data: email || '- -',
+    id,
+    style: {},
+    label: 'user-email',
+  };
+};
+
+const displayNameCell = (displayName, id) => {
+  return {
+    data: displayName || '- -',
+    id,
+    style: {},
+    label: 'display-name',
+  };
+};
+
+
+export default function DataCustodianTable(props) {
+  const [researchers, setResearchers] = useState(props.researchers || []);
+  const [tableSize, setTableSize] = useState(10);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageCount, setPageCount] = useState(1);
+  const [filteredResearchers, setFilteredResearchers] = useState([]);
+  const [visibleResearchers, setVisibleResearchers] = useState([]);
+  const [selectedResearcher, setSelectedResearcher] = useState({});
+  const [showModal, setShowModal] = useState(false);
+  const [showConfirmation, setShowConfirmation] = useState(false);
+  const searchRef = useRef('');
+  const [confirmationModalMsg, setConfirmationModalMsg] = useState('');
+  const [confirmationTitle, setConfirmationTitle] = useState('');
+  const [confirmType, setConfirmType] = useState('delete');
+  const { signingOfficial, unregisteredResearchers, isLoading } = props;
+
+  const handleSearchChange = tableSearchHandler(
+    researchers,
+    setFilteredResearchers,
+    setCurrentPage,
+    'signingOfficialResearchers'
+  );
+
+  const showConfirmationModal = ({
+    custodian,
+    message,
+    title,
+    confirmType,
+  }) => {
+    setSelectedResearcher(custodian);
+    setShowConfirmation(true);
+    setConfirmationModalMsg(message);
+    setConfirmationTitle(title);
+    setConfirmType(confirmType);
+  };
+
+  //init hook, need to make ajax calls here
+  useEffect(() => {
+    const init = async () => {
+      try {
+        setResearchers(props.researchers);
+      } catch (error) {
+        Notifications.showError({
+          text: 'Failed to initialize researcher table',
+        });
+      }
+    };
+    init();
+  }, [props.researchers]);
+
+  useEffect(() => {
+    searchOnFilteredList(
+      searchRef.current.value,
+      researchers,
+      researcherFilterFunction,
+      setFilteredResearchers
+    );
+  }, [researchers]);
+
+  useEffect(() => {
+    recalculateVisibleTable({
+      tableSize,
+      pageCount,
+      filteredList: filteredResearchers,
+      currentPage,
+      setPageCount,
+      setCurrentPage,
+      setVisibleList: setVisibleResearchers,
+    });
+  }, [tableSize, pageCount, filteredResearchers, currentPage]);
+
+  const goToPage = useCallback(
+    (value) => {
+      if (value >= 1 && value <= pageCount) {
+        setCurrentPage(value);
+      }
+    },
+    [pageCount]
+  );
+
+  const changeTableSize = useCallback((value) => {
+    if (value > 0 && !isNaN(parseInt(value))) {
+      setTableSize(value);
+    }
+  }, []);
+
+  const paginationBar = h(PaginationBar, {
+    pageCount,
+    currentPage,
+    tableSize,
+    goToPage,
+    changeTableSize,
+  });
+
+  const processResearcherRowData = (researchers = []) => {
+    return researchers.map((researcher) => {
+      const {displayName, email, id, roles} = researcher;
+      return [
+        displayNameCell(displayName, id),
+        emailCell(email, id),
+        CustodianCell({
+          custodian: researcher,
+          showConfirmationModal,
+          institutionId: signingOfficial.institutionId,
+        }),
+        roleCell(roles, id),
+        // activeDarCountCell(count, id)
+      ];
+    });
+  };
+
+  const columnHeaderData = [
+    columnHeaderFormat.name,
+    columnHeaderFormat.email,
+    columnHeaderFormat.institution,
+    columnHeaderFormat.role,
+    // columnHeaderFormat.activeDARs -> add this back in when back-end supports this
+  ];
+
+  const showModalOnClick = () => {
+    setSelectedResearcher({ institutionId: signingOfficial.institutionId });
+    setShowModal(true);
+  };
+
+  //NOTE: check to see if function works as expected
+  const issueCustodian = async (selectedResearcher, researchers) => {
+    let messageName;
+    const {id, email, displayName} = selectedResearcher;
+    try {
+      const listCopy = cloneDeep(researchers);
+      let targetIndex = findIndex(
+        (researcher) => id === researcher.dacUserId
+      )(listCopy);
+      if (targetIndex === -1) {
+        const targetUnregisteredResearcher = find(
+          (researcher) => id === researcher.dacUserId
+        )(props.unregisteredResearchers);
+        if(!isNil(targetUnregisteredResearcher)) {
+          Notifications.showError({
+            text: `${targetUnregisteredResearcher.email || targetUnregisteredResearcher.displayName} is already a Data Custodian`
+          });
+        } else {
+          listCopy.unshift(selectedResearcher);
+          messageName = email;
+        }
+      } else {
+        messageName = displayName;
+      }
+      setResearchers(listCopy);
+      setShowConfirmation(false);
+      setShowModal(false);
+      Notifications.showSuccess({
+        text: `Issued ${messageName} as Data Custodian`,
+      });
+    } catch (error) {
+      Notifications.showError({
+        text: `Error issuing ${messageName} as Data Custodian`,
+      });
+    }
+  };
+
+  const removeDataCustodian = async (selectedResearcher, researchers) => {
+    const { id, displayName, email, userId } = selectedResearcher;
+    const listCopy = cloneDeep(researchers);
+    const messageName = displayName || email;
+    try {
+      const targetIndex = findIndex((researcher) => {
+        return !isNil(researcher) && id === researcher.id;
+      })(researchers);
+      if (
+        isNil(userId) ||
+        researchers[targetIndex].institutionId !== signingOfficial.institutionId
+      ) {
+        listCopy.splice(targetIndex, 1);
+      }
+      setResearchers(listCopy);
+      setShowConfirmation(false);
+      Notifications.showSuccess({
+        text: `Removed ${messageName} as a Data Custodian`,
+      });
+    } catch (error) {
+      Notifications.showError({
+        text: `Error removing ${messageName} as a Data Custodian`,
+      });
+    }
+  };
+
+  return h(Fragment, {}, [
+    div(
+      {
+        style: {
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-end',
+        },
+      },
+      [
+        div({ style: Styles.LEFT_HEADER_SECTION }, [
+          div({ style: { ...Styles.ICON_CONTAINER, textAlign: 'center' } }, [
+            img({
+              id: 'user-icon',
+              src: userIcon,
+            }),
+          ]),
+          div({ style: Styles.HEADER_CONTAINER }, [
+            div({ style: { ...Styles.SUB_HEADER, marginTop: '0' } }, [
+              'Researchers',
+            ]),
+            div(
+              {
+                style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {
+                  fontSize: '16px',
+                }),
+              },
+              [
+                "My Institution's Researchers. Issue or Remove Researcher privileges below.",
+              ]
+            ),
+          ]),
+        ]),
+        h(SearchBar, { handleSearchChange, searchRef }),
+        div({ style: {} }, [
+          h(SimpleButton, {
+            onClick: () => showModalOnClick(),
+            baseColor: Theme.palette.secondary,
+            label: 'Add New Researcher',
+            additionalStyle: {
+              width: '20rem',
+            },
+          }),
+        ]),
+      ]
+    ),
+    h(SimpleTable, {
+      isLoading,
+      rowData: processResearcherRowData(visibleResearchers),
+      columnHeaders: columnHeaderData,
+      styles,
+      tableSize,
+      paginationBar,
+    }),
+    //NOTE: need to make a new modal? Or genericize the already existing modal
+    // h(LibraryCardFormModal, {
+    //   showModal,
+    //   createOnClick: (researcher) => issueCustodian(researcher, researchers),
+    //   closeModal: () => setShowModal(false),
+    //   researcher: selectedResearcher,
+    //   users: unregisteredResearchers,
+    //   institutions: [], //pass in empty array to force modal to hide institution dropdown
+    //   modalType: 'add',
+    // }),
+    h(ConfirmationModal, {
+      showConfirmation,
+      closeConfirmation: () => setShowConfirmation(false),
+      title: confirmationTitle,
+      message: confirmationModalMsg,
+      header: `${selectedResearcher.userName || selectedResearcher.userEmail} - ${
+        !isNil(selectedResearcher.institution) ? selectedResearcher.institution.name : ''
+      }`,
+      onConfirm: () =>
+        confirmType == 'delete'
+          ? removeDataCustodian(selectedResearcher, researchers)
+          : issueCustodian(selectedResearcher, researchers),
+    }),
+  ]);
+}

--- a/src/components/modals/DataCustodianFormModal.js
+++ b/src/components/modals/DataCustodianFormModal.js
@@ -1,0 +1,167 @@
+import { useState, useEffect } from 'react';
+import { cloneDeep, isObject, includes, isNil, isEmpty } from 'lodash/fp';
+import { h, div, label } from 'react-hyperscript-helpers';
+import { Styles } from '../../libs/theme';
+import CloseIconComponent from '../CloseIconComponent';
+import Modal from 'react-modal';
+import Creatable from 'react-select/creatable';
+import SimpleButton from '../SimpleButton';
+import { Theme } from '../../libs/theme';
+
+//NOTE: functionality is set for demo purposes on SO Console (no admin functionality)
+//As such, changes to "data" don't persist
+
+const FormFieldRow = (props) => {
+  const {
+    user,
+    dropdownOptions,
+    updateUser,
+    setUser,
+  } = props;
+
+  const nonCustodians = dropdownOptions.filter((option) => {
+    return !option.isDataCustodian;
+  });
+  const [filteredDropdown, setFilteredDropdown] = useState(nonCustodians);
+
+  //filter function for users dropdown
+  const userListFilter = ({ searchTerm, user, setUser, action }) => {
+    let filteredCopy;
+    if (isEmpty(searchTerm)) {
+      filteredCopy = filteredDropdown;
+    } else {
+      const copiedDropdown = cloneDeep(filteredDropdown);
+      filteredCopy = copiedDropdown.filter((user) => {
+        const userNameFilter = !isEmpty(user.displayName)
+          ? includes(user.displayName)(searchTerm)
+          : false;
+        const emailFilter = !isEmpty(user.email)
+          ? includes(user.email)(searchTerm)
+          : false;
+        return userNameFilter || emailFilter;
+      });
+    }
+    setFilteredDropdown(filteredCopy);
+    if (action !== 'input-blur' && action !== `menu-close`) {
+      setUser(Object.assign({}, user, { email: searchTerm }));
+    }
+  };
+
+  let template = div({ style: { marginBottom: '2%' } }, [
+    label({}, ['Users']),
+    h(Creatable, {
+      key: 'select-user',
+      isClearable: true,
+      onChange: updateUser,
+      createOptionPosition: 'first',
+      onInputChange: (input, { action }) =>
+        userListFilter({ input, user, setUser, action }),
+      getNewOptionData: (input) => {
+        return { email: input };
+      },
+      options: dropdownOptions,
+      placeholder: 'Select or type a new user email',
+      isOptionSelected: () => false, //Workaround to prevent odd react-select behavior where all dropdown options are highlighted
+      getOptionLabel: (option) =>
+        `${option.displayName || 'New User'} (${
+          option.email || 'No email provided'
+        })` || option.email,
+    }),
+  ]);
+  return div({ display: 'flex' }, [template]);
+};
+
+export default function DataCustodianFormModal(props) {
+  //NOTE: dropdown options need to be passed down from parent component
+  const {
+    showModal,
+    createOnClick,
+    closeModal,
+    users,
+  } = props;
+
+  const [user, setUser] = useState(props.user);
+
+  //initialization hook, sets card as state variables
+  useEffect(() => {
+    setUser(props.user);
+  }, [props.user]);
+
+  //onChange function, used to change associated user on Creatable dropdown selection
+  const updateUser = (value) => {
+    let targetUser = {};
+    if (isObject(value)) {
+      targetUser = value;
+    } else {
+      targetUser.email = value;
+    }
+    setUser(targetUser);
+  };
+
+  //boolean function, used to determine if submit button should be disabled
+  const isConfirmDisabled = (user) => {
+    debugger; // eslint-disable-line
+    return isNil(user) || isNil(user.email);
+  };
+
+  return h(
+    Modal,
+    {
+      isOpen: showModal,
+      onRequestClose: closeModal,
+      shouldCloseOnOverlayClick: true,
+      style: {
+        content: { ...Styles.MODAL.CONTENT },
+        overlay: {
+          backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        },
+      },
+    },
+    [
+      div({ style: Styles.MODAL.CONTENT }, [
+        h(CloseIconComponent, { closeFn: closeModal }),
+        div({ style: Styles.MODAL.TITLE_HEADER }, ['Add Data Custodian']),
+        div({ style: { borderBottom: '1px solid #1FB50' } }, []),
+        //users dropdown
+        h(FormFieldRow, {
+          user,
+          updateUser,
+          setUser,
+          dropdownOptions: users,
+        }),
+        div(
+          {
+            style: {
+              display: 'flex',
+              marginLeft: '85%',
+              justifyContent: 'space-between',
+            },
+          },
+          [
+            h(SimpleButton, {
+              onClick: () => createOnClick(user),
+              additionalStyle: {
+                flex: 1,
+                display: 'inline-block',
+                margin: '5%',
+              },
+              baseColor: Theme.palette.secondary,
+              disabled: isConfirmDisabled(user),
+              label: 'Add'
+            }),
+            h(SimpleButton, {
+              onClick: closeModal,
+              additionalStyle: {
+                flex: 1,
+                display: 'inline-block',
+                margin: '5%',
+              },
+              baseColor: Theme.palette.secondary,
+              label: 'Cancel',
+            }),
+          ]
+        ),
+      ]),
+    ]
+  );
+}

--- a/src/components/signing_official_table/SigningOfficialTable.js
+++ b/src/components/signing_official_table/SigningOfficialTable.js
@@ -292,7 +292,6 @@ export default function SigningOfficialTable(props) {
     let messageName;
     try {
       const listCopy = cloneDeep(researchers);
-      //NOTE: institution_id and userName can be supplied by the back-end
       const newLibraryCard = await LibraryCard.createLibraryCard(selectedCard);
       const {userEmail, userName, userId} = newLibraryCard;
       let targetIndex = findIndex((researcher) => userId === researcher.dacUserId)(listCopy);

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -15,42 +15,9 @@ import {consoleTypes} from "../components/dar_table/DarTableActions";
 import { USER_ROLES } from "../libs/utils";
 import DataCustodianTable from "../components/data_custodian_table/DataCustodianTable";
 
-const defaultTabStyle = {
-  fontStyle: '1.8rem',
-  fontWeight: 400,
-  borderBottom: '0px'
-};
-
-const getSelectedTabStyle = (style) => {
-  const {color} = style;
-  return Object.assign(
-    {},
-    style,
-    { borderBottom: `3px solid ${color}`, fontWeight: 400 }
-  );
-};
-
 const tabs = {
   custodian: 'custodian',
   researcher: 'researchers'
-};
-
-const getCustodianTabStyle = (style) => {
-  const custodianTabStyle = {
-    color: 'red',
-    marginRight: '4rem',
-  };
-  return Object.assign({}, style, custodianTabStyle);
-};
-
-const getResearcherTabStyle = (style) => {
-  const researcherTabStyle = { color: 'blue' };
-  return Object.assign({}, style, researcherTabStyle);
-};
-
-const getOnMouseEnterStyle = (style) => {
-  const hoverStyle = { fontWeight: 600 };
-  return Object.assign({}, style, hoverStyle);
 };
 
 export default function SigningOfficialConsole(props) {

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -104,8 +104,6 @@ export default function SigningOfficialConsole(props) {
 
   return (
     div({style: Styles.PAGE}, [
-      //NOTE: need to have selective divs here
-      //NOTE: need a state variable to track state change (with associated function click)
       div({ isRendered: !isLoading, style: {display: "flex"}}, [
         div({style: {...Styles.HEADER_CONTAINER, paddingTop: "3rem", paddingBottom: "2rem"}}, [
           div({style: Styles.TITLE}, ["Welcome " +signingOfficial.displayName+ "!"]),
@@ -123,7 +121,7 @@ export default function SigningOfficialConsole(props) {
       ]),
       div({style: {borderTop: '1px solid #BABEC1', height: 0}}, []),
       div({style: {}, class: 'signing-official-tabs'}, [
-        //NOTE: need to come up with styling for tabs and containers
+        //NOTE: placeholder styling for now, can come up with more definitive designs later
         div({style: {display: 'flex'}, class: 'tab-selection-container'}, [
           h(SelectableText, {
             label: 'Data Custodian',

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -157,7 +157,7 @@ export default function SigningOfficialConsole(props) {
           div({style: Styles.HEADER_CONTAINER}, [
             div({style: {...Styles.SUB_HEADER, marginTop: '0'}}, ["Data Access Requests"]),
             div({style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '16px'})}, [
-              "My Institution's DARs: Records from all current and closed data access requests.",
+              "Your Institution's DARs: Records from all current and closed data access requests.",
             ]),
           ])
         ]),

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -4,6 +4,7 @@ import {div, a, h, img} from "react-hyperscript-helpers";
 import {Styles} from "../libs/theme";
 import SigningOfficialTable from "../components/signing_official_table/SigningOfficialTable";
 import DarTableSkeletonLoader from "../components/TableSkeletonLoader";
+import SelectableText from "../components/SelectableText";
 import {tableHeaderTemplate, tableRowLoadingTemplate} from "../components/dar_table/DarTable";
 import DarTable from "../components/dar_table/DarTable";
 import lockIcon from "../images/lock-icon.png";
@@ -12,6 +13,45 @@ import {darSearchHandler, processElectionStatus, getElectionDate, updateLists as
 import {User, DAR} from "../libs/ajax";
 import {consoleTypes} from "../components/dar_table/DarTableActions";
 import { USER_ROLES } from "../libs/utils";
+import DataCustodianTable from "../components/data_custodian_table/DataCustodianTable";
+
+const defaultTabStyle = {
+  fontStyle: '1.8rem',
+  fontWeight: 400,
+  borderBottom: '0px'
+};
+
+const getSelectedTabStyle = (style) => {
+  const {color} = style;
+  return Object.assign(
+    {},
+    style,
+    { borderBottom: `3px solid ${color}`, fontWeight: 400 }
+  );
+};
+
+const tabs = {
+  custodian: 'custodian',
+  researcher: 'researchers'
+};
+
+const getCustodianTabStyle = (style) => {
+  const custodianTabStyle = {
+    color: 'red',
+    marginRight: '4rem',
+  };
+  return Object.assign({}, style, custodianTabStyle);
+};
+
+const getResearcherTabStyle = (style) => {
+  const researcherTabStyle = { color: 'blue' };
+  return Object.assign({}, style, researcherTabStyle);
+};
+
+const getOnMouseEnterStyle = (style) => {
+  const hoverStyle = { fontWeight: 600 };
+  return Object.assign({}, style, hoverStyle);
+};
 
 export default function SigningOfficialConsole(props) {
   const [signingOfficial, setSiginingOfficial] = useState({});
@@ -22,6 +62,7 @@ export default function SigningOfficialConsole(props) {
   const [filteredDarList, setFilteredDarList] = useState();
   const [currentDarPage, setCurrentDarPage] = useState(1);
   const [darPageSize, setDarPageSize] = useState(10);
+  const [selectedTag, setSelectedTag] = useState(tabs.custodian);
   const [descendantOrderDars, setDescendantOrderDars] = useState(false);
 
   //states to be added and used for manage researcher component
@@ -63,6 +104,8 @@ export default function SigningOfficialConsole(props) {
 
   return (
     div({style: Styles.PAGE}, [
+      //NOTE: need to have selective divs here
+      //NOTE: need a state variable to track state change (with associated function click)
       div({ isRendered: !isLoading, style: {display: "flex"}}, [
         div({style: {...Styles.HEADER_CONTAINER, paddingTop: "3rem", paddingBottom: "2rem"}}, [
           div({style: Styles.TITLE}, ["Welcome " +signingOfficial.displayName+ "!"]),
@@ -73,13 +116,35 @@ export default function SigningOfficialConsole(props) {
               href: 'https://broad-duos.zendesk.com/hc/en-us/articles/360060402751-Signing-Official-User-Guide',
               target: '_blank',
               id: 'so-console-info-link'},
-            ['Click Here for more information'])
+            ['Click Here for more information']),
+
           ])
         ])
       ]),
       div({style: {borderTop: '1px solid #BABEC1', height: 0}}, []),
-      //researcher table goes here
-      h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+      div({style: {}, class: 'signing-official-tabs'}, [
+        //NOTE: need to come up with styling for tabs and containers
+        div({style: {display: 'flex'}, class: 'tab-selection-container'}, [
+          h(SelectableText, {
+            label: 'Data Custodian',
+            color: 'red',
+            fontSize: `1.8rem`,
+            componentType: tabs.custodian,
+            setSelected: setSelectedTag,
+            selectedType: selectedTag
+          }),
+          h(SelectableText, {
+            label: 'Researchers',
+            color: 'blue',
+            fontSize: '1.8rem',
+            componentType: tabs.researcher,
+            setSelected: setSelectedTag,
+            selectedType: selectedTag
+          })
+        ]),
+        h(SigningOfficialTable, {isRendered: selectedTag === tabs.researcher, researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+        h(DataCustodianTable, {isRendered: selectedTag === tabs.custodian, researchers, signingOfficial, unregisteredResearchers, isLoading}, [])
+      ]),
       div({style: {display: 'flex', justifyContent: "space-between"}}, [
         div({className: "left-header-section", style: Styles.LEFT_HEADER_SECTION}, [
           div({style: Styles.ICON_CONTAINER}, [


### PR DESCRIPTION
Addresses [DUOS-1438](https://broadworkbench.atlassian.net/browse/DUOS-1438)

PR adds a Data Custodian sub-component to the SO Console that allows a user to issue/revoke for demo purposes. This means that while the UI will have state updates, there are no updates being saved to the back-end (which means perceived updates will not persist). Demo is only for the SO Console, which means Admin functionality is not available.

This is not meant to be the final version of the sub-component, however the demo will provide a good jumping off point once Data Custodian work begins.
 
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
