### PR TITLE
DUOS-1483[risk=no] Set academic email to Gmail, removed conditional rendering on Submit button (ResearcherProfile)

### DIFF
--- a/src/components/modals/DataCustodianFormModal.js
+++ b/src/components/modals/DataCustodianFormModal.js
@@ -100,7 +100,6 @@ export default function DataCustodianFormModal(props) {
 
   //boolean function, used to determine if submit button should be disabled
   const isConfirmDisabled = (user) => {
-    debugger; // eslint-disable-line
     return isNil(user) || isNil(user.email);
   };
 

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -102,7 +102,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
       prev.additionalEmail = isNil(user.additionalEmail) ? '' : user.additionalEmail;
       prev.institutionId = user.institutionId;
       prev.institutionList = institutionList;
-      prev.profile.academicEmail = researcherProps.academicEmail;
+      prev.profile.academicEmail = researcherProps.academicEmail || user.email;
       prev.profile.address1 = researcherProps.address1;
       prev.profile.address2 = researcherProps.address2;
       prev.profile.checkNotifications = (researcherProps.checkNotifications === 'true');
@@ -390,7 +390,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
 
   updateResearcher = async (profile) => {
     const profileClone = this.cloneProfile(profile);
-    await Researcher.updateProperties(this.state.currentUser.dacUserId, true, profileClone);
+    await Researcher.updateProperties(Storage.getCurrentUser().dacUserId, true, profileClone);
     await this.saveUser();
     this.setState({ showDialogSubmit: false });
     this.props.history.push({ pathname: 'dataset_catalog' });
@@ -1006,7 +1006,7 @@ export const ResearcherProfile = hh(class ResearcherProfile extends Component {
                 ]),
 
                 div({ className: 'col-lg-8 col-xs-6' }, [
-                  button({ id: 'btn_submit', isRendered: completed === true, onClick: this.submit, className: 'f-right btn-primary common-background' }, [
+                  button({ id: 'btn_submit', onClick: this.submit, className: 'f-right btn-primary common-background' }, [
                     'Submit'
                   ]),
                   ConfirmationDialog({


### PR DESCRIPTION
Addresses [DUOS-1483](https://broadworkbench.atlassian.net/browse/DUOS-1483)

- PR removes conditional rendering on submit button (Is there a reason to hide the submit button on the profile page anymore?)
- PR uses Google User's email address as a fallback assignment to academic email (since email editing has been removed in academic email is a holdover of when the field was editable)
- PR uses Storage to obtain current user's id for profile update request
- PR removes stray debugger from demo page (unrelated, but noticed it while working on this PR)

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
