### PR TITLE
[DUOS-2198][risk=low] Updates to use /api/dataset/v2/{id} get endpoint.

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -323,7 +323,7 @@ export const DataSet = {
   },
 
   getDataSetsByDatasetId: async dataSetId => {
-    const url = `${await getApiUrl()}/api/dataset/${dataSetId}`;
+    const url = `${await getApiUrl()}/api/dataset/v2/${dataSetId}`;
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },


### PR DESCRIPTION
[DUOS-2198](https://broadworkbench.atlassian.net/browse/DUOS-2198) is to update the front end to use the /api/dataset/v2/{id} GET endpoint because the /api/dataset/{id} GET is deprecated.

Upon manual testing of saving a dataset edit, it was discovered that the v2 endpoint needed a fix covered [by this consent PR](https://github.com/DataBiosphere/consent/pull/1821).  This ticket should merge AFTER that PR has been resolved.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
