### PR TITLE
DUOS-1908[risk=no] Updated dataUseTranslation to correctly handle POA, Gender, and Pediatric on Data Use

### DIFF
--- a/cypress/component/DataUseTranslation/data_use_translation.spec.js
+++ b/cypress/component/DataUseTranslation/data_use_translation.spec.js
@@ -1,0 +1,130 @@
+/* eslint-disable no-undef */
+import { processDefinedLimitations, consentTranslations } from '../../../src/libs/dataUseTranslation';
+import { isEmpty, cloneDeep } from 'lodash/fp';
+
+const mockDataUse = {
+  diseaseRestrictions: []
+};
+
+describe('Data Use Translation', () => {
+  describe('procesDefinedLimitations()', () => {
+    it('translates Populations, Origins, and Ancestry (POA) if it has been marked in the data use', () => {
+      const targetKey = 'populationOriginsAncestry';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {diseaseRestrictions: [], populationOriginsAncestry: true});
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      const targetTranslation = consentTranslations[targetKey];
+      expect(!isEmpty(resp)).to.be.true;
+      expect(resp.code).to.equal(targetTranslation.code);
+      expect(resp.description).to.equal(targetTranslation.description);
+    });
+
+    it("translates HMB if it's been marked in the data use", () => {
+      const targetKey = 'hmbResearch';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {[targetKey]: true, diseaseRestrictions: []});
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      const targetTranslation = consentTranslations[targetKey];
+      expect(!isEmpty(resp)).to.be.true;
+      expect(resp.code).to.equal(targetTranslation.code);
+      expect(resp.description).to.equal(targetTranslation.description);
+    });
+
+    it('translates HMB if diseaseRestrictions is an empty array', () => {
+      const targetKey = 'hmbResearch';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {diseaseRestrictions: [], [targetKey]: true});
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      const targetTranslation = consentTranslations[targetKey];
+      expect(!isEmpty(resp)).to.be.true;
+      expect(resp.code).to.equal(targetTranslation.code);
+      expect(resp.description).to.equal(targetTranslation.description);
+    });
+
+    it('does not translate HMB if diseaseRestrictions is populated', () => {
+      const targetKey = 'hmbResearch';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        diseaseRestrictions: ['test'],
+        [targetKey]: true,
+      });
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      expect(isEmpty(resp)).to.be.true;
+    });
+
+    it('translates General Research Use (GRU) if selected', () => {
+      const targetKey = 'generalUse';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        [targetKey]: true,
+        diseaseRestrictions: []
+      });
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      const targetTranslation = consentTranslations[targetKey];
+      expect(!isEmpty(resp)).to.be.true;
+      expect(resp.code).to.equal(targetTranslation.code);
+      expect(resp.description).to.equal(targetTranslation.description);
+    });
+
+    it('does not translate GRU if HMB is selected', () => {
+      const targetKey = 'generalUse';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        [targetKey]: true,
+        hmbResearch: true,
+        diseaseRestrictions: []
+      });
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      expect(isEmpty(resp)).to.be.true;
+    });
+
+    it('does not translate GRU if diseaseRestrictions is populated', () => {
+      const targetKey = 'generalUse';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        [targetKey]: true,
+        diseaseRestrictions: ['test'],
+      });
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      expect(isEmpty(resp)).to.be.true;
+    });
+
+    it('does not translate GRU if POA is selected', () => {
+      const targetKey = 'generalUse';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        [targetKey]: true,
+        populationOriginsAncestry: true,
+        diseaseRestrictions: []
+      });
+      const resp = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations);
+      expect(isEmpty(resp)).to.be.true;
+    });
+
+    it('translates Pediatric Studies (PSO) if pediatric is selected', () => {
+      const targetKey = 'pediatric';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        [targetKey]: true,
+        diseaseRestrictions: [],
+      });
+      const resp = processDefinedLimitations(
+        targetKey,
+        modifiedMockData,
+        consentTranslations
+      );
+      const targetTranslation = consentTranslations[targetKey];
+      expect(!isEmpty(resp)).to.be.true;
+      expect(resp.code).to.equal(targetTranslation.code);
+      expect(resp.description).to.equal(targetTranslation.description);
+    });
+
+    it('translates Gender Studies (GSO) if gender is selected', () => {
+      const targetKey = 'gender';
+      const modifiedMockData = Object.assign(cloneDeep(mockDataUse), {
+        [targetKey]: true,
+        diseaseRestrictions: [],
+      });
+      const resp = processDefinedLimitations(
+        targetKey,
+        modifiedMockData,
+        consentTranslations
+      );
+      const targetTranslation = consentTranslations[targetKey];
+      expect(!isEmpty(resp)).to.be.true;
+      expect(resp.code).to.equal(targetTranslation.code);
+      expect(resp.description).to.equal(targetTranslation.description);
+    });
+  });
+});

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -159,6 +159,14 @@ export const consentTranslations = {
   geographicalRestrictions: {
     code: 'GS',
     description: 'Use is limited to within a certain geographic area'
+  },
+  gender: {
+    code: 'GEN',
+    description: 'Use is limited to gender studies only'  //This is a placeholder, give me a better phrase on the PR review
+  },
+  pediatric: {
+    code: 'PSO',
+    description: 'Use is limited to pediatric studies only' //This is a placeholder, give me a better phrase on the PR review
   }
 };
 
@@ -210,16 +218,15 @@ export const processDefinedLimitations = (
 ) => {
   const targetKeys = ['hmbResearch', 'populationOriginsAncestry', 'generalUse'];
   const isHMBActive =
-    dataUse.hmbResearch && isEmpty(dataUse.diseaseRestrictions);
-  const isGeneralUseActive = dataUse.generalUse && !isHMBActive;
-  const isPOAActive =
-    !isGeneralUseActive && !isHMBActive && isEmpty(dataUse.diseaseRestrictions);
+    !!dataUse.hmbResearch && isEmpty(dataUse.diseaseRestrictions);
+  const isPOAActive = !!dataUse.populationOriginsAncestry;
+  const isGeneralUseActive = !!dataUse.generalUse && !isHMBActive && !isPOAActive && isEmpty(dataUse.diseaseRestrictions);
   let statement;
   if (
     !targetKeys.includes(key) ||
     (key === 'hmbResearch' && isHMBActive) ||
     (key === 'populationOriginsAncestry' && isPOAActive) ||
-    (key === 'generalUse' && !isHMBActive)
+    (key === 'generalUse' && isGeneralUseActive)
   ) {
     statement = consentTranslations[key];
   }

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -113,61 +113,63 @@ export const srpTranslations = {
 export const consentTranslations = {
   generalUse: {
     code: 'GRU',
-    description: 'Use is permitted for any research purpose'
+    description: 'Use is permitted for any research purpose',
   },
   hmbResearch: {
     code: 'HMB',
-    description: 'Use is permitted for a health, medical, or biomedical research purpose'
+    description: 'Use is permitted for a health, medical, or biomedical research purpose',
   },
   diseaseRestrictions: (restrictions) => {
-    if (isEmpty(restrictions)) { return 'Use is permitted for the specified disease(s): Not specified'; }
+    if (isEmpty(restrictions)) {
+      return 'Use is permitted for the specified disease(s): Not specified';
+    }
     const restrictionList = restrictions.join(', ');
     return {
       code: 'DS',
       alternateLabel: `DS ${restrictions.join('-')}`,
-      description: `Use is permitted for the specified disease(s): ${restrictionList}`
+      description: `Use is permitted for the specified disease(s): ${restrictionList}`,
     };
   },
   populationOriginsAncestry: {
     code: 'POA',
-    description: 'Use is limited to population, origin, or ancestry research'
+    description: 'Use is limited to population, origin, or ancestry research',
   },
   methodsResearch: {
     code: 'NMDS',
-    description: 'Use for methods development research (e.g., development of software or algorithms) only within the bounds of other use limitations'
+    description: 'Use for methods development research (e.g., development of software or algorithms) only within the bounds of other use limitations',
   },
   geneticStudiesOnly: {
     code: 'GSO',
-    description: 'Use is limited to genetic studies only'
+    description: 'Use is limited to genetic studies only',
   },
   commercialUse: {
     code: 'NPU',
-    description: 'Use is limited to non-profit and non-commercial research'
+    description: 'Use is limited to non-profit and non-commercial research',
   },
   publicationResults: {
     code: 'PUB',
-    description: 'Use requires users to make results of studies using the data available to the larger scientific community'
+    description: 'Use requires users to make results of studies using the data available to the larger scientific community',
   },
   collaboratorRequired: {
     code: 'COL',
-    description: 'Use requires users to collaborate with the primary study investigators'
+    description: 'Use requires users to collaborate with the primary study investigators',
   },
   ethicsApprovalRequired: {
     code: 'IRB',
-    description: 'Use requires users to provide documentation of local IRB/ERB approval'
+    description: 'Use requires users to provide documentation of local IRB/ERB approval',
   },
   geographicalRestrictions: {
     code: 'GS',
-    description: 'Use is limited to within a certain geographic area'
+    description: 'Use is limited to within a certain geographic area',
   },
   gender: {
-    code: 'GEN',
-    description: 'Use is limited to gender studies only'  //This is a placeholder, give me a better phrase on the PR review
+    code: 'RS-G',
+    description: 'Use is limited to research involving a particular gender',
   },
   pediatric: {
-    code: 'PSO',
-    description: 'Use is limited to pediatric studies only' //This is a placeholder, give me a better phrase on the PR review
-  }
+    code: 'RS-PD',
+    description: 'Use is limited to pediatric research',
+  },
 };
 
 const getOntologyName = async(urls) => {


### PR DESCRIPTION
Addresses [DUOS-1908](https://broadworkbench.atlassian.net/browse/DUOS-1908)

PR updates `processDefinedLimitations` on `dataUseTranslations.js` to correctly handle POA, pediatric, and gender keys on data use objects. PR also adds a new test suite for this function.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
