### PR TITLE
[DUOS-1445][risk=no] Conditional display of institution selection for SOs

### DIFF
--- a/src/pages/BackgroundSignIn.js
+++ b/src/pages/BackgroundSignIn.js
@@ -39,7 +39,7 @@ export default function BackgroundSignIn(props) {
       Storage.setGoogleData({ accessToken: accessToken });
       getUser().then(
         user => {
-          user = Object.assign(user, setUserRoleStatuses(user));
+          user = Object.assign(user, setUserRoleStatuses(user, Storage));
           setIsLogged();
           setLoading(false);
           redirect(user);
@@ -56,7 +56,7 @@ export default function BackgroundSignIn(props) {
               // If the user exists, just log them in.
               getUser().then(
                 user => {
-                  user = Object.assign(user, setUserRoleStatuses(user));
+                  user = Object.assign(user, setUserRoleStatuses(user, Storage));
                   setIsLogged();
                   redirect(user);
                   setLoading(false);

--- a/src/pages/BackgroundSignIn.js
+++ b/src/pages/BackgroundSignIn.js
@@ -1,7 +1,7 @@
 import { User } from '../libs/ajax';
 import { Storage } from '../libs/storage';
 import { div, form, input, label, textarea, br, h } from 'react-hyperscript-helpers';
-import { Navigation, USER_ROLES } from '../libs/utils';
+import { Navigation, setUserRoleStatuses } from '../libs/utils';
 import { useState, useEffect } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { SpinnerComponent } from '../components/SpinnerComponent';
@@ -28,18 +28,6 @@ export default function BackgroundSignIn(props) {
       Navigation.back(user, history);
       if (onSignIn)
         onSignIn();
-    };
-
-    const setUserRoleStatuses = (user) => {
-      const currentUserRoles = user.roles.map(roles => roles.name);
-      user.isChairPerson = currentUserRoles.indexOf(USER_ROLES.chairperson) > -1;
-      user.isMember = currentUserRoles.indexOf(USER_ROLES.member) > -1;
-      user.isAdmin = currentUserRoles.indexOf(USER_ROLES.admin) > -1;
-      user.isResearcher = currentUserRoles.indexOf(USER_ROLES.researcher) > -1;
-      user.isDataOwner = currentUserRoles.indexOf(USER_ROLES.dataOwner) > -1;
-      user.isAlumni = currentUserRoles.indexOf(USER_ROLES.alumni) > -1;
-      Storage.setCurrentUser(user);
-      return user;
     };
 
     const setIsLogged = () => {

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -2,20 +2,7 @@ import {Component} from 'react';
 import {getNames} from 'country-list';
 import {cloneDeep, find, get, isEmpty, isNil, omit, omitBy, trim} from 'lodash';
 import ReactTooltip from 'react-tooltip';
-import {
-  button,
-  div,
-  form,
-  h,
-  hh,
-  hr,
-  input,
-  label,
-  option,
-  select,
-  span,
-  textarea,
-} from 'react-hyperscript-helpers';
+import {button, div, form, h, hh, hr, input, label, option, select, span, textarea,} from 'react-hyperscript-helpers';
 import {LibraryCards} from '../components/LibraryCards';
 import {ConfirmationDialog} from '../components/ConfirmationDialog';
 import {eRACommons} from '../components/eRACommons';
@@ -26,11 +13,7 @@ import {SearchSelect} from '../components/SearchSelect';
 import {Institution, Researcher, User} from '../libs/ajax';
 import {NotificationService} from '../libs/notificationService';
 import {Storage} from '../libs/storage';
-import {
-  getPropertyValuesFromUser,
-  setUserRoleStatuses,
-  USER_ROLES,
-} from '../libs/utils';
+import {getPropertyValuesFromUser, setUserRoleStatuses, USER_ROLES,} from '../libs/utils';
 
 export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -29,7 +29,6 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     this.setState(prev => {
       prev.notificationData = notificationData;
       prev.currentUser = Storage.getCurrentUser();
-      prev.isResearcher = Storage.getCurrentUser().isResearcher;
       return prev;
     });
   }
@@ -467,8 +466,9 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
     const countryNames = this.generateCountryNames();
     const stateNames = this.generateStateNames();
     let completed = this.state.profile.completed;
-    const { showValidationMessages } = this.state;
+    const { currentUser, institutionId, showValidationMessages } = this.state;
     const libraryCards = get(this.state.currentUser, 'libraryCards', []);
+    let isSigningOfficial = get(currentUser, 'isSigningOfficial', false);
 
     return (
 
@@ -480,7 +480,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
               id: 'researcherProfile',
               color: 'common',
               title: 'Your Profile',
-              description: this.state.isResearcher ? 'Please complete the following information to be able to request access to dataset(s)' : ''
+              description: 'Please complete the following information to be able to request access to dataset(s)'
             }),
             hr({ className: 'section-separator' })
           ]),
@@ -627,7 +627,9 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                     'Institution Name* ',
                     span({
                       className: 'glyphicon glyphicon-question-sign tooltip-icon',
-                      "data-tip": "If your preferred institution cannot be found, please submit a ticket to have it added.",
+                      "data-tip": (isSigningOfficial && !isNil(institutionId)) ?
+                        "As a 'Signing Official', your institution cannot be changed here. Please submit a ticket to have it changed." :
+                        "If your preferred institution cannot be found, please submit a ticket to have it added.",
                       'data-for': 'tip_profileState',
                     })
                   ]),

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -690,8 +690,8 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                     span({
                       className: 'glyphicon glyphicon-question-sign tooltip-icon',
                       "data-tip": (isSigningOfficial && !isNil(institutionId)) ?
-                        "As a 'Signing Official', your institution cannot be changed here. Please submit a ticket to have it changed." :
-                        "If your preferred institution cannot be found, please submit a ticket to have it added.",
+                        "As a 'Signing Official', your institution cannot be changed here. Please submit a support request via the 'Contact Us' form to have it changed." :
+                        "If your preferred institution cannot be found, please submit a support request via the 'Contact Us' form to have it added.",
                       'data-for': 'tip_profileState',
                     })
                   ]),


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1445

Signing officials are prohibited from updating their institution to prevent users from changing institutions just to issue library cards that might be outside of their normal institution. Signing Officials must go through customer support to accomplish this.

## Changes
* Minor update in background sign-in to reduce code duplication
* Update the rendered institution selection depending on user state.
  * SOs with no institution -> render institution selection
  * Any other user -> render institution selection
  * SOs with institution -> render the existing institution in a disabled state

## SO with Existing Institution
<img width="1354" alt="Screen Shot 2021-10-04 at 1 48 44 PM" src="https://user-images.githubusercontent.com/116679/135900320-ce9652ff-8f15-4270-a3c9-fc3342130974.png">


## Any Other User
<img width="1354" alt="Screen Shot 2021-10-04 at 1 48 17 PM" src="https://user-images.githubusercontent.com/116679/135900431-b7493ec8-dc9a-4b32-b23a-367e9a4078c1.png">



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
