### PR TITLE
[DUOS-1740][risk=no] Workaround for react-error-overlay bug with hot-reloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "eslint-plugin-react": "7.29.4",
         "google-auth-library": "8.0.0",
         "html-webpack-plugin": "4.5.2",
+        "react-error-overlay": "6.0.9",
         "react-scripts": "4.0.3",
         "source-map-explorer": "2.5.2",
         "start-server-and-test": "1.14.0"
@@ -20681,9 +20682,9 @@
       }
     },
     "node_modules/react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "node_modules/react-ga": {
@@ -33892,7 +33893,7 @@
         "listr2": "^3.8.3",
         "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
-        "minimist": "^1.2.6",
+        "minimist": "1.2.6",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
@@ -40143,7 +40144,7 @@
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "1.2.6"
           }
         }
       }
@@ -40992,7 +40993,7 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "1.2.6"
       }
     },
     "mocked-env": {
@@ -43676,9 +43677,9 @@
       }
     },
     "react-error-overlay": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.10.tgz",
-      "integrity": "sha512-mKR90fX7Pm5seCOfz8q9F+66VCc1PGsWSBxKbITjfKVQHMNF2zudxHnMdJiB1fRCb+XsbQV9sO9DCkgsMQgBIA==",
+      "version": "6.0.9",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
+      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
       "dev": true
     },
     "react-ga": {
@@ -47677,7 +47678,7 @@
         "axios": "^0.21.1",
         "joi": "^17.4.0",
         "lodash": "^4.17.21",
-        "minimist": "^1.2.5",
+        "minimist": "1.2.6",
         "rxjs": "^7.1.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-react": "7.29.4",
     "google-auth-library": "8.0.0",
     "html-webpack-plugin": "4.5.2",
+    "react-error-overlay": "6.0.9",
     "react-scripts": "4.0.3",
     "source-map-explorer": "2.5.2",
     "start-server-and-test": "1.14.0"

--- a/src/App.css
+++ b/src/App.css
@@ -1,11 +1,3 @@
-/* Workaround for a react-error-overlay bug:
-  https://github.com/facebook/create-react-app/issues/11773
-  https://github.com/facebook/create-react-app/issues/12064
-*/
-body > iframe {
-  pointer-events: none;
-}
-
 .App {
   text-align: center;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,11 @@
+/* Workaround for a react-error-overlay bug:
+  https://github.com/facebook/create-react-app/issues/11773
+  https://github.com/facebook/create-react-app/issues/12064
+*/
+body > iframe {
+  pointer-events: none;
+}
+
 .App {
   text-align: center;
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

Fixes a dev dependency bug in react-error-overlay where hot reloaded pages have an overlay that breaks text selection and links on the refreshed page.

See https://github.com/facebook/create-react-app/issues?q=is%3Aissue+is%3Aopen+process+not+defined+ for more related issues, specifically 12064 and 11773.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
