### PR TITLE
[DUOS-1918][risk=no] font/ui changes to voting pages

### DIFF
--- a/cypress/component/DataUseVoteSummary/data_use_vote_summary.spec.js
+++ b/cypress/component/DataUseVoteSummary/data_use_vote_summary.spec.js
@@ -2,10 +2,11 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import DataUseVoteSummary from '../../../src/components/common/DataUseVoteSummary/DataUseVoteSummary';
+import {rpVoteKey} from '../../../src/utils/DarCollectionUtils';
 
 const buckets = [
   {
-    key: 'RP Vote',
+    key: rpVoteKey,
     isRP: true,
     votes: [{
       rp: {
@@ -26,7 +27,7 @@ const buckets = [
 
 const bucketsWithMultipleElections = [
   {
-    key: 'RP Vote',
+    key: rpVoteKey,
     isRP: true,
     votes: [
       {
@@ -61,7 +62,7 @@ const bucketsWithMultipleElections = [
 
 const bucketsWithMixedVotes = [
   {
-    key: 'RP Vote',
+    key: rpVoteKey,
     isRP: true,
     votes: [{
       rp: {

--- a/cypress/component/DataUseVoteSummary/data_use_vote_summary.spec.js
+++ b/cypress/component/DataUseVoteSummary/data_use_vote_summary.spec.js
@@ -94,7 +94,7 @@ describe('DataUseVoteSummary - Tests', function() {
     component.should('exist');
     const rows = cy.get('.vote-summary-row');
     rows.should('have.length', 1);
-    const bucketResult1 = cy.get('.vote-result-box-text-RP-Vote');
+    const bucketResult1 = cy.get('.vote-result-box-text-RUS-Vote');
     bucketResult1.should('exist');
     const bucketResult2 = cy.get('.vote-result-box-text-Bucket-2');
     bucketResult2.should('exist');
@@ -122,7 +122,7 @@ describe('DataUseVoteSummary - Tests', function() {
       />
     );
 
-    cy.get('.vote-result-mixed-icon-RP-Vote').should('exist');
+    cy.get('.vote-result-mixed-icon-RUS-Vote').should('exist');
     cy.get('.vote-result-mixed-icon-Bucket-2').should('exist');
   });
 
@@ -136,7 +136,7 @@ describe('DataUseVoteSummary - Tests', function() {
       />
     );
 
-    cy.get('.vote-result-mixed-icon-RP-Vote').should('exist');
+    cy.get('.vote-result-mixed-icon-RUS-Vote').should('exist');
     cy.get('.vote-result-mixed-icon-Bucket-2').should('exist');
   });
 
@@ -150,7 +150,7 @@ describe('DataUseVoteSummary - Tests', function() {
       />
     );
 
-    cy.get('.vote-result-mixed-icon-RP-Vote').should('exist');
+    cy.get('.vote-result-mixed-icon-RUS-Vote').should('exist');
     cy.get('.vote-result-mixed-icon-Bucket-2').should('exist');
   });
 });

--- a/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
@@ -214,7 +214,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
         adminPage={false}
       />
     );
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', ' YES');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'YES');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
   });

--- a/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
@@ -27,7 +27,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
         adminPage={false}
       />
     );
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote*');
+    cy.get('[datacy=vote-subsection-heading]').should('not.be.visible');
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.yes);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
   });
@@ -41,7 +41,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
         adminPage={false}
       />
     );
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote*');
+    cy.get('[datacy=vote-subsection-heading]').should('not.be.visible');
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
   });
@@ -196,7 +196,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
     );
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote*(Vote and Rationale cannot be updated after submitting)');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', '(Vote and Rationale cannot be updated after submitting)');
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').click();

--- a/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.js
@@ -200,7 +200,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').click();
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NO');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NO');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
   });
@@ -214,7 +214,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
         adminPage={false}
       />
     );
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: YES');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', ' YES');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
   });
@@ -250,7 +250,7 @@ describe('CollectionSubmitVoteBox - Tests', function() {
     );
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NOT SELECTED');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NOT SELECTED');
     cy.get('textarea').should('be.disabled');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -128,7 +128,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: YES');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'YES');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');
@@ -176,7 +176,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('textarea').should('not.be.disabled');
     cy.get('[datacy=no-collection-vote-button]').click();
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NO');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NO');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');
@@ -197,7 +197,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NOT SELECTED');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NOT SELECTED');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');
@@ -218,7 +218,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NOT SELECTED');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NOT SELECTED');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');
@@ -239,7 +239,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: YES');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'YES');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');
@@ -261,7 +261,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NO');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NO');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -120,7 +120,7 @@ beforeEach(() => {
 });
 
 describe('MultiDatasetVoteTab - Tests', function() {
-  it('Renders srp slab', function () {
+  it('Renders rp slab', function () {
     mount(
       <MultiDatasetVotingTab
         darInfo={darInfo}
@@ -130,8 +130,8 @@ describe('MultiDatasetVoteTab - Tests', function() {
       />
     );
 
-    cy.get('[datacy=srp-slab]').should('be.visible');
-    cy.get('[datacy=srp-expanded]').should('not.exist');
+    cy.get('[datacy=rp-slab]').should('be.visible');
+    cy.get('[datacy=rp-expanded]').should('not.exist');
     cy.contains('primary');
     cy.contains('DS');
   });

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -5,6 +5,7 @@ import {Storage} from '../../../src/libs/storage';
 import {User} from '../../../src/libs/ajax';
 import MultiDatasetVotingTab, {votingColors} from '../../../src/pages/dar_collection_review/MultiDatasetVotingTab';
 import {filterBucketsForUser} from '../../../src/pages/dar_collection_review/DarCollectionReview';
+import {rpVoteKey} from '../../../src/utils/DarCollectionUtils';
 
 const darInfo = {
   rus: 'test',
@@ -227,7 +228,7 @@ describe('MultiDatasetVoteTab - Tests', function() {
 describe('filterBucketsForUser - Tests', function() {
   it('Filters out buckets if current user has no votes in it', function () {
     const currentUser = {userId: 100};
-    const rpBucket = {isRP: true, key: 'RP Vote'};
+    const rpBucket = {isRP: true, key: rpVoteKey};
     const prefilteredBuckets = [rpBucket, bucket1, bucket2];
 
     const filteredBuckets = filterBucketsForUser(currentUser, prefilteredBuckets);

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -133,7 +133,6 @@ describe('MultiDatasetVoteTab - Tests', function() {
 
     cy.get('[datacy=rp-slab]').should('be.visible');
     cy.get('[datacy=rp-expanded]').should('not.exist');
-    cy.contains('primary');
     cy.contains('DS');
   });
 

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -20,6 +20,9 @@ const darInfoPrimarySecondaryUse = {
   'illegalBehavior': true
 };
 
+const primaryUseCode = primaryUseCode;
+const secondaryUseCode = secondaryUseCode;
+
 const votesForElection1 = {
   rp: {
     finalVotes: [
@@ -84,8 +87,8 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         darInfo={darInfoPrimaryUseManualReviewFalse}
       />
     );
-    cy.contains('primary');
-    cy.get('secondary').should('not.exist');
+    cy.contains(primaryUseCode);
+    cy.get(secondaryUseCode).should('not.exist');
   });
 
   it('Renders secondary data use pill', function() {
@@ -94,8 +97,8 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         darInfo={darInfoSecondaryUseManualReviewTrue}
       />
     );
-    cy.contains('secondary');
-    cy.get('primary').should('not.exist');
+    cy.contains(secondaryUseCode);
+    cy.get(primaryUseCode).should('not.exist');
   });
 
   it('Renders primary and secondary data use pills', function() {
@@ -104,8 +107,8 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         darInfo={darInfoPrimarySecondaryUse}
       />
     );
-    cy.contains('primary');
-    cy.contains('secondary');
+    cy.contains(primaryUseCode);
+    cy.contains(secondaryUseCode);
   });
 
   it('Renders link to expand when collapsed', function() {
@@ -138,8 +141,8 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     const link = cy.contains('Expand to view Research Purpose and Vote');
     link.click();
-    cy.contains('primary');
-    cy.contains('secondary');
+    cy.contains(primaryUseCode);
+    cy.contains(secondaryUseCode);
   });
 
   it('Renders research purpose when expanded', function() {
@@ -206,8 +209,8 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         isLoading={true}
       />
     );
-    cy.get('primary').should('not.exist');
-    cy.get('secondary').should('not.exist');
+    cy.get(primaryUseCode).should('not.exist');
+    cy.get(secondaryUseCode).should('not.exist');
   });
 
   it('Does not render link to expand/collapse when loading', function() {

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -20,8 +20,8 @@ const darInfoPrimarySecondaryUse = {
   'illegalBehavior': true
 };
 
-const primaryUseCode = primaryUseCode;
-const secondaryUseCode = secondaryUseCode;
+const primaryUseCode = 'primaryUseCode';
+const secondaryUseCode = 'secondaryUseCode';
 
 const votesForElection1 = {
   rp: {

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -351,7 +351,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     const link = cy.contains('Expand to view Research Purpose and Vote');
     link.click();
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NOT SELECTED');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NOT SELECTED');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');
@@ -373,7 +373,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     const link = cy.contains('Expand to view Research Purpose and Vote');
     link.click();
 
-    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'Your Vote: NO');
+    cy.get('[datacy=vote-subsection-heading]').should('have.text', 'NO');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
     cy.get('[datacy=no-collection-vote-button]').should('not.exist');
     cy.get('textarea').should('be.disabled');

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -20,8 +20,8 @@ const darInfoPrimarySecondaryUse = {
   'illegalBehavior': true
 };
 
-const primaryUseCode = 'primaryUseCode';
-const secondaryUseCode = 'secondaryUseCode';
+const primaryUseCode = 'DS';
+const secondaryUseCode = 'OTHER';
 
 const votesForElection1 = {
   rp: {

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -74,8 +74,8 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         darInfo={darInfoPrimaryUseManualReviewFalse}
       />
     );
-    cy.get('[datacy=srp-slab]').should('be.visible');
-    cy.get('[datacy=srp-expanded]').should('not.exist');
+    cy.get('[datacy=rp-slab]').should('be.visible');
+    cy.get('[datacy=rp-expanded]').should('not.exist');
   });
 
   it('Renders primary data use pill', function() {

--- a/cypress/component/utils/dar_collection_utils.spec.js
+++ b/cypress/component/utils/dar_collection_utils.spec.js
@@ -675,7 +675,7 @@ describe('getMatchDataForBuckets', () => {
     const buckets = cloneDeep(mockBuckets);
     await getMatchDataForBuckets(buckets);
     buckets.forEach(bucket => {
-      if(bucket.key.toLowerCase() !== rpVoteKey) {
+      if(bucket.key.toLowerCase() !== rpVoteKey.toLowerCase()) {
         const {algorithmResult} = bucket;
         expect(algorithmResult).to.not.be.empty;
         expect(algorithmResult.result).to.equal('Yes');
@@ -690,7 +690,7 @@ describe('getMatchDataForBuckets', () => {
     const buckets = cloneDeep(mockBuckets);
     await getMatchDataForBuckets(buckets);
     buckets.forEach(bucket => {
-      if(bucket.key.toLowerCase() !== rpVoteKey) {
+      if(bucket.key.toLowerCase() !== rpVoteKey.toLowerCase()) {
         const {algorithmResult} = bucket;
         expect(algorithmResult).to.not.be.empty;
         expect(algorithmResult.result).to.equal('N/A');

--- a/cypress/component/utils/dar_collection_utils.spec.js
+++ b/cypress/component/utils/dar_collection_utils.spec.js
@@ -675,7 +675,7 @@ describe('getMatchDataForBuckets', () => {
     const buckets = cloneDeep(mockBuckets);
     await getMatchDataForBuckets(buckets);
     buckets.forEach(bucket => {
-      if(bucket.key.toLowerCase() !== 'rp vote') {
+      if(bucket.key.toLowerCase() !== rpVoteKey) {
         const {algorithmResult} = bucket;
         expect(algorithmResult).to.not.be.empty;
         expect(algorithmResult.result).to.equal('Yes');

--- a/cypress/component/utils/dar_collection_utils.spec.js
+++ b/cypress/component/utils/dar_collection_utils.spec.js
@@ -101,7 +101,7 @@ const openableDars = {
 
 const mockBuckets = [
   {
-    key: 'RP Vote',
+    key: rpVoteKey,
     isRP: true
   },
   {
@@ -690,7 +690,7 @@ describe('getMatchDataForBuckets', () => {
     const buckets = cloneDeep(mockBuckets);
     await getMatchDataForBuckets(buckets);
     buckets.forEach(bucket => {
-      if(bucket.key.toLowerCase() !== 'rp vote') {
+      if(bucket.key.toLowerCase() !== rpVoteKey) {
         const {algorithmResult} = bucket;
         expect(algorithmResult).to.not.be.empty;
         expect(algorithmResult.result).to.equal('N/A');

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -152,7 +152,7 @@ export default function CollectionSubmitVoteBox(props) {
           textarea({
             name: 'Rationale Input',
             value: rationale,
-            placeholder: 'Optional: Describe your rationale or add comments here',
+            placeholder: 'Optional: Describe your rationale or add comments here. Enter your comments prior to voting.',
             onChange: e => setRationale(e.target.value),
             onBlur: updateRationale,
             style: styles.rationaleTextArea,

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -151,7 +151,7 @@ export default function CollectionSubmitVoteBox(props) {
           textarea({
             name: 'Rationale Input',
             value: rationale,
-            placeholder: 'Optional: Describe your rationale or add comments here. Enter your comments prior to voting.',
+            placeholder: 'Optional: Enter your comments and describe your rationale prior to voting.',
             onChange: e => setRationale(e.target.value),
             onBlur: updateRationale,
             style: styles.rationaleTextArea,

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -20,7 +20,8 @@ const styles = {
   },
   content: {
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
+    columnGap: '5rem',
     padding: '0 15px'
   },
   subsection: {
@@ -53,11 +54,9 @@ const VoteSubsectionHeading = ({ vote, adminPage, isFinal, isVotingDisabled }) =
     heading = isNil(vote) ?
       'The vote has not been finalized' :
       `The final vote is: ${voteResultText}`;
-  } else {
-    // if read-only, describe the vote in a statement; otherwise prompt the user to vote
-    heading = isVotingDisabled ?
-      `Your Vote: ${voteResultText}` :
-      'Your Vote*';
+  } else if (isVotingDisabled) {
+    // if read-only, describe the vote in a statement
+    heading = `Your Vote: ${voteResultText}`;
   }
 
   // determines if text is needed to remind the user that their vote will be final once submitting

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.js
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.js
@@ -55,8 +55,8 @@ const VoteSubsectionHeading = ({ vote, adminPage, isFinal, isVotingDisabled }) =
       'The vote has not been finalized' :
       `The final vote is: ${voteResultText}`;
   } else if (isVotingDisabled) {
-    // if read-only, describe the vote in a statement
-    heading = `Your Vote: ${voteResultText}`;
+    // if read-only, describe the vote
+    heading = voteResultText;
   }
 
   // determines if text is needed to remind the user that their vote will be final once submitting

--- a/src/components/collection_voting_slab/DataUsePill.js
+++ b/src/components/collection_voting_slab/DataUsePill.js
@@ -1,5 +1,6 @@
 import {div, span} from 'react-hyperscript-helpers';
 import {isNil} from 'lodash';
+import {map} from 'lodash/fp';
 
 const styles = {
   baseStyle: {
@@ -28,11 +29,20 @@ const styles = {
 };
 
 
-export default function DataUsePill(props) {
+export function DataUsePill(props) {
   const {dataUse} = props;
 
   return div({key: `data_use_pill_${dataUse.code}`, style: styles.baseStyle}, [
     span({ style: styles.code }, !isNil(dataUse) ? [dataUse.code] : []),
     span({ style: styles.description }, !isNil(dataUse) ? [dataUse.description] : [])
   ]);
+}
+
+export function DataUsePills(dataUses){
+  return map( dataUse => {
+    return DataUsePill({
+      dataUse,
+      key: dataUse.code
+    });
+  })(dataUses);
 }

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
@@ -4,7 +4,7 @@ import {filter, flatMap, flow, map, isNil, isEmpty, get, includes, every, toLowe
 import {Storage} from '../../libs/storage';
 import {useEffect, useState} from 'react';
 import DatasetsRequestedPanel from './DatasetsRequestedPanel';
-import {ChairVoteInfo, dataUsePills} from './ResearchProposalVoteSlab';
+import {ChairVoteInfo} from './ResearchProposalVoteSlab';
 import {
   extractDacDataAccessVotesFromBucket,
   extractDatasetIdsFromBucket,
@@ -13,6 +13,7 @@ import {
 import {Alert} from '../Alert';
 import {ScrollToTopButton} from '../ScrollButton';
 import {convertLabelToKey} from '../../libs/utils';
+import {DataUsePills} from './DataUsePill';
 
 const styles = {
   baseStyle: {
@@ -67,7 +68,7 @@ export default function MultiDatasetVoteSlab(props) {
   const DataUseSummary = () => {
     const dataUses = get('dataUses')(bucket);
     return !isNil(dataUses)
-      ? div({style: styles.dataUses}, [dataUsePills(dataUses)])
+      ? div({style: styles.dataUses}, [DataUsePills(dataUses)])
       : div();
   };
 

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -95,11 +95,7 @@ const animationAttributes = {
 const DataUseSummary = ({translatedDataUse}) => {
   return flatMap( key => {
     const dataUses = translatedDataUse[key];
-    const label = span({style: styles.dataUseCategoryLabel, isRendered: !isEmpty(dataUses)}, [key + ':']);
-    return div({key: `data-use-${key}-container`}, [
-      label,
-      dataUsePills(dataUses)
-    ]);
+    return dataUsePills(dataUses);
   })(keys(translatedDataUse));
 };
 

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -21,6 +21,7 @@ import {ScrollToTopButton} from '../ScrollButton';
 const styles = {
   baseStyle: {
     fontFamily: 'Montserrat',
+    paddingBottom: '35px'
   },
   slabTitle: {
     color: '#000000',

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -2,7 +2,7 @@ import {useEffect, useState} from 'react';
 import {a, div, h, span} from 'react-hyperscript-helpers';
 import {DataUseTranslation} from '../../libs/dataUseTranslation';
 import {isEmpty, isNil, flatMap, map, keys, get} from 'lodash/fp';
-import DataUsePill from './DataUsePill';
+import {DataUsePill, DataUsePills} from './DataUsePill';
 import DataUseAlertBox from './DataUseAlertBox';
 import {AnimatePresence, motion} from 'framer-motion';
 import CollectionSubmitVoteBox from '../collection_vote_box/CollectionSubmitVoteBox';
@@ -95,17 +95,8 @@ const animationAttributes = {
 const DataUseSummary = ({translatedDataUse}) => {
   return flatMap( key => {
     const dataUses = translatedDataUse[key];
-    return dataUsePills(dataUses);
+    return DataUsePills(dataUses);
   })(keys(translatedDataUse));
-};
-
-export const dataUsePills = (dataUses) => {
-  return map( dataUse => {
-    return DataUsePill({
-      dataUse,
-      key: dataUse.code
-    });
-  })(dataUses);
 };
 
 const SkeletonLoader = () => {

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -1,8 +1,8 @@
 import {useEffect, useState} from 'react';
 import {a, div, h, span} from 'react-hyperscript-helpers';
 import {DataUseTranslation} from '../../libs/dataUseTranslation';
-import {isEmpty, isNil, flatMap, map, keys, get} from 'lodash/fp';
-import {DataUsePill, DataUsePills} from './DataUsePill';
+import {isEmpty, isNil, flatMap, keys, get} from 'lodash/fp';
+import {DataUsePills} from './DataUsePill';
 import DataUseAlertBox from './DataUseAlertBox';
 import {AnimatePresence, motion} from 'framer-motion';
 import CollectionSubmitVoteBox from '../collection_vote_box/CollectionSubmitVoteBox';

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -185,9 +185,9 @@ export default function ResearchProposalVoteSlab(props) {
     setCurrentUserVotes(extractUserRPVotesFromBucket(bucket, user, isChair, adminPage));
   }, [bucket, isChair, adminPage]);
 
-  return div({ datacy: 'srp-slab', style: styles.baseStyle }, [
+  return div({ datacy: 'rp-slab', style: styles.baseStyle }, [
     div({ style: styles.slabTitle, id: convertLabelToKey(get('key')(bucket)) }, [
-      'Structured Research Purpose',
+      'Research Use Statement (GA4GH DUO)',
       h(ScrollToTopButton, {to: '.header-container'})
     ]),
     div({ isRendered: isLoading, className: 'text-placeholder', style: {height: '100px'}} ),
@@ -203,9 +203,9 @@ export default function ResearchProposalVoteSlab(props) {
       h(AnimatePresence, { initial: false }, [
         expanded && (
           h(motion.section, animationAttributes, [
-            div({ datacy: 'srp-expanded', style: styles.expandedData }, [
+            div({ datacy: 'rp-expanded', style: styles.expandedData }, [
               div({ datacy: 'research-purpose' }, [
-                span({ style: styles.researchPurposeTitle }, ['Research Purpose']),
+                span({ style: styles.researchPurposeTitle }, ['Research Use Statement (Narrative)']),
                 h(ResearchPurposeSummary, {darInfo}),
                 h(DataUseAlertBox, {translatedDataUse}),
                 h(CollectionSubmitVoteBox, {

--- a/src/components/common/DataUseVoteSummary/DataUseVoteSummary.js
+++ b/src/components/common/DataUseVoteSummary/DataUseVoteSummary.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { h, div } from 'react-hyperscript-helpers';
+import {h, div, span} from 'react-hyperscript-helpers';
 import {chunk, map, range} from 'lodash/fp';
 import ReactTooltip from 'react-tooltip';
 import VoteResultBox from './VoteResultBox';
@@ -42,7 +42,16 @@ export default function DataUseVoteSummary({dataUseBuckets, currentUser, isLoadi
   //convert is once again used here to provide unique key identifier for the row
   //necessary for React when rendering elements provided by an array
   const rowTemplate = map.convert({cap:false})((row, index) =>
-    div({ style: { display: 'flex', justifyContent: 'flex-start', flexWrap: 'wrap' }, className: 'vote-summary-row', key: `summary-row-${index}` }, elementTemplate(row))
+    div({
+      className: 'vote-summary-row', key: `summary-row-${index}`,
+      style: {
+        display: 'flex',
+        justifyContent: 'flex-start',
+        flexWrap: 'wrap',
+        margin: '1% 0'
+      }
+    },
+    elementTemplate(row))
   );
 
   const elementTemplate = (row = []) => {
@@ -81,9 +90,9 @@ export default function DataUseVoteSummary({dataUseBuckets, currentUser, isLoadi
 
   return !isLoading ?
     div({
-      className: 'vote-summary-header-component',
-      style: {margin: '1% 0'}
+      className: 'vote-summary-header-component'
     }, [
+      span({style: {color: '#777777'}}, ['Final Vote Summary']),
       rowTemplate(chunkedBuckets),
       h(ReactTooltip, {
         id: 'vote-result',

--- a/src/components/common/DataUseVoteSummary/DataUseVoteSummary.js
+++ b/src/components/common/DataUseVoteSummary/DataUseVoteSummary.js
@@ -48,7 +48,7 @@ export default function DataUseVoteSummary({dataUseBuckets, currentUser, isLoadi
         display: 'flex',
         justifyContent: 'flex-start',
         flexWrap: 'wrap',
-        margin: '1% 0'
+        margin: '0.5% 0'
       }
     },
     elementTemplate(row))

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -88,7 +88,7 @@ export default function MultiDatasetVotingTab(props) {
   };
 
   return div({style: styles.baseStyle}, [
-    div({style: styles.title}, ['Research Proposal']),
+    div({style: styles.title}, ['Research Use Statement']),
     Alert({
       type: 'danger',
       title: missingLibraryCardMessage,

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.js
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.js
@@ -28,7 +28,7 @@ const styles = {
     fontFamily: 'Montserrat',
     fontSize: '2.4rem',
     fontWeight: 'bold',
-    marginBottom: '10px'
+    paddingBottom: '20px'
   }
 };
 
@@ -41,7 +41,7 @@ export default function MultiDatasetVotingTab(props) {
   const missingLibraryCardMessage = 'The Researcher must have a Library Card before data access can be granted.\n' +
     (!adminPage ? 'You can still deny this request and/or vote on the Structured Research Purpose.' : '');
 
-  useEffect( () => {
+  useEffect(() => {
     setCollectionDatasets(get('datasets')(collection));
     setRpBucket(find(bucket => get('isRP')(bucket))(buckets));
     setDataBuckets(filter(bucket => get('isRP')(bucket) !== true)(buckets));
@@ -62,7 +62,7 @@ export default function MultiDatasetVotingTab(props) {
   const DatasetVoteSlabs = () => {
     const isApprovalDisabled = dataAccessApprovalDisabled();
     return map(bucket => {
-      return h(MultiDatasetVoteSlab,{
+      return h(MultiDatasetVoteSlab, {
         title: bucket.key,
         bucket,
         dacDatasetIds,
@@ -95,17 +95,18 @@ export default function MultiDatasetVotingTab(props) {
       id: 'missing_lc',
       isRendered: dataAccessApprovalDisabled() && !readOnly
     }),
+    h(ResearchProposalVoteSlab, {
+      updateFinalVote,
+      darInfo,
+      bucket: rpBucket,
+      key: 'rp-vote',
+      isChair,
+      isLoading,
+      readOnly,
+      adminPage,
+    }),
+    div({style: styles.title}, ['Datasets Requested by Data Use']),
     div({style: styles.slabs}, [
-      h(ResearchProposalVoteSlab, {
-        updateFinalVote,
-        darInfo,
-        bucket: rpBucket,
-        key: 'rp-vote',
-        isChair,
-        isLoading,
-        readOnly,
-        adminPage,
-      }),
       DatasetVoteSlabs()
     ])
   ]);

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -261,7 +261,7 @@ export const getMatchDataForBuckets = async (buckets) => {
   forEach((bucket) => {
     const {key, elections = []} = bucket;
     let dataAccessReferenceId;
-    if(toLower(key) !== 'rp vote') {
+    if(toLower(key) !== rpVoteKey) {
       elections.every((darElections = []) => {
         dataAccessReferenceId = (
           find(election => toLower(election.electionType) === 'dataaccess')(darElections) || {}

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -24,7 +24,7 @@ import { formatDate, Notifications } from '../libs/utils';
 import { Collections, Match } from '../libs/ajax';
 import { processMatchData } from './VoteUtils';
 
-export const rpVoteKey = 'RP Vote';
+export const rpVoteKey = 'RUS Vote';
 
 //Initial step, organizes raw data for further processing in later function/steps
 export const generatePreProcessedBucketData = async ({dars, datasets}) => {

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -261,7 +261,7 @@ export const getMatchDataForBuckets = async (buckets) => {
   forEach((bucket) => {
     const {key, elections = []} = bucket;
     let dataAccessReferenceId;
-    if(toLower(key) !== rpVoteKey) {
+    if(toLower(key) !== toLower(rpVoteKey)) {
       elections.every((darElections = []) => {
         dataAccessReferenceId = (
           find(election => toLower(election.electionType) === 'dataaccess')(darElections) || {}


### PR DESCRIPTION
Addresses [DUOS-1918](https://broadworkbench.atlassian.net/browse/DUOS-1918)
Changes:
(Notes from Miro)
- Add title "Final Vote Summary" in lightweight grey above `DataUseVoteSummary` header 
- Change "RP" to "RUS" in RP Vote `VoteResultBox` of `DataUseVoteSummary` header 
- Change "Research Proposal" heading of `MultiDatasetVotingTab` to "Research Use Statement"
- Change "Structured Research Purpose" on `ResearchProposalVoteSlab` to "Research Use Statement (GA4GH DUO)"
- Remove "Primary" and "Secondary" labels to data use pills 
- Change "Research Purpose" subheading of `ResearchProposalVoteSlab` to Research Use Statement (Narrative)
- Remove 'Your Vote' text above voting buttons 
- Add "Enter your comments prior to voting" to rationale text box 
- Add: "Datasets Requested by Data Use" above dataset slabs in same format as 'Research Proposal' from the top of the page 

Changes not on Miro board comments:
-  changed dataCy fields containing srp to rp since "Structured Research Purpose" is no longer a term being used 
- moved function that mapped data uses to data use pills from `ResearchProposalVoteSlab` file to `DataUsePill` file since used by both `ResearchProposalVoteSlab` and `MultiDatasetVoteSlab` components 
- use rpVoteKey consistently rather than comparing against a string 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
