### PR TITLE
[DUOS-1952][risk=no] Only render DataUseVoteSummary if there are buckets to display

### DIFF
--- a/cypress/component/DataUseVoteSummary/data_use_vote_summary.spec.js
+++ b/cypress/component/DataUseVoteSummary/data_use_vote_summary.spec.js
@@ -112,6 +112,17 @@ describe('DataUseVoteSummary - Tests', function() {
     component.should('not.exist');
   });
 
+  it('should not render if dataUseBuckets is empty', function() {
+    mount(
+      <DataUseVoteSummary
+        dataUseBuckets={[]}
+        currentUser={{userId: 1}}
+        isLoading={true}
+      />
+    );
+    cy.get('.vote-summary-header-component').should('not.exist');
+  });
+
   it('filters out final votes outside of the current user\'s DAC if adminPage is false', function() {
     mount(
       <DataUseVoteSummary

--- a/src/components/common/DataUseVoteSummary/DataUseVoteSummary.js
+++ b/src/components/common/DataUseVoteSummary/DataUseVoteSummary.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import {h, div, span} from 'react-hyperscript-helpers';
-import {chunk, map, range} from 'lodash/fp';
+import {chunk, isEmpty, map, range} from 'lodash/fp';
 import ReactTooltip from 'react-tooltip';
 import VoteResultBox from './VoteResultBox';
 import {extractDacFinalVotesFromBucket} from '../../../utils/DarCollectionUtils';
@@ -90,7 +90,8 @@ export default function DataUseVoteSummary({dataUseBuckets, currentUser, isLoadi
 
   return !isLoading ?
     div({
-      className: 'vote-summary-header-component'
+      className: 'vote-summary-header-component',
+      isRendered: !isEmpty(chunkedBuckets)
     }, [
       span({style: {color: '#777777'}}, ['Final Vote Summary']),
       rowTemplate(chunkedBuckets),


### PR DESCRIPTION
Addresses [DUOS-1952](https://broadworkbench.atlassian.net/browse/DUOS-1952)
Fixes bug on chair view of the dar collection review page for collections with an "Unreviewed" status. Previously, "Final Vote Summary" text was visible even though no vote summary boxes appeared in the `DataUseVoteSumary` header 

Before:
![Before](https://user-images.githubusercontent.com/81024249/180042853-984b78c3-a761-4d54-b763-469992727035.png)

After:
![After](https://user-images.githubusercontent.com/81024249/180042878-59937a6e-ff76-4d8b-9a8a-c66c532cea63.png)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
