### PR TITLE
[DUOS-1740][risk=no] Update google-github-actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,11 +21,11 @@ jobs:
       id: short-sha
       run: echo "::set-output name=sha::$(git rev-parse --short=12 HEAD)"
     - name: Auth to GCR
-      uses: google-github-actions/setup-gcloud@v0
+      uses: 'google-github-actions/auth@v1'
       with:
-        version: '270.0.0'
-        service_account_email: ${{ secrets.GCR_PUBLISH_EMAIL }}
-        service_account_key: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+        credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+    - name: 'Set up Cloud SDK'
+      uses: 'google-github-actions/setup-gcloud@v1'
     - name: Auth Docker for GCR
       run: gcloud auth configure-docker --quiet
     - name: Construct tags


### PR DESCRIPTION
Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

Update gcloud auth action

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
