### PR TITLE
[DUOS-1740][risk=no] Add separate build action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,10 @@
+on: [pull_request]
+name: docker build
+jobs:
+  scan:
+    name: docker build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build Image
+        run: docker build .


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

Currently, the only action that runs a docker build is run for non-dependabot PRs. So, when a dependabot update breaks the docker build ([for example](https://github.com/DataBiosphere/duos-ui/pull/1957)), we only find out about it if we run that locally or merge it to dev. This action will catch those kinds of errors so we know about them beforehand.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
