### PR TITLE
DUOS-1742[risk=no] Corrected Final Vote Bucketing logic in DarCollectionUtils

### DIFF
--- a/src/components/common/DataUseVoteSummary/VoteResultContainer.js
+++ b/src/components/common/DataUseVoteSummary/VoteResultContainer.js
@@ -1,6 +1,6 @@
 import VoteResultIcon from './VoteResultIcon';
 import VoteResultLabel from './VoteResultLabel';
-import { isEmpty } from 'lodash/fp';
+import { isEmpty, filter, isNil } from 'lodash/fp';
 import { h, div } from 'react-hyperscript-helpers';
 
 //helper function to generate keys for rendered elements
@@ -9,16 +9,18 @@ const convertLabelToKey = (label) => {
 };
 
 const determineUnanimousVoteResult = ({votes = []}) => {
-  const voteCount = votes.length;
-  if (isEmpty(votes) || voteCount < 1) {
+  const filteredVotes = filter((vote) => !isNil(vote.vote))(votes);
+  if (isEmpty(filteredVotes)) {
     return 'underReview';
   }
+  const voteCount = filteredVotes.length;
+
   let voteTally = {
     true: 0,
     false: 0,
   };
 
-  votes.forEach((vote = {}) => {
+  filteredVotes.forEach((vote = {}) => {
     voteTally[vote.vote] += 1;
   });
 

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -116,7 +116,7 @@ const processVotesForBucket = (darElections) => {
         default:
           break;
       }
-      if(lowerCaseType === targetFinalType && !isNil(vote.vote)) {
+      if(lowerCaseType === targetFinalType) {
         targetFinal.push(vote);
       }
     })(dateSortedVotes);


### PR DESCRIPTION
Addresses [DUOS-1742](https://broadworkbench.atlassian.net/browse/DUOS-1742)

PR corrects bucketing logic regarding finalVotes in `DarCollectionUtils` by removing the undefined vote check. This allows the finalVote array to populate correctly for the Chair tab component to use when updating the chair/final vote. PR also updates the `VoteSummaryHeader` to account for the change in bucketing logic (it now has to filter out the undefined final vote values).

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
