### PR TITLE
[DUOS-1736][risk=no] Update signin component

### DIFF
--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -14,4 +14,4 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           install: false
-          command: npx cypress run-ct
+          command: npx cypress run-ct -p 8080

--- a/TESTING.md
+++ b/TESTING.md
@@ -37,12 +37,13 @@ Run Cypress headless:
 See https://www.cypress.io/blog/2021/04/06/introducing-the-cypress-component-test-runner/ for more detailed information
 
 This command opens a browser window with component tests visible. 
-You don't need to have a running server started, this will do that for you. 
+You don't need to have a running server started, this will do that for you.
+(Note that specifying any port with `open-ct` will default to 3000, this seems to be a cypress bug) 
 ```
-    npx cypress open-ct
+    npx cypress open-ct -p 3000
 ```
 
 This runs component tests headless:
 ```
-    npx cypress run-ct
+    npx cypress run-ct -p 8080
 ```

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,5 @@
 {
   "baseUrl": "http://localhost:3000/",
-  "port": 3000,
   "chromeWebSecurity": false,
   "component": {
     "testFiles": "**/*.spec.js",

--- a/cypress.json
+++ b/cypress.json
@@ -1,10 +1,11 @@
 {
   "baseUrl": "http://localhost:3000/",
+  "port": 3000,
   "chromeWebSecurity": false,
   "component": {
     "testFiles": "**/*.spec.js",
     "src": [
-      "./src/components/common", 
+      "./src/components/common",
       "./cypress/component/"
     ]
   }

--- a/cypress/component/SignIn/sign_in.spec.js
+++ b/cypress/component/SignIn/sign_in.spec.js
@@ -5,18 +5,26 @@ import {mount} from '@cypress/react';
 import SignIn from '../../../src/components/SignIn';
 import { Config } from '../../../src/libs/config';
 
+const signInText = "Sign-in";
+
+// Note that we do not want to click the signin button
+// in tests as that would trigger an auth-flow we cannot
+// replicate in a test environment.
 describe('Sign In Component', function() {
-  it('Sign In Button Loads', function () {
+  it('Sign In Button Loads when client id is valid', function () {
     cy.viewport(600, 300);
     // Load the client id from perf so we can have a valid button
     cy.readFile('config/perf.json').then((config) => {
       const clientId = config.clientId;
       cy.stub(Config, 'getGoogleClientId').returns(clientId);
       mount(<SignIn />);
-      cy.contains("Sign-in").should('exist');
+      cy.contains(signInText).should('exist');
     });
   });
-  // Note that we do not want to click the signin button
-  // in tests as that would trigger an auth-flow we cannot
-  // replicate in a test environment.
+  it('Spinner loads when client id is empty', function () {
+    cy.viewport(600, 300);
+    cy.stub(Config, 'getGoogleClientId').returns('');
+    mount(<SignIn />);
+    cy.contains(signInText).should('not.exist');
+  });
 });

--- a/cypress/component/SignIn/sign_in.spec.js
+++ b/cypress/component/SignIn/sign_in.spec.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-undef */
+
+import React from 'react';
+import {mount} from '@cypress/react';
+import SignIn from '../../../src/components/SignIn';
+import { Config } from '../../../src/libs/config';
+
+describe('Sign In Component', function() {
+  it('Sign In Button Loads', function () {
+    cy.viewport(600, 300);
+    // Load the client id from perf so we can have a valid button
+    cy.readFile('config/perf.json').then((config) => {
+      const clientId = config.clientId;
+      cy.stub(Config, 'getGoogleClientId').returns(clientId);
+      mount(<SignIn />);
+      cy.contains("Sign-in").should('exist');
+    });
+  });
+  // Note that we do not want to click the signin button
+  // in tests as that would trigger an auth-flow we cannot
+  // replicate in a test environment.
+});

--- a/cypress/integration/home_spec.js
+++ b/cypress/integration/home_spec.js
@@ -5,7 +5,7 @@ describe('Home', function() {
   it('Home page loads correctly', function() {
     cy.visit('');
     cy.contains('DUOS');
-    cy.contains('Sign in with Google');
+    cy.contains('Sign-in/Register');
     cy.contains('What is DUOS and how does it work?');
     cy.contains('Are you a DAC member?');
     cy.contains('Are you a Signing Official?');

--- a/src/App.js
+++ b/src/App.js
@@ -61,15 +61,15 @@ function App() {
 
   }, [history]);
 
-  const signOut = () => {
-    Storage.setUserIsLogged(false);
-    Storage.clearStorage();
-    setIsLoggedIn(false);
+  const signOut = async () => {
+    await Storage.setUserIsLogged(false);
+    await Storage.clearStorage();
+    await setIsLoggedIn(false);
   };
 
-  const signIn = () => {
-    Storage.setUserIsLogged(true);
-    setIsLoggedIn(true);
+  const signIn = async () => {
+    await Storage.setUserIsLogged(true);
+    await setIsLoggedIn(true);
   };
 
   return (

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -28,8 +28,8 @@ export default function SignIn(props) {
     Storage.setGoogleData(response);
     try {
       const userRes = await User.getMe();
-      setUser(Object.assign(userRes, setUserRoleStatuses(userRes, Storage)));
-      redirect(user);
+      await setUser(Object.assign(userRes, setUserRoleStatuses(userRes, Storage)));
+      redirect(userRes);
     } catch (error) {
       try {
         let registeredUser = await User.registerUser();
@@ -45,9 +45,9 @@ export default function SignIn(props) {
               break;
             case 409:
               try {
-                let user = await this.getUser();
-                user = Object.assign({}, user, setUserRoleStatuses(user, Storage));
-                redirect(user);
+                let userRes = await User.getMe();
+                await setUser(Object.assign({}, userRes, setUserRoleStatuses(userRes, Storage)));
+                redirect(userRes);
               } catch (error) {
                 Storage.clearStorage();
               }
@@ -77,8 +77,8 @@ export default function SignIn(props) {
     }
   };
 
-  const redirect = useCallback((user) => {
-    Navigation.back(user, history);
+  const redirect = useCallback(async (user) => {
+    await Navigation.back(user, history);
     onSignIn();
   }, [onSignIn, history]);
 

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -59,6 +59,7 @@ export default function SignIn(props) {
               setErrorDisplay({show: true, title: 'Error', msg: JSON.stringify(error)});
               break;
             case 409:
+              // If the user exists, regardless of conflict state, log them in.
               try {
                 await setUserInStorageAndRedirect();
               } catch (error) {

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -1,162 +1,125 @@
-import _ from 'lodash/fp';
-import { Component } from 'react';
+import {isEmpty, isNil} from 'lodash/fp';
+import {useEffect, useState, useCallback} from 'react';
 import GoogleLogin from 'react-google-login';
-import { div, h, hh, img, span, button } from 'react-hyperscript-helpers';
-import { Alert } from './Alert';
-import { User } from '../libs/ajax';
-import { Config } from '../libs/config';
-import { Storage } from '../libs/storage';
-import { Navigation, setUserRoleStatuses } from '../libs/utils';
+import {button, div, h, img, span} from 'react-hyperscript-helpers';
+import {Alert} from './Alert';
+import {User} from '../libs/ajax';
+import {Config} from '../libs/config';
+import {Storage} from '../libs/storage';
+import {Navigation, setUserRoleStatuses} from '../libs/utils';
 import loadingIndicator from '../images/loading-indicator.svg';
-import { Spinner } from './Spinner';
-export const SignIn = hh(class SignIn extends Component {
+import {Spinner} from './Spinner';
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      clientId: '',
-      error: {},
+export default function SignIn(props) {
+
+  const [clientId, setClientId] = useState('');
+  const [user, setUser] = useState({});
+  const [errorDisplay, setErrorDisplay] = useState({});
+  const {onSignIn, history, customStyle} = props;
+
+  useEffect(() => {
+    const init = async () => {
+      setClientId(`${await Config.getGoogleClientId()}`);
     };
-    this.getGoogleClientId();
-  }
+    init();
+  }, []);
 
-  getGoogleClientId = async () => {
-    const clientKey = `${ await Config.getGoogleClientId() }`;
-    this.setState(prev => {
-      prev.clientId = clientKey;
-      return prev;
-    });
-  };
-
-  getUser = async () => {
-    return await User.getMe();
-  };
-
-  responseGoogle = async (response) => {
+  const responseGoogle = async (response) => {
     Storage.setGoogleData(response);
-    try{
-      const userRes = await this.getUser();
-      const user = Object.assign(userRes, setUserRoleStatuses(userRes, Storage));
-      this.redirect(user);
-    } catch(error) {
+    try {
+      const userRes = await User.getMe();
+      setUser(Object.assign(userRes, setUserRoleStatuses(userRes, Storage)));
+      redirect(user);
+    } catch (error) {
       try {
         let registeredUser = await User.registerUser();
         this.setUserRoleStatuses(registeredUser, Storage);
-        this.props.onSignIn(); //is this async?
-        this.props.history.push('/profile');
-      } catch(error) {
-        try{
+        onSignIn();
+        history.push('/profile');
+      } catch (error) {
+        try {
           const status = error.status;
-          switch(status) {
+          switch (status) {
             case 400:
-              this.setState(prev => {
-                prev.error = {show: true, title: 'Error', msg: JSON.stringify(error)};
-                return prev;
-              });
+              setErrorDisplay({show: true, title: 'Error', msg: JSON.stringify(error)});
               break;
             case 409:
               try {
                 let user = await this.getUser();
                 user = Object.assign({}, user, setUserRoleStatuses(user, Storage));
-                this.redirect(user);
-              } catch(error) {
+                redirect(user);
+              } catch (error) {
                 Storage.clearStorage();
               }
               break;
             default:
-              this.setState(prev => {
-                prev.error = { show: true, title: 'Error', msg: 'Unexpected error, please try again'};
-                return prev;
-              });
+              setErrorDisplay({show: true, title: 'Error', msg: 'Unexpected error, please try again'});
               break;
           }
-        } catch(error) {
-          this.setState(prev => {
-            prev.error = {show: true, title: 'Error', msg: JSON.stringify(error)};
-            return prev;
-          });
+        } catch (error) {
+          setErrorDisplay({show: true, title: 'Error', msg: JSON.stringify(error)});
         }
       }
     }
   };
 
-  forbidden = (response) => {
+  const forbidden = (response) => {
     Storage.clearStorage();
     if (response.error === 'popup_closed_by_user') {
-      this.setState(prev => {
-        prev.error = {
-          description: span({}, ['Sign-in cancelled ... ', img({ height: '20px', src: loadingIndicator })])
-        };
-        return prev;
+      setErrorDisplay({
+        description: span({}, ['Sign-in cancelled ... ', img({height: '20px', src: loadingIndicator})])
       });
       setTimeout(() => {
-        this.setState(prev => {
-          prev.error = {};
-          return prev;
-        });
+        setErrorDisplay({});
       }, 3000);
     } else {
-      this.setState(prev => {
-        prev.error = { 'title': response.error, 'description': response.details };
-        return prev;
-      });
+      setErrorDisplay({'title': response.error, 'description': response.details});
     }
   };
 
-  redirect = (user) => {
-    Navigation.back(user, this.props.history);
-    this.props.onSignIn();
-  };
+  const redirect = useCallback((user) => {
+    Navigation.back(user, history);
+    onSignIn();
+  }, [onSignIn, history]);
 
-  renderSpinnerIfDisabled = (disabled) => {
-    const defaultStyle = {
+  const spinnerOrSigninButton = () => {
+    const disabled = clientId === '';
+    const defaultProps = {
+      buttonText: 'Sign-in/Register',
       scope: 'openid email profile',
       height: '44px',
       width: '180px',
       theme: 'dark',
-      clientId: this.state.clientId,
-      onSuccess: this.responseGoogle,
-      onFailure: this.forbidden,
-      disabledStyle: { 'opacity': '25%', 'cursor': 'not-allowed' }
+      clientId: clientId,
+      onSuccess: responseGoogle,
+      onFailure: forbidden,
+      disabledStyle: {'opacity': '25%', 'cursor': 'not-allowed'}
     };
     return disabled ?
       Spinner :
       h(GoogleLogin,
-        _.isNil(this.props.customStyle) ? defaultStyle : {
-          render: (props) => button({className: 'btn-primary', onClick: props.onClick, style: this.props.customStyle}, 'Submit a Data Access Request'),
-          ...defaultStyle
+        isNil(customStyle) ? defaultProps : {
+          render: (props) => button({
+            className: 'btn-primary',
+            onClick: props.onClick,
+            style: customStyle
+          }, 'Submit a Data Access Request'),
+          ...defaultProps
         });
   };
 
-  render() {
+  return (
+    div({}, [
+      div({isRendered: !isEmpty(errorDisplay), className: 'dialog-alert'}, [
+        Alert({
+          id: 'dialog',
+          type: 'danger',
+          title: errorDisplay.title,
+          description: errorDisplay.description
+        })
+      ]),
+      div({isRendered: isEmpty(errorDisplay)}, [spinnerOrSigninButton()])
+    ])
+  );
+}
 
-    let googleLoginButton;
-
-    if (this.state.clientId === '') {
-      googleLoginButton = Spinner;
-    } else {
-      googleLoginButton = h(GoogleLogin, {
-        scope: 'openid email profile',
-        clientId: this.state.clientId,
-        onSuccess: this.responseGoogle,
-        onFailure: this.forbidden,
-        render: ({disabled}) => this.renderSpinnerIfDisabled(disabled)
-      }
-      );
-    }
-
-    return (
-      div({}, [
-        div({ isRendered: !_.isEmpty(this.state.error), className: 'dialog-alert' }, [
-          Alert({
-            id: 'dialog',
-            type: 'danger',
-            title: this.state.error.title,
-            description: this.state.error.description
-          })
-        ]),
-        div({ isRendered: _.isEmpty(this.state.error) }, [googleLoginButton])
-      ])
-    );
-  }
-});

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -33,15 +33,15 @@ export default function SignIn(props) {
     Storage.setGoogleData(response);
     try {
       const user = await User.getMe();
-      await setUserRoleStatuses(user, Storage);
-      onSignIn();
+      setUserRoleStatuses(user, Storage);
+      await onSignIn();
       redirect(user);
     } catch (error) {
       try {
         // New users without an existing account will error out in the above call
         // Register them and redirect them to the profile page.
         const registeredUser = await User.registerUser();
-        await setUserRoleStatuses(registeredUser, Storage);
+        setUserRoleStatuses(registeredUser, Storage);
         onSignIn();
         history.push('/profile');
       } catch (error) {
@@ -54,7 +54,8 @@ export default function SignIn(props) {
               break;
             case 409:
               try {
-                const user = await User.getMe();
+                let user = await User.getMe();
+                user = setUserRoleStatuses(user, Storage);
                 redirect(user);
               } catch (error) {
                 Storage.clearStorage();

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -29,8 +29,7 @@ export default function SignIn(props) {
     return () => (isSubscribed = false);
   }, []);
 
-  // Utility function called in the normal case and
-  // in the undocumented 409 response code case
+  // Utility function called in the normal success case and in the undocumented 409 case
   const setUserInStorageAndRedirect = async () => {
     const user = await User.getMe();
     setUserRoleStatuses(user, Storage);

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -250,23 +250,25 @@ export const setUserRoleStatuses = (user, Storage) => {
 
 export const Navigation = {
   back: async (user, history) => {
-    const page = user.isChairPerson ? '/chair_console'
-      : user.isMember ? '/member_console'
-        : user.isAdmin ? '/admin_console'
-          : user.isResearcher ? '/dataset_catalog'
-            : user.isDataOwner ? '/data_owner_console'
-              : user.isAlumni ? '/summary_votes'
-                : '/';
+    const page =
+      user.isAdmin ? '/admin_console'
+        :user.isChairPerson ? '/chair_console'
+          : user.isMember ? '/member_console'
+            : user.isResearcher ? '/dataset_catalog'
+              : user.isDataOwner ? '/data_owner_console'
+                : user.isAlumni ? '/summary_votes'
+                  : '/';
     history.push(page);
   },
   console: async (user, history) => {
-    const page = user.isChairPerson ? '/chair_console'
-      : user.isMember ? '/member_console'
-        : user.isAdmin ? '/admin_console'
-          : user.isResearcher ? '/researcher_console'
-            : user.isDataOwner ? '/data_owner_console'
-              : user.isAlumni ? '/summary_votes'
-                : '/';
+    const page =
+      user.isAdmin ? '/admin_console'
+        : user.isChairPerson ? '/chair_console'
+          : user.isMember ? '/member_console'
+            : user.isResearcher ? '/researcher_console'
+              : user.isDataOwner ? '/data_owner_console'
+                : user.isAlumni ? '/summary_votes'
+                  : '/';
     history.push(page);
   }
 };

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,6 +1,6 @@
 import { Component } from 'react';
-import { a, button, div, h, h1, h3, img, p, span } from 'react-hyperscript-helpers';
-import { SignIn } from '../components/SignIn';
+import { a, button, div, h, h1, h3, img, p } from 'react-hyperscript-helpers';
+import SignIn from '../components/SignIn';
 import { ReadMore } from '../components/ReadMore';
 import homeHeaderBackground from '../images/home_header_background.png';
 import duosLogoImg from '../images/duos_logo.svg';
@@ -106,15 +106,6 @@ class Home extends Component {
       right: '1rem',
     };
 
-    const registerPositionStyle = {
-      position: 'absolute',
-      top: "7.5rem",
-      right: "4rem",
-      zIndex: 1000,
-      margin: "3px"
-    };
-
-
     return (
 
       div({ className: 'row' }, [
@@ -122,15 +113,7 @@ class Home extends Component {
           div({ className: 'row', style: { backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}, [
             img({ style: { height: 'inherit', minWidth: '100%' }, src: homeHeaderBackground}),
             div({ isRendered: !isLogged, style: signInPositionStyle}, [
-              span({ style: {color: "#FFFFFF" }}, ['Already registered?']),
-              SignIn({ props: this.props, onSignIn: () => onSignIn(), history })
-            ]),
-            div({isRendered: !isLogged, style: registerPositionStyle}, [
-              span({ style: { color: '#FFFFFF' }}, ['If not, ',
-                a({
-                  href: 'https://accounts.google.com/SignUp?continue:https%3A%2F%2Faccounts.google.com%2Fo%2Foauth2%2Fauth%3Fopenid.realm%26scope%3Demail%2Bprofile%2Bopenid%26response_type%3Dpermission%26redirect_uri%3Dstoragerelay%3A%2F%2Fhttp%2Flocalhost%3A8000%3Fid%253Dauth721210%26ss_domain%3Dhttp%3A%2F%2Flocalhost%3A8000%26client_id%3D832251491634-smgc3b2pogqer1mmdrd3hrqic3leof3p.apps.googleusercontent.com%26fetch_basic_profile%3Dtrue%26hl%3Des-419%26from_login%3D1%26as%3D43c5de35a7316d00&ltmpl:popup',
-                }, ['register here'])
-              ])
+              h(SignIn, { props: this.props, onSignIn, history })
             ]),
             div({ style: { position: 'absolute', width: '100%', top: '50%', left: '50%', transform: 'translate(-50%, -50%)'}}, [
               img({ style: duosLogo , alt: 'DUOS logo', src: duosLogoImg }),
@@ -171,8 +154,7 @@ class Home extends Component {
                         style: { color: '#fff' }
                       }, ['Submit a Data Access Request'])
                     ]) :
-                    SignIn({ props: this.props, onSignIn: () => onSignIn(), history: history, customStyle: buttonStyle
-                    })
+                    h(SignIn, { props: this.props, onSignIn, history, customStyle: buttonStyle})
                 ])
               ]),
             ])


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1736

* Updates component to a function
* Updated button text
* Simplified the button generation
* Minor update to default console/back link based on role
* Updated port specs for cypress tests. We need a non-random port for the google client id, but specifying them is buggy in cypress.

## Testing
To test the new user case, sign up with a brand new user OR, spin up a local consent, point your local UI to that, and then connect to the local consent database. Delete any records for any user you want to test (i.e. `delete from user_role where user_id = ?;` and `delete from dacuser where dacuserid = ?;`, etc., repeating for DARs. We also have a delete user by email endpoint (https://consent.dsde-dev.broadinstitute.org/#/User/delete_api_user__email_), but that's not exactly 100% comprehensive and may fail depending on your user.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
