### PR TITLE
[DUOS-2032][risk=no] bug fix for blank researcher email field in dar collection review

### DIFF
--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -24,6 +24,7 @@ const styles = {
     display: 'flex',
     justifyContent: 'flex-start',
     marginBottom: '3rem',
+    columnGap: '2rem'
   },
   title: {
     fontWeight: 800,

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -86,7 +86,6 @@ export default function DarCollectionReview(props) {
   const [currentUser, setCurrentUser] = useState({});
   const [researcherProfile, setResearcherProfile] = useState({});
   const [dataUseBuckets, setDataUseBuckets] = useState([]);
-  const [researcherProperties, setResearcherProperties] = useState({});
   const { adminPage = false, readOnly = false } = props;
 
   const init = useCallback(async () => {
@@ -96,11 +95,6 @@ export default function DarCollectionReview(props) {
       const { dars, datasets } = collection;
       const darInfo = find((d) => !isEmpty(d.data))(collection.dars).data;
       const researcherProfile = await User.getById(collection.createUserId);
-      const researcherProperties = {};
-      researcherProfile.researcherProperties.forEach((property) => {
-        const { propertyKey, propertyValue } = property;
-        researcherProperties[propertyKey] = propertyValue;
-      });
       const processedBuckets = await flow([
         generatePreProcessedBucketData,
         processDataUseBuckets,
@@ -109,7 +103,6 @@ export default function DarCollectionReview(props) {
       const filteredBuckets = adminPage
         ? processedBuckets
         : filterBucketsForUser(user, processedBuckets);
-      setResearcherProperties(researcherProperties);
       setDataUseBuckets(filteredBuckets);
       setCollection(collection);
       setCurrentUser(user);
@@ -215,7 +208,7 @@ export default function DarCollectionReview(props) {
           isRendered: selectedTab === tabs.applicationInformation,
           institution: get('institution.name')(researcherProfile),
           researcher: researcherProfile.displayName,
-          email: researcherProperties.academicEmail,
+          email: researcherProfile.email,
           nonTechSummary: darInfo.nonTechRus,
           isLoading: subcomponentLoading,
           collection: collection,


### PR DESCRIPTION
Addresses [DUOS-2032](https://broadworkbench.atlassian.net/browse/DUOS-2032)
- use `researcherProfile.email` instead of deprecated `researcherProperties.academicEmail` for email prop
- remove unused `researcherProperties` code 
- add column gap between rows in Applicant Information to prevent Researcher Email from getting to close to Institution

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
