### PR TITLE
[DUOS-1835][risk=no] hide algorithm decision for rp slab

### DIFF
--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -155,6 +155,7 @@ export const ChairVoteInfo = ({dacVotes, isChair, isLoading, algorithmResult = {
           h(CollectionAlgorithmDecision, {
             algorithmResult,
             styleOverride: { borderLeft: '1px solid #333F52' },
+            isRendered: !isEmpty(algorithmResult)
           }),
         ]
       ),


### PR DESCRIPTION
[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/DUOS-1835)
Summary of Changes:
- Only render `CollectionAlgorithmDecision` if the `algorithmResult` property of a bucket is not empty; `algorithmResult` is not generated for RP buckets, so the algorithm decision does not appear for RP slabs

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
