### PR TITLE
[DUOS-1525][risk=no] Remove unnecessary cancel button

### DIFF
--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -250,8 +250,7 @@ class ResearcherConsole extends Component {
                       button({
                         id: darInfo.dar.data.darCode + "_btnCancel", name: "btn_cancel", isRendered: isNil(darInfo.election), className: "cell-button cancel-color",
                         onClick: this.cancelDar, value: darInfo.dar.referenceId
-                      }, ["Cancel"]),
-                      button({ isRendered: isNil(darInfo.election) ? false : darInfo.election.status === 'Canceled' , className: "disabled" }, ["Canceled"]),
+                      }, ["Cancel"])
                     ]),
                     div({ className: "col-xs-1 cell-body f-center" }, [
                       button({

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -248,7 +248,7 @@ class ResearcherConsole extends Component {
                     ]),
                     div({ className: "col-xs-1 cell-body f-center" }, [
                       button({
-                        isRendered: isNil(darInfo.election) && !canceled,
+                        isRendered: !opened && !canceled,
                         id: darInfo.dar.data.darCode + "_btnCancel",
                         name: "btn_cancel",
                         className: "cell-button cancel-color",

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -248,8 +248,12 @@ class ResearcherConsole extends Component {
                     ]),
                     div({ className: "col-xs-1 cell-body f-center" }, [
                       button({
-                        id: darInfo.dar.data.darCode + "_btnCancel", name: "btn_cancel", isRendered: isNil(darInfo.election), className: "cell-button cancel-color",
-                        onClick: this.cancelDar, value: darInfo.dar.referenceId
+                        isRendered: isNil(darInfo.election) && !canceled,
+                        id: darInfo.dar.data.darCode + "_btnCancel",
+                        name: "btn_cancel",
+                        className: "cell-button cancel-color",
+                        onClick: this.cancelDar,
+                        value: darInfo.dar.referenceId
                       }, ["Cancel"])
                     ]),
                     div({ className: "col-xs-1 cell-body f-center" }, [


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1525

* Remove unnecessary cancel button
* Update the logic for when to show the cancel button. Cancel is only valid for DARs in Submitted state. Nothing else is cancelable from the researcher's console, even for admins/chairs - that has to happen from an admin/chair console.

## Before:
### Researcher
<img width="1447" alt="Screen Shot 2021-12-02 at 8 51 22 AM" src="https://user-images.githubusercontent.com/116679/144435325-5b51c2d3-2758-48b2-9646-439a0e32afba.png">

### Admin/Chair
<img width="1447" alt="Screen Shot 2021-12-02 at 8 51 18 AM" src="https://user-images.githubusercontent.com/116679/144435203-67070500-30a8-4c78-a52f-d57ec04985b7.png">

## New:
<img width="1447" alt="Screen Shot 2021-12-02 at 8 51 39 AM" src="https://user-images.githubusercontent.com/116679/144435236-72385ccc-f81f-46f3-af25-6d3d21fdcf74.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
