### PR TITLE
[DUOS-1614][risk=no] create dpa markdown and add to modal for issuing data submitter permissions

### DIFF
--- a/cypress/component/SigningOfficialTable/dpa_text.spec.js
+++ b/cypress/component/SigningOfficialTable/dpa_text.spec.js
@@ -33,7 +33,6 @@ describe('DataCustodianTable - Tests', function () {
           userId: 1,
           displayName: 'researcher',
           roles: [{name: 'Researcher'}],
-          libraryCards: []
         }
       ]}
       unregisteredResearchers={[]}
@@ -43,28 +42,5 @@ describe('DataCustodianTable - Tests', function () {
     button.click();
     const dpaHeader = cy.contains(dpaHeaderText);
     expect(dpaHeader).to.exist;
-  });
-
-
-  it('Deactivate modal does not display the DPA Text', function () {
-    cy.viewport(600, 300);
-    mount(<DataCustodianTable
-      isLoading={false}
-      signingOfficial={{institutionId: 1}}
-      researchers={[
-        {
-          email: 'email',
-          userId: 1,
-          displayName: 'researcher',
-          roles: [{name: 'Researcher'}],
-          libraryCards: [{id: 1}]
-        }
-      ]}
-      unregisteredResearchers={[]}
-    />);
-    const button = cy.get('button').last();
-    expect(button).to.exist;
-    button.click();
-    cy.contains(dpaHeaderText).should('not.exist');
   });
 });

--- a/cypress/component/SigningOfficialTable/dpa_text.spec.js
+++ b/cypress/component/SigningOfficialTable/dpa_text.spec.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-undef */
+
+import React from 'react';
+import { mount } from 'cypress/react';
+import DataCustodianTable from '../../../src/components/data_custodian_table/DataCustodianTable';
+
+const dpaHeaderText = 'BROAD DATA USE OVERSIGHT SYSTEM (DUOS) - DATA PROVIDER AGREEMENT';
+
+describe('DataCustodianTable - Tests', function () {
+  it('Add New Data Submitter modal displays the DPA Text', function () {
+    cy.viewport(600, 300);
+    mount(<DataCustodianTable
+      isLoading={false}
+      signingOfficial={{institutionId: 1}}
+      researchers={[]}
+      unregisteredResearchers={[]}
+    />);
+    const button = cy.contains('ADD NEW DATA SUBMITTER', {matchCase: false});
+    expect(button).to.exist;
+    button.click();
+    const dpaHeader = cy.contains(dpaHeaderText, {matchCase: false});
+    expect(dpaHeader).to.exist;
+  });
+
+  it('Issue modal displays the DPA Text', function () {
+    cy.viewport(600, 300);
+    mount(<DataCustodianTable
+      isLoading={false}
+      signingOfficial={{institutionId: 1}}
+      researchers={[
+        {
+          email: 'email',
+          userId: 1,
+          displayName: 'researcher',
+          roles: [{name: 'Researcher'}],
+          libraryCards: []
+        }
+      ]}
+      unregisteredResearchers={[]}
+    />);
+    const button = cy.get('button').last();
+    expect(button).to.exist;
+    button.click();
+    const dpaHeader = cy.contains(dpaHeaderText);
+    expect(dpaHeader).to.exist;
+  });
+
+
+  it('Deactivate modal does not display the DPA Text', function () {
+    cy.viewport(600, 300);
+    mount(<DataCustodianTable
+      isLoading={false}
+      signingOfficial={{institutionId: 1}}
+      researchers={[
+        {
+          email: 'email',
+          userId: 1,
+          displayName: 'researcher',
+          roles: [{name: 'Researcher'}],
+          libraryCards: [{id: 1}]
+        }
+      ]}
+      unregisteredResearchers={[]}
+    />);
+    const button = cy.get('button').last();
+    expect(button).to.exist;
+    button.click();
+    cy.contains(dpaHeaderText).should('not.exist');
+  });
+});

--- a/src/assets/DPA.md
+++ b/src/assets/DPA.md
@@ -17,8 +17,8 @@ and for compliance herewith by its Authorized Submission Representatives.\
 To implement DUOS, Broad has entered into, and may in the future enter into, certain “***Library Card Agreements***”
 with various institutions  (each, a “***Requestor***”). The Library Card Agreement (“**LCA**”) enables Requestors to
 request access to Data through DUOS. A link to the form of LCA and, from time to time, as applicable, any updates
-thereto, is available via DUOS*. Each LCA enables multiple investigators at a Requestor institution  (“**
-Requestor Investigators**”)
+thereto, is available via DUOS*. Each LCA enables multiple investigators at a Requestor institution  
+(“**Requestor Investigators**”)
 to request access to Data registered on DUOS. Requestor Investigators are issued Library Cards and are then able to
 apply for access to Data identified as available on DUOS. Access to any Data registered on DUOS is subject to
 Requestor’s LCA, review and approval by the data access committee (“**DAC**,” as further defined in Section 15 below)

--- a/src/assets/DPA.md
+++ b/src/assets/DPA.md
@@ -32,8 +32,9 @@ authorized user of the Data under the Requestor’s LCA without any further acti
 Submitter and Requestor.\
 \
 See Section 15 below for the meaning of certain capitalized terms that are not otherwise defined in the text of this
-Agreement.\
-\
+Agreement.
+
+
 1. ***Data Registration***. Data Submitter may register one or more specified datasets to be listed in and
 managed under DUOS by submitting a Data Registration Form (“**DRF**”) through a live link on DUOS.\
 \

--- a/src/assets/DPA.md
+++ b/src/assets/DPA.md
@@ -1,8 +1,8 @@
-<h4 style="text-align:center; text-decoration:underline"> BROAD DATA USE OVERSIGHT SYSTEM (DUOS) - DATA PROVIDER AGREEMENT </h4>
-
+**BROAD DATA USE OVERSIGHT SYSTEM (DUOS) - DATA PROVIDER AGREEMENT**\
+\
 The undersigned (“Data Submitter”) registers to submit Data to the DUOS Dataset Catalog as of the date of Data
-Submitter’s electronic agreement to these term and conditions  (“Registration Date").
-
+Submitter’s electronic agreement to these term and conditions  (“Registration Date").\
+\
 ***Introduction***. The Broad Institute, Inc.  (“**Broad**”)  seeks to improve human health and use science and genomics
 to advance the understanding of human disease. Enabling widespread access and analysis of scientific data is essential
 to Broad’s mission and consistent with its tax-exempt status. Through its Data Use Oversight System (“***DUOS***”) Broad
@@ -12,38 +12,38 @@ Data Submitter, an institution, to register Data in DUOS and issue permissions t
 Submission Representatives  (defined below) to register and submit datasets in the DUOS Dataset Catalog (***see***
 **https://duos.broadinstitute.org/dataset_catalog**, the “Application”) at such Authorized Submission Representatives’
 discretion and provided further, the Data Submitter is and remains responsible for its compliance with this Agreement
-and for compliance herewith by its Authorized Submission Representatives.
-
+and for compliance herewith by its Authorized Submission Representatives.\
+\
 To implement DUOS, Broad has entered into, and may in the future enter into, certain “***Library Card Agreements***”
 with various institutions  (each, a “***Requestor***”). The Library Card Agreement (“**LCA**”) enables Requestors to
 request access to Data through DUOS. A link to the form of LCA and, from time to time, as applicable, any updates
-thereto, is available via DUOS<sup>1</sup>. Each LCA enables multiple investigators at a Requestor institution  (“**
+thereto, is available via DUOS*. Each LCA enables multiple investigators at a Requestor institution  (“**
 Requestor Investigators**”)
 to request access to Data registered on DUOS. Requestor Investigators are issued Library Cards and are then able to
 apply for access to Data identified as available on DUOS. Access to any Data registered on DUOS is subject to
 Requestor’s LCA, review and approval by the data access committee (“**DAC**,” as further defined in Section 15 below)
-and Data Submitter’s terms and conditions of use coded into DUOS, as more fully provided in Section 1 below.
-
+and Data Submitter’s terms and conditions of use coded into DUOS, as more fully provided in Section 1 below.\
+\
 Data Submitter, from time to time may register Data under its control in DUOS to be matched and made available for
 access and use by Requestors and their respective Requestor Investigators. Upon DAC approval to grant access to certain
 specified Data to a Requestor or Requestor Investigator (and the Requestor Investigator’s signed attestation in the data
 access request, “**DAR**,” see Section 15), that Data’s conditions and terms of use restrictions coded in DUOS bind the
 authorized user of the Data under the Requestor’s LCA without any further action or documentation by and between Data
-Submitter and Requestor.
-
+Submitter and Requestor.\
+\
 See Section 15 below for the meaning of certain capitalized terms that are not otherwise defined in the text of this
-Agreement.
-
-1.&ensp;&ensp;***Data Registration***. Data Submitter may register one or more specified datasets to be listed in and
-managed under DUOS by submitting a Data Registration Form (“**DRF**”) through a live link on DUOS.
-
+Agreement.\
+\
+1. ***Data Registration***. Data Submitter may register one or more specified datasets to be listed in and
+managed under DUOS by submitting a Data Registration Form (“**DRF**”) through a live link on DUOS.\
+\
 Data Submitter shall complete a DRF for each dataset that it seeks to make available through DUOS for matching with
 Requestor Investigators’ research requests submitted via DUOS. The DRF shall be submitted by an authorized
 representative of the Data Submitter and include all access criteria and use restrictions applicable to such Data, all
 in a form and format suitable and compatible for inclusion and coding into DUOS. Broad shall include and code such
 description(s), access criteria and use restrictions into DUOS, enabling Library Card Holders to request access to such
-Data through DUOS.
-
+Data through DUOS.\
+\
 Data Submitter may, at its option, authorize multiple investigators or representatives to submit DRFs for registration
 of Data on DUOS through the corresponding digital interfaces in the DUOS Application (“Authorized Submission
 Representatives”). For the avoidance of doubt, Data Submitter (i) is not required to list or register all or any of its
@@ -52,17 +52,17 @@ Authorized Submission Representatives. Data Submitter shall also be permitted, a
 the DUOS system to any Data included in DUOS, it being understood and agreed that Broad shall have no responsibility
 with respect thereto.
 
-2.&ensp;&ensp;***Access to Data***. Data Submitter may establish and maintain a DAC to review, and approve access to its
+2. ***Access to Data***. Data Submitter may establish and maintain a DAC to review, and approve access to its
 Data registered on DUOS during the Term. Each DAR under a LCA must be submitted directly to a DAC registered in DUOS.
 Data Submitter shall include the name of the contact person(s)  and contact information for the DAC through the DRF, and
 shall be responsible for updating such information as necessary through the DUOS Application interface. The DAC and not
 Broad, is responsible for determining whether to grant or deny access to each applicable Data requested under a DAR.
 Broad shall have no input or decision making responsibility or authority as to any grant or denial of access to any
-specific Data, which decision shall be in Data Submitter’s DAC’s sole discretion.
-
+specific Data, which decision shall be in Data Submitter’s DAC’s sole discretion.\
+\
 Only in the event that such Data access is granted by the DAC, the Data or access to the Data shall be provided to the
-Library Card Holder.
-
+Library Card Holder.\
+\
 Broad and Data Submitter expect that Requestors, Library Card Holders, and Authorized Users of Data will recognize and
 comply with all restrictions on access and use of Data, requirements for confidentiality, security and publication of
 Data, restrictions on the sharing of Data, all other terms and conditions contained in the applicable LCAs and DARs, any
@@ -72,7 +72,9 @@ confirming any such compliance by Requestors, Library Card Holders, and Authoriz
 provisions of Section 14  (Term and Termination) below and as provided in LCAs, access to any requested Data shall be
 granted for a renewable period of one (1) year.
 
-3.&ensp;&ensp;***Library Cards***. Requestor Investigators granted Library Card permission by each Requestor will be
+
+
+3. ***Library Cards***. Requestor Investigators granted Library Card permission by each Requestor will be
 named in such Requestor’s list of approved Library Card Holders on DUOS in the manner indicated in DUOS. Once a
 Requestor Investigator has been approved as Library Card Holder, and so long as such Library Card is in effect, such
 Requestor Investigator may make DARs for Data registered on DUOS. Data Submitter understands and agrees that a Library
@@ -82,7 +84,8 @@ reports to that Library Card Holder; and (ii) the Internal Collaborators (see Se
 are employees of Requestor and listed as Internal Collaborators on the DAR for access and use of the specified Data (as
 provided in the LCA).
 
-4.&ensp;&ensp;***Requestor Responsibilities***. Under its LCA each Requestor agrees that, by issuing Library Cards to
+
+4. ***Requestor Responsibilities***. Under its LCA each Requestor agrees that, by issuing Library Cards to
 Requestor Investigators, the Requestor is pre-authorizing its Requestor Investigators to submit DARs directly to the DAC
 using a live link in DUOS, without further Requestor review. By issuing a Library Card to a Requestor Investigator, each
 Requestor certifies that the Requestor Investigator is (i) in good standing (e.g., no known sanctions) with the
@@ -94,7 +97,8 @@ have any responsibility or liability for performance or compliance by any Reques
 foregoing certifications or confirming compliance therewith, or for any obligations of a Requestor or its Requestor
 Investigators to Data Submitter.
 
-5.&ensp;&ensp;***Representations and Warranties***. Broad represents and warrants to the Data Submitter that the Data
+
+5. ***Representations and Warranties***. Broad represents and warrants to the Data Submitter that the Data
 use restrictions furnished by the Data Submitter to Broad via DUOS at the time of coding will be coded in DUOS in
 accordance with the instructions of Data Submitter. Data Submitter represents and warrants to Broad that (a) its Data’s
 use restrictions as coded in DUOS are consistent and sufficient to comply with the Applicable Law and applicable
@@ -102,9 +106,11 @@ consents under which such Data was collected, and  (b)  Data Submitter owns or o
 access to the Data and has the legal right to grant and provide access to the Data through DUOS subject to the Data use
 restrictions provided by Data Submitter to Broad via DUOS.
 
-6.&ensp;&ensp;***No Other Representations or Warranties; Disclaimer***.
 
-&ensp;&ensp;&ensp; 6.1 &ensp; Except as specifically provided in Section 5 above, DUOS and all Data registered and made
+
+6. ***No Other Representations or Warranties; Disclaimer***.\
+\
+6.1 Except as specifically provided in Section 5 above, DUOS and all Data registered and made
 available for access, accessed and/or used pursuant to this Agreement and any LCA are provided “AS IS” AND WITHOUT ANY
 REPRESENTATION OR WARRANTY. WITHOUT LIMITING THE FOREGOING, EXCEPT AS SPECIFICALLY PROVIDED IN SECTION 5 ABOVE, BROAD
 AND DATA SUBMITTER MAKE NO REPRESENTATIONS AND EXTEND NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
@@ -114,60 +120,66 @@ IT IS INTENDED, (C) THAT THE DATA AND DUOS DO NOT CONTAIN ANY “VIRUS” OR OTH
 DISABLE, DISRUPT OR OTHERWISE HARM OR IMPAIR ANY INFORMATION, SOFTWARE, HARDWARE OR OTHER COMPUTER OR NETWORK
 COMPONENT,    (D)    REGARDING MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR  (E)  THAT THE ACCESS TO OR USE
 OF THE DATA AND/OR DUOS WILL NOT INFRINGE, MISAPPROPRIATE OR OTHERWISE VIOLATE ANY PATENT, COPYRIGHT, TRADEMARK OR OTHER
-INTELLECTUAL OR PROPRIETARY RIGHTS OF ANY PERSON OR ENTITY.
-
-&ensp;&ensp;&ensp; 6.2 &ensp; EXCEPT TO THE EXTENT PROHIBITED BY LAW, IN NO EVENT WILL BROAD OR DATA SUBMITTER BE LIABLE
+INTELLECTUAL OR PROPRIETARY RIGHTS OF ANY PERSON OR ENTITY.\
+\
+6.2  EXCEPT TO THE EXTENT PROHIBITED BY LAW, IN NO EVENT WILL BROAD OR DATA SUBMITTER BE LIABLE
 FOR ANY SPECIAL, INDIRECT, INCIDENTAL, CONSEQUENTIAL, EXEMPLARY OR PUNITIVE DAMAGES OR LOST PROFITS ARISING OUT OF OR
 RELATED TO DUOS AND/OR THIS AGREEMENT, WHETHER OR NOT THE POSSIBILITY OF SUCH DAMAGES WAS REASONABLY FORESEEABLE OR
-DISCLOSED
+DISCLOSED.
 
-7.&ensp;&ensp;***MONETARY LIMITATION OF LIABILITY***. EXCEPT AS TO “ASSUMPTION OF LIABILITY AND INDEMNIFICATION” IN
+
+
+7. ***MONETARY LIMITATION OF LIABILITY***. EXCEPT AS TO “ASSUMPTION OF LIABILITY AND INDEMNIFICATION” IN
 SECTION 8 BELOW, THE MAXIMUM LIABILITY OF EITHER PARTY TO THE OTHER PARTY FOR CLAIMS ARISING FROM OR RELATING TO THIS
 AGREEMENT SHALL BE THE GREATER OF THE MONETARY AMOUNT RECEIVED BY BROAD FROM DATA SUBMITTER UNDER THIS AGREEMENT, IF
-ANY, OR THE TOTAL SUM OF ONE THOUSAND U.S. DOLLARS ($1000).
-
+ANY, OR THE TOTAL SUM OF ONE THOUSAND U.S. DOLLARS ($1000).\
+\
 THE FOREGOING LIMITATIONS APPLY REGARDLESS OF WHETHER THE CLAIM IS BROUGHT UNDER CONTRACT, TORT, WARRANTY OR OTHERWISE.
 
-8.&ensp;&ensp;***Assumption of Liability and Indemnification***.
 
-***If the Data Submitter is a Federal or State entity or non-profit organization:***
-
-&ensp;&ensp; Except to the extent prohibited by law, Data Submitter assumes all liability for damages which may arise
+8. ***Assumption of Liability and Indemnification***.\
+\
+***If the Data Submitter is a Federal or State entity or non-profit organization:***\
+\
+Except to the extent prohibited by law, Data Submitter assumes all liability for damages which may arise
 from any Requestor’s or its Authorized Users’ access, use, storage or disposal of the Data and that under no
 circumstances will Broad, and its respective affiliates, and their respective directors, officers, employees,
 investigators and personnel, and their respective successors, heirs and assigns, be liable to Data Submitter for any
 loss, claim or demand made by Requestor, or made against Requestor by any other Party, due to or arising from access,
 use, storage, transfer or disposal of the Data by Requestor or any Authorized User, except to the extent permitted by
-law when caused by the gross negligence or willful misconduct of Broad.
-
-***If the Data Submitter is a for-profit organization:***
-
-&ensp;&ensp; Data Submitter hereby indemnifies and holds harmless Broad and each of its affiliates, and their respective
+law when caused by the gross negligence or willful misconduct of Broad.\
+\
+***If the Data Submitter is a for-profit organization:***\
+\
+Data Submitter hereby indemnifies and holds harmless Broad and each of its affiliates, and their respective
 directors, officers, employees, investigators and personnel, and successors, heirs and assigns, against all claims,
 losses, expenses and damages (including reasonable attorney's fees)  arising out of or relating to this Agreement or the
 access, use, storage, transfer or disposal of any Data by any Requestor, its Authorized Users or any third party, or any
 breach of a material provision of this Agreement by the Data Submitter, except to the extent that any such claim arises
 out of Broad's gross negligence or willful misconduct.
 
-9.&ensp;&ensp;***Notices***.
 
-&ensp;&ensp;&ensp; 9.1 &ensp; Data Submitter will promptly update the DUOS Application interfaces, according to any
+9. ***Notices***.\
+\
+9.1 Data Submitter will promptly update the DUOS Application interfaces, according to any
 changes or departures of Authorized Submission Representative(s).
 
-10.&ensp;&ensp;***Amendment of Use Restrictions by Data Submitter***. Broad acknowledges that it may be necessary for
+
+10. ***Amendment of Use Restrictions by Data Submitter***. Broad acknowledges that it may be necessary for
 Data Submitter to alter the terms of the Data use restrictions for its Data from time to time. As an example, this may
 include specific provisions relating to the Data required by Data Submitter. In the event that changes are required,
 Data Submitter, by an Authorized Submission Representative, will contact the Library Card Holder directly to inform it
 of the changes in writing and the Library Card Holder may elect to accept the changes or terminate the applicable DAR
 and access to such Data.
 
-11.&ensp;&ensp;***Data Submitter Rights***. Pursuant to each LCA, each Requestor agrees that Data Submitter under an
+
+11. ***Data Submitter Rights***. Pursuant to each LCA, each Requestor agrees that Data Submitter under an
 approved DAR is an express third party beneficiary of the LCA. Data Submitter has the right to enforce the DAR, the data
 access and use restrictions of a LCA and all restrictions in an approved DAR, directly against each Requestor, without
 any obligation, intervention or involvement of any nature from Broad. Broad has no responsibility for any data access
 and use restrictions of a LCA or DAR breach or enforcement thereof, all of which are the sole rights and obligations of
-the Data Submitter.
-
+the Data Submitter.\
+\
 Notwithstanding the foregoing, Data Submitter shall promptly notify Broad in writing in the event of any LCA or DAR
 enforcement action or activity, or any claim or dispute with respect thereto, and of any termination by Data Submitter
 of any DAR approval and/or access rights to any Data due to non-compliance or breach by any Requestor, Library Card
@@ -175,7 +187,8 @@ Holder or other Authorized User, of any DAR or any data access and use restricti
 approved DAR, Data Submitter may, independently and in its sole discretion, remove access permissions granted by the DAC
 in the applicable repository for such Data outside of DUOS.
 
-12.&ensp;&ensp;***Non-Use of Names***. Neither Party will use the other Party’s (or any Requestor’s) name, trademarks,
+
+12. ***Non-Use of Names***. Neither Party will use the other Party’s (or any Requestor’s) name, trademarks,
 or other logos in any publicity, advertising, or news release without the prior written approval of an authorized
 representative of such other Party  (or, in the case of a Requestor, such Requestor). In the case of Broad, such
 approval can only be granted by Broad’s Office of Communications which may be contacted at
@@ -185,29 +198,32 @@ provided that any such statement accurately and appropriately describes the rela
 any manner imply endorsement by the other Party whose name is being used, and will not violate any confidentiality
 obligation imposed by any Applicable Law or regulation or this Agreement.
 
-13.&ensp;&ensp;***Ownership***. As amongst Broad, the Requestor and a Data Submitter, Data is owned by the Data
+
+13. ***Ownership***. As amongst Broad, the Requestor and a Data Submitter, Data is owned by the Data
 Submitter, the DUOS system is owned by Broad, and the results of the use of the Data by the Requestor in connection with
 the Project are owned by the Requestor.
 
-14.&ensp;&ensp;***Termination***.
 
-&ensp;&ensp;&ensp; 14.1 &ensp; This Agreement shall commence as of the Registration Date and continue in full force and
-effect until terminated by a Party as provided in this Section 14 (“Term”).
-
-&ensp;&ensp;&ensp; 14.2 &ensp; Either Party may terminate this Agreement upon ninety (90) days’ prior written notice to
+14. ***Termination***.\
+\
+14.1 This Agreement shall commence as of the Registration Date and continue in full force and
+effect until terminated by a Party as provided in this Section 14 (“Term”).\
+\
+14.2 Either Party may terminate this Agreement upon ninety (90) days’ prior written notice to
 the other Party. Any such termination of this Agreement will not terminate any outstanding approved DARs with respect to
 any Data under any LCA, which will, so long as Broad continues to use and manage DUOS as contemplated by this Agreement,
-continue until the end of the applicable access period then in effect under an approved DAR.
-
-&ensp;&ensp;&ensp; 14.3 &ensp; Either Party may terminate this Agreement upon written notice if the other Party
+continue until the end of the applicable access period then in effect under an approved DAR.\
+\
+14.3 Either Party may terminate this Agreement upon written notice if the other Party
 materially breaches this Agreement and fails to cure such breach within thirty  (30)  days following receipt of written
 notice specifying the breach. Any such termination of this Agreement will not terminate any outstanding approved DARs
 with respect to any Data under any LCA, which will, so long as Broad continues to use and manage DUOS as contemplated by
 this Agreement, continue until the end of the applicable access period then in effect under an approved DAR.
 
-15.&ensp;&ensp;***Certain Definitions.***
 
-&ensp;&ensp;&ensp; 15.1 &ensp; ***Applicable Laws:***&ensp; All Federal, state, local and foreign statutes, ordinances,
+15. ***Certain Definitions.***\
+\
+15.1 &ensp;***Applicable Laws:***&ensp; All Federal, state, local and foreign statutes, ordinances,
 regulations, rules, laws, codes, and other legal requirements of any type of any governmental authority  (collectively,
 “***Laws***”), including, without limitation, all applicable Laws concerning the privacy, protection, processing,
 storage, access, use, exchange, disclosure, transfer, disposal and/or security of personal information or other data,
@@ -215,59 +231,61 @@ including without limitation,  (i)
 the Health Insurance Portability and Accountability Act of 1996, PL 104-191  (HIPAA), as modified by the Health
 Information Technology for Economic and Clinical Health  (HITECH) Act, Title XIII of the American Recovery and
 Reinvestment Act of 2009, PL 1105;  (ii)  the Patient Protection and Affordable Care Act, Public Law 111-148; and  (iii)
-the European General Data Protection Regulation  (GDPR), EU Directive 95/46/EC, and EU Directive 2002/58/EC.
-
-&ensp;&ensp;&ensp; 15.2 &ensp; ***Authorized User(s):***&ensp; The individuals at Requestor who are under the
+the European General Data Protection Regulation  (GDPR), EU Directive 95/46/EC, and EU Directive 2002/58/EC.\
+\
+15.2 &ensp;***Authorized User(s):***&ensp; The individuals at Requestor who are under the
 supervision of the Library Card Holder or their Internal Collaborators at Requestor listed on the applicable DAR to whom
 the DAC grants access to specified Data for a specified period of time and only for the purposes outlined in the Library
-Card Holder’s approved research use statement contained in the applicable DAR. This includes the Library Card Holder.
-
-&ensp;&ensp;&ensp; 15.3 &ensp; ***Data:***&ensp; The data and materials, including genomic and imaging datasets owned (
+Card Holder’s approved research use statement contained in the applicable DAR. This includes the Library Card Holder.\
+\
+15.3 &ensp;***Data:***&ensp; The data and materials, including genomic and imaging datasets owned (
 or to which access is otherwise controlled) by Data Submitter, which are listed on DUOS for managed access and to which
-a Library Card Holder has requested access.
-
-&ensp;&ensp;&ensp; 15.4 &ensp; ***DAC:***&ensp; A data access committee established by Data Submitter that grants or
-denies access to Data contributed by the Data Submitter and registered on DUOS on behalf of the Data Submitter.
-
-&ensp;&ensp;&ensp; 15.5 &ensp; ***DAR:***&ensp; A data access request submitted to the DAC for access by one or more
+a Library Card Holder has requested access.\
+\
+15.4 &ensp;***DAC:***&ensp; A data access committee established by Data Submitter that grants or
+denies access to Data contributed by the Data Submitter and registered on DUOS on behalf of the Data Submitter.\
+\
+15.5 &ensp;***DAR:***&ensp; A data access request submitted to the DAC for access by one or more
 specified individuals specifying the Data to which access is sought and the planned research use. The DAR form is
 available in DUOS and each DAR will be submitted through DUOS. The DAR is attested and signed by the Requestor
 Investigator requesting the Data. Except to the extent specifically provided in an applicable LCA, Requestor
-collaborators and Project team members must be from the same organization.
-
-&ensp;&ensp;&ensp; 15.6 &ensp; ***Institutional Signing Official:***&ensp; The individual that has institutional
+collaborators and Project team members must be from the same organization.\
+\
+15.6 &ensp;***Institutional Signing Official:***&ensp; The individual that has institutional
 authority to legally bind the Requestor in matters relating to such Requestor’s LCA, as named from time to time pursuant
-to the terms thereof.
-
-&ensp;&ensp;&ensp; 15.7 &ensp; ***Internal Collaborator:***&ensp; Employees of Requestor not under the supervision of
+to the terms thereof.\
+\
+15.7 &ensp;***Internal Collaborator:***&ensp; Employees of Requestor not under the supervision of
 the applicable Library Card Holder but who assist with the Library Card Holder’s Project involving the Data as specified
-in the applicable DAR.
-
-&ensp;&ensp;&ensp; 15.8 &ensp; ***Library Card:***&ensp; A status which can be issued to a Requestor Investigator by the
+in the applicable DAR.\
+\
+15.8 &ensp;***Library Card:***&ensp; A status which can be issued to a Requestor Investigator by the
 Requestor through a signed LCA and by adding the Requestor Investigator to the Library Card “whitelist” in DUOS in the
 manner indicated in DUOS, which allows the Requestor Investigator to make future DARs for Data managed by DUOS, without
-requiring the signature of the Institutional Signing Official on each DAR, for a period of one (1) year.
-
-&ensp;&ensp;&ensp; 15.9 &ensp; ***Library Card Holder:***&ensp; A Requestor Investigator who has been issued a Library
-Card pursuant to the terms of a LCA.
-
-&ensp;&ensp;&ensp; 15.10 &ensp; ***Project:***&ensp; A project for which a Library Card Holder has requested access to
-Data. A description of the applicable Project will be set out in the applicable DAR.
-
-&ensp;&ensp;&ensp; 15.11 &ensp; ***Project Close-Out:***&ensp; Termination of a Project that used Data from DUOS and
-confirmation of Data destruction, as applicable.
-
-&ensp;&ensp;&ensp;15.12 &ensp; ***Project Renewal:***&ensp; Renewal of a Requestor Investigator’s access to Data for a
-previously-approved Project.
-
-&ensp;&ensp;&ensp; 15.13 &ensp; ***Requestor Investigator:***&ensp; The principal investigator (or other person
+requiring the signature of the Institutional Signing Official on each DAR, for a period of one (1) year.\
+\
+15.9 &ensp;***Library Card Holder:***&ensp; A Requestor Investigator who has been issued a Library
+Card pursuant to the terms of a LCA.\
+\
+15.10 &ensp;***Project:***&ensp; A project for which a Library Card Holder has requested access to
+Data. A description of the applicable Project will be set out in the applicable DAR.\
+\
+15.11 &ensp;***Project Close-Out:***&ensp; Termination of a Project that used Data from DUOS and
+confirmation of Data destruction, as applicable.\
+\
+15.12 &ensp;***Project Renewal:***&ensp; Renewal of a Requestor Investigator’s access to Data for a
+previously-approved Project.\
+\
+15.13 &ensp; ***Requestor Investigator:***&ensp; The principal investigator (or other person
 specifically approved by the applicable Requestor) for the applicable Project, who prepares DARs, Project Renewals and
 Project Close-Outs for such Project. To be able to submit a DAR, a Requestor Investigator must be a permanent employee
-of the Requestor.
+of the Requestor.\
+\
+15.14 &ensp;***Research Participant:***&ensp; An individual whose data form part of the Data.
 
-&ensp;&ensp;&ensp; 15.14 &ensp; ***Research Participant:***&ensp; An individual whose data form part of the Data.
 
-16.&ensp;&ensp;***Entire Agreement***. This Agreement constitutes the entire agreement of the parties with respect to
+
+16. ***Entire Agreement***. This Agreement constitutes the entire agreement of the parties with respect to
 the subject matter hereof and supersedes all prior oral or written agreements, arrangements or understandings between
 them relating to such subject matter.
 
@@ -275,5 +293,5 @@ them relating to such subject matter.
 Rev. 2022-02-24
 
 -------------
-<sup>1</sup>Broad will not materially change the LCA to accommodate individual Requestors. Broad may modify the form of
+*Broad will not materially change the LCA to accommodate individual Requestors. Broad may modify the form of
 LCA from time to time, in its sole discretion, including due to modifications or improvements to DUOS

--- a/src/assets/DPA.md
+++ b/src/assets/DPA.md
@@ -1,0 +1,279 @@
+<h4 style="text-align:center; text-decoration:underline"> BROAD DATA USE OVERSIGHT SYSTEM (DUOS) - DATA PROVIDER AGREEMENT </h4>
+
+The undersigned (“Data Submitter”) registers to submit Data to the DUOS Dataset Catalog as of the date of Data
+Submitter’s electronic agreement to these term and conditions  (“Registration Date").
+
+***Introduction***. The Broad Institute, Inc.  (“**Broad**”)  seeks to improve human health and use science and genomics
+to advance the understanding of human disease. Enabling widespread access and analysis of scientific data is essential
+to Broad’s mission and consistent with its tax-exempt status. Through its Data Use Oversight System (“***DUOS***”) Broad
+registers and enables widespread access to various types of data and materials, including genomic and imaging data to
+promote global scientific and genomic research. Per these terms and conditions  (this “Agreement”), Broad allows the
+Data Submitter, an institution, to register Data in DUOS and issue permissions to the Data Submitter’s Authorized
+Submission Representatives  (defined below) to register and submit datasets in the DUOS Dataset Catalog (***see***
+**https://duos.broadinstitute.org/dataset_catalog**, the “Application”) at such Authorized Submission Representatives’
+discretion and provided further, the Data Submitter is and remains responsible for its compliance with this Agreement
+and for compliance herewith by its Authorized Submission Representatives.
+
+To implement DUOS, Broad has entered into, and may in the future enter into, certain “***Library Card Agreements***”
+with various institutions  (each, a “***Requestor***”). The Library Card Agreement (“**LCA**”) enables Requestors to
+request access to Data through DUOS. A link to the form of LCA and, from time to time, as applicable, any updates
+thereto, is available via DUOS<sup>1</sup>. Each LCA enables multiple investigators at a Requestor institution  (“**
+Requestor Investigators**”)
+to request access to Data registered on DUOS. Requestor Investigators are issued Library Cards and are then able to
+apply for access to Data identified as available on DUOS. Access to any Data registered on DUOS is subject to
+Requestor’s LCA, review and approval by the data access committee (“**DAC**,” as further defined in Section 15 below)
+and Data Submitter’s terms and conditions of use coded into DUOS, as more fully provided in Section 1 below.
+
+Data Submitter, from time to time may register Data under its control in DUOS to be matched and made available for
+access and use by Requestors and their respective Requestor Investigators. Upon DAC approval to grant access to certain
+specified Data to a Requestor or Requestor Investigator (and the Requestor Investigator’s signed attestation in the data
+access request, “**DAR**,” see Section 15), that Data’s conditions and terms of use restrictions coded in DUOS bind the
+authorized user of the Data under the Requestor’s LCA without any further action or documentation by and between Data
+Submitter and Requestor.
+
+See Section 15 below for the meaning of certain capitalized terms that are not otherwise defined in the text of this
+Agreement.
+
+1.&ensp;&ensp;***Data Registration***. Data Submitter may register one or more specified datasets to be listed in and
+managed under DUOS by submitting a Data Registration Form (“**DRF**”) through a live link on DUOS.
+
+Data Submitter shall complete a DRF for each dataset that it seeks to make available through DUOS for matching with
+Requestor Investigators’ research requests submitted via DUOS. The DRF shall be submitted by an authorized
+representative of the Data Submitter and include all access criteria and use restrictions applicable to such Data, all
+in a form and format suitable and compatible for inclusion and coding into DUOS. Broad shall include and code such
+description(s), access criteria and use restrictions into DUOS, enabling Library Card Holders to request access to such
+Data through DUOS.
+
+Data Submitter may, at its option, authorize multiple investigators or representatives to submit DRFs for registration
+of Data on DUOS through the corresponding digital interfaces in the DUOS Application (“Authorized Submission
+Representatives”). For the avoidance of doubt, Data Submitter (i) is not required to list or register all or any of its
+Data in DUOS, but may select which Data to register on a dataset by dataset basis; and  (ii)  may identify multiple
+Authorized Submission Representatives. Data Submitter shall also be permitted, at its option, to grant access outside of
+the DUOS system to any Data included in DUOS, it being understood and agreed that Broad shall have no responsibility
+with respect thereto.
+
+2.&ensp;&ensp;***Access to Data***. Data Submitter may establish and maintain a DAC to review, and approve access to its
+Data registered on DUOS during the Term. Each DAR under a LCA must be submitted directly to a DAC registered in DUOS.
+Data Submitter shall include the name of the contact person(s)  and contact information for the DAC through the DRF, and
+shall be responsible for updating such information as necessary through the DUOS Application interface. The DAC and not
+Broad, is responsible for determining whether to grant or deny access to each applicable Data requested under a DAR.
+Broad shall have no input or decision making responsibility or authority as to any grant or denial of access to any
+specific Data, which decision shall be in Data Submitter’s DAC’s sole discretion.
+
+Only in the event that such Data access is granted by the DAC, the Data or access to the Data shall be provided to the
+Library Card Holder.
+
+Broad and Data Submitter expect that Requestors, Library Card Holders, and Authorized Users of Data will recognize and
+comply with all restrictions on access and use of Data, requirements for confidentiality, security and publication of
+Data, restrictions on the sharing of Data, all other terms and conditions contained in the applicable LCAs and DARs, any
+restrictions on such Data use as specified by Data Submitter for inclusion in DUOS and all Applicable Laws. However,
+Broad shall have no responsibility or liability for any such compliance or non-compliance, or for monitoring or
+confirming any such compliance by Requestors, Library Card Holders, and Authorized Users of Data. Subject to the
+provisions of Section 14  (Term and Termination) below and as provided in LCAs, access to any requested Data shall be
+granted for a renewable period of one (1) year.
+
+3.&ensp;&ensp;***Library Cards***. Requestor Investigators granted Library Card permission by each Requestor will be
+named in such Requestor’s list of approved Library Card Holders on DUOS in the manner indicated in DUOS. Once a
+Requestor Investigator has been approved as Library Card Holder, and so long as such Library Card is in effect, such
+Requestor Investigator may make DARs for Data registered on DUOS. Data Submitter understands and agrees that a Library
+Card issued to a particular Requestor Investigator permits that Requestor Investigator to apply for use of available
+Data and, once approved by the DAC, permits use of the specified Data, by: (i) any person at the same Requestor who
+reports to that Library Card Holder; and (ii) the Internal Collaborators (see Section 15) of the Library Card Holder who
+are employees of Requestor and listed as Internal Collaborators on the DAR for access and use of the specified Data (as
+provided in the LCA).
+
+4.&ensp;&ensp;***Requestor Responsibilities***. Under its LCA each Requestor agrees that, by issuing Library Cards to
+Requestor Investigators, the Requestor is pre-authorizing its Requestor Investigators to submit DARs directly to the DAC
+using a live link in DUOS, without further Requestor review. By issuing a Library Card to a Requestor Investigator, each
+Requestor certifies that the Requestor Investigator is (i) in good standing (e.g., no known sanctions) with the
+Requestor, relevant funding agencies and relevant regulatory agencies, and (ii) eligible to conduct independent
+research. In addition, each Requestor is responsible for ensuring its Library Card Holders submit a Project Renewal or
+Project Close-Out prior to the expiration date of the one (1) year data access period. Data Submitter understands that
+(i) DUOS identifies Data as available for access upon approval by the DAC, and (ii) under no circumstances does Broad
+have any responsibility or liability for performance or compliance by any Requestor of its LCA obligations, any of the
+foregoing certifications or confirming compliance therewith, or for any obligations of a Requestor or its Requestor
+Investigators to Data Submitter.
+
+5.&ensp;&ensp;***Representations and Warranties***. Broad represents and warrants to the Data Submitter that the Data
+use restrictions furnished by the Data Submitter to Broad via DUOS at the time of coding will be coded in DUOS in
+accordance with the instructions of Data Submitter. Data Submitter represents and warrants to Broad that (a) its Data’s
+use restrictions as coded in DUOS are consistent and sufficient to comply with the Applicable Law and applicable
+consents under which such Data was collected, and  (b)  Data Submitter owns or otherwise has the legal right to control
+access to the Data and has the legal right to grant and provide access to the Data through DUOS subject to the Data use
+restrictions provided by Data Submitter to Broad via DUOS.
+
+6.&ensp;&ensp;***No Other Representations or Warranties; Disclaimer***.
+
+&ensp;&ensp;&ensp; 6.1 &ensp; Except as specifically provided in Section 5 above, DUOS and all Data registered and made
+available for access, accessed and/or used pursuant to this Agreement and any LCA are provided “AS IS” AND WITHOUT ANY
+REPRESENTATION OR WARRANTY. WITHOUT LIMITING THE FOREGOING, EXCEPT AS SPECIFICALLY PROVIDED IN SECTION 5 ABOVE, BROAD
+AND DATA SUBMITTER MAKE NO REPRESENTATIONS AND EXTEND NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING,
+WITHOUT LIMITATION, ANY REPRESENTATION OR WARRANTY    (A)    REGARDING THE ACCURACY, COMPLETENESS OR CURRENCY OF THE
+DATA,    (B)    REGARDING THE ACCESSIBILITY OF THE DATA AND/OR THE CONTINUED OPERATION OF DUOS IN THE MANNER FOR WHICH
+IT IS INTENDED, (C) THAT THE DATA AND DUOS DO NOT CONTAIN ANY “VIRUS” OR OTHER CODE OR OTHER ITEM OF ANY KIND THAT MAY
+DISABLE, DISRUPT OR OTHERWISE HARM OR IMPAIR ANY INFORMATION, SOFTWARE, HARDWARE OR OTHER COMPUTER OR NETWORK
+COMPONENT,    (D)    REGARDING MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR  (E)  THAT THE ACCESS TO OR USE
+OF THE DATA AND/OR DUOS WILL NOT INFRINGE, MISAPPROPRIATE OR OTHERWISE VIOLATE ANY PATENT, COPYRIGHT, TRADEMARK OR OTHER
+INTELLECTUAL OR PROPRIETARY RIGHTS OF ANY PERSON OR ENTITY.
+
+&ensp;&ensp;&ensp; 6.2 &ensp; EXCEPT TO THE EXTENT PROHIBITED BY LAW, IN NO EVENT WILL BROAD OR DATA SUBMITTER BE LIABLE
+FOR ANY SPECIAL, INDIRECT, INCIDENTAL, CONSEQUENTIAL, EXEMPLARY OR PUNITIVE DAMAGES OR LOST PROFITS ARISING OUT OF OR
+RELATED TO DUOS AND/OR THIS AGREEMENT, WHETHER OR NOT THE POSSIBILITY OF SUCH DAMAGES WAS REASONABLY FORESEEABLE OR
+DISCLOSED
+
+7.&ensp;&ensp;***MONETARY LIMITATION OF LIABILITY***. EXCEPT AS TO “ASSUMPTION OF LIABILITY AND INDEMNIFICATION” IN
+SECTION 8 BELOW, THE MAXIMUM LIABILITY OF EITHER PARTY TO THE OTHER PARTY FOR CLAIMS ARISING FROM OR RELATING TO THIS
+AGREEMENT SHALL BE THE GREATER OF THE MONETARY AMOUNT RECEIVED BY BROAD FROM DATA SUBMITTER UNDER THIS AGREEMENT, IF
+ANY, OR THE TOTAL SUM OF ONE THOUSAND U.S. DOLLARS ($1000).
+
+THE FOREGOING LIMITATIONS APPLY REGARDLESS OF WHETHER THE CLAIM IS BROUGHT UNDER CONTRACT, TORT, WARRANTY OR OTHERWISE.
+
+8.&ensp;&ensp;***Assumption of Liability and Indemnification***.
+
+***If the Data Submitter is a Federal or State entity or non-profit organization:***
+
+&ensp;&ensp; Except to the extent prohibited by law, Data Submitter assumes all liability for damages which may arise
+from any Requestor’s or its Authorized Users’ access, use, storage or disposal of the Data and that under no
+circumstances will Broad, and its respective affiliates, and their respective directors, officers, employees,
+investigators and personnel, and their respective successors, heirs and assigns, be liable to Data Submitter for any
+loss, claim or demand made by Requestor, or made against Requestor by any other Party, due to or arising from access,
+use, storage, transfer or disposal of the Data by Requestor or any Authorized User, except to the extent permitted by
+law when caused by the gross negligence or willful misconduct of Broad.
+
+***If the Data Submitter is a for-profit organization:***
+
+&ensp;&ensp; Data Submitter hereby indemnifies and holds harmless Broad and each of its affiliates, and their respective
+directors, officers, employees, investigators and personnel, and successors, heirs and assigns, against all claims,
+losses, expenses and damages (including reasonable attorney's fees)  arising out of or relating to this Agreement or the
+access, use, storage, transfer or disposal of any Data by any Requestor, its Authorized Users or any third party, or any
+breach of a material provision of this Agreement by the Data Submitter, except to the extent that any such claim arises
+out of Broad's gross negligence or willful misconduct.
+
+9.&ensp;&ensp;***Notices***.
+
+&ensp;&ensp;&ensp; 9.1 &ensp; Data Submitter will promptly update the DUOS Application interfaces, according to any
+changes or departures of Authorized Submission Representative(s).
+
+10.&ensp;&ensp;***Amendment of Use Restrictions by Data Submitter***. Broad acknowledges that it may be necessary for
+Data Submitter to alter the terms of the Data use restrictions for its Data from time to time. As an example, this may
+include specific provisions relating to the Data required by Data Submitter. In the event that changes are required,
+Data Submitter, by an Authorized Submission Representative, will contact the Library Card Holder directly to inform it
+of the changes in writing and the Library Card Holder may elect to accept the changes or terminate the applicable DAR
+and access to such Data.
+
+11.&ensp;&ensp;***Data Submitter Rights***. Pursuant to each LCA, each Requestor agrees that Data Submitter under an
+approved DAR is an express third party beneficiary of the LCA. Data Submitter has the right to enforce the DAR, the data
+access and use restrictions of a LCA and all restrictions in an approved DAR, directly against each Requestor, without
+any obligation, intervention or involvement of any nature from Broad. Broad has no responsibility for any data access
+and use restrictions of a LCA or DAR breach or enforcement thereof, all of which are the sole rights and obligations of
+the Data Submitter.
+
+Notwithstanding the foregoing, Data Submitter shall promptly notify Broad in writing in the event of any LCA or DAR
+enforcement action or activity, or any claim or dispute with respect thereto, and of any termination by Data Submitter
+of any DAR approval and/or access rights to any Data due to non-compliance or breach by any Requestor, Library Card
+Holder or other Authorized User, of any DAR or any data access and use restrictions. In the event of termination of an
+approved DAR, Data Submitter may, independently and in its sole discretion, remove access permissions granted by the DAC
+in the applicable repository for such Data outside of DUOS.
+
+12.&ensp;&ensp;***Non-Use of Names***. Neither Party will use the other Party’s (or any Requestor’s) name, trademarks,
+or other logos in any publicity, advertising, or news release without the prior written approval of an authorized
+representative of such other Party  (or, in the case of a Requestor, such Requestor). In the case of Broad, such
+approval can only be granted by Broad’s Office of Communications which may be contacted at
+**communications@broadinstitute.org** or as otherwise specified on Broad’s website. Each Party may disclose factual
+information regarding the existence and purpose of this Agreement without written permission from the other Party,
+provided that any such statement accurately and appropriately describes the relationship of the Parties and will not in
+any manner imply endorsement by the other Party whose name is being used, and will not violate any confidentiality
+obligation imposed by any Applicable Law or regulation or this Agreement.
+
+13.&ensp;&ensp;***Ownership***. As amongst Broad, the Requestor and a Data Submitter, Data is owned by the Data
+Submitter, the DUOS system is owned by Broad, and the results of the use of the Data by the Requestor in connection with
+the Project are owned by the Requestor.
+
+14.&ensp;&ensp;***Termination***.
+
+&ensp;&ensp;&ensp; 14.1 &ensp; This Agreement shall commence as of the Registration Date and continue in full force and
+effect until terminated by a Party as provided in this Section 14 (“Term”).
+
+&ensp;&ensp;&ensp; 14.2 &ensp; Either Party may terminate this Agreement upon ninety (90) days’ prior written notice to
+the other Party. Any such termination of this Agreement will not terminate any outstanding approved DARs with respect to
+any Data under any LCA, which will, so long as Broad continues to use and manage DUOS as contemplated by this Agreement,
+continue until the end of the applicable access period then in effect under an approved DAR.
+
+&ensp;&ensp;&ensp; 14.3 &ensp; Either Party may terminate this Agreement upon written notice if the other Party
+materially breaches this Agreement and fails to cure such breach within thirty  (30)  days following receipt of written
+notice specifying the breach. Any such termination of this Agreement will not terminate any outstanding approved DARs
+with respect to any Data under any LCA, which will, so long as Broad continues to use and manage DUOS as contemplated by
+this Agreement, continue until the end of the applicable access period then in effect under an approved DAR.
+
+15.&ensp;&ensp;***Certain Definitions.***
+
+&ensp;&ensp;&ensp; 15.1 &ensp; ***Applicable Laws:***&ensp; All Federal, state, local and foreign statutes, ordinances,
+regulations, rules, laws, codes, and other legal requirements of any type of any governmental authority  (collectively,
+“***Laws***”), including, without limitation, all applicable Laws concerning the privacy, protection, processing,
+storage, access, use, exchange, disclosure, transfer, disposal and/or security of personal information or other data,
+including without limitation,  (i)
+the Health Insurance Portability and Accountability Act of 1996, PL 104-191  (HIPAA), as modified by the Health
+Information Technology for Economic and Clinical Health  (HITECH) Act, Title XIII of the American Recovery and
+Reinvestment Act of 2009, PL 1105;  (ii)  the Patient Protection and Affordable Care Act, Public Law 111-148; and  (iii)
+the European General Data Protection Regulation  (GDPR), EU Directive 95/46/EC, and EU Directive 2002/58/EC.
+
+&ensp;&ensp;&ensp; 15.2 &ensp; ***Authorized User(s):***&ensp; The individuals at Requestor who are under the
+supervision of the Library Card Holder or their Internal Collaborators at Requestor listed on the applicable DAR to whom
+the DAC grants access to specified Data for a specified period of time and only for the purposes outlined in the Library
+Card Holder’s approved research use statement contained in the applicable DAR. This includes the Library Card Holder.
+
+&ensp;&ensp;&ensp; 15.3 &ensp; ***Data:***&ensp; The data and materials, including genomic and imaging datasets owned (
+or to which access is otherwise controlled) by Data Submitter, which are listed on DUOS for managed access and to which
+a Library Card Holder has requested access.
+
+&ensp;&ensp;&ensp; 15.4 &ensp; ***DAC:***&ensp; A data access committee established by Data Submitter that grants or
+denies access to Data contributed by the Data Submitter and registered on DUOS on behalf of the Data Submitter.
+
+&ensp;&ensp;&ensp; 15.5 &ensp; ***DAR:***&ensp; A data access request submitted to the DAC for access by one or more
+specified individuals specifying the Data to which access is sought and the planned research use. The DAR form is
+available in DUOS and each DAR will be submitted through DUOS. The DAR is attested and signed by the Requestor
+Investigator requesting the Data. Except to the extent specifically provided in an applicable LCA, Requestor
+collaborators and Project team members must be from the same organization.
+
+&ensp;&ensp;&ensp; 15.6 &ensp; ***Institutional Signing Official:***&ensp; The individual that has institutional
+authority to legally bind the Requestor in matters relating to such Requestor’s LCA, as named from time to time pursuant
+to the terms thereof.
+
+&ensp;&ensp;&ensp; 15.7 &ensp; ***Internal Collaborator:***&ensp; Employees of Requestor not under the supervision of
+the applicable Library Card Holder but who assist with the Library Card Holder’s Project involving the Data as specified
+in the applicable DAR.
+
+&ensp;&ensp;&ensp; 15.8 &ensp; ***Library Card:***&ensp; A status which can be issued to a Requestor Investigator by the
+Requestor through a signed LCA and by adding the Requestor Investigator to the Library Card “whitelist” in DUOS in the
+manner indicated in DUOS, which allows the Requestor Investigator to make future DARs for Data managed by DUOS, without
+requiring the signature of the Institutional Signing Official on each DAR, for a period of one (1) year.
+
+&ensp;&ensp;&ensp; 15.9 &ensp; ***Library Card Holder:***&ensp; A Requestor Investigator who has been issued a Library
+Card pursuant to the terms of a LCA.
+
+&ensp;&ensp;&ensp; 15.10 &ensp; ***Project:***&ensp; A project for which a Library Card Holder has requested access to
+Data. A description of the applicable Project will be set out in the applicable DAR.
+
+&ensp;&ensp;&ensp; 15.11 &ensp; ***Project Close-Out:***&ensp; Termination of a Project that used Data from DUOS and
+confirmation of Data destruction, as applicable.
+
+&ensp;&ensp;&ensp;15.12 &ensp; ***Project Renewal:***&ensp; Renewal of a Requestor Investigator’s access to Data for a
+previously-approved Project.
+
+&ensp;&ensp;&ensp; 15.13 &ensp; ***Requestor Investigator:***&ensp; The principal investigator (or other person
+specifically approved by the applicable Requestor) for the applicable Project, who prepares DARs, Project Renewals and
+Project Close-Outs for such Project. To be able to submit a DAR, a Requestor Investigator must be a permanent employee
+of the Requestor.
+
+&ensp;&ensp;&ensp; 15.14 &ensp; ***Research Participant:***&ensp; An individual whose data form part of the Data.
+
+16.&ensp;&ensp;***Entire Agreement***. This Agreement constitutes the entire agreement of the parties with respect to
+the subject matter hereof and supersedes all prior oral or written agreements, arrangements or understandings between
+them relating to such subject matter.
+
+
+Rev. 2022-02-24
+
+-------------
+<sup>1</sup>Broad will not materially change the LCA to accommodate individual Requestors. Broad may modify the form of
+LCA from time to time, in its sole discretion, including due to modifications or improvements to DUOS

--- a/src/components/ScrollableMarkdownContainer.js
+++ b/src/components/ScrollableMarkdownContainer.js
@@ -1,0 +1,41 @@
+import ReactMarkdown from 'react-markdown';
+import {div} from 'react-hyperscript-helpers';
+import DOMPurify from 'dompurify';
+import React, {useEffect, useState} from 'react';
+import {isEmpty} from 'lodash/fp';
+
+
+export default function ScrollableMarkdownContainer(props) {
+  const [text, setText] = useState('');
+  const { markdown } = props;
+
+  useEffect(() => {
+    const init = async () => {
+      fetch(markdown)
+        .then((res) => res.text())
+        .then((md) => {
+          setText(md);
+        });
+    };
+    init();
+  }, [markdown]);
+
+  const generateContent = (text) => {
+    return <ReactMarkdown components={{a: (props) => <a target={'_blank'} {...props}/>}}>
+      {DOMPurify.sanitize(text, null)}
+    </ReactMarkdown>;
+  };
+
+  const content = generateContent(text);
+
+  return div({
+    isRendered: !isEmpty(content),
+    style: {
+      maxWidth: '700px',
+      minWidth: '700px',
+      maxHeight: '200px',
+      overflow: 'auto',
+      marginBottom: '25px'
+    }
+  }, [content]);
+}

--- a/src/components/data_custodian_table/DataCustodianTable.js
+++ b/src/components/data_custodian_table/DataCustodianTable.js
@@ -15,7 +15,7 @@ import {
   searchOnFilteredList
 } from '../../libs/utils';
 import ConfirmationModal from '../modals/ConfirmationModal';
-import DataSubmitterFormModal from '../modals/DataSubmitterFormModal';
+import DataCustodianFormModal from '../modals/DataCustodianFormModal';
 import ScrollableMarkdownContainer from '../ScrollableMarkdownContainer';
 import DpaMarkdown from '../../assets/DPA.md';
 import {confirmModalType} from '../signing_official_table/SigningOfficialTable';
@@ -399,7 +399,7 @@ export default function DataCustodianTable(props) {
       tableSize,
       paginationBar,
     }),
-    h(DataSubmitterFormModal, {
+    h(DataCustodianFormModal, {
       showModal,
       createOnClick: (researcher) => issueCustodian(researcher, researchers),
       closeModal: () => setShowModal(false),

--- a/src/components/data_custodian_table/DataCustodianTable.js
+++ b/src/components/data_custodian_table/DataCustodianTable.js
@@ -15,7 +15,7 @@ import {
   searchOnFilteredList
 } from '../../libs/utils';
 import ConfirmationModal from '../modals/ConfirmationModal';
-import DataCustodianFormModal from '../modals/DataCustodianFormModal';
+import DataSubmitterFormModal from '../modals/DataSubmitterFormModal';
 import ScrollableMarkdownContainer from '../ScrollableMarkdownContainer';
 import DpaMarkdown from '../../assets/DPA.md';
 import {confirmModalType} from '../signing_official_table/SigningOfficialTable';
@@ -399,7 +399,7 @@ export default function DataCustodianTable(props) {
       tableSize,
       paginationBar,
     }),
-    h(DataCustodianFormModal, {
+    h(DataSubmitterFormModal, {
       showModal,
       createOnClick: (researcher) => issueCustodian(researcher, researchers),
       closeModal: () => setShowModal(false),

--- a/src/components/data_custodian_table/DataCustodianTable.js
+++ b/src/components/data_custodian_table/DataCustodianTable.js
@@ -262,8 +262,7 @@ export default function DataCustodianTable(props) {
           showConfirmationModal,
           institutionId: signingOfficial.institutionId,
         }),
-        roleCell(roles, id),
-        // activeDarCountCell(count, id)
+        roleCell(roles, id)
       ];
     });
   };
@@ -273,7 +272,6 @@ export default function DataCustodianTable(props) {
     columnHeaderFormat.email,
     columnHeaderFormat.institution,
     columnHeaderFormat.role,
-    // columnHeaderFormat.activeDARs -> add this back in when back-end supports this
   ];
 
   const showModalOnClick = () => {
@@ -411,8 +409,8 @@ export default function DataCustodianTable(props) {
       showConfirmation,
       closeConfirmation: () => setShowConfirmation(false),
       title: confirmationTitle,
-      styleOverride: confirmModalType.issue ? { minWidth: '725px', minHeight: '475px' } : {},
-      message: confirmModalType.issue ? div([dpaContent, confirmationModalMsg]) : confirmationModalMsg,
+      styleOverride: confirmType === confirmModalType.issue ? { minWidth: '725px', minHeight: '475px' } : {},
+      message: confirmType === confirmModalType.issue ? div([dpaContent, confirmationModalMsg]) : confirmationModalMsg,
       header: `${selectedResearcher.displayName || selectedResearcher.email} - ${
         !isNil(selectedResearcher.institution) ? selectedResearcher.institution.name : ''
       }`,

--- a/src/components/modals/DataCustodianFormModal.js
+++ b/src/components/modals/DataCustodianFormModal.js
@@ -7,6 +7,8 @@ import Modal from 'react-modal';
 import Creatable from 'react-select/creatable';
 import SimpleButton from '../SimpleButton';
 import { Theme } from '../../libs/theme';
+import ScrollableMarkdownContainer from "../ScrollableMarkdownContainer";
+import DpaMarkdown from '../../assets/DPA.md';
 
 //NOTE: functionality is set for demo purposes on SO Console (no admin functionality)
 //As such, changes to "data" don't persist
@@ -78,6 +80,7 @@ export default function DataCustodianFormModal(props) {
     createOnClick,
     closeModal,
     users,
+    dpaContent
   } = props;
 
   const [user, setUser] = useState(props.user);
@@ -120,6 +123,9 @@ export default function DataCustodianFormModal(props) {
       div({ style: Styles.MODAL.CONTENT }, [
         h(CloseIconComponent, { closeFn: closeModal }),
         div({ style: Styles.MODAL.TITLE_HEADER }, ['Add Data Submitter']),
+        h(ScrollableMarkdownContainer, {
+          markdown: DpaMarkdown
+        }),
         div({ style: { borderBottom: '1px solid #1FB50' } }, []),
         //users dropdown
         h(FormFieldRow, {

--- a/src/components/modals/DataCustodianFormModal.js
+++ b/src/components/modals/DataCustodianFormModal.js
@@ -7,8 +7,6 @@ import Modal from 'react-modal';
 import Creatable from 'react-select/creatable';
 import SimpleButton from '../SimpleButton';
 import { Theme } from '../../libs/theme';
-import ScrollableMarkdownContainer from "../ScrollableMarkdownContainer";
-import DpaMarkdown from '../../assets/DPA.md';
 
 //NOTE: functionality is set for demo purposes on SO Console (no admin functionality)
 //As such, changes to "data" don't persist
@@ -123,9 +121,7 @@ export default function DataCustodianFormModal(props) {
       div({ style: Styles.MODAL.CONTENT }, [
         h(CloseIconComponent, { closeFn: closeModal }),
         div({ style: Styles.MODAL.TITLE_HEADER }, ['Add Data Submitter']),
-        h(ScrollableMarkdownContainer, {
-          markdown: DpaMarkdown
-        }),
+        dpaContent,
         div({ style: { borderBottom: '1px solid #1FB50' } }, []),
         //users dropdown
         h(FormFieldRow, {
@@ -139,7 +135,7 @@ export default function DataCustodianFormModal(props) {
             style: {
               display: 'flex',
               marginLeft: '85%',
-              justifyContent: 'space-between',
+              justifyContent: 'flex-end',
             },
           },
           [

--- a/src/components/modals/DataCustodianFormModal.js
+++ b/src/components/modals/DataCustodianFormModal.js
@@ -71,7 +71,7 @@ const FormFieldRow = (props) => {
   return div({ display: 'flex' }, [template]);
 };
 
-export default function DataSubmitterFormModal(props) {
+export default function DataCustodianFormModal(props) {
   //NOTE: dropdown options need to be passed down from parent component
   const {
     showModal,

--- a/src/components/modals/DataSubmitterFormModal.js
+++ b/src/components/modals/DataSubmitterFormModal.js
@@ -71,7 +71,7 @@ const FormFieldRow = (props) => {
   return div({ display: 'flex' }, [template]);
 };
 
-export default function DataCustodianFormModal(props) {
+export default function DataSubmitterFormModal(props) {
   //NOTE: dropdown options need to be passed down from parent component
   const {
     showModal,

--- a/src/components/modals/LibraryCardFormModal.js
+++ b/src/components/modals/LibraryCardFormModal.js
@@ -145,7 +145,7 @@ export default function LibraryCardFormModal(props) {
         ]),
         div({ style: { borderBottom: '1px solid #1FB50' } }, []),
         // Library Card Agreement Text
-        isEmpty(lcaContent) ? div() : div({style: { maxWidth: '700px', minWidth: '700px', maxHeight: '200px', overflow: 'auto', marginBottom: '25px' }}, [lcaContent]),
+        lcaContent,
         // LCA Terms Download
         LibraryCardAgreementTermsDownload,
         //users dropdown

--- a/src/components/signing_official_table/SigningOfficialTable.js
+++ b/src/components/signing_official_table/SigningOfficialTable.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, Fragment } from 'react';
+import { useState, useEffect, useCallback, useRef, Fragment } from 'react';
 import { Styles, Theme } from '../../libs/theme';
 import { a, h, div, img } from 'react-hyperscript-helpers';
 import userIcon from '../../images/icon_manage_users.png';
@@ -16,10 +16,9 @@ import {
 import LibraryCardFormModal from '../modals/LibraryCardFormModal';
 import ConfirmationModal from '../modals/ConfirmationModal';
 import { LibraryCard } from '../../libs/ajax';
-import ReactMarkdown from 'react-markdown';
-import DOMPurify from 'dompurify';
 import LcaMarkdown from '../../assets/LCA.md';
 import {LibraryCardAgreementTermsDownload} from '../LibraryCardAgreementTermsDownload';
+import ScrollableMarkdownContainer from '../ScrollableMarkdownContainer';
 
 //Styles specific to this table
 const styles = {
@@ -54,7 +53,7 @@ const columnHeaderFormat = {
 };
 
 // Used to determine which modal type to use for either issuing or deleting a Library Card.
-const confirmModalType = {
+export const confirmModalType = {
   issue: 'issue',
   delete: 'delete'
 };
@@ -183,20 +182,6 @@ const displayNameCell = (displayName, id) => {
   };
 };
 
-// const activeDarCountCell = (count, id) => {
-//   return {
-//     data: count || 0,
-//     id,
-//     style: {},
-//     label: 'active-dar-count'
-//   };
-// };
-
-const generateLcaText = (text) => {
-  return <ReactMarkdown components={{a: (props) => <a target={'_blank'} {...props}/>}}>
-    {DOMPurify.sanitize(text, null)}
-  </ReactMarkdown>;
-};
 
 export default function SigningOfficialTable(props) {
   const [researchers, setResearchers] = useState(props.researchers || []);
@@ -213,7 +198,6 @@ export default function SigningOfficialTable(props) {
   const [confirmationTitle, setConfirmationTitle] = useState('');
   const [confirmType, setConfirmType] = useState(confirmModalType.delete);
   const { signingOfficial, unregisteredResearchers, isLoading } = props;
-  const [lcaText, setLcaText] = useState('');
 
   //Search function for SearchBar component, function defined in utils
   const handleSearchChange = useCallback((searchTerms) => {
@@ -232,19 +216,6 @@ export default function SigningOfficialTable(props) {
     setConfirmationTitle(title);
     setConfirmType(confirmType);
   };
-
-  // Hook to initialize the LCA markdown content
-  // Should not update once loaded.
-  useEffect(() => {
-    const init = async () => {
-      fetch(LcaMarkdown)
-        .then((res) => res.text())
-        .then((md) => {
-          setLcaText(md);
-        });
-    };
-    init();
-  }, []);
 
   //init hook, need to make ajax calls here
   useEffect(() => {
@@ -387,7 +358,7 @@ export default function SigningOfficialTable(props) {
     }
   };
 
-  const lcaContent = generateLcaText(lcaText);
+  const lcaContent = ScrollableMarkdownContainer({markdown: LcaMarkdown});
 
   return h(Fragment, {}, [
     div({ style: { display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end'} }, [
@@ -457,7 +428,7 @@ export default function SigningOfficialTable(props) {
         confirmType === confirmModalType.delete
           ? div({}, [confirmationModalMsg])
           // Library Card Agreement Text
-          : div({}, [div({style: { maxWidth: '700px', minWidth: '700px', maxHeight: '200px', overflow: 'auto', marginBottom: '25px' }}, [lcaContent]), confirmationModalMsg]),
+          : div({}, [lcaContent, confirmationModalMsg]),
       header: `${selectedCard.userName || selectedCard.userEmail} - ${
         !isNil(selectedCard.institution) ? selectedCard.institution.name : ''
       }`,

--- a/src/pages/SigningOfficialResearchers.js
+++ b/src/pages/SigningOfficialResearchers.js
@@ -5,6 +5,7 @@ import {Styles} from '../libs/theme';
 import SigningOfficialTable from '../components/signing_official_table/SigningOfficialTable';
 import {User} from '../libs/ajax';
 import { USER_ROLES } from '../libs/utils';
+import DataCustodianTable from '../components/data_custodian_table/DataCustodianTable';
 
 
 export default function SigningOfficialResearchers() {
@@ -42,6 +43,7 @@ export default function SigningOfficialResearchers() {
     div({style: Styles.PAGE}, [
       div({style: {}, className: 'signing-official-tabs'}, [
         h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+        h(DataCustodianTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
       ])
     ])
   );

--- a/src/pages/SigningOfficialResearchers.js
+++ b/src/pages/SigningOfficialResearchers.js
@@ -5,7 +5,6 @@ import {Styles} from '../libs/theme';
 import SigningOfficialTable from '../components/signing_official_table/SigningOfficialTable';
 import {User} from '../libs/ajax';
 import { USER_ROLES } from '../libs/utils';
-import DataCustodianTable from '../components/data_custodian_table/DataCustodianTable';
 
 
 export default function SigningOfficialResearchers() {
@@ -42,8 +41,7 @@ export default function SigningOfficialResearchers() {
   return (
     div({style: Styles.PAGE}, [
       div({style: {}, className: 'signing-official-tabs'}, [
-        h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
-        h(DataCustodianTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, []),
+        h(SigningOfficialTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, [])
       ])
     ])
   );


### PR DESCRIPTION
Addresses [DUOS-1614](https://broadworkbench.atlassian.net/browse/DUOS-1614)

Summary of Changes:
- Create and format DPA markdown file 
- Create `ScrollableMarkdownContainer` for holding repeated code to turn markdown into displayed text
- Add DPA text to Data Submitter modals - "Add New Data Submitter" and "Issue" buttons 
- Update LCA displays to also use `ScrollableMarkdownContainer`

Testing: 
The table where the dpa appears isn't currently being displayed, so to test, add 
`h(DataCustodianTable, {researchers, signingOfficial, unregisteredResearchers, isLoading}, [])` at the bottom of the `SigningOfficialResearchers.js` to view it on the Researchers tab of the Signing Official console. 

 I kept the name of the table and modal as "data custodian" for now to make it easier to see the differences in code (I think github will display the changes as a whole file deleted and a whole file added if I change the name).



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
