### PR TITLE
[DUOS-2158][risk=no] Swap default pages for researcher tab

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -124,7 +124,7 @@ export const headerTabsConfig = [
   {
     label: 'Researcher Console',
     link: '/dataset_catalog',
-    search: 'researcher_console',
+    search: 'dataset_catalog',
     children: [
       { label: 'Data Catalog', link: '/dataset_catalog' },
       { label: 'DAR Requests', link: '/researcher_console' }
@@ -181,7 +181,7 @@ const NavigationTabsComponent = (props) => {
               to: {
                 pathname: tab.link,
                 state: {
-                  selectedMenuTab: selectedMenuTab,
+                  selectedMenuTab: tabIndex,
                 },
               },
               component: Link

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -123,11 +123,11 @@ export const headerTabsConfig = [
   },
   {
     label: 'Researcher Console',
-    link: '/researcher_console',
+    link: '/dataset_catalog',
     search: 'researcher_console',
     children: [
-      { label: 'DAR Requests', link: '/researcher_console' },
-      { label: 'Data Catalog', link: '/dataset_catalog' }
+      { label: 'Data Catalog', link: '/dataset_catalog' },
+      { label: 'DAR Requests', link: '/researcher_console' }
     ],
     isRendered: (user) => user.isResearcher
   }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2158

The default page for the researcher console is now set to the dataset catalog instead of the user's DARs.

### Old
<img width="1292" alt="Screen Shot 2022-11-03 at 5 31 43 AM" src="https://user-images.githubusercontent.com/116679/199687387-3e02cfe5-c194-47ca-ae1f-fbc495d3627b.png">


### New
<img width="1292" alt="Screen Shot 2022-11-03 at 5 31 49 AM" src="https://user-images.githubusercontent.com/116679/199687368-3369e669-76b2-463f-b0c4-3633859fb61d.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
