### PR TITLE
[DUOS-1948][risk=no] Ignore tos if Sam does not return a userStatus object 

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -39,7 +39,7 @@ export default function SignIn(props) {
     await onSignIn();
     const userStatus = await ToS.getStatus();
     const {tosAccepted} = userStatus;
-    if (!tosAccepted) {
+    if (!isEmpty(userStatus) && !tosAccepted) {
       await Storage.setUserIsLogged(false);
       history.push('/tos_acceptance');
     } else {


### PR DESCRIPTION
Addresses [DUOS-1948](https://broadworkbench.atlassian.net/browse/DUOS-1948)
Changes:
- Check before re-directing user to tos acceptance page that the userStatus object returned from Sam is not empty 
- Solution to repeated tos redirects due to Sam error 
----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
