### PR TITLE
DUOS-1740[risk=no] Update react-select to 5.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-protected-mailto": "1.0.3",
         "react-router-bootstrap": "0.25.0",
         "react-router-dom": "5.3.0",
-        "react-select": "5.5.4",
+        "react-select": "5.6.0",
         "react-tooltip": "4.4.3",
         "stackdriver-errors-js": "0.12.0",
         "usa-states": "0.0.6",
@@ -18672,9 +18672,9 @@
       }
     },
     "node_modules/react-select": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.5.4.tgz",
-      "integrity": "sha512-lyr19joBUm/CNJgjZMBSnFvJ/MeHCmBYvQ050qYAP3EPa7Oenlnx9guhU+SW0goYgxLQyqwRvkFllQpFAp8tmQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.6.0.tgz",
+      "integrity": "sha512-uUvP/72rA8NGhOL16RVBaeC12Wa4NUE0iXIa6hz0YRno9ZgxTmpuMeKzjR7vHcwmigpVCoe0prP+3NVb6Obq8Q==",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -36045,9 +36045,9 @@
       }
     },
     "react-select": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.5.4.tgz",
-      "integrity": "sha512-lyr19joBUm/CNJgjZMBSnFvJ/MeHCmBYvQ050qYAP3EPa7Oenlnx9guhU+SW0goYgxLQyqwRvkFllQpFAp8tmQ==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.6.0.tgz",
+      "integrity": "sha512-uUvP/72rA8NGhOL16RVBaeC12Wa4NUE0iXIa6hz0YRno9ZgxTmpuMeKzjR7vHcwmigpVCoe0prP+3NVb6Obq8Q==",
       "requires": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-protected-mailto": "1.0.3",
     "react-router-bootstrap": "0.25.0",
     "react-router-dom": "5.3.0",
-    "react-select": "5.5.4",
+    "react-select": "5.6.0",
     "react-tooltip": "4.4.3",
     "stackdriver-errors-js": "0.12.0",
     "usa-states": "0.0.6",

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -2,7 +2,7 @@ import { h, div, label, input, span, button, textarea } from 'react-hyperscript-
 import { cloneDeep, isNil, isEmpty, isString } from 'lodash/fp';
 import Creatable from 'react-select/creatable';
 import Select from 'react-select';
-import AsyncSelect from 'react-select/async/dist/react-select.esm';
+import AsyncSelect from 'react-select/async';
 import AsyncCreatable from 'react-select/async-creatable';
 import { FormField, FormValidators } from './forms';
 import { RadioButton } from '../RadioButton';

--- a/src/pages/DataSharingLanguageTool.js
+++ b/src/pages/DataSharingLanguageTool.js
@@ -1,7 +1,7 @@
 import {Styles} from '../libs/theme';
 import {a, br, button, div, h, input, label, span, textarea} from 'react-hyperscript-helpers';
 import {RadioButton} from '../components/RadioButton';
-import AsyncSelect from 'react-select/async/dist/react-select.esm';
+import AsyncSelect from 'react-select/async';
 import {isNil, isEmpty, head} from 'lodash/fp';
 import {Notifications, searchOntologies} from '../libs/utils';
 import {DataUseTranslation} from '../libs/dataUseTranslation';

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -43,9 +43,7 @@ export const DataSubmissionForm = () => {
 
   let formData = {};
 
-  const onChange = ({ key, value, isValid }) => {
-    /* eslint-disable no-console */
-    console.log('StudyInfo OnChange:', key, value, isValid);
+  const onChange = ({ key, value }) => {
     set(key, value, formData);
   };
 

--- a/src/pages/dar_application/TypeOfResearch.js
+++ b/src/pages/dar_application/TypeOfResearch.js
@@ -1,7 +1,7 @@
 import {div, h, hh, textarea, label, input, span} from 'react-hyperscript-helpers';
 import {RadioButton} from '../../components/RadioButton';
 import {Component} from 'react';
-import AsyncSelect from 'react-select/async/dist/react-select.esm';
+import AsyncSelect from 'react-select/async';
 import {DAR} from '../../libs/ajax';
 import * as fp from 'lodash/fp';
 


### PR DESCRIPTION
PR is essentially a dependency update, so it's addressing [DUOS-1740](https://broadworkbench.atlassian.net/browse/DUOS-1740)

The reason why it's not being handled through a dependabot PR is because the version update has changed some of the file locations, causing the previous import statements to be invalid. This, in turn, caused tests to fail because said file could not be found. So the PR is a version bump, updates to import statements, and removal of one stray console.log statement.


Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
