### PR TITLE
[DUOS-2138][risk=no] Update NPOA logic

### DIFF
--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -190,7 +190,9 @@ class DatasetRegistration extends Component {
     let moratorium = dataUse.publicationMoratorium;
     let nonProfit = fp.isNil(dataUse.commercialUse) ? false : !dataUse.commercialUse;
     let hmb = dataUse.hmbResearch;
-    let npoa = dataUse.populationOriginsAncestry;
+    // if the dataset's POA value is set to false, we need to check the NPOA (or NOT POA) option
+    // if the dataset's POA value is set to true, leave this unchecked
+    let npoa = (dataUse.populationOriginsAncestry === false);
     let diseases = dataUse.diseaseRestrictions;
     let other = dataUse.otherRestrictions;
     let primaryOtherText = dataUse.other;
@@ -643,7 +645,7 @@ class DatasetRegistration extends Component {
       result.publicationMoratorium = data.moratorium;
     }
     if (data.npoa) {
-      result.populationOriginsAncestry = data.npoa;
+      result.populationOriginsAncestry = false;
     }
     if (data.nonProfit) {
       result.commercialUse = !data.nonProfit;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2138

Minor update to the current dataset edit/create page to show the **NPOA** option correctly:

When editing an existing dataset:
* If dataset's `populationOriginsAncestry` is true (or null), we do not show **NPOA**
* If dataset's `populationOriginsAncestry` is false, we show **NPOA** as selected

When creating a new dataset (only visible when selecting **GRU**):
* If **NPOA** is unchecked, we do not set the dataset's `populationOriginsAncestry`
* If **NPOA** is checked, we set the dataset's `populationOriginsAncestry` as `false`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
