### PR TITLE
DUOS-1992[risk=no] Update search bar function to handle DARCollectionSummary on Console pages

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -542,30 +542,12 @@ export const getSearchFilterFunctions = () => {
     darCollections: (term, targetList) =>
       isEmpty(term) ? targetList :
         filter(collection => {
-          if(isEmpty(term)) {return true;}
-          let projectTitle, institution, createDate;
-          if(collection.isDraft) {
-            projectTitle = collection.projectTitle;
-            createDate = collection.createDate;
-            institution = collection.institution;
-          } else {
-            const referenceDar = find((dar) => !isEmpty(dar.data))(
-              collection.dars
-            );
-            const { data } = referenceDar;
-            projectTitle = data.projectTitle;
-            institution = data.institution;
-          }
-          const datasetCount = !isEmpty(collection.datasets) ? collection.datasets.length.toString() : '0';
-          const lowerCaseTerm = toLower(term);
-          createDate = formatDate(collection.createDate);
-          const { darCode, isDraft, createUser } = collection;
-          const researcherName = get('displayName')(createUser);
-          const status = toLower(isDraft ? collection.status : darCollectionUtils.determineCollectionStatus(collection)) || '';
+          const {darCode, datasetCount, institutionName, name, researcherName, status, submissionDate} = collection;
+          const formattedSubmissionDate = formatDate(submissionDate);
           const matched = find((phrase) => {
-            const termArr = lowerCaseTerm.split(' ');
-            return find(term => includes(term, phrase))(termArr);
-          })([datasetCount, toLower(darCode), toLower(createDate), toLower(projectTitle), toLower(status), toLower(institution), toLower(researcherName)]);
+            const termArr = term.split(' ');
+            return find(term => includes(toLower(term), toLower(phrase)))(termArr);
+          })([darCode, datasetCount, institutionName, name, researcherName, status, formattedSubmissionDate]);
           return !isNil(matched);
         })(targetList),
     darDrafts: (term, targetList) => filter(draftRecord => {


### PR DESCRIPTION
Addresses [DUOS-1992](https://broadworkbench.atlassian.net/browse/DUOS-1992)

PR updates the search bar function to handle the new DarCollectionSummary models sent to the console tables.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
