### PR TITLE
[DUOS-1852][DUOS-1868][risk=no] hide alert if in readOnly mode.

### DIFF
--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
@@ -79,7 +79,7 @@ export default function MultiDatasetVoteSlab(props) {
       h(Alert, {
         title: 'Voting is disabled since not all elections are open.',
         type: 'danger',
-        isRendered: !adminPage && !allOpenElections
+        isRendered: !adminPage && !allOpenElections && !readOnly
       }),
       h(CollectionSubmitVoteBox, {
         question: 'Should data access be granted to this applicant?',

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -91,7 +91,7 @@ export default function MultiDatasetVotingTab(props) {
       type: 'danger',
       title: missingLibraryCardMessage,
       id: 'missing_lc',
-      isRendered: dataAccessApprovalDisabled()
+      isRendered: dataAccessApprovalDisabled() && !readOnly
     }),
     div({style: styles.slabs}, [
       h(ResearchProposalVoteSlab, {


### PR DESCRIPTION
Sorry, wasn't able to find a DAR to test this on, this is just a pure code change that I *assume* works... no reason for it not to?

What I did to try to FIND one to test this on, i went to `/admin_review_collection`, clicked on one that had "Closed: 2", then clicked on the Chair Vote tab. The ticket suggests finding one that is approved or denied, but that doesn't seem to be one of the statuses in the table - I assume that a "Closed" dar was closed because it was either approved or denied. 

Anyway, that's the logic I went through here. I think this fulfills teh ticket tho, but I'm sorry I couldnt do it right!

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
