### PR TITLE
[DUOS-1618][risk=no] Add LCA Terms Download Link to LC Modals

### DIFF
--- a/src/components/LibraryCardAgreementTermsDownload.js
+++ b/src/components/LibraryCardAgreementTermsDownload.js
@@ -1,0 +1,15 @@
+import LibraryCardAgreementLink from '../assets/Library_Card_Agreement_2021.pdf';
+import DownloadIcon from 'react-material-icon-svg/dist/Download';
+import {a, div} from "react-hyperscript-helpers";
+import React from "react";
+
+const downloadIcon = <DownloadIcon fill={'black'} style={{verticalAlign: 'middle'}}/>;
+export const LibraryCardAgreementTermsDownload =
+  div({}, [
+    "I agree to the terms of the Library Card Agreement",
+    a({
+      id: 'link_downloadAgreement',
+      href: LibraryCardAgreementLink,
+      target: '_blank',
+      style: {marginLeft: '.5rem'}
+    }, [downloadIcon])]);

--- a/src/components/LibraryCardAgreementTermsDownload.js
+++ b/src/components/LibraryCardAgreementTermsDownload.js
@@ -1,12 +1,12 @@
 import LibraryCardAgreementLink from '../assets/Library_Card_Agreement_2021.pdf';
 import DownloadIcon from 'react-material-icon-svg/dist/Download';
-import {a, div} from "react-hyperscript-helpers";
-import React from "react";
+import {a, div} from 'react-hyperscript-helpers';
+import React from 'react';
 
 const downloadIcon = <DownloadIcon fill={'black'} style={{verticalAlign: 'middle'}}/>;
 export const LibraryCardAgreementTermsDownload =
   div({}, [
-    "I agree to the terms of the Library Card Agreement",
+    'I agree to the terms of the Library Card Agreement',
     a({
       id: 'link_downloadAgreement',
       href: LibraryCardAgreementLink,

--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -7,6 +7,7 @@ import Modal from 'react-modal';
 import {SearchSelect} from '../SearchSelect';
 import Creatable from 'react-select/creatable';
 import SimpleButton from '../SimpleButton';
+import {LibraryCardAgreementTermsDownload} from '../LibraryCardAgreementTermsDownload';
 
 const FormFieldRow = (props) => {
   const { card, dropdownOptions, updateInstitution, updateUser, modalType, setCard } = props;
@@ -145,6 +146,8 @@ export default function LibraryCardFormModal(props) {
         div({ style: { borderBottom: '1px solid #1FB50' } }, []),
         // Library Card Agreement Text
         isEmpty(lcaContent) ? div() : div({style: { maxWidth: '700px', minWidth: '700px', maxHeight: '200px', overflow: 'auto', marginBottom: '25px' }}, [lcaContent]),
+        // LCA Terms Download
+        LibraryCardAgreementTermsDownload,
         //users dropdown
         h(FormFieldRow, {
           card,

--- a/src/components/signing_official_table/SigningOfficialTable.js
+++ b/src/components/signing_official_table/SigningOfficialTable.js
@@ -20,6 +20,7 @@ import { LibraryCard } from "../../libs/ajax";
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
 import LcaMarkdown from '../../assets/LCA.md';
+import {LibraryCardAgreementTermsDownload} from '../LibraryCardAgreementTermsDownload';
 
 //Styles specific to this table
 const styles = {
@@ -75,7 +76,10 @@ const IssueLibraryCardButton = (props) => {
   //username can be confirmed on back-end -> if userId exists pull data from db, otherwise only save email
   //institution id should be determined from the logged in SO account on the back-end
   const {card, showConfirmationModal} = props;
-  const message = 'Are you sure you want to issue this library card?';
+  const message = div({}, [
+    // LCA Terms Download
+    LibraryCardAgreementTermsDownload,
+    'Are you sure you want to issue this library card?']);
   const title = 'Issue Library Card';
   return h(SimpleButton, {
     keyProp: `issue-card-${card.userEmail}`,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1618

## Changes
New component to show a terms agreement and download icon for the current LCA terms.

### Adding a new researcher
![Screen Shot 2022-02-23 at 1 32 49 PM](https://user-images.githubusercontent.com/116679/155384711-06672dec-f9a0-49b9-8640-300edb39c992.png)

### Issuing a new LC to a researcher
![Screen Shot 2022-02-23 at 1 33 02 PM](https://user-images.githubusercontent.com/116679/155384804-a71b0aff-1373-4e63-b37d-43465c4a1c4d.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
