### PR TITLE
[DUOS-1740][risk=no] Ignore the npm notice issues when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY src /usr/src/app/src
 COPY public /usr/src/app/public
 COPY package.json /usr/src/app/package.json
 COPY config/base_config.json /usr/src/app/public/config.json
+RUN npm config set update-notifier false
 RUN npm install --silent
 RUN npm run build --silent
 


### PR DESCRIPTION
# WIP

## Addresses

We started seeing errors from npm notice that break the build unnecessarily:
```
npm notice 
npm notice New minor version of npm available! 8.5.0 -> 8.10.0
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v8.10.0>
npm notice Run `npm install -g npm@8.10.0` to update!
npm notice 
The command '/bin/sh -c npm install --silent' returned a non-zero code: 1
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
