### PR TITLE
[DUOS-1919][risk=no] MultiDataset Application Info Page - Font/UI

### DIFF
--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -71,11 +71,8 @@ describe('Application Information', () => {
   it('does not render collaborator details container and sub-header if none provided', () => {
     const props = {};
     mount(<ApplicationInformation {...props} />);
-    const container = cy.get('.collaborator-details-container');
-    expect(container).to.not.exist;
-
-    const subheader = cy.get('.collaborator-details-subheader');
-    expect(subheader).to.not.exist;
+    cy.get('.collaborator-details-container').should('not.be.visible');
+    cy.get('.collaborator-details-subheader').should('not.be.visible');
   });
 
   it('renders institution details container and sub-header', () => {

--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -71,8 +71,7 @@ describe('Application Information', () => {
   it('does not render collaborator details container and sub-header if none provided', () => {
     const props = {};
     mount(<ApplicationInformation {...props} />);
-    cy.get('.collaborator-details-container').should('not.exist');
-    cy.get('.collaborator-details-subheader').should('not.exist');
+    cy.get('.collaborator-details-container').should('not.be.visible');
   });
 
   it('renders institution details container and sub-header', () => {

--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -71,8 +71,8 @@ describe('Application Information', () => {
   it('does not render collaborator details container and sub-header if none provided', () => {
     const props = {};
     mount(<ApplicationInformation {...props} />);
-    cy.get('.collaborator-details-container').should('not.be.visible');
-    cy.get('.collaborator-details-subheader').should('not.be.visible');
+    cy.get('.collaborator-details-container').should('not.exist');
+    cy.get('.collaborator-details-subheader').should('not.exist');
   });
 
   it('renders institution details container and sub-header', () => {

--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -55,15 +55,50 @@ describe('Application Information', () => {
     textbox.contains('test');
   });
 
-  it('renders the application details container and sub-header', () => {
-    const props = {};
+  it('renders the collaborator details container and sub-header if there are any to display', () => {
+    const props = {
+      externalCollaborators: [{name: 'Person A'}, {name: 'Person B'}]
+    };
     mount(<ApplicationInformation {...props} />);
-    const container = cy.get('.application-details-container');
+    const container = cy.get('.collaborator-details-container');
     expect(container).to.exist;
 
-    const subheader = cy.get('.application-details-subheader');
+    const subheader = cy.get('.collaborator-details-subheader');
     expect(subheader).to.exist;
-    subheader.contains('Application Details');
+    subheader.contains('Collaborators');
+  });
+
+  it('does not render collaborator details container and sub-header if none provided', () => {
+    const props = {};
+    mount(<ApplicationInformation {...props} />);
+    const container = cy.get('.collaborator-details-container');
+    expect(container).to.exist;
+
+    const subheader = cy.get('.collaborator-details-subheader');
+    expect(subheader).to.exist;
+    subheader.contains('Collaborators');
+  });
+
+  it('renders institution details container and sub-header', () => {
+    const props = {};
+    mount(<ApplicationInformation {...props} />);
+    const container = cy.get('.institution-details-container');
+    expect(container).to.exist;
+
+    const subheader = cy.get('.institution-details-subheader');
+    expect(subheader).to.exist;
+    subheader.contains('Institution');
+  });
+
+  it('renders cloud use container and sub-header', () => {
+    const props = {};
+    mount(<ApplicationInformation {...props} />);
+    const container = cy.get('.cloud-use-details-container');
+    expect(container).to.exist;
+
+    const subheader = cy.get('.cloud-use-details-subheader');
+    expect(subheader).to.exist;
+    subheader.contains('Cloud Use');
   });
 
   it('renders the cloud computing provider information if provided', () => {

--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -55,7 +55,7 @@ describe('Application Information', () => {
     textbox.contains('test');
   });
 
-  it('renders the collaborator details container and sub-header if there are any to display', () => {
+  it('renders the collaborator details container and sub-header if any provided', () => {
     const props = {
       externalCollaborators: [{name: 'Person A'}, {name: 'Person B'}]
     };
@@ -72,11 +72,10 @@ describe('Application Information', () => {
     const props = {};
     mount(<ApplicationInformation {...props} />);
     const container = cy.get('.collaborator-details-container');
-    expect(container).to.exist;
+    expect(container).to.not.exist;
 
     const subheader = cy.get('.collaborator-details-subheader');
-    expect(subheader).to.exist;
-    subheader.contains('Collaborators');
+    expect(subheader).to.not.exist;
   });
 
   it('renders institution details container and sub-header', () => {

--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -180,7 +180,6 @@ export default function ApplicationInformation(props) {
               }})
           ])  : ''
       ]),
-
     ])
   );
 }

--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -119,14 +119,20 @@ export default function ApplicationInformation(props) {
   const processCollaborators = (collaborators) =>
     collaborators.map(collaborator => collaborator.name).join(', ');
 
-  const appDetailLabels = [
+  const collaboratorLabels = [
     {value: processCollaborators(externalCollaborators), title: 'External Collaborators', key: 'external-collaborators'},
     {value: processCollaborators(internalCollaborators), title: 'Internal Collaborators', key: 'internal-collaborators'},
+    {value: processCollaborators(internalLabStaff), title: 'Internal Lab Staff', key: 'internal-lab-staff'},
+  ];
+
+  const institutionLabels = [
     {value: signingOfficial, title: 'Signing Official', key: 'signing-official'},
     {value: itDirector, title: 'IT Director', key: 'it-director'},
     {value: signingOfficialEmail, title: 'Signing Official Email', key: 'signing-official-email'},
     {value: itDirectorEmail, title: 'IT Director Email', key: 'it-director-email'},
-    {value: processCollaborators(internalLabStaff), title: 'Internal Lab Staff', key: 'internal-lab-staff'},
+  ];
+
+  const cloudUseLabels = [
     {value: anvilStorage, title: 'Using AnVIL only for storage and analysis', key: 'anvil-storage'},
     {value: localComputing, title: 'Requesting permission to use local computing', key: 'local-computing'},
     {value: cloudComputing, title: 'Requesting permission to use cloud computing', key: 'cloud-computing'},
@@ -151,9 +157,21 @@ export default function ApplicationInformation(props) {
             width: '100%',
           }})
       ]),
-      div({className: 'application-details-container', style: { margin: '2.5rem 0'}}, [
-        div({className: 'application-details-subheader', style: styles.subheader}, ['Application Details']),
-        dynamicRowGeneration(2, appDetailLabels, isLoading, cloudComputing),
+
+      div({className: 'collaborator-details-container', style: { margin: '3rem 0'}}, [
+        div({className: 'collaborator-details-subheader', style: styles.subheader,
+          isRendered: !(isEmpty(internalCollaborators) && isEmpty(externalCollaborators) && isEmpty(internalLabStaff))}, ['Collaborators']),
+        dynamicRowGeneration(2, collaboratorLabels, isLoading)
+      ]),
+
+      div({className: 'institution-details-container', style: { margin: '3rem 0'}}, [
+        div({className: 'institution-details-subheader', style: styles.subheader}, ['Institution']),
+        dynamicRowGeneration(2, institutionLabels, isLoading)
+      ]),
+
+      div({className: 'cloud-use-details-container', style: { margin: '3rem 0'}}, [
+        div({className: 'cloud-use-details-subheader', style: styles.subheader}, ['Cloud Use']),
+        dynamicRowGeneration(2, cloudUseLabels, isLoading, cloudComputing),
         (cloudComputing) ?
           div({className: 'cloud-provider-description-container'}, [
             !isLoading ? div({className: 'cloud-provider-description-textbox', style: styles.textBox}, [cloudProviderDescription])
@@ -162,6 +180,7 @@ export default function ApplicationInformation(props) {
               }})
           ])  : ''
       ]),
+
     ])
   );
 }

--- a/src/pages/dar_collection_review/ReviewHeader.js
+++ b/src/pages/dar_collection_review/ReviewHeader.js
@@ -6,25 +6,14 @@ const styles = {
     fontWeight: 600,
     marginRight: '1rem'
   },
-  secondaryHeader: {
-    fontSize: '3rem',
-    fontWeight: 600,
-    marginRight: '1rem',
-    marginBottom: '1.5rem',
-    paddingRight: '1rem',
-    borderRight: '1px solid black'
-  },
-  title: {
-    fontSize: '3rem',
-    fontWeight: 600,
-  },
   default: {
     fontSize: '1.1rem',
     fontWeight: 400
   },
   darCode: {
     borderRight: '2px solid black',
-    paddingRight: '0.5rem'
+    marginRight: '1rem',
+    paddingRight: '1rem',
   },
   containerRow: {
     margin: '0rem 1.2rem',
@@ -36,10 +25,15 @@ const styles = {
   primaryHeaderRow: {
     fontSize: '2.1rem',
     marginBottom: '3.2rem'
-  }
+  },
+  secondaryHeaderRow: {
+    fontSize: '3rem',
+    fontWeight: 600,
+  },
 };
 
 const appliedPrimaryHeaderStyle = Object.assign({}, styles.containerRow, styles.primaryHeaderRow);
+const appliedSecondaryHeaderStyle =  Object.assign({}, styles.containerRow, styles.secondaryHeaderRow);
 
 export default function ReviewHeader(props) {
   const {
@@ -51,15 +45,15 @@ export default function ReviewHeader(props) {
   } = props;
   return (
     h(Fragment, {}, [
-      div({className: 'header-container', isRendered: !isLoading}, [
+      div({className: 'header-container', isRendered: !isLoading, style: { marginBottom: '3rem' }}, [
         div({className: 'primary-header-row', style: appliedPrimaryHeaderStyle}, [
           span({style: styles.header}, [`Data Access Request Review${readOnly ? ' (read-only)' : ''}`])
         ]),
-        div({style: styles.containerRow}, [
-          div({className: 'collection-project-title', style: styles.title}, [projectTitle])
+        div({className: 'secondary-header-row', style: appliedSecondaryHeaderStyle}, [
+          span({style: styles.darCode}, [darCode]),
+          div({className: 'collection-project-title'}, [projectTitle])
         ]),
-        div({className: 'secondary-header-row', style: styles.containerRow}, [
-          span({style: styles.secondaryHeader}, [darCode]),
+        div({style: styles.containerRow}, [
           downloadLink
         ])
       ]),
@@ -68,11 +62,11 @@ export default function ReviewHeader(props) {
           div({className: 'text-placeholder', style: { width: '35rem', height: '2.5rem', marginBottom: '0.5rem'}}),
         ]),
         div({className: 'secondary-header-skeleton', style: styles.containerRow}, [
-          div({className: 'text-placeholder', style: {width: '10rem', height: '3rem', marginBottom: '0.5rem'}}),
-          div({className: 'text-placeholder', style: {width: '16rem', height: '3rem', marginBottom: '0.5rem'}})
+          div({className: 'text-placeholder', style: {width: '15rem', height: '4rem', marginBottom: '0.5rem'}}),
+          div({className: 'text-placeholder', style: {width: '40rem', height: '4rem', marginBottom: '0.5rem'}})
         ]),
         div({style: styles.containerRow}, [
-          div({className: 'text-placeholder', style: {width: '40rem', height: '4rem', marginBottom: '3.5rem'}})
+          div({className: 'text-placeholder', style: {width: '16rem', height: '3rem', marginBottom: '3.5rem'}})
         ])
       ])
     ])

--- a/src/pages/dar_collection_review/ReviewHeader.js
+++ b/src/pages/dar_collection_review/ReviewHeader.js
@@ -7,16 +7,16 @@ const styles = {
     marginRight: '1rem'
   },
   secondaryHeader: {
-    fontSize: '2.2rem',
-    fontWeight: 400,
+    fontSize: '3rem',
+    fontWeight: 600,
     marginRight: '1rem',
+    marginBottom: '1.5rem',
     paddingRight: '1rem',
     borderRight: '1px solid black'
   },
   title: {
     fontSize: '3rem',
     fontWeight: 600,
-    marginBottom: '1.5rem'
   },
   default: {
     fontSize: '1.1rem',
@@ -55,12 +55,12 @@ export default function ReviewHeader(props) {
         div({className: 'primary-header-row', style: appliedPrimaryHeaderStyle}, [
           span({style: styles.header}, [`Data Access Request Review${readOnly ? ' (read-only)' : ''}`])
         ]),
+        div({style: styles.containerRow}, [
+          div({className: 'collection-project-title', style: styles.title}, [projectTitle])
+        ]),
         div({className: 'secondary-header-row', style: styles.containerRow}, [
           span({style: styles.secondaryHeader}, [darCode]),
           downloadLink
-        ]),
-        div({style: styles.containerRow}, [
-          div({className: 'collection-project-title', style: styles.title}, [projectTitle])
         ])
       ]),
       div({className: 'header-skeleton-loader', isRendered: isLoading}, [


### PR DESCRIPTION
Addresses [DUOS-1919](https://broadworkbench.atlassian.net/browse/DUOS-1919)
Changes (taken from miro comments):
- break Application Details into 3 sections:
       - Collaborators (contains: lab staff, internal collaborators, external collaborators)
       - Institution (contains: SO name/email, IT Director name/email)
       - Cloud Use (contains: anvil, local compute, cloud compute, cloud provider)
- Switch Project title and Download icon/phrase; make DAR ID and Title all the same font as title is now

Since collaborators are optional, section title is conditionally rendered 
Font size and spacing might need tweaking 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
