### PR TITLE
[DUOS-1446][risk=no] Changed "missing" display names on SO console

### DIFF
--- a/src/components/data_custodian_table/DataCustodianTable.js
+++ b/src/components/data_custodian_table/DataCustodianTable.js
@@ -144,7 +144,7 @@ const emailCell = (email, id) => {
 
 const displayNameCell = (displayName, id) => {
   return {
-    data: displayName || '- -',
+    data: displayName || 'Invite sent, pending registration',
     id,
     style: {},
     label: 'display-name',

--- a/src/components/signing_official_table/SigningOfficialTable.js
+++ b/src/components/signing_official_table/SigningOfficialTable.js
@@ -157,7 +157,7 @@ const emailCell = (email, id) => {
 
 const displayNameCell = (displayName, id) => {
   return {
-    data: displayName || '- -',
+    data: displayName || 'Invite sent, pending registration',
     id,
     style: {},
     label: 'display-name'


### PR DESCRIPTION
Changed display names for never-signed-in users on signing official console from "- -" to "Invite sent, pending registration"

Issue: https://broadworkbench.atlassian.net/browse/DUOS-1446

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
