### PR TITLE
DUOS-1512[risk=no] Replaced Data Custodian with Data Submitter on text rendered on SO Console

### DIFF
--- a/src/components/data_custodian_table/DataCustodianTable.js
+++ b/src/components/data_custodian_table/DataCustodianTable.js
@@ -45,13 +45,13 @@ const columnHeaderFormat = {
   email: {label: 'Email', cellStyle: {width: styles.cellWidths.email}},
   name: {label: 'Name', cellStyle: {width: styles.cellWidths.name}},
   role: {label: 'Role', cellStyle: {width: styles.cellWidths.libraryCard}},
-  institution: {label: 'Custodian Status', cellStyle: {width: styles.cellWidths.institution}}
+  institution: {label: 'Submitter Status', cellStyle: {width: styles.cellWidths.institution}}
 };
 
 const RemoveDataCustodianButton = (props) => {
   const { researcher = {}, showConfirmationModal } = props;
-  const message = 'Are you sure you want to remove this Data Custodian?';
-  const title = 'Remove Data Custodian';
+  const message = 'Are you sure you want to remove this Data Submitter?';
+  const title = 'Remove Data Submitter';
   return h(SimpleButton, {
     keyProp: `remove-custodian-${researcher.id}`,
     label: 'Remove',
@@ -68,8 +68,8 @@ const RemoveDataCustodianButton = (props) => {
 
 const IssueDataCustodianButton = (props) => {
   const { researcher, showConfirmationModal } = props;
-  const message = 'Are you sure you want to make this person a Data Custodian?';
-  const title = 'Issue Data Custodian';
+  const message = 'Are you sure you want to make this person a Data Submitter?';
+  const title = 'Issue Data Submitter';
   return h(SimpleButton, {
     keyProp: `issue-card-${researcher.userEmail}`,
     label: 'Issue',
@@ -300,11 +300,11 @@ export default function DataCustodianTable(props) {
       setShowConfirmation(false);
       setShowModal(false);
       Notifications.showSuccess({
-        text: `Issued ${messageName} as Data Custodian`,
+        text: `Issued ${messageName} as Data Submitter`,
       });
     } catch (error) {
       Notifications.showError({
-        text: `Error issuing ${messageName} as Data Custodian`,
+        text: `Error issuing ${messageName} as Data Submitter`,
       });
     }
   };
@@ -329,11 +329,11 @@ export default function DataCustodianTable(props) {
       setResearchers(listCopy);
       setShowConfirmation(false);
       Notifications.showSuccess({
-        text: `Removed ${messageName} as a Data Custodian`,
+        text: `Removed ${messageName} as a Data Submitter`,
       });
     } catch (error) {
       Notifications.showError({
-        text: `Error removing ${messageName} as a Data Custodian`,
+        text: `Error removing ${messageName} as a Data Submitter`,
       });
     }
   };
@@ -357,7 +357,7 @@ export default function DataCustodianTable(props) {
           ]),
           div({ style: Styles.HEADER_CONTAINER }, [
             div({ style: { ...Styles.SUB_HEADER, marginTop: '0' } }, [
-              'Data Custodians',
+              'Data Submitters',
             ]),
             div(
               {
@@ -366,7 +366,7 @@ export default function DataCustodianTable(props) {
                 }),
               },
               [
-                "Your Institution's Data Custodians. Issue or Remove Data Custodian privileges below.",
+                "Your Institution's Data Submitters. Issue or remove Data Submitter privileges below.",
               ]
             ),
           ]),
@@ -376,7 +376,7 @@ export default function DataCustodianTable(props) {
           h(SimpleButton, {
             onClick: () => showModalOnClick(),
             baseColor: Theme.palette.secondary,
-            label: 'Add New Data Custodian',
+            label: 'Add New Data Submitter',
             additionalStyle: {
               width: '20rem',
             },

--- a/src/components/modals/DataCustodianFormModal.js
+++ b/src/components/modals/DataCustodianFormModal.js
@@ -119,7 +119,7 @@ export default function DataCustodianFormModal(props) {
     [
       div({ style: Styles.MODAL.CONTENT }, [
         h(CloseIconComponent, { closeFn: closeModal }),
-        div({ style: Styles.MODAL.TITLE_HEADER }, ['Add Data Custodian']),
+        div({ style: Styles.MODAL.TITLE_HEADER }, ['Add Data Submitter']),
         div({ style: { borderBottom: '1px solid #1FB50' } }, []),
         //users dropdown
         h(FormFieldRow, {

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -17,7 +17,7 @@ import DataCustodianTable from "../components/data_custodian_table/DataCustodian
 import { Config } from "../libs/config";
 
 const tabs = {
-  custodian: 'Data Custodian',
+  custodian: 'Data Submitter',
   researcher: 'Researchers'
 };
 


### PR DESCRIPTION
Addresses [DUOS-1512](https://broadworkbench.atlassian.net/browse/DUOS-1512)

PR replaces the term `Data Custodian` with `Data Submitter` on rendered text within the SO Console. 

**NOTE:** An additional ticket/PR will be made to update variable and component names to bring all references in line with each other. For now the string updates are needed for demo purposes.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
