### PR TITLE
[DUOS-1876][risk=no] updated table css for mobile view on vote summary card

### DIFF
--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -11,10 +11,9 @@ export default function CollectionAlgorithmDecision(props) {
     style: Object.assign(
       {
         padding: '4%',
-        flex: 1,
-        display: 'flex',
         justifyContent: 'space-around',
-        fontFamily: 'Montserrat'
+        fontFamily: 'Montserrat',
+        width: '50%'
       },
       styleOverride
     )

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -152,7 +152,8 @@ export const ChairVoteInfo = ({dacVotes, isChair, isLoading, algorithmResult = {
         [
           h(VotesPieChart, {
             votes: dacVotes,
-            title: adminPage ? 'DAC Votes (summary)' : "My DAC's Votes (summary)"
+            title: adminPage ? 'DAC Votes (summary)' : "My DAC's Votes (summary)",
+            styleOverride: { width: isEmpty(algorithmResult) ? '100%' : '50%' }
           }),
           h(CollectionAlgorithmDecision, {
             algorithmResult,

--- a/src/components/common/VotesPieChart.js
+++ b/src/components/common/VotesPieChart.js
@@ -34,7 +34,8 @@ export default function VotesPieChart(props) {
     pieHole = 0.3,
     height = 'inherit',
     width = '100%',
-    style = { padding: '20px 0', width: '50%' }
+    style = { padding: '20px 0', width: '50%' },
+    styleOverride,
   } = props;
 
   const processedVotes = useMemo(() => processVotes(votes), [votes]);
@@ -53,7 +54,7 @@ export default function VotesPieChart(props) {
   if(isEmpty(votes)) {
     return div({style, className: `${keyString}-pie-chart-no-data`}, [`No data for ${keyString}`]);
   }
-  return div({style}, [
+  return div({ style: { ...style, ...styleOverride }}, [
     h(Chart, {
       chartType: 'PieChart',
       data: processedVotes,

--- a/src/components/common/VotesPieChart.js
+++ b/src/components/common/VotesPieChart.js
@@ -34,7 +34,7 @@ export default function VotesPieChart(props) {
     pieHole = 0.3,
     height = 'inherit',
     width = '100%',
-    style = { padding: '20px 0', display: 'flex', flex: 1, }
+    style = { padding: '20px 0', width: '50%' }
   } = props;
 
   const processedVotes = useMemo(() => processVotes(votes), [votes]);

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -17,7 +17,6 @@ import {
   findIndex,
   cloneDeep,
   groupBy,
-  isEqual,
   flatten
 } from 'lodash/fp';
 import { translateDataUseRestrictionsFromDataUseArray } from '../libs/dataUseTranslation';


### PR DESCRIPTION
BEFORE
<img width="1440" alt="Screen Shot 2022-06-22 at 1 07 03 PM" src="https://user-images.githubusercontent.com/10501914/175096776-5e94da8b-c1f4-4f70-b184-962f54fcfdf7.png">
<img width="757" alt="Screen Shot 2022-06-22 at 1 07 11 PM" src="https://user-images.githubusercontent.com/10501914/175096749-9f18a66c-5db7-430f-92a9-421ab9f25bb7.png">

AFTER
<img width="1440" alt="Screen Shot 2022-06-22 at 1 04 12 PM" src="https://user-images.githubusercontent.com/10501914/175096829-f3ee75e6-1347-43f3-bd2d-9b6829321619.png">
<img width="758" alt="Screen Shot 2022-06-22 at 1 04 24 PM" src="https://user-images.githubusercontent.com/10501914/175096844-afc9fc11-c825-4d75-a1ca-d2417d77bcec.png">



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
