### PR TITLE
[DUOS-2023][risk=no] Adds download links for COL and IRB provided docs.

### DIFF
--- a/cypress/component/DarCollectionReview/application_information.spec.js
+++ b/cypress/component/DarCollectionReview/application_information.spec.js
@@ -251,5 +251,54 @@ describe('Application Information', () => {
     expect(anvilLabel).to.exist;
     anvilLabel.contains('Using AnVIL only for storage and analysis');
   });
+
+  it('redners expected document links', ()=> {
+    const props = {
+      irbDocumentLocation: 'some-uuid',
+      collaborationLetterLocation: 'some-other-uuid',
+      referenceId: 'dar-uuid',
+      irbDocumentName: 'irbdoc.txt',
+      collaborationLetterName: 'collab-letter.txt',
+    };
+
+    mount(<ApplicationInformation {...props} />);
+    const irbDocLink = cy.get('#irb-doc');
+    expect(irbDocLink).to.exist;
+    irbDocLink.contains('Download IRB Protocol');
+
+    const collabDocLink = cy.get('#collab-letter');
+    expect(collabDocLink).to.exist;
+    collabDocLink.contains('Download Collaboration Letter');
+
+  });
+
+  it('doesnt render a missing document link', ()=> {
+    const props = {
+      collaborationLetterLocation: 'some-other-uuid',
+      referenceId: 'dar-uuid',
+      collaborationLetterName: 'collab-letter.txt',
+    };
+
+    mount(<ApplicationInformation {...props} />);
+
+    cy.get('#irb-doc').should('not.exist');
+    const collabDocLink = cy.get('#collab-letter');
+    expect(collabDocLink).to.exist;
+    collabDocLink.contains('Download Collaboration Letter');
+  });
+
+  it('doesnt render without referenceId', ()=> {
+    const props = {
+      irbDocumentLocation: 'some-uuid',
+      collaborationLetterLocation: 'some-other-uuid',
+      irbDocumentName: 'irbdoc.txt',
+      collaborationLetterName: 'collab-letter.txt',
+    };
+
+    mount(<ApplicationInformation {...props} />);
+
+    cy.get('#irb-doc').should('not.exist');
+    cy.get('#collab-letter').should('not.exist');
+  });
 });
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -260,6 +260,18 @@ export const DAR = {
     return res.data;
   },
 
+  downloadDARDocument: async (referenceId, fileType, fileName) => {
+    const authOpts = Object.assign(Config.authOpts(), {responseType: 'blob'});
+    authOpts.headers = Object.assign(authOpts.headers, {
+      'Content-Type': 'application/octet-stream',
+      'Accept': 'application/octet-stream'
+    });
+    const url = `${await getApiUrl()}/api/dar/v2/${referenceId}/${fileType}`;
+    axios.get(url, authOpts).then((response) =>{
+      fileDownload(response.data, fileName);
+    });
+  },
+
   //NOTE: endpoints requires a dar id
   uploadDARDocument: async(file, darId, fileType) => {
     if(isFileEmpty(file)) {

--- a/src/pages/dar_collection_review/ApplicationInformation.js
+++ b/src/pages/dar_collection_review/ApplicationInformation.js
@@ -1,5 +1,7 @@
 import { div, label, span } from 'react-hyperscript-helpers';
-import {chunk, filter, isEmpty} from 'lodash/fp';
+import {chunk, filter, isEmpty, isNil} from 'lodash/fp';
+import { DAR } from '../../libs/ajax';
+import { DownloadLink } from '../../components/DownloadLink';
 
 const styles = {
   flexRowElement: {
@@ -47,7 +49,7 @@ const styles = {
     display: 'flex',
     justifyContent: 'space-between',
     marginBottom: '3rem',
-  },
+  }
 };
 
 const generateLabelSpanContents = (labelValue, key,  spanValue, isLoading) => {
@@ -61,6 +63,14 @@ const generateLabelSpanContents = (labelValue, key,  spanValue, isLoading) => {
       div({className: 'text-placeholder', key:`${label}-text-placeholder`, id: `${label}-label-placeholder`, style: {width: '70%', height: '3.2rem'}}),
     ]
   );
+};
+
+const generateLinkContents = (key, id, type, text, fileName, location) => {
+  return div(
+    {id: key, isRendered: !isNil(location) && !isNil(id)},
+    [
+      DownloadLink({label: text, onDownload: ()=>{DAR.downloadDARDocument(id, type, fileName);}})
+    ]);
 };
 
 // function to generate application details content
@@ -113,7 +123,12 @@ export default function ApplicationInformation(props) {
     cloudComputing = false,
     cloudProvider = '- -',
     rus,
-    cloudProviderDescription
+    cloudProviderDescription,
+    referenceId,
+    irbDocumentLocation,
+    collaborationLetterLocation,
+    irbDocumentName,
+    collaborationLetterName
   } = props;
 
   const processCollaborators = (collaborators) =>
@@ -187,6 +202,11 @@ export default function ApplicationInformation(props) {
               }})
           ])  : ''
       ]),
+
+      div({className: 'document-link-container', style: { margin: '1rem 0'}}, [
+        generateLinkContents('irb-doc',referenceId, 'irbDocument', 'Download IRB Protocol', irbDocumentName, irbDocumentLocation),
+        generateLinkContents('collab-letter', referenceId, 'collaborationDocument', 'Download Collaboration Letter', collaborationLetterName, collaborationLetterLocation)
+      ])
     ])
   );
 }

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -65,6 +65,7 @@ export default function DarCollectionReview(props) {
   const collectionId = props.match.params.collectionId;
   const [collection, setCollection] = useState({});
   const [darInfo, setDarInfo] = useState({});
+  const [referenceIdForDocuments, setReferenceIdForDocuments] = useState();
   const [isLoading, setIsLoading] = useState(true);
   const [subcomponentLoading, setSubcomponentLoading] = useState(true);
   const [tabs, setTabs] = useState({
@@ -82,6 +83,7 @@ export default function DarCollectionReview(props) {
       const collection = await Collections.getCollectionById(collectionId);
       const { dars, datasets } = collection;
       const darInfo = find((d) => !isEmpty(d.data))(collection.dars).data;
+      const referenceIdForDocuments = find((d) => !isEmpty(d.referenceId))(collection.dars).referenceId;
       const researcherProfile = await User.getById(collection.createUserId);
       const processedBuckets = await flow([
         generatePreProcessedBucketData,
@@ -99,6 +101,7 @@ export default function DarCollectionReview(props) {
       setTabs(tabsForUser(user, filteredBuckets, adminPage));
       setIsLoading(false);
       setSubcomponentLoading(false);
+      setReferenceIdForDocuments(referenceIdForDocuments);
     } catch (error) {
       Notifications.showError({
         text: 'Error initializing Data Access Request collection page. You have been redirected to your console',
@@ -211,6 +214,11 @@ export default function DarCollectionReview(props) {
           cloudProvider: darInfo.cloudProvider,
           cloudProviderDescription: darInfo.cloudProviderDescription,
           rus: darInfo.rus,
+          referenceId: referenceIdForDocuments,
+          irbDocumentLocation: darInfo.irbDocumentLocation,
+          collaborationLetterLocation: darInfo.collaborationLetterLocation,
+          irbDocumentName: darInfo.irbDocumentName,
+          collaborationLetterName: darInfo.collaborationLetterName
         }),
         h(MultiDatasetVotingTab, {
           isRendered: !adminPage && selectedTab === tabs.memberVote,


### PR DESCRIPTION
[DUOS-2023](https://broadworkbench.atlassian.net/browse/DUOS-2023) requests links are added to DARs where the applicant provided a COL or IRB document.
DarCollectionReview was modified to pass in the necessary information to ApplicationInformation to build links to the documents.
ajax was updated to include a download function for enabling document download with the required headers.
applicaiton_information.spec was updated to include tests to ensure the links were rendered correctly.

BEFORE
![Screen Shot 2022-11-07 at 1 12 29 PM](https://user-images.githubusercontent.com/111771148/200385128-12b4768e-db23-4081-9c29-0946f56daa45.png)

AFTER
![Screen Shot 2022-11-07 at 1 12 40 PM](https://user-images.githubusercontent.com/111771148/200385180-0f4ba9c6-7f53-454f-b058-ad92c04545e2.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
