### PR TITLE
[DUOS-1494][risk=no] Email validation function added to utils

### DIFF
--- a/src/components/modals/SupportRequestModal.js
+++ b/src/components/modals/SupportRequestModal.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { div, form, input, label, textarea, hh, h, select, span, option, section, button, p } from 'react-hyperscript-helpers';
 import { Support} from '../../libs/ajax';
 import { Storage } from '../../libs/storage';
-import { Notifications } from '../../libs/utils';
+import { Notifications, isEmailAddress } from '../../libs/utils';
 import { PageSubHeading } from '../PageSubHeading';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
@@ -159,7 +159,7 @@ export const SupportRequestModal = hh(
       let emailText = e.target.value;
       this.setState(prev => {
         prev.email = emailText;
-        prev.valid = /.+@.+\.[A-Za-z]+$/.test(emailText) ? true : false;
+        prev.valid = isEmailAddress(emailText);
         return prev;
       });
     };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -140,6 +140,11 @@ export const isFileEmpty = (file) => {
   return isNil(file) || file.size < 1 || file.length < 1;
 };
 
+export const isEmailAddress = (email) => {
+  const re = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+  return re.test(email);
+};
+
 export const USER_ROLES = {
   admin: 'Admin',
   chairperson: 'Chairperson',

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -13,7 +13,7 @@ import {AuthenticateNIH, Institution, Researcher, User} from '../libs/ajax';
 import {NotificationService} from '../libs/notificationService';
 import {Alert} from '../components/Alert';
 import {Storage} from '../libs/storage';
-import {getPropertyValuesFromUser, setUserRoleStatuses, USER_ROLES,} from '../libs/utils';
+import {getPropertyValuesFromUser, setUserRoleStatuses, USER_ROLES, isEmailAddress} from '../libs/utils';
 
 export default function ResearcherProfile(props) {
   const [profile, setProfile] = useState({
@@ -94,7 +94,7 @@ export default function ResearcherProfile(props) {
       incompletes.push('Name');
     }
 
-    if (!isValid(profile.academicEmail || profile.academicEmail.indexOf('@') === -1)) {
+    if (!isValid(profile.academicEmail) || !isEmailAddress(profile.academicEmail)) {
       incompletes.push('Email Address');
     }
 
@@ -130,7 +130,7 @@ export default function ResearcherProfile(props) {
       if (!isValid(profile.piName)) {
         incompletes.push('Principal Investigator Name');
       }
-      if (!isValid(profile.piEmail) || profile.piEmail.indexOf('@') === -1) {
+      if (!isValid(profile.piEmail) || !isEmailAddress(profile.piEmail)) {
         incompletes.push('Principal Investigator Email');
       }
     }
@@ -429,7 +429,7 @@ export default function ResearcherProfile(props) {
                 }),
                 span({
                   className: 'cancel-color required-field-error-span',
-                  isRendered: (!isNil(profile.additionalEmail) && profile.additionalEmail !== "" && profile.additionalEmail.indexOf('@') === -1)
+                  isRendered: (!isNil(profile.additionalEmail) && profile.additionalEmail !== "" && !isEmailAddress(profile.additionalEmail))
                 }, ['Email Address has invalid format'])
               ])
             ]),


### PR DESCRIPTION
Added function to utils.js to check email address fields for valid format
Issue: https://broadworkbench.atlassian.net/browse/DUOS-1494

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
