### PR TITLE
[DUOS-2116][risk=no] Filter objects and values to only include relevant datasets as return…

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -141,6 +141,8 @@ const columnHeaderData = (columns = defaultColumns) => {
   return columns.map((col) => columnHeaderConfig[col]);
 };
 
+const collectionsSummaryMap = [];
+
 const processCollectionRowData = ({
   collections, collectionIsExpanded, updateCollectionIsExpandedById,
   showConfirmationModal, columns = defaultColumns, consoleType = '',
@@ -153,6 +155,7 @@ const processCollectionRowData = ({
         submissionDate, status, actions,
         researcherName, name, institutionName
       } = collection;
+      collectionsSummaryMap[collection.darCollectionId] = collection;
       return columns.map((col) => {
         return columnHeaderConfig[col].cellDataFn({
           collection, darCollectionId, datasetIds, darCode, status, name,
@@ -200,7 +203,6 @@ export const DarCollectionTable = function DarCollectionTable(props) {
     collections, columns, isLoading, cancelCollection, reviseCollection,
     openCollection, goToVote, consoleType, relevantDatasets, deleteDraft,
   } = props;
-
   /*
     NOTE: This component will most likely be used in muliple consoles
     Right now the table is assuming a fetchAll request since it's being implemented for the ResearcherConsole
@@ -295,6 +297,7 @@ export const DarCollectionTable = function DarCollectionTable(props) {
           }
         }, [
           h(DarDatasetTable, {
+            summary: collectionsSummaryMap[darCollectionId],
             collection: fetchDarCollection(darCollectionId),
             isLoading: isNil(darCollectionCache[darCollectionId]),
           }),

--- a/src/components/dar_dataset_table/DarDatasetTable.js
+++ b/src/components/dar_dataset_table/DarDatasetTable.js
@@ -6,12 +6,13 @@ import PaginationBar from '../PaginationBar';
 import { recalculateVisibleTable, goToPage as updatePage } from '../../libs/utils';
 import SimpleTable from '../SimpleTable';
 import cellData from './DarDatasetTableCellData';
-import {flow, isNil} from 'lodash/fp';
+import {flow, isNil, intersection} from 'lodash/fp';
 import {
   generatePreProcessedBucketData,
   processDataUseBuckets,
 } from '../../utils/DarCollectionUtils';
 import {Notifications} from '../../libs/utils';
+import { isEmpty } from 'lodash';
 
 
 const storageDarDatasetSort = 'storageDarDatasetSort';
@@ -151,14 +152,32 @@ export const DarDatasetTable = (props) => {
   const [buckets, setBuckets] = useState([]);
 
   const {
-    collection, isLoading
+    collection, isLoading, summary
   } = props;
 
   const [isInitializing, setIsInitializing] = useState(true);
 
   const init = useCallback(async () => {
     try {
-      const { dars, datasets } = collection;
+      let { dars, datasets } = collection;
+      if (isEmpty(collection)) {
+        setBuckets([]);
+        return;
+      }
+      datasets = collection.datasets? collection.datasets.filter(dataset => summary.datasetIds.includes(dataset.dataSetId)):null;
+      const darKeys = Object.keys(dars);
+      dars = {};
+      darKeys.forEach(darKey => {
+        if(intersection(summary.datasetIds, collection.dars[darKey].datasetIds).length > 0) {
+          dars[darKey] = collection.dars[darKey];
+          const electionKeys = Object.keys(dars[darKey].elections);
+          electionKeys.forEach(electionKey => {
+            if (!summary.datasetIds.includes(dars[darKey].elections[electionKey].datasetId)) {
+              delete dars[darKey].elections[electionKey];
+            }
+          });
+        }
+      });
       if (isNil(dars) || isNil(datasets)) {
         setBuckets([]);
         return;
@@ -177,7 +196,7 @@ export const DarDatasetTable = (props) => {
       });
     }
     setIsInitializing(false);
-  }, [collection]);
+  }, [collection, summary]);
 
   useEffect(() => {
     try {

--- a/src/components/dar_dataset_table/DarDatasetTable.js
+++ b/src/components/dar_dataset_table/DarDatasetTable.js
@@ -6,7 +6,7 @@ import PaginationBar from '../PaginationBar';
 import { recalculateVisibleTable, goToPage as updatePage } from '../../libs/utils';
 import SimpleTable from '../SimpleTable';
 import cellData from './DarDatasetTableCellData';
-import {flow, isNil, intersection} from 'lodash/fp';
+import {flow, isNil, intersection, cloneDeep} from 'lodash/fp';
 import {
   generatePreProcessedBucketData,
   processDataUseBuckets,
@@ -159,23 +159,23 @@ export const DarDatasetTable = (props) => {
 
   const init = useCallback(async () => {
     try {
-      let { dars, datasets } = collection;
       if (isEmpty(collection)) {
         setBuckets([]);
         return;
       }
-      datasets = collection.datasets? collection.datasets.filter(dataset => summary.datasetIds.includes(dataset.dataSetId)):null;
+      let { dars, datasets } = cloneDeep(collection);
+      datasets = datasets ? datasets.filter(dataset => summary.datasetIds.includes(dataset.dataSetId)) : null;
       const darKeys = Object.keys(dars);
-      dars = {};
       darKeys.forEach(darKey => {
-        if(intersection(summary.datasetIds, collection.dars[darKey].datasetIds).length > 0) {
-          dars[darKey] = collection.dars[darKey];
+        if(intersection(summary.datasetIds, dars[darKey].datasetIds).length > 0) {
           const electionKeys = Object.keys(dars[darKey].elections);
           electionKeys.forEach(electionKey => {
             if (!summary.datasetIds.includes(dars[darKey].elections[electionKey].datasetId)) {
               delete dars[darKey].elections[electionKey];
             }
           });
+        } else {
+          delete dars[darKey];
         }
       });
       if (isNil(dars) || isNil(datasets)) {


### PR DESCRIPTION
[DUOS-2116](https://broadworkbench.atlassian.net/browse/DUOS-2216) identified two issues.  One issue is related to UX and workflow.  It _is_ functioning properly and as designed, but is reveals complexities behind the state machine.  New tickets were created to address those concerns.

The second issue related to the expandable list of datasets embedded in rows when the list of DARs are displayed to DAC members and chairs.
This PR code adds logic to filter the DAR Collection object to include only the datasets and elements needed for the datasets they have access to.  In deciding on the approach to implement, this was the least invasive as it left the core logic of bucket building as-is and added input filtering to existing functions.  Other (admin) code elements relied on the bucketing logic as-is.

An entirely different approach to consider may be to perform this filtering at the consent tier so that resource "collection" responses don't include the DARs, datasets, and elections that aren't relevant for the DAC Chair or Member.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
