### PR TITLE
[DUOS-1740][risk=no] Rework auth/push logic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,14 +20,8 @@ jobs:
     - name: Get Short Sha
       id: short-sha
       run: echo "::set-output name=sha::$(git rev-parse --short=12 HEAD)"
-    - name: Auth to GCR
-      uses: 'google-github-actions/auth@v1'
-      with:
-        credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
     - name: 'Set up Cloud SDK'
       uses: 'google-github-actions/setup-gcloud@v1'
-    - name: Auth Docker for GCR
-      run: gcloud auth configure-docker --quiet
     - name: Construct tags
       id: construct-tags
       run: |
@@ -48,6 +42,14 @@ jobs:
         .
     - name: Log Github Actor
       run: echo "${{ github.actor }}"
+    - name: Auth to GCR
+      if: github.actor != 'dependabot[bot]'
+      uses: 'google-github-actions/auth@v1'
+      with:
+        credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+    - name: Auth Docker for GCR
+      if: github.actor != 'dependabot[bot]'
+      run: gcloud auth configure-docker --quiet
     - name: Push Image to GCR
       if: github.actor != 'dependabot[bot]'
       run: |


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

See also:
* https://github.com/DataBiosphere/consent/pull/1849
* https://github.com/DataBiosphere/consent-ontology/pull/732

Minor update to the auth/push steps to check for dependabot PRs. to get past this error:
```
Run google-github-actions/auth@v1
Error: google-github-actions/auth failed with: retry function failed after 1 attempt: 
the GitHub Action workflow must specify exactly one of "workload_identity_provider" 
or "credentials_json"! If you are specifying input values via GitHub secrets, ensure 
the secret is being injected into the environment. By default, secrets are not passed 
to workflows triggered from forks, including Dependabot.
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
