### PR TITLE
[DUOS-2073][risk=no] Add validation to FormField props

### DIFF
--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -358,7 +358,7 @@ describe('FormField - Tests', () => {
     it('should run onChange event when user toggles the slider false', () => {
       cy.spy(props, 'onChange');
       mount(<FormField {...props}/>);
-      const selector = '#cb_publicVisibility_Visible';
+      const selector = '#publicVisibility';
       cy.get(selector).should('be.checked');
       cy.get(selector)
         .click()
@@ -371,7 +371,7 @@ describe('FormField - Tests', () => {
     it('should run onChange event when user toggles the slider true', () => {
       cy.spy(props, 'onChange');
       mount(<FormField {...props}/>);
-      const selector = '#cb_publicVisibility_Visible';
+      const selector = '#publicVisibility';
       cy.get(selector).should('be.checked');
       cy.get(selector)
         .click()

--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -421,7 +421,7 @@ describe('FormField - Tests', () => {
           'Analytical', 'Prospective', 'Retrospective',
           'Case report', 'Case series', 'Cross-sectional',
           'Cohort study'
-        ].map((opt) => {return {displayName: opt, displayValue: opt};})
+        ].map((opt) => {return {displayName: opt, displayText: opt};})
       };
     });
 
@@ -436,7 +436,7 @@ describe('FormField - Tests', () => {
       cy.spy(props, 'onChange');
       mount(<FormField {...props}/>);
       cy.get('#studyType').type('Obs{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: {displayName: 'Observational', displayValue: 'Observational'}, isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: {displayName: 'Observational', displayText: 'Observational'}, isValid: true});
       });
 
     });
@@ -454,7 +454,7 @@ describe('FormField - Tests', () => {
       props.isCreatable = true;
       mount(<FormField {...props}/>);
       cy.get('#studyType').type('asdf{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: {key: 'asdf', displayValue: 'asdf'}, isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: {key: 'asdf', displayText: 'asdf'}, isValid: true});
       });
     });
 
@@ -477,11 +477,11 @@ describe('FormField - Tests', () => {
       props.isMulti = true;
       mount(<FormField {...props}/>);
       cy.get('#studyType').type('Obs{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayValue: 'Observational'}], isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayText: 'Observational'}], isValid: true});
       });
 
       cy.get('#studyType').type('Prosp{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayValue: 'Observational'}, {displayName: 'Prospective', displayValue: 'Prospective'}], isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayText: 'Observational'}, {displayName: 'Prospective', displayText: 'Prospective'}], isValid: true});
       });
 
     });
@@ -492,15 +492,15 @@ describe('FormField - Tests', () => {
       props.isCreatable = true;
       mount(<FormField {...props}/>);
       cy.get('#studyType').type('Obs{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayValue: 'Observational'}], isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayText: 'Observational'}], isValid: true});
       });
 
       cy.get('#studyType').type('Prosp{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayValue: 'Observational'}, {displayName: 'Prospective', displayValue: 'Prospective'}], isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayText: 'Observational'}, {displayName: 'Prospective', displayText: 'Prospective'}], isValid: true});
       });
 
       cy.get('#studyType').type('asdf{enter}').then(() => {
-        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayValue: 'Observational'}, {displayName: 'Prospective', displayValue: 'Prospective'}, {key: 'asdf', displayValue: 'asdf'}], isValid: true});
+        expect(props.onChange).to.be.calledWith({key: 'studyType', value: [{displayName: 'Observational', displayText: 'Observational'}, {displayName: 'Prospective', displayText: 'Prospective'}, {key: 'asdf', displayText: 'asdf'}], isValid: true});
       });
 
     });

--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import { FormField, FormFieldTypes, FormTable, FormValidators } from '../../../src/components/forms/forms';
 import { isEmailAddress } from '../../../src/libs/utils';
-import { div } from 'react-hyperscript-helpers';
 
 let props;
 const baseProps = {
@@ -127,11 +126,11 @@ describe('FormField - Tests', () => {
     });
   });
 
-  describe('Form Control - Radio', () => {
+  describe('Form Control - Radio Group', () => {
     beforeEach(() => {
       props = {
         ...baseProps,
-        type: FormFieldTypes.RADIO,
+        type: FormFieldTypes.RADIOGROUP,
         id: 'radioGroup',
         options: [
           {
@@ -143,15 +142,11 @@ describe('FormField - Tests', () => {
             id: 'opt2',
             name: 'opt2',
             text: 'Option 2',
-            data: {
-              dacId: 102,
-            }
           },
           {
             id: 'opt3',
             name: 'opt3',
-            text: 'Option 3 (text)',
-            renderIfSelected: div({id: 'conditionallyRenderedDiv'}, []),
+            text: 'Option 3',
           }
         ]
       };
@@ -163,7 +158,6 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('exist');
       cy.get('#radioGroup_opt2').should('exist');
       cy.get('#radioGroup_opt3').should('exist');
-      cy.get('#conditionallyRenderedDiv').should('not.exist');
     });
 
     it('should able to check, only one at a time', () => {
@@ -173,14 +167,11 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('not.be.checked');
       cy.get('#radioGroup_opt2').should('not.be.checked');
       cy.get('#radioGroup_opt3').should('not.be.checked');
-      cy.get('#conditionallyRenderedDiv').should('not.exist');
 
       cy.get('#radioGroup_opt1').click().then(() => {
         expect(props.onChange).to.be.calledWith({
           key: 'radioGroup',
-          value: {
-            selected: 'opt1',
-          },
+          value: 'opt1',
           isValid: true
         });
       });
@@ -188,17 +179,11 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('be.checked');
       cy.get('#radioGroup_opt2').should('not.be.checked');
       cy.get('#radioGroup_opt3').should('not.be.checked');
-      cy.get('#conditionallyRenderedDiv').should('not.exist');
 
       cy.get('#radioGroup_opt2').click().then(() => {
         expect(props.onChange).to.be.calledWith({
           key: 'radioGroup',
-          value: {
-            selected: 'opt2',
-            data: {
-              dacId: 102,
-            }
-          },
+          value: 'opt2',
           isValid: true
         });
       });
@@ -206,14 +191,11 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('not.be.checked');
       cy.get('#radioGroup_opt2').should('be.checked');
       cy.get('#radioGroup_opt3').should('not.be.checked');
-      cy.get('#conditionallyRenderedDiv').should('not.exist');
 
       cy.get('#radioGroup_opt3').click().then(() => {
         expect(props.onChange).to.be.calledWith({
           key: 'radioGroup',
-          value: {
-            selected: 'opt3',
-          },
+          value: 'opt3',
           isValid: true
         });
       });
@@ -221,7 +203,6 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('not.be.checked');
       cy.get('#radioGroup_opt2').should('not.be.checked');
       cy.get('#radioGroup_opt3').should('be.checked');
-      cy.get('#conditionallyRenderedDiv').should('exist');
     });
 
 

--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import { FormField, FormFieldTypes, FormTable, FormValidators } from '../../../src/components/forms/forms';
 import { isEmailAddress } from '../../../src/libs/utils';
+import { validateFormProps } from '../../../src/components/forms/formUtils';
 
 let props;
 const baseProps = {
@@ -617,5 +618,9 @@ describe('FormField - Tests', () => {
       });
     });
 
+  });
+
+  describe('Form Control - Validation', () => {
+    
   });
 });

--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import { FormField, FormFieldTypes, FormTable, FormValidators } from '../../../src/components/forms/forms';
 import { isEmailAddress } from '../../../src/libs/utils';
+import { div } from 'react-hyperscript-helpers';
 
 let props;
 const baseProps = {
@@ -142,13 +143,15 @@ describe('FormField - Tests', () => {
             id: 'opt2',
             name: 'opt2',
             text: 'Option 2',
+            data: {
+              dacId: 102,
+            }
           },
           {
             id: 'opt3',
             name: 'opt3',
             text: 'Option 3 (text)',
-            type: 'string',
-            placeholder: 'Please specify.',
+            renderIfSelected: div({id: 'conditionallyRenderedDiv'}, []),
           }
         ]
       };
@@ -160,7 +163,7 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('exist');
       cy.get('#radioGroup_opt2').should('exist');
       cy.get('#radioGroup_opt3').should('exist');
-      cy.get('#radioGroup_opt3_text_input').should('not.exist');
+      cy.get('#conditionallyRenderedDiv').should('not.exist');
     });
 
     it('should able to check, only one at a time', () => {
@@ -170,7 +173,7 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('not.be.checked');
       cy.get('#radioGroup_opt2').should('not.be.checked');
       cy.get('#radioGroup_opt3').should('not.be.checked');
-      cy.get('#radioGroup_opt3_text_input').should('not.exist');
+      cy.get('#conditionallyRenderedDiv').should('not.exist');
 
       cy.get('#radioGroup_opt1').click().then(() => {
         expect(props.onChange).to.be.calledWith({
@@ -185,13 +188,16 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('be.checked');
       cy.get('#radioGroup_opt2').should('not.be.checked');
       cy.get('#radioGroup_opt3').should('not.be.checked');
-      cy.get('#radioGroup_opt3_text_input').should('not.exist');
+      cy.get('#conditionallyRenderedDiv').should('not.exist');
 
       cy.get('#radioGroup_opt2').click().then(() => {
         expect(props.onChange).to.be.calledWith({
           key: 'radioGroup',
           value: {
             selected: 'opt2',
+            data: {
+              dacId: 102,
+            }
           },
           isValid: true
         });
@@ -200,14 +206,13 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('not.be.checked');
       cy.get('#radioGroup_opt2').should('be.checked');
       cy.get('#radioGroup_opt3').should('not.be.checked');
-      cy.get('#radioGroup_opt3_text_input').should('not.exist');
+      cy.get('#conditionallyRenderedDiv').should('not.exist');
 
       cy.get('#radioGroup_opt3').click().then(() => {
         expect(props.onChange).to.be.calledWith({
           key: 'radioGroup',
           value: {
             selected: 'opt3',
-            value: '',
           },
           isValid: true
         });
@@ -216,18 +221,7 @@ describe('FormField - Tests', () => {
       cy.get('#radioGroup_opt1').should('not.be.checked');
       cy.get('#radioGroup_opt2').should('not.be.checked');
       cy.get('#radioGroup_opt3').should('be.checked');
-      cy.get('#radioGroup_opt3_text_input').should('exist');
-
-      cy.get('#radioGroup_opt3_text_input').type('Hello!').then(() => {
-        expect(props.onChange).to.be.calledWith({
-          key: 'radioGroup',
-          value: {
-            selected: 'opt3',
-            value: 'Hello!',
-          },
-          isValid: true
-        });
-      });
+      cy.get('#conditionallyRenderedDiv').should('exist');
     });
 
 

--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -3,7 +3,6 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import { FormField, FormFieldTypes, FormTable, FormValidators } from '../../../src/components/forms/forms';
 import { isEmailAddress } from '../../../src/libs/utils';
-import { validateFormProps } from '../../../src/components/forms/formUtils';
 
 let props;
 const baseProps = {
@@ -618,9 +617,5 @@ describe('FormField - Tests', () => {
       });
     });
 
-  });
-
-  describe('Form Control - Validation', () => {
-    
   });
 });

--- a/cypress/component/Forms/forms.spec.js
+++ b/cypress/component/Forms/forms.spec.js
@@ -616,6 +616,64 @@ describe('FormField - Tests', () => {
         cy.get('#delete-table-row-fileTypes-0').should('be.disabled');
       });
     });
+  });
+  describe('Prop validation', () => {
+    it('should not allow mounting if unknown prop', (done) => {
+      // this event will automatically be unbound when this
+      // test ends because it's attached to 'cy'
+      cy.on('uncaught:exception', (err) => {
 
+        // ensure the error is about an unknown field
+        expect(err.message).to.include('unknown');
+
+        // using mocha's async done callback to finish
+        // this test so we prove that an uncaught exception
+        // was thrown
+        done();
+
+        // return false to prevent the error from
+        // failing this test
+        return false;
+      });
+
+      mount(<FormField {
+        ...{asdf: 'asdf', id: 'example'}
+      } />);
+    });
+
+    it('errors if required prop not given', (done) => {
+      cy.on('uncaught:exception', (err) => {
+        expect(err.message).to.include('id');
+        done();
+        return false;
+      });
+
+      mount(<FormField {
+        ...{type: FormFieldTypes.TEXT,} // requires id
+      } />);
+    });
+
+    it('errors based on custom validation', (done) => {
+
+      cy.on('uncaught:exception', (err) => {
+        expect(err.message).to.include('example failure');
+        done();
+        return false;
+      });
+
+      mount(<FormField {
+        ...{
+          type: {
+            ...FormFieldTypes.TEXT,
+            ...{
+              customPropValidation: () => {
+                throw 'example failure';
+              }
+            }
+          },
+          id: 'example',
+        } // requires id
+      } />);
+    });
   });
 });

--- a/cypress/component/MultiDatasetVoteTab/data_use_alert_box.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/data_use_alert_box.spec.js
@@ -1,29 +1,29 @@
 /* eslint-disable no-undef */
 import React from 'react';
 import { mount } from 'cypress/react';
-import DataUseAlertBox from "../../../src/components/collection_voting_slab/DataUseAlertBox";
+import DataUseAlertBox from '../../../src/components/collection_voting_slab/DataUseAlertBox';
 
 const dataUseManualReviewTrue = {
-  "code": "ABC",
-  "description": "data use 1",
-  "manualReview": true,
+  'code': 'ABC',
+  'description': 'data use 1',
+  'manualReview': true,
 };
 
 const dataUseManualReviewTrue2 = {
-  "code": "DEF",
-  "description": "data use 2",
-  "manualReview": true,
+  'code': 'DEF',
+  'description': 'data use 2',
+  'manualReview': true,
 };
 
 const dataUseManualReviewFalse = {
-  "code": "MNOP",
-  "description": "data use 3",
-  "manualReview": false,
+  'code': 'MNOP',
+  'description': 'data use 3',
+  'manualReview': false,
 };
 
 const dataUseNoManualReview = {
-  "code": "XYZ",
-  "description": "data use 4",
+  'code': 'XYZ',
+  'description': 'data use 4',
 };
 
 
@@ -32,7 +32,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Renders the alert box and exclamation point when translated data use a manually reviewed data use', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"primary": [dataUseManualReviewTrue]}}
+        translatedDataUse={{'primary': [dataUseManualReviewTrue]}}
       />
     );
     const component = cy.get('[datacy=alert-box]').should('be.visible');
@@ -42,7 +42,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Does not render the alert box and exclamation point when translated data use a manually reviewed data use', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"primary": [dataUseManualReviewFalse]}}
+        translatedDataUse={{'primary': [dataUseManualReviewFalse]}}
       />
     );
     cy.get('[datacy=alert-box]').should('not.exist');
@@ -51,7 +51,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Does not render the description of a data use without a manuallyReviewed attribute', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"primary": [dataUseNoManualReview]}}
+        translatedDataUse={{'primary': [dataUseNoManualReview]}}
       />
     );
     cy.get('[datacy=alert-box]').should('not.exist');
@@ -60,7 +60,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Renders the description of a primary use manually reviewed data use', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"primary": [dataUseManualReviewTrue], "secondary": [dataUseManualReviewFalse]}}
+        translatedDataUse={{'primary': [dataUseManualReviewTrue], 'secondary': [dataUseManualReviewFalse]}}
       />
     );
     cy.get('[datacy=alert-box]').should('be.visible');
@@ -71,7 +71,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Renders the description of a secondary use manually reviewed data use', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"primary": [dataUseManualReviewFalse], "secondary": [dataUseManualReviewTrue]}}
+        translatedDataUse={{'primary': [dataUseManualReviewFalse], 'secondary': [dataUseManualReviewTrue]}}
       />
     );
     cy.get('[datacy=alert-box]').should('be.visible');
@@ -82,7 +82,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Renders the description multiple manually reviewed data uses in the same category', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"Primary": [dataUseManualReviewTrue, dataUseManualReviewTrue2]}}
+        translatedDataUse={{'Primary': [dataUseManualReviewTrue, dataUseManualReviewTrue2]}}
       />
     );
     cy.get('[datacy=alert-box]').should('be.visible');
@@ -93,7 +93,7 @@ describe('DataUseAlertBox - Tests', function() {
   it('Renders the description multiple manually reviewed data uses in different categories', function() {
     mount(
       <DataUseAlertBox
-        translatedDataUse={{"primary": [dataUseManualReviewTrue2], "secondary": [dataUseManualReviewTrue]}}
+        translatedDataUse={{'primary': [dataUseManualReviewTrue2], 'secondary': [dataUseManualReviewTrue]}}
       />
     );
     cy.get('[datacy=alert-box]').should('be.visible');

--- a/cypress/component/VoteSummaryTable/vote_summary_table.spec.js
+++ b/cypress/component/VoteSummaryTable/vote_summary_table.spec.js
@@ -1,13 +1,13 @@
 /* eslint-disable no-undef */
 import React from 'react';
 import { mount } from 'cypress/react';
-import VoteSummaryTable from "../../../src/components/vote_summary_table/VoteSummaryTable";
+import VoteSummaryTable from '../../../src/components/vote_summary_table/VoteSummaryTable';
 
 const dacVotes = [
   {
-    "displayName": "John Doe",
-    "updateDate": 1642032000000,
-    "vote": false,
+    'displayName': 'John Doe',
+    'updateDate': 1642032000000,
+    'vote': false,
   }
 ];
 
@@ -31,7 +31,7 @@ describe('VoteSummaryTable - Tests', function() {
       />
     );
     const component = cy.get('.table-data');
-    component.contains("No");
+    component.contains('No');
   });
 
   //this test works locally but fails on Github
@@ -56,7 +56,7 @@ describe('VoteSummaryTable - Tests', function() {
       />
     );
     const component = cy.get('.table-data');
-    component.contains("- -");
+    component.contains('- -');
   });
 
   it('Renders skeleton table if isLoading is true', function() {

--- a/cypress/component/VotesPieChart/votes_pie_chart.spec.js
+++ b/cypress/component/VotesPieChart/votes_pie_chart.spec.js
@@ -4,7 +4,7 @@ import { mount } from 'cypress/react';
 import VotesPieChart from '../../../src/components/common/VotesPieChart';
 
 const testVotes = [{vote: true}, {vote: false}, {}];
-const keyString = "test";
+const keyString = 'test';
 
 //NOTE: I think we should consider using Jest or other snapshot libraries for testing svg-based graphs
 //It's a lot harder to obtain text from svg due lack of identifiers for pinpoint locations

--- a/cypress/component/utils/vote_utils.spec.js
+++ b/cypress/component/utils/vote_utils.spec.js
@@ -6,7 +6,7 @@ describe('VoteUtil - processMatchData()', () => {
     expect(processMatchData({})).to.equal('N/A');
   });
   it('returns "Yes" if failed === false and match === true', () => {
-    expect(processMatchData({match: true, failed: false})).to.equal("Yes");
+    expect(processMatchData({match: true, failed: false})).to.equal('Yes');
   });
   it('returns "Unable to determine a system match" if failed === true', () => {
     expect(processMatchData({ failed: true, match: false })).to.equal('Unable to determine a system match');

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -61,7 +61,6 @@ export const RadioButton = (props) => {
             name: props.name,
             value: props.value,
             checked: props.defaultChecked,
-            defaultChecked: props.defaultChecked,
             onClick: props.onClick,
             disabled: props.disabled,
             onChange: props.onChange ? props.onChange : () => {}

--- a/src/components/RadioButton.js
+++ b/src/components/RadioButton.js
@@ -61,6 +61,7 @@ export const RadioButton = (props) => {
             name: props.name,
             value: props.value,
             checked: props.defaultChecked,
+            defaultChecked: props.defaultChecked,
             onClick: props.onClick,
             disabled: props.disabled,
           }),

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -65,8 +65,8 @@ const errorMessage = (error) => {
 //---------------------------------------------
 export const formInputGeneric = (config) => {
   const {
-    id, title, type, disabled,
-    placeholder,
+    id, title, disabled,
+    placeholder, type,
     inputStyle, ariaDescribedby,
     formValue, error, setError
   } = config;
@@ -258,7 +258,7 @@ export const formInputRadioGroup = (config) => {
       {
         name: 'other',
         text: 'Other',
-        type: 'string',
+        renderIfSelected: div({}, [...]),
         placeholder: 'Please specify.',
       }
     ]
@@ -281,6 +281,8 @@ export const formInputRadioGroup = (config) => {
         },
         options.map(((option, idx) => {
           const optionId = (!isNil(option.id) ? option.id : option.name);
+          const selected = !isNil(formValue) && formValue.selected === option.name;
+          const renderIfSelected = option.renderIfSelected;
 
           return div({
             key: idx,
@@ -290,17 +292,10 @@ export const formInputRadioGroup = (config) => {
               id: `${id}_${optionId}`,
               name: `${id}_${optionId}`,
               key: idx,
-              defaultChecked: !isNil(formValue) && formValue.selected === option.name,
+              defaultChecked: selected,
               onClick: () => {
-                if (option.type === 'string') {
-                  onFormInputChange(config, {
-                    selected: option.name,
-                    value: '',
-                  });
-                  return;
-                }
 
-                onFormInputChange(config, { selected: option.name });
+                onFormInputChange(config, (!isNil(option.data) ? { selected: option.name, data: option.data } : { selected: option.name }));
               },
               style: {
                 fontFamily: 'Montserrat',
@@ -309,28 +304,7 @@ export const formInputRadioGroup = (config) => {
               description: option.text,
               disabled,
             }),
-            input({
-              isRendered: option.type === 'string' && formValue.selected === option.name,
-              id: `${id}_${optionId}_text_input`,
-              type: 'text',
-              className: `form-control ${error ? 'errored' : ''}`,
-              placeholder: option.placeholder,
-              value: formValue.value,
-              style: {
-                ...styles.inputStyle,
-                ...{
-                  marginTop: '0.5rem',
-                }
-              },
-              disabled: disabled,
-              onChange: (event) => onFormInputChange(config, {
-                selected: option.name,
-                value: event.target.value,
-              }),
-              onFocus: () => setError(),
-              onBlur: (event) => validateFormInput(config, event.target.value),
-              'aria-describedby': ariaDescribedby,
-            }),
+            div({isRendered: (!isNil(renderIfSelected) && selected)}, [renderIfSelected]),
           ]);
         }))
       )

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -190,7 +190,7 @@ export const formInputSelect = (config) => {
 
   const isStringArr = isString(selectOptions[0]);
   const normalizedOptions = isStringArr
-    ? selectOptions.map((option) => { return {key: option, displayValue: option }; })
+    ? selectOptions.map((option) => { return { displayText: option }; })
     : selectOptions;
 
   return h(component, {
@@ -206,12 +206,12 @@ export const formInputSelect = (config) => {
       if (isStringArr) {
         if (isMulti) {
           // string result, multiple options
-          onFormInputChange(config, option?.map((o) => o.displayValue));
+          onFormInputChange(config, option?.map((o) => o.displayText));
           setFormValue(option);
           return;
         }
         // string result, only one option
-        onFormInputChange(config, option?.displayValue);
+        onFormInputChange(config, option?.displayText);
         setFormValue(option);
         return;
       }
@@ -227,15 +227,15 @@ export const formInputSelect = (config) => {
       }
     },
     options: normalizedOptions,
-    getOptionLabel: (option) => option.displayValue,
+    getOptionLabel: (option) => option.displayText,
     getNewOptionData: (inputValue) => {
-      return { key: inputValue, displayValue: inputValue };
+      return { key: inputValue, displayText: inputValue };
     },
     getOptionValue: (option) => { //value formatter for options, attr used to ensure empty strings are treated as undefined
-      if(isNil(option) || isEmpty(option.displayValue)) {
+      if(isNil(option) || isEmpty(option.displayText)) {
         return null;
       }
-      return isStringArr ? option.displayValue : option;
+      return isStringArr ? option.displayText : option;
     },
     value: formValue,
     ...selectConfig,

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -316,7 +316,7 @@ export const formInputCheckbox = (config) => {
   return div({ className: 'checkbox' }, [
     input({
       type: 'checkbox',
-      id: id,
+      id: `${id}`,
       checked: formValue,
       className: 'checkbox-inline',
       'aria-describedby': ariaDescribedby,
@@ -325,6 +325,7 @@ export const formInputCheckbox = (config) => {
     }),
     label({
       className: `regular-checkbox ${error ? 'errored' : ''}`,
+      htmlFor: `${id}`,
     }, [toggleText])
   ]);
 };

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -45,11 +45,13 @@ const normalizeValue = (value) => {
 };
 
 const onFormInputChange = (config, value) => {
-  const { id, onChange, setFormValue } = config;
+  const { id, name, onChange, setFormValue } = config;
+  const key = (!isNil(name) ? name : id);
+
   const normalizedValue = normalizeValue(value);
   const isValidInput = validateFormInput(config, normalizedValue);
 
-  onChange({key: id, value: normalizedValue, isValid: isValidInput });
+  onChange({key: key, value: normalizedValue, isValid: isValidInput });
   setFormValue(value);
 };
 
@@ -244,28 +246,6 @@ export const formInputSelect = (config) => {
 };
 
 export const formInputRadioGroup = (config) => {
-  /* options example:
-    [
-      {
-        name: 'open_access',
-        text: 'Open Access'
-      },
-      {
-        id: 'closed_access', // can specify id, uses name as id otherwise
-        name: 'closed_access',
-        text: 'Closed Access',
-      },
-      {
-        name: 'other',
-        text: 'Other',
-        renderIfSelected: div({}, [...]),
-        placeholder: 'Please specify.',
-      }
-    ]
-    if type is 'string', then a textbox is rendered
-    when checked.
-  */
-
   const {
     id, disabled,
     formValue, options
@@ -280,8 +260,6 @@ export const formInputRadioGroup = (config) => {
         },
         options.map(((option, idx) => {
           const optionId = (!isNil(option.id) ? option.id : option.name);
-          const selected = !isNil(formValue) && formValue.selected === option.name;
-          const renderIfSelected = option.renderIfSelected;
 
           return div({
             key: idx,
@@ -291,10 +269,10 @@ export const formInputRadioGroup = (config) => {
               id: `${id}_${optionId}`,
               name: `${id}_${optionId}`,
               key: idx,
-              defaultChecked: selected,
+              defaultChecked: !isNil(formValue) && formValue === option.name,
               onClick: () => {
 
-                onFormInputChange(config, (!isNil(option.data) ? { selected: option.name, data: option.data } : { selected: option.name }));
+                onFormInputChange(config, option.name);
               },
               style: {
                 fontFamily: 'Montserrat',
@@ -303,7 +281,6 @@ export const formInputRadioGroup = (config) => {
               description: option.text,
               disabled,
             }),
-            div({isRendered: (!isNil(renderIfSelected) && selected)}, [renderIfSelected]),
           ]);
         }))
       )

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -325,7 +325,6 @@ export const formInputCheckbox = (config) => {
     }),
     label({
       className: `regular-checkbox ${error ? 'errored' : ''}`,
-      htmlFor: id,
     }, [toggleText])
   ]);
 };
@@ -336,7 +335,7 @@ export const formInputSlider = (config) => {
   } = config;
 
   return div({ className: 'flex-row', style: { justifyContent: 'unset' } }, [
-    label({ className: 'switch', htmlFor: id }, [
+    label({ className: 'switch' }, [
       input({
         type: 'checkbox',
         id: id,

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -267,9 +267,8 @@ export const formInputRadioGroup = (config) => {
   */
 
   const {
-    id, disabled, error,
-    formValue, options, ariaDescribedby,
-    setError
+    id, disabled,
+    formValue, options
   } = config;
 
   return div({},

--- a/src/components/forms/formUtils.js
+++ b/src/components/forms/formUtils.js
@@ -1,0 +1,47 @@
+import {FormFieldTypes} from './forms'
+import { isNil, isEmpty, isString, isArray } from 'lodash/fp';
+
+const alwaysRequiredProps = ['id'];
+const alwaysPossibleProps = [
+  'name',
+  'disabled',
+  'description',
+  'title',
+  'ariaLevel',
+  'defaultValue',
+  'hideTitle',
+  'style',
+  'validators',
+  'onChange',
+  'type'
+];
+
+export const validateFormProps = (props) => {
+  const type = (!isNil(props.type) ? props.type : FormFieldTypes.TEXT)
+  
+  const requiredProps = type.requiredProps || [];
+  const possibleProps = type.possibleProps || [];
+
+  requiredProps.push(...alwaysRequiredProps);
+  possibleProps.push(...alwaysPossibleProps);
+  possibleProps.push(...requiredProps);
+
+  const propKeys = Object.keys(props);
+
+  propKeys.forEach((prop) => {
+    if (!possibleProps.includes(prop)) {
+      throw `unknown prop ${prop}`;
+    }
+  });
+
+  requiredProps.forEach((requiredProp) => {
+    if (!propKeys.includes(requiredProp)) {
+      throw `prop ${requiredProp} is required`;
+    }
+  });
+
+  if (!isNil(type.customPropValidation)) {
+    type.customPropValidation(props);
+  }
+
+} 

--- a/src/components/forms/formUtils.js
+++ b/src/components/forms/formUtils.js
@@ -1,35 +1,21 @@
-import {FormFieldTypes} from './forms';
-import { isNil, isFunction } from 'lodash/fp';
-
-const alwaysRequiredProps = ['id'];
-const alwaysPossibleProps = [
-  'name',
-  'disabled',
-  'description',
-  'title',
-  'ariaLevel',
-  'defaultValue',
-  'hideTitle',
-  'style',
-  'validators',
-  'onChange',
-  'type'
-];
+import { FormFieldTypes, commonRequiredProps, commonOptionalProps } from './forms';
+import { isNil, isFunction, isArray, isEmpty, isString } from 'lodash/fp';
+import { isEmailAddress } from '../../libs/utils';
 
 export const validateFormProps = (props) => {
   const type = (!isNil(props.type) ? props.type : FormFieldTypes.TEXT);
 
   const requiredProps = type.requiredProps || [];
-  const possibleProps = type.possibleProps || [];
+  const optionalProps = type.optionalProps || [];
 
-  requiredProps.push(...alwaysRequiredProps);
-  possibleProps.push(...alwaysPossibleProps);
-  possibleProps.push(...requiredProps);
+  requiredProps.push(...commonRequiredProps);
+  optionalProps.push(...commonOptionalProps);
+  optionalProps.push(...requiredProps);
 
   const propKeys = Object.keys(props);
 
   propKeys.forEach((prop) => {
-    if (!possibleProps.includes(prop)) {
+    if (!optionalProps.includes(prop)) {
       throw `unknown prop ${prop}`;
     }
   });
@@ -43,4 +29,80 @@ export const validateFormProps = (props) => {
   if (isFunction(type.customPropValidation)) {
     type.customPropValidation(props);
   }
+};
+
+
+export const customSelectPropValidation = (props) => {
+  if (!isArray(props.selectOptions)) {
+    throw 'prop \'selectOptions\' must be an array';
+  }
+
+  if (isEmpty(props.selectOptions)) {
+    throw '\'selectOptions\' cannot be empty';
+  }
+
+  const isStringArr = isString(props.selectOptions[0]);
+
+  props.selectOptions.forEach((opt) => {
+    if (isStringArr) {
+      if (!isString(opt)) {
+        throw 'all values in \'selectOptions\' must be string typed';
+      }
+
+      return;
+    }
+
+    if (isNil(opt.displayText)) {
+      throw 'every value in \'selectOptions\' needs a \'displayText\' field';
+    }
+  });
+};
+
+export const customRadioPropValidation = (props) => {
+  if (!isArray(props.options)) {
+    throw '\'options\' prop must be an array.';
+  }
+
+  props.options.forEach((opt) => {
+    if (isNil(opt.name)) {
+      throw 'each option in \'options\' prop must have a \'name\' field';
+    }
+
+    if (isNil(opt.text)) {
+      throw 'each option in \'options\' prop must have a \'text\' field';
+    }
+
+    if (!isNil(opt.type) && !['boolean', 'string'].includes(opt.type)) {
+      throw `radio group option types can be 'boolean' or 'string', not: '${opt.type}'`;
+    }
+  });
+};
+
+export const updateSelectDefaultValue = ({ selectOptions, defaultValue }) => {
+  const isStringArr = isString(selectOptions[0]);
+  return isStringArr
+    ? { key: defaultValue, displayText: defaultValue }
+    : defaultValue;
+};
+
+export const requiredValidator = {
+  isValid: (value) => value !== undefined && value !== null && value !== '',
+  msg: 'Please enter a value',
+};
+
+export const urlValidator = {
+  isValid: (val) => {
+    try {
+      new URL(val);
+    } catch (_) {
+      return false;
+    }
+    return true;
+  },
+  msg: 'Please enter a valid url (e.g., https://www.google.com)',
+};
+
+export const emailValidator = {
+  isValid: isEmailAddress,
+  msg: 'Please enter a valid email address (e.g., person@example.com)',
 };

--- a/src/components/forms/formUtils.js
+++ b/src/components/forms/formUtils.js
@@ -1,5 +1,5 @@
-import {FormFieldTypes} from './forms'
-import { isNil, isEmpty, isString, isArray } from 'lodash/fp';
+import {FormFieldTypes} from './forms';
+import { isNil } from 'lodash/fp';
 
 const alwaysRequiredProps = ['id'];
 const alwaysPossibleProps = [
@@ -17,8 +17,8 @@ const alwaysPossibleProps = [
 ];
 
 export const validateFormProps = (props) => {
-  const type = (!isNil(props.type) ? props.type : FormFieldTypes.TEXT)
-  
+  const type = (!isNil(props.type) ? props.type : FormFieldTypes.TEXT);
+
   const requiredProps = type.requiredProps || [];
   const possibleProps = type.possibleProps || [];
 
@@ -44,4 +44,4 @@ export const validateFormProps = (props) => {
     type.customPropValidation(props);
   }
 
-} 
+};

--- a/src/components/forms/formUtils.js
+++ b/src/components/forms/formUtils.js
@@ -75,13 +75,6 @@ export const customRadioPropValidation = (props) => {
   });
 };
 
-export const updateSelectDefaultValue = ({ selectOptions, defaultValue }) => {
-  const isStringArr = isString(selectOptions[0]);
-  return isStringArr
-    ? { key: defaultValue, displayText: defaultValue }
-    : defaultValue;
-};
-
 export const requiredValidator = {
   isValid: (value) => value !== undefined && value !== null && value !== '',
   msg: 'Please enter a value',

--- a/src/components/forms/formUtils.js
+++ b/src/components/forms/formUtils.js
@@ -72,9 +72,6 @@ export const customRadioPropValidation = (props) => {
       throw 'each option in \'options\' prop must have a \'text\' field';
     }
 
-    if (!isNil(opt.type) && !['boolean', 'string'].includes(opt.type)) {
-      throw `radio group option types can be 'boolean' or 'string', not: '${opt.type}'`;
-    }
   });
 };
 

--- a/src/components/forms/formUtils.js
+++ b/src/components/forms/formUtils.js
@@ -1,5 +1,5 @@
 import {FormFieldTypes} from './forms';
-import { isNil } from 'lodash/fp';
+import { isNil, isFunction } from 'lodash/fp';
 
 const alwaysRequiredProps = ['id'];
 const alwaysPossibleProps = [
@@ -40,8 +40,7 @@ export const validateFormProps = (props) => {
     }
   });
 
-  if (!isNil(type.customPropValidation)) {
+  if (isFunction(type.customPropValidation)) {
     type.customPropValidation(props);
   }
-
 };

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -8,7 +8,6 @@ import {
   requiredValidator,
   urlValidator,
   emailValidator,
-  updateSelectDefaultValue,
 } from './formUtils';
 import {
   formInputGeneric,
@@ -28,6 +27,7 @@ export const commonOptionalProps = [
   'description',
   'title',
   'ariaLevel',
+  'ariaDescribedby',
   'defaultValue',
   'hideTitle',
   'style',
@@ -36,9 +36,9 @@ export const commonOptionalProps = [
   'type'
 ];
 
-// ----------------------------------------------- //
-// ======       MAIN FORM FIELD TYPES       ====== //
-// ----------------------------------------------- //
+// ----------------------------------------------------------------------------------------------------- //
+// ======                                  MAIN FORM FIELD TYPES                                  ====== //
+// ----------------------------------------------------------------------------------------------------- //
 export const FormFieldTypes = {
   MULTITEXT: {
     defaultValue: [],
@@ -46,7 +46,6 @@ export const FormFieldTypes = {
     requiredProps: [],
     optionalProps: [
       'placeholder',
-      'ariaDescribedby',
       'inputStyle'
     ],
   },
@@ -69,9 +68,7 @@ export const FormFieldTypes = {
       //  {name: 'other', text: 'Other', renderIfSelected: h(FormField, ...) }
       // ]
     ],
-    optionalProps: [
-      'ariaDescribedBy',
-    ],
+    optionalProps: [],
     customPropValidation: customRadioPropValidation,
   },
   TEXT: {
@@ -80,9 +77,7 @@ export const FormFieldTypes = {
     requiredProps: [],
     optionalProps: [
       'placeholder',
-      'inputStyle',
-      'ariaDescribedby',
-    ],
+      'inputStyle'],
   },
   NUMBER: {
     defaultValue: '',
@@ -90,8 +85,7 @@ export const FormFieldTypes = {
     requiredProps: [],
     optionalProps: [
       'placeholder',
-      'inputStyle',
-      'ariaDescribedby',
+      'inputStyle'
     ],
   },
   CHECKBOX: {
@@ -102,7 +96,12 @@ export const FormFieldTypes = {
   },
   SELECT: {
     defaultValue: (config) => (config?.isMulti ? [] : ''),
-    updateDefaultValue: updateSelectDefaultValue,
+    updateDefaultValue: ({ selectOptions, defaultValue }) => {
+      const isStringArr = isString(selectOptions[0]);
+      return isStringArr
+        ? { key: defaultValue, displayText: defaultValue }
+        : defaultValue;
+    },
     component: formInputSelect,
     requiredProps: [
       'selectOptions'
@@ -117,23 +116,24 @@ export const FormFieldTypes = {
       'isCreatable', // allows user to input their own
       'isMulti',
       'placeholder',
-      'ariaDescribedby',
-      'required',
       'selectConfig',
     ],
     customPropValidation: customSelectPropValidation,
   },
 };
 
+// ----------------------------------------------------------------------------------------------------- //
+// ======                                     FORM VALIDATORS                                     ====== //
+// ----------------------------------------------------------------------------------------------------- //
 export const FormValidators = {
   REQUIRED: requiredValidator,
   URL: urlValidator,
   EMAIL: emailValidator,
 };
 
-// ----------------------------------------------- //
-// ======          MAIN COMPONENTS          ====== //
-// ----------------------------------------------- //
+// ----------------------------------------------------------------------------------------------------- //
+// ======                                     MAIN COMPONENTS                                     ====== //
+// ----------------------------------------------------------------------------------------------------- //
 export const FormField = (config) => {
   const {
     id, type = FormFieldTypes.TEXT, ariaLevel,

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -57,7 +57,7 @@ export const FormFieldTypes = {
       'toggleText',
     ],
   },
-  RADIO: {
+  RADIOGROUP: {
     defaultValue: null,
     component: formInputRadioGroup,
     requiredProps: [
@@ -65,7 +65,7 @@ export const FormFieldTypes = {
       // 'options' example:
       // [
       //  {name: 'opt_1', text: 'Option 1'},
-      //  {name: 'other', text: 'Other', renderIfSelected: h(FormField, ...) }
+      //  {id: 'custom_id_other', name: 'other', text: 'Other'}
       // ]
     ],
     optionalProps: [],

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -60,7 +60,7 @@ export const FormFieldTypes = {
         if (!isNil(opt.type) && !['boolean', 'string'].includes(opt.type)) {
           throw `radio group option types can be 'boolean' or 'string', not: '${opt.type}'`;
         }
-      })
+      });
     }
   },
   TEXT: {
@@ -113,6 +113,7 @@ export const FormFieldTypes = {
       'ariaDescribedby',
       'required',
       'disabled',
+      'selectConfig',
     ],
     customPropValidation: (props) => {
       if (!isArray(props.selectOptions)) {
@@ -123,21 +124,21 @@ export const FormFieldTypes = {
         throw '\'selectOptions\' cannot be empty';
       }
 
-      const isStringArr = isString(props.selectOptions[0])
+      const isStringArr = isString(props.selectOptions[0]);
 
       props.selectOptions.forEach((opt) => {
         if (isStringArr) {
           if (!isString(opt)) {
             throw 'all values in \'selectOptions\' must be string typed';
           }
-          
+
           return;
         }
 
         if (isNil(opt.displayText)) {
           throw 'every value in \'selectOptions\' needs a \'displayText\' field';
         }
-      })
+      });
     }
   },
 };
@@ -219,7 +220,7 @@ export const FormField = (config) => {
 
   useEffect(() => {
     validateFormProps(config);
-  }, [config])
+  }, [config]);
 
   return div({
     key: `formControl_${id}`,

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -66,7 +66,7 @@ export const FormFieldTypes = {
       // 'options' example:
       // [
       //  {name: 'opt_1', text: 'Option 1'},
-      //  {name: 'other', text: 'Other', type: 'string'} <-- will have textbox
+      //  {name: 'other', text: 'Other', renderIfSelected: h(FormField, ...) }
       // ]
     ],
     optionalProps: [
@@ -98,10 +98,7 @@ export const FormFieldTypes = {
     defaultValue: (config) => (config?.valueType === 'string' ? '' : false),
     component: formInputCheckbox,
     requiredProps: [],
-    optionalProps: [
-      'placeholder',
-      'inputStyle',
-    ],
+    optionalProps: [],
   },
   SELECT: {
     defaultValue: (config) => (config?.isMulti ? [] : ''),

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { h, div, label, span, button } from 'react-hyperscript-helpers';
-import { cloneDeep, isFunction } from 'lodash/fp';
+import { cloneDeep, isFunction, isString } from 'lodash/fp';
 import {
   validateFormProps,
   customRadioPropValidation,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2073

Also included: 
- Cleanup to make the prop naming of `SELECT` clearer (imo)

Now, if you provide a prop which is unknown to formfield, an exception will be thrown. SImilarly, fields which are required, such as `id` or `selectOptions` will also throw an exception. For select, validation will also occur to ensure that the `selectOptions` passed are valid.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
