### PR TITLE
[DUOS-1857][risk=no] Added signing official's ability to get to the dar collec…

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -82,7 +82,7 @@ const Routes = (props) => (
         : ''
     }
     {
-      props.env === 'dev' ? <AuthenticatedRoute path="/dar_collection/:collectionId" component={DarCollectionReview} props={props} rolesAllowed={[USER_ROLES.researcher, USER_ROLES.chairperson, USER_ROLES.member]}/>
+      props.env === 'dev' ? <AuthenticatedRoute path="/dar_collection/:collectionId" component={DarCollectionReview} props={props} rolesAllowed={[USER_ROLES.researcher, USER_ROLES.chairperson, USER_ROLES.member, USER_ROLES.signingOfficial]}/>
         : ''
     }
     {

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -8,6 +8,7 @@ import MemberActions from './MemberActions';
 import ResearcherActions from './ResearcherActions';
 import DarCollectionAdminReviewLink from './DarCollectionAdminReviewLink';
 import {Link} from 'react-router-dom';
+import { consoleTypes } from '../dar_table/DarTableActions';
 
 export function projectTitleCellData({projectTitle = '- -', darCollectionId, label= 'project-title'}) {
   return {
@@ -26,8 +27,9 @@ export function darCodeCellData({darCode = '- -', darCollectionId, status, conso
   let darCodeData;
 
   switch (consoleType) {
-    case 'chairperson':
-    case 'member' :
+    case consoleTypes.CHAIR:
+    case consoleTypes.MEMBER:
+    case consoleTypes.SIGNING_OFFICIAL:
       darCodeData = dacLinkToCollection(darCode, status, darCollectionId);
       break;
     default :
@@ -135,16 +137,16 @@ export function consoleActionsCellData({collection, reviewCollection, goToVote, 
   let actionComponent;
 
   switch (consoleType) {
-    case 'admin':
+    case consoleTypes.ADMIN:
       actionComponent = h(AdminActions, {collection, showConfirmationModal});
       break;
-    case 'chairperson':
+    case consoleTypes.CHAIR:
       actionComponent = h(ChairActions, {collection, showConfirmationModal, goToVote, relevantDatasets});
       break;
-    case 'member':
+    case consoleTypes.MEMBER:
       actionComponent = h(MemberActions, {collection, showConfirmationModal, goToVote});
       break;
-    case 'researcher':
+    case consoleTypes.RESEARCHER:
     default:
       actionComponent = h(ResearcherActions, {collection, showConfirmationModal, reviewCollection, resumeCollection});
       break;

--- a/src/components/dar_table/DarTableActions.js
+++ b/src/components/dar_table/DarTableActions.js
@@ -6,10 +6,12 @@ import DarTableOpenButton from './DarTableOpenButton';
 import DarTableCancelButton from './DarTableCancelButton';
 
 export const consoleTypes = {
+  ADMIN: 'admin',
   MEMBER: 'member',
   MANAGE_ACCESS: 'manageAccess',
   CHAIR: 'chair',
-  SIGNING_OFFICIAL: 'signingOfficial'
+  SIGNING_OFFICIAL: 'signingOfficial',
+  RESEARCHER: 'researcher'
 };
 
 export default function DarTableActions(props) {

--- a/src/pages/AdminManageDarCollections.js
+++ b/src/pages/AdminManageDarCollections.js
@@ -7,6 +7,7 @@ import {h, div, img} from 'react-hyperscript-helpers';
 import lockIcon from '../images/lock-icon.png';
 import { DarCollectionTable, DarCollectionTableColumnOptions } from '../components/dar_collection_table/DarCollectionTable';
 import { cancelCollectionFn, openCollectionFn, updateCollectionFn } from '../utils/DarCollectionUtils';
+import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 export default function AdminManageDarCollections() {
   const [collections, setCollections] = useState([]);
@@ -90,7 +91,7 @@ export default function AdminManageDarCollections() {
       cancelCollection,
       reviseCollection: null,
       openCollection,
-      consoleType: 'admin'
+      consoleType: consoleTypes.ADMIN
     }),
   ]);
 }

--- a/src/pages/MemberConsole.js
+++ b/src/pages/MemberConsole.js
@@ -10,7 +10,7 @@ import { updateLists as updateListsInit } from '../libs/utils';
 import { tableHeaderTemplate, tableRowLoadingTemplate } from '../components/dar_table/DarTable';
 import DarTableSkeletonLoader from '../components/TableSkeletonLoader';
 import { isNil } from 'lodash/fp';
-import {consoleTypes} from '../components/dar_table/DarTableActions';
+import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 export default function NewMemberConsole(props) {
   const [electionList, setElectionList] = useState([]);

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -7,6 +7,7 @@ import {h, div, img} from 'react-hyperscript-helpers';
 import lockIcon from '../images/lock-icon.png';
 import { DarCollectionTable, DarCollectionTableColumnOptions } from '../components/dar_collection_table/DarCollectionTable';
 import { cancelCollectionFn, openCollectionFn, updateCollectionFn } from '../utils/DarCollectionUtils';
+import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 export default function NewChairConsole(props) {
   const [collections, setCollections] = useState([]);
@@ -99,7 +100,7 @@ export default function NewChairConsole(props) {
       reviseCollection: null,
       openCollection,
       goToVote,
-      consoleType: 'chairperson'
+      consoleType: consoleTypes.CHAIR
     }),
   ]);
 }

--- a/src/pages/NewMemberConsole.js
+++ b/src/pages/NewMemberConsole.js
@@ -6,6 +6,7 @@ import { Styles } from '../libs/theme';
 import {h, div, img} from 'react-hyperscript-helpers';
 import lockIcon from '../images/lock-icon.png';
 import { DarCollectionTable, DarCollectionTableColumnOptions } from '../components/dar_collection_table/DarCollectionTable';
+import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 export default function NewMemberConsole(props) {
   const [collections, setCollections] = useState([]);
@@ -94,7 +95,7 @@ export default function NewMemberConsole(props) {
       relevantDatasets,
       reviseCollection: null,
       goToVote,
-      consoleType: 'member'
+      consoleType: consoleTypes.MEMBER
     }),
   ]);
 }

--- a/src/pages/NewResearcherConsole.js
+++ b/src/pages/NewResearcherConsole.js
@@ -7,6 +7,7 @@ import { DarCollectionTableColumnOptions, DarCollectionTable } from '../componen
 import accessIcon from '../images/icon_access.png';
 import { Notifications, searchOnFilteredList, getSearchFilterFunctions } from '../libs/utils';
 import SearchBar from '../components/SearchBar';
+import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 const createPropertiesForDraft = (keys, values) =>
   keys.map((propertyKey, index) => ({
@@ -230,7 +231,7 @@ export default function NewResearcherConsole() {
         cancelCollection,
         reviseCollection,
         deleteDraft,
-        consoleType: 'researcher',
+        consoleType: consoleTypes.RESEARCHER,
       })
     ]),
   ]);

--- a/src/pages/SigningOfficialDarRequests.js
+++ b/src/pages/SigningOfficialDarRequests.js
@@ -6,6 +6,7 @@ import lockIcon from '../images/lock-icon.png';
 import {Collections} from '../libs/ajax';
 import { USER_ROLES } from '../libs/utils';
 import { DarCollectionTableColumnOptions, DarCollectionTable } from '../components/dar_collection_table/DarCollectionTable';
+import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 export default function SigningOfficialDarRequests() {
   const [collectionList, setCollectionList] = useState([]);
@@ -62,7 +63,8 @@ export default function SigningOfficialDarRequests() {
           isLoading,
           cancelCollection: null,
           reviseCollection: null,
-          actionsDisabled: true
+          actionsDisabled: true,
+          consoleType: consoleTypes.SIGNING_OFFICIAL
         }, [])
       ])
     ])


### PR DESCRIPTION
- Added signing official's ability to get to the dar collection page
- added table link to the dar page
- Updated consoleTypes switch statements to use the constants instead of hardcoding the values

BEFORE:
![image](https://user-images.githubusercontent.com/10501914/173468164-16998a8e-d173-41ee-b7dd-ebbcef64dff7.png)

AFTER:
![image](https://user-images.githubusercontent.com/10501914/173468150-9d39d96a-2b90-40e0-9f3b-3d2e95bdeffe.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
