### PR TITLE
[DUOS-1501][risk=no] Add robust redirects after login

### DIFF
--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -1,12 +1,12 @@
 import {isEmpty, isNil} from 'lodash/fp';
-import {useEffect, useState, useCallback} from 'react';
+import {useEffect, useState} from 'react';
 import GoogleLogin from 'react-google-login';
 import {a, button, div, h, img, span} from 'react-hyperscript-helpers';
 import {Alert} from './Alert';
 import {ToS, User} from '../libs/ajax';
 import {Config} from '../libs/config';
 import {Storage} from '../libs/storage';
-import {Navigation, setUserRoleStatuses} from '../libs/utils';
+import {setUserRoleStatuses} from '../libs/utils';
 import loadingIndicator from '../images/loading-indicator.svg';
 import {Spinner} from './Spinner';
 import ReactTooltip from 'react-tooltip';
@@ -32,7 +32,7 @@ export default function SignIn(props) {
 
   // Utility function called in the normal success case and in the undocumented 409 case
   // Check for ToS Acceptance - redirect user if not set.
-  const checkToSAndRedirect = async () => {
+  const checkToSAndRedirect = async (redirectPath) => {
     // Check if the user has accepted ToS yet or not:
     const user = await User.getMe();
     setUserRoleStatuses(user, Storage);
@@ -41,16 +41,23 @@ export default function SignIn(props) {
     const {tosAccepted} = userStatus;
     if (!isEmpty(userStatus) && !tosAccepted) {
       await Storage.setUserIsLogged(false);
-      history.push('/tos_acceptance');
+      history.push(`/tos_acceptance?redirectTo=${redirectPath}`);
     } else {
-      redirect(user);
+      history.push(redirectPath);
     }
   };
 
   const onSuccess = async (response) => {
     Storage.setGoogleData(response);
+
+    // if 'redirectTo' exists, redirect there. otherwise,
+    // redirect to the page the user attempted to go to before
+    // signing in.
+    const queryParams = new URLSearchParams(window.location.search);
+    let currentPage = queryParams.get('redirectTo') ? queryParams.get('redirectTo') : window.location.pathname;
+
     try {
-      await checkToSAndRedirect();
+      await checkToSAndRedirect(currentPage);
     } catch (error) {
       try {
         // New users without an existing account will error out in the above call
@@ -58,7 +65,7 @@ export default function SignIn(props) {
         const registeredUser = await User.registerUser();
         setUserRoleStatuses(registeredUser, Storage);
         await onSignIn();
-        history.push('/tos_acceptance');
+        history.push(`/tos_acceptance?redirectTo=${currentPage}`);
       } catch (error) {
         // Handle common error cases
         try {
@@ -70,7 +77,7 @@ export default function SignIn(props) {
             case 409:
               // If the user exists, regardless of conflict state, log them in.
               try {
-                await checkToSAndRedirect();
+                await checkToSAndRedirect(currentPage);
               } catch (error) {
                 Storage.clearStorage();
               }
@@ -99,10 +106,6 @@ export default function SignIn(props) {
       setErrorDisplay({'title': response.error, 'description': response.details});
     }
   };
-
-  const redirect = useCallback( (user) => {
-    Navigation.back(user, history);
-  }, [history]);
 
   const spinnerOrSigninButton = () => {
     const disabled = clientId === '';

--- a/src/pages/TermsOfServiceAcceptance.js
+++ b/src/pages/TermsOfServiceAcceptance.js
@@ -22,7 +22,12 @@ export default function TermsOfServiceAcceptance(props) {
     await TosService.acceptTos();
     await Storage.setUserIsLogged(true);
 
-    history.push('/profile');
+    // if there is a redirectTo, we should go to that. otherwise, just go to the appropriate
+    // user's profile.
+    const queryParams = new URLSearchParams(window.location.search);
+    const redirect = queryParams.get('redirectTo') ? queryParams.get('redirectTo') : '/profile';
+
+    history.push(redirect);
   }, [history]);
 
   const acceptButton = h(SimpleButton, {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1501

Example cases which must redirect properly:
- `https://local.broadinstitute.org:3000/dataset_catalog` should redirect to dataset catalog after logging in with an existing user.
- `https://local.broadinstitute.org:3000/home?redirectTo=dataset_catalog` should redirect to dataset catalog after logging in with an existing user.
- `https://local.broadinstitute.org:3000/dataset_catalog` should redirect to dataset catalog after accepting ToS with a new user.
- `https://local.broadinstitute.org:3000/home?redirectTo=dataset_catalog` should redirect to dataset catalog  after accepting ToS with a new user.

Can use https://consent.dsde-dev.broadinstitute.org/#/User/delete_api_user__email_ to delete a user for testing new user flow.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
