### PR TITLE
[DUOS-1768][risk=no] Filter Dataset Count on Chair Console

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -180,14 +180,15 @@ const columnHeaderData = (columns = defaultColumns) => {
   return columns.map((col) => columnHeaderConfig[col]);
 };
 
-const processCollectionRowData = ({ collections, openCollection, showConfirmationModal, actionsDisabled, columns = defaultColumns, consoleType = '', goToVote, reviewCollection, relevantDatasets}) => {
+const processCollectionRowData = ({ collections, openCollection, showConfirmationModal, actionsDisabled, columns = defaultColumns, consoleType = '', goToVote, reviewCollection}) => {
   if(!isNil(collections)) {
     return collections.map((collection) => {
-      const { darCollectionId, darCode, createDate, datasets, createUser } = collection;
+      const { darCollectionId, darCode, createDate, createUser } = collection;
+      const relevantDatasets = collection.datasets;
       const status = determineCollectionStatus(collection, relevantDatasets);
       return columns.map((col) => {
         return columnHeaderConfig[col].cellDataFn({
-          collection, darCollectionId, datasets, darCode, status,
+          collection, darCollectionId, darCode, status,
           createDate, createUser, actionsDisabled,
           showConfirmationModal, consoleType,
           openCollection, goToVote, reviewCollection, relevantDatasets

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -224,7 +224,7 @@ export const DarCollectionTable = function DarCollectionTable(props) {
   const [consoleAction, setConsoleAction] = useState();
   const {
     collections, columns, isLoading, cancelCollection, reviseCollection, reviewCollection,
-    openCollection, actionsDisabled, goToVote, consoleType, relevantDatasets
+    openCollection, actionsDisabled, goToVote, consoleType
   } = props;
 
   /*
@@ -251,8 +251,7 @@ export const DarCollectionTable = function DarCollectionTable(props) {
         consoleType,
         openCollection,
         goToVote,
-        reviewCollection,
-        relevantDatasets
+        reviewCollection
       }),
       currentPage,
       setPageCount,
@@ -260,7 +259,7 @@ export const DarCollectionTable = function DarCollectionTable(props) {
       setVisibleList: setVisibleCollections,
       sort
     });
-  }, [tableSize, currentPage, pageCount, collections, sort, columns, actionsDisabled, consoleType, openCollection, goToVote, relevantDatasets, reviewCollection]);
+  }, [tableSize, currentPage, pageCount, collections, sort, columns, actionsDisabled, consoleType, openCollection, goToVote, reviewCollection]);
 
   const showConfirmationModal = (collection, action = '') => {
     setConsoleAction(action);

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -103,9 +103,9 @@ export function institutionCellData({institution = '- -', darCollectionId, label
   };
 }
 
-export function datasetCountCellData({datasets = '- -', darCollectionId, label = 'datasets'}) {
+export function datasetCountCellData({relevantDatasets = '- -', darCollectionId, label = 'datasets'}) {
   return {
-    data: datasets.length,
+    data: relevantDatasets.length,
     id: darCollectionId,
     style: {
       color: '#333F52',

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -11,7 +11,6 @@ import { cancelCollectionFn, openCollectionFn, updateCollectionFn } from '../uti
 export default function NewChairConsole(props) {
   const [collections, setCollections] = useState([]);
   const [filteredList, setFilteredList] = useState([]);
-  const [relevantDatasets, setRelevantDatasets] = useState();
   const [isLoading, setIsLoading] = useState(true);
   const searchRef = useRef('');
   const filterFn = getSearchFilterFunctions().darCollections;
@@ -31,7 +30,6 @@ export default function NewChairConsole(props) {
           Collections.getCollectionsByRoleName('chairperson')
         ]);
         setCollections(collections);
-        setRelevantDatasets(collections);
         setFilteredList(collections);
         setIsLoading(false);
       } catch(error) {
@@ -93,7 +91,6 @@ export default function NewChairConsole(props) {
         DarCollectionTableColumnOptions.ACTIONS,
       ],
       isLoading,
-      relevantDatasets,
       cancelCollection,
       reviseCollection: null,
       openCollection,

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -27,12 +27,11 @@ export default function NewChairConsole(props) {
   useEffect(() => {
     const init = async() => {
       try {
-        const [collections, datasets] = await Promise.all([
-          Collections.getCollectionsByRoleName('chairperson'),
-          User.getUserRelevantDatasets()
+        const [collections] = await Promise.all([
+          Collections.getCollectionsByRoleName('chairperson')
         ]);
         setCollections(collections);
-        setRelevantDatasets(datasets);
+        setRelevantDatasets(collections);
         setFilteredList(collections);
         setIsLoading(false);
       } catch(error) {

--- a/src/pages/NewMemberConsole.js
+++ b/src/pages/NewMemberConsole.js
@@ -10,7 +10,6 @@ import { DarCollectionTable, DarCollectionTableColumnOptions } from '../componen
 export default function NewMemberConsole(props) {
   const [collections, setCollections] = useState([]);
   const [filteredList, setFilteredList] = useState([]);
-  const [relevantDatasets, setRelevantDatasets] = useState();
   const [isLoading, setIsLoading] = useState(true);
   const searchRef = useRef('');
   const filterFn = getSearchFilterFunctions().darCollections;
@@ -25,12 +24,10 @@ export default function NewMemberConsole(props) {
   useEffect(() => {
     const init = async () => {
       try {
-        const [collections, datasets] = await Promise.all([
-          Collections.getCollectionsByRoleName('member'),
-          User.getUserRelevantDatasets(), //still need this on this console for status cell
+        const [collections] = await Promise.all([
+          Collections.getCollectionsByRoleName('member')
         ]);
         setCollections(collections);
-        setRelevantDatasets(datasets);
         setFilteredList(collections);
         setIsLoading(false);
       } catch (error) {
@@ -91,7 +88,6 @@ export default function NewMemberConsole(props) {
         DarCollectionTableColumnOptions.ACTIONS,
       ],
       isLoading,
-      relevantDatasets,
       reviseCollection: null,
       goToVote,
       consoleType: 'member'


### PR DESCRIPTION
[DUOS-1768](https://broadworkbench.atlassian.net/browse/DUOS-1768)

Summary of changes:
- Removed datasets variable and call to getUserRelevantDatasets from the NewChairConsole (handling filtering within getCollectionsByRoleName).
- Populate the relevantDatasets variable from collection.datasets in the DarCollectionTable.
- Passing through the relevantDatasets variable to the dataset count function in DarCollectionTableCellData.

Open Questions:
- Need to add a relevant test (DarCollectionServiceTest?)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
