### PR TITLE
[DUOS-1877][risk=no] unbolded text

### DIFF
--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -98,9 +98,12 @@ export default function CollectionSubmitVoteBox(props) {
 
   const VoteSubsectionHeading = () => {
     const heading = (isFinal || adminPage) ?
-      `${!adminPage ? 'Your Vote* (Vote and Rationale cannot be updated after submitting)' : 'Vote*'}` :
+      `${!adminPage ? 'Your Vote*' : 'Vote*'}` :
       'Your Vote*';
-    return span({className: 'vote-subsection-heading'},[heading]);
+    return div([
+      span({className: 'vote-subsection-heading'},[heading]),
+      !adminPage && span({ style: { marginLeft: 5, fontWeight: 'normal' } }, ['(Vote and Rationale cannot be updated after submitting)'])
+    ]);
   };
 
   return (


### PR DESCRIPTION
Before
<img width="713" alt="Screen Shot 2022-06-14 at 5 30 29 PM" src="https://user-images.githubusercontent.com/10501914/173692683-9828d64b-9a08-4867-b8cb-b5dd185b6710.png">

After
<img width="559" alt="Screen Shot 2022-06-14 at 5 29 25 PM" src="https://user-images.githubusercontent.com/10501914/173692706-0dfa9e40-10d6-4504-9819-5575bbf1e295.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
