### PR TITLE
DUOS-1938[risk=no] Updated dar.data.datasetId references in bucketing logic

### DIFF
--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -68,7 +68,7 @@ export const generatePreProcessedBucketData = async ({dars, datasets}) => {
   });
 
   forEach((dar) => {
-    const darDatasetId = dar.data.datasetIds[0];
+    const darDatasetId = dar.datasetIds[0];
     const targetBucket = datasetBucketMap[darDatasetId];
     targetBucket.dars.push(dar);
   })(dars);


### PR DESCRIPTION
Addresses [DUOS-1938](https://broadworkbench.atlassian.net/browse/DUOS-1938)

Back-end changes have made the dataset ids accessible on `dar.datasetIds`. While `dar.data.datasetIds` does exist, its value is not updated upon dar submission, meaning that the first element on that array will be the same for each dar. This results in incorrect bucketing logic where all dars and elections are sorted into whatever bucket contains the first dataset in `dar.data.datasetIds`

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
