### PR TITLE
[DUOS-1945][risk=no] Filter draft dars by id as a workaround for the draft endpoint error

### DIFF
--- a/src/pages/NewResearcherConsole.js
+++ b/src/pages/NewResearcherConsole.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { div, h, img } from 'react-hyperscript-helpers';
-import {cloneDeep, map, findIndex, isEmpty, flow, concat} from 'lodash/fp';
+import {cloneDeep, map, findIndex, isEmpty, flow, concat, uniqBy} from 'lodash/fp';
 import { Styles } from '../libs/theme';
 import { Collections, DAR } from '../libs/ajax';
 import { DarCollectionTableColumnOptions, DarCollectionTable } from '../components/dar_collection_table/DarCollectionTable';
@@ -66,13 +66,15 @@ export default function NewResearcherConsole() {
         DAR.getDraftDarRequestList()
       ]);
       const [fetchedCollections, fetchedDraftsPayload] = promiseReturns;
-      //Need some extra formatting steps for drafts due to different payload format
+      // Need some extra formatting steps for drafts due to different payload format
+      // Workaround for the API returning a cartesian product of draft dars
+      const uniqueFetchedDrafts = uniqBy('dar.id')(fetchedDraftsPayload.value || []);
       const fetchedDrafts = {
         status: fetchedDraftsPayload.status,
         value: flow(
           map((draftPayload) => draftPayload.dar),
           map(formatDraft),
-        )(fetchedDraftsPayload.value || [])
+        )(uniqueFetchedDrafts || [])
       };
       let collectionArray = [];
       collectionArray = handlePromise(


### PR DESCRIPTION
## Addresses
UI side of https://broadworkbench.atlassian.net/browse/DUOS-1945 until we can get an API PR in place.

The v2 manage draft endpoint is returning a cartesian product of draft DARs due to the addition of dataset ids. This filters them down on the front end as a quick fix.

See also: https://github.com/DataBiosphere/consent/pull/1661

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
