### PR TITLE
[DUOS-2233][risk=no] Add broad dataset catalog page

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -37,6 +37,7 @@ import TermsOfServiceAcceptance from './pages/TermsOfServiceAcceptance';
 import { HealthCheck } from './pages/HealthCheck';
 import DataSubmissionForm from './pages/DataSubmissionForm';
 import {ensureSoHasDaaAcknowledgement} from './components/SigningOfficialDaaAgreementWrapper';
+import BroadDatasetCatalog from './pages/dac_dataset_catalog/BroadDatasetCatalog';
 
 const Routes = (props) => (
   <Switch>
@@ -90,6 +91,7 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/admin_manage_lc/" component={AdminManageLC} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_dar_collections/" component={AdminManageDarCollections} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/dataset_catalog" component={DatasetCatalog} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
+    {(props.env === 'local' || props.env === 'dev') && <AuthenticatedRoute path="/broad_dataset_catalog" component={BroadDatasetCatalog} props={props} rolesAllowed={[USER_ROLES.researcher]}/>}
     <AuthenticatedRoute path="/dataset_statistics/:datasetId" component={DatasetStatistics} props={props}
       rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/tos_acceptance" component={TermsOfServiceAcceptance} props={props} rolesAllowed={[USER_ROLES.all]} />

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -1,6 +1,6 @@
 import {filter, find, flow, getOr, includes, isEmpty, isNil, map} from 'lodash/fp';
 import {Fragment, useEffect, useState, useCallback } from 'react';
-import {a, button, div, form, h, input, label, span, table, tbody, td, th, thead, tr} from 'react-hyperscript-helpers';
+import {a, button, div, form, h, input, label, span, table, tbody, td, th, thead, tr, img} from 'react-hyperscript-helpers';
 import ReactTooltip from 'react-tooltip';
 import {ConfirmationDialog} from '../components/ConfirmationDialog';
 import {ConnectDatasetModal} from '../components/modals/ConnectDatasetModal';
@@ -24,6 +24,13 @@ const tableBody = {
 
 export default function DatasetCatalog(props) {
 
+  const {
+    customDacDatasetPage
+  } = props;
+
+  const isCustomDacDatasetPage = !isNil(customDacDatasetPage);
+  const color = isCustomDacDatasetPage ? customDacDatasetPage.color : 'dataset';
+
   // Data states
   const [currentUser, setCurrentUser] = useState({});
   const [datasetList, setDatasetList] = useState([]);
@@ -35,6 +42,8 @@ export default function DatasetCatalog(props) {
   // Selection States
   const [currentPageAllDatasets, setCurrentPageAllDatasets] = useState(1);
   const [currentPageOnlySelected, setCurrentPageOnlySelected] = useState(1);
+
+  const [filterToDacIds, setFilterToDacIds] = useState(customDacDatasetPage?.dacIds);
 
   const [dataUse, setDataUse] = useState();
   const [errorMessage, setErrorMessage] = useState();
@@ -114,7 +123,13 @@ export default function DatasetCatalog(props) {
         return true;
       };
       const visibleDatasets = filterToOnlySelected ? selectedDatasets : datasetList;
-      const results = visibleDatasets.filter(searchTable(searchDulText)).slice((theCurrentPage - 1) * pageSize, theCurrentPage * pageSize);
+      const results = (
+        visibleDatasets
+          .filter(searchTable(searchDulText))
+          .filter((row) => {
+            return (!isNil(filterToDacIds) ? filterToDacIds.includes(row['dacId']) : true);
+          })
+          .slice((theCurrentPage - 1) * pageSize, theCurrentPage * pageSize));
       await Promise.all(results.map(async(dataset) => {
         if (isNil(dataset.codeList)) {
           if (!dataset.dataUse || isEmpty(dataset.dataUse)) {
@@ -134,7 +149,7 @@ export default function DatasetCatalog(props) {
     };
     doEnrichment();
 
-  },[searchDulText, pageSize, selectedDatasets, datasetList, filterToOnlySelected, currentPageOnlySelected, currentPageAllDatasets]);
+  }, [searchDulText, pageSize, selectedDatasets, datasetList, filterToOnlySelected, currentPageOnlySelected, currentPageAllDatasets, filterToDacIds]);
 
   const applyDatasetSort = useCallback((sortParams, datasets) => {
     const sortedList = datasets.sort((a, b) => {
@@ -437,25 +452,70 @@ export default function DatasetCatalog(props) {
       div({ className: 'container container-wide' }, [
 
         div({ className: 'row no-margin' }, [
-          div({ className: 'col-lg-7 col-md-7 col-sm-12 col-xs-12 no-padding' }, [
+          div({
+            className: ' no-padding',
+            style: {
+              display: 'flex',
+              alignItems: 'center',
+            }
+          }, [
             PageHeading({
               id: 'datasetCatalog',
-              imgSrc: datasetIcon,
-              iconSize: 'large',
-              color: 'dataset',
-              title: 'Dataset Catalog',
+              imgSrc: isCustomDacDatasetPage ? undefined : datasetIcon,
+              iconSize: isCustomDacDatasetPage ? 'none' : 'large',
+              color: color,
+              title: (!isCustomDacDatasetPage ? 'Dataset Catalog' : `${customDacDatasetPage.dacName} Dataset Catalog`),
               description: 'Search and select datasets then click \'Apply for Access\' to request access'
             }),
+            div({
+              isRendered: isCustomDacDatasetPage,
+              style: {
+                width: '100%'
+              }
+            }, [
+              img({
+                isRendered: isCustomDacDatasetPage,
+                src: customDacDatasetPage?.icon,
+                style: {
+                  float: 'right',
+                }
+              })
+            ])
           ]),
-          div({ className: 'right'}, [
-            div({ className: 'col-lg-7 col-md-7 col-sm-7 col-xs-7 search-wrapper' }, [
-              h(SearchBox, { id: 'datasetCatalog', searchHandler: handleSearchDul, pageHandler: handlePageChange, color: 'dataset' })
+          div({
+            className: 'right'
+          }, [
+            div({ className: 'col-lg-7 col-md-7 col-sm-7 col-xs-7 search-wrapper', style: { display: 'flex' } }, [
+              h(SearchBox, { id: 'datasetCatalog', searchHandler: handleSearchDul, pageHandler: handlePageChange, color: 'dataset' }),
+              div({
+                className: 'checkbox',
+                isRendered: isCustomDacDatasetPage,
+                style: {
+                  marginLeft: '10px',
+                  width: '50%'
+                }
+              }, [
+                input({
+                  checked: filterToDacIds === customDacDatasetPage?.dacIds,
+                  type: 'checkbox',
+                  'select-all': 'true',
+                  className: 'checkbox-inline',
+                  id: 'chk_filterDacId',
+                  onChange: () => {
+                    setFilterToDacIds(isNil(filterToDacIds) ? customDacDatasetPage?.dacIds : undefined);
+                    setCurrentPageOnlySelected(1);
+                    setCurrentPageAllDatasets(1);
+                  },
+                }),
+                label({ className: 'regular-checkbox', htmlFor: 'chk_filterDacId' }, [`Filter to only ${customDacDatasetPage?.dacName} data`]),
+              ]),
             ]),
+
             button({
               id: 'btn_addDataset',
               isRendered: (currentUser.isAdmin || currentUser.isChairPerson),
               onClick: () => props.history.push({ pathname: 'dataset_registration' }),
-              className: 'f-right btn-primary dataset-background search-wrapper',
+              className: `f-right btn-primary ${color}-background search-wrapper`,
               'data-tip': 'Add a new Dataset', 'data-for': 'tip_addDataset'
             }, ['Add Dataset',
               span({ className: 'glyphicon glyphicon-plus-sign', style: { 'marginLeft': '5px' }, 'aria-hidden': 'true' })
@@ -516,7 +576,7 @@ export default function DatasetCatalog(props) {
               }),
               label({ id: 'lbl_onlySelected', className: 'regular-checkbox', htmlFor: 'chk_onlySelected' },
                 [`Show ${numDatasetsSelected} Dataset${(numDatasetsSelected != 1?'s':'')} Selected`])
-            ])
+            ]),
           ]),
 
           div({ className: currentUser.isAdmin ? 'table-scroll-admin' : 'table-scroll' }, [
@@ -583,7 +643,7 @@ export default function DatasetCatalog(props) {
                               disabled: !isEditDatasetEnabled(dataset)
                             }, [
                               span({
-                                className: 'cm-icon-button glyphicon glyphicon-pencil caret-margin dataset-color', 'aria-hidden': 'true',
+                                className: `cm-icon-button glyphicon glyphicon-pencil caret-margin ${color}-color`, 'aria-hidden': 'true',
                                 'data-tip': 'Edit dataset', 'data-for': 'tip_edit'
                               })
                             ]),
@@ -594,7 +654,7 @@ export default function DatasetCatalog(props) {
                               disabled: !isEditDatasetEnabled(dataset)
                             }, [
                               span({
-                                className: 'cm-icon-button glyphicon glyphicon-ok-circle caret-margin dataset-color', 'aria-hidden': 'true',
+                                className: `cm-icon-button glyphicon glyphicon-ok-circle caret-margin ${color}-color`, 'aria-hidden': 'true',
                                 'data-tip': 'Disable dataset', 'data-for': 'tip_disable'
                               })
                             ]),
@@ -617,7 +677,7 @@ export default function DatasetCatalog(props) {
                             }, [
                               span({
                                 className: 'cm-icon-button glyphicon glyphicon-link caret-margin ' +
-                                  (dataset.isAssociatedToDataOwners ? 'dataset-color' : 'default-color'), 'aria-hidden': 'true',
+                                  (dataset.isAssociatedToDataOwners ? `${color}-color` : 'default-color'), 'aria-hidden': 'true',
                                 'data-tip': 'Connect with Data Owner', 'data-for': 'tip_connect'
                               })
                             ])
@@ -761,7 +821,7 @@ export default function DatasetCatalog(props) {
             download: '',
             disabled: selectedDatasets.length === 0,
             onClick: download,
-            className: 'col-lg-5 col-md-5 col-sm-5 col-xs-5 btn-primary dataset-background'
+            className: `col-lg-5 col-md-5 col-sm-5 col-xs-5 btn-primary ${color}-background`
           }, [
             'Download Dataset List',
             span({ className: 'glyphicon glyphicon-download', style: { 'marginLeft': '5px' }, 'aria-hidden': 'true' })
@@ -773,7 +833,7 @@ export default function DatasetCatalog(props) {
             isRendered: currentUser.isResearcher,
             disabled: (selectedDatasets.length === 0),
             onClick: () => exportToRequest(),
-            className: 'btn-primary dataset-background search-wrapper',
+            className: `btn-primary ${color}-background search-wrapper`,
             'data-tip': 'Request Access for selected Datasets', 'data-for': 'tip_requestAccess'
           }, ['Apply for Access'])
         ]),

--- a/src/pages/dac_dataset_catalog/BroadDatasetCatalog.js
+++ b/src/pages/dac_dataset_catalog/BroadDatasetCatalog.js
@@ -10,7 +10,7 @@ export const BroadDatasetCatalog = (props) => {
       customDacDatasetPage={{
         icon: BroadLogoIcon,
         dacName: 'Broad Institute',
-        dacIds: [10],
+        dacIds: [1],
         color: 'broad',
       }}
       history={props.history}

--- a/src/pages/dac_dataset_catalog/BroadDatasetCatalog.js
+++ b/src/pages/dac_dataset_catalog/BroadDatasetCatalog.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import '../DatasetCatalog';
+import BroadLogoIcon from '../../images/broad_logo.png';
+import DatasetCatalog from '../DatasetCatalog';
+import './custom_dataset_catalogs.css';
+
+export const BroadDatasetCatalog = (props) => {
+  return <div>
+    <DatasetCatalog
+      customDacDatasetPage={{
+        icon: BroadLogoIcon,
+        dacName: 'Broad Institute',
+        dacIds: [10],
+        color: 'broad',
+      }}
+      history={props.history}
+    />
+  </div>;
+};
+
+export default BroadDatasetCatalog;

--- a/src/pages/dac_dataset_catalog/custom_dataset_catalogs.css
+++ b/src/pages/dac_dataset_catalog/custom_dataset_catalogs.css
@@ -1,0 +1,8 @@
+/* COLORS */
+.broad-color {
+  color: #0948B7 !important;
+}
+
+.broad-background {
+  background: #0948B7 !important;
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2233

Basically, Jonathan wanted to have a dataset catalog page which is specific to an institution/DAC. It would have their primary color, logo, and by default only show their datasets. This is an 'experiment' to see what this would look like for Broad DACs, with the ability to very easily expand to new DACs.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
