### PR TITLE
[DUOS-2077][risk=no] Button to Send Reminder to DAC Member to Vote

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -427,7 +427,29 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.get('.row-data-3').should('contain.text', 'Matt').should('contain.text', 'Yes');
   });
 
+
   it('Renders filler text when some fields of vote are empty', function() {
+    mount(
+      <MultiDatasetVoteSlab
+        title={'GROUP 1'}
+        bucket={{
+          elections: [openElection2],
+          votes: [votesForOpenElection2]
+        }}
+        dacDatasetIds={[20]}
+        isChair={false}
+      />
+    );
+    cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
+
+    cy.get('.table-data').should('not.exist');
+    cy.get('#show-member-vote-dropdown').click();
+    cy.get('.table-data').should('exist');
+    cy.get('.row-data-0').should('contain.text', 'Joe').should('contain.text', '- -');
+    cy.get('.row-data-2').should('contain.text', 'Matt').should('contain.text', '- -');
+  });
+
+  it('Renders send reminder button when user is chair and no vote', function() {
     mount(
       <MultiDatasetVoteSlab
         title={'GROUP 1'}
@@ -444,7 +466,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
     cy.get('.table-data').should('exist');
-    cy.get('.row-data-0').should('contain.text', 'Joe').should('contain.text', '- -');
+    cy.get('.row-data-0').should('contain.text', 'Joe').should('contain.text', 'Send Reminder');
     cy.get('.row-data-2').should('contain.text', 'Matt').should('contain.text', '- -');
   });
 });

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -542,7 +542,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         bucket={{
           votes: [votesForElection2]
         }}
-        isChair={true}
+        isChair={false}
       />
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
@@ -554,6 +554,27 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.get('#show-member-vote-dropdown').click();
     cy.get('.table-data').should('exist');
     cy.get('.row-data-0').should('contain.text', 'Joe').should('contain.text', '- -');
+    cy.get('.row-data-2').should('contain.text', 'Matt').should('contain.text', '- -');
+  });
+
+  it('Allows sending reminder if no vote', function() {
+    mount(
+      <ResearchProposalVoteSlab
+        bucket={{
+          votes: [votesForElection2]
+        }}
+        isChair={true}
+      />
+    );
+    cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
+
+    const link = cy.contains(expandSlabLinkText);
+    link.click();
+
+    cy.get('.table-data').should('not.exist');
+    cy.get('#show-member-vote-dropdown').click();
+    cy.get('.table-data').should('exist');
+    cy.get('.row-data-0').should('contain.text', 'Joe').should('contain.text', 'Send Reminder');
     cy.get('.row-data-2').should('contain.text', 'Matt').should('contain.text', '- -');
   });
 

--- a/src/components/collection_voting_slab/MemberVoteSummary.js
+++ b/src/components/collection_voting_slab/MemberVoteSummary.js
@@ -42,7 +42,7 @@ export const MemberVoteSummary = (props) => {
       isRendered: showMemberVotes,
       isLoading,
       adminPage,
-      isChair
+      isChair,
     }),
   ]);
 };

--- a/src/components/collection_voting_slab/MemberVoteSummary.js
+++ b/src/components/collection_voting_slab/MemberVoteSummary.js
@@ -13,6 +13,7 @@ export const MemberVoteSummary = (props) => {
     isLoading = false,
     title = 'DAC Member Votes (detail)',
     adminPage = false,
+    isChair = false,
     dacVotes
   } = props;
 
@@ -40,7 +41,8 @@ export const MemberVoteSummary = (props) => {
       dacVotes: collapseVotesByUser(dacVotes),
       isRendered: showMemberVotes,
       isLoading,
-      adminPage
+      adminPage,
+      isChair
     }),
   ]);
 };

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.js
@@ -103,6 +103,7 @@ export default function MultiDatasetVoteSlab(props) {
         title: adminPage ? 'DAC Member Votes' : (isChair ? 'My DAC Member\'s Votes (detail)' : 'Other DAC Member\'s Votes'),
         isLoading,
         adminPage,
+        isChair,
       }),
     ]);
   };

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -206,7 +206,8 @@ export default function ResearchProposalVoteSlab(props) {
                   title: adminPage ? 'DAC Member Votes' : (isChair ? 'My DAC Member\'s Votes (detail)' : 'Other DAC Member\'s Votes'),
                   isLoading,
                   dacVotes,
-                  adminPage
+                  adminPage,
+                  isChair
                 })
               ]),
             ]),

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -206,7 +206,8 @@ export default function ResearchProposalVoteSlab(props) {
                   title: adminPage ? 'DAC Member Votes' : (isChair ? 'My DAC Member\'s Votes (detail)' : 'Other DAC Member\'s Votes'),
                   isLoading,
                   dacVotes,
-                  adminPage
+                  adminPage,
+                  isChair,
                 })
               ]),
             ]),

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -206,8 +206,7 @@ export default function ResearchProposalVoteSlab(props) {
                   title: adminPage ? 'DAC Member Votes' : (isChair ? 'My DAC Member\'s Votes (detail)' : 'Other DAC Member\'s Votes'),
                   isLoading,
                   dacVotes,
-                  adminPage,
-                  isChair,
+                  adminPage
                 })
               ]),
             ]),

--- a/src/components/vote_summary_table/VoteSummaryTable.js
+++ b/src/components/vote_summary_table/VoteSummaryTable.js
@@ -5,6 +5,7 @@ import {isNil, isEmpty} from 'lodash/fp';
 import {useEffect, useState} from 'react';
 import {sortVisibleTable} from '../../libs/utils';
 import { Email } from '../../libs/ajax';
+import { Notifications } from '../../libs/utils';
 
 const styles = {
   baseStyle: {
@@ -73,7 +74,11 @@ const voteToString = (vote) => {
 };
 
 const reminderLink = (voteId) => {
-  return <a onClick={() => {Email.sendReminderEmail(voteId);}}>
+  return <a onClick={() => {
+    Email.sendReminderEmail(voteId)
+      .then(() => Notifications.showSuccess({text: 'Successfully sent reminder.'}))
+      .catch(() => Notifications.showError({text: 'There was an issue sending the reminder. Please try again later.'}));
+  }}>
   Send Reminder
   </a>;
 };

--- a/src/components/vote_summary_table/VoteSummaryTable.js
+++ b/src/components/vote_summary_table/VoteSummaryTable.js
@@ -52,7 +52,7 @@ const columnHeaderData = () => {
   return [vote, name, date, rationale];
 };
 
-const processVoteSummaryRowData = ({ dacVotes, isChair = false }) => {
+const processVoteSummaryRowData = ({ dacVotes, isChair }) => {
   if(!isNil(dacVotes)) {
     return dacVotes.map((dacVote) => {
       const { vote, displayName, voteId, lastUpdated, rationale } =
@@ -70,7 +70,7 @@ const processVoteSummaryRowData = ({ dacVotes, isChair = false }) => {
 
 const voteToString = (vote) => {
   return isNil(vote) ? '- -' : (vote ? 'Yes' : 'No');
-}
+};
 
 const reminderLink = (voteId) => {
   return <a onClick={() => {Email.sendReminderEmail(voteId);}}>
@@ -79,10 +79,11 @@ const reminderLink = (voteId) => {
 };
 
 function voteCellData({vote, voteId, isChair, label = 'vote'}) {
-  const data = 
-    (isChair && (isNil(vote) || isNil(voteId))
+  const data = (
+    isChair && (isNil(vote) || isNil(voteId))
       ? reminderLink(voteId)
-      : voteToString(vote));
+      : voteToString(vote)
+  );
 
   return {
     data: data,
@@ -135,7 +136,7 @@ export default function VoteSummaryTable(props) {
       })
     );
     if(!isEmpty(dacVotes)){ setTableSize(dacVotes.length);}
-  }, [sort, dacVotes]);
+  }, [sort, dacVotes, isChair]);
 
   return <SimpleTable
     isLoading={isLoading}

--- a/src/components/vote_summary_table/VoteSummaryTable.js
+++ b/src/components/vote_summary_table/VoteSummaryTable.js
@@ -1,9 +1,10 @@
+import React from 'react';
 import SimpleTable from '../SimpleTable';
-import {h} from 'react-hyperscript-helpers';
 import {Styles} from '../../libs/theme';
 import {isNil, isEmpty} from 'lodash/fp';
 import {useEffect, useState} from 'react';
 import {sortVisibleTable} from '../../libs/utils';
+import { Email } from '../../libs/ajax';
 
 const styles = {
   baseStyle: {
@@ -69,7 +70,12 @@ const processVoteSummaryRowData = ({ dacVotes }) => {
 
 function voteCellData({vote, voteId, label = 'vote'}) {
   return {
-    data: isNil(vote) ? '- -' : vote ? 'Yes' : 'No',
+    data: (isNil(vote) || isNil(voteId)) ? (
+      <a onClick={() => {Email.sendReminderEmail(voteId);}}>
+      Send Reminder
+      </a>
+    ) : vote ? 'Yes' : 'No',
+    value: isNil(vote) ? '-' : (vote ? 'Yes' : 'No'),
     id: voteId,
     cellStyle: { width: styles.cellWidths.vote },
     label
@@ -120,13 +126,13 @@ export default function VoteSummaryTable(props) {
     if(!isEmpty(dacVotes)){ setTableSize(dacVotes.length);}
   }, [sort, dacVotes]);
 
-  return h(SimpleTable, {
-    isLoading,
-    rowData: visibleVotes,
-    columnHeaders: columnHeaderData(),
-    tableSize,
-    styles,
-    sort,
-    onSort: setSort
-  });
+  return <SimpleTable
+    isLoading={isLoading}
+    rowData={visibleVotes}
+    columnHeaders={columnHeaderData()}
+    tableSize={tableSize}
+    styles={styles}
+    sort={sort}
+    onSort={setSort}
+  />;
 }

--- a/src/components/vote_summary_table/VoteSummaryTable.js
+++ b/src/components/vote_summary_table/VoteSummaryTable.js
@@ -52,13 +52,13 @@ const columnHeaderData = () => {
   return [vote, name, date, rationale];
 };
 
-const processVoteSummaryRowData = ({ dacVotes }) => {
+const processVoteSummaryRowData = ({ dacVotes, isChair = false }) => {
   if(!isNil(dacVotes)) {
     return dacVotes.map((dacVote) => {
       const { vote, displayName, voteId, lastUpdated, rationale } =
         dacVote;
       return [
-        voteCellData({ vote, voteId }),
+        voteCellData({ vote, voteId, isChair }),
         nameCellData({ name: displayName, voteId }),
         dateCellData({ date: lastUpdated, voteId }),
         rationaleCellData({ rationale, voteId }),
@@ -68,13 +68,24 @@ const processVoteSummaryRowData = ({ dacVotes }) => {
 };
 
 
-function voteCellData({vote, voteId, label = 'vote'}) {
+const voteToString = (vote) => {
+  return isNil(vote) ? '- -' : (vote ? 'Yes' : 'No');
+}
+
+const reminderLink = (voteId) => {
+  return <a onClick={() => {Email.sendReminderEmail(voteId);}}>
+  Send Reminder
+  </a>;
+};
+
+function voteCellData({vote, voteId, isChair, label = 'vote'}) {
+  const data = 
+    (isChair && (isNil(vote) || isNil(voteId))
+      ? reminderLink(voteId)
+      : voteToString(vote));
+
   return {
-    data: (isNil(vote) || isNil(voteId)) ? (
-      <a onClick={() => {Email.sendReminderEmail(voteId);}}>
-      Send Reminder
-      </a>
-    ) : vote ? 'Yes' : 'No',
+    data: data,
     value: isNil(vote) ? '-' : (vote ? 'Yes' : 'No'),
     id: voteId,
     cellStyle: { width: styles.cellWidths.vote },
@@ -114,12 +125,12 @@ export default function VoteSummaryTable(props) {
   const [sort, setSort] = useState({ colIndex: 0, dir: 1 });
   const [visibleVotes, setVisibleVotes] = useState([]);
   const [tableSize, setTableSize] = useState(5);
-  const { dacVotes, isLoading } = props;
+  const { dacVotes, isLoading, isChair = false } = props;
 
   useEffect(() => {
     setVisibleVotes(
       sortVisibleTable({
-        list: processVoteSummaryRowData({ dacVotes }),
+        list: processVoteSummaryRowData({ dacVotes, isChair }),
         sort
       })
     );


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2077

I tried out multiple ways of presenting this to the user. The ticket specifically suggests using a bell icon with a tooltip. However, upon implementation, I found it confusing and felt that an unfamiliar user would have no idea what the bell does until they hover over it (if they ever do). I changed it to be like the original, old table, which just had some clickable text which says "Send Reminder" if the user is a chair and the member has not voted.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DUOS-2077]: https://broadworkbench.atlassian.net/browse/DUOS-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ