### PR TITLE
DDO-2531 Automatically deploy duos to dev after PR merge [low]

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,8 @@ env:
 jobs:
   tag-build-push:
     runs-on: ubuntu-latest
+    outputs:
+      sha-tag: ${{ steps.construct-tags.outputs.sha-tag }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -69,20 +71,22 @@ jobs:
         fields: repo,commit,author,action,eventName,ref,workflow,job,took
 
   report-to-sherlock:
+    if: github.event_name == 'push'
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: [tag, publish-job]
+    needs: [tag-build-push]
     with:
-      new-version: ${{ needs.tag.outputs.tag }}
+      new-version: ${{ needs.tag-build-push.outputs.sha-tag }}
       chart-name: 'duos'
     permissions:
       contents: 'read'
       id-token: 'write'
 
   set-version-in-dev:
+    if: github.event_name == 'push'
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: [tag, publish-job, report-to-sherlock]
+    needs: [tag-build-push, report-to-sherlock]
     with:
-      new-version: ${{ needs.tag.outputs.tag }}
+      new-version: ${{ needs.tag.outputs.sha-tag }}
       chart-name: 'duos'
       environment-name: 'dev'
     secrets:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,7 +86,7 @@ jobs:
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [tag-build-push, report-to-sherlock]
     with:
-      new-version: ${{ needs.tag.outputs.sha-tag }}
+      new-version: ${{ needs.tag-build-push.outputs.sha-tag }}
       chart-name: 'duos'
       environment-name: 'dev'
     secrets:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,14 +55,7 @@ jobs:
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}
-    - name: Dispatch to terra-helmfile
-      if: github.event_name == 'push'
-      uses: broadinstitute/repository-dispatch@master
-      with:
-        token: ${{ secrets.BROADBOT_TOKEN }}
-        repository: broadinstitute/terra-helmfile
-        event-type: update-service
-        client-payload: '{"service": "duos", "version": "${{ steps.short-sha.outputs.sha }}", "dev_only": false}'
+
     - name: Notify Slack
       # only notify for develop branch build
       if: github.event_name == 'push'
@@ -75,4 +68,25 @@ jobs:
         channel: "#duos-notifications"
         fields: repo,commit,author,action,eventName,ref,workflow,job,took
 
+  report-to-sherlock:
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: [tag, publish-job]
+    with:
+      new-version: ${{ needs.tag.outputs.tag }}
+      chart-name: 'duos'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  set-version-in-dev:
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [tag, publish-job, report-to-sherlock]
+    with:
+      new-version: ${{ needs.tag.outputs.tag }}
+      chart-name: 'duos'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'
 


### PR DESCRIPTION
This PR is a small CI/CD change that shamelessly copies @jack-r-warren's build reporting workflow to DUOS, so that new DUOS builds are automatically deployed to dev on PR merge.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
