### PR TITLE
[DUOS-1740][risk=no] Remove @mui/styled-engine dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@material-ui/core": "4.12.4",
         "@material-ui/icons": "4.11.3",
         "@mui/material": "5.10.13",
-        "@mui/styled-engine": "5.10.8",
         "axios": "^1.1.3",
         "bootstrap": "3.4.1",
         "country-list": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@material-ui/core": "4.12.4",
     "@material-ui/icons": "4.11.3",
     "@mui/material": "5.10.13",
-    "@mui/styled-engine": "5.10.8",
     "axios": "^1.1.3",
     "bootstrap": "3.4.1",
     "country-list": "2.2.0",


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

See https://github.com/DataBiosphere/duos-ui/pull/1916 for background. `@mui/styled-engine` is unused.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
