### PR TITLE
[DUOS-1901][risk=no] Add Liveness check

### DIFF
--- a/cypress/e2e/liveness.cy.js
+++ b/cypress/e2e/liveness.cy.js
@@ -1,0 +1,11 @@
+/* eslint-disable no-undef */
+
+
+describe('Status', function() {
+
+  it('Liveness successfully loads', function() {
+    cy.visit('liveness');
+    cy.contains('DUOS is healthy!')
+  });
+
+});

--- a/cypress/e2e/liveness.cy.js
+++ b/cypress/e2e/liveness.cy.js
@@ -5,7 +5,7 @@ describe('Status', function() {
 
   it('Liveness successfully loads', function() {
     cy.visit('liveness');
-    cy.contains('DUOS is healthy!')
+    cy.contains('DUOS is healthy!');
   });
 
 });

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -44,12 +44,14 @@ import NewChairConsole from './pages/NewChairConsole';
 import NewMemberConsole from './pages/NewMemberConsole';
 import TermsOfService from './pages/TermsOfService';
 import TermsOfServiceAcceptance from './pages/TermsOfServiceAcceptance';
+import { HealthCheck } from './pages/HealthCheck';
 
 const Routes = (props) => (
   <Switch>
     <Route exact path="/" render={(routeProps) => <Home {...routeProps} {...props} />} />
     <Route exact path="/home" render={(routeProps) => <Home {...routeProps} {...props} />} />
     <Route exact path="/status" render={(routeProps) => Status(mergeAll([routeProps, props]))} />
+    <Route exact path="/liveness" render={() => HealthCheck()} />
     <Route exact path="/backgroundsignin" render={
       (routeProps) =>
         props.env

--- a/src/pages/HealthCheck.js
+++ b/src/pages/HealthCheck.js
@@ -1,0 +1,14 @@
+import { Component } from 'react';
+import { div, p, hh } from 'react-hyperscript-helpers';
+
+
+export const HealthCheck = hh(class HealthCheck extends Component {
+
+  render() {
+    return (
+      div({ style: { margin: '2rem' } }, [
+        p({}, 'DUOS is healthy!')
+      ]));
+  }
+
+});


### PR DESCRIPTION
## Partially addresses

https://broadworkbench.atlassian.net/browse/DUOS-1901

### Related PRS
Consent PR: https://github.com/DataBiosphere/consent/pull/1664
DUOS PR: https://github.com/DataBiosphere/duos-ui/pull/1701
Ontology PR: https://github.com/DataBiosphere/consent-ontology/pull/660
Helmfile PR: https://github.com/broadinstitute/terra-helmfile/pull/310

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
