### PR TITLE
[DUOS-1777][risk=no] add bypass for lc requirement on dar submission

### DIFF
--- a/cypress/component/DataAccessRequest/researcher_info.spec.js
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.js
@@ -66,7 +66,8 @@ describe('Researcher Info', () => {
   });
 
   it('renders the missing library cards alert correctly', () => {
-    mount(<WrappedResearcherInfo {...props}/>);
+    const mergedProps = {...props, ...{checkNihDataOnly: false}};
+    mount(<WrappedResearcherInfo {...mergedProps}/>);
     cy.get('[dataCy=researcher-info-missing-library-cards]').should('be.visible');
     cy.get('[dataCy=researcher-info-profile-unsubmitted]').should('not.exist');
     cy.get('[dataCy=researcher-info-profile-submitted]').should('not.exist');

--- a/cypress/component/DataAccessRequest/researcher_info.spec.js
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.js
@@ -80,6 +80,14 @@ describe('Researcher Info', () => {
     cy.get('[dataCy=researcher-info-missing-library-cards]').should('not.exist');
   });
 
+  it('renders the profile submitted alert for researcher without library cards if only NIH data requested', () => {
+    const mergedProps = {...props, ...{completed: true, checkNihDataOnly: true}};
+    mount(<WrappedResearcherInfo {...mergedProps}/>);
+    cy.get('[dataCy=researcher-info-profile-submitted]').should('be.visible');
+    cy.get('[dataCy=researcher-info-profile-unsubmitted]').should('not.exist');
+    cy.get('[dataCy=researcher-info-missing-library-cards]').should('not.exist');
+  });
+
   it('renders the profile unsubmitted alert', () => {
     const mergedProps = {...props, ...{completed: false, researcherUser: researcherUserWithLibraryCards}};
     mount(<WrappedResearcherInfo {...mergedProps}/>);
@@ -88,4 +96,11 @@ describe('Researcher Info', () => {
     cy.get('[dataCy=researcher-info-missing-library-cards]').should('not.exist');
   });
 
+  it('renders the profile unsubmitted alert for researcher without library cards if only NIH data requested', () => {
+    const mergedProps = {...props, ...{completed: false, checkNihDataOnly: true}};
+    mount(<WrappedResearcherInfo {...mergedProps}/>);
+    cy.get('[dataCy=researcher-info-profile-unsubmitted]').should('be.visible');
+    cy.get('[dataCy=researcher-info-profile-submitted]').should('not.exist');
+    cy.get('[dataCy=researcher-info-missing-library-cards]').should('not.exist');
+  });
 });

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -41,6 +41,7 @@ class DataAccessRequestApplication extends Component {
         internalCollaborators: [],
         externalCollaborators: [],
         checkCollaborator: false,
+        checkNihDataOnly: false,
         rus: '',
         nonTechRus: '',
         linkedIn: '',
@@ -855,6 +856,7 @@ class DataAccessRequestApplication extends Component {
       orcid = '',
       researcherGate = '',
       checkCollaborator = false,
+      checkNihDataOnly = false,
       darCode,
       hmb = false,
       poa = false,
@@ -1015,6 +1017,7 @@ class DataAccessRequestApplication extends Component {
             div({ isRendered: this.state.step === 1 && (this.state.formData.researcher !== '') }, [
               h(ResearcherInfo, ({
                 checkCollaborator: checkCollaborator,
+                checkNihDataOnly: checkNihDataOnly,
                 completed: this.state.completed,
                 darCode: this.state.formData.darCode,
                 eRACommonsDestination: eRACommonsDestination,

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -898,7 +898,7 @@ class DataAccessRequestApplication extends Component {
     const step1Invalid = this.step1InvalidResult(this.step1InvalidChecks());
     const step2Invalid = this.verifyStep2();
     const step3Invalid = this.step3InvalidResult();
-    const libraryCardInvalid = isEmpty(get(this.state.researcher, 'libraryCards', []));
+    const libraryCardInvalid = isEmpty(get(this.state.researcher, 'libraryCards', [])) && !checkNihDataOnly;
 
     //NOTE: component is only here temporarily until component conversion has been complete
     //ideally this, along with the other variable initialization should be done with a useEffect hook

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -58,27 +58,29 @@ export default function ResearcherInfo(props) {
 
   //initial state variable assignment
   const [checkCollaborator, setCheckCollaborator] = useState(props.checkCollaborator);
+  const [checkNihDataOnly, setCheckNihDataOnly] = useState(props.checkNihDataOnly);
   const [signingOfficial, setSigningOfficial] = useState();
   const [itDirector, setITDirector] = useState(props.itDirector || '');
   const [anvilUse, setAnvilUse] = useState(props.anvilUse || '');
   const [cloudUse, setCloudUse] = useState(props.cloudUse || '');
   const [localUse, setLocalUse] = useState(props.localUse || '');
   const [researcherUser, setResearcherUser] = useState(props.researcherUser);
-  const [hasLibraryCards, setHasLibraryCards] = useState(false);
+  const [libraryCardReqSatisfied, setLibraryCardReqSatisfied] = useState(false);
 
   useEffect(() => {
-    setHasLibraryCards(!isEmpty(get('libraryCards')(researcherUser)));
-  }, [researcherUser]);
+    setLibraryCardReqSatisfied(!isEmpty(get('libraryCards')(researcherUser)) || checkNihDataOnly);
+  }, [checkNihDataOnly, researcherUser]);
 
   useEffect(() => {
     setSigningOfficial(props.signingOfficial);
     setCheckCollaborator(props.checkCollaborator);
+    setCheckNihDataOnly(props.checkNihDataOnly);
     setITDirector(props.itDirector);
     setAnvilUse(props.anvilUse);
     setCloudUse(props.cloudUse);
     setLocalUse(props.localUse);
     setResearcherUser(props.researcherUser);
-  }, [props.signingOfficial, props.checkCollaborator, props.itDirector, props.anvilUse, props.cloudUse, props.localUse, props.researcherUser]);
+  }, [props.signingOfficial, props.checkCollaborator, props.itDirector, props.anvilUse, props.cloudUse, props.localUse, props.researcherUser, props.checkNihDataOnly]);
 
   const cloudRadioGroup = div({
     className: 'radio-inline',
@@ -123,18 +125,31 @@ export default function ResearcherInfo(props) {
 
         div({
           datacy: 'researcher-info-missing-library-cards',
-          isRendered: !hasLibraryCards, className: 'rp-alert' }, [
+          isRendered: !libraryCardReqSatisfied, className: 'rp-alert' }, [
           Alert({ id: 'missingLibraryCard', type: 'danger', title: missingLibraryCard })
         ]),
         div({
           datacy: 'researcher-info-profile-unsubmitted',
-          isRendered: (completed === false && hasLibraryCards), className: 'rp-alert' }, [
+          isRendered: (completed === false && libraryCardReqSatisfied), className: 'rp-alert' }, [
           Alert({ id: 'profileUnsubmitted', type: 'danger', title: profileUnsubmitted })
         ]),
         div({
           datacy: 'researcher-info-profile-submitted',
-          isRendered: (completed === true && hasLibraryCards), className: 'rp-alert' }, [
+          isRendered: (completed === true && libraryCardReqSatisfied), className: 'rp-alert' }, [
           Alert({ id: 'profileSubmitted', type: 'info', title: profileSubmitted })
+        ]),
+        div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group checkbox' }, [
+          input({
+            type: 'checkbox',
+            id: 'chk_nih_data_only',
+            name: 'checkNihDataOnly',
+            className: 'checkbox-inline rp-checkbox',
+            disabled: !isNil(darCode),
+            checked: checkNihDataOnly,
+            onChange: (e) => formFieldChange({name: 'checkNihDataOnly', value: e.target.checked})
+          }),
+          label({ className: 'regular-checkbox rp-choice-questions', htmlFor: 'chk_nih_data_only' },
+            ['I am exclusively applying for NIH/NHGRI data (ex. GTex)'])
         ]),
 
         h3({ className: 'rp-form-title access-color' }, ['1. Researcher Information']),


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1777)
Summary of Changes:
- Add field in DAR form data to track if checkbox for NIH dataset use only is checked
- Change hasLibraryCards to libraryCardReqSatisified and modify to include status of check box 
- Add tests

[Link to Consent PR](https://github.com/DataBiosphere/consent/pull/1559)
PR above needs to be used as the backend in order to save the status of the checkbox

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
