### PR TITLE
[DUOS-1778][risk=no] Update admin manage collections page styles to match newest chair console

### DIFF
--- a/src/pages/AdminManageDarCollections.js
+++ b/src/pages/AdminManageDarCollections.js
@@ -41,7 +41,7 @@ export default function AdminManageDarCollections() {
   const openCollection = openCollectionFn({updateCollections});
 
   return div({ style: Styles.PAGE }, [
-    div({ style: { display: 'flex', justifyContent: 'space-between' } }, [
+    div({ style: { display: 'flex', justifyContent: 'space-between', width: '112%', marginLeft: '-6%', padding: '0 2.5%' } }, [
       div(
         { className: 'left-header-section', style: Styles.LEFT_HEADER_SECTION },
         [
@@ -53,14 +53,19 @@ export default function AdminManageDarCollections() {
             }),
           ]),
           div({ style: Styles.HEADER_CONTAINER }, [
-            div({ style: { ...Styles.TITLE} }, [
-              'Data Access Request Collections',
+            div({ style: {
+              fontFamily: 'Montserrat',
+              fontWeight: 600,
+              fontSize: '2.8rem'
+            } }, [
+              'Manage Data Access Request Collections',
             ]),
             div(
               {
-                style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {
-                  fontSize: '16px',
-                }),
+                style: {
+                  fontFamily: 'Montserrat',
+                  fontSize: '1.6rem'
+                },
               },
               ['List of all DAR Collections saved in DUOS']
             ),


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1778

Minor style updates to match the latest styles in the chair console.

### New view:
![Screen Shot 2022-05-31 at 1 38 23 PM](https://user-images.githubusercontent.com/116679/171243836-e32b46aa-e63d-4769-ba9c-5ad89d1987ad.png)

### Old view:
![Screen Shot 2022-05-31 at 1 38 31 PM](https://user-images.githubusercontent.com/116679/171243970-31a13aa6-2958-4a64-9d5d-1754c8269a56.png)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
