### PR TITLE
[DUOS-1782][risk=no] filter vote summary header

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -118,7 +118,7 @@ describe('MultiDatasetVoteTab - Tests', function() {
     cy.contains("DS");
   });
 
-  it('Renders dataset voting slab if the DAC votes on datasets in that bucket', function () {
+  it('Renders dataset voting slab with vote button selected', function () {
     mount(
       <MultiDatasetVotingTab
         darInfo={darInfo}
@@ -134,21 +134,6 @@ describe('MultiDatasetVoteTab - Tests', function() {
     cy.contains("GRU");
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', 'rgb(255, 255, 255)');
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', 'rgb(218, 0, 3)');
-  });
-
-  it('Does not renders dataset voting slab if the DAC does not vote on datasets in that bucket', function () {
-    mount(
-      <MultiDatasetVotingTab
-        darInfo={darInfo}
-        buckets={[bucket2]}
-        collection={collection}
-        isChair={false}
-      />
-    );
-    cy.stub(Storage, 'getCurrentUser').returns({dacUserId: 100});
-    cy.stub(User, 'getUserRelevantDatasets').returns([{dataSetId: 300}, {dataSetId: 400}]);
-
-    cy.get('[datacy=dataset-vote-slab]').should('not.exist');
   });
 
   it('Renders multiple dataset voting slabs', function () {

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -4,7 +4,6 @@ import {mount} from "@cypress/react";
 import {Storage} from "../../../src/libs/storage";
 import {User} from "../../../src/libs/ajax";
 import MultiDatasetVotingTab from "../../../src/pages/dar_collection_review/MultiDatasetVotingTab";
-import {collapseVotesByUser} from "../../../src/utils/DarCollectionUtils";
 import {filterBucketsForUser} from "../../../src/pages/dar_collection_review/DarCollectionReview";
 
 const darInfo = {

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -4,6 +4,8 @@ import {mount} from "@cypress/react";
 import {Storage} from "../../../src/libs/storage";
 import {User} from "../../../src/libs/ajax";
 import MultiDatasetVotingTab from "../../../src/pages/dar_collection_review/MultiDatasetVotingTab";
+import {collapseVotesByUser} from "../../../src/utils/DarCollectionUtils";
+import {filterBucketsForUser} from "../../../src/pages/dar_collection_review/DarCollectionReview";
 
 const darInfo = {
   "rus": "test",
@@ -189,3 +191,28 @@ describe('MultiDatasetVoteTab - Tests', function() {
     cy.get('.table-data').should('not.exist');
   });
 });
+
+describe('filterBucketsForUser - Tests', function() {
+  it('Filters out buckets if current user has no votes in it', function () {
+    const currentUser = {dacUserId: 100};
+    const prefilteredBuckets = [bucket1, bucket2];
+
+    const filteredBuckets = filterBucketsForUser(currentUser, prefilteredBuckets);
+    expect(filteredBuckets).to.have.lengthOf(1);
+    expect(filteredBuckets).to.deep.include(bucket1);
+    expect(filteredBuckets).to.not.deep.include(bucket2);
+  });
+
+  it('Does not filter out rp buckets or buckets with votes by the current user', function () {
+    const currentUser = {dacUserId: 200};
+    const rpBucket = {isRp: true, key: 'RP Vote'};
+    const prefilteredBuckets = [rpBucket, bucket1, bucket2];
+
+    const filteredBuckets = filterBucketsForUser(currentUser, prefilteredBuckets);
+    expect(filteredBuckets).to.have.lengthOf(3);
+    expect(filteredBuckets).to.deep.include(rpBucket);
+    expect(filteredBuckets).to.deep.include(bucket1);
+    expect(filteredBuckets).to.deep.include(bucket2);
+  });
+});
+

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -246,7 +246,7 @@ describe('filterBucketsForUser - Tests', function() {
 
   it('Does not filter out rp buckets or buckets with votes by the current user', function () {
     const currentUser = {dacUserId: 200};
-    const rpBucket = {isRp: true, key: 'RP Vote'};
+    const rpBucket = {isRP: true, key: 'RP Vote'};
     const prefilteredBuckets = [rpBucket, bucket1, bucket2];
 
     const filteredBuckets = filterBucketsForUser(currentUser, prefilteredBuckets);

--- a/cypress/component/utils/dar_collection_utils.spec.js
+++ b/cypress/component/utils/dar_collection_utils.spec.js
@@ -435,7 +435,7 @@ describe('extractUserDataAccessVotesFromBucket', () => {
     expect(votes).to.not.deep.include({dacUserId: 3});
   });
 
-  it('only returns final and chairperson votes if isChair is true', () => {
+  it('only returns chairperson votes if isChair is true', () => {
     const bucket = {
       votes: [
         {
@@ -493,8 +493,7 @@ describe('extractUserRPVotesFromBucket', () => {
         {
           rp: {
             memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}],
-            finalVotes: [{vote: true, dacUserId: 1}]
+            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}]
           },
         },
       ]
@@ -509,14 +508,13 @@ describe('extractUserRPVotesFromBucket', () => {
     expect(votes).to.not.deep.include({dacUserId: 3});
   });
 
-  it('only returns final and chairperson votes if isChair is true', () => {
+  it('only returns chairperson votes if isChair is true', () => {
     const bucket = {
       votes: [
         {
           rp: {
             memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}],
-            finalVotes: [{vote: true, dacUserId: 1}]
+            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}]
           },
         },
       ]
@@ -524,8 +522,7 @@ describe('extractUserRPVotesFromBucket', () => {
     const user = {dacUserId: 1};
 
     const votes = extractUserRPVotesFromBucket(bucket, user, true);
-    expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({vote: true, dacUserId: 1});
+    expect(votes).to.have.lengthOf(1);
     expect(votes).to.not.deep.include({dacUserId: 1});
     expect(votes).to.not.deep.include({vote: false, dacUserId: 2});
     expect(votes).to.not.deep.include({dacUserId: 3});

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -7,7 +7,7 @@ import TabControl from '../../components/TabControl';
 import RedirectLink from '../../components/RedirectLink';
 import ReviewHeader from './ReviewHeader';
 import ApplicationInformation from './ApplicationInformation';
-import {find, isEmpty, flow, filter, map, some, get} from 'lodash/fp';
+import {find, isEmpty, flow, filter, map, get} from 'lodash/fp';
 import {
   extractUserDataAccessVotesFromBucket,
   generatePreProcessedBucketData,

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -81,11 +81,7 @@ export default function DarCollectionReview(props) {
   const [researcherProperties, setResearcherProperties] = useState({});
 
   const tabsForUser = useCallback((user, buckets) => {
-    const userHasVotesForCollection = flow(
-      filter(bucket => bucket.key !== 'RP Vote'),
-      map(bucket => extractUserDataAccessVotesFromBucket(bucket, user, false)),
-      some(votes => !isEmpty(votes))
-    )(buckets);
+    const userHasVotesForCollection = !isEmpty(filter(bucket => bucket.key !== 'RP Vote')(buckets));
 
     const updatedTabs = {applicationInformation: 'Application Information'};
     if(userHasVotesForCollection) {

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -61,10 +61,9 @@ const userHasRole = (user, roleId) => {
 };
 
 export const filterBucketsForUser = (user, buckets) => {
-  const isRPBucket = (bucket) => get('isRP')(bucket);
   const containsVotesByUser = (bucket) => !isEmpty(extractUserDataAccessVotesFromBucket(bucket, user, false));
 
-  return filter(bucket => isRPBucket(bucket) || containsVotesByUser(bucket))(buckets);
+  return filter(bucket => get('isRP')(bucket) || containsVotesByUser(bucket))(buckets);
 };
 
 export default function DarCollectionReview(props) {

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -60,6 +60,13 @@ const userHasRole = (user, roleId) => {
   return !isEmpty(matches);
 };
 
+export const filterBucketsForUser = (user, buckets) => {
+  const isRPBucket = (bucket) => get('key')(bucket) === 'RP Vote';
+  const containsVotesByUser = (bucket) => !isEmpty(extractUserDataAccessVotesFromBucket(bucket, user, false));
+
+  return filter(bucket => isRPBucket(bucket) || containsVotesByUser(bucket))(buckets);
+};
+
 export default function DarCollectionReview(props) {
   const collectionId = props.match.params.collectionId;
   const [collection, setCollection] = useState({});
@@ -92,13 +99,6 @@ export default function DarCollectionReview(props) {
 
     return updatedTabs;
   }, []);
-
-  const filterBucketsForUser = (user, buckets) => {
-    const isRPBucket = (bucket) => get('key')(bucket) === 'RP Vote';
-    const containsVotesByUser = (bucket) => !isEmpty(extractUserDataAccessVotesFromBucket(bucket, user, false));
-
-    return filter(bucket => isRPBucket(bucket) || containsVotesByUser(bucket))(buckets);
-  };
 
   useEffect(() => {
     const init = async () => {

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -93,6 +93,13 @@ export default function DarCollectionReview(props) {
     return updatedTabs;
   }, []);
 
+  const filterBucketsForUser = (user, buckets) => {
+    const isRPBucket = (bucket) => get('key')(bucket) === 'RP Vote';
+    const containsVotesByUser = (bucket) => !isEmpty(extractUserDataAccessVotesFromBucket(bucket, user, false));
+
+    return filter(bucket => isRPBucket(bucket) || containsVotesByUser(bucket))(buckets);
+  };
+
   useEffect(() => {
     const init = async () => {
       const user = Storage.getCurrentUser();
@@ -110,13 +117,14 @@ export default function DarCollectionReview(props) {
           generatePreProcessedBucketData,
           processDataUseBuckets,
         ])({ dars, datasets });
+        const filteredBuckets = filterBucketsForUser(user, processedBuckets);
         setResearcherProperties(researcherProperties);
-        setDataUseBuckets(processedBuckets);
+        setDataUseBuckets(filteredBuckets);
         setCollection(collection);
         setCurrentUser(user);
         setDarInfo(darInfo);
         setResearcherProfile(researcherProfile);
-        setTabs(tabsForUser(user, processedBuckets));
+        setTabs(tabsForUser(user, filteredBuckets));
         //setTimeout used to render skeleton loader while sub-components are initializing data for render
         const timeout = setTimeout(() => {
           setIsLoading(false);

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -61,7 +61,7 @@ const userHasRole = (user, roleId) => {
 };
 
 export const filterBucketsForUser = (user, buckets) => {
-  const isRPBucket = (bucket) => get('key')(bucket) === 'RP Vote';
+  const isRPBucket = (bucket) => get('isRP')(bucket);
   const containsVotesByUser = (bucket) => !isEmpty(extractUserDataAccessVotesFromBucket(bucket, user, false));
 
   return filter(bucket => isRPBucket(bucket) || containsVotesByUser(bucket))(buckets);
@@ -81,7 +81,8 @@ export default function DarCollectionReview(props) {
   const [researcherProperties, setResearcherProperties] = useState({});
 
   const tabsForUser = useCallback((user, buckets) => {
-    const userHasVotesForCollection = !isEmpty(filter(bucket => bucket.key !== 'RP Vote')(buckets));
+    const dataAccessBucketsForUser = filter(bucket => get('isRP')(bucket) !== true)(buckets);
+    const userHasVotesForCollection = !isEmpty(dataAccessBucketsForUser);
 
     const updatedTabs = {applicationInformation: 'Application Information'};
     if(userHasVotesForCollection) {

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -2,9 +2,8 @@ import MultiDatasetVoteSlab from "../../components/collection_voting_slab/MultiD
 import {div, h} from "react-hyperscript-helpers";
 import ResearchProposalVoteSlab from "../../components/collection_voting_slab/ResearchProposalVoteSlab";
 import {useEffect, useState} from "react";
-import {find, get, filter, flow, sortBy, map, isNil} from 'lodash/fp';
+import {find, get, filter, flow, sortBy, map, isNil, isEmpty} from 'lodash/fp';
 import {User} from "../../libs/ajax";
-import {extractUserDataAccessVotesFromBucket} from "../../utils/DarCollectionUtils";
 import {Alert} from "../../components/Alert";
 
 const styles = {

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -37,9 +37,9 @@ export default function MultiDatasetVotingTab(props) {
 
   useEffect( () => {
     setCollectionDatasets(get('datasets')(collection));
-    setRpBucket(find(bucket => get('key')(bucket) === 'RP Vote')(buckets));
+    setRpBucket(find(bucket => get('isRP')(bucket))(buckets));
     setDataBuckets(flow(
-      filter(bucket => get('key')(bucket) !== 'RP Vote'),
+      filter(bucket => get('isRP')(bucket) !== true),
       sortBy(bucket => get('key')(bucket))
     )(buckets));
   }, [buckets, collection]);

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -2,10 +2,8 @@ import MultiDatasetVoteSlab from "../../components/collection_voting_slab/MultiD
 import {div, h} from "react-hyperscript-helpers";
 import ResearchProposalVoteSlab from "../../components/collection_voting_slab/ResearchProposalVoteSlab";
 import {useEffect, useState} from "react";
-import {find, get, filter, flow, sortBy, map, isNil, isEmpty} from 'lodash/fp';
-import {Storage} from "../../libs/storage";
+import {find, get, filter, flow, sortBy, map, isNil} from 'lodash/fp';
 import {User} from "../../libs/ajax";
-import {extractUserDataAccessVotesFromBucket} from "../../utils/DarCollectionUtils";
 
 const styles = {
   baseStyle: {
@@ -23,11 +21,6 @@ const styles = {
   }
 };
 
-const containsVotesByUser = (bucket) => {
-  const user = Storage.getCurrentUser();
-  return !isEmpty(extractUserDataAccessVotesFromBucket(bucket, user));
-};
-
 export default function MultiDatasetVotingTab(props) {
   const [rpBucket, setRpBucket] = useState({});
   const [dataBuckets, setDataBuckets] = useState([]);
@@ -40,7 +33,6 @@ export default function MultiDatasetVotingTab(props) {
     setRpBucket(find(bucket => get('key')(bucket) === 'RP Vote')(buckets));
     setDataBuckets(flow(
       filter(bucket => get('key')(bucket) !== 'RP Vote'),
-      filter(bucket => containsVotesByUser(bucket)),
       sortBy(bucket => get('key')(bucket))
     )(buckets));
   }, [buckets, collection]);

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -206,7 +206,7 @@ export const extractUserRPVotesFromBucket = (bucket, user, isChair) => {
     map(voteData => voteData.rp),
     filter((rpData) => !isEmpty(rpData)),
     flatMap(filteredData => isChair ?
-      concat(filteredData.finalVotes, filteredData.chairpersonVotes) :
+      filteredData.chairpersonVotes :
       filteredData.memberVotes),
     filter(vote => vote.dacUserId === user.dacUserId)
   )(votes);

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -198,7 +198,7 @@ export const extractUserDataAccessVotesFromBucket = (bucket, user, isChair) => {
   )(votes);
 };
 
-//Gets this user's rp votes from this bucket; final and chairperson votes if isChair is true, member votes if false
+//Gets this user's rp votes from this bucket; chairperson votes if isChair is true, member votes if false
 export const extractUserRPVotesFromBucket = (bucket, user, isChair) => {
   const votes = !isNil(bucket) ? bucket.votes : [];
 


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1782)
Summary of changes:
- Only display  vote summary header boxes for buckets that the current user has votes in 
- Move filtering logic on buckets from `MultiDatasetVotingTab` to `DarCollectionReview` since it is now used both for `MultiDatasetVotingTab` and `DataUseVoteSummary` (the vote summary header)
- Update tests

Notes:
- I allowed RP buckets to pass the filter without checking for votes since there is an existing bug where RP elections aren't always created. The main reason I can think of for why someone would want to check for votes in the RP bucket is to not display any vote summary header boxes for an admin navigating to this page. It shouldn't really affect other roles since the `DarCollectionReview` page has restrictions on when it will load based on the current user's roles

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
