### PR TITLE
[DUOS-1669][risk=no] Added data submitter console

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@mui/styled-engine": "5.10.0",
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
-    "@react-pdf/renderer": "^2.3.0",
+    "@react-pdf/renderer": "2.2.0",
     "axios": "^0.27.2",
     "bootstrap": "3.4.1",
     "country-list": "2.2.0",

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -67,6 +67,72 @@ const styles = {
   }
 };
 
+export const headerTabsConfig = [
+  {
+    label: 'Admin Console',
+    link: '/admin_manage_dar_collections',
+    children: [
+      { label: 'DAR Requests', link: '/admin_manage_dar_collections' },
+      { label: 'Dataset Catalog', link: '/dataset_catalog' },
+      { label: 'DACs', link: '/manage_dac' },
+      { label: 'Statistics', link: '/summary_votes' },
+      { label: 'Users', link: '/admin_manage_users' },
+      { label: 'Institutions', link: '/admin_manage_institutions' },
+      { label: 'Library Cards', link: '/admin_manage_lc' }
+    ],
+    isRendered: (user) => user.isAdmin
+  },
+  {
+    label: 'SO Console',
+    link: '/signing_official_console/researchers',
+    children: [
+      { label: 'Researchers', link: '/signing_official_console/researchers' },
+      { label: 'DAR Requests', link: '/signing_official_console/dar_requests' }
+    ],
+    isRendered: (user) => user.isSigningOfficial
+  },
+  {
+    label: 'Researcher Console',
+    link: '/researcher_console',
+    search: 'researcher_console',
+    children: [
+      { label: 'DAR Requests', link: '/researcher_console' },
+      { label: 'Data Catalog', link: '/dataset_catalog' }
+    ],
+    isRendered: (user) => user.isResearcher
+  },
+  {
+    label: 'DAC Chair Console',
+    link: '/chair_console',
+    search: 'chair_console',
+    children: [
+      { label: 'DAR Requests', link: '/chair_console' },
+      { label: 'Datasets', link: '/dataset_catalog' },
+      { label: 'DAC Members', link: '/manage_dac' }
+    ],
+    isRendered: (user) => user.isChairPerson
+  },
+  {
+    label: 'DAC Member Console',
+    link: '/member_console',
+    search: 'member_console',
+    children: [
+      { label: 'DAR Requests', link: '/member_console' },
+      { label: 'Datasets', link: '/dataset_catalog' },
+    ],
+    isRendered: (user) => user.isMember
+  },
+  {
+    label: 'DS Console',
+    link: '/data_submission_form',
+    search: 'data_submission_form',
+    children: [
+      { label: 'Datasets', link: '/data_submission_form' }
+    ],
+    isRendered: (user) => user.isDataSubmitter || true
+  }
+];
+
 const NavigationTabsComponent = (props) => {
   const {
     orientation,
@@ -327,21 +393,11 @@ class DuosHeader extends Component {
   render() {
     const { classes, location } = this.props;
 
-    let isChairPerson = false;
-    let isMember = false;
-    let isAdmin = false;
-    let isResearcher = false;
-    let isSigningOfficial = false;
     let isLogged = Storage.userIsLogged();
     let currentUser = {};
 
     if (isLogged) {
       currentUser = Storage.getCurrentUser();
-      isChairPerson = currentUser.isChairPerson;
-      isMember = currentUser.isMember;
-      isAdmin = currentUser.isAdmin;
-      isResearcher = currentUser.isResearcher;
-      isSigningOfficial = currentUser.isSigningOfficial;
     }
 
     const duosLogoImage = {
@@ -393,57 +449,7 @@ class DuosHeader extends Component {
       url: this.props.location.pathname
     });
 
-    const tabs = [
-      isAdmin && {
-        label: 'Admin Console',
-        link: '/admin_manage_dar_collections',
-        children: [
-          { label: 'DAR Requests', link: '/admin_manage_dar_collections' },
-          { label: 'Dataset Catalog', link: '/dataset_catalog' },
-          { label: 'DACs', link: '/manage_dac' },
-          { label: 'Statistics', link: '/summary_votes' },
-          { label: 'Users', link: '/admin_manage_users' },
-          { label: 'Institutions', link: '/admin_manage_institutions' },
-          { label: 'Library Cards', link: '/admin_manage_lc' }
-        ]
-      },
-      isSigningOfficial && {
-        label: 'SO Console',
-        link: '/signing_official_console/researchers',
-        children: [
-          { label: 'Researchers', link: '/signing_official_console/researchers' },
-          { label: 'DAR Requests', link: '/signing_official_console/dar_requests' }
-        ]
-      },
-      isResearcher && {
-        label: 'Researcher Console',
-        link: '/researcher_console',
-        search: 'researcher_console',
-        children: [
-          { label: 'DAR Requests', link: '/researcher_console' },
-          { label: 'Data Catalog', link: '/dataset_catalog' }
-        ]
-      },
-      isChairPerson && {
-        label: 'DAC Chair Console',
-        link: '/chair_console',
-        search: 'chair_console',
-        children: [
-          { label: 'DAR Requests', link: '/chair_console' },
-          { label: 'Datasets', link: '/dataset_catalog' },
-          { label: 'DAC Members', link: '/manage_dac' }
-        ]
-      },
-      isMember && {
-        label: 'DAC Member Console',
-        link: '/member_console',
-        search: 'member_console',
-        children: [
-          { label: 'DAR Requests', link: '/member_console' },
-          { label: 'Datasets', link: '/dataset_catalog' },
-        ]
-      }
-    ].filter((data) => !!data);
+    const tabs = headerTabsConfig.filter((data) => data.isRendered(currentUser));
 
     // returns true if the current page the app is on is a part of this tab
     const isValidTab = (tab) => {

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -129,7 +129,7 @@ export const headerTabsConfig = [
     children: [
       { label: 'Datasets', link: '/data_submission_form' }
     ],
-    isRendered: (user) => user.isDataSubmitter || true
+    isRendered: (user) => user.isDataSubmitter
   }
 ];
 

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -92,16 +92,6 @@ export const headerTabsConfig = [
     isRendered: (user) => user.isSigningOfficial
   },
   {
-    label: 'Researcher Console',
-    link: '/researcher_console',
-    search: 'researcher_console',
-    children: [
-      { label: 'DAR Requests', link: '/researcher_console' },
-      { label: 'Data Catalog', link: '/dataset_catalog' }
-    ],
-    isRendered: (user) => user.isResearcher
-  },
-  {
     label: 'DAC Chair Console',
     link: '/chair_console',
     search: 'chair_console',
@@ -130,6 +120,16 @@ export const headerTabsConfig = [
       { label: 'Datasets', link: '/data_submission_form' }
     ],
     isRendered: (user) => user.isDataSubmitter
+  },
+  {
+    label: 'Researcher Console',
+    link: '/researcher_console',
+    search: 'researcher_console',
+    children: [
+      { label: 'DAR Requests', link: '/researcher_console' },
+      { label: 'Data Catalog', link: '/dataset_catalog' }
+    ],
+    isRendered: (user) => user.isResearcher
   }
 ];
 

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -404,7 +404,7 @@ export const FormTable = (config) => {
     }),
     // add new row to table button
     div({
-      style: { display: 'flex', width: '100%', justifyContent: 'flex-end' },
+      style: { display: 'flex', width: '100%', justifyContent: 'flex-end', marginTop: 10 },
       isRendered: enableAddingRow
     }, [
       h(button, {

--- a/src/components/modals/SupportRequestModal.js
+++ b/src/components/modals/SupportRequestModal.js
@@ -11,7 +11,12 @@ import Modal from 'react-modal';
 import * as fp from 'lodash/fp';
 import addHelpIcon from '../../images/icon_add_help.png';
 
-Modal.setAppElement('#root');
+try {
+  Modal.setAppElement('#root');
+} catch (error) {
+  // trycatch for unit testing purposes, since #root may not always exist
+  // when testing a component in isolation
+}
 
 export const SupportRequestModal = hh(
   class SupportRequestModal extends Component {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -6,6 +6,7 @@ import { DAR, DataSet } from './ajax';
 import {Theme, Styles } from './theme';
 import { each, flatMap, flatten, flow, forEach as lodashFPForEach, get, getOr, indexOf, uniq, values, find, first, map, isEmpty, filter, cloneDeep, isNil, toLower, includes, every, capitalize } from 'lodash/fp';
 import {User} from './ajax';
+import { headerTabsConfig } from '../components/DuosHeader';
 
 export const UserProperties = {
   SUGGESTED_SIGNING_OFFICIAL: 'suggestedSigningOfficial',
@@ -163,6 +164,7 @@ export const USER_ROLES = {
   researcher: 'Researcher',
   alumni: 'Alumni',
   signingOfficial: 'SigningOfficial',
+  dataSubmitter: 'DataSubmitter',
   all: 'All'
 };
 
@@ -212,29 +214,26 @@ export const setUserRoleStatuses = (user, Storage) => {
   user.isResearcher = currentUserRoles.indexOf(USER_ROLES.researcher) > -1;
   user.isAlumni = currentUserRoles.indexOf(USER_ROLES.alumni) > -1;
   user.isSigningOfficial = currentUserRoles.indexOf(USER_ROLES.signingOfficial) > -1;
+  user.isDataSubmitter = currentUserRoles.indexOf(USER_ROLES.dataSubmitter) > -1;
   Storage.setCurrentUser(user);
   return user;
 };
 
 export const Navigation = {
   back: async (user, history) => {
+    let firstConsole = headerTabsConfig.find(config => config.isRendered(user));
     let page =
-      user.isAdmin ? '/admin_manage_dar_collections'
-        :user.isChairPerson ? '/chair_console'
-          : user.isMember ? '/member_console'
-            : user.isResearcher ? '/dataset_catalog'
-              : user.isAlumni ? '/summary_votes'
-                : '/';
+      firstConsole ? firstConsole.link
+        : user.isAlumni ? '/summary_votes'
+          : '/';
     history.push(page);
   },
   console: async (user, history) => {
+    let firstConsole = headerTabsConfig.find(config => config.isRendered(user));
     let page =
-      user.isAdmin ? '/admin_manage_dar_collections'
-        : user.isChairPerson ? '/chair_console'
-          : user.isMember ? '/member_console'
-            : user.isResearcher ? '/researcher_console'
-              : user.isAlumni ? '/summary_votes'
-                : '/';
+      firstConsole ? firstConsole.link
+        : user.isAlumni ? '/summary_votes'
+          : '/';
     history.push(page);
   }
 };


### PR DESCRIPTION
Updated to add data submitter header link, console page.

Currently, it seems like the data submitter role does not yet exist (at least from the consent swagger-ui that role id was not indicated under the users tab), but this pr could be changed to make it fit when if there are discrepancies!

Overall, there were a few more changes to this PR to try to make updating roles simpler, by moving consolidating them a little bit more.

- Moved the tab configs out of the component level so it is only rendered once (since it is a static variable atm)
- Added field "isRendered" to the tab config to remove the manual declarations of roles (ie: `isChairPerson` and `isResearcher`... etc)
- Added new header tab config for data submitter
- Added data submitter role to the utils
- Modified redirection navigation route to default to use the tabConfigs to determine which page to load when the user first logs in (ie: first console, first link). States that did not exist as part of the console were kept at the ends.
