### PR TITLE
DUOS-1508[risk=no] Removed unused AccessVotes variable from Access Review

### DIFF
--- a/src/pages/access_review/AccessReview.js
+++ b/src/pages/access_review/AccessReview.js
@@ -42,7 +42,7 @@ class AccessReview extends React.PureComponent {
         const accessElectionReview = await Election.findDataAccessElectionReview(accessElection.electionId);
         const rpElectionReview = isNil(accessElection) ? null : await Election.findRPElectionReview(accessElection.electionId);
         const rpElection = isNil(rpElectionReview) ? null : rpElectionReview.election;
-        return {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection};
+        return {accessElectionReview, accessElection, rpElectionReview, rpElection};
       } catch(error) {
         Notifications.showError({text: 'Error initializing Election Data'});
         return Promise.reject(error);
@@ -55,7 +55,7 @@ class AccessReview extends React.PureComponent {
     ]);
 
     const {datasets, darInfo, consent, researcherProfile} = darData;
-    const {accessVote, accessElectionReview, accessElection, rpElectionReview, rpElection} = electionData;
+    const {accessElectionReview, accessElection, rpElectionReview, rpElection} = electionData;
 
     let allVotes = [];
     if (!isNil(accessElection)) {
@@ -66,7 +66,7 @@ class AccessReview extends React.PureComponent {
       allVotes = allVotes.concat(rpVotes);
     }
 
-    this.setState({ allVotes, darId, accessVote, accessElection, rpElection, darInfo, consent, accessElectionReview, rpElectionReview, researcherProfile, datasets });
+    this.setState({ allVotes, darId, accessElection, rpElection, darInfo, consent, accessElectionReview, rpElectionReview, researcherProfile, datasets });
   }
 
   render() {


### PR DESCRIPTION
Addresses [DUOS-1508](https://broadworkbench.atlassian.net/browse/DUOS-1508)

Bugfix for initialization error on `AccessReview`. Root cause was an old variable that was no longer in use (value never initialized) but was still being referenced/passed along in code. It would be sent on return for some functions, but its value was never used. Nevertheless referencing an uninitialized variable will cause the error.

NOTE: This error only shows up on deployed builds. I was unable to reproduce this on a local build. Luckily the dev-k8 domain was able to produce the following output shown below. Production shows a similar output, however the code is minified so variable names are reduced to simple letters.

<img width="1778" alt="Screen Shot 2021-11-16 at 7 29 16 AM" src="https://user-images.githubusercontent.com/6664778/141986382-5fcabf71-52d1-4b71-86ea-9a69ccc230be.png">

![image](https://user-images.githubusercontent.com/6664778/141986630-7336a0d7-a06d-42a9-8b2c-601f4ac102eb.png)



Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
