### PR TITLE
DUOS-1887[risk=med] Enable nav refactor for Prod with updated env conditionals

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,6 @@ import './App.css';
 import { Config } from './libs/config';
 import DuosFooter from './components/DuosFooter';
 import DuosHeader from './components/DuosHeader';
-import DuosHeaderOld from './components/DuosHeaderOld';
 import {useHistory} from 'react-router-dom';
 import loadingImage from './images/loading-indicator.svg';
 
@@ -73,16 +72,11 @@ function App() {
     await setIsLoggedIn(true);
   };
 
-  // TODO: Remove this when all the new navigation features are available
-  const header = env !== 'prod'
-    ? h(DuosHeader, { onSignOut: signOut })
-    : h(DuosHeaderOld, { onSignOut: signOut });
-
   return (
     div({ className: 'body' }, [
       div({ className: 'wrap' }, [
         div({ className: 'main' }, [
-          header,
+          h(DuosHeader, { onSignOut: signOut }),
           h(Spinner, {
             name: 'mainSpinner', group: 'duos', loadingImage
           }),

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -259,9 +259,8 @@ export const Navigation = {
         :user.isChairPerson ? '/new_chair_console'
           : user.isMember ? '/new_member_console'
             : user.isResearcher ? '/dataset_catalog'
-              : user.isDataOwner ? '/data_owner_console'
-                : user.isAlumni ? '/summary_votes'
-                  : '/';
+              : user.isAlumni ? '/summary_votes'
+                : '/';
     history.push(page);
   },
   console: async (user, history) => {
@@ -270,9 +269,8 @@ export const Navigation = {
         : user.isChairPerson ? '/new_chair_console'
           : user.isMember ? '/new_member_console'
             : user.isResearcher ? '/new_researcher_console'
-              : user.isDataOwner ? '/data_owner_console'
-                : user.isAlumni ? '/summary_votes'
-                  : '/';
+              : user.isAlumni ? '/summary_votes'
+                : '/';
     history.push(page);
   }
 };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -6,7 +6,6 @@ import { DAR, DataSet } from './ajax';
 import {Theme, Styles } from './theme';
 import { each, flatMap, flatten, flow, forEach, get, getOr, indexOf, uniq, values, find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq, every, pick, capitalize } from 'lodash/fp';
 import {User} from './ajax';
-import {Config} from './config';
 
 export const UserProperties = {
   ACADEMIC_EMAIL: 'academicEmail',
@@ -255,51 +254,25 @@ export const setUserRoleStatuses = (user, Storage) => {
 
 export const Navigation = {
   back: async (user, history) => {
-    const env = await Config.getEnv();
-    let page;
-    if (env !== 'prod') {
-      page =
-        user.isAdmin ? '/admin_manage_dar_collections'
-          :user.isChairPerson ? '/new_chair_console'
-            : user.isMember ? '/new_member_console'
-              : user.isResearcher ? '/dataset_catalog'
-                : user.isDataOwner ? '/data_owner_console'
-                  : user.isAlumni ? '/summary_votes'
-                    : '/';
-    } else {
-      page =
-        user.isAdmin ? '/admin_manage_dar_collections'
-          :user.isChairPerson ? '/new_chair_console'
-            : user.isMember ? '/new_member_console'
-              : user.isResearcher ? '/dataset_catalog'
-                : user.isDataOwner ? '/data_owner_console'
-                  : user.isAlumni ? '/summary_votes'
-                    : '/';
-    }
+    let page =
+      user.isAdmin ? '/admin_manage_dar_collections'
+        :user.isChairPerson ? '/new_chair_console'
+          : user.isMember ? '/new_member_console'
+            : user.isResearcher ? '/dataset_catalog'
+              : user.isDataOwner ? '/data_owner_console'
+                : user.isAlumni ? '/summary_votes'
+                  : '/';
     history.push(page);
   },
   console: async (user, history) => {
-    const env = await Config.getEnv();
-    let page;
-    if (env !== 'prod') {
-      page =
-        user.isAdmin ? '/admin_manage_dar_collections'
-          : user.isChairPerson ? '/new_chair_console'
-            : user.isMember ? '/new_member_console'
-              : user.isResearcher ? '/new_researcher_console'
-                : user.isDataOwner ? '/data_owner_console'
-                  : user.isAlumni ? '/summary_votes'
-                    : '/';
-    } else {
-      page =
-          user.isAdmin ? '/admin_manage_dar_collections'
-            : user.isChairPerson ? '/new_chair_console'
-              : user.isMember ? '/new_member_console'
-                : user.isResearcher ? '/new_researcher_console'
-                  : user.isDataOwner ? '/data_owner_console'
-                    : user.isAlumni ? '/summary_votes'
-                      : '/';
-    }
+    let page =
+      user.isAdmin ? '/admin_manage_dar_collections'
+        : user.isChairPerson ? '/new_chair_console'
+          : user.isMember ? '/new_member_console'
+            : user.isResearcher ? '/new_researcher_console'
+              : user.isDataOwner ? '/data_owner_console'
+                : user.isAlumni ? '/summary_votes'
+                  : '/';
     history.push(page);
   }
 };

--- a/src/pages/AdminConsole.js
+++ b/src/pages/AdminConsole.js
@@ -18,7 +18,6 @@ class AdminConsole extends Component {
       showModal: false,
       showAddUserModal: false,
       dulUnreviewedCases: 0,
-      darUnreviewedCases: 0,
       timeOut: {},
       isDataSetElection: {},
       env: props.env
@@ -40,14 +39,6 @@ class AdminConsole extends Component {
       duls => {
         this.setState({
           dulUnreviewedCases: duls.dulUnReviewedCases,
-        });
-      }
-    );
-
-    PendingCases.findDARUnReviewed().then(
-      dars => {
-        this.setState({
-          darUnreviewedCases: dars.darUnReviewedCases,
         });
       }
     );
@@ -87,7 +78,7 @@ class AdminConsole extends Component {
 
   render() {
 
-    const { currentUser, dulUnreviewedCases, darUnreviewedCases } = this.state;
+    const { currentUser, dulUnreviewedCases } = this.state;
 
     return (
 

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -109,6 +109,7 @@ export default function SigningOfficialConsole(props) {
           })
         ]),
         h(SigningOfficialTable, {isRendered: selectedTag === tabs.researcher, researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+        //NOTE: Links to this custodian table have been removed, we are retaining it with the intention of repurposing it for data submitters
         h(DataCustodianTable, {isRendered: selectedTag === tabs.custodian, researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
         h(DarCollectionTable, {
           isRendered: selectedTag === tabs.collections,

--- a/src/pages/SigningOfficialConsole.js
+++ b/src/pages/SigningOfficialConsole.js
@@ -14,7 +14,6 @@ import {User, DAR, Collections} from '../libs/ajax';
 import {consoleTypes} from '../components/dar_table/DarTableActions';
 import { USER_ROLES } from '../libs/utils';
 import DataCustodianTable from '../components/data_custodian_table/DataCustodianTable';
-import { Config } from '../libs/config';
 import { DarCollectionTableColumnOptions, DarCollectionTable } from '../components/dar_collection_table/DarCollectionTable';
 
 const tabs = {
@@ -24,7 +23,6 @@ const tabs = {
 };
 
 export default function SigningOfficialConsole(props) {
-  const [env, setEnv] = useState();
   const [signingOfficial, setSiginingOfficial] = useState({});
   const [researchers, setResearchers] = useState([]);
   const [unregisteredResearchers, setUnregisteredResearchers] = useState();
@@ -44,9 +42,7 @@ export default function SigningOfficialConsole(props) {
     const init = async() => {
       try {
         setIsLoading(true);
-        //NOTE: Config.getEnv is async, can't just use it directly in isRendered
         //Need to assign to state variable on Component init for template reference
-        const envValue = await Config.getEnv();
         const soUser = await User.getMe();
         const soPromises = await Promise.all([
           User.list(USER_ROLES.signingOfficial),
@@ -64,7 +60,6 @@ export default function SigningOfficialConsole(props) {
         setDarList(darList);
         setCollectionList(collectionList);
         setFilteredDarList(darList);
-        setEnv(envValue);
         setIsLoading(false);
       } catch(error) {
         Notifications.showError({text: 'Error: Unable to retrieve current user from server'});
@@ -114,7 +109,7 @@ export default function SigningOfficialConsole(props) {
           })
         ]),
         h(SigningOfficialTable, {isRendered: selectedTag === tabs.researcher, researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
-        h(DataCustodianTable, {isRendered: selectedTag === tabs.custodian && env !== 'prod', researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+        h(DataCustodianTable, {isRendered: selectedTag === tabs.custodian, researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
         h(DarCollectionTable, {
           isRendered: selectedTag === tabs.collections,
           collections: collectionList,

--- a/src/pages/SigningOfficialDataSubmitters.js
+++ b/src/pages/SigningOfficialDataSubmitters.js
@@ -43,6 +43,7 @@ export default function SigningOfficialConsole() {
   return (
     div({style: Styles.PAGE}, [
       div({style: {}, className: 'signing-official-tabs'}, [
+        //NOTE: Links to this custodian table have been removed, we are retaining it with the intention of repurposing it for data submitters
         h(DataCustodianTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
       ])
     ])

--- a/src/pages/SigningOfficialDataSubmitters.js
+++ b/src/pages/SigningOfficialDataSubmitters.js
@@ -5,11 +5,9 @@ import {Styles} from '../libs/theme';
 import {User} from '../libs/ajax';
 import { USER_ROLES } from '../libs/utils';
 import DataCustodianTable from '../components/data_custodian_table/DataCustodianTable';
-import { Config } from '../libs/config';
 
 
 export default function SigningOfficialConsole() {
-  const [env, setEnv] = useState();
   const [signingOfficial, setSigningOfficial] = useState({});
   const [researchers, setResearchers] = useState([]);
   const [unregisteredResearchers, setUnregisteredResearchers] = useState();
@@ -21,9 +19,7 @@ export default function SigningOfficialConsole() {
     const init = async() => {
       try {
         setIsLoading(true);
-        //NOTE: Config.getEnv is async, can't just use it directly in isRendered
         //Need to assign to state variable on Component init for template reference
-        const envValue = await Config.getEnv();
         const soUser = await User.getMe();
         const soPromises = await Promise.all([
           User.list(USER_ROLES.signingOfficial),
@@ -34,7 +30,6 @@ export default function SigningOfficialConsole() {
         setUnregisteredResearchers(unregisteredResearchers);
         setResearchers(researcherList);
         setSigningOfficial(soUser);
-        setEnv(envValue);
         setIsLoading(false);
       } catch(error) {
         Notifications.showError({text: 'Error: Unable to retrieve current user from server'});
@@ -48,7 +43,7 @@ export default function SigningOfficialConsole() {
   return (
     div({style: Styles.PAGE}, [
       div({style: {}, className: 'signing-official-tabs'}, [
-        h(DataCustodianTable, {isRendered: env !== 'prod', researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+        h(DataCustodianTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
       ])
     ])
   );


### PR DESCRIPTION
[DUOS-1887](https://broadworkbench.atlassian.net/browse/DUOS-1887)
- Updated the app to exclusively use the new DUOS header.
- Updated utils to remove conditional logic that considers environment for navigation.
- Removed conditional logic that considers environment for DataCustodianTable visibility in the Signing Official Console.
- Fixed a no-unused-vars from the MDV changes.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
