### PR TITLE
[DUOS-1786][risk=no] update alignment of dar collection review

### DIFF
--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -167,7 +167,7 @@ export default function DarCollectionReview(props) {
       }),
       h(DataUseVoteSummary, { dataUseBuckets, isLoading }),
     ]),
-    div({ className: 'review-page-body', style: {padding: '1% 0% 0% 10%', backgroundColor: tabContainerColor} }, [ //TODO: take the margin measurements and apply as padding here
+    div({ className: 'review-page-body', style: {padding: '1% 0% 0% 5.3%', backgroundColor: tabContainerColor} }, [ //TODO: take the margin measurements and apply as padding here
       h(TabControl, {
         labels: Object.values(tabs),
         selectedTab,

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -167,7 +167,7 @@ export default function DarCollectionReview(props) {
       }),
       h(DataUseVoteSummary, { dataUseBuckets, isLoading }),
     ]),
-    div({ className: 'review-page-body', style: {padding: '1% 0% 0% 5.3%', backgroundColor: tabContainerColor} }, [ //TODO: take the margin measurements and apply as padding here
+    div({ className: 'review-page-body', style: {padding: '1% 0% 0% 5.2%', backgroundColor: tabContainerColor} }, [ //TODO: take the margin measurements and apply as padding here
       h(TabControl, {
         labels: Object.values(tabs),
         selectedTab,


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1786)
Summary of changes:
- Change margin percentages of `review-page-body` so that the tab body aligns with vote summary section above  

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
