### PR TITLE
[DUOS-2163][risk=no] Add NIH Insitutional Certification Upload to Data Submission Consent Group

### DIFF
--- a/cypress/component/DataSubmission/consent_group.spec.js
+++ b/cypress/component/DataSubmission/consent_group.spec.js
@@ -9,6 +9,9 @@ const props = {
   parentConsentGroup: {},
   saveConsentGroup: () => {},
   deleteConsentGroup: () => {},
+  nihInstitutionalCertificationFile: null,
+  updateNihInstitutionalCertificationFile: () => {},
+
 };
 
 let propCopy = {};

--- a/cypress/component/DataSubmission/data_access_governance.spec.js
+++ b/cypress/component/DataSubmission/data_access_governance.spec.js
@@ -27,21 +27,21 @@ describe('Data Access Governance', function () {
   it('Only renders consent group info if closed access', function () {
     mount(<DataSubmissionForm />);
 
-    cy.get('#btn_addInstitution').should('not.exist');
+    cy.get('#btn_addConsentGroup').should('not.exist');
     cy.get('#dataAccessCommitteeId').should('not.exist');
 
     cy.get('#dataSharingPlan_closed_access').check();
 
 
-    cy.get('#btn_addInstitution').should('exist');
+    cy.get('#btn_addConsentGroup').should('exist');
     cy.get('#dataAccessCommitteeId').should('exist');
     cy.get('#0_consentGroupForm').should('not.exist');
-    cy.get('#btn_addInstitution').click();
+    cy.get('#btn_addConsentGroup').click();
     cy.get('#0_consentGroupForm').should('exist');
 
     cy.get('#dataSharingPlan_open_access').check();
 
-    cy.get('#btn_addInstitution').should('not.exist');
+    cy.get('#btn_addConsentGroup').should('not.exist');
     cy.get('#dataAccessCommitteeId').should('not.exist');
     cy.get('#0_consentGroupForm').should('not.exist');
 
@@ -55,17 +55,17 @@ describe('Data Access Governance', function () {
     cy.get('#1_consentGroupForm').should('not.exist');
     cy.get('#2_consentGroupForm').should('not.exist');
 
-    cy.get('#btn_addInstitution').click();
+    cy.get('#btn_addConsentGroup').click();
     cy.get('#0_consentGroupForm').should('exist');
     cy.get('#1_consentGroupForm').should('not.exist');
     cy.get('#2_consentGroupForm').should('not.exist');
 
-    cy.get('#btn_addInstitution').click();
+    cy.get('#btn_addConsentGroup').click();
     cy.get('#0_consentGroupForm').should('exist');
     cy.get('#1_consentGroupForm').should('exist');
     cy.get('#2_consentGroupForm').should('not.exist');
 
-    cy.get('#btn_addInstitution').click();
+    cy.get('#btn_addConsentGroup').click();
     cy.get('#0_consentGroupForm').should('exist');
     cy.get('#1_consentGroupForm').should('exist');
     cy.get('#2_consentGroupForm').should('exist');
@@ -77,9 +77,9 @@ describe('Data Access Governance', function () {
 
     cy.get('#dataSharingPlan_closed_access').check();
 
-    cy.get('#btn_addInstitution').click();
-    cy.get('#btn_addInstitution').click();
-    cy.get('#btn_addInstitution').click();
+    cy.get('#btn_addConsentGroup').click();
+    cy.get('#btn_addConsentGroup').click();
+    cy.get('#btn_addConsentGroup').click();
 
     cy.get('#0_consentGroupForm').should('exist');
     cy.get('#1_consentGroupForm').should('exist');

--- a/src/components/data_submission/DataAccessGovernance.js
+++ b/src/components/data_submission/DataAccessGovernance.js
@@ -1,6 +1,6 @@
 import ConsentGroupForm from './consent_group/ConsentGroupForm';
-import { useEffect, useState } from 'react';
-import { cloneDeep, isNil, every } from 'lodash/fp';
+import { useEffect, useState, useCallback } from 'react';
+import { isNil, every } from 'lodash/fp';
 import { div, h, h2, a, span } from 'react-hyperscript-helpers';
 import { DAC } from '../../libs/ajax';
 import { FormFieldTypes, FormField } from '../forms/forms';
@@ -47,39 +47,49 @@ export const DataAccessGovernance = (props) => {
     onChange({key: 'consentGroups', value: groups, isValid: valid});
   }, [consentGroupsState, onChange]);
 
-  const addNewConsentGroup = () => {
-    const newConsentGroupsState = cloneDeep(consentGroupsState);
-    newConsentGroupsState.push({
-      consentGroup: {},
-      editMode: true,
-      valid: false,
+  const addNewConsentGroup = useCallback(() => {
+    setConsentGroupsState((state) => {
+      state.push({
+        consentGroup: {},
+        nihInsitutionalCertificationFile: null,
+        editMode: true,
+        valid: false,
+      });
+      return state;
     });
-    setConsentGroupsState(newConsentGroupsState);
-  };
+  }, []);
 
-  const deleteConsentGroup = (idx) => {
-    const newConsentGroupsState = cloneDeep(consentGroupsState);
-    newConsentGroupsState[idx] = undefined;
-    setConsentGroupsState(newConsentGroupsState);
-  };
+  const deleteConsentGroup = useCallback((idx) => {
+    setConsentGroupsState((state) => {
+      state[idx] = undefined; // if deleted directly, keys based on idx would break.
+      return state;
+    });
+  }, []);
 
-  const updateConsentGroup = (idx, value, isValid) => {
-    const newConsentGroupsState = cloneDeep(consentGroupsState);
-    newConsentGroupsState[idx] = {
-      editMode: false,
-      valid: isValid,
-      consentGroup: {
-        ...consentGroupsState[idx],
+  const updateConsentGroup = useCallback((idx, value, isValid) => {
+    setConsentGroupsState((state) => {
+      state[idx].editMode = false;
+      state[idx].valid = isValid;
+      state[idx].consentGroup = {
+        ...state[idx].consentGroup,
         ...value,
-      }
-    };
-    setConsentGroupsState(newConsentGroupsState);
-  };
+      };
+      return state;
+    });
+  }, []);
+
+  const updateNihInstitutionalCertificationFile = useCallback((idx, file) => {
+    setConsentGroupsState((state) => {
+      state[idx].nihInsitutionalCertificationFile = file;
+      return state;
+    });
+  }, []);
 
   const startEditConsentGroup = (idx) => {
-    const newConsentGroupsState = cloneDeep(consentGroupsState);
-    newConsentGroupsState[idx].editMode = true;
-    setConsentGroupsState(newConsentGroupsState);
+    setConsentGroupsState((state) => {
+      state[idx].editMode = true;
+      return state;
+    });
   };
 
   return div({
@@ -134,7 +144,7 @@ export const DataAccessGovernance = (props) => {
             margin: '2rem 0 2rem 0'
           }}, [
           a({
-            id: 'btn_addInstitution',
+            id: 'btn_addConsentGroup',
             className: 'btn-primary btn-add common-background',
             onClick: () => addNewConsentGroup(),
           }, [
@@ -154,6 +164,7 @@ export const DataAccessGovernance = (props) => {
               idx: idx,
               saveConsentGroup: (newGroup) => updateConsentGroup(idx, newGroup),
               deleteConsentGroup: () => deleteConsentGroup(idx),
+              updateNihInstitutionalCertificationFile: (file) => updateNihInstitutionalCertificationFile(idx, file),
               startEditConsentGroup: () => startEditConsentGroup(idx),
             });
           })

--- a/src/components/data_submission/DataAccessGovernance.js
+++ b/src/components/data_submission/DataAccessGovernance.js
@@ -1,6 +1,6 @@
 import ConsentGroupForm from './consent_group/ConsentGroupForm';
 import { useEffect, useState, useCallback } from 'react';
-import { isNil, every } from 'lodash/fp';
+import { isNil, every, cloneDeep } from 'lodash/fp';
 import { div, h, h2, a, span } from 'react-hyperscript-helpers';
 import { DAC } from '../../libs/ajax';
 import { FormFieldTypes, FormField } from '../forms/forms';
@@ -41,56 +41,70 @@ export const DataAccessGovernance = (props) => {
   useEffect(() => {
     const filteredConsentGroupsState = consentGroupsState.filter(state => !isNil(state));
 
-    const groups = filteredConsentGroupsState.map(state => state.consentGroup);
+    const groups = filteredConsentGroupsState.map(state => {
+      return {
+        ...state.consentGroup,
+        ...{
+          nihInsitutionalCertificationFileName: state?.nihInsitutionalCertificationFile?.name,
+        },
+      };
+    });
     const valid = every(filteredConsentGroupsState.map(state => (!state.editMode) && state.valid));
 
     onChange({key: 'consentGroups', value: groups, isValid: valid});
   }, [consentGroupsState, onChange]);
 
   const addNewConsentGroup = useCallback(() => {
-    setConsentGroupsState((state) => {
-      state.push({
+    setConsentGroupsState((consentGroupsState) => {
+      const newConsentGroupsState = cloneDeep(consentGroupsState);
+      newConsentGroupsState.push({
         consentGroup: {},
         nihInsitutionalCertificationFile: null,
         editMode: true,
         valid: false,
       });
-      return state;
+
+      return newConsentGroupsState;
     });
   }, []);
 
   const deleteConsentGroup = useCallback((idx) => {
-    setConsentGroupsState((state) => {
-      state[idx] = undefined; // if deleted directly, keys based on idx would break.
-      return state;
+    setConsentGroupsState((consentGroupsState) => {
+      const newConsentGroupsState = cloneDeep(consentGroupsState);
+      newConsentGroupsState[idx] = undefined; // if deleted directly, keys based on idx would break.
+      return newConsentGroupsState;
     });
   }, []);
 
   const updateConsentGroup = useCallback((idx, value, isValid) => {
-    setConsentGroupsState((state) => {
-      state[idx].editMode = false;
-      state[idx].valid = isValid;
-      state[idx].consentGroup = {
-        ...state[idx].consentGroup,
+    setConsentGroupsState((consentGroupsState) => {
+      const newConsentGroupsState = cloneDeep(consentGroupsState);
+
+      newConsentGroupsState[idx].editMode = false;
+      newConsentGroupsState[idx].valid = isValid;
+      newConsentGroupsState[idx].consentGroup = {
+        ...newConsentGroupsState[idx].consentGroup,
         ...value,
       };
-      return state;
+      return newConsentGroupsState;
     });
   }, []);
 
   const updateNihInstitutionalCertificationFile = useCallback((idx, file) => {
-    setConsentGroupsState((state) => {
-      state[idx].nihInsitutionalCertificationFile = file;
-      return state;
+    setConsentGroupsState((consentGroupsState) => {
+      const newConsentGroupsState = cloneDeep(consentGroupsState);
+      newConsentGroupsState[idx].nihInsitutionalCertificationFile = file;
+      return newConsentGroupsState;
     });
   }, []);
 
-  const startEditConsentGroup = (idx) => {
-    setConsentGroupsState((state) => {
-      state[idx].editMode = true;
-      return state;
+  const startEditConsentGroup = useCallback((idx) => {
+    setConsentGroupsState((consentGroupsState) => {
+      const newConsentGroupsState = cloneDeep(consentGroupsState);
+      newConsentGroupsState[idx].editMode = true;
+      return newConsentGroupsState;
     });
-  };
+  }, []);
 
   return div({
     className: 'data-submitter-section',
@@ -154,7 +168,7 @@ export const DataAccessGovernance = (props) => {
 
         // consent groups
         consentGroupsState
-          .map((state, idx) => {
+          ?.map((state, idx) => {
             if (isNil(state)) {
               return div({}, []);
             }

--- a/src/components/data_submission/consent_group/ConsentGroupForm.js
+++ b/src/components/data_submission/consent_group/ConsentGroupForm.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { div, h, span, a, button } from 'react-hyperscript-helpers';
 import ConsentGroupSummary from './ConsentGroupSummary';
 import { EditConsentGroup } from './EditConsentGroup';
@@ -43,11 +43,6 @@ export const ConsentGroupForm = (props) => {
   });
 
   const [nihInstitutionalCertificationFile, setNihInstitutionalCertificationFile] = useState(null);
-
-  useEffect(() => {
-    updateNihInstitutionalCertificationFile(nihInstitutionalCertificationFile);
-  }, [nihInstitutionalCertificationFile, updateNihInstitutionalCertificationFile]);
-
   const [consentGroupValidationErrors, setConsentGroupValidationErrors] = useState([]);
   const [editMode, setEditMode] = useState(true);
 
@@ -69,7 +64,15 @@ export const ConsentGroupForm = (props) => {
     (editMode
       ? h(EditConsentGroup, {
         ...props,
-        ...{consentGroup: consentGroup, setConsentGroup: setConsentGroup, nihInstitutionalCertificationFile, setNihInstitutionalCertificationFile},
+        ...{
+          consentGroup: consentGroup,
+          setConsentGroup: setConsentGroup,
+          nihInstitutionalCertificationFile,
+          setNihInstitutionalCertificationFile: (file) => {
+            setNihInstitutionalCertificationFile(file);
+            updateNihInstitutionalCertificationFile(file);
+          }
+        },
       })
       : h(ConsentGroupSummary, {
         ...props,

--- a/src/components/data_submission/consent_group/ConsentGroupForm.js
+++ b/src/components/data_submission/consent_group/ConsentGroupForm.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { div, h, span, a, button } from 'react-hyperscript-helpers';
 import ConsentGroupSummary from './ConsentGroupSummary';
 import { EditConsentGroup } from './EditConsentGroup';
@@ -8,6 +8,7 @@ export const ConsentGroupForm = (props) => {
   const {
     idx,
     saveConsentGroup,
+    updateNihInstitutionalCertificationFile,
     deleteConsentGroup,
   } = props;
 
@@ -41,6 +42,11 @@ export const ConsentGroupForm = (props) => {
     fileTypes: [{}],
   });
 
+  const [nihInstitutionalCertificationFile, setNihInstitutionalCertificationFile] = useState(null);
+
+  useEffect(() => {
+    updateNihInstitutionalCertificationFile(nihInstitutionalCertificationFile);
+  }, [nihInstitutionalCertificationFile, updateNihInstitutionalCertificationFile]);
 
   const [consentGroupValidationErrors, setConsentGroupValidationErrors] = useState([]);
   const [editMode, setEditMode] = useState(true);
@@ -63,11 +69,11 @@ export const ConsentGroupForm = (props) => {
     (editMode
       ? h(EditConsentGroup, {
         ...props,
-        ...{consentGroup: consentGroup, setConsentGroup: setConsentGroup},
+        ...{consentGroup: consentGroup, setConsentGroup: setConsentGroup, nihInstitutionalCertificationFile, setNihInstitutionalCertificationFile},
       })
       : h(ConsentGroupSummary, {
         ...props,
-        ...{consentGroup: consentGroup, id: idx+'_consentGroupSummary'},
+        ...{consentGroup: consentGroup, id: idx+'_consentGroupSummary', nihInstitutionalCertificationFile},
       })),
 
     // save + delete

--- a/src/components/data_submission/consent_group/ConsentGroupSummary.js
+++ b/src/components/data_submission/consent_group/ConsentGroupSummary.js
@@ -71,6 +71,7 @@ const secondaryConsentFields = [
 export const ConsentGroupSummary = (props) => {
   const {
     consentGroup,
+    nihInstitutionalCertificationFile,
     id
   } = props;
 
@@ -225,6 +226,22 @@ export const ConsentGroupSummary = (props) => {
           p({}, ['# of Participants: ', span({style: {fontStyle: 'italic'}}, [`${ft.numberOfParticipants}`])]),
         ]))),
       ]),
+    ]),
+    div({
+      isRendered: !isNil(nihInstitutionalCertificationFile),
+    }, [
+      p({
+        style: {
+          fontWeight: 'bold',
+          fontSize: '16px',
+        }
+      }, ['NIH Institutional Certification File']),
+      input({
+        disabled: true,
+        type: 'text',
+        className: 'form-control',
+        value: nihInstitutionalCertificationFile?.name,
+      }),
     ]),
   ]);
 };

--- a/src/components/data_submission/consent_group/ConsentGroupSummary.js
+++ b/src/components/data_submission/consent_group/ConsentGroupSummary.js
@@ -185,7 +185,7 @@ export const ConsentGroupSummary = (props) => {
             fontWeight: 'bold',
             fontSize: '16px',
           }
-        }, ['Secondary Group(s)']),
+        }, 'Secondary Group(s)'),
         summarizeSecondaryGroup(),
       ]),
 
@@ -199,7 +199,7 @@ export const ConsentGroupSummary = (props) => {
             fontWeight: 'bold',
             fontSize: '16px',
           }
-        }, ['Data Location']),
+        }, 'Data Location'),
         p({}, [
           (!isNil(consentGroup.dataLocation)? consentGroup.dataLocation.join(', ') : ''),
         ]),
@@ -215,15 +215,15 @@ export const ConsentGroupSummary = (props) => {
             fontSize: '16px',
           }
         }, ['File Types']),
-        div({}, consentGroup.fileTypes.map((ft, idx) => p({
+        div({}, consentGroup.fileTypes.map((ft, idx) => div({
           key: idx,
           style: {
             marginBottom: '20px',
           }
         }, [
-          p({}, ['File Type: ', span({style: {fontStyle: 'italic'}}, [`${ft.fileType}`])]),
-          p({}, ['Functional Equivalence: ', span({style: {fontStyle: 'italic'}}, [`${ft.functionalEquivalence}`])]),
-          p({}, ['# of Participants: ', span({style: {fontStyle: 'italic'}}, [`${ft.numberOfParticipants}`])]),
+          div({}, ['File Type: ', span({style: {fontStyle: 'italic'}}, [`${ft.fileType}`])]),
+          div({}, ['Functional Equivalence: ', span({style: {fontStyle: 'italic'}}, [`${ft.functionalEquivalence}`])]),
+          div({}, ['# of Participants: ', span({style: {fontStyle: 'italic'}}, [`${ft.numberOfParticipants}`])]),
         ]))),
       ]),
     ]),
@@ -235,7 +235,7 @@ export const ConsentGroupSummary = (props) => {
           fontWeight: 'bold',
           fontSize: '16px',
         }
-      }, ['NIH Institutional Certification File']),
+      }, 'NIH Institutional Certification File'),
       input({
         disabled: true,
         type: 'text',

--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -35,6 +35,8 @@ export const EditConsentGroup = (props) => {
   const {
     consentGroup,
     setConsentGroup,
+    nihInstitutionalCertificationFile,
+    setNihInstitutionalCertificationFile,
     idx,
   } = props;
 
@@ -418,5 +420,15 @@ export const EditConsentGroup = (props) => {
       minLength: 1,
       onChange
     }),
+
+    h(FormField, {
+      type: FormFieldTypes.FILE,
+      title: 'NIH Institutional Certification',
+      description: 'If an Institutional Certification for this consent group exists, please upload it here',
+      id: idx+'_nihInstituionalCertificationFile',
+      name: 'nihInstituionalCertificationFile',
+      defaultValue: nihInstitutionalCertificationFile,
+      onChange: ({value}) => setNihInstitutionalCertificationFile(value),
+    })
   ]);
 };


### PR DESCRIPTION
### Addresses

I'm not exactly sure how file uploads will work for the Data Submission Form. As it is, this will expose a file object for each consent group, which can be used in any way once we're ready to send the form data.

https://broadworkbench.atlassian.net/browse/DUOS-2163


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
