### PR TITLE
[DUOS-1896][risk=no] Ensure UserProperties deprecation does not break frontend

### DIFF
--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -4,7 +4,6 @@ import {DataUseTranslation} from '../libs/dataUseTranslation';
 import {isNil, isEmpty} from 'lodash/fp';
 import { Theme } from '../libs/theme';
 import {useEffect, useState} from 'react';
-import {getPropertyValuesFromUser} from '../libs/utils';
 
 const styles = StyleSheet.create({
   page: {
@@ -156,11 +155,9 @@ export default function ApplicationDownloadLink(props) {
   const internalCollaborators = getCollaborators(darInfo, 'internalCollaborators');
   const externalCollaborators = getCollaborators(darInfo, 'externalCollaborators');
   const labCollaborators = getCollaborators(darInfo, 'labCollaborators');
-  const researcherProps = getPropertyValuesFromUser(researcherProfile);
-  const location = (researcherProps.city && researcherProps.state ? (researcherProps.city).concat(', ').concat(researcherProps.state) : '');
+
   // Use PDFViewer during development to see changes to the document immediately
   // return h(PDFViewer, {width: 1800, height: 800}, [
-
   const document = h(Document, {}, [
     h(Page, {style: styles.page}, [ //Researcher Info Page
       h(View, {}, [
@@ -168,52 +165,11 @@ export default function ApplicationDownloadLink(props) {
         h(Text, {style: styles.subHeader}, ['Applicant Information']),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
-            label: 'NIH eRA Commons ID',
-            text: `${researcherProps.eraCommonsId}`,
-            style: {marginRight: 30}
-          }),
-          h(SmallLabelTextComponent, {
-            label: 'LinkedIn Profile',
-            text: `${researcherProps.linkedIn}`
-          })
-        ]),
-        h(View, {style: styles.flexboxContainer}, [
-          h(SmallLabelTextComponent, {
-            label: 'ORC ID',
-            text: `${researcherProps.orcid}`,
-            style: {marginRight: 30}
-          }),
-          h(SmallLabelTextComponent, {
-            label: 'ResearcherGate ID',
-            text: `${researcherProps.researcherGate}`
-          }),
-        ]),
-        h(View, {style: styles.flexboxContainer}, [
-          h(SmallLabelTextComponent, {
             label: 'Researcher',
             text: researcherProfile.displayName,
             style: {marginRight: 30}
           }),
-          h(SmallLabelTextComponent, {
-            label: 'Principal Investigator', text: `${researcherProps.piName}`
-          })
-        ]),
-        h(View, {style: styles.flexboxContainer}, [
-          h(SmallLabelTextComponent, {label: 'Institution', text: `${institution}`, style: {marginRight: 30}}),
-          h(SmallLabelTextComponent, {
-            label: 'Department',
-            text: `${researcherProps.department}`
-          })
-        ]),
-        h(View, {style: styles.flexboxContainer}, [
-          h(SmallLabelTextComponent, {
-            label: 'Location', text: `${location}`,
-            style: {marginRight: 30}
-          }),
-          h(SmallLabelTextComponent, {
-            label: 'Researcher Email',
-            text: `${researcherProps.academicEmail}`
-          }),
+          h(SmallLabelTextComponent, {label: 'Institution', text: `${institution}`}),
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {

--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -173,6 +173,13 @@ export default function ApplicationDownloadLink(props) {
         ]),
         h(View, {style: styles.flexboxContainer}, [
           h(SmallLabelTextComponent, {
+            label: 'NIH eRA Commons ID',
+            text: `${researcherProfile.eraCommonsId}`,
+            style: {marginRight: 30}
+          }),
+        ]),
+        h(View, {style: styles.flexboxContainer}, [
+          h(SmallLabelTextComponent, {
             label: 'Signing Official',
             text: darInfo.signingOfficial,
             style: {marginRight: 30}

--- a/src/components/ApplicationDownloadLink.js
+++ b/src/components/ApplicationDownloadLink.js
@@ -157,7 +157,7 @@ export default function ApplicationDownloadLink(props) {
   const externalCollaborators = getCollaborators(darInfo, 'externalCollaborators');
   const labCollaborators = getCollaborators(darInfo, 'labCollaborators');
   const researcherProps = getPropertyValuesFromUser(researcherProfile);
-  const location = (researcherProps.city).concat(', ').concat(researcherProps.state);
+  const location = (researcherProps.city && researcherProps.state ? (researcherProps.city).concat(', ').concat(researcherProps.state) : '');
   // Use PDFViewer during development to see changes to the document immediately
   // return h(PDFViewer, {width: 1800, height: 800}, [
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -4,7 +4,7 @@ import 'noty/lib/themes/bootstrap-v3.css';
 import {map as nonFPMap} from 'lodash';
 import { DAR, DataSet } from './ajax';
 import {Theme, Styles } from './theme';
-import { each, flatMap, flatten, flow, forEach, get, getOr, indexOf, uniq, values, find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq, every, pick, capitalize } from 'lodash/fp';
+import { each, flatMap, flatten, flow, forEach, get, getOr, indexOf, uniq, values, find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, sortedUniq, every, capitalize } from 'lodash/fp';
 import {User} from './ajax';
 
 export const UserProperties = {
@@ -804,25 +804,8 @@ export const evaluateTrueString = (boolString) => {
 //helper method for ResearcherInfo component in DAR application page
 export const completedResearcherInfoCheck = (properties) => {
   const {
-    piName,
-    isThePI,
-    havePI,
-    piEmail,
-    institutionId,
+    institutionId
   } = properties;
-
-  const piCheck = ({isThePI, havePI, piEmail, piName}) => {
-    //conditions listed are invalid checks
-    //if all are true, value returned MUST be false, since pi portion of the form is incomplete
-    const isThePIFalse = !evaluateTrueString(isThePI);
-    const havePITrue = evaluateTrueString(havePI);
-    const piAttrEmpty = isEmpty(piName) || isEmpty(piEmail);
-    return !(isThePIFalse && havePITrue && piAttrEmpty);
-  };
-
-  const stringAttrs = pick(['displayName', 'address1', 'city', 'state', 'zipCode', 'country'])(properties);
-  const stringAttrsCompleted = every((string) => !isEmpty(string))(stringAttrs);
   const institutionPresent = !isNil(institutionId);
-  const piValid = piCheck({isThePI, havePI, piEmail, piName});
-  return piValid && stringAttrsCompleted && institutionPresent;
+  return institutionPresent;
 };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -8,29 +8,6 @@ import { each, flatMap, flatten, flow, forEach, get, getOr, indexOf, uniq, value
 import {User} from './ajax';
 
 export const UserProperties = {
-  ACADEMIC_EMAIL: 'academicEmail',
-  ADDRESS1: 'address1',
-  ADDRESS2: 'address2',
-  CHECK_NOTIFICATIONS: 'checkNotifications',
-  CITY: 'city',
-  COMPLETED: 'completed',
-  COUNTRY: 'country',
-  DEPARTMENT: 'department',
-  DIVISION: 'division',
-  ERA_AUTHORIZED: 'eraAuthorized',
-  ERA_EXPIRATION: 'eraExpiration',
-  HAVE_PI: 'havePI',
-  IS_THE_PI: 'isThePI',
-  LINKEDIN : 'linkedIn',
-  ORCID: 'orcid',
-  PI_EMAIL: 'piEmail',
-  PI_NAME: 'piName',
-  PI_ERA_COMMONS_ID: 'piERACommonsID',
-  PUBMED_ID: 'pubmedID',
-  RESEARCHER_GATE: 'researcherGate',
-  SCIENTIFIC_URL: 'scientificURL',
-  STATE: 'state',
-  ZIPCODE: 'zipcode',
   SUGGESTED_SIGNING_OFFICIAL: 'suggestedSigningOfficial',
   SELECTED_SIGNING_OFFICIAL_ID: 'selectedSigningOfficialId',
   INSTITUTION_ID: 'institutionId',
@@ -119,30 +96,6 @@ export const findPropertyValue = (propName, researcher) => {
 
 export const getPropertyValuesFromUser = (user) => {
   let researcherProps = {
-    academicEmail: findPropertyValue(UserProperties.ACADEMIC_EMAIL, user),
-    address1: findPropertyValue(UserProperties.ADDRESS1, user),
-    address2: findPropertyValue(UserProperties.ADDRESS2, user),
-    department: findPropertyValue(UserProperties.DEPARTMENT, user),
-    division: findPropertyValue(UserProperties.DIVISION, user),
-    checkNotifications: findPropertyValue(UserProperties.CHECK_NOTIFICATIONS, user),
-    city: findPropertyValue(UserProperties.CITY, user),
-    country: findPropertyValue(UserProperties.COUNTRY, user),
-    completed: findPropertyValue(UserProperties.COMPLETED, user),
-    eraAuthorized: findPropertyValue(UserProperties.ERA_AUTHORIZED, user),
-    eraCommonsId: user.eraCommonsId,
-    eraExpiration: findPropertyValue(UserProperties.ERA_EXPIRATION, user),
-    havePI: findPropertyValue(UserProperties.HAVE_PI, user),
-    isThePI: findPropertyValue(UserProperties.IS_THE_PI, user),
-    linkedIn: findPropertyValue(UserProperties.LINKEDIN, user),
-    orcid: findPropertyValue(UserProperties.ORCID, user),
-    piName: findPropertyValue(UserProperties.IS_THE_PI, user) === 'true' ? user.displayName : findPropertyValue(UserProperties.PI_NAME, user),
-    piEmail: findPropertyValue(UserProperties.IS_THE_PI, user) === 'true' ? user.email : findPropertyValue(UserProperties.PI_EMAIL, user),
-    piERACommonsID: findPropertyValue(UserProperties.PI_ERA_COMMONS_ID, user),
-    pubmedID: findPropertyValue(UserProperties.PUBMED_ID, user),
-    researcherGate: findPropertyValue(UserProperties.RESEARCHER_GATE, user),
-    scientificURL: findPropertyValue(UserProperties.SCIENTIFIC_URL, user),
-    state: findPropertyValue(UserProperties.STATE, user),
-    zipcode: findPropertyValue(UserProperties.ZIPCODE, user),
     institutionId: findPropertyValue(UserProperties.INSTITUTION_ID, user),
     suggestedInstitution: findPropertyValue(UserProperties.SUGGESTED_INSTITUTION, user),
     selectedSigningOfficialId: findPropertyValue(UserProperties.SELECTED_SIGNING_OFFICIAL_ID, user),
@@ -814,6 +767,5 @@ export const completedResearcherInfoCheck = (properties) => {
   const {
     institutionId
   } = properties;
-  const institutionPresent = !isNil(institutionId);
-  return institutionPresent;
+  return !isNil(institutionId);
 };

--- a/src/pages/DataAccessRequestApplication.js
+++ b/src/pages/DataAccessRequestApplication.js
@@ -5,8 +5,6 @@ import DataAccessRequest from './dar_application/DataAccessRequest';
 import ResearchPurposeStatement from './dar_application/ResearchPurposeStatement';
 import DataUseAgreements from './dar_application/DataUseAgreements';
 import {
-  completedResearcherInfoCheck,
-  getPropertyValuesFromUser,
   isFileEmpty,
   Navigation,
   Notifications as NotyUtil
@@ -32,7 +30,6 @@ class DataAccessRequestApplication extends Component {
       file: {
         name: ''
       },
-      completed: '',
       showDialogSubmit: false,
       showDialogSave: false,
       step: 1,
@@ -210,30 +207,11 @@ class DataAccessRequestApplication extends Component {
       Storage.removeData('dar_application');
     }
 
-    let rpProperties = getPropertyValuesFromUser(researcher);
     formData.researcher = isNil(researcher) ? '' : researcher.displayName;
     formData.institution = isNil(researcher)  || isNil(researcher.institution)? '' : researcher.institution.name;
-    formData.department = rpProperties.department;
-    formData.division = rpProperties.division;
-    formData.address1 = rpProperties.address1;
-    formData.address2 = rpProperties.address2;
-    formData.city = rpProperties.city;
-    formData.zipCode = rpProperties.zipCode;
-    formData.country = rpProperties.country;
-    formData.state = rpProperties.state;
-    formData.academicEmail = rpProperties.academicEmail;
-    formData.pubmedId = rpProperties.pubmedID;
-    formData.scientificUrl = rpProperties.scientificURL;
     formData.userId = researcher.userId;
 
-    let completed = false;
-    if (!isNil(formData.darCode)) {
-      completed = '';
-    } else if (rpProperties.completed !== '') {
-      completed = completedResearcherInfoCheck(rpProperties);
-    }
     this.setState(prev => {
-      prev.completed = completed;
       prev.formData = merge(prev.formData, formData);
       return prev;
     });

--- a/src/pages/access_review/AppSummary.js
+++ b/src/pages/access_review/AppSummary.js
@@ -8,8 +8,6 @@ import { ApplicantInfo } from './ApplicantInfo';
 import { DownloadLink } from '../../components/DownloadLink';
 import { DataUseTranslation } from '../../libs/dataUseTranslation';
 import {isNil, isEmpty} from 'lodash/fp';
-import {findPropertyValue} from '../../libs/utils';
-import {UserProperties} from '../../libs/utils';
 
 const ROOT = {
   fontFamily: 'Arial',
@@ -68,13 +66,6 @@ export const AppSummary = hh(class AppSummary extends React.Component {
 
   render() {
     const { darInfo, accessElection, consent, researcherProfile } = this.props;
-    const isThePi = findPropertyValue(UserProperties.IS_THE_PI, researcherProfile);
-    const piName = isThePi === true ?
-      researcherProfile.displayName
-      : findPropertyValue(UserProperties.PI_NAME, researcherProfile);
-    const department = findPropertyValue(UserProperties.DEPARTMENT, researcherProfile);
-    const city = findPropertyValue(UserProperties.CITY, researcherProfile);
-    const country = findPropertyValue(UserProperties.COUNTRY, researcherProfile);
     const mrDAR = !isNil(accessElection) ? JSON.stringify(accessElection.useRestriction, null, 2) : null;
     const mrDUL = JSON.stringify(consent.useRestriction, null, 2);
     const translatedRestrictionsList = this.state.translatedRestrictions.map((restrictionObj, index) => {
@@ -139,11 +130,7 @@ export const AppSummary = hh(class AppSummary extends React.Component {
             researcherProfile: researcherProfile,
             institution: this.state.institution,
             content: {
-              principalInvestigator: piName,
               researcher: researcherProfile.displayName,
-              department,
-              city,
-              country
             },
           })]
         )


### PR DESCRIPTION
## Partially addresses 

https://broadworkbench.atlassian.net/browse/DUOS-1896

Basic frontend changes to ensure that https://github.com/DataBiosphere/consent/pull/1650 does not break the UI.

Checked the places user props were used and made sure it didn't break; made small changes if no nil checks. Created [new story](https://broadworkbench.atlassian.net/browse/DUOS-1936) to remove all references of outdated user props.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
