### PR TITLE
DUOS-2024[risk=no] Remove icons from Add buttons on Admin's Manage DAC and Manage Users page

### DIFF
--- a/src/pages/AdminManageUsers.js
+++ b/src/pages/AdminManageUsers.js
@@ -125,7 +125,6 @@ export const AdminManageUsers = function AdminManageUsers() {
             className: 'btn-primary btn-add common-background',
             onClick: addUser
           }, [
-            div({ className: 'all-icons add-user_white' }),
             span({}, ['Add User']),
           ]),
         ]),

--- a/src/pages/manage_dac/ManageDac.js
+++ b/src/pages/manage_dac/ManageDac.js
@@ -159,7 +159,6 @@ export const ManageDac = function ManageDac() {
           },
           onClick: addDac
         }, [
-          div({className: 'all-icons add-dac_white'}),
           span({}, ['Add DAC'])
         ])
       ])


### PR DESCRIPTION
Addresses [DUOS-2024](https://broadworkbench.atlassian.net/browse/DUOS-2024)

PR removes the broken icons associated to the "Add" buttons on the Admin Manage DAC and Admin Manage Users page.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
