### PR TITLE
[DUOS-1922][risk=no] refactor UI partial dar code logic

### DIFF
--- a/src/components/dar_drafts_table/DarDraftTable.js
+++ b/src/components/dar_drafts_table/DarDraftTable.js
@@ -155,7 +155,8 @@ const processDraftsRowData = ({visibleDrafts, showConfirmationModal, history}) =
   if(!isEmpty(visibleDrafts)) {
     return visibleDrafts.map((draft) => {
       const { id, data, createDate, updateDate } = draft;
-      const { projectTitle, partialDarCode } = !isEmpty(data) ? data : {};
+      const { projectTitle } = !isEmpty(data) ? data : {};
+      const partialDarCode = 'DRAFT_DAR_' + formatDate(createDate);
       return [
         partialDarCodeCell({partialDarCode, id}),
         projectTitleCell({projectTitle, id}),

--- a/src/pages/NewResearcherConsole.js
+++ b/src/pages/NewResearcherConsole.js
@@ -5,21 +5,22 @@ import { Styles } from '../libs/theme';
 import { Collections, DAR } from '../libs/ajax';
 import { DarCollectionTableColumnOptions, DarCollectionTable } from '../components/dar_collection_table/DarCollectionTable';
 import accessIcon from '../images/icon_access.png';
-import { Notifications, searchOnFilteredList, getSearchFilterFunctions } from '../libs/utils';
+import {Notifications, searchOnFilteredList, getSearchFilterFunctions, formatDate} from '../libs/utils';
 import SearchBar from '../components/SearchBar';
 import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 const formatDraft = (draft) => {
   const { data, referenceId, id } = draft;
   const {
-    partialDarCode,
     projectTitle,
     datasets,
     institution,
+    createDate
   } = data;
+  const darCode = 'DRAFT_DAR_' + formatDate(createDate);
 
   const output =  {
-    darCode: replace('temp', 'DRAFT')(partialDarCode),
+    darCode,
     referenceId,
     darCollectionId: id,
     projectTitle,

--- a/src/pages/NewResearcherConsole.js
+++ b/src/pages/NewResearcherConsole.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { div, h, img } from 'react-hyperscript-helpers';
-import {cloneDeep, map, findIndex, isEmpty, flow, concat, replace} from 'lodash/fp';
+import {cloneDeep, map, findIndex, isEmpty, flow, concat} from 'lodash/fp';
 import { Styles } from '../libs/theme';
 import { Collections, DAR } from '../libs/ajax';
 import { DarCollectionTableColumnOptions, DarCollectionTable } from '../components/dar_collection_table/DarCollectionTable';
@@ -10,12 +10,11 @@ import SearchBar from '../components/SearchBar';
 import { consoleTypes } from '../components/dar_table/DarTableActions';
 
 const formatDraft = (draft) => {
-  const { data, referenceId, id } = draft;
+  const { data, referenceId, id, createDate } = draft;
   const {
     projectTitle,
     datasets,
     institution,
-    createDate
   } = data;
   const darCode = 'DRAFT_DAR_' + formatDate(createDate);
 

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -312,7 +312,7 @@ class ResearcherConsole extends Component {
 
                 this.state.partialDars.slice((currentPartialDarPage - 1) * partialDarLimit, currentPartialDarPage * partialDarLimit).map((pdar, idx) => {
                   const formattedCreateDate = formatDate(pdar.dar.createDate);
-                  const partialDarCode = 'temp_DAR_' + formattedCreateDate;
+                  const partialDarCode = 'DRAFT_DAR_' + formattedCreateDate;
                   return h(Fragment, { key: partialDarCode + '_' + idx }, [
                     div({ key: partialDarCode, id: partialDarCode, className: 'row no-margin tableRowPartial' }, [
                       a({

--- a/src/pages/ResearcherConsole.js
+++ b/src/pages/ResearcherConsole.js
@@ -1,6 +1,5 @@
 import { Component, Fragment } from 'react';
 import { div, button, hr, a, span, h } from 'react-hyperscript-helpers';
-import * as Utils from '../libs/utils';
 import { PageHeading } from '../components/PageHeading';
 import { PageSubHeading } from '../components/PageSubHeading';
 import { PaginatorBar } from '../components/PaginatorBar';
@@ -11,7 +10,7 @@ import { Link } from 'react-router-dom';
 import { Theme } from '../libs/theme';
 import accessIcon from '../images/icon_access.png';
 import {find, getOr, isNil} from 'lodash/fp';
-import {USER_ROLES, wasFinalVoteTrue} from '../libs/utils';
+import {formatDate, getColumnSort, USER_ROLES, wasFinalVoteTrue} from '../libs/utils';
 
 class ResearcherConsole extends Component {
 
@@ -64,7 +63,7 @@ class ResearcherConsole extends Component {
     });
   };
 
-  sortDars = Utils.getColumnSort(() => { return this.state ? this.state.dars: []; }, (sortedData, descendantOrder) => {
+  sortDars = getColumnSort(() => { return this.state ? this.state.dars: []; }, (sortedData, descendantOrder) => {
     this.setState(prev => {
       prev.dars = sortedData;
       prev.darDescOrder = !descendantOrder;
@@ -72,7 +71,7 @@ class ResearcherConsole extends Component {
     });
   });
 
-  sortPartials = Utils.getColumnSort(() => { return this.state ? this.state.partialDars: []; }, (sortedData, descendantOrder) => {
+  sortPartials = getColumnSort(() => { return this.state ? this.state.partialDars: []; }, (sortedData, descendantOrder) => {
     this.setState(prev => {
       prev.partialDars = sortedData;
       prev.partialDescOrder = !descendantOrder;
@@ -238,7 +237,7 @@ class ResearcherConsole extends Component {
                   div({ key: darInfo.dar.data.darCode, id: darInfo.dar.data.darCode, className: 'row no-margin tableRow' }, [
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + '_darId', name: 'darId', className: 'col-xs-2' }, [darInfo.dar.data.darCode]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + '_projectTitle', name: 'projectTitle', className: 'col-xs-4' }, [darInfo.dar.data.projectTitle]),
-                    div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + '_createDate', name: 'createDate', className: 'col-xs-2' }, [Utils.formatDate(darInfo.dar.createDate)]),
+                    div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + '_createDate', name: 'createDate', className: 'col-xs-2' }, [formatDate(darInfo.dar.createDate)]),
                     div({ style: Theme.textTableBody, id: darInfo.dar.data.darCode + '_electionStatus', name: 'electionStatus', className: 'col-xs-2 bold f-center' }, [
                       span({ isRendered: !opened && !canceled}, ['Submitted']),
                       span({ isRendered: opened && !canceled ? darInfo.election.status === 'Open' || darInfo.election.status === 'Final' || darInfo.election.status === 'PendingApproval' : false}, ['In review']),
@@ -312,10 +311,12 @@ class ResearcherConsole extends Component {
                 hr({ className: 'table-head-separator' }),
 
                 this.state.partialDars.slice((currentPartialDarPage - 1) * partialDarLimit, currentPartialDarPage * partialDarLimit).map((pdar, idx) => {
-                  return h(Fragment, { key: pdar.dar.data.partialDarCode + '_' + idx }, [
-                    div({ key: pdar.dar.data.partialDarCode, id: pdar.dar.data.partialDarCode, className: 'row no-margin tableRowPartial' }, [
+                  const formattedCreateDate = formatDate(pdar.dar.createDate);
+                  const partialDarCode = 'temp_DAR_' + formattedCreateDate;
+                  return h(Fragment, { key: partialDarCode + '_' + idx }, [
+                    div({ key: partialDarCode, id: partialDarCode, className: 'row no-margin tableRowPartial' }, [
                       a({
-                        id: pdar.dar.data.partialDarCode + '_btnDelete',
+                        id: partialDarCode + '_btnDelete',
                         name: 'btn_delete',
                         className: 'col-xs-1 cell-body delete-dar default-color',
                         onClick: this.deletePartialDar,
@@ -324,12 +325,12 @@ class ResearcherConsole extends Component {
                         span({ className: 'cm-icon-button glyphicon glyphicon-trash caret-margin', 'aria-hidden': 'true', value: pdar.dar.referenceId }),
                       ]),
 
-                      div({ style: Theme.textTableBody, id: pdar.dar.data.partialDarCode + '_partialId', name: 'partialId', className: 'col-xs-2' }, [pdar.dar.data.partialDarCode]),
-                      div({ style: Theme.textTableBody, id: pdar.dar.data.partialDarCode + '_partialTitle', name: 'partialTitle', className: 'col-xs-5' }, [pdar.dar.data.projectTitle]),
-                      div({ style: Theme.textTableBody, id: pdar.dar.data.partialDarCode + '_partialDate', name: 'partialDate', className: 'col-xs-2' }, [Utils.formatDate(pdar.dar.createDate)]),
+                      div({ style: Theme.textTableBody, id: partialDarCode + '_partialId', name: 'partialId', className: 'col-xs-2' }, [partialDarCode]),
+                      div({ style: Theme.textTableBody, id: partialDarCode + '_partialTitle', name: 'partialTitle', className: 'col-xs-5' }, [pdar.dar.data.projectTitle]),
+                      div({ style: Theme.textTableBody, id: partialDarCode + '_partialDate', name: 'partialDate', className: 'col-xs-2' }, [formattedCreateDate]),
                       div({className: 'col-xs-2 cell-body f-center' }, [
                         button({
-                          id: pdar.dar.data.partialDarCode + '_btnResume',
+                          id: partialDarCode + '_btnResume',
                           name: 'btn_resume',
                           className: 'cell-button hover-color',
                         }, [


### PR DESCRIPTION
Addresses [DUOS-1922](https://broadworkbench.atlassian.net/browse/DUOS-1922)
Changes:
- Refactor `NewResearcherConsole` and `ResearcherConsole` to calculate partialDarCode from `createDate` rather than pulling it from `dar.data.partialDarCode`
- Also found `DarDraftTable` using partialDarCode and switched that out (although this table isn't in use)
- Remove * import from `ResearcherConsole`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
