### PR TITLE
DUOS-1995[risk=no] Revert "[DUOS-1740]: Bump react-material-icon-svg from 3.19.0 to 3.20.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "react-google-login": "5.2.2",
         "react-hyperscript-helpers": "2.0.0",
         "react-markdown": "8.0.3",
-        "react-material-icon-svg": "3.20.0",
+        "react-material-icon-svg": "3.19.0",
         "react-modal": "3.15.1",
         "react-paginating": "1.4.0",
         "react-protected-mailto": "1.0.3",
@@ -20849,9 +20849,9 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react-material-icon-svg": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/react-material-icon-svg/-/react-material-icon-svg-3.20.0.tgz",
-      "integrity": "sha512-MIrn+7FO4r0oH0cdVVYURRmKPk853HKsdwEaEkYFgCoNS422Zt5Z4B/BRY3DBB9cf+gyVudLxGNO24AD41a7fw=="
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/react-material-icon-svg/-/react-material-icon-svg-3.19.0.tgz",
+      "integrity": "sha512-kde43nU16RgG1p2ECiCU8wazU8fGn8uU3gCD135E44qnKXbPrCiYeTgxu4XISLEIStOjR13dSOuM0eroNwKdSQ=="
     },
     "node_modules/react-modal": {
       "version": "3.15.1",
@@ -43615,9 +43615,9 @@
       }
     },
     "react-material-icon-svg": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/react-material-icon-svg/-/react-material-icon-svg-3.20.0.tgz",
-      "integrity": "sha512-MIrn+7FO4r0oH0cdVVYURRmKPk853HKsdwEaEkYFgCoNS422Zt5Z4B/BRY3DBB9cf+gyVudLxGNO24AD41a7fw=="
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/react-material-icon-svg/-/react-material-icon-svg-3.19.0.tgz",
+      "integrity": "sha512-kde43nU16RgG1p2ECiCU8wazU8fGn8uU3gCD135E44qnKXbPrCiYeTgxu4XISLEIStOjR13dSOuM0eroNwKdSQ=="
     },
     "react-modal": {
       "version": "3.15.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-google-login": "5.2.2",
     "react-hyperscript-helpers": "2.0.0",
     "react-markdown": "8.0.3",
-    "react-material-icon-svg": "3.20.0",
+    "react-material-icon-svg": "3.19.0",
     "react-modal": "3.15.1",
     "react-paginating": "1.4.0",
     "react-protected-mailto": "1.0.3",


### PR DESCRIPTION
Addresses [DUOS-1995](https://broadworkbench.atlassian.net/browse/DUOS-1995)

Reverts DataBiosphere/duos-ui#1702, which caused the library card download icon to grow to an insane size on the SO console modals.

To see the difference, switch the version number on your `package.json`, run `npm install`, and then start up the application with `npm start`