### PR TITLE
[DUOS-2152][risk=no] Update compose to latest proxy image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,8 @@
 #   * site.conf
 # Ensure that /etc/hosts contains an entry for:
 # 	127.0.0.1	local.broadinstitute.org
+# Ensure that `public/config.json` is pointing to the correct env (not local), i.e.:
+#   ... "env": "dev", ...
 # Build:
 #   docker build . -t duos
 # Run:
@@ -27,7 +29,7 @@ services:
     restart: always
 
   proxy:
-    image: broadinstitute/openidc-proxy:tcell_3_1_0
+    image: us.gcr.io/broad-dsp-gcr-public/httpd-terra-proxy:v0.1.16
     container_name: duos-proxy
     hostname: local.broadinstitute.org
     links:
@@ -36,10 +38,10 @@ services:
       - 80:8080
       - 443:443
     volumes:
+      - ./ca-bundle.crt:/etc/ssl/certs/server-ca-bundle.crt:ro
       - ./server.crt:/etc/ssl/certs/server.crt:ro
       - ./server.key:/etc/ssl/private/server.key:ro
-      - ./ca-bundle.crt:/etc/ssl/certs/ca-bundle.crt:ro
-      - ./site.conf:/etc/apache2/sites-available/site.conf:ro
+      - ./site.conf:/etc/httpd/conf.d/site.conf:ro
     environment:
       AUTH_TYPE: AuthType None
       LOG_LEVEL: warn


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2152

See also: https://github.com/broadinstitute/terra-helmfile/pull/3628

This PR updates the local compose used for testing to use the latest proxy image we're using in production.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
