### PR TITLE
DUOS-1622[risk=no] edit user new page no modal

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -45,6 +45,7 @@ import AdminManageInstitutions from './pages/AdminManageInstitutions';
 import AdminManageLC from './pages/AdminManageLC';
 import DatasetStatistics from "./pages/DatasetStatistics";
 import DarCollectionReview from './pages/dar_collection_review/DarCollectionReview';
+import {AdminEditUser} from "./pages/AdminEditUser";
 
 const Routes = (props) => (
   <Switch>
@@ -70,6 +71,7 @@ const Routes = (props) => (
     <Route path="/data_sharing_language_tool" component={DataSharingLanguageTool} />
     <AuthenticatedRoute path="/admin_console" component={AdminConsole} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_users" component={AdminManageUsers} props={props} rolesAllowed={[USER_ROLES.admin]} />
+    <AuthenticatedRoute path="/admin_edit_user/:dacUserId" component={AdminEditUser} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/manage_dac" component={ManageDac} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/admin_manage_institutions" component={AdminManageInstitutions} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/summary_votes" component={SummaryVotes} props={props} rolesAllowed={[USER_ROLES.all]} />

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -38,43 +38,20 @@ export const AddUserModal = hh(class AddUserModal extends Component {
       return;
     }
 
-    if (this.props.user) {
-      const user = await User.getByEmail(this.props.user.email);
-      const currentRoles = _.map(user.roles, (ur) => {return { 'roleId': ur.roleId, 'name': ur.name };});
-      const updatedRoles = _.isEmpty(currentRoles) ? [researcherRole] : currentRoles;
+    this.setState({
+      displayName: '',
+      email: '',
+      updatedRoles: [researcherRole],
+      emailPreference: false
+    },
+    () => {
+      let r1 = this.nameRef.current;
+      let r2 = this.emailRef.current;
       this.setState({
-        mode: 'Edit',
-        displayName: user.displayName,
-        email: user.email,
-        user: user,
-        updatedRoles: updatedRoles,
-        emailPreference: user.emailPreference
-      },
-      () => {
-        let r1 = this.nameRef.current;
-        let r2 = this.emailRef.current;
-        this.setState({
-          displayNameValid: r1.validity.valid,
-          emailValid: r2.validity.valid
-        });
+        displayNameValid: r1.validity.valid,
+        emailValid: r2.validity.valid
       });
-    } else {
-      this.setState({
-        mode: 'Add',
-        displayName: '',
-        email: '',
-        updatedRoles: [researcherRole],
-        emailPreference: false
-      },
-      () => {
-        let r1 = this.nameRef.current;
-        let r2 = this.emailRef.current;
-        this.setState({
-          displayNameValid: r1.validity.valid,
-          emailValid: r2.validity.valid
-        });
-      });
-    }
+    });
   }
 
   OKHandler = async (event) => {
@@ -91,24 +68,9 @@ export const AddUserModal = hh(class AddUserModal extends Component {
       emailPreference: this.state.emailPreference,
       roles: this.state.updatedRoles
     };
-    switch (this.state.mode) {
-      case 'Add': {
-        user.email = this.state.email;
-        const createdUser = await User.create(user);
-        this.setState({ emailValid: createdUser });
-        break;
-      }
-      case 'Edit': {
-        user.dacUserId = this.state.user.dacUserId;
-        const payload = { updatedUser: user };
-        const updatedUser = await User.update(payload, this.state.user.dacUserId);
-        this.setState({ emailValid: updatedUser });
-        break;
-      }
-      default:
-        break;
-    }
-
+    user.email = this.state.email;
+    const createdUser = await User.create(user);
+    this.setState({ emailValid: createdUser });
     event.preventDefault();
 
     if (this.state.emailValid !== false) {
@@ -182,11 +144,11 @@ export const AddUserModal = hh(class AddUserModal extends Component {
         disableOkBtn: !validForm,
         onRequestClose: this.closeHandler,
         onAfterOpen: this.afterOpenHandler,
-        imgSrc: this.state.mode === 'Add' ? addUserIcon : editUserIcon,
+        imgSrc: addUserIcon,
         color: 'common',
-        title: this.state.mode === 'Add' ? 'Add User' : 'Edit User',
-        description: this.state.mode === 'Add' ? 'Catalog a new User in the system' : 'Edit a User in the system',
-        action: { label: this.state.mode === 'Add' ? 'Add' : 'Save', handler: this.OKHandler }
+        title: 'Add User',
+        description: 'Catalog a new User in the system',
+        action: { label: 'Add', handler: this.OKHandler }
       },
       [
         form({ className: 'form-horizontal css-form', name: 'userForm', encType: 'multipart/form-data', onChange: this.formChange }, [
@@ -263,9 +225,6 @@ export const AddUserModal = hh(class AddUserModal extends Component {
               ])
             ]),
           ])
-        ]),
-        div({ isRendered: _.has(user, "dacUserId") }, [
-          ResearcherReview({userId: _.get(user, "dacUserId")})
         ]),
 
         div({ isRendered: this.state.emailValid === false && this.state.submitted === true }, [

--- a/src/components/modals/AddUserModal.js
+++ b/src/components/modals/AddUserModal.js
@@ -5,9 +5,7 @@ import { User } from '../../libs/ajax';
 import { USER_ROLES } from '../../libs/utils';
 import { Alert } from '../Alert';
 import { BaseModal } from '../BaseModal';
-import { ResearcherReview } from '../../pages/ResearcherReview';
 import addUserIcon from '../../images/icon_add_user.png';
-import editUserIcon from '../../images/icon_edit_user.png';
 
 const adminRole = { 'roleId': 4, 'name': USER_ROLES.admin };
 const researcherRole = { 'roleId': 5, 'name': USER_ROLES.researcher };
@@ -136,7 +134,6 @@ export const AddUserModal = hh(class AddUserModal extends Component {
   render() {
     const { displayName, email, displayNameValid, emailValid } = this.state;
     const validForm = displayNameValid && emailValid;
-    const { user } = this.props;
     return (
       BaseModal({
         id: 'addUserModal',

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -921,9 +921,22 @@ export const User = {
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'GET' }]));
     return res.json();
   },
+
   getUnassignedUsers: async () => {
     const url = `${await Config.getApiUrl()}/api/user/institution/unassigned`;
     const res = await axios.get(url, Config.authOpts());
+    return res.data;
+  },
+
+  addRoleToUser: async (userId, roleId) => {
+    const url = `${await Config.getApiUrl()}/api/user/${userId}/${roleId}`;
+    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'PUT' }]));
+    return res.data;
+  },
+
+  deleteRoleFromUser: async (userId, roleId) => {
+    const url = `${await Config.getApiUrl()}/api/user/${userId}/${roleId}`;
+    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
     return res.data;
   }
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -930,13 +930,13 @@ export const User = {
 
   addRoleToUser: async (userId, roleId) => {
     const url = `${await Config.getApiUrl()}/api/user/${userId}/${roleId}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'PUT' }]));
+    const res = await fetchAny(url, fp.mergeAll([Config.authOpts(), { method: 'PUT' }]));
     return res.json();
   },
 
   deleteRoleFromUser: async (userId, roleId) => {
     const url = `${await Config.getApiUrl()}/api/user/${userId}/${roleId}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
+    const res = await fetchAny(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
     return res.json();
   }
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -931,13 +931,13 @@ export const User = {
   addRoleToUser: async (userId, roleId) => {
     const url = `${await Config.getApiUrl()}/api/user/${userId}/${roleId}`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'PUT' }]));
-    return res.data;
+    return res.json();
   },
 
   deleteRoleFromUser: async (userId, roleId) => {
     const url = `${await Config.getApiUrl()}/api/user/${userId}/${roleId}`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
-    return res.data;
+    return res.json();
   }
 
 };

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -66,9 +66,10 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     const updatedUser = await User.update(payload, userId);
     await this.updateRolesIfDifferent(userId, this.state.updatedRoles);
 
-    this.setState({
-      user: updatedUser,
-      displayNameValid: updatedUser
+    console.log("Updating the user in state: " + JSON.stringify(updatedUser));
+    this.setState(prev => {
+      prev.user = Object.assign({}, updatedUser);
+      prev.displayNameValid = this.nameRef.current.validity.valid;
     });
   };
 
@@ -137,7 +138,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
 
   render() {
-    const {user, displayName, email, displayNameValid} = this.state;
+    const {displayName, email, displayNameValid} = this.state;
     return (
       div({className: "container container-wide"}, [
         div({className: "row no-margin"}, [
@@ -293,8 +294,8 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
             ])
           ]),
           ResearcherReview({
-            isRendered: !isEmpty(user),
-            user: user
+            isRendered: !isEmpty(this.state.user),
+            user: this.state.user
           })
         ])
       ])

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -218,8 +218,8 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                     placeholder: 'e.g. username@broadinstitute.org',
                     required: true,
                     value: email,
-                    onChange: this.handleChange,
-                    ref: this.emailRef
+                    ref: this.emailRef,
+                    disabled: true
                   })
                 ])
               ]),

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -165,7 +165,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       return !_.isEmpty(admins);
     };
 
-    //TODO change to not rely on this.state.updatedRoles
     isSigningOfficial = () => {
       const signingOfficials = _.filter(this.state.updatedRoles, _.matches(signingOfficialRole));
       return !_.isEmpty(signingOfficials);

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -10,6 +10,7 @@ import {PageHeading} from "../components/PageHeading";
 
 const adminRole = {'roleId': 4, 'name': USER_ROLES.admin};
 const researcherRole = {'roleId': 5, 'name': USER_ROLES.researcher};
+const signingOfficialRole = {'roleId': 7, 'name': USER_ROLES.signingOfficial};
 
 export const AdminEditUser = hh(class AdminEditUser extends Component {
 
@@ -105,6 +106,24 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     });
   };
 
+  signingOfficialChanged = (e) => {
+    const checkState = e.target.checked;
+    // True? add admin role to state.updatedRoles
+    // False? remove admin role from state.updatedRoles
+    let newRoles = [researcherRole];
+    if (checkState) {
+      newRoles = _.concat(this.state.updatedRoles, signingOfficialRole);
+    } else {
+      newRoles = _.filter(this.state.updatedRoles, (r) => {
+        return r.roleId !== signingOfficialRole.roleId;
+      });
+    }
+    this.setState(prev => {
+      prev.updatedRoles = newRoles;
+      return prev;
+    });
+  };
+
   handleChange = (e) => {
     const name = e.target.name;
     const validName = name + 'Valid';
@@ -124,6 +143,12 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   isAdmin = () => {
     const admins = _.filter(this.state.updatedRoles, _.matches(adminRole));
     return !_.isEmpty(admins);
+  };
+
+  //TODO change to not rely on this.state.updatedRoles
+  isSigningOfficial = () => {
+    const signingOfficials = _.filter(this.state.updatedRoles, _.matches(signingOfficialRole));
+    return !_.isEmpty(signingOfficials);
   };
 
   render() {
@@ -200,9 +225,9 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                       input({
                         type: 'checkbox',
                         id: 'chk_signing_official',
-                        checked: this.isAdmin(),
+                        checked: this.isSigningOfficial(),
                         className: 'checkbox-inline user-checkbox',
-                        onChange: this.adminChanged
+                        onChange: this.signingOfficialChanged
                       }),
                       label({
                         id: 'lbl_signing_official',

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -35,13 +35,10 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   }
 
   async componentDidMount() {
-
-    if (this.props.user) {
-      const user = await User.getByEmail(this.props.user.email);
+      const user = await User.getById(this.props.match.params.dacUserId);
       const currentRoles = _.map(user.roles, (ur) => {return { 'roleId': ur.roleId, 'name': ur.name };});
       const updatedRoles = _.isEmpty(currentRoles) ? [researcherRole] : currentRoles;
       this.setState({
-          mode: 'Edit',
           displayName: user.displayName,
           email: user.email,
           user: user,
@@ -56,23 +53,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
             emailValid: r2.validity.valid
           });
         });
-    } else {
-      this.setState({
-          mode: 'Add',
-          displayName: '',
-          email: '',
-          updatedRoles: [researcherRole],
-          emailPreference: false
-        },
-        () => {
-          let r1 = this.nameRef.current;
-          let r2 = this.emailRef.current;
-          this.setState({
-            displayNameValid: r1.validity.valid,
-            emailValid: r2.validity.valid
-          });
-        });
-    }
   }
 
   OKHandler = async (event) => {

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -66,10 +66,9 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     const updatedUser = await User.update(payload, userId);
     await this.updateRolesIfDifferent(userId, this.state.updatedRoles);
 
-    console.log("Updating the user in state: " + JSON.stringify(updatedUser));
-    this.setState(prev => {
-      prev.user = Object.assign({}, updatedUser);
-      prev.displayNameValid = this.nameRef.current.validity.valid;
+    this.setState({
+      user: Object.assign({}, updatedUser),
+      displayNameValid: this.nameRef.current.validity.valid
     });
   };
 

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -1,10 +1,9 @@
 import _ from 'lodash';
 import {union, contains, map} from 'lodash/fp';
-import React, {Component, Fragment} from 'react';
-import {button, div, form, h, hh, input, label} from 'react-hyperscript-helpers';
+import React, {Component} from 'react';
+import {button, div, form, hh, input, label} from 'react-hyperscript-helpers';
 import {User} from '../libs/ajax';
 import {USER_ROLES} from '../libs/utils';
-import {Alert} from '../components/Alert';
 import {ResearcherReview} from './ResearcherReview';
 import editUserIcon from '../images/icon_edit_user.png';
 import {PageHeading} from "../components/PageHeading";

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -247,7 +247,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                 ]),
               ])
             ]),
-            ResearcherReview({userId: _.get(user, "dacUserId")}),
+            ResearcherReview({userId: this.props.match.params.dacUserId}),
 
             div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
               Alert({

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -22,7 +22,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       displayName: '',
       email: '',
       displayNameValid: false,
-   //   emailValid: false,
       submitted: false,
       alerts: [],
       updatedRoles: [researcherRole],
@@ -30,7 +29,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     };
 
     this.nameRef = React.createRef();
-    this.emailRef = React.createRef();
   }
 
   async componentDidMount() {
@@ -47,11 +45,8 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       emailPreference: user.emailPreference
     },
     () => {
-      let r1 = this.nameRef.current;
-      let r2 = this.emailRef.current;
       this.setState({
-        displayNameValid: r1.validity.valid,
-    //    emailValid: r2.validity.valid
+        displayNameValid: this.nameRef.current.validity.valid,
       });
     });
   }
@@ -114,7 +109,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   };
 
   formIsValid = () => {
-    return this.state.displayNameValid;// && this.state.emailValid;
+    return this.state.displayNameValid;
   };
 
   emailPreferenceChanged = (e) => {
@@ -218,7 +213,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                     placeholder: 'e.g. username@broadinstitute.org',
                     required: true,
                     value: email,
-                    ref: this.emailRef,
                     disabled: true
                   })
                 ])

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -1,12 +1,13 @@
 import _ from 'lodash';
 import React, {Component, Fragment} from 'react';
-import {div, form, h, hh, input, label} from 'react-hyperscript-helpers';
+import {button, div, form, h, hh, input, label} from 'react-hyperscript-helpers';
 import {User} from '../libs/ajax';
 import {USER_ROLES} from '../libs/utils';
 import {Alert} from '../components/Alert';
 import {ResearcherReview} from './ResearcherReview';
 import editUserIcon from '../images/icon_edit_user.png';
 import {PageHeading} from "../components/PageHeading";
+import SimpleButton from "../components/SimpleButton";
 
 const adminRole = {'roleId': 4, 'name': USER_ROLES.admin};
 const researcherRole = {'roleId': 5, 'name': USER_ROLES.researcher};
@@ -141,7 +142,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   render() {
     const {displayName, email, displayNameValid, emailValid} = this.state;
     const validForm = displayNameValid && emailValid;
-    const {user} = this.props;
+    const {dacUserId} = this.props.match.params;
     return (
       div({className: "container container-wide"}, [
         div({className: "row no-margin"}, [
@@ -158,7 +159,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
           div({className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding"}, [
 
             form({
-              className: 'form-horizontal css-form',
+              className: 'form-horizontal css-form ',
               name: 'userForm',
               encType: 'multipart/form-data',
               onChange: this.formChange
@@ -245,9 +246,18 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                       ['Disable Admin email notifications'])
                   ])
                 ]),
+                //TODO: refactor into separate component + not refresh when clicked
+                div({ className: 'col-lg-12 col-xs-12 inline-block' }, [
+                  button({
+                    id: 'btn_save',
+                    onClick: () => {},
+                    className: 'f-right btn-primary common-background',
+                    disabled: !validForm
+                  }, ['Save']),
+                ])
               ])
             ]),
-            ResearcherReview({userId: this.props.match.params.dacUserId}),
+            ResearcherReview({userId: dacUserId}),
 
             div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
               Alert({

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -7,7 +7,6 @@ import {Alert} from '../components/Alert';
 import {ResearcherReview} from './ResearcherReview';
 import editUserIcon from '../images/icon_edit_user.png';
 import {PageHeading} from "../components/PageHeading";
-import SimpleButton from "../components/SimpleButton";
 
 const adminRole = {'roleId': 4, 'name': USER_ROLES.admin};
 const researcherRole = {'roleId': 5, 'name': USER_ROLES.researcher};
@@ -76,20 +75,8 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     this.setState({emailValid: updatedUser});
 
     event.preventDefault();
-
-    if (this.state.emailValid !== false) {
-      this.props.onOKRequest('addUser');
-    }
-
   };
 
-  closeHandler = () => {
-    this.props.onCloseRequest('addUser');
-  };
-
-  afterOpenHandler = () => {
-    this.props.onAfterOpen('addUser');
-  };
 
   emailPreferenceChanged = (e) => {
     // disable notifications checkbox is not checked: -> Set email preference TRUE
@@ -246,11 +233,11 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                       ['Disable Admin email notifications'])
                   ])
                 ]),
-                //TODO: refactor into separate component + not refresh when clicked
+                //TODO: refactor into separate component
                 div({ className: 'col-lg-12 col-xs-12 inline-block' }, [
                   button({
                     id: 'btn_save',
-                    onClick: () => {},
+                    onClick: this.OKHandler,
                     className: 'f-right btn-primary common-background',
                     disabled: !validForm
                   }, ['Save']),

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -65,12 +65,12 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     if (validForm === false) {
       return;
     }
+    const userId = this.state.user.dacUserId;
     let user = {
+      dacUserId: userId,
       displayName: this.state.displayName,
       emailPreference: this.state.emailPreference,
     };
-    const userId = this.state.user.dacUserId;
-    user.dacUserId = userId;
     const payload = {updatedUser: user};
     const updatedUser = await User.update(payload, userId);
 
@@ -78,7 +78,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
     this.setState({
       submitted: true,
-      emailValid: updatedUser
+      emailValid: updatedUser,
     });
   };
 
@@ -178,14 +178,9 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       });
     };
 
-    isAdmin = () => {
-      const admins = _.filter(this.state.updatedRoles, _.matches(adminRole));
-      return !_.isEmpty(admins);
-    };
-
-    isSigningOfficial = () => {
-      const signingOfficials = _.filter(this.state.updatedRoles, _.matches(signingOfficialRole));
-      return !_.isEmpty(signingOfficials);
+    userIsRole = (role) => {
+      const matches = _.filter(this.state.updatedRoles, _.matches(role));
+      return !_.isEmpty(matches);
     };
 
     render()
@@ -262,7 +257,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                         input({
                           type: 'checkbox',
                           id: 'chk_signing_official',
-                          checked: this.isSigningOfficial(),
+                          checked: this.userIsRole(signingOfficialRole),
                           className: 'checkbox-inline user-checkbox',
                           onChange: this.signingOfficialChanged
                         }),
@@ -285,7 +280,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                       input({
                         type: 'checkbox',
                         id: 'chk_admin',
-                        checked: this.isAdmin(),
+                        checked: this.userIsRole(adminRole),
                         className: 'checkbox-inline user-checkbox',
                         onChange: this.adminChanged
                       }),
@@ -299,7 +294,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                 ]),
                 div({className: 'form-group'}, [
                   div({
-                    isRendered: this.isAdmin(),
+                    isRendered: this.userIsRole(adminRole),
                     className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
                     style: {'paddingLeft': '30px'}
                   }, [
@@ -328,7 +323,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                 ])
               ])
             ]),
-            ResearcherReview({userId: dacUserId}),
+            ResearcherReview({userId: dacUserId, user: this.state.user}),
 
             div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
               Alert({

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -223,6 +223,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                         type: 'checkbox',
                         id: 'chk_researcher',
                         checked: true,
+                        readOnly: true,
                         className: 'checkbox-inline user-checkbox',
                       }),
                       label({

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -126,34 +126,16 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       });
     };
 
-    adminChanged = (e) => {
+    roleStatusChanged = (e, role) => {
       const checkState = e.target.checked;
-      // True? add admin role to state.updatedRoles
-      // False? remove admin role from state.updatedRoles
+      // True? add role to state.updatedRoles
+      // False? remove role from state.updatedRoles
       let newRoles = [researcherRole];
       if (checkState) {
-        newRoles = _.concat(this.state.updatedRoles, adminRole);
+        newRoles = _.concat(this.state.updatedRoles, role);
       } else {
         newRoles = _.filter(this.state.updatedRoles, (r) => {
-          return r.roleId !== adminRole.roleId;
-        });
-      }
-      this.setState(prev => {
-        prev.updatedRoles = newRoles;
-        return prev;
-      });
-    };
-
-    signingOfficialChanged = (e) => {
-      const checkState = e.target.checked;
-      // True? add admin role to state.updatedRoles
-      // False? remove admin role from state.updatedRoles
-      let newRoles = [researcherRole];
-      if (checkState) {
-        newRoles = _.concat(this.state.updatedRoles, signingOfficialRole);
-      } else {
-        newRoles = _.filter(this.state.updatedRoles, (r) => {
-          return r.roleId !== signingOfficialRole.roleId;
+          return r.roleId !== role.roleId;
         });
       }
       this.setState(prev => {
@@ -259,7 +241,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                           id: 'chk_signing_official',
                           checked: this.userIsRole(signingOfficialRole),
                           className: 'checkbox-inline user-checkbox',
-                          onChange: this.signingOfficialChanged
+                          onChange: e => this.roleStatusChanged(e, signingOfficialRole)
                         }),
                         label({
                           id: 'lbl_signing_official',
@@ -282,7 +264,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                         id: 'chk_admin',
                         checked: this.userIsRole(adminRole),
                         className: 'checkbox-inline user-checkbox',
-                        onChange: this.adminChanged
+                        onChange: e => this.roleStatusChanged(e, adminRole)
                       }),
                       label({
                         id: 'lbl_admin',

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -35,9 +35,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   }
 
   async componentDidMount() {
-    if (this.props.showModal === false) {
-      return;
-    }
 
     if (this.props.user) {
       const user = await User.getByEmail(this.props.user.email);
@@ -92,23 +89,10 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       emailPreference: this.state.emailPreference,
       roles: this.state.updatedRoles
     };
-    switch (this.state.mode) {
-      case 'Add': {
-        user.email = this.state.email;
-        const createdUser = await User.create(user);
-        this.setState({ emailValid: createdUser });
-        break;
-      }
-      case 'Edit': {
         user.dacUserId = this.state.user.dacUserId;
         const payload = { updatedUser: user };
         const updatedUser = await User.update(payload, this.state.user.dacUserId);
         this.setState({ emailValid: updatedUser });
-        break;
-      }
-      default:
-        break;
-    }
 
     event.preventDefault();
 

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -65,16 +65,14 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     if (validForm === false) {
       return;
     }
+    const userId = this.state.user.dacUserId;
     let user = {
+      dacUserId: userId,
       displayName: this.state.displayName,
       emailPreference: this.state.emailPreference,
-      roles: this.state.updatedRoles
     };
-    const userId = this.state.user.dacUserId;
-    user.dacUserId = userId;
     const payload = {updatedUser: user};
     const updatedUser = await User.update(payload, userId);
-
     await this.updateRolesIfDifferent(userId, this.state.updatedRoles);
 
     this.setState({
@@ -83,27 +81,18 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     });
   };
 
-  //TODO: currently doesn't seem to be updating roles (neither does User.update above)
   updateRolesIfDifferent = async (userId, updatedRoles) => {
     const user = await User.getById(userId);
     const currentRoles = user.roles;
 
     _.map(updatedRoles, role => {
-      console.log(JSON.stringify(updatedRoles));
-      console.log(JSON.stringify(role));
-
       if (!contains(currentRoles, role)) {
-        console.log("adding role to user");
         User.addRoleToUser(userId, role.roleId);
       }
     });
 
     _.map(currentRoles, role => {
-      console.log(JSON.stringify(currentRoles));
-      console.log(JSON.stringify(role));
-
       if (!contains(updatedRoles, role)) {
-        console.log("deleting role from user");
         User.deleteRoleFromUser(userId, role.roleId);
       }
     });

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -22,7 +22,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       displayName: '',
       email: '',
       displayNameValid: false,
-      emailValid: false,
+   //   emailValid: false,
       submitted: false,
       alerts: [],
       updatedRoles: [researcherRole],
@@ -51,7 +51,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       let r2 = this.emailRef.current;
       this.setState({
         displayNameValid: r1.validity.valid,
-        emailValid: r2.validity.valid
+    //    emailValid: r2.validity.valid
       });
     });
   }
@@ -75,7 +75,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
     this.setState({
       submitted: true,
-      emailValid: updatedUser
+      displayNameValid: updatedUser
     });
   };
 
@@ -114,7 +114,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   };
 
   formIsValid = () => {
-    return this.state.displayNameValid && this.state.emailValid;
+    return this.state.displayNameValid;// && this.state.emailValid;
   };
 
   emailPreferenceChanged = (e) => {
@@ -317,23 +317,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
               ])
             ])
           ]),
-          ResearcherReview({userId: dacUserId}),
-
-          div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
-            Alert({
-              id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
-              description: 'There is a user already registered with this google account.'
-            })
-          ]),
-          div({isRendered: this.state.alerts.length > 0}, [
-            this.state.alerts.map((alert, ix) => {
-              return (
-                h(Fragment, {key: 'alert_' + ix}, [
-                  Alert({id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg})
-                ])
-              );
-            })
-          ])
+          ResearcherReview({userId: dacUserId})
         ])
       ])
     );

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -23,7 +23,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       email: '',
       displayNameValid: false,
       emailValid: false,
-      invalidForm: true,
       submitted: false,
       alerts: [],
       updatedRoles: [researcherRole],
@@ -61,8 +60,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     event.persist();
     event.preventDefault();
 
-    const validForm = this.state.displayNameValid && this.state.emailValid;
-    if (validForm === false) {
+    if (!this.formIsValid()) {
       return;
     }
     const userId = this.state.user.dacUserId;
@@ -116,6 +114,9 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     });
   };
 
+  formIsValid = () => {
+    return this.state.displayNameValid && this.state.emailValid;
+  };
 
     emailPreferenceChanged = (e) => {
       // disable notifications checkbox is not checked: -> Set email preference TRUE
@@ -153,13 +154,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       });
     };
 
-    formChange = () => {
-      this.setState(prev => {
-        prev.invalidForm = (prev.displayNameValid && prev.emailValid);
-        return prev;
-      });
-    };
-
     userIsRole = (role) => {
       const matches = _.filter(this.state.updatedRoles, _.matches(role));
       return !_.isEmpty(matches);
@@ -167,8 +161,8 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
     render()
     {
-      const {displayName, email, displayNameValid, emailValid} = this.state;
-      const validForm = displayNameValid && emailValid;
+      const {displayName, email} = this.state;
+      const validForm = this.formIsValid();
       const {dacUserId} = this.props.match.params;
       return (
         div({className: "container container-wide"}, [
@@ -189,7 +183,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                 className: 'form-horizontal css-form ',
                 name: 'userForm',
                 encType: 'multipart/form-data',
-                onChange: this.formChange
               }, [
                 div({className: 'form-group first-form-group'}, [
                   label({

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -1,0 +1,286 @@
+import _ from 'lodash';
+import React, { Component, Fragment } from 'react';
+import { div, form, h, hh, input, label } from 'react-hyperscript-helpers';
+import { User } from '../libs/ajax';
+import { USER_ROLES } from '../libs/utils';
+import { Alert } from '../components/Alert';
+import { ResearcherReview } from './ResearcherReview';
+//import addUserIcon from '../../images/icon_add_user.png';
+//import editUserIcon from '../../images/icon_edit_user.png';
+import {PageHeading} from "../components/PageHeading";
+import manageUsersIcon from "../images/icon_manage_users.png";
+
+const adminRole = { 'roleId': 4, 'name': USER_ROLES.admin };
+const researcherRole = { 'roleId': 5, 'name': USER_ROLES.researcher };
+
+export const AdminEditUser = hh(class AdminEditUser extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      displayName: '',
+      email: '',
+      displayNameValid: false,
+      emailValid: false,
+      invalidForm: true,
+      submitted: false,
+      alerts: [],
+      updatedRoles: [researcherRole],
+      emailPreference: false
+    };
+
+    this.nameRef = React.createRef();
+    this.emailRef = React.createRef();
+  }
+
+  async componentDidMount() {
+    if (this.props.showModal === false) {
+      return;
+    }
+
+    if (this.props.user) {
+      const user = await User.getByEmail(this.props.user.email);
+      const currentRoles = _.map(user.roles, (ur) => {return { 'roleId': ur.roleId, 'name': ur.name };});
+      const updatedRoles = _.isEmpty(currentRoles) ? [researcherRole] : currentRoles;
+      this.setState({
+          mode: 'Edit',
+          displayName: user.displayName,
+          email: user.email,
+          user: user,
+          updatedRoles: updatedRoles,
+          emailPreference: user.emailPreference
+        },
+        () => {
+          let r1 = this.nameRef.current;
+          let r2 = this.emailRef.current;
+          this.setState({
+            displayNameValid: r1.validity.valid,
+            emailValid: r2.validity.valid
+          });
+        });
+    } else {
+      this.setState({
+          mode: 'Add',
+          displayName: '',
+          email: '',
+          updatedRoles: [researcherRole],
+          emailPreference: false
+        },
+        () => {
+          let r1 = this.nameRef.current;
+          let r2 = this.emailRef.current;
+          this.setState({
+            displayNameValid: r1.validity.valid,
+            emailValid: r2.validity.valid
+          });
+        });
+    }
+  }
+
+  OKHandler = async (event) => {
+    event.persist();
+    this.setState({
+      submitted: true
+    });
+    const validForm = this.state.displayNameValid && this.state.emailValid;
+    if (validForm === false) {
+      return;
+    }
+    let user = {
+      displayName: this.state.displayName,
+      emailPreference: this.state.emailPreference,
+      roles: this.state.updatedRoles
+    };
+    switch (this.state.mode) {
+      case 'Add': {
+        user.email = this.state.email;
+        const createdUser = await User.create(user);
+        this.setState({ emailValid: createdUser });
+        break;
+      }
+      case 'Edit': {
+        user.dacUserId = this.state.user.dacUserId;
+        const payload = { updatedUser: user };
+        const updatedUser = await User.update(payload, this.state.user.dacUserId);
+        this.setState({ emailValid: updatedUser });
+        break;
+      }
+      default:
+        break;
+    }
+
+    event.preventDefault();
+
+    if (this.state.emailValid !== false) {
+      this.props.onOKRequest('addUser');
+    }
+
+  };
+
+  closeHandler = () => {
+    this.props.onCloseRequest('addUser');
+  };
+
+  afterOpenHandler = () => {
+    this.props.onAfterOpen('addUser');
+  };
+
+  emailPreferenceChanged = (e) => {
+    // disable notifications checkbox is not checked: -> Set email preference TRUE
+    // disable notifications checkbox is checked:     -> Set email preference FALSE
+    const checkState = e.target.checked;
+    this.setState({
+      emailPreference: !checkState
+    });
+  };
+
+  adminChanged = (e) => {
+    const checkState = e.target.checked;
+    // True? add admin role to state.updatedRoles
+    // False? remove admin role from state.updatedRoles
+    let newRoles = [researcherRole];
+    if (checkState) {
+      newRoles = _.concat(this.state.updatedRoles, adminRole);
+    } else {
+      newRoles = _.filter(this.state.updatedRoles, (r) => {return r.roleId !== adminRole.roleId;});
+    }
+    this.setState(prev => {
+      prev.updatedRoles = newRoles;
+      return prev;
+    });
+  };
+
+  handleChange = (e) => {
+    const name = e.target.name;
+    const validName = name + 'Valid';
+    this.setState({
+      [name]: e.target.value,
+      [validName]: e.currentTarget.validity.valid
+    });
+  };
+
+  formChange = () => {
+    this.setState(prev => {
+      prev.invalidForm = (prev.displayNameValid && prev.emailValid);
+      return prev;
+    });
+  };
+
+  isAdmin = () => {
+    const admins = _.filter(this.state.updatedRoles, _.matches(adminRole));
+    return !_.isEmpty(admins);
+  };
+
+  render() {
+    const { displayName, email, displayNameValid, emailValid } = this.state;
+    const validForm = displayNameValid && emailValid;
+    const { user } = this.props;
+    return (
+      div({ className: "container container-wide" }, [
+        div({ className: "row no-margin" }, [
+          div({ className: "col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding" }, [
+            PageHeading({ id: "editUser", imgSrc: manageUsersIcon, iconSize: "medium", color: "common", title: "Edit User", description: "Edit a User in the system" }),
+          ]),
+          div({ className: "col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding" }, [
+
+          form({ className: 'form-horizontal css-form', name: 'userForm', encType: 'multipart/form-data', onChange: this.formChange }, [
+            div({ className: 'form-group first-form-group' }, [
+              label({ id: 'lbl_name', className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Name']),
+              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8' }, [
+                input({
+                  type: 'text',
+                  name: 'displayName',
+                  id: 'txt_name',
+                  className: 'form-control col-lg-12 vote-input',
+                  placeholder: 'User name',
+                  required: true,
+                  value: displayName,
+                  autoFocus: true,
+                  onChange: this.handleChange,
+                  ref: this.nameRef
+                })
+              ])
+            ]),
+
+            div({ className: 'form-group' }, [
+              label({ id: 'lbl_email', className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Google account id']),
+              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8' }, [
+                input({
+                  type: 'email',
+                  name: 'email',
+                  id: 'txt_email',
+                  className: 'form-control col-lg-12 vote-input',
+                  placeholder: 'e.g. username@broadinstitute.org',
+                  required: true,
+                  value: email,
+                  onChange: this.handleChange,
+                  ref: this.emailRef
+                })
+              ])
+            ]),
+
+            div({ className: 'form-group' }, [
+              label({ className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Role']),
+              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold' }, [
+                div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
+                  div({ className: 'checkbox' }, [
+                    input({
+                      type: 'checkbox',
+                      id: 'chk_admin',
+                      checked: this.isAdmin(),
+                      className: 'checkbox-inline user-checkbox',
+                      onChange: this.adminChanged
+                    }),
+                    label({ id: 'lbl_admin', className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_admin' }, ['Admin'])
+                  ])
+                ])
+              ])
+            ]),
+            div({ className: 'form-group' }, [
+              div({
+                isRendered: this.isAdmin(),
+                className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
+                style: { 'paddingLeft': '30px' }
+              }, [
+                div({ className: 'checkbox' }, [
+                  input({
+                    id: 'chk_emailPreference',
+                    type: 'checkbox',
+                    className: 'checkbox-inline user-checkbox',
+                    // If email preference is TRUE  -> disable checkbox is not checked
+                    // If email preference is FALSE -> disable checkbox is checked
+                    checked: !this.state.emailPreference,
+                    onChange: this.emailPreferenceChanged
+                  }),
+                  label({ className: 'regular-checkbox rp-choice-questions bold', htmlFor: 'chk_emailPreference' },
+                    ['Disable Admin email notifications'])
+                ])
+              ]),
+            ])
+          ]),
+          div({ isRendered: _.has(user, "dacUserId") }, [
+            ResearcherReview({userId: _.get(user, "dacUserId")})
+          ]),
+
+          div({ isRendered: this.state.emailValid === false && this.state.submitted === true }, [
+            Alert({
+              id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
+              description: 'There is a user already registered with this google account.'
+            })
+          ]),
+            div({ isRendered: this.state.alerts.length > 0 }, [
+              this.state.alerts.map((alert, ix) => {
+                return (
+                  h(Fragment, { key: 'alert_' + ix }, [
+                    Alert({ id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg })
+                  ])
+                );
+              })])
+         ])
+        ])
+        ])
+    );
+
+  }
+});

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -191,9 +191,32 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                   })
                 ])
               ]),
-
+              //TODO: potentially isolate checkbox in own component
               div({className: 'form-group'}, [
                 label({className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'}, ['Role']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold'}, [
+                  div({className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6'}, [
+                    div({className: 'checkbox'}, [
+                      input({
+                        type: 'checkbox',
+                        id: 'chk_signing_official',
+                        checked: this.isAdmin(),
+                        className: 'checkbox-inline user-checkbox',
+                        onChange: this.adminChanged
+                      }),
+                      label({
+                        id: 'lbl_signing_official',
+                        className: 'regular-checkbox rp-choice-questions',
+                        htmlFor: 'chk_signing_official'
+                      }, ['Signing Official'])
+                    ]),
+                  ])
+                ]),
+              ]),
+
+              div({className: 'form-group'}, [
+                //TODO: currently removing this messes up spacing, but it no longer serves a purpose
+                label({className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'}, ['']),
                 div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold'}, [
                   div({className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6'}, [
                     div({className: 'checkbox'}, [
@@ -264,6 +287,5 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
         ])
       ])
     );
-
   }
 });

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import contains from 'lodash/fp';
 import React, {Component, Fragment} from 'react';
 import {button, div, form, h, hh, input, label} from 'react-hyperscript-helpers';
 import {User} from '../libs/ajax';
@@ -58,9 +59,8 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
   OKHandler = async (event) => {
     event.persist();
-    this.setState({
-      submitted: true
-    });
+    event.preventDefault();
+
     const validForm = this.state.displayNameValid && this.state.emailValid;
     if (validForm === false) {
       return;
@@ -74,10 +74,13 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     user.dacUserId = userId;
     const payload = {updatedUser: user};
     const updatedUser = await User.update(payload, userId);
-    this.setState({emailValid: updatedUser});
 
     await this.updateRolesIfDifferent(userId, this.state.updatedRoles);
-    event.preventDefault();
+
+    this.setState({
+      submitted: true,
+      emailValid: updatedUser
+    });
   };
 
   //TODO: currently doesn't seem to be updating roles (neither does User.update above)
@@ -86,13 +89,21 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     const currentRoles = user.roles;
 
     _.map(updatedRoles, role => {
-      if (_.contains(currentRoles, role)) {
+      console.log(JSON.stringify(updatedRoles));
+      console.log(JSON.stringify(role));
+
+      if (!contains(currentRoles, role)) {
+        console.log("adding role to user");
         User.addRoleToUser(userId, role.roleId);
       }
     });
 
     _.map(currentRoles, role => {
-      if (!_.contains(updatedRoles, role)) {
+      console.log(JSON.stringify(currentRoles));
+      console.log(JSON.stringify(role));
+
+      if (!contains(updatedRoles, role)) {
+        console.log("deleting role from user");
         User.deleteRoleFromUser(userId, role.roleId);
       }
     });

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -21,8 +21,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       displayName: '',
       email: '',
       displayNameValid: false,
-      submitted: false,
-      alerts: [],
       updatedRoles: [researcherRole],
       emailPreference: false
     };
@@ -68,7 +66,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     await this.updateRolesIfDifferent(userId, this.state.updatedRoles);
 
     this.setState({
-      submitted: true,
       displayNameValid: updatedUser
     });
   };

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -71,7 +71,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     };
     const payload = {updatedUser: user};
     const updatedUser = await User.update(payload, userId);
-
     await this.updateRolesIfDifferent(userId, this.state.updatedRoles);
 
     this.setState({
@@ -118,205 +117,205 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     return this.state.displayNameValid && this.state.emailValid;
   };
 
-    emailPreferenceChanged = (e) => {
-      // disable notifications checkbox is not checked: -> Set email preference TRUE
-      // disable notifications checkbox is checked:     -> Set email preference FALSE
-      const checkState = e.target.checked;
-      this.setState({
-        emailPreference: !checkState
+  emailPreferenceChanged = (e) => {
+    // disable notifications checkbox is not checked: -> Set email preference TRUE
+    // disable notifications checkbox is checked:     -> Set email preference FALSE
+    const checkState = e.target.checked;
+    this.setState({
+      emailPreference: !checkState
+    });
+  };
+
+  roleStatusChanged = (e, role) => {
+    const checkState = e.target.checked;
+    // True? add role to state.updatedRoles
+    // False? remove role from state.updatedRoles
+    let newRoles = [researcherRole];
+    if (checkState) {
+      newRoles = _.concat(this.state.updatedRoles, role);
+    } else {
+      newRoles = _.filter(this.state.updatedRoles, (r) => {
+        return r.roleId !== role.roleId;
       });
-    };
+    }
+    this.setState(prev => {
+      prev.updatedRoles = newRoles;
+      return prev;
+    });
+  };
 
-    roleStatusChanged = (e, role) => {
-      const checkState = e.target.checked;
-      // True? add role to state.updatedRoles
-      // False? remove role from state.updatedRoles
-      let newRoles = [researcherRole];
-      if (checkState) {
-        newRoles = _.concat(this.state.updatedRoles, role);
-      } else {
-        newRoles = _.filter(this.state.updatedRoles, (r) => {
-          return r.roleId !== role.roleId;
-        });
-      }
-      this.setState(prev => {
-        prev.updatedRoles = newRoles;
-        return prev;
-      });
-    };
+  userHasRole = (role) => {
+    const matches = _.filter(this.state.updatedRoles, _.matches(role));
+    return !_.isEmpty(matches);
+  };
 
-    handleChange = (e) => {
-      const name = e.target.name;
-      const validName = name + 'Valid';
-      this.setState({
-        [name]: e.target.value,
-        [validName]: e.currentTarget.validity.valid
-      });
-    };
+  handleChange = (e) => {
+    const name = e.target.name;
+    const validName = name + 'Valid';
+    this.setState({
+      [name]: e.target.value,
+      [validName]: e.currentTarget.validity.valid
+    });
+  };
 
-    userIsRole = (role) => {
-      const matches = _.filter(this.state.updatedRoles, _.matches(role));
-      return !_.isEmpty(matches);
-    };
 
-    render()
-    {
-      const {displayName, email} = this.state;
-      const validForm = this.formIsValid();
-      const {dacUserId} = this.props.match.params;
-      return (
-        div({className: "container container-wide"}, [
-          div({className: "row no-margin"}, [
-            div({className: "col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding"}, [
-              PageHeading({
-                id: "editUser",
-                imgSrc: editUserIcon,
-                iconSize: "medium",
-                color: "common",
-                title: "Edit User",
-                description: "Edit a User in the system"
-              }),
-            ]),
-            div({className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding"}, [
+  render() {
+    const {displayName, email} = this.state;
+    const validForm = this.formIsValid();
+    const {dacUserId} = this.props.match.params;
+    return (
+      div({className: "container container-wide"}, [
+        div({className: "row no-margin"}, [
+          div({className: "col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding"}, [
+            PageHeading({
+              id: "editUser",
+              imgSrc: editUserIcon,
+              iconSize: "medium",
+              color: "common",
+              title: "Edit User",
+              description: "Edit a User in the system"
+            }),
+          ]),
+          div({className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding"}, [
 
-              form({
-                className: 'form-horizontal css-form ',
-                name: 'userForm',
-                encType: 'multipart/form-data',
-              }, [
-                div({className: 'form-group first-form-group'}, [
-                  label({
-                    id: 'lbl_name',
-                    className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'
-                  }, ['Name']),
-                  div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8'}, [
-                    input({
-                      type: 'text',
-                      name: 'displayName',
-                      id: 'txt_name',
-                      className: 'form-control col-lg-12 vote-input',
-                      placeholder: 'User name',
-                      required: true,
-                      value: displayName,
-                      autoFocus: true,
-                      onChange: this.handleChange,
-                      ref: this.nameRef
-                    })
-                  ])
-                ]),
+            form({
+              className: 'form-horizontal css-form ',
+              name: 'userForm',
+              encType: 'multipart/form-data',
+            }, [
+              div({className: 'form-group first-form-group'}, [
+                label({
+                  id: 'lbl_name',
+                  className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'
+                }, ['Name']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8'}, [
+                  input({
+                    type: 'text',
+                    name: 'displayName',
+                    id: 'txt_name',
+                    className: 'form-control col-lg-12 vote-input',
+                    placeholder: 'User name',
+                    required: true,
+                    value: displayName,
+                    autoFocus: true,
+                    onChange: this.handleChange,
+                    ref: this.nameRef
+                  })
+                ])
+              ]),
 
-                div({className: 'form-group'}, [
-                  label({
-                    id: 'lbl_email',
-                    className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'
-                  }, ['Google account id']),
-                  div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8'}, [
-                    input({
-                      type: 'email',
-                      name: 'email',
-                      id: 'txt_email',
-                      className: 'form-control col-lg-12 vote-input',
-                      placeholder: 'e.g. username@broadinstitute.org',
-                      required: true,
-                      value: email,
-                      onChange: this.handleChange,
-                      ref: this.emailRef
-                    })
-                  ])
-                ]),
-                div({className: 'form-group'}, [
-                  label({className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'}, ['Roles']),
-                  div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold'}, [
-                    div({className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6'}, [
-                      div({className: 'checkbox'}, [
-                        input({
-                          type: 'checkbox',
-                          id: 'chk_signing_official',
-                          checked: this.userIsRole(signingOfficialRole),
-                          className: 'checkbox-inline user-checkbox',
-                          onChange: e => this.roleStatusChanged(e, signingOfficialRole)
-                        }),
-                        label({
-                          id: 'lbl_signing_official',
-                          className: 'regular-checkbox rp-choice-questions',
-                          htmlFor: 'chk_signing_official'
-                        }, ['Signing Official'])
-                      ]),
-                    ])
-                  ]),
-                ]),
-
-                div({className: 'form-group'}, [
-                  div({
-                    className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
-                    style: {'paddingLeft': '30px'}
-                  }, [
+              div({className: 'form-group'}, [
+                label({
+                  id: 'lbl_email',
+                  className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'
+                }, ['Google account id']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8'}, [
+                  input({
+                    type: 'email',
+                    name: 'email',
+                    id: 'txt_email',
+                    className: 'form-control col-lg-12 vote-input',
+                    placeholder: 'e.g. username@broadinstitute.org',
+                    required: true,
+                    value: email,
+                    onChange: this.handleChange,
+                    ref: this.emailRef
+                  })
+                ])
+              ]),
+              div({className: 'form-group'}, [
+                label({className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'}, ['Roles']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold'}, [
+                  div({className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6'}, [
                     div({className: 'checkbox'}, [
                       input({
                         type: 'checkbox',
-                        id: 'chk_admin',
-                        checked: this.userIsRole(adminRole),
+                        id: 'chk_signing_official',
+                        checked: this.userHasRole(signingOfficialRole),
                         className: 'checkbox-inline user-checkbox',
-                        onChange: e => this.roleStatusChanged(e, adminRole)
+                        onChange: e => this.roleStatusChanged(e, signingOfficialRole)
                       }),
                       label({
-                        id: 'lbl_admin',
+                        id: 'lbl_signing_official',
                         className: 'regular-checkbox rp-choice-questions',
-                        htmlFor: 'chk_admin'
-                      }, ['Admin'])
-                    ])
+                        htmlFor: 'chk_signing_official'
+                      }, ['Signing Official'])
+                    ]),
                   ])
                 ]),
-                div({className: 'form-group'}, [
-                  div({
-                    isRendered: this.userIsRole(adminRole),
-                    className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
-                    style: {'paddingLeft': '30px'}
-                  }, [
-                    div({className: 'checkbox'}, [
-                      input({
-                        id: 'chk_emailPreference',
-                        type: 'checkbox',
-                        className: 'checkbox-inline user-checkbox',
-                        // If email preference is TRUE  -> disable checkbox is not checked
-                        // If email preference is FALSE -> disable checkbox is checked
-                        checked: !this.state.emailPreference,
-                        onChange: this.emailPreferenceChanged
-                      }),
-                      label({className: 'regular-checkbox rp-choice-questions bold', htmlFor: 'chk_emailPreference'},
-                        ['Disable Admin email notifications'])
-                    ])
-                  ])
-                ]),
-                div({className: 'col-lg-12 col-xs-12 inline-block'}, [
-                  button({
-                    id: 'btn_save',
-                    onClick: this.OKHandler,
-                    className: 'f-right btn-primary common-background',
-                    disabled: !validForm
-                  }, ['Save']),
-                ])
-              ])
-            ]),
-            ResearcherReview({userId: dacUserId, user: this.state.user}),
+              ]),
 
-            div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
-              Alert({
-                id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
-                description: 'There is a user already registered with this google account.'
-              })
-            ]),
-            div({isRendered: this.state.alerts.length > 0}, [
-              this.state.alerts.map((alert, ix) => {
-                return (
-                  h(Fragment, {key: 'alert_' + ix}, [
-                    Alert({id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg})
+              div({className: 'form-group'}, [
+                div({
+                  className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
+                  style: {'paddingLeft': '30px'}
+                }, [
+                  div({className: 'checkbox'}, [
+                    input({
+                      type: 'checkbox',
+                      id: 'chk_admin',
+                      checked: this.userHasRole(adminRole),
+                      className: 'checkbox-inline user-checkbox',
+                      onChange: e => this.roleStatusChanged(e, adminRole)
+                    }),
+                    label({
+                      id: 'lbl_admin',
+                      className: 'regular-checkbox rp-choice-questions',
+                      htmlFor: 'chk_admin'
+                    }, ['Admin'])
                   ])
-                );
-              })
+                ])
+              ]),
+              div({className: 'form-group'}, [
+                div({
+                  isRendered: this.userHasRole(adminRole),
+                  className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
+                  style: {'paddingLeft': '30px'}
+                }, [
+                  div({className: 'checkbox'}, [
+                    input({
+                      id: 'chk_emailPreference',
+                      type: 'checkbox',
+                      className: 'checkbox-inline user-checkbox',
+                      // If email preference is TRUE  -> disable checkbox is not checked
+                      // If email preference is FALSE -> disable checkbox is checked
+                      checked: !this.state.emailPreference,
+                      onChange: this.emailPreferenceChanged
+                    }),
+                    label({className: 'regular-checkbox rp-choice-questions bold', htmlFor: 'chk_emailPreference'},
+                      ['Disable Admin email notifications'])
+                  ])
+                ])
+              ]),
+              div({className: 'col-lg-12 col-xs-12 inline-block'}, [
+                button({
+                  id: 'btn_save',
+                  onClick: this.OKHandler,
+                  className: 'f-right btn-primary common-background',
+                  disabled: !validForm
+                }, ['Save']),
+              ])
             ])
+          ]),
+          ResearcherReview({userId: dacUserId, user: this.state.user}),
+
+          div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
+            Alert({
+              id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
+              description: 'There is a user already registered with this google account.'
+            })
+          ]),
+          div({isRendered: this.state.alerts.length > 0}, [
+            this.state.alerts.map((alert, ix) => {
+              return (
+                h(Fragment, {key: 'alert_' + ix}, [
+                  Alert({id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg})
+                ])
+              );
+            })
           ])
         ])
-      );
-    }
+      ])
+    );
+  }
 });

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -75,7 +75,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
     this.setState({
       submitted: true,
-      emailValid: updatedUser,
+      emailValid: updatedUser
     });
   };
 
@@ -223,6 +223,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                   })
                 ])
               ]),
+
               div({className: 'form-group'}, [
                 label({className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'}, ['Roles']),
                 div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold'}, [
@@ -230,21 +231,40 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                     div({className: 'checkbox'}, [
                       input({
                         type: 'checkbox',
-                        id: 'chk_signing_official',
-                        checked: this.userHasRole(signingOfficialRole),
+                        id: 'chk_researcher',
+                        checked: true,
                         className: 'checkbox-inline user-checkbox',
-                        onChange: e => this.roleStatusChanged(e, signingOfficialRole)
                       }),
                       label({
-                        id: 'lbl_signing_official',
+                        id: 'lbl_researcher',
                         className: 'regular-checkbox rp-choice-questions',
-                        htmlFor: 'chk_signing_official'
-                      }, ['Signing Official'])
+                        htmlFor: 'chk_researcher'
+                      }, ['Researcher'])
                     ]),
                   ])
                 ]),
               ]),
-
+              div({className: 'form-group'}, [
+                div({
+                  className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
+                  style: {'paddingLeft': '30px'}
+                }, [
+                  div({className: 'checkbox'}, [
+                    input({
+                      type: 'checkbox',
+                      id: 'chk_signing_official',
+                      checked: this.userHasRole(signingOfficialRole),
+                      className: 'checkbox-inline user-checkbox',
+                      onChange: e => this.roleStatusChanged(e, signingOfficialRole)
+                    }),
+                    label({
+                      id: 'lbl_signing_official',
+                      className: 'regular-checkbox rp-choice-questions',
+                      htmlFor: 'chk_signing_official'
+                    }, ['Signing Official'])
+                  ]),
+                ])
+              ]),
               div({className: 'form-group'}, [
                 div({
                   className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
@@ -297,7 +317,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
               ])
             ])
           ]),
-          ResearcherReview({userId: dacUserId, user: this.state.user}),
+          ResearcherReview({userId: dacUserId}),
 
           div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
             Alert({

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -50,7 +50,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   }
 
   OKHandler = async (event) => {
-    event.persist();
     event.preventDefault();
 
     if (!this.state.displayNameValid) {

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -52,7 +52,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     event.persist();
     event.preventDefault();
 
-    if (!this.formIsValid()) {
+    if (!this.state.displayNameValid) {
       return;
     }
     const userId = this.state.user.dacUserId;
@@ -104,10 +104,6 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     });
   };
 
-  formIsValid = () => {
-    return this.state.displayNameValid;
-  };
-
   emailPreferenceChanged = (e) => {
     // disable notifications checkbox is not checked: -> Set email preference TRUE
     // disable notifications checkbox is checked:     -> Set email preference FALSE
@@ -151,8 +147,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
 
 
   render() {
-    const {displayName, email} = this.state;
-    const validForm = this.formIsValid();
+    const {displayName, email, displayNameValid} = this.state;
     const {dacUserId} = this.props.match.params;
     return (
       div({className: "container container-wide"}, [
@@ -303,7 +298,7 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
                   id: 'btn_save',
                   onClick: this.OKHandler,
                   className: 'f-right btn-primary common-background',
-                  disabled: !validForm
+                  disabled: !displayNameValid
                 }, ['Save']),
               ])
             ])

--- a/src/pages/AdminEditUser.js
+++ b/src/pages/AdminEditUser.js
@@ -1,17 +1,15 @@
 import _ from 'lodash';
-import React, { Component, Fragment } from 'react';
-import { div, form, h, hh, input, label } from 'react-hyperscript-helpers';
-import { User } from '../libs/ajax';
-import { USER_ROLES } from '../libs/utils';
-import { Alert } from '../components/Alert';
-import { ResearcherReview } from './ResearcherReview';
-//import addUserIcon from '../../images/icon_add_user.png';
-//import editUserIcon from '../../images/icon_edit_user.png';
+import React, {Component, Fragment} from 'react';
+import {div, form, h, hh, input, label} from 'react-hyperscript-helpers';
+import {User} from '../libs/ajax';
+import {USER_ROLES} from '../libs/utils';
+import {Alert} from '../components/Alert';
+import {ResearcherReview} from './ResearcherReview';
+import editUserIcon from '../images/icon_edit_user.png';
 import {PageHeading} from "../components/PageHeading";
-import manageUsersIcon from "../images/icon_manage_users.png";
 
-const adminRole = { 'roleId': 4, 'name': USER_ROLES.admin };
-const researcherRole = { 'roleId': 5, 'name': USER_ROLES.researcher };
+const adminRole = {'roleId': 4, 'name': USER_ROLES.admin};
+const researcherRole = {'roleId': 5, 'name': USER_ROLES.researcher};
 
 export const AdminEditUser = hh(class AdminEditUser extends Component {
 
@@ -35,24 +33,26 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   }
 
   async componentDidMount() {
-      const user = await User.getById(this.props.match.params.dacUserId);
-      const currentRoles = _.map(user.roles, (ur) => {return { 'roleId': ur.roleId, 'name': ur.name };});
-      const updatedRoles = _.isEmpty(currentRoles) ? [researcherRole] : currentRoles;
+    const user = await User.getById(this.props.match.params.dacUserId);
+    const currentRoles = _.map(user.roles, (ur) => {
+      return {'roleId': ur.roleId, 'name': ur.name};
+    });
+    const updatedRoles = _.isEmpty(currentRoles) ? [researcherRole] : currentRoles;
+    this.setState({
+      displayName: user.displayName,
+      email: user.email,
+      user: user,
+      updatedRoles: updatedRoles,
+      emailPreference: user.emailPreference
+    },
+    () => {
+      let r1 = this.nameRef.current;
+      let r2 = this.emailRef.current;
       this.setState({
-          displayName: user.displayName,
-          email: user.email,
-          user: user,
-          updatedRoles: updatedRoles,
-          emailPreference: user.emailPreference
-        },
-        () => {
-          let r1 = this.nameRef.current;
-          let r2 = this.emailRef.current;
-          this.setState({
-            displayNameValid: r1.validity.valid,
-            emailValid: r2.validity.valid
-          });
-        });
+        displayNameValid: r1.validity.valid,
+        emailValid: r2.validity.valid
+      });
+    });
   }
 
   OKHandler = async (event) => {
@@ -69,10 +69,10 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
       emailPreference: this.state.emailPreference,
       roles: this.state.updatedRoles
     };
-        user.dacUserId = this.state.user.dacUserId;
-        const payload = { updatedUser: user };
-        const updatedUser = await User.update(payload, this.state.user.dacUserId);
-        this.setState({ emailValid: updatedUser });
+    user.dacUserId = this.state.user.dacUserId;
+    const payload = {updatedUser: user};
+    const updatedUser = await User.update(payload, this.state.user.dacUserId);
+    this.setState({emailValid: updatedUser});
 
     event.preventDefault();
 
@@ -107,7 +107,9 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
     if (checkState) {
       newRoles = _.concat(this.state.updatedRoles, adminRole);
     } else {
-      newRoles = _.filter(this.state.updatedRoles, (r) => {return r.roleId !== adminRole.roleId;});
+      newRoles = _.filter(this.state.updatedRoles, (r) => {
+        return r.roleId !== adminRole.roleId;
+      });
     }
     this.setState(prev => {
       prev.updatedRoles = newRoles;
@@ -137,113 +139,133 @@ export const AdminEditUser = hh(class AdminEditUser extends Component {
   };
 
   render() {
-    const { displayName, email, displayNameValid, emailValid } = this.state;
+    const {displayName, email, displayNameValid, emailValid} = this.state;
     const validForm = displayNameValid && emailValid;
-    const { user } = this.props;
+    const {user} = this.props;
     return (
-      div({ className: "container container-wide" }, [
-        div({ className: "row no-margin" }, [
-          div({ className: "col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding" }, [
-            PageHeading({ id: "editUser", imgSrc: manageUsersIcon, iconSize: "medium", color: "common", title: "Edit User", description: "Edit a User in the system" }),
+      div({className: "container container-wide"}, [
+        div({className: "row no-margin"}, [
+          div({className: "col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding"}, [
+            PageHeading({
+              id: "editUser",
+              imgSrc: editUserIcon,
+              iconSize: "medium",
+              color: "common",
+              title: "Edit User",
+              description: "Edit a User in the system"
+            }),
           ]),
-          div({ className: "col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding" }, [
+          div({className: "col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding"}, [
 
-          form({ className: 'form-horizontal css-form', name: 'userForm', encType: 'multipart/form-data', onChange: this.formChange }, [
-            div({ className: 'form-group first-form-group' }, [
-              label({ id: 'lbl_name', className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Name']),
-              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8' }, [
-                input({
-                  type: 'text',
-                  name: 'displayName',
-                  id: 'txt_name',
-                  className: 'form-control col-lg-12 vote-input',
-                  placeholder: 'User name',
-                  required: true,
-                  value: displayName,
-                  autoFocus: true,
-                  onChange: this.handleChange,
-                  ref: this.nameRef
-                })
-              ])
-            ]),
-
-            div({ className: 'form-group' }, [
-              label({ id: 'lbl_email', className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Google account id']),
-              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8' }, [
-                input({
-                  type: 'email',
-                  name: 'email',
-                  id: 'txt_email',
-                  className: 'form-control col-lg-12 vote-input',
-                  placeholder: 'e.g. username@broadinstitute.org',
-                  required: true,
-                  value: email,
-                  onChange: this.handleChange,
-                  ref: this.emailRef
-                })
-              ])
-            ]),
-
-            div({ className: 'form-group' }, [
-              label({ className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color' }, ['Role']),
-              div({ className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold' }, [
-                div({ className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6' }, [
-                  div({ className: 'checkbox' }, [
-                    input({
-                      type: 'checkbox',
-                      id: 'chk_admin',
-                      checked: this.isAdmin(),
-                      className: 'checkbox-inline user-checkbox',
-                      onChange: this.adminChanged
-                    }),
-                    label({ id: 'lbl_admin', className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_admin' }, ['Admin'])
-                  ])
-                ])
-              ])
-            ]),
-            div({ className: 'form-group' }, [
-              div({
-                isRendered: this.isAdmin(),
-                className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
-                style: { 'paddingLeft': '30px' }
-              }, [
-                div({ className: 'checkbox' }, [
+            form({
+              className: 'form-horizontal css-form',
+              name: 'userForm',
+              encType: 'multipart/form-data',
+              onChange: this.formChange
+            }, [
+              div({className: 'form-group first-form-group'}, [
+                label({
+                  id: 'lbl_name',
+                  className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'
+                }, ['Name']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8'}, [
                   input({
-                    id: 'chk_emailPreference',
-                    type: 'checkbox',
-                    className: 'checkbox-inline user-checkbox',
-                    // If email preference is TRUE  -> disable checkbox is not checked
-                    // If email preference is FALSE -> disable checkbox is checked
-                    checked: !this.state.emailPreference,
-                    onChange: this.emailPreferenceChanged
-                  }),
-                  label({ className: 'regular-checkbox rp-choice-questions bold', htmlFor: 'chk_emailPreference' },
-                    ['Disable Admin email notifications'])
+                    type: 'text',
+                    name: 'displayName',
+                    id: 'txt_name',
+                    className: 'form-control col-lg-12 vote-input',
+                    placeholder: 'User name',
+                    required: true,
+                    value: displayName,
+                    autoFocus: true,
+                    onChange: this.handleChange,
+                    ref: this.nameRef
+                  })
                 ])
               ]),
-            ])
-          ]),
-          div({ isRendered: _.has(user, "dacUserId") }, [
-            ResearcherReview({userId: _.get(user, "dacUserId")})
-          ]),
 
-          div({ isRendered: this.state.emailValid === false && this.state.submitted === true }, [
-            Alert({
-              id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
-              description: 'There is a user already registered with this google account.'
-            })
-          ]),
-            div({ isRendered: this.state.alerts.length > 0 }, [
+              div({className: 'form-group'}, [
+                label({
+                  id: 'lbl_email',
+                  className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'
+                }, ['Google account id']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8'}, [
+                  input({
+                    type: 'email',
+                    name: 'email',
+                    id: 'txt_email',
+                    className: 'form-control col-lg-12 vote-input',
+                    placeholder: 'e.g. username@broadinstitute.org',
+                    required: true,
+                    value: email,
+                    onChange: this.handleChange,
+                    ref: this.emailRef
+                  })
+                ])
+              ]),
+
+              div({className: 'form-group'}, [
+                label({className: 'col-lg-3 col-md-3 col-sm-3 col-xs-4 control-label common-color'}, ['Role']),
+                div({className: 'col-lg-9 col-md-9 col-sm-9 col-xs-8 bold'}, [
+                  div({className: 'col-lg-6 col-md-6 col-sm-6 col-xs-6'}, [
+                    div({className: 'checkbox'}, [
+                      input({
+                        type: 'checkbox',
+                        id: 'chk_admin',
+                        checked: this.isAdmin(),
+                        className: 'checkbox-inline user-checkbox',
+                        onChange: this.adminChanged
+                      }),
+                      label({
+                        id: 'lbl_admin',
+                        className: 'regular-checkbox rp-choice-questions',
+                        htmlFor: 'chk_admin'
+                      }, ['Admin'])
+                    ])
+                  ])
+                ])
+              ]),
+              div({className: 'form-group'}, [
+                div({
+                  isRendered: this.isAdmin(),
+                  className: 'col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4',
+                  style: {'paddingLeft': '30px'}
+                }, [
+                  div({className: 'checkbox'}, [
+                    input({
+                      id: 'chk_emailPreference',
+                      type: 'checkbox',
+                      className: 'checkbox-inline user-checkbox',
+                      // If email preference is TRUE  -> disable checkbox is not checked
+                      // If email preference is FALSE -> disable checkbox is checked
+                      checked: !this.state.emailPreference,
+                      onChange: this.emailPreferenceChanged
+                    }),
+                    label({className: 'regular-checkbox rp-choice-questions bold', htmlFor: 'chk_emailPreference'},
+                      ['Disable Admin email notifications'])
+                  ])
+                ]),
+              ])
+            ]),
+            ResearcherReview({userId: _.get(user, "dacUserId")}),
+
+            div({isRendered: this.state.emailValid === false && this.state.submitted === true}, [
+              Alert({
+                id: 'emailUsed', type: 'danger', title: 'Conflicts to resolve!',
+                description: 'There is a user already registered with this google account.'
+              })
+            ]),
+            div({isRendered: this.state.alerts.length > 0}, [
               this.state.alerts.map((alert, ix) => {
                 return (
-                  h(Fragment, { key: 'alert_' + ix }, [
-                    Alert({ id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg })
+                  h(Fragment, {key: 'alert_' + ix}, [
+                    Alert({id: 'modal_' + ix, type: alert.type, title: alert.title, description: alert.msg})
                   ])
                 );
               })])
-         ])
+          ])
         ])
-        ])
+      ])
     );
 
   }

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -88,15 +88,6 @@ class AdminManageUsers extends Component {
   };
 
   editUser = (user) => () => {
-    /*
-    this.setState(prev => {
-      prev.userEmail = user.email;
-      prev.user = user;
-      prev.showAddUserModal = true;
-      return prev;
-    });
-
-     */
     this.props.history.push(`/admin_edit_user/${user.dacUserId}`);
   };
 

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -88,18 +88,16 @@ class AdminManageUsers extends Component {
   };
 
   editUser = (user) => () => {
+    /*
     this.setState(prev => {
       prev.userEmail = user.email;
       prev.user = user;
       prev.showAddUserModal = true;
       return prev;
     });
-    this.props.history.push(`/admin_edit_user/${user.dacUserId}`);
-  };
 
-  //TODO: delete since researcher review page no longer exists
-  openResearcherReview = (userId) => {
-    this.props.history.push(`researcher_review/${userId}`);
+     */
+    this.props.history.push(`/admin_edit_user/${user.dacUserId}`);
   };
 
   okModal = async () => {

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -94,7 +94,7 @@ class AdminManageUsers extends Component {
       prev.showAddUserModal = true;
       return prev;
     });
-    this.props.history.push(`/admin_edit_user/${user.dacUserId}`)
+    this.props.history.push(`/admin_edit_user/${user.dacUserId}`);
   };
 
   //TODO: delete since researcher review page no longer exists

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -96,6 +96,7 @@ class AdminManageUsers extends Component {
     });
   };
 
+  //TODO: delete since researcher review page no longer exists
   openResearcherReview = (userId) => {
     this.props.history.push(`researcher_review/${userId}`);
   };
@@ -190,7 +191,7 @@ class AdminManageUsers extends Component {
                     id: user.dacUserId + "_btnEditUser",
                     name: 'btn_editUser',
                     className: "cell-button hover-color",
-                    onClick: this.editUser(user)
+                    onClick: () => this.props.history.push(`/admin_edit_user/${user.dacUserId}`), //TODO move in separate function and fix route
                   }, ["Edit"]),
                 ]),
               ]),

--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -94,6 +94,7 @@ class AdminManageUsers extends Component {
       prev.showAddUserModal = true;
       return prev;
     });
+    this.props.history.push(`/admin_edit_user/${user.dacUserId}`)
   };
 
   //TODO: delete since researcher review page no longer exists
@@ -191,7 +192,7 @@ class AdminManageUsers extends Component {
                     id: user.dacUserId + "_btnEditUser",
                     name: 'btn_editUser',
                     className: "cell-button hover-color",
-                    onClick: () => this.props.history.push(`/admin_edit_user/${user.dacUserId}`), //TODO move in separate function and fix route
+                    onClick: this.editUser(user)
                   }, ["Edit"]),
                 ]),
               ]),

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -54,8 +54,15 @@ export const ResearcherReview = hh(class ResearcherReview extends Component {
     });
   };
 
-  render() {
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.user !== prevProps.user) {
+      this.setState({
+        user: this.props.user
+      });
+    }
+  }
 
+  render() {
     const { formData, user, institution } = this.state;
 
     return (

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -39,11 +39,12 @@ export const ResearcherReview = hh(class ResearcherReview extends Component {
     };
   }
 
-  async componentDidMount() {
-    await this.findResearcherInfo();
+  componentDidMount() {
+    this.calculateResearcherInfo();
   }
 
-  findResearcherInfo = async () => {
+  calculateResearcherInfo = () => {
+    console.log("Processing props.user: " + JSON.stringify(this.props.user));
     const user = this.props.user;
     let researcherProps = getPropertyValuesFromUser(user);
     this.setState(prev => {

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -44,7 +44,6 @@ export const ResearcherReview = hh(class ResearcherReview extends Component {
   }
 
   calculateResearcherInfo = () => {
-    console.log("Processing props.user: " + JSON.stringify(this.props.user));
     const user = this.props.user;
     let researcherProps = getPropertyValuesFromUser(user);
     this.setState(prev => {

--- a/src/pages/ResearcherReview.js
+++ b/src/pages/ResearcherReview.js
@@ -1,6 +1,5 @@
 import { Component } from 'react';
 import { div, hh, label, form, textarea } from 'react-hyperscript-helpers';
-import { User } from "../libs/ajax";
 import {getPropertyValuesFromUser} from "../libs/utils";
 import {isNil} from "lodash/fp";
 import { isEmpty } from 'lodash';
@@ -40,25 +39,20 @@ export const ResearcherReview = hh(class ResearcherReview extends Component {
     };
   }
 
-  componentDidMount() {
-    this.findResearcherInfo();
+  async componentDidMount() {
+    await this.findResearcherInfo();
   }
 
-  async findResearcherInfo() {
-
-    const user = await User.getById(this.props.userId);
+  findResearcherInfo = async () => {
+    const user = this.props.user;
     let researcherProps = getPropertyValuesFromUser(user);
-
     this.setState(prev => {
       prev.user = user;
-      if(!isEmpty(user.institution)) {
-        prev.institution = user.institution;
-      }
+      prev.institution = !isEmpty(user.institution) ?  user.institution : null;
       prev.formData = researcherProps;
       return prev;
     });
-  }
-
+  };
 
   render() {
 


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1622)
Summary of changes:

- Converted modal on admin page for editing existing users into a separate page 
- Added checkbox for adding or removing signing official role for user 
- Added read-only checkbox to show that every user should have a researcher role 
- Created endpoints for api calls to add or remove user roles 
- Removed edit user case from the AddUserModal

_______________
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
