### PR TITLE
[DUOS-1586][risk=no] Show search box to all users

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -331,7 +331,7 @@ export default function DatasetCatalog(props) {
               description: "Search and select datasets then click 'Apply for Access' to request access"
             }),
           ]),
-          div({ className: 'right', isRendered: (currentUser.isAdmin || currentUser.isChairPerson) }, [
+          div({ className: 'right'}, [
             div({ className: 'col-lg-7 col-md-7 col-sm-7 col-xs-7 search-wrapper' }, [
               h(SearchBox, { id: 'datasetCatalog', searchHandler: handleSearchDul, pageHandler: handlePageChange, color: 'dataset' })
             ]),


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1586

As of https://github.com/DataBiosphere/duos-ui/pull/729, we made the search box hidden to non-admin, non-chair users which was a non-intentional regression. This PR re-enables the search box for all users.

![Screen Shot 2022-01-18 at 11 37 26 AM](https://user-images.githubusercontent.com/116679/149979401-55572098-702c-4214-803e-e55473574e54.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
