### PR TITLE
[DUOS-2205][risk=no] Adds DAR form test and fixes issues identified in building test.

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -706,10 +706,15 @@ beforeEach(() => {
 describe('DAR Review', () => {
   it('renders the collections-review-page div', () => {
     mount(<DarCollectionReview {...props}/>);
-    const container = cy.get('.collection-review-page').find('.tab-selection-Chair');
-    container.should('exist').should('be.visible');
+    const chairContainer = cy.get('.collection-review-page').find('.tab-selection-Chair');
+    const memberContainer = cy.get('.collection-review-page').find('.tab-selection-Member');
+    chairContainer.should('exist').should('be.visible');
+    memberContainer.should('exist').should('be.visible');
     cy.get('.dataset-list-item').should('not.exist');
-    container.click().then(()=>{
+    chairContainer.click().then(()=>{
+      cy.get('.dataset-list-item').should('exist').should('be.visible').contains('Sleep Apnea');
+    });
+    memberContainer.click().then(()=>{
       cy.get('.dataset-list-item').should('exist').should('be.visible').contains('Sleep Apnea');
     });
   });

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -1,0 +1,716 @@
+/* eslint-disable no-undef */
+import { React } from 'react';
+import { mount } from 'cypress/react18';
+import DarCollectionReview from '../../../src/pages/dar_collection_review/DarCollectionReview';
+import { Collections, User, Match } from '../../../src/libs/ajax';
+import { Storage } from '../../../src/libs/storage';
+import { Navigation } from '../../../src/libs/utils';
+import { OntologyService } from '../../../src/libs/ontologyService';
+
+
+const dar = {
+  'darCollectionId': 777,
+  'darCode': 'DAR-XXX',
+  'createDate': 1669229413840,
+  'createUser': {
+    'userId': 7,
+    'dacUserId': 7,
+    'email': 'Bob.Jones@prodigy.com',
+    'displayName': 'Bob Jones',
+    'createDate': 1668229413840,
+    'roles': null,
+    'properties': [
+      {
+        'propertyId': 19000,
+        'userId': 7,
+        'propertyKey': 'suggestedInstitution',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 18999,
+        'userId': 7,
+        'propertyKey': 'suggestedSigningOfficial',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 18998,
+        'userId': 7,
+        'propertyKey': 'selectedSigningOfficialId',
+        'propertyValue': '5555'
+      },
+      {
+        'propertyId': 18995,
+        'userId': 7,
+        'propertyKey': 'eraExpiration',
+        'propertyValue': '1670117014385'
+      },
+      {
+        'propertyId': 18994,
+        'userId': 7,
+        'propertyKey': 'eraAuthorized',
+        'propertyValue': 'true'
+      },
+      {
+        'propertyId': 17158,
+        'userId': 7,
+        'propertyKey': 'scientificURL',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17157,
+        'userId': 7,
+        'propertyKey': 'isThePI',
+        'propertyValue': 'true'
+      },
+      {
+        'propertyId': 17156,
+        'userId': 7,
+        'propertyKey': 'department',
+        'propertyValue': 'TPS'
+      },
+      {
+        'propertyId': 17155,
+        'userId': 7,
+        'propertyKey': 'checkNotifications',
+        'propertyValue': 'true'
+      },
+      {
+        'propertyId': 17154,
+        'userId': 7,
+        'propertyKey': 'state',
+        'propertyValue': 'CA'
+      },
+      {
+        'propertyId': 17153,
+        'userId': 7,
+        'propertyKey': 'researcherGate',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17152,
+        'userId': 7,
+        'propertyKey': 'piERACommonsID',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17151,
+        'userId': 7,
+        'propertyKey': 'academicEmail',
+        'propertyValue': 'Bob.Jones@prodigy.com'
+      },
+      {
+        'propertyId': 17150,
+        'userId': 7,
+        'propertyKey': 'zipcode',
+        'propertyValue': '90210'
+      },
+      {
+        'propertyId': 17149,
+        'userId': 7,
+        'propertyKey': 'division',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17867,
+        'userId': 7,
+        'propertyKey': 'piName',
+        'propertyValue': 'Bob Jones'
+      },
+      {
+        'propertyId': 17147,
+        'userId': 7,
+        'propertyKey': 'pubmedID',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17146,
+        'userId': 7,
+        'propertyKey': 'linkedIn',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17145,
+        'userId': 7,
+        'propertyKey': 'completed',
+        'propertyValue': 'true'
+      },
+      {
+        'propertyId': 17144,
+        'userId': 7,
+        'propertyKey': 'orcid',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17143,
+        'userId': 7,
+        'propertyKey': 'havePI',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17142,
+        'userId': 7,
+        'propertyKey': 'address1',
+        'propertyValue': '1313 Mockingbird Lane'
+      },
+      {
+        'propertyId': 17141,
+        'userId': 7,
+        'propertyKey': 'piEmail',
+        'propertyValue': 'Bob.Jones@prodigy.com'
+      },
+      {
+        'propertyId': 17140,
+        'userId': 7,
+        'propertyKey': 'city',
+        'propertyValue': 'Mockingbird Heights'
+      },
+      {
+        'propertyId': 17139,
+        'userId': 7,
+        'propertyKey': 'address2',
+        'propertyValue': ''
+      },
+      {
+        'propertyId': 17138,
+        'userId': 7,
+        'propertyKey': 'country',
+        'propertyValue': 'USA'
+      }
+    ],
+    'emailPreference': true,
+    'institutionId': 90210,
+    'eraCommonsId': 'HERMAN',
+    'institution': {
+      'id': 90210,
+      'name': 'Ace Industries',
+      'itDirectorName': null,
+      'itDirectorEmail': null,
+      'signingOfficials': null,
+      'institutionUrl': null,
+      'dunsNumber': null,
+      'orgChartUrl': null,
+      'verificationUrl': null,
+      'verificationFilename': null,
+      'organizationType': null,
+      'createDate': 1626700443000,
+      'createUserId': null,
+      'updateDate': null,
+      'updateUserId': null,
+      'createUser': null,
+      'updateUser': null
+    },
+    'libraryCards': [
+      {
+        'id': 182,
+        'userId': 7,
+        'institutionId': 90210,
+        'eraCommonsId': null,
+        'userName': 'Bob Jones',
+        'userEmail': 'Bob.Jones@prodigy.com',
+        'createDate': 1667817915000,
+        'createUserId': 5555,
+        'updateDate': null,
+        'updateUserId': null,
+        'institution': null
+      }
+    ]
+  },
+  'createUserId': 7,
+  'updateDate': null,
+  'updateUserId': null,
+  'dars': {
+    'dars-id-123': {
+      'id': 2147,
+      'referenceId': 'dars-id-123',
+      'collectionId': 777,
+      'data': {
+        'referenceId': 'dars-id-123',
+        'institution': 'Ace Industries',
+        'projectTitle': 'Collection of sleep apnea samples',
+        'checkCollaborator': false,
+        'checkNihDataOnly': false,
+        'researcher': 'Bob Jones',
+        'rus': 'One good RUS\n',
+        'nonTechRus': 'One non-technical RUS\n',
+        'diseases': true,
+        'methods': true,
+        'other': false,
+        'ontologies': [
+          {
+            'id': 'http://purl.obolibrary.org/obo/DOID_8577',
+            'label': 'sleep apnea',
+            'definition': null,
+            'synonyms': null
+          }
+        ],
+        'forProfit': false,
+        'oneGender': false,
+        'pediatric': false,
+        'illegalBehavior': false,
+        'addiction': false,
+        'sexualDiseases': false,
+        'stigmatizedDiseases': false,
+        'vulnerablePopulation': false,
+        'populationMigration': false,
+        'psychiatricTraits': false,
+        'notHealth': false,
+        'hmb': false,
+        'poa': false,
+        'datasets': [
+          {
+            'key': '867',
+            'value': '867',
+            'label': 'Sleep Apnea'
+          }
+        ],
+        'darCode': 'DAR-XXX',
+        'createDate': 1667971415440,
+        'sortDate': 1667971415440,
+        'datasetIds': [
+          13
+        ],
+        'datasetDetail': [],
+        'anvilUse': false,
+        'localUse': true,
+        'itDirector': 'Jared Dunn',
+        'signingOfficial': 'Alice Smith (Alice.Smith@prodigy.com)',
+        'labCollaborators': [],
+        'internalCollaborators': [
+          {
+            'approverStatus': null,
+            'email': 'homer.simpson@aol.com',
+            'eraCommonsId': 'HOMER-SIMPSON-4',
+            'name': 'Homer Simpson',
+            'title': 'Researcher',
+            'uuid': 'researcher-2'
+          }
+        ],
+        'externalCollaborators': [],
+        'pubAcknowledgement': false,
+        'dsacknowledgement': false,
+        'gsoacknowledgement': false
+      },
+      'draft': false,
+      'userId': 7,
+      'createDate': 1667970929000,
+      'sortDate': 1669229413840,
+      'submissionDate': 1669229413840,
+      'updateDate': 1669229413840,
+      'elections': {
+        '8888': {
+          'electionId': 8888,
+          'electionType': 'DataAccess',
+          'status': 'Open',
+          'createDate': 1669062648000,
+          'referenceId': 'dars-id-123',
+          'dataSetId': 13,
+          'votes': {
+            '8675': {
+              'voteId': 8675,
+              'vote': true,
+              'dacUserId': 4444,
+              'createDate': 1669062648000,
+              'updateDate': 1669120753000,
+              'electionId': 8888,
+              'rationale': '',
+              'type': 'DAC',
+              'displayName': 'Beth Johnson'
+            },
+            '8676': {
+              'voteId': 8676,
+              'dacUserId': 11111,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'DAC',
+              'displayName': 'Ted Lasso'
+            },
+            '8677': {
+              'voteId': 8677,
+              'dacUserId': 11111,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'Chairperson',
+              'displayName': 'Ted Lasso'
+            },
+            '8678': {
+              'voteId': 8678,
+              'dacUserId': 11111,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'FINAL',
+              'displayName': 'Ted Lasso'
+            },
+            '8679': {
+              'voteId': 8679,
+              'dacUserId': 11111,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'AGREEMENT',
+              'displayName': 'Ted Lasso'
+            },
+            '8680': {
+              'voteId': 8680,
+              'dacUserId': 9988,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'DAC',
+              'displayName': 'Stuart Williams'
+            },
+            '8681': {
+              'voteId': 8681,
+              'dacUserId': 9988,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'Chairperson',
+              'displayName': 'Stuart Williams'
+            },
+            '8682': {
+              'voteId': 8682,
+              'dacUserId': 9988,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'FINAL',
+              'displayName': 'Stuart Williams'
+            },
+            '8683': {
+              'voteId': 8683,
+              'dacUserId': 9988,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'AGREEMENT',
+              'displayName': 'Stuart Williams'
+            },
+            '8684': {
+              'voteId': 8684,
+              'dacUserId': 4585,
+              'createDate': 1669062648000,
+              'electionId': 8888,
+              'type': 'DAC',
+              'displayName': 'Sue Smtih'
+            }
+          }
+        },
+        '1776': {
+          'electionId': 1776,
+          'electionType': 'RP',
+          'status': 'Open',
+          'createDate': 1669062648000,
+          'referenceId': 'dars-id-123',
+          'dataSetId': 13,
+          'votes': {
+            '8688': {
+              'voteId': 8688,
+              'dacUserId': 9988,
+              'createDate': 1669062648000,
+              'electionId': 1776,
+              'type': 'DAC',
+              'displayName': 'Stuart Williams'
+            },
+            '8689': {
+              'voteId': 8689,
+              'dacUserId': 9988,
+              'createDate': 1669062648000,
+              'electionId': 1776,
+              'type': 'Chairperson',
+              'displayName': 'Stuart Williams'
+            },
+            '8690': {
+              'voteId': 8690,
+              'dacUserId': 4585,
+              'createDate': 1669062648000,
+              'electionId': 1776,
+              'type': 'DAC',
+              'displayName': 'Sue Smtih'
+            },
+            '8685': {
+              'voteId': 8685,
+              'dacUserId': 4444,
+              'createDate': 1669062648000,
+              'electionId': 1776,
+              'type': 'DAC',
+              'displayName': 'Beth Johnson'
+            },
+            '8686': {
+              'voteId': 8686,
+              'dacUserId': 11111,
+              'createDate': 1669062648000,
+              'electionId': 1776,
+              'type': 'DAC',
+              'displayName': 'Ted Lasso'
+            },
+            '8687': {
+              'voteId': 8687,
+              'dacUserId': 11111,
+              'createDate': 1669062648000,
+              'electionId': 1776,
+              'type': 'Chairperson',
+              'displayName': 'Ted Lasso'
+            }
+          }
+        }
+      },
+      'datasetIds': [
+        13
+      ]
+    }
+  },
+  'datasets': [
+    {
+      'dataSetId': 13,
+      'objectId': null,
+      'name': 'Sleep Apnea',
+      'datasetName': 'Sleep Apnea',
+      'createDate': 1567123200000,
+      'createUserId': null,
+      'updateDate': 1643730658770,
+      'updateUserId': 11111,
+      'active': true,
+      'consentName': null,
+      'needsApproval': null,
+      'alias': 999,
+      'datasetIdentifier': 'DUOS-00999',
+      'dataUse': {
+        'diseaseRestrictions': [
+          'http://purl.obolibrary.org/obo/DOID_0050847'
+        ],
+        'populationOriginsAncestry': true,
+        'controlSetOption': 'Yes'
+      },
+      'dacId': 1,
+      'consentId': 'B177D3C2-CDD8-4153-9CBF-AE4F0C34609A',
+      'translatedUseRestriction': 'Samples are restricted for use under the following conditions:\nData use is limited for studying: sleep apnea [DS]\nFuture use for population origins or ancestry research is prohibited. [POA]\nCommercial use is not prohibited.\nData use for methods development research irrespective of the specified data use limitations is not prohibited.\nFuture use as a control set for diseases other than those specified is prohibited. [NCTRL]',
+      'deletable': false,
+      'sharingPlanDocument': null,
+      'sharingPlanDocumentName': null,
+      'properties': [
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': '# of participants',
+          'propertyValue': 17,
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'Number',
+          'propertyTypeAsString': 'number',
+          'propertyValueAsString': '17'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Dataset Name',
+          'propertyValue': 'Sleep Apnea',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'Sleep Apnea'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Description',
+          'propertyValue': 'Single cell RNA-sequence',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'Single cell RNA-sequence'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Data Type',
+          'propertyValue': 'RNA-seq',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'RNA-seq'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Data Depositor',
+          'propertyValue': 'data_depositor@example.com',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'data_depositor@example.com'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Principal Investigator(PI)',
+          'propertyValue': 'Lisa Simpson, Betty White',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'Lisa Simpson, Betty White'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Species',
+          'propertyValue': 'Human',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'Human'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'Phenotype/Indication',
+          'propertyValue': 'sleep apnea',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'sleep apnea'
+        },
+        {
+          'propertyId': null,
+          'dataSetId': 13,
+          'propertyKey': null,
+          'propertyName': 'dbGAP',
+          'propertyValue': 'https://...',
+          'createDate': null,
+          'schemaProperty': null,
+          'propertyType': 'String',
+          'propertyTypeAsString': 'string',
+          'propertyValueAsString': 'https://...'
+        }
+      ],
+      'dacApproval': true
+    }
+  ]
+};
+
+const props = {
+  'history': {
+    'length': 50,
+    'action': 'PUSH',
+    'location': {
+      'pathname': '/admin_review_collection/777',
+      'search': '',
+      'hash': '',
+      'key': 'z0i073'
+    }
+  },
+  'location': {
+    'pathname': '/admin_review_collection/777',
+    'search': '',
+    'hash': '',
+    'key': 'z0i073'
+  },
+  'match': {
+    'path': '/admin_review_collection/:collectionId',
+    'url': '/admin_review_collection/777',
+    'isExact': true,
+    'params': {
+      'collectionId': '777'
+    }
+  },
+  'adminPage': false,
+  'isLogged': true,
+  'env': 'local'
+};
+
+const user = {
+  userId: 11111,
+  roles: [
+    {
+      dacId: 11111,
+      userRoleId: 586,
+      userId: 1,
+      roleId: 2,
+      name: 'Chairperson'
+    }
+  ]
+};
+
+const researcher = {
+  'userId': 7,
+  'dacUserId': 7,
+  'email': 'Bob.Jones@prodigy.com',
+  'displayName': 'Bob Jones',
+  'createDate': 1668229413840,
+  'roles': null
+};
+
+const ontologyResponse = [
+];
+
+const matchResponse = [
+  {
+    'id': 911,
+    'consent': 'DUOS-00099',
+    'purpose': 'dars-id-123',
+    'match': true,
+    'failed': false,
+    'createDate': 1668729600000,
+    'algorithmVersion': 'v2',
+    'failureReasons': []
+  }
+];
+
+const dacDatasets = [{
+  'datasetName': null,
+  'dacId': 3,
+  'dataSetId': 13,
+  'consentId': 'B177D3C2-CDD8-4153-9CBF-AE4F0C34609A',
+  'translatedUseRestriction': '',
+  'deletable': null,
+  'properties': [
+    {
+      'propertyName': 'Dataset Name',
+      'propertyValue': 'Sleep Apnea'
+    }
+  ],
+  'active': true,
+  'needsApproval': true,
+  'isAssociatedToDataOwners': null,
+  'updateAssociationToDataOwnerAllowed': null,
+  'alias': 'DUOS-000999',
+  'objectId': null,
+  'createDate': 1648512000000,
+  'createUserId': 5052,
+  'updateDate': 1648590021870,
+  'updateUserId': 5052,
+  'dataUse': {
+    'generalUse': true
+  }
+}];
+
+beforeEach(() => {
+  cy.stub(Collections, 'getCollectionById').returns(dar);
+  cy.stub(Storage, 'getCurrentUser').returns(user);
+  cy.stub(User, 'getById').returns(researcher);
+  cy.stub(Navigation, 'console').returns({});
+  cy.stub(OntologyService, 'searchOntology').returns(ontologyResponse);
+  cy.stub(Match, 'findMatchBatch').returns(matchResponse);
+  cy.stub(User, 'getUserRelevantDatasets').returns(dacDatasets);
+});
+
+describe('DAR Review', () => {
+  it('renders the collections-review-page div', () => {
+    mount(<DarCollectionReview {...props}/>);
+    const container = cy.get('.collection-review-page').find('.tab-selection-Chair');
+    container.should('exist').should('be.visible');
+    cy.get('.dataset-list-item').should('not.exist');
+    container.click().then(()=>{
+      cy.get('.dataset-list-item').should('exist').should('be.visible').contains('Sleep Apnea');
+    });
+  });
+});

--- a/src/components/SelectableText.js
+++ b/src/components/SelectableText.js
@@ -23,12 +23,12 @@ const defaultHoverStyle = {fontWeight: 600, cursor: 'pointer'};
 export default function SelectableText({label, setSelected, selectedType, styleOverride = {}, isDisabled = false}) {
 
   const {baseStyle, tabSelected, tabUnselected, tabHover} = styleOverride;
-  const [style, setStyle] = useState(utilizedUnselectedStyle);
 
 
   const utilizedUnselectedStyle = useMemo(() => {
     return Object.assign({}, tabUnselected || defaultUnselectedStyle, baseStyle);
   }, [tabUnselected, baseStyle]);
+  const [style, setStyle] = useState(utilizedUnselectedStyle);
   const utilizedHoverStyle = useMemo(() => {
     return Object.assign({}, style, tabHover || defaultHoverStyle, baseStyle);
   }, [tabHover, baseStyle, style]);

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,5 +1,5 @@
 import {isNil, isEmpty, filter, join, concat, clone, uniq, head} from 'lodash/fp';
-import { searchOntology, extractDOIDFromUrl } from './ontologyService';
+import { OntologyService } from './ontologyService';
 import { Notifications } from './utils';
 
 export const ControlledAccessType = {
@@ -216,9 +216,9 @@ export const consentTranslations = {
 };
 
 const getOntologyName = async(urls) => {
-  const doidArr = extractDOIDFromUrl(urls);
+  const doidArr = OntologyService.extractDOIDFromUrl(urls);
   const params = doidArr.join(',');
-  const ontology = await searchOntology(params);
+  const ontology = await OntologyService.searchOntology(params);
   return ontology.map(data => data.label);
 };
 

--- a/src/libs/ontologyService.js
+++ b/src/libs/ontologyService.js
@@ -2,27 +2,26 @@ import axios from 'axios';
 import { Notifications } from '../libs/utils';
 import { getOntologyUrl } from './ajax';
 
-export async function searchOntology(obolibraryURL) {
-  const baseURL = await getOntologyUrl();
-  const params = {id: obolibraryURL};
-  try{
-    let resp = await axios.get(`${baseURL}/search`, {params});
-    return resp.data;
-  } catch(error) {
-    Notifications.showError('Error: Ontology Search Request failed');
-  }
-}
 
-export function extractDOIDFromUrl(urls) {
-  const doidArr = [];
-  urls.forEach(url => {
-    const startIdx = url.search(/DOID_\d+/);
-    if (startIdx > -1) {
-      doidArr.push(url.slice(startIdx));
+export const OntologyService = {
+  searchOntology: async (obolibraryURL) => {
+    const baseURL = await getOntologyUrl();
+    const params = {id: obolibraryURL};
+    try{
+      let resp = await axios.get(`${baseURL}/search`, {params});
+      return resp.data;
+    } catch(error) {
+      Notifications.showError('Error: Ontology Search Request failed');
     }
-  });
-
-  return doidArr;
-}
-
-export default { searchOntology };
+  },
+  extractDOIDFromUrl: (urls) => {
+    const doidArr = [];
+    urls.forEach(url => {
+      const startIdx = url.search(/DOID_\d+/);
+      if (startIdx > -1) {
+        doidArr.push(url.slice(startIdx));
+      }
+    });
+    return doidArr;
+  }
+};

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -15,7 +15,7 @@ import AsyncSelect from 'react-select/async';
 import DataProviderAgreement from '../assets/Data_Provider_Agreement.pdf';
 import addDatasetIcon from '../images/icon_dataset_add.png';
 import { searchOntologies } from '../libs/utils';
-import { searchOntology, extractDOIDFromUrl } from '../libs/ontologyService';
+import { OntologyService } from '../libs/ontologyService';
 
 class DatasetRegistration extends Component {
 
@@ -173,9 +173,9 @@ class DatasetRegistration extends Component {
     if (fp.isEmpty(urls)) {
       return [];
     } else {
-      const doidArr = extractDOIDFromUrl(urls);
+      const doidArr = OntologyService.extractDOIDFromUrl(urls);
       const urlParams = doidArr.join(',');
-      const ontologies = await searchOntology(urlParams);
+      const ontologies = await OntologyService.searchOntology(urlParams);
       return ontologies;
     }
   }

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -60,6 +60,30 @@ const userHasRole = (user, roleId) => {
   return !isEmpty(matches);
 };
 
+const tabsForUser = (user, buckets, adminPage = false) => {
+  if (adminPage) {
+    return {
+      applicationInformation: 'Application Information',
+      chairVote: 'Chair Vote'
+    };
+  }
+  const dataAccessBucketsForUser = filter(
+    (bucket) => get('isRP')(bucket) !== true
+  )(buckets);
+  const userHasVotesForCollection = !isEmpty(dataAccessBucketsForUser);
+
+  const updatedTabs = { applicationInformation: 'Application Information' };
+  if (userHasVotesForCollection) {
+    if (userHasRole(user, chairpersonRoleId)) {
+      updatedTabs.memberVote = 'Member Vote';
+      updatedTabs.chairVote = 'Chair Vote';
+    } else if (userHasRole(user, memberRoleId)) {
+      updatedTabs.memberVote = 'Member Vote';
+    }
+  }
+  return updatedTabs;
+};
+
 export default function DarCollectionReview(props) {
   const collectionId = props.match.params.collectionId;
   const [collection, setCollection] = useState({});
@@ -105,38 +129,13 @@ export default function DarCollectionReview(props) {
       });
       Navigation.console(user, props.history);
     }
-  }, [adminPage, props.history, tabsForUser, collectionId]);
+  }, [adminPage, props.history, collectionId]);
 
   //Remember, votes are contained within buckets, so updating final votes will update the bucket
   //define updateFinalVote as a callback function so that its function definition can be updated alongside dataUseBucket
   const updateFinalVoteFn = useCallback((key, votePayload, voteIds) => {
     return updateFinalVote({key, votePayload, voteIds, dataUseBuckets, setDataUseBuckets});
   }, [dataUseBuckets]);
-
-  const tabsForUser = useCallback((user, buckets, adminPage = false) => {
-    if (adminPage) {
-      return {
-        applicationInformation: 'Application Information',
-        chairVote: 'Chair Vote'
-      };
-    }
-    const dataAccessBucketsForUser = filter(
-      (bucket) => get('isRP')(bucket) !== true
-    )(buckets);
-    const userHasVotesForCollection = !isEmpty(dataAccessBucketsForUser);
-
-    const updatedTabs = { applicationInformation: 'Application Information' };
-    if (userHasVotesForCollection) {
-      if (userHasRole(user, chairpersonRoleId)) {
-        updatedTabs.memberVote = 'Member Vote';
-        updatedTabs.chairVote = 'Chair Vote';
-      } else if (userHasRole(user, memberRoleId)) {
-        updatedTabs.memberVote = 'Member Vote';
-      }
-    }
-
-    return updatedTabs;
-  }, []);
 
   useEffect(() => {
     try {


### PR DESCRIPTION
[DUOS-2205](https://broadworkbench.atlassian.net/browse/DUOS-2205) is a bug report that indicates the dataset names may not be visible on the Member and Chair voting tabs.
This PR adds a basic test to load a DAR as a user with both the member and chairperson roles so that the test can use the chair tab to verify the dataset name appears at the bottom.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
