### PR TITLE
[DUOS-1475][risk=no] Use secrets synced via TF

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,11 +18,11 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         env:
-          CYPRESS_ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN }}
-          CYPRESS_CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR }}
-          CYPRESS_MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER }}
-          CYPRESS_RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER }}
-          CYPRESS_SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL }}
+          CYPRESS_ADMIN: ${{ secrets.DUOS_AUTOMATION_ADMIN_SA }}
+          CYPRESS_CHAIR: ${{ secrets.DUOS_AUTOMATION_CHAIR_SA }}
+          CYPRESS_MEMBER: ${{ secrets.DUOS_AUTOMATION_MEMBER_SA }}
+          CYPRESS_RESEARCHER: ${{ secrets.DUOS_AUTOMATION_RESEARCHER_SA }}
+          CYPRESS_SIGNING_OFFICIAL: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL_SA }}
         with:
           start: npm start
           wait-on: 'http://localhost:3000'


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1475
See also: https://github.com/broadinstitute/terraform-ap-deployments/pull/442

## Notes
This PR updates the cypress tests to use TF-synced account names for automated tests. Previously, we were using secrets that were manually added to github. 

We needed to create new secrets in vault for the TF PR to work. To do that, we created new secret paths with values in this form:
```
{
  "key": {... sa json object ...}
}
```
The TF PR pulls the value of `key` from the vault path and pushes it to github as a new secret.

## TODO: 
Once this PR is working/approved, we can remove the old secrets.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
