### PR TITLE
[DUOS-1421][risk=no] Handle ontology status more flexibly

### DIFF
--- a/src/pages/Status.js
+++ b/src/pages/Status.js
@@ -12,8 +12,7 @@ export const Status = hh(class Status extends Component {
     super(props);
     this.state = {
       consentStatus: {},
-      ontologyStatus: {},
-      fireCloudStatus: {}
+      ontologyStatus: {}
     };
   }
 

--- a/src/pages/Status.js
+++ b/src/pages/Status.js
@@ -22,7 +22,7 @@ export const Status = hh(class Status extends Component {
   };
 
   isOntologyHealthy = (elements) => {
-    let ok = getOr(undefined)('ok')(elements);
+    const ok = getOr(undefined)('ok')(elements);
     if (!isNil(ok)) {
       // return the OK status from ontology if it exists
       return ok;

--- a/src/pages/Status.js
+++ b/src/pages/Status.js
@@ -1,4 +1,4 @@
-import { get, map, uniq } from 'lodash/fp';
+import { getOr, isNil, map, uniq } from 'lodash/fp';
 import React, { Component } from 'react';
 import { a, div, h2, hh, hr, li, pre, ul } from 'react-hyperscript-helpers';
 import CheckboxMarkedCircleOutline from 'react-material-icon-svg/dist/CheckboxMarkedCircleOutline';
@@ -18,13 +18,19 @@ export const Status = hh(class Status extends Component {
   }
 
   isConsentHealthy = (elements) => {
-    return get('ok')(elements);
+    return getOr(false)('ok')(elements);
   };
 
   isOntologyHealthy = (elements) => {
-    // find all values of "healthy" and ensure that they are all true
-    const bools = uniq(map('healthy')(elements));
-    return bools.length === 1 && bools[0];
+    let ok = getOr(undefined)('ok')(elements);
+    if (!isNil(ok)) {
+      // return the OK status from ontology if it exists
+      return ok;
+    } else {
+      // find all values of "healthy" and ensure that they are all true
+      const bools = uniq(map('healthy')(elements));
+      return bools.length === 1 && bools[0];
+    }
   };
 
   async componentDidMount() {


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-1421

See also: https://github.com/DataBiosphere/consent-ontology/pull/527

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
