### PR TITLE
[DUOS-1784] populate the pi in console pages

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, Fragment, useCallback } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import { isNil, isEmpty, find } from 'lodash/fp';
+import {isNil, isEmpty, find, flow, get} from 'lodash/fp';
 import { Styles } from '../../libs/theme';
 import PaginationBar from '../PaginationBar';
 import { recalculateVisibleTable, goToPage as updatePage, darCollectionUtils } from '../../libs/utils';
@@ -14,6 +14,17 @@ export const getProjectTitle = ((collection) => {
     const darData = find((dar) => !isEmpty(dar.data))(collection.dars).data;
     return darData.projectTitle;
   }
+});
+
+export const getPiName = ((collection) => {
+  // eslint-disable-next-line no-debugger
+  debugger;
+  return flow(
+    get('createUser'),
+    get('properties'),
+    find(property => property.propertyKey === 'piName'),
+    get('propertyValue')
+  )(collection);
 });
 
 export const styles = {
@@ -110,7 +121,10 @@ const columnHeaderConfig = {
   pi: {
     label: 'PI',
     cellStyle: { width: styles.cellWidth.pi },
-    cellDataFn: cellData.piCellData,
+    cellDataFn: (props) => {
+      props.piName = getPiName(props.collection);
+      return cellData.piCellData(props);
+    },
     sortable: true
   },
   institution: {

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, Fragment, useCallback } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
-import {isNil, isEmpty, find, flow, get} from 'lodash/fp';
+import {isNil, isEmpty, find, flow, get, isEqual} from 'lodash/fp';
 import { Styles } from '../../libs/theme';
 import PaginationBar from '../PaginationBar';
 import { recalculateVisibleTable, goToPage as updatePage, darCollectionUtils } from '../../libs/utils';
@@ -16,16 +16,22 @@ export const getProjectTitle = ((collection) => {
   }
 });
 
-export const getPiName = ((collection) => {
-  // eslint-disable-next-line no-debugger
-  debugger;
-  return flow(
-    get('createUser'),
+const getPI = (createUser) => {
+  const createUserIsPI = flow(
+    get('properties'),
+    find(property => property.propertyKey === 'isThePI'),
+    get('propertyValue'),
+    isEqual('true')
+  )(createUser);
+
+  const piName = flow(
     get('properties'),
     find(property => property.propertyKey === 'piName'),
     get('propertyValue')
-  )(collection);
-});
+  )(createUser);
+
+  return createUserIsPI ? createUser.displayName : piName;
+};
 
 export const styles = {
   baseStyle: {
@@ -122,7 +128,7 @@ const columnHeaderConfig = {
     label: 'PI',
     cellStyle: { width: styles.cellWidth.pi },
     cellDataFn: (props) => {
-      props.piName = getPiName(props.collection);
+      props.piName = getPI(props.createUser);
       return cellData.piCellData(props);
     },
     sortable: true

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -1,4 +1,4 @@
-import {isNil} from "lodash/fp";
+import {isEmpty, isNil} from "lodash/fp";
 import {formatDate, isCollectionCanceled} from "../../libs/utils";
 import {div, h} from "react-hyperscript-helpers";
 import CancelCollectionButton from "./CancelCollectionButton";
@@ -47,9 +47,9 @@ export function submissionDateCellData({createDate, darCollectionId, label = 'su
   };
 }
 
-export function piCellData({piName = '- -', darCollectionId, label = 'pi'}) {
+export function piCellData({piName, darCollectionId, label = 'pi'}) {
   return {
-    data: piName,
+    data: !isEmpty(piName) ? piName : '- -',
     id: darCollectionId,
     style: {
       color: '#354052',

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -47,9 +47,9 @@ export function submissionDateCellData({createDate, darCollectionId, label = 'su
   };
 }
 
-export function piCellData({darCollectionId, pi, label = 'pi'}) {
+export function piCellData({piName = '- -', darCollectionId, label = 'pi'}) {
   return {
-    data: '- -',
+    data: piName,
     id: darCollectionId,
     style: {
       color: '#354052',


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1784)
Summary of changes:

Populate PIs in `DarCollectionTable`, using:
- the `createUser`'s `displayName` if their `isThePI` property is true
- the `createUser`'s `piName` property if their `isThePI` property is false
- `- -` as filler if `isThePI` is false and `piName` is empty 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
