### PR TITLE
[DUOS-2167][risk=no] Adds 'Modifiers' section to bucket pills.

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -5,6 +5,7 @@ import MultiDatasetVoteSlab from '../../../src/components/collection_voting_slab
 import {Storage} from '../../../src/libs/storage';
 import {Votes} from '../../../src/libs/ajax';
 import {votingColors} from '../../../src/pages/dar_collection_review/MultiDatasetVotingTab';
+import {ControlledAccessType} from '../../../src/libs/dataUseTranslation';
 
 const openElection1 = [
   {dataSetId: 10, electionId: 101, status: 'Open', electionType: 'DataAccess'},
@@ -75,8 +76,9 @@ describe('MultiDatasetVoteSlab - Tests', function() {
         title={'GROUP 1'}
         bucket={{
           dataUses: [
-            {code: 'GRU', description: 'Use is permitted for any research purpose'},
-            {code: 'HMB', description: 'Use is permitted for a health, medical, or biomedical research purpose'}
+            {code: 'GRU', description: 'Use is permitted for any research purpose', type: ControlledAccessType.permissions},
+            {code: 'HMB', description: 'Use is permitted for a health, medical, or biomedical research purpose', type: ControlledAccessType.permissions},
+            {code: 'NCU', description: 'The dataset will be used in a study related to a commercial purpose.', type: ControlledAccessType.modifiers}
           ]
         }}
         dacDatasetIds={[10, 20]}
@@ -88,6 +90,9 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.contains('Use is permitted for any research purpose');
     cy.contains('HMB');
     cy.contains('Use is permitted for a health, medical, or biomedical research purpose');
+    cy.contains(ControlledAccessType.modifiers);
+    cy.contains('NCU');
+    cy.contains('The dataset will be used in a study related to a commercial purpose.');
   });
 
   it('Renders a selected vote button when all current user votes match (Member)', function() {

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -6,6 +6,7 @@ import {User} from '../../../src/libs/ajax';
 import MultiDatasetVotingTab, {votingColors} from '../../../src/pages/dar_collection_review/MultiDatasetVotingTab';
 import {filterBucketsForUser} from '../../../src/utils/DarCollectionUtils.js';
 import {rpVoteKey} from '../../../src/utils/DarCollectionUtils';
+import {ControlledAccessType} from '../../../src/libs/dataUseTranslation';
 
 const darInfo = {
   rus: 'test',
@@ -51,7 +52,7 @@ const bucket1 = {
     },
   ],
   dataUses: [
-    {code: 'GRU', description: 'Use is permitted for any research purpose'},
+    {code: 'GRU', description: 'Use is permitted for any research purpose', type: ControlledAccessType.permissions},
   ]
 };
 
@@ -92,7 +93,7 @@ const bucket2 = {
     },
   ],
   dataUses: [
-    {code: 'HMB', description: 'Use is permitted for a health, medical, or biomedical research purpose'}
+    {code: 'HMB', description: 'Use is permitted for a health, medical, or biomedical research purpose', type: ControlledAccessType.permissions}
   ]
 };
 

--- a/src/components/collection_voting_slab/DataUsePill.js
+++ b/src/components/collection_voting_slab/DataUsePill.js
@@ -1,4 +1,4 @@
-import {div, h2, span} from 'react-hyperscript-helpers';
+import {div, h3, span} from 'react-hyperscript-helpers';
 import {isNil} from 'lodash';
 import {map} from 'lodash/fp';
 import { ControlledAccessType } from '../../libs/dataUseTranslation';
@@ -23,6 +23,9 @@ const styles = {
     justifyContent: 'center',
     display: 'flex'
   },
+  subheading: {
+    fontWeight: 'bold',
+  },
   description: {
     color: '#333F52',
     fontWeight: '500',
@@ -45,7 +48,7 @@ export function DataUsePills(dataUses){
   return(
     div([map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})(permissionsUses),
       div({isRendered: modifierUses.length > 0},[
-        h2(ControlledAccessType.modifiers),
+        h3({style: styles.subheading}, ControlledAccessType.modifiers),
         map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})((modifierUses))
       ])
     ])

--- a/src/components/collection_voting_slab/DataUsePill.js
+++ b/src/components/collection_voting_slab/DataUsePill.js
@@ -1,6 +1,7 @@
-import {div, span} from 'react-hyperscript-helpers';
+import {div, h2, span} from 'react-hyperscript-helpers';
 import {isNil} from 'lodash';
 import {map} from 'lodash/fp';
+import { ControlledAccessType } from '../../libs/dataUseTranslation';
 
 const styles = {
   baseStyle: {
@@ -32,17 +33,21 @@ const styles = {
 export function DataUsePill(props) {
   const {dataUse} = props;
 
-  return div({key: `data_use_pill_${dataUse.code}`, style: styles.baseStyle}, [
+  return div({key: `data_use_pill_${dataUse.type}_${dataUse.code}`, style: styles.baseStyle}, [
     span({ style: styles.code }, !isNil(dataUse) ? [dataUse.code] : []),
     span({ style: styles.description }, !isNil(dataUse) ? [dataUse.description] : [])
   ]);
 }
 
 export function DataUsePills(dataUses){
-  return map( dataUse => {
-    return DataUsePill({
-      dataUse,
-      key: dataUse.code
-    });
-  })(dataUses);
+  const permissionsUses = dataUses.filter(dataUse => dataUse.type === ControlledAccessType.permissions);
+  const modifierUses = dataUses.filter(dataUse => dataUse.type === ControlledAccessType.modifiers);
+  return(
+    div({},[map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})(permissionsUses),
+      div({isRendered: modifierUses.length > 0},[
+        h2({}, ControlledAccessType.modifiers),
+        map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})((modifierUses))
+      ])
+    ])
+  );
 }

--- a/src/components/collection_voting_slab/DataUsePill.js
+++ b/src/components/collection_voting_slab/DataUsePill.js
@@ -43,9 +43,9 @@ export function DataUsePills(dataUses){
   const permissionsUses = dataUses.filter(dataUse => dataUse.type === ControlledAccessType.permissions);
   const modifierUses = dataUses.filter(dataUse => dataUse.type === ControlledAccessType.modifiers);
   return(
-    div({},[map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})(permissionsUses),
+    div([map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})(permissionsUses),
       div({isRendered: modifierUses.length > 0},[
-        h2({}, ControlledAccessType.modifiers),
+        h2(ControlledAccessType.modifiers),
         map(dataUse=>{return DataUsePill({dataUse, key: dataUse.code});})((modifierUses))
       ])
     ])

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -94,7 +94,7 @@ const animationAttributes = {
 const DataUseSummary = ({translatedDataUse}) => {
   return flatMap( key => {
     const dataUses = translatedDataUse[key];
-    return DataUsePills(dataUses);
+    return div({key: key},[DataUsePills(dataUses)]);
   })(keys(translatedDataUse));
 };
 

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -2,22 +2,30 @@ import {isNil, isEmpty, filter, join, concat, clone, uniq, head} from 'lodash/fp
 import { searchOntology, extractDOIDFromUrl } from './ontologyService';
 import { Notifications } from './utils';
 
+export const ControlledAccessType = {
+  permissions: 'Permissions',
+  modifiers: 'Modifiers'
+};
+
 export const srpTranslations = {
   hmb: {
     code: 'HMB',
     description: 'The primary purpose of the study is to investigate a health/medical/biomedical (or biological) phenomenon or condition.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.permissions
   },
   poa: {
     code: 'POA',
     description: 'The dataset will be used for the study of Population Origins/Migration patterns.',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.permissions
   },
   diseases: (diseases) => {
     let outputStruct = {
       code: 'DS',
       description: 'The dataset will be used for disease related studies',
-      manualReview: false
+      manualReview: false,
+      type: ControlledAccessType.permissions
     };
     if(!isEmpty(diseases)) {
       const diseaseArray = diseases.sort().map((disease) => disease.label);
@@ -29,89 +37,106 @@ export const srpTranslations = {
   researchTypeDisease: {
     code: 'DS',
     description: 'The primary purpose of the research is to learn more about a particular disease or disorder, a trait, or a set of related conditions.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.permissions
   },
   other: (otherText) => {
     return {
       code: 'OTHER',
       description: isEmpty(otherText) ? 'Other: Not provided' : otherText,
-      manualReview: true
+      manualReview: true,
+      type: ControlledAccessType.permissions
     };
   },
   methods: {
     code: 'MDS',
     description: 'The primary purpose of the research is to develop and/or validate new methods for analyzing or interpreting data. Data will be used for developing and/or validating new methods.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   controls: {
     code: 'CTRL',
     description: 'The reason for this request is to increase the number of controls available for a comparison group.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   forProfit: {
     code: 'NCU',
     description: 'The dataset will be used in a study related to a commercial purpose.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   notForProfit: {
     code: 'NPU',
     description: 'This dataset will not be used in a study related to a commercial purpose.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   genderFemale: {
     code: 'POP-F',
     description: 'The dataset will be used for the study of females.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   genderMale: {
     code: 'POP-M',
     description: 'The dataset will be used for the study of males.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   pediatric: {
     code: 'POP-P',
     description: 'The dataset will be used for the study of children.',
-    manualReview: false
+    manualReview: false,
+    type: ControlledAccessType.modifiers
   },
   illegalBehavior: {
     code: 'OTHER',
     description: 'The dataset will be used for the study of illegal behaviors (violence, domestic abuse, prostitution, sexual victimization).',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   addiction: {
     code: 'OTHER',
     description: 'The dataset will be used for the study of alcohol or drug abuse, or abuse of other addictive products.',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   sexualDiseases: {
     code: 'OTHER',
     description: 'The dataset will be used for the study of sexual preferences or sexually transmitted diseases.',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   stigmatizedDiseases: {
     code: 'OTHER',
     description: 'The dataset will be used for the study of stigmatizing illnesses.',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   vulnerablePopulation: {
     code: 'OTHER',
     description: 'The dataset will be used for a study targeting a vulnerable population as defined in 456 CFR (children, prisoners, pregnant women, mentally disabled persons, or [SIGNIFICANTLY] economically or educationally disadvantaged persons).',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   population: {
     code: 'OTHER',
     description: 'The dataset will be used to study variations within the general population (e.g., general substructure of a population).',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   psychiatricTraits: {
     code: 'OTHER',
     description: 'The dataset will be used for the study of psychological traits, including intelligence, attention, emotion.',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   },
   notHealth: {
     code: 'OTHER',
     description: 'The dataset will be used for the research that correlates ethnicity, race, or gender with genotypic or other phenotypic variables, for purposes beyond biomedical or health-related research, or in ways may not be easily related to Health.',
-    manualReview: true
+    manualReview: true,
+    type: ControlledAccessType.modifiers
   }
 };
 
@@ -119,10 +144,12 @@ export const consentTranslations = {
   generalUse: {
     code: 'GRU',
     description: 'Use is permitted for any research purpose',
+    type: ControlledAccessType.permissions,
   },
   hmbResearch: {
     code: 'HMB',
     description: 'Use is permitted for a health, medical, or biomedical research purpose',
+    type: ControlledAccessType.permissions,
   },
   diseaseRestrictions: (restrictions) => {
     if (isEmpty(restrictions)) {
@@ -133,47 +160,58 @@ export const consentTranslations = {
       code: 'DS',
       alternateLabel: `DS ${restrictions.join('-')}`,
       description: `Use is permitted for the specified disease(s): ${restrictionList}`,
+      type: ControlledAccessType.permissions,
     };
   },
   populationOriginsAncestry: {
     code: 'POA',
     description: 'Use is limited to population, origin, or ancestry research',
+    type: ControlledAccessType.permissions,
   },
   methodsResearch: {
     code: 'NMDS',
     description: 'Use for methods development research (e.g., development of software or algorithms) only within the bounds of other use limitations',
+    type: ControlledAccessType.modifiers,
   },
   geneticStudiesOnly: {
     code: 'GSO',
     description: 'Use is limited to genetic studies only',
+    type: ControlledAccessType.modifiers,
   },
   commercialUse: {
     code: 'NPU',
     description: 'Use is limited to non-profit and non-commercial research',
+    type: ControlledAccessType.modifiers,
   },
   publicationResults: {
     code: 'PUB',
     description: 'Use requires users to make results of studies using the data available to the larger scientific community',
+    type: ControlledAccessType.modifiers,
   },
   collaboratorRequired: {
     code: 'COL',
     description: 'Use requires users to collaborate with the primary study investigators',
+    type: ControlledAccessType.modifiers,
   },
   ethicsApprovalRequired: {
     code: 'IRB',
     description: 'Use requires users to provide documentation of local IRB/ERB approval',
+    type: ControlledAccessType.modifiers,
   },
   geographicalRestrictions: {
     code: 'GS',
     description: 'Use is limited to within a certain geographic area',
+    type: ControlledAccessType.modifiers,
   },
   gender: {
     code: 'RS-G',
     description: 'Use is limited to research involving a particular gender',
+    type: ControlledAccessType.modifiers,
   },
   pediatric: {
     code: 'RS-PD',
     description: 'Use is limited to pediatric research',
+    type: ControlledAccessType.modifiers,
   },
 };
 


### PR DESCRIPTION
[DUOS-2167](https://broadworkbench.atlassian.net/browse/DUOS-2167) Modifies DataUsePills and callers so that the list is built with a heading added before the "Modifiers"

To accomplish this:
ControlledAccessType was added with two properties: permissions and modifiers (dataUseTranslation).
Each member of srpTranslations and consentTranslations now has a type property assigned to either ControlledAccessType.permissions or ControlledAccessType.modifiers
DataUsePill was updated to group by ControlledAccessType and render the new heading above modifiers

Tests were adjusted to add the new type property and validate both groups render and the appropriate "Modifiers" heading appears.

BEFORE
![Screen Shot 2022-11-02 at 8 47 39 PM](https://user-images.githubusercontent.com/111771148/199629312-3ee752ea-349b-4a1c-aa13-d8bc79e758aa.png)

AFTER
![Screen Shot 2022-11-03 at 10 42 36 AM](https://user-images.githubusercontent.com/111771148/199751981-76d710fc-632f-44d6-80be-d221fe34d58b.png)



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
