### PR TITLE
[DUOS-1521][risk=no] Fix incorrect denied election status display

### DIFF
--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -220,8 +220,8 @@ class ResearcherConsole extends Component {
               this.state.dars.slice((currentDarPage - 1) * darLimit, currentDarPage * darLimit).map((darInfo, idx) => {
                 const opened = !isNil(darInfo.election);
                 // Look for any FINAL votes with a `true` value. Legacy default
-                // value was finalAccessVoteValue, so fall back to that if we
-                // don't have any votes.
+                // value was `election.finalAccessVote`, so fall back to that if
+                // we don't have any votes.
                 const finalAccessVoteValue = getOr(false)('finalAccessVote')(darInfo.election);
                 // This uses the same logic we use in the chair/admin console
                 const finalVote = isNil(darInfo.votes) ? null : find(wasFinalVoteTrue)(darInfo.votes);

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -226,6 +226,8 @@ class ResearcherConsole extends Component {
                 // This uses the same logic we use in the chair/admin console
                 const finalVote = isNil(darInfo.votes) ? null : find(wasFinalVoteTrue)(darInfo.votes);
                 const finalVoteValue = isNil(finalVote) ? finalAccessVoteValue : finalVote.vote;
+                //if the dar was canceled by an admin or chair the canceled status will be on the election
+                //if the researcher canceled the dar the canceled status will be on the dar data
                 const canceled =
                 !isNil(darInfo.dar.data.status) ?
                   darInfo.dar.data.status === 'Canceled'

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -219,10 +219,11 @@ class ResearcherConsole extends Component {
 
               this.state.dars.slice((currentDarPage - 1) * darLimit, currentDarPage * darLimit).map((darInfo, idx) => {
                 const opened = !isNil(darInfo.election);
-                // Look for any FINAL votes with a `true` value.
-                // Legacy default value was finalAccessVoteValue, so fall back
-                // to that if we don't have any votes.
+                // Look for any FINAL votes with a `true` value. Legacy default
+                // value was finalAccessVoteValue, so fall back to that if we
+                // don't have any votes.
                 const finalAccessVoteValue = getOr(false)('finalAccessVote')(darInfo.election);
+                // This uses the same logic we use in the chair/admin console
                 const finalVote = isNil(darInfo.votes) ? null : find(wasFinalVoteTrue)(darInfo.votes);
                 const finalVoteValue = isNil(finalVote) ? finalAccessVoteValue : finalVote.vote;
                 const canceled =


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1521

Use the same logic that we use on the chair/admin pages to determine approval/denial election status.
See also https://github.com/DataBiosphere/consent/pull/1362 where we do some data population for safety and consistency.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
