### PR TITLE
[DUOS-1941][risk=no] Track # selected datasets, allow filtering to selected

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -37,6 +37,7 @@ export default function DatasetCatalog(props) {
   const [searchDulText, setSearchDulText] = useState();
   const [selectedDataset, setSelectedDataset] = useState();
   const [selectedDatasetId, setSelectedDatasetId] = useState();
+  const [numDatasetsSelected, setNumDatasetsSelected] = useState();
 
   // Modal States
   const [showConnectDataset, setShowConnectDataset] = useState(false);
@@ -45,6 +46,7 @@ export default function DatasetCatalog(props) {
   const [showDatasetEnable, setShowDatasetEnable] = useState(false);
   const [showDatasetEdit, setShowDatasetEdit] = useState(false);
   const [showTranslatedDULModal, setShowTranslatedDULModal] = useState(false);
+
 
   const getDatasets = useCallback(async () => {
     let datasets = await DataSet.getDatasets();
@@ -67,6 +69,10 @@ export default function DatasetCatalog(props) {
     })(datasets);
     applyDatasetSort(sort, datasets);
   }, [applyDatasetSort, sort]);
+
+  useEffect(() => {
+    setNumDatasetsSelected(datasetList.filter((ds) => ds.checked).length);
+  }, [datasetList]);
 
   // Initialize page data
   useEffect( () => {
@@ -388,6 +394,17 @@ export default function DatasetCatalog(props) {
               input({ checked: allChecked, type: 'checkbox', 'select-all': 'true', className: 'checkbox-inline', id: 'chk_selectAll', onChange: selectAll }),
               label({ className: 'regular-checkbox', htmlFor: 'chk_selectAll' }, []),
             ]),
+            div({
+              className: 'text-right',
+              style: {
+                paddingTop: '5px',
+                paddingRight: '20px',
+                marginBottom: '0px',
+                paddingBottom: '0px'
+              }
+            }, [
+              span({}, [`${numDatasetsSelected} dataset${(numDatasetsSelected != 1?'s':'')} selected.`])
+            ])
           ]),
 
           div({ className: currentUser.isAdmin ? 'table-scroll-admin' : 'table-scroll' }, [

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -400,24 +400,57 @@ export default function DatasetCatalog(props) {
 
         div({style: Theme.lightTable}, [
           form({ className: 'pos-relative' }, [
-            div({ className: 'checkbox check-all' }, [
-              input({ checked: allChecked, type: 'checkbox', 'select-all': 'true', className: 'checkbox-inline', id: 'chk_selectAll', onChange: selectAll }),
-              label({ className: 'regular-checkbox', htmlFor: 'chk_selectAll' }, []),
-            ]),
             div({
-              className: 'text-right',
+              className: 'checkbox display-inline-block',
               style: {
-                paddingTop: '5px',
-                paddingRight: '20px',
+                marginLeft: '28px',
                 marginBottom: '0px',
-                paddingBottom: '0px'
               }
             }, [
-              a({
-                onClick: () => {
+              input({ checked: allChecked,
+                type: 'checkbox',
+                'select-all': 'true',
+                className: 'checkbox-inline',
+                id: 'chk_selectAll',
+                onChange: selectAll
+              }),
+              label({ className: 'regular-checkbox', htmlFor: 'chk_selectAll' }, ['Select All Visible']),
+            ]),
+
+            // vertical line
+            div({
+              className: 'display-inline-block',
+              style: {
+                top: '13px',
+                position: 'absolute',
+              }
+            }, [
+              div({
+                style: {
+                  borderLeft: '1px solid rgb(204, 204, 204)',
+                  height: '15px'
+                }
+              }, []),
+            ]),
+
+            div({
+              className: 'checkbox display-inline-block',
+              style: {
+                marginLeft: '18px',
+                marginBottom: '0px',
+              }
+            }, [
+              input({
+                type: 'checkbox',
+                id: 'chk_onlySelected',
+                checked: filterToOnlySelected,
+                className: 'checkbox-inline',
+                onChange: () => {
                   setFilterToOnlySelected(!filterToOnlySelected);
                 }
-              }, [`${numDatasetsSelected} dataset${(numDatasetsSelected != 1?'s':'')} selected.`])
+              }),
+              label({ id: 'lbl_onlySelected', className: 'regular-checkbox', htmlFor: 'chk_onlySelected' },
+                [`Show ${numDatasetsSelected} dataset${(numDatasetsSelected != 1?'s':'')} selected`])
             ])
           ]),
 

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -450,7 +450,7 @@ export default function DatasetCatalog(props) {
                 }
               }),
               label({ id: 'lbl_onlySelected', className: 'regular-checkbox', htmlFor: 'chk_onlySelected' },
-                [`Show ${numDatasetsSelected} dataset${(numDatasetsSelected != 1?'s':'')} selected`])
+                [`Show ${numDatasetsSelected} Dataset${(numDatasetsSelected != 1?'s':'')} Selected`])
             ])
           ]),
 

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -26,6 +26,8 @@ export default function DatasetCatalog(props) {
   const [currentUser, setCurrentUser] = useState({});
   const [datasetList, setDatasetList] = useState([]);
   const [sort, setSort] = useState({ field: 'alias', dir: 1 });
+  const [numDatasetsSelected, setNumDatasetsSelected] = useState(0);
+  const [selectedDatasets, setSeelctedDatasets] = useState([]);
 
   // Selection States
   const [allChecked, setAllChecked] = useState(false);
@@ -37,7 +39,6 @@ export default function DatasetCatalog(props) {
   const [searchDulText, setSearchDulText] = useState();
   const [selectedDataset, setSelectedDataset] = useState();
   const [selectedDatasetId, setSelectedDatasetId] = useState();
-  const [numDatasetsSelected, setNumDatasetsSelected] = useState();
 
   // Modal States
   const [showConnectDataset, setShowConnectDataset] = useState(false);
@@ -46,6 +47,8 @@ export default function DatasetCatalog(props) {
   const [showDatasetEnable, setShowDatasetEnable] = useState(false);
   const [showDatasetEdit, setShowDatasetEdit] = useState(false);
   const [showTranslatedDULModal, setShowTranslatedDULModal] = useState(false);
+
+  const [filterToOnlySelected, setFilterToOnlySelected] = useState(false);
 
 
   const getDatasets = useCallback(async () => {
@@ -71,7 +74,10 @@ export default function DatasetCatalog(props) {
   }, [applyDatasetSort, sort]);
 
   useEffect(() => {
-    setNumDatasetsSelected(datasetList.filter((ds) => ds.checked).length);
+    const selected = datasetList.filter((ds) => ds.checked);
+
+    setNumDatasetsSelected(selected.length);
+    setSeelctedDatasets(selected);
   }, [datasetList]);
 
   // Initialize page data
@@ -357,6 +363,10 @@ export default function DatasetCatalog(props) {
     return false;
   };
 
+  const visibleDatasets = () => {
+    return (filterToOnlySelected ? selectedDatasets : datasetList);
+  };
+
   return (
     h(Fragment, {}, [
       div({ className: 'container container-wide' }, [
@@ -403,7 +413,11 @@ export default function DatasetCatalog(props) {
                 paddingBottom: '0px'
               }
             }, [
-              span({}, [`${numDatasetsSelected} dataset${(numDatasetsSelected != 1?'s':'')} selected.`])
+              a({
+                onClick: () => {
+                  setFilterToOnlySelected(!filterToOnlySelected);
+                }
+              }, [`${numDatasetsSelected} dataset${(numDatasetsSelected != 1?'s':'')} selected.`])
             ])
           ]),
 
@@ -432,7 +446,8 @@ export default function DatasetCatalog(props) {
               ]),
 
               tbody({ isRendered: !isNil(datasetList) && !isEmpty(datasetList) }, [
-                datasetList.filter(searchTable(searchDulText))
+                visibleDatasets()
+                  .filter(searchTable(searchDulText))
                   .slice((currentPage - 1) * pageSize, currentPage * pageSize)
                   .map((dataset, trIndex) => {
                     return h(Fragment, { key: trIndex }, [
@@ -642,7 +657,7 @@ export default function DatasetCatalog(props) {
           ]),
           div({ style: { 'margin': '0 20px 15px 20px' } }, [
             PaginatorBar({
-              total: datasetList.filter(searchTable(searchDulText)).length,
+              total: visibleDatasets().filter(searchTable(searchDulText)).length,
               limit: pageSize,
               currentPage: currentPage,
               onPageChange: handlePageChange,


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1941

I also added the ability to filter according to the datasets which have been selected: see discussions in the #duos-ux slack channel for context.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
