### PR TITLE
[DUOS-1779][risk=no] Update Confirmation Modal Styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,11 @@
       "name": "duos-ui",
       "version": "1.0.0",
       "dependencies": {
+        "@emotion/styled": "11.8.1",
         "@material-ui/core": "4.12.4",
         "@material-ui/icons": "4.11.3",
+        "@mui/material": "5.8.2",
+        "@mui/styled-engine": "5.8.0",
         "@react-pdf/renderer": "^2.1.2",
         "axios": "^0.27.2",
         "bootstrap": "3.4.1",
@@ -2259,6 +2262,39 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
       "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
     },
+    "node_modules/@emotion/styled": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.8.1.tgz",
+      "integrity": "sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/babel-plugin": "^11.7.1",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/utils": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/styled/node_modules/@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4"
+      }
+    },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
@@ -3337,6 +3373,230 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-alpha.83",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.83.tgz",
+      "integrity": "sha512-/bFcjiI36R2Epf2Y3BkZOIdxrz5uMLqOU4cRai4igJ8DHTRMZDeKbOff0SdvwJNwg8r6oPUyoeOpsWkaOOX9/g==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@mui/types": "^7.1.3",
+        "@mui/utils": "^5.8.0",
+        "@popperjs/core": "^2.11.5",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/base/node_modules/@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.8.2.tgz",
+      "integrity": "sha512-w/A1KG9Czf42uTyJOiRU5U1VullOz1R3xcsBvv3BtKCCWdVP+D6v/Yb8v0tJpIixMEbjeWzWGjotQBU0nd+yNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/base": "5.0.0-alpha.83",
+        "@mui/system": "^5.8.2",
+        "@mui/types": "^7.1.3",
+        "@mui/utils": "^5.8.0",
+        "@types/react-transition-group": "^4.4.4",
+        "clsx": "^1.1.1",
+        "csstype": "^3.1.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "prop-types": "^15.8.1",
+        "react-is": "^17.0.2",
+        "react-transition-group": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material/node_modules/csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.8.0.tgz",
+      "integrity": "sha512-MjRAneTmCKLR9u2S4jtjLUe6gpHxlbb4g2bqpDJ2PdwlvwsWIUzbc/gVB4dvccljXeWxr5G2M/Co2blXisvFIw==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.8.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.8.0.tgz",
+      "integrity": "sha512-Q3spibB8/EgeMYHc+/o3RRTnAYkSl7ROCLhXJ830W8HZ2/iDiyYp16UcxKPurkXvLhUaILyofPVrP3Su2uKsAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@emotion/cache": "^11.7.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.8.2.tgz",
+      "integrity": "sha512-N74gDNKM+MnWvKTMmCPvCVLH4f0ZzakP1bcMDaPctrHwcyxNcEmtTGNpIiVk0Iu7vtThZAFL3DjHpINPGF7+cg==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/private-theming": "^5.8.0",
+        "@mui/styled-engine": "^5.8.0",
+        "@mui/types": "^7.1.3",
+        "@mui/utils": "^5.8.0",
+        "clsx": "^1.1.1",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system/node_modules/csstype": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+      "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+    },
+    "node_modules/@mui/types": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.3.tgz",
+      "integrity": "sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==",
+      "peerDependencies": {
+        "@types/react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.8.0.tgz",
+      "integrity": "sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^17.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3420,6 +3680,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@react-pdf/fns": {
@@ -4163,9 +4432,9 @@
       "dev": true
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "node_modules/@types/q": {
       "version": "1.5.5",
@@ -4181,6 +4450,14 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-is": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "dependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -29391,6 +29668,28 @@
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
       "integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
     },
+    "@emotion/styled": {
+      "version": "11.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.8.1.tgz",
+      "integrity": "sha512-OghEVAYBZMpEquHZwuelXcRjRJQOVayvbmNR0zr174NHdmMgrNkLC6TljKC5h9lZLkN5WGrdUcrKlOJ4phhoTQ==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@emotion/babel-plugin": "^11.7.1",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/utils": "^1.1.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+          "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4"
+          }
+        }
+      }
+    },
     "@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
@@ -30199,6 +30498,117 @@
         "react-is": "^16.8.0 || ^17.0.0"
       }
     },
+    "@mui/base": {
+      "version": "5.0.0-alpha.83",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-alpha.83.tgz",
+      "integrity": "sha512-/bFcjiI36R2Epf2Y3BkZOIdxrz5uMLqOU4cRai4igJ8DHTRMZDeKbOff0SdvwJNwg8r6oPUyoeOpsWkaOOX9/g==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@emotion/is-prop-valid": "^1.1.2",
+        "@mui/types": "^7.1.3",
+        "@mui/utils": "^5.8.0",
+        "@popperjs/core": "^2.11.5",
+        "clsx": "^1.1.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^17.0.2"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+          "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4"
+          }
+        }
+      }
+    },
+    "@mui/material": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.8.2.tgz",
+      "integrity": "sha512-w/A1KG9Czf42uTyJOiRU5U1VullOz1R3xcsBvv3BtKCCWdVP+D6v/Yb8v0tJpIixMEbjeWzWGjotQBU0nd+yNA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/base": "5.0.0-alpha.83",
+        "@mui/system": "^5.8.2",
+        "@mui/types": "^7.1.3",
+        "@mui/utils": "^5.8.0",
+        "@types/react-transition-group": "^4.4.4",
+        "clsx": "^1.1.1",
+        "csstype": "^3.1.0",
+        "hoist-non-react-statics": "^3.3.2",
+        "prop-types": "^15.8.1",
+        "react-is": "^17.0.2",
+        "react-transition-group": "^4.4.2"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        }
+      }
+    },
+    "@mui/private-theming": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.8.0.tgz",
+      "integrity": "sha512-MjRAneTmCKLR9u2S4jtjLUe6gpHxlbb4g2bqpDJ2PdwlvwsWIUzbc/gVB4dvccljXeWxr5G2M/Co2blXisvFIw==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/utils": "^5.8.0",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/styled-engine": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.8.0.tgz",
+      "integrity": "sha512-Q3spibB8/EgeMYHc+/o3RRTnAYkSl7ROCLhXJ830W8HZ2/iDiyYp16UcxKPurkXvLhUaILyofPVrP3Su2uKsAw==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@emotion/cache": "^11.7.1",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "@mui/system": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.8.2.tgz",
+      "integrity": "sha512-N74gDNKM+MnWvKTMmCPvCVLH4f0ZzakP1bcMDaPctrHwcyxNcEmtTGNpIiVk0Iu7vtThZAFL3DjHpINPGF7+cg==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@mui/private-theming": "^5.8.0",
+        "@mui/styled-engine": "^5.8.0",
+        "@mui/types": "^7.1.3",
+        "@mui/utils": "^5.8.0",
+        "clsx": "^1.1.1",
+        "csstype": "^3.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz",
+          "integrity": "sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA=="
+        }
+      }
+    },
+    "@mui/types": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.1.3.tgz",
+      "integrity": "sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==",
+      "requires": {}
+    },
+    "@mui/utils": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.8.0.tgz",
+      "integrity": "sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==",
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^16.7.1 || ^17.0.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^17.0.2"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -30263,6 +30673,11 @@
           "dev": true
         }
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.5",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
+      "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
     "@react-pdf/fns": {
       "version": "1.0.0",
@@ -30877,9 +31292,9 @@
       "dev": true
     },
     "@types/prop-types": {
-      "version": "15.7.4",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -30902,6 +31317,14 @@
           "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
           "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
         }
+      }
+    },
+    "@types/react-is": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+      "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "@emotion/styled": "11.8.1",
+    "@mui/material": "5.8.2",
+    "@mui/styled-engine": "5.8.0",
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@react-pdf/renderer": "^2.1.2",

--- a/src/components/dar_collection_table/CollectionConfirmationModal.js
+++ b/src/components/dar_collection_table/CollectionConfirmationModal.js
@@ -32,7 +32,6 @@ export default function CollectionConfirmationModal(props) {
   const cancelModal =
     h(ConfirmationModal, {
       showConfirmation,
-      styleOverride: {height: '35%'},
       closeConfirmation: () => setShowConfirmation(false),
       title: 'Cancel DAR Collection',
       message: `Are you sure you want to cancel ${collection.darCode}?`,

--- a/src/components/dar_collection_table/CollectionConfirmationModal.js
+++ b/src/components/dar_collection_table/CollectionConfirmationModal.js
@@ -52,7 +52,6 @@ export default function CollectionConfirmationModal(props) {
 
   const openModal = h(ConfirmationModal, {
     showConfirmation,
-    styleOverride: { height: '35%' },
     closeConfirmation: () => setShowConfirmation(false),
     title: 'Open DAR Collection',
     message: `Are you sure you want to open ${collection.darCode}?`,

--- a/src/components/dar_collection_table/CollectionConfirmationModal.js
+++ b/src/components/dar_collection_table/CollectionConfirmationModal.js
@@ -35,7 +35,7 @@ export default function CollectionConfirmationModal(props) {
       closeConfirmation: () => setShowConfirmation(false),
       title: 'Cancel DAR Collection',
       message: `Are you sure you want to cancel ${collection.darCode}?`,
-      header: getModalHeader,
+      header: getModalHeader(),
       onConfirm: cancelOnClick
     });
 
@@ -46,7 +46,7 @@ export default function CollectionConfirmationModal(props) {
       closeConfirmation: () => setShowConfirmation(false),
       title: 'Revise DAR Collection',
       message: `Are you sure you want to revise ${collection.darCode}?`,
-      header: getModalHeader,
+      header: getModalHeader(),
       onConfirm: reviseOnClick
     });
 
@@ -55,7 +55,7 @@ export default function CollectionConfirmationModal(props) {
     closeConfirmation: () => setShowConfirmation(false),
     title: 'Open DAR Collection',
     message: `Are you sure you want to open ${collection.darCode}?`,
-    header: getModalHeader,
+    header: getModalHeader(),
     onConfirm: openOnClick,
   });
 

--- a/src/components/dar_drafts_table/DarDraftTable.js
+++ b/src/components/dar_drafts_table/DarDraftTable.js
@@ -97,7 +97,7 @@ const ResumeDraftButton = (props) => {
 
 //helper function to create id string for error messages
 const getIdentifier = ({id, data}) => {
-  return !isEmpty(data) ? (data.projectTitle || data.tempDarCode) : id;
+  return !isEmpty(data) ? (data.projectTitle || data.partialDarCode) : id;
 };
 
 //sub-component that renders draft delete button

--- a/src/components/dar_drafts_table/DarDraftTable.js
+++ b/src/components/dar_drafts_table/DarDraftTable.js
@@ -246,7 +246,7 @@ export default function DarDraftTable(props) {
       closeConfirmation: () => setShowConfirmation(false),
       title: 'Delete Draft DAR',
       message: `Are you sure you want to delete DAR draft ${getIdentifier({id: selectedDraft.id, data: selectedDraft.data})}`,
-      header: getModalHeader,
+      header: getModalHeader(),
       onConfirm: deleteOnClick
     })
   ]);

--- a/src/components/dar_drafts_table/DarDraftTable.js
+++ b/src/components/dar_drafts_table/DarDraftTable.js
@@ -246,7 +246,7 @@ export default function DarDraftTable(props) {
       closeConfirmation: () => setShowConfirmation(false),
       title: 'Delete Draft DAR',
       message: `Are you sure you want to delete DAR draft ${getIdentifier({id: selectedDraft.id, data: selectedDraft.data})}`,
-      header: getModalHeader(),
+      header: getModalHeader,
       onConfirm: deleteOnClick
     })
   ]);

--- a/src/components/dar_drafts_table/DarDraftTable.js
+++ b/src/components/dar_drafts_table/DarDraftTable.js
@@ -243,7 +243,6 @@ export default function DarDraftTable(props) {
     }),
     h(ConfirmationModal, {
       showConfirmation,
-      styleOverrise: { height: '35%' },
       closeConfirmation: () => setShowConfirmation(false),
       title: 'Delete Draft DAR',
       message: `Are you sure you want to delete DAR draft ${getIdentifier({id: selectedDraft.id, data: selectedDraft.data})}`,

--- a/src/components/modals/ConfirmationModal.css
+++ b/src/components/modals/ConfirmationModal.css
@@ -1,0 +1,40 @@
+
+.confirmation-modal {
+    height: 250px;
+    inset: 20%;
+    font-family: Montserrat, sans-serif;
+    padding: 2%;
+    position: absolute;
+    background-color: white;
+    border: 1px solid lightgrey;
+    border-radius: 4px;
+}
+
+.confirmation-modal-header {
+    display: flex;
+    font-size: 16px;
+    font-weight: 600;
+    justify-content: left;
+    color: #1F3B50;
+}
+
+.confirmation-modal-title {
+    display: flex;
+    font-size: 28px;
+    font-weight: 600;
+    justify-content: left;
+    margin-bottom: 4%;
+    color: #1F3B50;
+}
+
+.confirmation-modal-message {
+    font-size: 16px;
+    font-weight: 400;
+    width: 70%;
+}
+
+.confirmation-modal-actions {
+    margin-top: 2rem;
+    float: right;
+}
+

--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -1,35 +1,56 @@
-import {button, div, h} from 'react-hyperscript-helpers';
-import {Styles} from '../../libs/theme';
+import React from 'react';
+import {div, h} from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import CloseIconComponent from '../CloseIconComponent';
+import './ConfirmationModal.css';
+import {styled} from '@mui/material/styles';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
 
 const ConfirmationModal = (props) => {
-  const {showConfirmation, closeConfirmation, title, message, header, onConfirm, styleOverride = {}} = props;
+  const {showConfirmation, closeConfirmation, title, message, header, onConfirm} = props;
   const closeFn = () => closeConfirmation();
 
-  const confirmButton = button({className: 'cell-button hover-color', onClick: onConfirm}, ['Confirm']);
-  const computedStyle = Object.assign({}, Styles.MODAL.CONFIRMATION, styleOverride);
+  const SecondaryButton = styled(Button)(() => ({
+    fontFamily: 'Montserrat, sans-serif',
+    color: 'rgb(0, 96, 159)',
+    backgroundColor: 'white',
+    borderRadius: '4px',
+    fontSize: '1.45rem',
+    borderColor: 'rgb(0, 96, 159)',
+    '&:hover': {
+      borderColor: 'rgb(52,156,224)',
+      color: 'rgb(52,156,224)'
+    },
+  }));
+
+  const PrimaryButton = styled(Button)(({theme}) => ({
+    fontFamily: 'Montserrat, sans-serif',
+    color: theme.palette.getContrastText('rgb(0, 96, 159)'),
+    backgroundColor: 'rgb(0, 96, 159)',
+    borderRadius: '4px',
+    fontSize: '1.45rem',
+    '&:hover': {
+      backgroundColor: 'rgb(52,156,224)',
+    },
+  }));
+
+  const actionButtons = <Stack spacing={2} direction={'row'}>
+    <SecondaryButton variant={'outlined'} className={'confirmation-modal-secondary-button'} onClick={closeFn}>Cancel</SecondaryButton>
+    <PrimaryButton variant={'contained'} className={'confirmation-modal-primary-button'} onClick={onConfirm}>Confirm</PrimaryButton>
+  </Stack>;
 
   return h(Modal, {
     isOpen: showConfirmation,
     shouldCloseOnOverlayClick: true,
-    style: {
-      content: computedStyle
-    }
+    className: 'confirmation-modal'
   }, [
-    div({style: Styles.MODAL.CONFIRMATION}, [
+    div({}, [
       h(CloseIconComponent, {closeFn}),
-      div({style: Styles.MODAL.DAR_SUBHEADER}, [header]),
-      div({style: Styles.MODAL.TITLE_HEADER}, [title]),
-      div({style: Styles.MODAL.DAR_DETAIL}, [message]),
-      div({style: {width: '40%', float: 'right'}}, [
-        div({style: {width: '45%', float: 'left'}}, [
-          button({className: 'cell-button cancel-color', onClick: closeFn }, ['Cancel'])
-        ]),
-        div({style: {width: '45%', float: 'right'}}, [
-          confirmButton
-        ])
-      ])
+      div({className: 'confirmation-modal-header'}, [header]),
+      div({className: 'confirmation-modal-title'}, [title]),
+      div({className: 'confirmation-modal-message'}, [message]),
+      div({className: 'confirmation-modal-actions'}, [actionButtons])
     ])
   ]);
 };

--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -45,6 +45,8 @@ const ConfirmationModal = (props) => {
 
   return h(Modal, {
     isOpen: showConfirmation,
+    onRequestClose: closeFn,
+    shouldCloseOnEsc: true,
     shouldCloseOnOverlayClick: true,
     className: 'confirmation-modal',
     style: { content: styleOverride }

--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -47,7 +47,7 @@ const ConfirmationModal = (props) => {
     isOpen: showConfirmation,
     shouldCloseOnOverlayClick: true,
     className: 'confirmation-modal',
-    style: styleOverride
+    style: { content: styleOverride }
   }, [
     div({}, [
       h(CloseIconComponent, {closeFn}),

--- a/src/components/modals/ConfirmationModal.js
+++ b/src/components/modals/ConfirmationModal.js
@@ -8,30 +8,33 @@ import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 
 const ConfirmationModal = (props) => {
-  const {showConfirmation, closeConfirmation, title, message, header, onConfirm} = props;
+  const {showConfirmation, closeConfirmation, title, message, header, onConfirm, styleOverride = {}} = props;
   const closeFn = () => closeConfirmation();
+
+  const duosBlue = 'rgb(0, 96, 159)';
+  const duosBlueHover = 'rgb(9,72,183)';
 
   const SecondaryButton = styled(Button)(() => ({
     fontFamily: 'Montserrat, sans-serif',
-    color: 'rgb(0, 96, 159)',
+    color: duosBlue,
     backgroundColor: 'white',
     borderRadius: '4px',
     fontSize: '1.45rem',
-    borderColor: 'rgb(0, 96, 159)',
+    borderColor: duosBlue,
     '&:hover': {
-      borderColor: 'rgb(52,156,224)',
-      color: 'rgb(52,156,224)'
+      borderColor: duosBlueHover,
+      color: duosBlueHover
     },
   }));
 
   const PrimaryButton = styled(Button)(({theme}) => ({
     fontFamily: 'Montserrat, sans-serif',
-    color: theme.palette.getContrastText('rgb(0, 96, 159)'),
-    backgroundColor: 'rgb(0, 96, 159)',
+    color: theme.palette.getContrastText(duosBlue),
+    backgroundColor: duosBlue,
     borderRadius: '4px',
     fontSize: '1.45rem',
     '&:hover': {
-      backgroundColor: 'rgb(52,156,224)',
+      backgroundColor: duosBlueHover,
     },
   }));
 
@@ -43,7 +46,8 @@ const ConfirmationModal = (props) => {
   return h(Modal, {
     isOpen: showConfirmation,
     shouldCloseOnOverlayClick: true,
-    className: 'confirmation-modal'
+    className: 'confirmation-modal',
+    style: styleOverride
   }, [
     div({}, [
       h(CloseIconComponent, {closeFn}),

--- a/src/components/signing_official_table/SigningOfficialTable.js
+++ b/src/components/signing_official_table/SigningOfficialTable.js
@@ -53,6 +53,12 @@ const columnHeaderFormat = {
   // activeDARs: {label: 'Active DARs', cellStyle: {width: styles.cellWidths.activeDARs}}
 };
 
+// Used to determine which modal type to use for either issuing or deleting a Library Card.
+const confirmModalType = {
+  issue: 'issue',
+  delete: 'delete'
+};
+
 const DeactivateLibraryCardButton = (props) => {
   const {card = {}, showConfirmationModal} = props;
   const message = 'Are you sure you want to deactivate this library card?';
@@ -63,13 +69,12 @@ const DeactivateLibraryCardButton = (props) => {
     baseColor: Theme.palette.error,
     hoverColor: 'rgb(194, 38,11)',
     additionalStyle: {
-      width: '30%',
       padding: '2.25% 5%',
       fontSize: '1.45rem',
       fontWeight: 600,
       fontFamily: 'Montserrat'
     },
-    onClick: () => showConfirmationModal({card, message, title, confirmType: 'delete'})
+    onClick: () => showConfirmationModal({card, message, title, confirmType: confirmModalType.delete})
   });
 };
 
@@ -94,7 +99,7 @@ const IssueLibraryCardButton = (props) => {
       fontWeight: 600,
       fontFamily: 'Montserrat'
     },
-    onClick: () => showConfirmationModal({ card, message, title, confirmType: 'issue' }),
+    onClick: () => showConfirmationModal({ card, message, title, confirmType: confirmModalType.issue }),
   });
 };
 
@@ -203,7 +208,7 @@ export default function SigningOfficialTable(props) {
   const searchRef = useRef('');
   const [confirmationModalMsg, setConfirmationModalMsg] = useState('');
   const [confirmationTitle, setConfirmationTitle] = useState('');
-  const [confirmType, setConfirmType] = useState('delete');
+  const [confirmType, setConfirmType] = useState(confirmModalType.delete);
   const { signingOfficial, unregisteredResearchers, isLoading } = props;
   const [lcaText, setLcaText] = useState('');
 
@@ -436,9 +441,10 @@ export default function SigningOfficialTable(props) {
       showConfirmation,
       closeConfirmation: () => setShowConfirmation(false),
       title: confirmationTitle,
-      styleOverride: {minWidth: '725px', minHeight: '475px'},
+      // The issue modal requires a larger view than normal
+      styleOverride: confirmType === confirmModalType.issue ? { minWidth: '725px', minHeight: '475px' } : {},
       message:
-        confirmType === 'delete'
+        confirmType === confirmModalType.delete
           ? div({}, [confirmationModalMsg])
           // Library Card Agreement Text
           : div({}, [div({style: { maxWidth: '700px', minWidth: '700px', maxHeight: '200px', overflow: 'auto', marginBottom: '25px' }}, [lcaContent]), confirmationModalMsg]),
@@ -446,7 +452,7 @@ export default function SigningOfficialTable(props) {
         !isNil(selectedCard.institution) ? selectedCard.institution.name : ''
       }`,
       onConfirm: () =>
-        confirmType === 'delete'
+        confirmType === confirmModalType.delete
           ? deactivateLibraryCard(selectedCard, researchers)
           : issueLibraryCard(selectedCard, researchers)
     }),

--- a/src/components/signing_official_table/SigningOfficialTable.js
+++ b/src/components/signing_official_table/SigningOfficialTable.js
@@ -436,7 +436,7 @@ export default function SigningOfficialTable(props) {
       showConfirmation,
       closeConfirmation: () => setShowConfirmation(false),
       title: confirmationTitle,
-      styleOverride: {minWidth: '700px', minHeight: '450px'},
+      styleOverride: {minWidth: '725px', minHeight: '475px'},
       message:
         confirmType === 'delete'
           ? div({}, [confirmationModalMsg])


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1779

## Changes

* Minor updates to the confirmation dialog to use the current button styles for all of our console pages.
* Updated usages of the confirmation dialog where necessary to tweak for the new fonts/buttons/etc.
* Also addressed minor bug fixes found during review.

### New: 

![Screen Shot 2022-06-01 at 2 14 52 PM](https://user-images.githubusercontent.com/116679/171474297-b2a35763-9775-471f-b226-009339f0f40e.png)

![Screen Shot 2022-06-01 at 2 17 23 PM](https://user-images.githubusercontent.com/116679/171474683-ccac355a-7965-4ee2-b20b-d2bd524cb6cf.png)

### Old

![Screen Shot 2022-06-01 at 2 16 28 PM](https://user-images.githubusercontent.com/116679/171474410-f6d71f50-6a01-42dd-a63b-356495fae746.png)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
