### PR TITLE
[No Ticket] Move source-map-explorer to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react-router-dom": "5.3.0",
     "react-select": "5.2.2",
     "react-tooltip": "4.2.21",
-    "source-map-explorer": "2.5.2",
     "stackdriver-errors-js": "0.12.0",
     "usa-states": "0.0.6",
     "uuid": "8.3.2"
@@ -65,6 +64,7 @@
     "google-auth-library": "7.14.1",
     "html-webpack-plugin": "4.5.2",
     "react-scripts": "4.0.3",
+    "source-map-explorer": "2.5.2",
     "start-server-and-test": "1.14.0"
   },
   "browserslist": [


### PR DESCRIPTION
PR moves `source-map-explorer`, a developer utility package, over to devDependencies. This also resolves the npm audit flag being thrown due to its `async` dependency.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
