### PR TITLE
[DUOS-1710] library card revocation while dar vote open

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
@@ -245,4 +245,43 @@ describe('CollectionSubmitVoteBox - Tests', function() {
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
     cy.get('textarea').should('be.disabled');
   });
+
+  it('disables yes vote button if isApprovalDisabled is true', function () {
+    mount(
+      <CollectionSubmitVoteBox
+        votes={votesMixed}
+        isFinal={false}
+        question={"question"}
+        isDisabled={false}
+        isApprovalDisabled={true}
+      />
+    );
+    cy.stub(Votes, 'updateVotesByIds');
+
+    cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    cy.get('[datacy=yes-collection-vote-button]').click();
+    cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+  });
+
+  it('does not disable no vote button if isApprovalDisabled is true', function () {
+    mount(
+      <CollectionSubmitVoteBox
+        votes={votesMixed}
+        isFinal={false}
+        question={"question"}
+        isDisabled={false}
+        isApprovalDisabled={true}
+      />
+    );
+    cy.stub(Votes, 'updateVotesByIds');
+
+    cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    cy.get('[datacy=no-collection-vote-button]').click();
+    cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
+    cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', 'rgb(218, 0, 3)');
+    cy.get('textarea').should('not.be.disabled');
+  });
 });

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -96,7 +96,19 @@ const collection = {
   datasets: [
     {dataSetId: 300},
     {dataSetId: 400}
-  ]
+  ],
+  createUser: {
+    libraryCards: [{id: 1}]
+  }
+};
+
+const collectionMissingLibraryCard = {
+  datasets: [
+    {dataSetId: 300}
+  ],
+  createUser: {
+    libraryCards: []
+  }
 };
 
 describe('MultiDatasetVoteTab - Tests', function() {
@@ -202,5 +214,35 @@ describe('MultiDatasetVoteTab - Tests', function() {
 
     cy.get('[datacy=dataset-vote-slab]').should('be.visible');
     cy.get('.table-data').should('not.exist');
+  });
+
+  it('Renders warning text that data access cannot be approved when the researcher is missing a library card', function () {
+    mount(
+      <MultiDatasetVotingTab
+        darInfo={darInfo}
+        buckets={[bucket1, bucket2]}
+        collection={collectionMissingLibraryCard}
+        isChair={true}
+      />
+    );
+    cy.stub(Storage, 'getCurrentUser').returns({dacUserId: 200});
+    cy.stub(User, 'getUserRelevantDatasets').returns([{dataSetId: 300}, {dataSetId: 400}]);
+
+    cy.get('[id=missing_lc_alert]').should('be.visible');
+  });
+
+  it('Does not render warning text that data access cannot be approved when the researcher has a library card', function () {
+    mount(
+      <MultiDatasetVotingTab
+        darInfo={darInfo}
+        buckets={[bucket1, bucket2]}
+        collection={collection}
+        isChair={true}
+      />
+    );
+    cy.stub(Storage, 'getCurrentUser').returns({dacUserId: 200});
+    cy.stub(User, 'getUserRelevantDatasets').returns([{dataSetId: 300}, {dataSetId: 400}]);
+
+    cy.get('[id=missing_lc_alert]').should('not.exist');
   });
 });

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -44,11 +44,11 @@ export default function CollectionSubmitVoteBox(props) {
   const [vote, setVote] = useState();
   const [rationale, setRationale] = useState('');
   const [submitted, setSubmitted] = useState(false);
-  const [disabled, setDisabled] = useState(false);
+  const [isVotingDisabled, setIsVotingDisabled] = useState(false);
   const {question, votes, isFinal, isApprovalDisabled, isLoading} = props;
 
   useEffect(() => {
-    setDisabled(props.isDisabled || (isFinal && submitted) || isLoading);
+    setIsVotingDisabled(props.isDisabled || (isFinal && submitted) || isLoading);
   }, [props.isDisabled, isFinal, submitted, isLoading]);
 
   useEffect(() => {
@@ -112,12 +112,12 @@ export default function CollectionSubmitVoteBox(props) {
           div({style: styles.voteButtons}, [
             h(CollectionVoteYesButton, {
               onClick: () => updateVote(true),
-              disabled: disabled || isApprovalDisabled,
+              disabled: isVotingDisabled || isApprovalDisabled,
               isSelected: vote === true
             }),
             h(CollectionVoteNoButton, {
               onClick: () => updateVote(false),
-              disabled,
+              disabled: isVotingDisabled,
               isSelected: vote === false,
             })
           ])
@@ -132,7 +132,7 @@ export default function CollectionSubmitVoteBox(props) {
             onBlur: updateRationale,
             style: styles.rationaleTextArea,
             rows: 4,
-            disabled
+            disabled: isVotingDisabled
           }),
         ])
       ]),

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -45,7 +45,7 @@ export default function CollectionSubmitVoteBox(props) {
   const [rationale, setRationale] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [disabled, setDisabled] = useState(false);
-  const {question, votes, isFinal, isLoading} = props;
+  const {question, votes, isFinal, isApprovalDisabled, isLoading} = props;
 
   useEffect(() => {
     setDisabled(props.isDisabled || (isFinal && submitted) || isLoading);
@@ -112,7 +112,7 @@ export default function CollectionSubmitVoteBox(props) {
           div({style: styles.voteButtons}, [
             h(CollectionVoteYesButton, {
               onClick: () => updateVote(true),
-              disabled,
+              disabled: disabled || isApprovalDisabled,
               isSelected: vote === true
             }),
             h(CollectionVoteNoButton, {

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
@@ -51,7 +51,7 @@ export default function MultiDatasetVoteSlab(props) {
   const [currentUserVotes, setCurrentUserVotes] = useState([]);
   const [dacVotes, setDacVotes] = useState([]);
   const [bucketDatasetIds, setBucketDatasetIds] = useState([]);
-  const {title, bucket, collectionDatasets, dacDatasetIds, isChair, isLoading} = props;
+  const {title, bucket, collectionDatasets, dacDatasetIds, isChair, isApprovalDisabled, isLoading} = props;
 
   useEffect(() => {
     const user = Storage.getCurrentUser();
@@ -86,6 +86,7 @@ export default function MultiDatasetVoteSlab(props) {
         votes: currentUserVotes,
         isFinal: isChair,
         isDisabled: isEmpty(currentUserVotes) || !allOpenElections,
+        isApprovalDisabled,
         isLoading
       }),
       ChairVoteInfo({dacVotes, isChair, isLoading})

--- a/src/pages/access_review/VoteAsChair.js
+++ b/src/pages/access_review/VoteAsChair.js
@@ -93,6 +93,7 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
         disabled: !rpElectionOpen
       });
     return div({ id: 'chair-vote' }, [
+      div({ style: ERROR, isRendered: hasLibraryCard === false}, [errorMessage]),
       accessVoteQuestion,
       rpVoteQuestion,
       div({ style: LINK_SECTION }, [
@@ -103,8 +104,7 @@ export const VoteAsChair = hh(class VoteAsChair extends React.PureComponent {
       ]),
       div({ style: {color: this.state.viewMatchResults ? 'inherit' : 'transparent'} }, [
         this.formatMatchData(matchData)
-      ]),
-      div({ style: ERROR, isRendered: hasLibraryCard === false}, [errorMessage])
+      ])
     ]);
   }
 });

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -57,6 +57,14 @@ export default function MultiDatasetVotingTab(props) {
     init();
   }, []);
 
+  const isApprovalDisabled = () => {
+    const researcherLibraryCards = flow(
+      get('createUser'),
+      get('libraryCards')
+    )(collection);
+    const researcherMissingLibraryCards = isNil(researcherLibraryCards) || isEmpty(researcherLibraryCards);
+    return isChair && researcherMissingLibraryCards;
+  };
 
   const DatasetVoteSlabs = () => {
     let index = 0;

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -57,16 +57,14 @@ export default function MultiDatasetVotingTab(props) {
     init();
   }, []);
 
-  const isApprovalDisabled = () => {
+  const DatasetVoteSlabs = () => {
     const researcherLibraryCards = flow(
       get('createUser'),
       get('libraryCards')
     )(collection);
     const researcherMissingLibraryCards = isNil(researcherLibraryCards) || isEmpty(researcherLibraryCards);
-    return isChair && researcherMissingLibraryCards;
-  };
+    const isApprovalDisabled = isChair && researcherMissingLibraryCards;
 
-  const DatasetVoteSlabs = () => {
     let index = 0;
     return map(bucket => {
       index++;
@@ -76,6 +74,7 @@ export default function MultiDatasetVotingTab(props) {
         dacDatasetIds,
         collectionDatasets,
         isChair,
+        isApprovalDisabled,
         key: bucket.key
       });
     })(dataBuckets);

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -17,7 +17,7 @@ const styles = {
   slabs: {
     display: 'flex',
     flexDirection: 'column',
-    rowGap: '35px',
+    rowGap: '35px'
   },
   title: {
     color: '#333F52',


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1710)
Summary of changes:
- If the current user is a chair person and the `createUser` of a collection is missing a library card (revoked after submitting a DAR), then approving data access on the chair tab for that collection is disabled and a static message is displayed. No change in functionality for the member tab or for srp slabs 

Testing:
- log in as a researcher with a library card or create a new user and issue them a library card through the admin console
- have another user who is a chairperson for a DAC with associated datasets
- create a DAR as the researcher using datasets associated with the chairperson's DAC 
- open election for the DAR as admin or chairperson 
- As the chairperson, navigate to the DarCollectionReview page of the DAR. There should be no warning text, and the yes button should not be disabled for data access slabs for both the member and chair tabs.
- As admin, revoke the researcher's library card 
- As the chairperson, now warning text should appear and the yes button on data access slabs is disabled for the chair tab. Member tab is normal.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
