### PR TITLE
DUOS-1740[risk=no] Upgrade Cypress to 10.10 and fix failing test

### DIFF
--- a/cypress/component/DataSubmission/data_access_governance.spec.js
+++ b/cypress/component/DataSubmission/data_access_governance.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-undef */
 import React from 'react';
-import { DAC, User } from '../../../src/libs/ajax';
+import { DAC, User, Institution } from '../../../src/libs/ajax';
 import DataSubmissionForm from '../../../src/pages/DataSubmissionForm';
 import { mount } from 'cypress/react';
 
@@ -20,6 +20,7 @@ const user = {
 beforeEach(() => {
   cy.stub(DAC, 'list').returns(Promise.resolve(dacs));
   cy.stub(User, 'getMe').returns(user);
+  cy.stub(Institution, 'list').returns([{name: 'Test Instituion'}]);
 });
 
 describe('Data Access Governance', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@babel/eslint-plugin": "7.19.1",
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/preset-react": "7.18.6",
-        "cypress": "10.9.0",
+        "cypress": "10.10.0",
         "eslint": "7.32.0",
         "eslint-plugin-flowtype": "7.0.0",
         "eslint-plugin-react": "7.31.8",
@@ -7519,9 +7519,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/cypress": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.9.0.tgz",
-      "integrity": "sha512-MjIWrRpc+bQM9U4kSSdATZWZ2hUqHGFEQTF7dfeZRa4MnalMtc88FIE49USWP2ZVtfy5WPBcgfBX+YorFqGElA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
+      "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -27939,9 +27939,9 @@
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "cypress": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.9.0.tgz",
-      "integrity": "sha512-MjIWrRpc+bQM9U4kSSdATZWZ2hUqHGFEQTF7dfeZRa4MnalMtc88FIE49USWP2ZVtfy5WPBcgfBX+YorFqGElA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
+      "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@babel/eslint-plugin": "7.19.1",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/preset-react": "7.18.6",
-    "cypress": "10.9.0",
+    "cypress": "10.10.0",
     "eslint": "7.32.0",
     "eslint-plugin-flowtype": "7.0.0",
     "eslint-plugin-react": "7.31.8",


### PR DESCRIPTION
Addresses [DUOS-2159](https://broadworkbench.atlassian.net/browse/DUOS-2159), but is labelled under DUOS-1740 due to it being a dependency update.

PR upgrades Cypress from 10.9 to 10.10, causing a previously passing test to fail locally. Upon further inspection, the failing tests was missing a stub, indicating that 10.9 failed to correctly evaluate that particular test. Adding the stub corrects the error and causes the test to pass.

There needs to be additional investigations as to why the Github Action also failed to notice the missing stub, but that should be done as a separate task.

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
