### PR TITLE
[DUOS-1448][risk=no] Add ToS link to home page

### DIFF
--- a/cypress/component/SigningOfficialTable/lca_text.spec.js
+++ b/cypress/component/SigningOfficialTable/lca_text.spec.js
@@ -47,26 +47,25 @@ describe('SigningOfficialTable - Tests', function() {
   });
 
   // This test works locally, but fails in github actions :-(
-  // Leaving this here in case we sort out why the action job doesn't work.
-  // it('SigningOfficialTable - Deactivate modal does not display the LCA Text', function() {
-  //   cy.viewport(600, 300);
-  //   mount(<SigningOfficialTable
-  //     isLoading={false}
-  //     signingOfficial={{institutionId: 1}}
-  //     researchers={[
-  //       {
-  //         email: 'email',
-  //         dacUserId: 1,
-  //         displayName: 'researcher',
-  //         roles: [{name: 'Researcher'}],
-  //         libraryCards: [{id: 1}]
-  //       }
-  //     ]}
-  //     unregisteredResearchers={[]}
-  //   />);
-  //   const button = cy.get('button').last();
-  //   expect(button).to.exist;
-  //   button.click();
-  //   cy.contains(lcaHeaderText).should('not.exist');
-  // });
+  it.skip('SigningOfficialTable - Deactivate modal does not display the LCA Text', function() {
+    cy.viewport(600, 300);
+    mount(<SigningOfficialTable
+      isLoading={false}
+      signingOfficial={{institutionId: 1}}
+      researchers={[
+        {
+          email: 'email',
+          dacUserId: 1,
+          displayName: 'researcher',
+          roles: [{name: 'Researcher'}],
+          libraryCards: [{id: 1}]
+        }
+      ]}
+      unregisteredResearchers={[]}
+    />);
+    const button = cy.get('button').last();
+    expect(button).to.exist;
+    button.click();
+    cy.contains(lcaHeaderText).should('not.exist');
+  });
 });

--- a/cypress/component/TermsOfService/tos.spec.js
+++ b/cypress/component/TermsOfService/tos.spec.js
@@ -5,8 +5,8 @@ import {mount} from '@cypress/react';
 import TermsOfService from '../../../src/pages/TermsOfService';
 import { ToS } from '../../../src/libs/ajax';
 
-describe('Terms of Service Page - Tests', function() {
-  it('Terms of Service Page Loads', function () {
+describe('Terms of Service Page', function() {
+  it('Standard text loads correctly', function () {
     cy.viewport(600, 300);
     const text = 'TOS Text';
     cy.stub(ToS, 'getDUOSText').returns(text);
@@ -14,7 +14,7 @@ describe('Terms of Service Page - Tests', function() {
     cy.contains(text).should('exist');
   });
 
-  it('Terms of Service Page Translates Markdown', function () {
+  it('Markdown text loads correctly', function () {
     cy.viewport(600, 300);
     const text = 'TOS Text';
     const rawMarkdown = '# ' + text;

--- a/cypress/component/TermsOfService/tos.spec.js
+++ b/cypress/component/TermsOfService/tos.spec.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-undef */
+
+import React from 'react';
+import {mount} from '@cypress/react';
+import TermsOfService from '../../../src/pages/TermsOfService';
+import { ToS } from '../../../src/libs/ajax';
+
+describe('Terms of Service Page - Tests', function() {
+  it('Terms of Service Page Loads', function () {
+    cy.viewport(600, 300);
+    const text = 'TOS Text';
+    cy.stub(ToS, 'getDUOSText').returns(text);
+    mount(<TermsOfService />);
+    cy.contains(text).should('exist');
+  });
+
+  it('Terms of Service Page Translates Markdown', function () {
+    cy.viewport(600, 300);
+    const text = 'TOS Text';
+    const rawMarkdown = '# ' + text;
+    cy.stub(ToS, 'getDUOSText').returns(rawMarkdown);
+    mount(<TermsOfService />);
+    cy.contains(text).should('exist');
+    cy.contains(rawMarkdown).should('not.exist');
+  });
+});

--- a/cypress/component/TermsOfService/tos.spec.js
+++ b/cypress/component/TermsOfService/tos.spec.js
@@ -5,10 +5,11 @@ import {mount} from '@cypress/react';
 import TermsOfService from '../../../src/pages/TermsOfService';
 import { ToS } from '../../../src/libs/ajax';
 
+const text = 'TOS Text';
+
 describe('Terms of Service Page', function() {
   it('Standard text loads correctly', function () {
     cy.viewport(600, 300);
-    const text = 'TOS Text';
     cy.stub(ToS, 'getDUOSText').returns(text);
     mount(<TermsOfService />);
     cy.contains(text).should('exist');
@@ -16,7 +17,6 @@ describe('Terms of Service Page', function() {
 
   it('Markdown text loads correctly', function () {
     cy.viewport(600, 300);
-    const text = 'TOS Text';
     const rawMarkdown = '# ' + text;
     cy.stub(ToS, 'getDUOSText').returns(rawMarkdown);
     mount(<TermsOfService />);

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -49,6 +49,7 @@ import AdminManageDarCollections from './pages/AdminManageDarCollections';
 import {AdminEditUser} from "./pages/AdminEditUser";
 import NewChairConsole from './pages/NewChairConsole';
 import NewMemberConsole from './pages/NewMemberConsole';
+import TermsOfService from './pages/TermsOfService';
 
 const Routes = (props) => (
   <Switch>
@@ -71,6 +72,7 @@ const Routes = (props) => (
     <Route path="/nih_ic_webform" component={NIHICWebform} />
     <Route path="/nih_pilot_info" component={NIHPilotInfo} />
     <Route path="/privacy" component={PrivacyPolicy} />
+    <Route path="/tos" component={TermsOfService} />
     <Route path="/data_sharing_language_tool" component={DataSharingLanguageTool} />
     <AuthenticatedRoute path="/admin_console" component={AdminConsole} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_users" component={AdminManageUsers} props={props} rolesAllowed={[USER_ROLES.admin]} />

--- a/src/components/DuosFooter.js
+++ b/src/components/DuosFooter.js
@@ -30,7 +30,7 @@ function DuosFooter() {
         ul({ className: "footer-links" }, [
           li({ className: "footer-links__item" }, ["\u00A9 Broad Institute"]),
           li({ className: "footer-links__item" }, [a({ href: "/privacy" }, ["Privacy Policy"]),]),
-          li({ className: "footer-links__item" }, [a({ target: '_blank', href: "https://www.broadinstitute.org/terms-conditions" }, ["Terms of Service"]),]),
+          li({ className: "footer-links__item" }, [a({ href: '/tos' }, ["Terms of Service"]),]),
           li({ className: 'footer-links__item' }, [a({ href: '/status' }, ['Status'])])
         ])
       ])

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1152,6 +1152,14 @@ export const LibraryCard = {
   }
 };
 
+export const ToS = {
+  getDUOSText: async () => {
+    const url = `${await Config.getApiUrl()}/tos/text/duos`;
+    const res = await axios.get(url, Config.textPlainOpts());
+    return res.data;
+  }
+};
+
 const fetchOk = async (...args) => {
   //TODO: Remove spinnerService calls
   spinnerService.showAll();

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -48,6 +48,14 @@ export const Config = {
     },
   }),
 
+  textPlainOpts: (token = Token.getToken()) => ({
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'text/plain',
+      'X-App-ID': 'DUOS',
+    },
+  }),
+
   fileOpts: (token = Token.getToken()) => ({
     headers: {
       Authorization: `Bearer ${token}`,

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -1,0 +1,28 @@
+import {ToS} from '../libs/ajax';
+import {div} from 'react-hyperscript-helpers';
+import React, {useEffect, useState} from 'react';
+import ReactMarkdown from 'react-markdown';
+import DOMPurify from 'dompurify';
+
+
+export default function TermsOfService() {
+
+  const formatMarkdown = (markdown) => {
+    return <ReactMarkdown
+      components={{a: (props) => <a target={'_blank'} {...props}/>}}>
+      {DOMPurify.sanitize(markdown)}
+    </ReactMarkdown>;
+  };
+
+  const [tosText, setTosText] = useState('');
+
+  useEffect(() => {
+    const init = async () => {
+      const text = await ToS.getDUOSText();
+      setTosText(text.replace('https://app.terra.bio/#', '/'));
+    };
+    init();
+  }, []);
+
+  return div({className: 'markdown-body'}, [formatMarkdown(tosText)]);
+}


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1448

## Changes
* Update our ToS link to point to a local ToS page with content that comes from Sam
* Re-wrote the privacy link from app.terra to our own version of the privacy policy
* Test
* Minor update to a commented out test - uncommented it for legibility and added skip so it doesn't fail in github action

## Example
![Screen Shot 2022-04-13 at 3 24 44 PM](https://user-images.githubusercontent.com/116679/163255155-ce71f3ec-7ab0-4536-b4c2-a2f05149804e.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
