### PR TITLE
DUOS-1594[risk=no] Refactor serial ontology calls to use bulk id param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33834,7 +33834,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "1.2.6",
+        "minimist": "^1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -40066,7 +40066,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "1.2.6"
+            "minimist": "^1.2.0"
           }
         }
       }
@@ -40912,7 +40912,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "1.2.6"
+        "minimist": "^1.2.5"
       }
     },
     "mocked-env": {
@@ -47576,7 +47576,7 @@
         "axios": "^0.21.1",
         "joi": "^17.4.0",
         "lodash": "^4.17.21",
-        "minimist": "1.2.6",
+        "minimist": "^1.2.5",
         "rxjs": "^7.1.0"
       },
       "dependencies": {

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,5 +1,5 @@
 import {isNil, isEmpty, filter, join, concat, clone, uniq, head, flow} from 'lodash/fp';
-import { searchOntology } from './ontologyService';
+import { searchOntology, extractDOIDFromUrl } from './ontologyService';
 import { Notifications } from './utils';
 
 export const srpTranslations = {
@@ -163,8 +163,9 @@ export const consentTranslations = {
 };
 
 const getOntologyName = async(urls) => {
-  const joinedUrls = urls.join(',');
-  const ontology = await searchOntology(joinedUrls);
+  const doidArr = extractDOIDFromUrl(urls);
+  const params = doidArr.join(',');
+  const ontology = await searchOntology(params);
   return ontology.map(data => data.label);
 };
 

--- a/src/libs/ontologyService.js
+++ b/src/libs/ontologyService.js
@@ -13,4 +13,16 @@ export async function searchOntology(obolibraryURL) {
   }
 }
 
+export function extractDOIDFromUrl(urls) {
+  const doidArr = [];
+  urls.forEach(url => {
+    const startIdx = url.search(/DOID_\d+/);
+    if (startIdx > -1) {
+      doidArr.push(url.slice(startIdx));
+    }
+  });
+
+  return urls;
+}
+
 export default { searchOntology };

--- a/src/libs/ontologyService.js
+++ b/src/libs/ontologyService.js
@@ -7,7 +7,7 @@ export async function searchOntology(obolibraryURL) {
   const params = {id: obolibraryURL};
   try{
     let resp = await axios.get(`${baseURL}search`, {params});
-    return resp.data[0];
+    return resp.data;
   } catch(error) {
     Notifications.showError('Error: Ontology Search Request failed');
   }

--- a/src/libs/ontologyService.js
+++ b/src/libs/ontologyService.js
@@ -22,7 +22,7 @@ export function extractDOIDFromUrl(urls) {
     }
   });
 
-  return urls;
+  return doidArr;
 }
 
 export default { searchOntology };

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -169,15 +169,12 @@ class DatasetRegistration extends Component {
     }
   }
 
-  async getOntologies(urls) {
+  async getOntologies(urls = []) {
     if (fp.isEmpty(urls)) {
       return [];
-    }
-    else {
-      let ontologies = await Promise.all(
-        urls.map(url => searchOntology(url)
-          .then(data => { return data; })
-        ));
+    } else {
+      const urlParams = urls.join(',');
+      const ontologies = await searchOntology(urlParams);
       return ontologies;
     }
   }

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -15,7 +15,7 @@ import AsyncSelect from 'react-select/async';
 import DataProviderAgreement from '../assets/Data_Provider_Agreement.pdf';
 import addDatasetIcon from '../images/icon_dataset_add.png';
 import { searchOntologies } from "../libs/utils";
-import {searchOntology} from "../libs/ontologyService";
+import { searchOntology, extractDOIDFromUrl } from '../libs/ontologyService';
 
 class DatasetRegistration extends Component {
 
@@ -173,7 +173,8 @@ class DatasetRegistration extends Component {
     if (fp.isEmpty(urls)) {
       return [];
     } else {
-      const urlParams = urls.join(',');
+      const doidArr = extractDOIDFromUrl(urls);
+      const urlParams = doidArr.join(',');
       const ontologies = await searchOntology(urlParams);
       return ontologies;
     }


### PR DESCRIPTION
Addresses [DUOS-1594](https://broadworkbench.atlassian.net/browse/DUOS-1594)

PR swaps out old ontology request flow (parallel async requests, one for each ontology) with a single API request with a separated ids as an id param.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
