### PR TITLE
DUOS-1889[risk=no] Removed duplicate DAC Chair link and updated DAC Member Console Label

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -545,18 +545,8 @@ class DuosHeader extends Component {
           { label: 'DAC Members', link: '/manage_dac' }
         ]
       },
-      isChairPerson && {
-        label: 'DAC Chair Console',
-        link: this.state.dacChairPath,
-        search: 'chair_console',
-        children: [
-          { label: 'Manage DARs', link: this.state.dacChairPath },
-          { label: 'Datasets', link: '/dataset_catalog' },
-          { label: 'DAC Members', link: '/manage_dac' }
-        ]
-      },
       isMember && {
-        label: 'DAC Console',
+        label: 'DAC Member Console',
         link: this.state.dacMemberPath,
         search: 'member_console',
         children: [


### PR DESCRIPTION
Addresses [DUOS-1889](https://broadworkbench.atlassian.net/browse/DUOS-1889)

PR removes duplicate Chair link on `DuosHeader` and updates the member link label to `DAC Member Console`
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
