### PR TITLE
[DUOS-1947][risk=no] fixed unreadable button on researcher console…

### DIFF
--- a/src/components/dar_collection_table/ResearcherActions.js
+++ b/src/components/dar_collection_table/ResearcherActions.js
@@ -135,7 +135,6 @@ export default function ResearcherActions(props) {
     fontColor: 'white',
     hoverStyle: hoverPrimaryButtonStyle,
     additionalStyle: {
-      width: '37%',
       padding: '3%',
       marginRight: '2%',
       fontSize: '1.45rem',


### PR DESCRIPTION
Removed width to prevent the button from being unreadable at smaller screen sizes - This may not be the fix for the specific issue in the ticket, but I was not able to reproduce at hte same screen size listed in the ticket.

BEFORE
<img width="691" alt="Screen Shot 2022-07-21 at 11 52 42 AM" src="https://user-images.githubusercontent.com/10501914/180258577-416a8482-eab8-480a-8901-5ed6be2318e0.png">

AFTER
<img width="691" alt="Screen Shot 2022-07-21 at 11 51 55 AM" src="https://user-images.githubusercontent.com/10501914/180258599-48eee4ab-fbea-420a-bdb7-5c201a47e57c.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
