### PR TITLE
[DUOS-256][risk=no] Update build/push to GCR action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       with:
         version: '270.0.0'
         service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
-        service_account_key: ${{ secrets.GCR_PUBLISH_KEY }}
+        service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
     - name: Auth Docker for GCR
       run: gcloud auth configure-docker --quiet
     - name: Construct tags
@@ -62,7 +62,7 @@ jobs:
       if: github.event_name == 'push'
       uses: broadinstitute/repository-dispatch@master
       with:
-        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        token: ${{ secrets.BROADBOT_TOKEN }}
         repository: broadinstitute/terra-helmfile
         event-type: update-service
         client-payload: '{"service": "duos", "version": "${{ steps.short-sha.outputs.sha }}", "dev_only": false}'


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-256
Standardizes the secret names we use across services for pushing images to GCR

## Folllow-on Tasks
* Remove `GCR_PUBLISH_KEY` and `REPO_ACCESS_TOKEN` from secrets once all existing PRs are moved through

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
