### PR TITLE
[DUOS-2051][risk=no] Adjust dar code styling in DarCollectionTable for draft dars 

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -38,7 +38,7 @@ export const styles = {
     border: 'none'
   }),
   cellWidth: {
-    darCode: '10%',
+    darCode: '12.5%',
     projectTitle: '18%',
     submissionDate: '12.5%',
     researcher: '10%',

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -40,7 +40,8 @@ export function darCodeCellData({darCode = '- -', darCollectionId, status, conso
     style: {
       color: styles.color.darCode,
       fontSize: styles.fontSize.darCode,
-      fontWeight: '500'
+      fontWeight: '500',
+      overflowWrap: 'break-word'
     },
     label
   };


### PR DESCRIPTION
Addresses [DUOS-2051](https://broadworkbench.atlassian.net/browse/DUOS-2051)

I originally created this ticket hoping to break on the underscores, but since the draft dar code is one word, this just wraps the text at an arbitrary point. This keeps it in it's cell, but depending on screen width it may break between letters or numbers of the date, which isn't ideal. I wasn't able to delete the ticket after creating it, so feel free to close if the old approach is preferred  

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
