### PR TITLE
[DUOS-1860][risk=no] Making DAR language consistent?

### DIFF
--- a/src/components/ApplicationSummary.js
+++ b/src/components/ApplicationSummary.js
@@ -110,7 +110,7 @@ export const ApplicationSummary = hh(class ApplicationSummary extends PureCompon
               onClick: () => Utils.download('machine-readable-DAR.json', mrDAR),
               filename: 'machine-readable-DAR.json',
               value: mrDAR, className: 'italic hover-color'
-            }, ['Download DAR machine-readable format'])
+            }, ['Download Data Access Request machine-readable format'])
           ]),
 
           div({ className: 'row dar-summary' }, [

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -540,7 +540,7 @@ class DuosHeader extends Component {
         link: this.state.dacChairPath,
         search: 'chair_console',
         children: [
-          { label: 'Manage DARs', link: this.state.dacChairPath },
+          { label: 'DAR Requests', link: this.state.dacChairPath },
           { label: 'Datasets', link: '/dataset_catalog' },
           { label: 'DAC Members', link: '/manage_dac' }
         ]

--- a/src/components/dar_collection_table/CollectionConfirmationModal.js
+++ b/src/components/dar_collection_table/CollectionConfirmationModal.js
@@ -38,7 +38,7 @@ export default function CollectionConfirmationModal(props) {
     h(ConfirmationModal, {
       showConfirmation,
       closeConfirmation: () => setShowConfirmation(false),
-      title: 'Cancel DAR Collection',
+      title: 'Cancel Data Access Request',
       message: `Are you sure you want to cancel ${collection.darCode}?`,
       header: getModalHeader(),
       onConfirm: cancelOnClick
@@ -49,7 +49,7 @@ export default function CollectionConfirmationModal(props) {
       showConfirmation,
       styleOverride: {height: '35%'},
       closeConfirmation: () => setShowConfirmation(false),
-      title: 'Revise DAR Collection',
+      title: 'Revise Data Access Request',
       message: `Are you sure you want to revise ${collection.darCode}?`,
       header: getModalHeader(),
       onConfirm: reviseOnClick
@@ -58,7 +58,7 @@ export default function CollectionConfirmationModal(props) {
   const openModal = h(ConfirmationModal, {
     showConfirmation,
     closeConfirmation: () => setShowConfirmation(false),
-    title: 'Open DAR Collection',
+    title: 'Open Data Access Request',
     message: `Are you sure you want to open ${collection.darCode}?`,
     header: getModalHeader(),
     onConfirm: openOnClick,
@@ -68,7 +68,7 @@ export default function CollectionConfirmationModal(props) {
     showConfirmation,
     styleOverride: { height: '35%' },
     closeConfirmation: () => setShowConfirmation(false),
-    title: 'Delete DAR Collection Draft',
+    title: 'Delete Data Access Request Draft',
     message: `Are you sure you want to delete ${collection.darCode}?`,
     header: getModalHeader(),
     onConfirm: deleteOnClick,

--- a/src/components/dar_drafts_table/DarDraftTable.js
+++ b/src/components/dar_drafts_table/DarDraftTable.js
@@ -244,8 +244,8 @@ export default function DarDraftTable(props) {
     h(ConfirmationModal, {
       showConfirmation,
       closeConfirmation: () => setShowConfirmation(false),
-      title: 'Delete Draft DAR',
-      message: `Are you sure you want to delete DAR draft ${getIdentifier({id: selectedDraft.id, data: selectedDraft.data})}`,
+      title: 'Delete Draft Data Access Request',
+      message: `Are you sure you want to delete Data Access Request draft ${getIdentifier({id: selectedDraft.id, data: selectedDraft.data})}`,
       header: getModalHeader(),
       onConfirm: deleteOnClick
     })

--- a/src/pages/AdminConsole.js
+++ b/src/pages/AdminConsole.js
@@ -183,8 +183,8 @@ class AdminConsole extends Component {
                   id: 'btn_manageDarCollections',
                   url: '/admin_manage_dar_collections',
                   color: 'access',
-                  title: 'Manage DAR Collection',
-                  description: 'Select and access DAR Collections for review',
+                  title: 'Manage Data Access Request',
+                  description: 'Select and access Data Access Request Collections for review',
                   iconName: 'manage-access',
                   iconSize: 'large',
                 })

--- a/src/pages/AdminManageDarCollections.js
+++ b/src/pages/AdminManageDarCollections.js
@@ -59,7 +59,7 @@ export default function AdminManageDarCollections() {
               fontWeight: 600,
               fontSize: '2.8rem'
             } }, [
-              'Manage Data Access Request Collections',
+              'All Data Access Requests',
             ]),
             div(
               {
@@ -68,7 +68,7 @@ export default function AdminManageDarCollections() {
                   fontSize: '1.6rem'
                 },
               },
-              ['List of all DAR Collections saved in DUOS']
+              ['List of all Data Access Requests saved in DUOS']
             ),
           ]),
         ]

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -648,7 +648,7 @@ class DataAccessRequestApplication extends Component {
           showDialogSubmit: false
         });
         NotyUtil.showError({
-          text: 'Error: DAR submission failed'
+          text: 'Error: Data Access Request submission failed'
         });
       }
     } else {
@@ -726,7 +726,7 @@ class DataAccessRequestApplication extends Component {
         prev.disableOkBtn = false;
         return prev;
       });
-      NotyUtil.showError('Error saving partial DAR update');
+      NotyUtil.showError('Error saving partial Data Access Request update');
     }
   };
 

--- a/src/pages/NewChairConsole.js
+++ b/src/pages/NewChairConsole.js
@@ -66,7 +66,7 @@ export default function NewChairConsole(props) {
               fontWeight: 600,
               fontSize: '2.8rem'
             } }, [
-              'Manage Data Access Request Collections',
+              `My DAC's Data Access Requests`,
             ]),
             div(
               {

--- a/src/pages/NewMemberConsole.js
+++ b/src/pages/NewMemberConsole.js
@@ -63,7 +63,7 @@ export default function NewMemberConsole(props) {
               fontWeight: 600,
               fontSize: '2.8rem'
             } }, [
-              'Manage Data Access Request Collections',
+              `My DAC's Data Access Requests`,
             ]),
             div(
               {

--- a/src/pages/NewResearcherConsole.js
+++ b/src/pages/NewResearcherConsole.js
@@ -94,13 +94,13 @@ export default function NewResearcherConsole() {
         fetchedCollections,
         collectionArray,
         errorMsg,
-        'Failed to fetch DAR Collection'
+        'Failed to fetch Data Access Request Collection'
       );
       collectionArray = handlePromise(
         fetchedDrafts,
         collectionArray,
         errorMsg,
-        'Failed to fetch DAR Drafts'
+        'Failed to fetch Data Access Request Drafts'
       );
       if(!isEmpty(errorMsg)) {
         Notifications.showError({text: errorMsg.join('\n')});
@@ -178,11 +178,11 @@ export default function NewResearcherConsole() {
       } else {
         collectionsClone.splice(targetIndex, 1);
         setResearcherCollections(collectionsClone);
-        Notifications.showSuccess({text: `Deleted DAR Draft ${identifier}`});
+        Notifications.showSuccess({text: `Deleted Data Access Request Draft ${identifier}`});
       }
     } catch (error) {
       Notifications.showError({
-        text: `Failed to delete DAR Draft ${identifier}`,
+        text: `Failed to delete Data Access Request Draft ${identifier}`,
       });
     }
 
@@ -201,14 +201,14 @@ export default function NewResearcherConsole() {
             }),
           ]),
           div({ style: Styles.HEADER_CONTAINER }, [
-            div({ style: Styles.TITLE }, ['Researcher Console']),
+            div({ style: Styles.TITLE }, ['My Data Access Requests']),
             div(
               {
                 style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {
                   fontSize: '18px',
                 }),
               },
-              [`Select and manage DAR Collections and Drafts below`]
+              [`Select and manage Data Access Requests and Drafts below`]
             ),
           ]),
         ]

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -150,7 +150,7 @@ export default function SigningOfficialConsole(props) {
           div({style: Styles.HEADER_CONTAINER}, [
             div({style: {...Styles.SUB_HEADER, marginTop: '0'}}, ['Data Access Requests']),
             div({style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '16px'})}, [
-              'Your Institution\'s DARs: Records from all current and closed data access requests.',
+              'Your Institution\'s Data Access Requests: Records from all current and closed data access requests.',
             ]),
           ])
         ]),

--- a/src/pages/SigningOfficialDarRequests.js
+++ b/src/pages/SigningOfficialDarRequests.js
@@ -43,7 +43,7 @@ export default function SigningOfficialDarRequests() {
           div({style: Styles.HEADER_CONTAINER}, [
             div({style: {...Styles.SUB_HEADER, marginTop: '0'}}, [`My Institution's Data Access Requests`]),
             div({style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '16px'})}, [
-              'Your Institution\'s DARs: Records from all current and closed data access requests.',
+              'Your Institution\'s Data Access Requests: Records from all current and closed data access requests.',
             ]),
           ])
         ])

--- a/src/pages/SigningOfficialDarRequests.js
+++ b/src/pages/SigningOfficialDarRequests.js
@@ -41,7 +41,7 @@ export default function SigningOfficialDarRequests() {
             })
           ]),
           div({style: Styles.HEADER_CONTAINER}, [
-            div({style: {...Styles.SUB_HEADER, marginTop: '0'}}, ['DAR Requests']),
+            div({style: {...Styles.SUB_HEADER, marginTop: '0'}}, [`My Institution's Data Access Requests`]),
             div({style: Object.assign({}, Styles.MEDIUM_DESCRIPTION, {fontSize: '16px'})}, [
               'Your Institution\'s DARs: Records from all current and closed data access requests.',
             ]),

--- a/src/pages/access_review/DarApplication.js
+++ b/src/pages/access_review/DarApplication.js
@@ -86,7 +86,7 @@ export const DarApplication = hh(class DarApplication extends React.PureComponen
           span({style: {...HEADER, paddingLeft: '5px'}}, [datasetName])
         ]),
         div({style: SECTION, isRendered: isAdmin }, [
-          span({ style: HEADER_BOLD }, ['DAC Final DAR Decision: ']),
+          span({ style: HEADER_BOLD }, ['DAC Final Data Access Request Decision: ']),
           span({ style: {...HEADER, paddingLeft: '5px'}}, [finalDecision])
         ]),
         div({ isRendered: isAdmin }, [

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -523,7 +523,7 @@ export default function ResearcherInfo(props) {
                 Policy. External Collaborators must be at the PI or equivalent level and are not required to have a Library Card in order to access data,
                 although it is encouraged. Note: External Collaborators must submit an independent DAR approved by their signing Official
                 to collaborate on this project. External Collaborators will be able to add their Lab Staff, as needed, via their independent DAR. Approval of
-                this DAR does not indicate approval of the External Collaborators listed.`
+                this Data Access Request does not indicate approval of the External Collaborators listed.`
                 ])
               ])
             ]),

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -120,7 +120,7 @@ export default function DarCollectionReview(props) {
       setSubcomponentLoading(false);
     } catch (error) {
       Notifications.showError({
-        text: 'Error initializing DAR collection page. You have been redirected to your console',
+        text: 'Error initializing Data Access Request collection page. You have been redirected to your console',
       });
       Navigation.console(user, props.history);
     }


### PR DESCRIPTION
**From the ticket:**
- Console Titles:
- - Admin: “All Data Access Requests”
- - Researcher: “My Data Access Requests”
- - DACs: “My DAC’s Data Access Requests”
- - SOs: “My Institution’s Data Access Requests”

Nav Links:
DAR Requests

Modals:
Refer to them by their full title, “Data Access Request”

Other notes: 
- Wasn't sure what the modals were, but I did a generic search for "DAR" -> "Data Access Request", which may have been overkill.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
