### PR TITLE
[DUOS-1692] Add reject ToS button

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -66,7 +66,7 @@ const Routes = (props) => (
     <Route path="/nih_ic_webform" component={NIHICWebform} />
     <Route path="/nih_pilot_info" component={NIHPilotInfo} />
     <Route path="/privacy" component={PrivacyPolicy} />
-    <Route path="/tos" component={TermsOfService} />
+    <Route path="/tos" component={TermsOfService} props={props} />
     <Route path="/tos_acceptance" component={TermsOfServiceAcceptance} props={props} />
     <Route path="/data_sharing_language_tool" component={DataSharingLanguageTool} />
     <AuthenticatedRoute path="/admin_console" component={AdminConsole} props={props} rolesAllowed={[USER_ROLES.admin]} />

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1137,6 +1137,11 @@ export const ToS = {
     const url = `${await Config.getApiUrl()}/api/sam/register/self/tos`;
     const res = await axios.post(url, {}, Config.authOpts());
     return res.data;
+  },
+  rejectToS: async () => {
+    const url = `${await Config.getApiUrl()}api/sam/register/self/tos`;
+    const res = await axios.delete(url, Config.authOpts());
+    return res.data;
   }
 };
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -1139,7 +1139,7 @@ export const ToS = {
     return res.data;
   },
   rejectToS: async () => {
-    const url = `${await Config.getApiUrl()}api/sam/register/self/tos`;
+    const url = `${await Config.getApiUrl()}/api/sam/register/self/tos`;
     const res = await axios.delete(url, Config.authOpts());
     return res.data;
   }

--- a/src/libs/tosService.js
+++ b/src/libs/tosService.js
@@ -52,4 +52,8 @@ export const TosService = {
     return await ToS.acceptToS();
   },
 
+  rejectTos: async () => {
+    return await ToS.rejectToS();
+  },
+
 };

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -9,6 +9,7 @@ export default function TermsOfService(props) {
 
   const [tosText, setTosText] = useState('');
   const {history} = props;
+  const isLogged = Storage.userIsLogged();
 
   useEffect(() => {
     const init = async () => {
@@ -32,7 +33,7 @@ export default function TermsOfService(props) {
     div({style: TosService.getContainerStyle()}, [
       h1({style: {color: '#00609f', marginLeft: '25px'}}, ['DUOS Terms of Service']),
       div({style: TosService.getScrollableStyle(), className: 'markdown-body'}, [tosText]),
-      div({style: {display: 'flex', justifyContent: 'right', paddingRight: '5rem'}}, [
+      div({isRendered: isLogged, style: {display: 'flex', justifyContent: 'right', paddingRight: '5rem'}}, [
         h(SimpleButton, {
           keyProp: 'tos-accept',
           label: 'Reject Terms of Service',

--- a/src/pages/TermsOfService.js
+++ b/src/pages/TermsOfService.js
@@ -1,11 +1,14 @@
-import {div, h1} from 'react-hyperscript-helpers';
+import {div, h1, h} from 'react-hyperscript-helpers';
 import {useEffect, useState} from 'react';
+import { Storage } from '../libs/storage';
 import {TosService} from '../libs/tosService';
+import SimpleButton from '../components/SimpleButton';
 
 
-export default function TermsOfService() {
+export default function TermsOfService(props) {
 
   const [tosText, setTosText] = useState('');
+  const {history} = props;
 
   useEffect(() => {
     const init = async () => {
@@ -15,10 +18,38 @@ export default function TermsOfService() {
     init();
   }, []);
 
+  const rejectAndSignOut = async () => {
+    // update Sam that ToS was rejected
+    await TosService.rejectTos();
+
+    // log user out and send them back home.
+    await Storage.setUserIsLogged(false);
+    await Storage.clearStorage();
+    history.push('/');
+  };
+
   return div({style: TosService.getBackgroundStyle()}, [
     div({style: TosService.getContainerStyle()}, [
       h1({style: {color: '#00609f', marginLeft: '25px'}}, ['DUOS Terms of Service']),
-      div({style: TosService.getScrollableStyle(), className: 'markdown-body'}, [tosText])
-    ])
+      div({style: TosService.getScrollableStyle(), className: 'markdown-body'}, [tosText]),
+      div({style: {display: 'flex', justifyContent: 'right', paddingRight: '5rem'}}, [
+        h(SimpleButton, {
+          keyProp: 'tos-accept',
+          label: 'Reject Terms of Service',
+          isRendered: true,
+          onClick: rejectAndSignOut,
+          baseColor: '#d13b07',
+          hoverStyle: {
+            backgroundColor: '#b83206',
+            color: 'white'
+          },
+          additionalStyle: {
+            textTransform: 'none',
+            padding: '5px 10px',
+            fontSize: '1.45rem',
+          },
+        })
+      ]),
+    ]),
   ]);
 }


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1692

Adds 'Reject' button the ToS page, which allows a user to reject the terms after they've already logged in and accepted.

Requires backend on [this branch](https://github.com/DataBiosphere/consent/tree/DUOS-1691-reject-tos) as a new endpoint had to be created.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
