### PR TITLE
[DUOS-1589][risk=no] deprecate-user-rationale

### DIFF
--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -37,13 +37,6 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
             label({ className: 'control-label no-padding' }, ['Status: ']),
             span({ id: 'lbl_researcherStatus', className: 'response-label', style: { 'paddingLeft': '5px' } }, [darInfo.status])
           ]),
-          div({ isRendered: darInfo.hasAdminComment, className: 'row no-margin' }, [
-            span({}, [
-              label({ className: 'control-label no-padding' }, ['Comments: ']),
-              span({ id: 'lbl_adminComment', className: 'response-label', style: { 'paddingLeft': '5px' } },
-                [darInfo.adminComment])
-            ])
-          ]),
           div({ isRendered: !ld.isEmpty(libraryCards), className: 'row no-margin' }, [
             label({ className: 'control-label no-padding' }, ['Library Cards: ']),
             LibraryCards({

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -238,8 +238,6 @@ export const DAR = {
     darInfo.country = rawDar.country;
     darInfo.status = rawDar.status;
     darInfo.restrictions = rawDar.restrictions;
-    darInfo.hasAdminComment = researcher.rationale != null;
-    darInfo.adminComment = researcher.rationale;
     const purposeStatements = DataUseTranslation.generatePurposeStatement(darInfo);
     const researchType = DataUseTranslation.generateResearchTypes(darInfo);
     darInfo.hasPurposeStatements = purposeStatements && purposeStatements.length > 0;


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1589)

- removed researcher.rationale from ajax.js 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
