### PR TITLE
[DUOS-2179][risk=low] Fix UI build and local development related errors.

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -303,9 +303,7 @@ export const DarCollectionTable = function DarCollectionTable(props) {
       ]);
     }
 
-    return div({}, [
-      renderedRow,
-    ]);
+    return renderedRow;
   }, [darCollectionCache, fetchDarCollection, collectionIsExpanded]);
 
   return h(Fragment, {}, [

--- a/src/libs/notificationService.js
+++ b/src/libs/notificationService.js
@@ -44,11 +44,14 @@ export const NotificationService = {
    * @returns {Promise<JSON>}
    */
   getBannerObjectById: async (id) => {
-    const banners = await NotificationService.getBanners();
-    if (!fp.isEmpty(banners)) {
-      return fp.find({active: true, id: id})(banners);
+    try {
+      const banners = await NotificationService.getBanners();
+      if (!fp.isEmpty(banners)) {
+        return fp.find({active: true, id: id})(banners);
+      }
+    } catch(error) {
+      return null;
     }
-    return undefined;
   },
 
 };

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -71,7 +71,6 @@ export default function DarCollectionReview(props) {
     applicationInformation: 'Application Information'
   });
   const [selectedTab, setSelectedTab] = useState(tabs.applicationInformation);
-  const [currentUser, setCurrentUser] = useState({});
   const [researcherProfile, setResearcherProfile] = useState({});
   const [dataUseBuckets, setDataUseBuckets] = useState([]);
   const { adminPage = false, readOnly = false } = props;
@@ -94,7 +93,6 @@ export default function DarCollectionReview(props) {
         : filterBucketsForUser(user, processedBuckets);
       setDataUseBuckets(filteredBuckets);
       setCollection(collection);
-      setCurrentUser(user);
       setDarInfo(darInfo);
       setResearcherProfile(researcherProfile);
       setTabs(tabsForUser(user, filteredBuckets, adminPage));


### PR DESCRIPTION
[DUOS-2179 ](https://broadworkbench.atlassian.net/browse/DUOS-2179) notes an issue with local development that causes the dataset registration page not to load fully.

This PR fixes that issue by catching errors (404's returned by the local proxy) and allowing the code to proceed.

While implementing the fix for this, two other issues were noted and resolved by this PR:

- Lint in the form of an unused variable was removed
- The rowRenderer in the DarCollectionTable now returns a renderedRow instead of nesting it within a div.  The div isn't required because the resulting rendered DataRows.renderedRow is already encapsulated in a div.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
