### PR TITLE
[DUOS-1780][risk=no] at a glance panel disable display

### DIFF
--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -1,5 +1,4 @@
-import { div, label, span, h } from 'react-hyperscript-helpers';
-import AtAGlance from './AtAGlance';
+import { div, label, span } from 'react-hyperscript-helpers';
 import {chunk, filter, isEmpty} from "lodash/fp";
 
 const styles = {
@@ -108,8 +107,6 @@ export default function ApplicationInformation(props) {
     piEmail = '- -',
     nonTechSummary,
     isLoading = false,
-    collection,
-    dataUseBuckets,
     externalCollaborators = [],
     internalCollaborators = [],
     signingOfficial = '- -',

--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -139,12 +139,8 @@ export default function ApplicationInformation(props) {
   ];
 
   return (
-    div({className: 'application-information-page', style: {padding: '3%', backgroundColor: 'white'}}, [
-      !isLoading
-        ? h(AtAGlance, {collection: collection, dataUseBuckets: dataUseBuckets, styles: styles})
-        : div({className: 'text-placeholder', key: 'application-information-title-placeholder', style: {height: '5rem', width: '20%', marginBottom: '2rem'}}),
-
-      div({className: 'applicant-information-container', style: { margin: '2.5rem 0'}}, [
+    div({className: 'application-information-page', style: {padding: '2% 3%', backgroundColor: 'white'}}, [
+      div({className: 'applicant-information-container', style: { margin: '0 0 2.5rem 0'}}, [
         div({className: 'applicant-information-subheader', style: styles.title}, ["Applicant Information"]),
         div({className: 'information-row', style: styles.row}, [
           generateLabelSpanContents('Researcher', 'researcher', researcher, isLoading),


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1780)
Summary of changes:
- Remove `AtAGlance` panel from `ApplicationInformation` so that it is no longer displayed on DAR collection pages
- Adjust padding above "Application Information" title

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
