### PR TITLE
[DUOS-2254][risk=no] Handle unmodifiable error

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -507,7 +507,11 @@ export const searchOntologies = (query, callback) => {
 
 export const setStyle = (disabled, baseStyle, targetColorAttribute) => {
   let appliedStyle = disabled ? {[targetColorAttribute] : Theme.palette.disabled} : {};
-  return Object.assign(baseStyle, appliedStyle);
+  try {
+    return Object.assign(baseStyle, appliedStyle);
+  } catch (e) {
+    return baseStyle;
+  }
 };
 
 export const setDivAttributes = (disabled, onClick, style, dataTip, onMouseEnter, onMouseLeave, key) => {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2254

When developing locally, this error is triggered when closing a dac modal on the manage dacs page:

```
utils.js:510 Uncaught TypeError: Cannot assign to read only property 'color' of object '#<Object>'
    at Function.assign (<anonymous>)
    at setStyle (utils.js:510:1)
    at TableIconButton (TableIconButton.js:46:1)
    at renderWithHooks (react-dom.development.js:16305:1)
    at mountIndeterminateComponent (react-dom.development.js:20074:1)
    at beginWork (react-dom.development.js:21587:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:4164:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:4213:1)
    at invokeGuardedCallback (react-dom.development.js:4277:1)
    at beginWork$1 (react-dom.development.js:27451:1)
```

This error is not triggered in the compiled version that runs on dev.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
