### PR TITLE
[DUOS-2063][risk=no] Remove unused ajax calls

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -728,22 +728,6 @@ export const PendingCases = {
 
 };
 
-export const Researcher = {
-
-  createProperties: async (properties) => {
-    const url = `${await getApiUrl()}/api/user/profile`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(properties), { method: 'POST' }]));
-    return await res;
-  },
-
-  updateProperties: async (userId, validate, properties) => {
-    const url = `${await getApiUrl()}/api/user/profile?validate=${validate}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(properties), { method: 'PUT' }]));
-    return res.json();
-  },
-
-};
-
 export const StatFiles = {
 
   getDARsReport: async (reportType, fileName) => {


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2063

This PR removes unused API calls to consent. See also: https://github.com/DataBiosphere/consent/pull/1730

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
