### PR TITLE
[DUOS-2020][risk=no] Show Match Failure Reasons in the DAC voting screen

### DIFF
--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -4,7 +4,7 @@ import{ isNil } from 'lodash/fp';
 
 export default function CollectionAlgorithmDecision(props) {
   const {algorithmResult = {}, styleOverride = {}} = props;
-  const { createDate, id, result } = algorithmResult;
+  const { createDate, id, result, failureReasons} = algorithmResult;
 
   const containerProps = {
     id: `collection-algorithm-id-${id}`,
@@ -30,6 +30,10 @@ export default function CollectionAlgorithmDecision(props) {
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-date-label`, style: {paddingRight: '1%'}}, ['Date:']),
           span({id: `collection-${id}-date-value`, style: {fontWeight: 400}}, [!isNil(createDate) ? formatDate(createDate) : 'N/A'])
+        ]),
+        div({style: {fontSize: '1.5rem'}}, [
+          span({id: `collection-${id}-reason-label`, style: {paddingRight: '1%'}}, ['Reason:']),
+          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}}, [failureReasons.join('\n') || 'N/A'])
         ])
       ])
     ])

--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -34,7 +34,7 @@ export default function CollectionAlgorithmDecision(props) {
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-reason-label`, style: {paddingRight: '1%'}}, ['Reason:']),
           span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}},
-            [!isEmpty(failureReasons) ? failureReasons.map((r) => p([r])) : 'N/A'])
+            [!isEmpty(failureReasons) ? failureReasons.map((r, idx) => p({key: idx}, [r])) : 'N/A'])
         ])
       ])
     ])

--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -33,7 +33,7 @@ export default function CollectionAlgorithmDecision(props) {
         ]),
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-reason-label`, style: {paddingRight: '1%'}}, ['Reason:']),
-          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}}, [!isNil(failureReasons) ? failureReasons : 'N/A'])
+          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}}, [!isNil(failureReasons) ? failureReasons.join(' ') : 'N/A'])
         ])
       ])
     ])

--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -33,7 +33,7 @@ export default function CollectionAlgorithmDecision(props) {
         ]),
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-reason-label`, style: {paddingRight: '1%'}}, ['Reason:']),
-          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}}, [failureReasons.join('\n') || 'N/A'])
+          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}}, [!isNil(failureReasons) ? failureReasons : 'N/A'])
         ])
       ])
     ])

--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -33,7 +33,8 @@ export default function CollectionAlgorithmDecision(props) {
         ]),
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-reason-label`, style: {paddingRight: '1%'}}, ['Reason:']),
-          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}}, [!isNil(failureReasons) ? failureReasons.join(' ') : 'N/A'])
+          span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}},
+            [!isNil(failureReasons) ? failureReasons.map((r) => span([r + ' '])) : 'N/A'])
         ])
       ])
     ])

--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -1,6 +1,6 @@
-import { div, h5, span, } from 'react-hyperscript-helpers';
+import { div, h5, p, span, } from 'react-hyperscript-helpers';
 import { formatDate } from '../libs/utils';
-import{ isNil } from 'lodash/fp';
+import{ isEmpty, isNil } from 'lodash/fp';
 
 export default function CollectionAlgorithmDecision(props) {
   const {algorithmResult = {}, styleOverride = {}} = props;
@@ -34,7 +34,7 @@ export default function CollectionAlgorithmDecision(props) {
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-reason-label`, style: {paddingRight: '1%'}}, ['Reason:']),
           span({id: `collection-${id}-reason-value`, style: {fontWeight: 400}},
-            [!isNil(failureReasons) ? failureReasons.map((r) => span([r + ' '])) : 'N/A'])
+            [!isEmpty(failureReasons) ? failureReasons.map((r) => p([r])) : 'N/A'])
         ])
       ])
     ])

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -275,7 +275,7 @@ export const getMatchDataForBuckets = async (buckets) => {
         electionIdBucketMap[dataAccessReferenceId] = bucket;
       }
 
-      bucket.algorithmResult = {result: 'N/A', createDate: undefined, failureReasons: 'N/A', id: key};
+      bucket.algorithmResult = {result: 'N/A', createDate: undefined, failureReasons: undefined, id: key};
     }
   })(buckets);
 

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -275,18 +275,19 @@ export const getMatchDataForBuckets = async (buckets) => {
         electionIdBucketMap[dataAccessReferenceId] = bucket;
       }
 
-      bucket.algorithmResult = {result: 'N/A', createDate: undefined, id: key};
+      bucket.algorithmResult = {result: 'N/A', createDate: undefined, failureReasons: 'N/A', id: key};
     }
   })(buckets);
 
   const matchData = idsArr.length > 0 ? await Match.findMatchBatch(idsArr) : [];
   matchData.forEach((match) => {
-    const { purpose, createDate, id } = match;
+    const { purpose, createDate, failureReasons, id } = match;
     const targetBucket = electionIdBucketMap[purpose];
     if(!isNil(targetBucket)) {
       targetBucket.algorithmResult = {
         result: processMatchData(match),
         createDate,
+        failureReasons,
         id
       };
     }


### PR DESCRIPTION
[DUOS-2020](https://broadworkbench.atlassian.net/browse/DUOS-2020)

- Added a div for the failureReasons in the CollectionAlgorithmDecision.
- Updated algorithmResult in DarCollectionUtils to include failureReasons.

To test, look at the Chair Vote tab for dar_collection 493.
This collection has multiple failure reasons:
<img width="662" alt="Screen Shot 2022-08-31 at 8 39 26 AM" src="https://user-images.githubusercontent.com/59845076/187680326-484a03df-c19e-478a-b2a8-81b5a6cbb30c.png">
I was trying to format the string somehow - using ".join('\n') directly in the span worked but caused errors for collections that did not have a failure reason. I may try adding a formatMethod in utils.js specifically for a list of strings.

Any suggestions would be helpful.
Also need to figure out a good way to test this.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a JIRA ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
