### PR TITLE
DUOS-1493[risk=no] Added Completed Status Helper functions for DAR Application

### DIFF
--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -4,7 +4,7 @@ import ResearcherInfo from './dar_application/ResearcherInfo';
 import DataAccessRequest from './dar_application/DataAccessRequest';
 import ResearchPurposeStatement from './dar_application/ResearchPurposeStatement';
 import DataUseAgreements from './dar_application/DataUseAgreements';
-import {Notifications as NotyUtil } from '../libs/utils';
+import {completedResearcherInfoCheck, Notifications as NotyUtil } from '../libs/utils';
 import { TypeOfResearch } from './dar_application/TypeOfResearch';
 import { ConfirmationDialog } from '../components/ConfirmationDialog';
 import { Notification } from '../components/Notification';
@@ -234,7 +234,7 @@ class DataAccessRequestApplication extends Component {
     if (!fp.isNil(formData.darCode)) {
       completed = '';
     } else if (rpProperties.completed !== '') {
-      completed = rpProperties.completed;
+      completed = completedResearcherInfoCheck(rpProperties);
     }
     this.setState(prev => {
       prev.completed = completed;


### PR DESCRIPTION
Addresses [DUOS-1493](https://broadworkbench.atlassian.net/browse/DUOS-1493)

PR adds helper function to `utils.js` to better evaluate completed status for the `ResearcherInfo` portion of the application. 

`userProperties.completed`, which is normally what should be referred to, is not reliable due to one situation

- User fills everything but the eraCommonsId on the profile -> `userProperties.completed` set to false on profile submission.
- User then visits the DAR application page and fills the `eraCommonsId` there. `eraCommonsId` is updated, but `userProperties.completed` is not (remains false).

Helper function was created because user properties are present within the DAR Application component, therefore the completed status evaluation can be made client side. eraCommonsId is not evaluated since

- value can be updated on the DAR Application page, therefore no alert message needs to be triggered on it being missing
- DAR Application component logic already flags missing inputs as part of it's validation logic, `eraCommonsId` is no exception.


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
