### PR TITLE
[DUOS-1767][risk=no] add tool tip to admin chair cancel icon

### DIFF
--- a/src/components/SimpleTable.js
+++ b/src/components/SimpleTable.js
@@ -2,7 +2,6 @@ import { isNil } from 'lodash/fp';
 import { div, h, span } from 'react-hyperscript-helpers';
 import { Styles } from '../libs/theme';
 import ReactTooltip from 'react-tooltip';
-import { useEffect } from 'react';
 
 //Component that renders skeleton loader on loading
 const SkeletonLoader = ({columnRow, columnHeaders, baseStyle, tableSize}) => {
@@ -108,14 +107,18 @@ export default function SimpleTable(props) {
     onSort
   } = props;
 
-  useEffect(() => {
-    ReactTooltip.rebuild();
-  }, [rowData]);
-
   const {baseStyle, columnStyle, containerOverride} = styles;
   const columnRow = h(ColumnRow, {key: 'column-row-container', columnHeaders, baseStyle, columnStyle, sort, onSort});
   const tableTemplate = [columnRow, h(DataRows, {rowData, baseStyle, columnHeaders, key: 'table-data-rows'})];
   const output = isLoading ? h(SkeletonLoader, {columnRow, columnHeaders, baseStyle, tableSize}) : tableTemplate;
-  return div({className: 'table-data', style: containerOverride || Styles.TABLE.CONTAINER, role: 'table'},
-    [output, isNil(paginationBar) ? div() : paginationBar]);
+  return div([
+    div({className: 'table-data', style: containerOverride || Styles.TABLE.CONTAINER, role: 'table'},
+      [output, isNil(paginationBar) ? div() : paginationBar]),
+    h(ReactTooltip, {
+      place: 'left',
+      effect: 'solid',
+      multiline: true,
+      className: 'tooltip-wrapper'
+    })
+  ]);
 }

--- a/src/components/TableIconButton.js
+++ b/src/components/TableIconButton.js
@@ -3,6 +3,8 @@ import { h, span } from 'react-hyperscript-helpers';
 import { applyHoverEffects, setDivAttributes, setStyle } from '../libs/utils';
 import { makeStyles } from '@material-ui/core';
 import { isNil } from 'lodash';
+import {useEffect} from "react";
+import ReactTooltip from "react-tooltip";
 
 const useStyles = makeStyles({
   root: {
@@ -14,6 +16,11 @@ const useStyles = makeStyles({
 });
 
 export default function TableIconButton(props) {
+
+  useEffect(() => {
+    ReactTooltip.rebuild();
+  }, []);
+
   const onMouseEnterFn = (e) => {
     applyHoverEffects(e, hoverStyle);
   };

--- a/src/components/dar_collection_table/AdminActions.js
+++ b/src/components/dar_collection_table/AdminActions.js
@@ -73,6 +73,7 @@ export default function AdminActions(props) {
     onClick: () => cancelOnClick(collection),
     style: baseCancelButtonStyle,
     hoverStyle: hoverCancelButtonStyle,
+    dataTip: 'Cancel Elections',
     icon: Block,
   };
 

--- a/src/components/dar_collection_table/ChairActions.js
+++ b/src/components/dar_collection_table/ChairActions.js
@@ -174,6 +174,7 @@ export default function ChairActions(props) {
     onClick: () => cancelOnClick(collection),
     style: baseCancelButtonStyle,
     hoverStyle: hoverCancelButtonStyle,
+    dataTip: 'Cancel Elections',
     icon: Block,
   };
 

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -7,6 +7,7 @@ import { recalculateVisibleTable, goToPage as updatePage, darCollectionUtils } f
 import SimpleTable from '../SimpleTable';
 import cellData from './DarCollectionTableCellData';
 import CollectionConfirmationModal from "./CollectionConfirmationModal";
+import ReactTooltip from "react-tooltip";
 
 const { determineCollectionStatus } = darCollectionUtils;
 export const getProjectTitle = ((collection) => {
@@ -275,6 +276,12 @@ export const DarCollectionTable = function DarCollectionTable(props) {
       resubmitCollection,
       openCollection,
       consoleAction
+    }),
+    h(ReactTooltip, {
+      place: 'left',
+      effect: 'solid',
+      multiline: true,
+      className: 'tooltip-wrapper'
     })
   ]);
 };

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -7,7 +7,6 @@ import { recalculateVisibleTable, goToPage as updatePage, darCollectionUtils } f
 import SimpleTable from '../SimpleTable';
 import cellData from './DarCollectionTableCellData';
 import CollectionConfirmationModal from "./CollectionConfirmationModal";
-import ReactTooltip from "react-tooltip";
 
 const { determineCollectionStatus } = darCollectionUtils;
 export const getProjectTitle = ((collection) => {
@@ -277,11 +276,5 @@ export const DarCollectionTable = function DarCollectionTable(props) {
       openCollection,
       consoleAction
     }),
-    h(ReactTooltip, {
-      place: 'left',
-      effect: 'solid',
-      multiline: true,
-      className: 'tooltip-wrapper'
-    })
   ]);
 };

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -275,6 +275,6 @@ export const DarCollectionTable = function DarCollectionTable(props) {
       resubmitCollection,
       openCollection,
       consoleAction
-    }),
+    })
   ]);
 };


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1767)
Summary of changes:

- Add 'Cancel Elections' tooltip to cancel icon on the DarCollectionsTable for admins and chairs (visible through `/new_chair_console` and `/admin_manage_dar_collections` pages)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
