### PR TITLE
[DUOS-1611][risk=no] Custom highlighting for Narrative RUS

### DIFF
--- a/cypress/component/highlight_text.spec.js
+++ b/cypress/component/highlight_text.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
 import HighlightText from '../../src/components/HighlightText';
 import { mount } from 'cypress/react';
+import React from 'react';
 
 describe('HighlightText - Tests', function() {
   it('Renders text with no highlighting if no matches', function() {

--- a/cypress/component/highlight_text.spec.js
+++ b/cypress/component/highlight_text.spec.js
@@ -27,7 +27,7 @@ describe('HighlightText - Tests', function() {
 
   it('Highlights with the correct color, irrelevant of casing.', function() {
     const text = (
-      'The quick brown fox jumps over the lazy log.'
+      'ThE quick BroWn fox jUMpS over tHe laZy log.'
     );
 
     mount(

--- a/cypress/component/highlight_text.spec.js
+++ b/cypress/component/highlight_text.spec.js
@@ -1,0 +1,172 @@
+import HighlightText from '../../src/components/HighlightText';
+import { mount } from 'cypress/react';
+
+describe('HighlightText - Tests', function() {
+  it('Renders text with no highlighting if no matches', function() {
+    const lorem = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.';
+
+    mount(
+      <HighlightText
+        highlight={[
+          {
+            bgColor: 'black',
+            textColor: 'black',
+            words: ['unrelated', 'unused', 'words'],
+          }
+        ]}
+        text={lorem}
+      />
+    );
+    // first highlight chunk is entire text
+    cy.get('[data-cy="highlight-0"]').contains(lorem);
+    // no further chunks
+    cy.get('[data-cy="highlight-1"]').should('not.exist');
+  });
+
+  it('Highlights with the correct color, irrelevant of casing.', function() {
+    const text = (
+      'The quick brown fox jumps over the lazy log.'
+    );
+
+    mount(
+      <HighlightText
+        highlight={[
+          {
+            bgColor: 'rgb(0, 0, 0)',
+            textColor: 'rgb(255, 255, 255)',
+            words: ['the', 'jumps'],
+          }
+        ]}
+        text={text}
+      />
+    );
+    // first highlight chunk; regex allows us to ensure there is no extra text
+    cy.get('[data-cy="highlight-0"]').contains(/^The$/);
+    // highlighted CSS props
+    cy.get('[data-cy="highlight-0"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-0"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+
+    cy.get('[data-cy="highlight-1"]').contains(/^ quick brown fox $/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-1"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-1"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+
+    cy.get('[data-cy="highlight-2"]').contains(/^jumps$/);
+    // highlighted CSS props
+    cy.get('[data-cy="highlight-2"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-2"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+
+    cy.get('[data-cy="highlight-3"]').contains(/^ over $/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-3"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-3"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+
+    cy.get('[data-cy="highlight-4"]').contains(/^the$/);
+    // highlighted CSS props
+    cy.get('[data-cy="highlight-4"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-4"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+
+    cy.get('[data-cy="highlight-5"]').contains(/^ lazy log.$/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-5"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-5"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+  });
+
+  it('Highlights with the multiple colors.', function() {
+    const text = (
+      'Example text. Test'
+    );
+
+    mount(
+      <HighlightText
+        highlight={[
+          // black bg, white text
+          {
+            bgColor: 'rgb(0, 0, 0)',
+            textColor: 'rgb(255, 255, 255)',
+            words: ['example', 'test'],
+          },
+
+          // blue bg, red text
+          {
+            bgColor: 'rgb(0, 255, 0)',
+            textColor: 'rgb(255, 0, 0)',
+            words: ['text'],
+          }
+        ]}
+        text={text}
+      />
+    );
+
+    cy.get('[data-cy="highlight-0"]').contains(/^Example$/);
+    // black highlighted CSS props
+    cy.get('[data-cy="highlight-0"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-0"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+
+    cy.get('[data-cy="highlight-1"]').contains(/^ $/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-1"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-1"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+
+    cy.get('[data-cy="highlight-2"]').contains(/^text$/);
+    // blue highlighted CSS props
+    cy.get('[data-cy="highlight-2"]').should('have.css', 'background-color', 'rgb(0, 255, 0)');
+    cy.get('[data-cy="highlight-2"]').should('have.css', 'color', 'rgb(255, 0, 0)');
+
+
+    cy.get('[data-cy="highlight-3"]').contains(/^. $/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-3"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-3"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+
+
+    cy.get('[data-cy="highlight-4"]').contains(/^Test$/);
+    // black highlighted CSS props
+    cy.get('[data-cy="highlight-4"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-4"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+  });
+
+
+  it('Does not highlight word if it isn\'t surrounded by whitespace or punctuation.', function() {
+    const text = (
+      'Example; asdfexample exampleasdf Words. multiple words. ahhhhmultiple words'
+    );
+
+    mount(
+      <HighlightText
+        highlight={[
+          // black bg, white text
+          {
+            bgColor: 'rgb(0, 0, 0)',
+            textColor: 'rgb(255, 255, 255)',
+            words: ['example', 'multiple words'],
+          },
+        ]}
+        text={text}
+      />
+    );
+
+    cy.get('[data-cy="highlight-0"]').contains(/^Example$/);
+    // black highlighted CSS props
+    cy.get('[data-cy="highlight-0"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-0"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+
+
+    cy.get('[data-cy="highlight-1"]').contains(/^; asdfexample exampleasdf Words. $/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-1"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-1"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+
+    cy.get('[data-cy="highlight-2"]').contains(/^multiple words$/);
+    // black highlighted CSS props
+    cy.get('[data-cy="highlight-2"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    cy.get('[data-cy="highlight-2"]').should('have.css', 'color', 'rgb(255, 255, 255)');
+
+
+    cy.get('[data-cy="highlight-3"]').contains(/^. ahhhhmultiple words$/);
+    // default, unchanged CSS props
+    cy.get('[data-cy="highlight-3"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
+    cy.get('[data-cy="highlight-3"]').should('have.css', 'color', 'rgb(0, 0, 0)');
+
+  });
+});

--- a/cypress/component/highlight_text.spec.js
+++ b/cypress/component/highlight_text.spec.js
@@ -43,17 +43,17 @@ describe('HighlightText - Tests', function() {
       />
     );
     // first highlight chunk; regex allows us to ensure there is no extra text
-    cy.get('[data-cy="highlight-0"]').contains(/^The$/);
+    cy.get('[data-cy="highlight-0"]').contains(/^ThE$/);
     // highlighted CSS props
     cy.get('[data-cy="highlight-0"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
     cy.get('[data-cy="highlight-0"]').should('have.css', 'color', 'rgb(255, 255, 255)');
 
-    cy.get('[data-cy="highlight-1"]').contains(/^ quick brown fox $/);
+    cy.get('[data-cy="highlight-1"]').contains(/^ quick BroWn fox $/);
     // default, unchanged CSS props
     cy.get('[data-cy="highlight-1"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
     cy.get('[data-cy="highlight-1"]').should('have.css', 'color', 'rgb(0, 0, 0)');
 
-    cy.get('[data-cy="highlight-2"]').contains(/^jumps$/);
+    cy.get('[data-cy="highlight-2"]').contains(/^jUMpS$/);
     // highlighted CSS props
     cy.get('[data-cy="highlight-2"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
     cy.get('[data-cy="highlight-2"]').should('have.css', 'color', 'rgb(255, 255, 255)');
@@ -63,12 +63,12 @@ describe('HighlightText - Tests', function() {
     cy.get('[data-cy="highlight-3"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
     cy.get('[data-cy="highlight-3"]').should('have.css', 'color', 'rgb(0, 0, 0)');
 
-    cy.get('[data-cy="highlight-4"]').contains(/^the$/);
+    cy.get('[data-cy="highlight-4"]').contains(/^tHe$/);
     // highlighted CSS props
     cy.get('[data-cy="highlight-4"]').should('have.css', 'background-color', 'rgb(0, 0, 0)');
     cy.get('[data-cy="highlight-4"]').should('have.css', 'color', 'rgb(255, 255, 255)');
 
-    cy.get('[data-cy="highlight-5"]').contains(/^ lazy log.$/);
+    cy.get('[data-cy="highlight-5"]').contains(/^ laZy log.$/);
     // default, unchanged CSS props
     cy.get('[data-cy="highlight-5"]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)');
     cy.get('[data-cy="highlight-5"]').should('have.css', 'color', 'rgb(0, 0, 0)');

--- a/cypress/component/highlight_text.spec.js
+++ b/cypress/component/highlight_text.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import HighlightText from '../../src/components/HighlightText';
 import { mount } from 'cypress/react';
 

--- a/src/components/HighlightText.js
+++ b/src/components/HighlightText.js
@@ -1,0 +1,101 @@
+import React, {useCallback} from 'react';
+
+export const HighlightText = (props) => {
+  const {
+    /**
+     * highlight:
+     *   Specifies any number of highlight colors and words
+     *   to highlight with those colors.
+     * schema:
+     *   [
+     *    { bgColor: ..., textColor: ... , words: [ ... ] },
+     *    { bgColor: ..., textColor: ... , words: [ ... ] },
+     *   ]
+     */
+    highlight,
+    text,
+  } = props;
+
+  // searches through text one character at a time
+  // looking for words to highlight
+  const splitAndHighlight = useCallback(() => {
+    const output = [];
+
+    const pushOutput = ({
+      text,
+      bgColor=undefined,
+      textColor=undefined,
+      fontWeight=undefined
+    }) => {
+      return (
+        <span
+          key={output.length}
+          style={{
+            backgroundColor: bgColor,
+            color: textColor,
+            fontWeight: fontWeight
+          }}>
+          {text}
+        </span>
+      );
+    };
+
+
+    // keeps track of last unhighlighted text
+    let lastIndex = 0;
+
+    // scan through text by character
+    for (let idx = 0; idx < text.length; idx++) {
+
+      // scan through all of the highlightable words to
+      // see if the current index matches any of the words
+      for (const highlightConfig of highlight) {
+        for (const word of highlightConfig.words) {
+          if (idx+word.length >= text.length) {
+            continue;
+          }
+
+          const textAtCurrWordLength = text.slice(idx, idx+word.length);
+
+          // if there is a highlightable word here, then
+          // render the text up until now, and the current
+          // word with the highlighted background and text
+          // color.
+          if (textAtCurrWordLength.toLowerCase() === word.toLowerCase()) {
+            output.push(pushOutput({
+              text: text.slice(lastIndex, idx)
+            }));
+            output.push(pushOutput({
+              text: textAtCurrWordLength,
+              bgColor: highlightConfig.bgColor,
+              textColor: highlightConfig.textColor,
+              fontWeight: 'bold'
+            }));
+
+            // update indices:
+            // lastIndex now allows slicing after last highlighted word
+            // idx now scans after the new highlighted word
+            lastIndex = idx+word.length;
+            idx = lastIndex-1;
+          }
+        }
+      }
+    }
+
+    if (lastIndex !== text.length) {
+      output.push(pushOutput({text: text.slice(lastIndex, text.length)}));
+    }
+
+
+    return <div>
+      {output}
+    </div>;
+  }, [highlight, text]);
+
+  return <div>
+    {splitAndHighlight()}
+  </div>;
+
+};
+
+export default HighlightText;

--- a/src/components/HighlightText.js
+++ b/src/components/HighlightText.js
@@ -1,6 +1,58 @@
 import { isNil } from 'lodash';
 import React, {useCallback} from 'react';
 
+/**
+ * Checks within a text that the characters between
+ * startIdx and endIdx are complete words.
+ *
+ * E.g.,
+ *    text="Biometric", startIdx=3 (m), endIdx=8 (c) => false
+ *    text="The metric", startIdx=4 (m), endIdx=9 (c) => true
+ */
+const punctuation = ['.', ',', ':', ';', '!', '?'];
+const isStandaloneWord = (text, startIdx, endIdx) => {
+  if (startIdx !== 0) {
+    const char = text.charAt(startIdx-1);
+
+    if (char.trim() !== '' && !punctuation.includes(char)) {
+      return false;
+    }
+  }
+
+  if (endIdx !== text.length-1) {
+    const char = text.charAt(endIdx);
+
+    if (char.trim() !== '' && !punctuation.includes(char)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+
+const findHighlightableMatch = (highlight, text, idx) => {
+  for (const highlightConfig of highlight) {
+    for (const word of highlightConfig.words) {
+      const textAtCurrWordLength = text.slice(idx, idx+word.length);
+
+
+      const textIsStandalone = isStandaloneWord(text, idx, idx+word.length);
+      const textMatchesHighlightableWord = textAtCurrWordLength.toLowerCase() === word.toLowerCase();
+
+      if (textIsStandalone && textMatchesHighlightableWord) {
+        return {
+          word: textAtCurrWordLength,
+          bgColor: highlightConfig.bgColor,
+          textColor: highlightConfig.textColor,
+        };
+      }
+    }
+  }
+
+  return null;
+};
+
 export const HighlightText = (props) => {
   const {
     /**
@@ -35,6 +87,7 @@ export const HighlightText = (props) => {
       return (
         <span
           key={output.length}
+          data-cy={`highlight-${output.length}`}
           style={{
             backgroundColor: bgColor,
             color: textColor,
@@ -47,48 +100,42 @@ export const HighlightText = (props) => {
 
 
     // keeps track of last unhighlighted text
-    let lastIndex = 0;
+    let endOfLastHighlight = 0;
 
     // scan through text by character
     for (let idx = 0; idx < text.length; idx++) {
+      const match = findHighlightableMatch(highlight, text, idx);
 
-      // scan through all of the highlightable words to
-      // see if the current index matches any of the words
-      for (const highlightConfig of highlight) {
-        for (const word of highlightConfig.words) {
-          if (idx+word.length >= text.length) {
-            continue;
-          }
-
-          const textAtCurrWordLength = text.slice(idx, idx+word.length);
-
-          // if there is a highlightable word here, then
-          // render the text up until now, and the current
-          // word with the highlighted background and text
-          // color.
-          if (textAtCurrWordLength.toLowerCase() === word.toLowerCase()) {
-            output.push(pushOutput({
-              text: text.slice(lastIndex, idx)
-            }));
-            output.push(pushOutput({
-              text: textAtCurrWordLength,
-              bgColor: highlightConfig.bgColor,
-              textColor: highlightConfig.textColor,
-              fontWeight: 'bold'
-            }));
-
-            // update indices:
-            // lastIndex now allows slicing after last highlighted word
-            // idx now scans after the new highlighted word
-            lastIndex = idx+word.length;
-            idx = lastIndex-1;
-          }
-        }
+      if (isNil(match)) {
+        continue;
       }
+
+      const {
+        word,
+        bgColor,
+        textColor
+      } = match;
+
+      if (endOfLastHighlight !== idx) {
+        output.push(pushOutput({
+          text: text.slice(endOfLastHighlight, idx)
+        }));
+      }
+      output.push(pushOutput({
+        text: word,
+        bgColor: bgColor,
+        textColor: textColor,
+        fontWeight: 'bold'
+      }));
+
+      // update indices:
+      // idx now scans after the new highlighted word
+      endOfLastHighlight = idx+word.length;
+      idx = endOfLastHighlight-1;
     }
 
-    if (lastIndex !== text.length) {
-      output.push(pushOutput({text: text.slice(lastIndex, text.length)}));
+    if (endOfLastHighlight !== text.length) {
+      output.push(pushOutput({text: text.slice(endOfLastHighlight, text.length)}));
     }
 
 

--- a/src/components/HighlightText.js
+++ b/src/components/HighlightText.js
@@ -1,3 +1,4 @@
+import { isNil } from 'lodash';
 import React, {useCallback} from 'react';
 
 export const HighlightText = (props) => {
@@ -19,6 +20,10 @@ export const HighlightText = (props) => {
   // searches through text one character at a time
   // looking for words to highlight
   const splitAndHighlight = useCallback(() => {
+    if (isNil(text)) {
+      return <div></div>;
+    }
+
     const output = [];
 
     const pushOutput = ({

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -16,6 +16,7 @@ import CollectionAlgorithmDecision from '../CollectionAlgorithmDecision';
 import {convertLabelToKey} from '../../libs/utils';
 import {ScrollToTopButton} from '../ScrollButton';
 import MemberVoteSummary from './MemberVoteSummary';
+import HighlightText from '../HighlightText';
 
 const styles = {
   baseStyle: {
@@ -91,6 +92,27 @@ const animationAttributes = {
   transition:{duration: 0.5, ease: [0.50, 0.62, 0.23, 0.98]}
 };
 
+const highlightedWords = [
+  {
+    bgColor: 'rgba(0,0,100,.2)',
+    textColor: '#0948B7',
+    words: [
+      'Health',
+      'Medical',
+      'Biomedical',
+      'Disease',
+      'Methods',
+      'Algorithm',
+      'Population',
+      'Origin',
+      'Ancestry',
+      'Controls',
+      'Commercial',
+      'Profit'
+    ]
+  }
+];
+
 const DataUseSummary = ({translatedDataUse}) => {
   return flatMap( key => {
     const dataUses = translatedDataUse[key];
@@ -116,7 +138,12 @@ const CollapseExpandLink = ({expanded, setExpanded}) => {
 
 const ResearchPurposeSummary = ({darInfo}) => {
   return !isNil(darInfo) ?
-    div({style: styles.researchPurposeSummary}, [darInfo.rus]) :
+    div({style: styles.researchPurposeSummary}, [
+      h(HighlightText, {
+        highlight: highlightedWords,
+        text: darInfo.rus,
+      })
+    ]) :
     div();
 };
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -115,11 +115,29 @@ export const applyHoverEffects = (e, style) => {
   });
 };
 
-export const highlightExactMatches = (highlightedWords, content) => {
+export const highlightExactMatches = (highlightedWords, bgColor, textColor, content) => {
   const regexWords = highlightedWords.map(w => '\\b' + w + '\\b');
   const regexString = '(' + regexWords.join('|') + ')';
   const regex = new RegExp(regexString, 'gi');
-  return content.replace(regex, '<span style=\'background-color: yellow\'>$1</span>');
+  return content.replace(regex, `<span style='background-color: ${bgColor}'>$1</span>`);
+};
+
+/**
+ * Highlights according to given config.
+ * highlightConfig: [{bgColor: ..., textColor: ..., words: [...]}]
+ */
+export const highlight = (highlightConfig, content) => {
+  let finalContent = content;
+
+  highlightConfig.forEach((config) => {
+    console.log(config);
+    const words = config.words;
+    const bgColor = config.bgColor;
+    const textColor = config.textColor;
+    finalContent = highlightExactMatches(words, bgColor, textColor, finalContent);
+  });
+
+  return finalContent;
 };
 
 //currently, dars contain a list of datasets (any length) and a list of length 1 of a datasetId

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -115,31 +115,6 @@ export const applyHoverEffects = (e, style) => {
   });
 };
 
-export const highlightExactMatches = (highlightedWords, bgColor, textColor, content) => {
-  const regexWords = highlightedWords.map(w => '\\b' + w + '\\b');
-  const regexString = '(' + regexWords.join('|') + ')';
-  const regex = new RegExp(regexString, 'gi');
-  return content.replace(regex, `<span style='background-color: ${bgColor}'>$1</span>`);
-};
-
-/**
- * Highlights according to given config.
- * highlightConfig: [{bgColor: ..., textColor: ..., words: [...]}]
- */
-export const highlight = (highlightConfig, content) => {
-  let finalContent = content;
-
-  highlightConfig.forEach((config) => {
-    console.log(config);
-    const words = config.words;
-    const bgColor = config.bgColor;
-    const textColor = config.textColor;
-    finalContent = highlightExactMatches(words, bgColor, textColor, finalContent);
-  });
-
-  return finalContent;
-};
-
 //currently, dars contain a list of datasets (any length) and a list of length 1 of a datasetId
 //go through the list of datasets and get the name of the dataset whose id is in the datasetId list
 export const getNameOfDatasetForThisDAR = (datasets, datasetId) => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1611

Initially, I tried to use the old code in utils for highlighting. However, it used raw regex and HTML tags, which gave me concerns of safety, since we would have to sanitize user input while still forcing raw html to render. Instead, I created a new, custom highlighting component which allows multiple colors and multiple banks of words and does not use regex or any raw html, so user input is guaranteed sanitized. I looked into packages that could do this, but I couldn't find a major highlighting package which allowed multiple different colors.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
