### PR TITLE
[DUOS-2173][risk=no]Add conditional message to profile for DAR request checkbox

### DIFF
--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -495,6 +495,12 @@ export default function ResearcherProfile(props) {
                     });
                   }),
 
+                  div({
+                    isRendered: supportRequests.checkRequestDataAccess,
+                    style: {border: '1px solid purple', color: 'purple'}}, [
+                    'Before you can submit a data access request, your Signing Official must register and issue you a Library Card in DUOS'
+                  ]),
+
                   div({ className: 'col-xs-12' }, [
                     div({ style: { margin: '15px 0 10px' }}, [
                       `Is there anything else you'd like to request?`

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -497,7 +497,7 @@ export default function ResearcherProfile(props) {
 
                   div({
                     isRendered: supportRequests.checkRequestDataAccess,
-                    style: {border: '1px solid purple', color: 'purple'}}, [
+                    style: {border: '1px solid purple', color: 'purple', padding: "10px"}}, [
                     'Before you can submit a data access request, your Signing Official must register and issue you a Library Card in DUOS'
                   ]),
 

--- a/src/pages/ResearcherProfile.js
+++ b/src/pages/ResearcherProfile.js
@@ -497,7 +497,7 @@ export default function ResearcherProfile(props) {
 
                   div({
                     isRendered: supportRequests.checkRequestDataAccess,
-                    style: {border: '1px solid purple', color: 'purple', padding: "10px"}}, [
+                    style: {border: '1px solid purple', color: 'purple', padding: '10px'}}, [
                     'Before you can submit a data access request, your Signing Official must register and issue you a Library Card in DUOS'
                   ]),
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2173

Adds a new informational message to the user profile page when a user selects "Request access to data"
<img width="930" alt="image" src="https://user-images.githubusercontent.com/91574136/213005716-87052250-87d2-4c7e-8a93-ae1012f8405b.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
