### PR TITLE
[DUOS-1454][risk=no] Add frame-ancestors to CSP

### DIFF
--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -11,7 +11,7 @@ map $sent_http_content_type $expires {
 server {
   listen 8080;
   expires $expires;
-  add_header Content-Security-Policy "default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.firecloud.org *.broadinstitute.org *.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com broadinstitute.zendesk.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com;";
+  add_header Content-Security-Policy "frame-ancestors 'self' app.powerbi.com; default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.firecloud.org *.broadinstitute.org *.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com broadinstitute.zendesk.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com;";
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;

--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -11,7 +11,7 @@ map $sent_http_content_type $expires {
 server {
   listen 8080;
   expires $expires;
-  add_header Content-Security-Policy "frame-ancestors 'self' app.powerbi.com; default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.firecloud.org *.broadinstitute.org *.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com broadinstitute.zendesk.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com;";
+  add_header Content-Security-Policy "default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.firecloud.org *.broadinstitute.org *.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com broadinstitute.zendesk.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com; frame-ancestors 'self' app.powerbi.com;";
   location / {
     root   /usr/share/nginx/html;
     index  index.html index.htm;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1454

This PR adds a `frame-ancestors` CSP directive to all UI responses.

## Steps to Reproduce
Build a new image, and run that image locally:
```
docker build . -t duos
docker run -v ${PWD}/public/config.json:/usr/share/nginx/html/config.json:ro -p 80:8080 duos:latest
```

Examine the headers:
```
➜  curl -I localhost
HTTP/1.1 200 OK
Server: nginx/1.21.3
Date: Tue, 05 Oct 2021 16:27:02 GMT
Content-Type: text/html
Content-Length: 2649
Last-Modified: Tue, 05 Oct 2021 16:10:59 GMT
Connection: keep-alive
ETag: "615c7913-a59"
Expires: Thu, 01 Jan 1970 00:00:01 GMT
Cache-Control: no-cache
Content-Security-Policy: default-src 'self' accounts.google.com app.powerbi.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com; connect-src 'self' *.firecloud.org *.broadinstitute.org *.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com broadinstitute.zendesk.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com; frame-ancestors 'self' app.powerbi.com;
Accept-Ranges: bytes
```

As an admin, log in and view the "Statistics" page. This is where we have a frame. That page should display correctly.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
