### PR TITLE
[DUOS-2130][risk=no] Add Data Submitters Tab to SO Console

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -84,7 +84,7 @@ export const headerTabsConfig = [
   },
   {
     label: 'SO Console',
-    link: '/signing_official_console/researchers',
+    link: '/signing_official_console/data_submitters',
     children: [
       { label: 'Data Submitters', link: '/signing_official_console/data_submitters' },
       { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -86,9 +86,9 @@ export const headerTabsConfig = [
     label: 'SO Console',
     link: '/signing_official_console/researchers',
     children: [
-      { label: 'Researchers', link: '/signing_official_console/researchers' },
+      { label: 'Data Submitters', link: '/signing_official_console/data_submitters' },
       { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },
-      { label: 'Data Submitters', link: '/signing_official_console/data_submitters' }
+      { label: 'Researchers', link: '/signing_official_console/researchers' }
     ],
     isRendered: (user) => user.isSigningOfficial
   },

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -87,7 +87,8 @@ export const headerTabsConfig = [
     link: '/signing_official_console/researchers',
     children: [
       { label: 'Researchers', link: '/signing_official_console/researchers' },
-      { label: 'DAR Requests', link: '/signing_official_console/dar_requests' }
+      { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },
+      { label: 'Data Submitters', link: '/signing_official_console/data_submitters' }
     ],
     isRendered: (user) => user.isSigningOfficial
   },


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2130

This PR adds, as the default tab for SOs, a new data submitters tab.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
