### PR TITLE
[no-ticket][risk=no] Update reviewers to team instead of individuals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,9 @@ updates:
       interval: "daily"
     target-branch: "develop"
     reviewers:
-      - "rushtong"
-      - "JVThomas"
+      - "@DataBiosphere/DUOS"
     assignees:
-      - "rushtong"
-      - "JVThomas"
+      - "@DataBiosphere/DUOS"
     labels:
       - "dependency"
       - "npm"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     target-branch: "develop"
     reviewers:
       - "@DataBiosphere/DUOS"
-    assignees:
-      - "@DataBiosphere/DUOS"
     labels:
       - "dependency"
       - "npm"
@@ -20,8 +18,6 @@ updates:
       interval: "daily"
     target-branch: "develop"
     reviewers:
-      - "@DataBiosphere/DUOS"
-    assignees:
       - "@DataBiosphere/DUOS"
     labels:
       - "dependency"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,9 @@ updates:
       interval: "daily"
     target-branch: "develop"
     reviewers:
-      - "rushtong"
+      - "@DataBiosphere/DUOS"
     assignees:
-      - "rushtong"
+      - "@DataBiosphere/DUOS"
     labels:
       - "dependency"
       - "docker"


### PR DESCRIPTION
Minor update to the default assignee/reviewers for all PRs to this repo

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
