### PR TITLE
[DUOS-1834][risk=no] Updated style of sorting icons

### DIFF
--- a/src/components/SimpleTable.js
+++ b/src/components/SimpleTable.js
@@ -1,7 +1,8 @@
 import { isNil } from 'lodash/fp';
-import { div, h, span } from 'react-hyperscript-helpers';
+import { div, h } from 'react-hyperscript-helpers';
 import { Styles } from '../libs/theme';
 import ReactTooltip from 'react-tooltip';
+import { ArrowDropUp, ArrowDropDown } from '@material-ui/icons';
 
 //Component that renders skeleton loader on loading
 const SkeletonLoader = ({columnRow, columnHeaders, baseStyle, tableSize}) => {
@@ -54,7 +55,10 @@ const ColumnRow = ({columnHeaders, baseStyle, columnStyle, sort, onSort}) => {
           }
         }, [
           label,
-          span({ className: 'glyphicon sort-icon glyphicon-sort' })
+          div({className: 'sort-container'}, [
+            h(ArrowDropUp, { className: `sort-icon sort-icon-up ${sort.colIndex === colIndex && sort.dir === -1 ? 'active' : ''}` }),
+            h(ArrowDropDown, { className: `sort-icon sort-icon-down ${sort.colIndex === colIndex && sort.dir === 1 ? 'active': ''}` })
+          ])
         ])
         : label
     ]);

--- a/src/index.css
+++ b/src/index.css
@@ -630,6 +630,28 @@ small {
   color: #2FA4E7;
 }
 
+.cell-sort .sort-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.cell-sort .sort-container .sort-icon {
+  font-size: 20px;
+  opacity: 0.4;
+}
+
+.cell-sort .sort-container .sort-icon.active {
+  opacity: 1;
+}
+
+.cell-sort .sort-container .sort-icon.sort-icon-up {
+  transform: translateY(7px);
+}
+
+.cell-sort .sort-container .sort-icon.sort-icon-down {
+  transform: translateY(-7px);
+}
+
 .cell-sort .sort-icon {
   color: #777777;
   font-size: 10px;


### PR DESCRIPTION
To give more indication as to which column is sorted on right now. Decided to do this work because it was confusing to work on DUOS-1834 while not really being able to immediately tell what the sort was

**Before**
<img width="249" alt="Screen Shot 2022-05-27 at 3 23 21 PM" src="https://user-images.githubusercontent.com/10501914/170777051-f3eaf6d5-0cf5-49b0-8d36-3dba7e55a15a.png">

**AFTER**
<img width="181" alt="Screen Shot 2022-05-27 at 3 21 15 PM" src="https://user-images.githubusercontent.com/10501914/170777076-5573c55c-59ab-49de-8453-1af536ce5dcd.png">
<img width="193" alt="Screen Shot 2022-05-27 at 3 21 20 PM" src="https://user-images.githubusercontent.com/10501914/170777079-b8fad67b-0e41-4432-8bed-8b9349cfb194.png">
<img width="223" alt="Screen Shot 2022-05-27 at 3 21 25 PM" src="https://user-images.githubusercontent.com/10501914/170777080-837ed825-8ee6-4b73-8632-05b84860491f.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
