### PR TITLE
[DUOS-2192]risk=no] Remove dataset statistics link

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -604,8 +604,7 @@ export default function DatasetCatalog(props) {
                           id: trIndex + '_datasetName', name: 'datasetName',
                           className: 'cell-size ' + (!dataset.active ? !!'dataset-disabled' : ''),
                           style: tableBody
-                        }, [findPropertyValue(dataset, 'Dataset Name')]
-                        ),
+                        }, [findPropertyValue(dataset, 'Dataset Name')]),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -604,14 +604,8 @@ export default function DatasetCatalog(props) {
                           id: trIndex + '_datasetName', name: 'datasetName',
                           className: 'cell-size ' + (!dataset.active ? !!'dataset-disabled' : ''),
                           style: tableBody
-                        }, [
-                          a({
-                            href: `/dataset_statistics/${dataset.dataSetId}`,
-                            className: 'enabled'
-                          }, [
-                            findPropertyValue(dataset, 'Dataset Name')
-                          ])
-                        ]),
+                        }, [findPropertyValue(dataset, 'Dataset Name')]
+                        ),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2192

The dataset stats link is showing inaccurate data. Remove until we have a fix in place for it.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
