### PR TITLE
[DUOS-2025][risk=no] Remove IT / SO director fields from applicant information section

### DIFF
--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -197,32 +197,32 @@ describe('Application Information', () => {
     requestSpan.contains('Person E, Person F');
   });
 
-  it('renders the signing official and signing official email', () => {
+  it('renders the signing official and signing official', () => {
     const props = {
       signingOfficialEmail: 'test@test.com',
     };
     mount(<ApplicationInformation {...props} />);
 
-    const emailLabel = cy.get('#signing-official-email-label');
+    const emailLabel = cy.get('#signing-official-label');
     expect(emailLabel).to.exist;
-    emailLabel.contains('Signing Official Email');
+    emailLabel.contains('Signing Official');
 
-    const emailSpan = cy.get('#signing-official-email-span');
+    const emailSpan = cy.get('#signing-official-span');
     expect(emailSpan).to.exist;
     emailSpan.contains('test@test.com');
   });
 
-  it('renders the IT director and IT director email', () => {
+  it('renders the IT director and IT director', () => {
     const props = {
       itDirectorEmail: 'test@test.com',
     };
     mount(<ApplicationInformation {...props} />);
 
-    const emailLabel = cy.get('#it-director-email-label');
+    const emailLabel = cy.get('#it-director-label');
     expect(emailLabel).to.exist;
-    emailLabel.contains('IT Director Email');
+    emailLabel.contains('IT Director');
 
-    const emailSpan = cy.get('#it-director-email-span');
+    const emailSpan = cy.get('#it-director-span');
     expect(emailSpan).to.exist;
     emailSpan.contains('test@test.com');
   });

--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -199,17 +199,9 @@ describe('Application Information', () => {
 
   it('renders the signing official and signing official email', () => {
     const props = {
-      signingOfficial: 'Person SO',
       signingOfficialEmail: 'test@test.com',
     };
     mount(<ApplicationInformation {...props} />);
-    const nameLabel = cy.get('#signing-official-label');
-    expect(nameLabel).to.exist;
-    nameLabel.contains('Signing Official');
-
-    const nameSpan =  cy.get('#signing-official-span');
-    expect(nameSpan).to.exist;
-    nameSpan.contains('Person SO');
 
     const emailLabel = cy.get('#signing-official-email-label');
     expect(emailLabel).to.exist;
@@ -222,17 +214,9 @@ describe('Application Information', () => {
 
   it('renders the IT director and IT director email', () => {
     const props = {
-      itDirector: 'Person SO',
       itDirectorEmail: 'test@test.com',
     };
     mount(<ApplicationInformation {...props} />);
-    const nameLabel = cy.get('#it-director-label');
-    expect(nameLabel).to.exist;
-    nameLabel.contains('IT Director');
-
-    const nameSpan = cy.get('#it-director-span');
-    expect(nameSpan).to.exist;
-    nameSpan.contains('Person SO');
 
     const emailLabel = cy.get('#it-director-email-label');
     expect(emailLabel).to.exist;

--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -105,8 +105,6 @@ export default function ApplicationInformation(props) {
     isLoading = false,
     externalCollaborators = [],
     internalCollaborators = [],
-    signingOfficial = '- -',
-    itDirector = '- -',
     signingOfficialEmail = '- -',
     itDirectorEmail = '- -',
     internalLabStaff = [],
@@ -127,8 +125,6 @@ export default function ApplicationInformation(props) {
   ];
 
   const institutionLabels = [
-    {value: signingOfficial, title: 'Signing Official', key: 'signing-official'},
-    {value: itDirector, title: 'IT Director', key: 'it-director'},
     {value: signingOfficialEmail, title: 'Signing Official Email', key: 'signing-official-email'},
     {value: itDirectorEmail, title: 'IT Director Email', key: 'it-director-email'},
   ];

--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -125,8 +125,8 @@ export default function ApplicationInformation(props) {
   ];
 
   const institutionLabels = [
-    {value: signingOfficialEmail, title: 'Signing Official Email', key: 'signing-official-email'},
-    {value: itDirectorEmail, title: 'IT Director Email', key: 'it-director-email'},
+    {value: signingOfficialEmail, title: 'Signing Official', key: 'signing-official'},
+    {value: itDirectorEmail, title: 'IT Director', key: 'it-director'},
   ];
 
   const cloudUseLabels = [


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2025

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
