### PR TITLE
[DUOS-2218] Refactoring delete pattern for collaborators

### DIFF
--- a/cypress/component/DataAccessRequest/researcher_info_new.spec.js
+++ b/cypress/component/DataAccessRequest/researcher_info_new.spec.js
@@ -215,7 +215,7 @@ describe('Researcher Info', () => {
     // also check the delete button on the edit form
     cy.get('#0_editCollaborator').click();
     cy.get('#0_deleteMember').click();
-    cy.get('.confirmation-modal-primary-button').click();
+    cy.get('.delete-modal-primary-button').click();
     cy.get('#0_summary').should('not.exist');
     cy.get('[dataCy=internal-lab-staff]')
       .find('.collaborator-list-component')

--- a/cypress/component/DataAccessRequest/researcher_info_new.spec.js
+++ b/cypress/component/DataAccessRequest/researcher_info_new.spec.js
@@ -215,7 +215,7 @@ describe('Researcher Info', () => {
     // also check the delete button on the edit form
     cy.get('#0_editCollaborator').click();
     cy.get('#0_deleteMember').click();
-    cy.get('#0_confirmDeleteMember').click();
+    cy.get('.confirmation-modal-primary-button').click();
     cy.get('#0_summary').should('not.exist');
     cy.get('[dataCy=internal-lab-staff]')
       .find('.collaborator-list-component')

--- a/src/pages/dar_application/collaborator/CollaboratorForm.js
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.js
@@ -138,7 +138,7 @@ export default function CollaboratorForm (props) {
         a({
           id: index+'_deleteMember',
           isRendered: !isNil(props.collaborator) && !props.deleteMode,
-          onClick: () => setShowConfirmationModal(true),
+          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false) },
           style: { verticalAlign: 'middle', lineHeight: '4rem', float: 'right' }
         }, [
           span({

--- a/src/pages/dar_application/collaborator/CollaboratorForm.js
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.js
@@ -6,7 +6,7 @@ import { isEmpty, isNil } from 'lodash/fp';
 import { v4 as uuidV4} from 'uuid';
 import { DarValidationMessages } from '../DarValidationMessages';
 import { computeCollaboratorErrors } from '../../../utils/darFormUtils';
-import DeleteCollaboratorModal from './DeleteCollaboratorModal'
+import DeleteCollaboratorModal from './DeleteCollaboratorModal';
 
 export default function CollaboratorForm (props) {
   const {

--- a/src/pages/dar_application/collaborator/CollaboratorForm.js
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { a, div, h, h2, span, p } from 'react-hyperscript-helpers';
 import { FormFieldTypes, FormField, FormValidators } from '../../../components/forms/forms';
 import { useEffect, useState } from 'react';
@@ -5,7 +6,7 @@ import { isEmpty, isNil } from 'lodash/fp';
 import { v4 as uuidV4} from 'uuid';
 import { DarValidationMessages } from '../DarValidationMessages';
 import { computeCollaboratorErrors } from '../../../utils/darFormUtils';
-import  ConfirmationModal  from '../../../components/modals/ConfirmationModal';
+import DeleteCollaboratorModal from './DeleteCollaboratorModal'
 
 export default function CollaboratorForm (props) {
   const {
@@ -20,7 +21,7 @@ export default function CollaboratorForm (props) {
   const [approverStatus, setApproverStatus] = useState('');
   const [uuid, setUuid] = useState('');
   const [collaboratorValidationErrors, setCollaboratorValidationErrors] = useState([]);
-  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+  const [showDeleteCollaboratorModal, setShowDeleteCollaboratorModal] = useState(false);
 
   useEffect(() => {
     if (!isEmpty(collaborator)) {
@@ -40,8 +41,8 @@ export default function CollaboratorForm (props) {
     props.updateEditState(false);
   };
 
-  const closeConfirmation = () => {
-    setShowConfirmationModal(false);
+  const closeDelete = () => {
+    setShowDeleteCollaboratorModal(false);
   };
 
   return div({
@@ -138,7 +139,7 @@ export default function CollaboratorForm (props) {
         a({
           id: index+'_deleteMember',
           isRendered: !isNil(props.collaborator) && !props.deleteMode,
-          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false); },
+          onClick: () => { setShowDeleteCollaboratorModal(true), props.toggleDeleteBool(false); },
           style: { verticalAlign: 'middle', lineHeight: '4rem', float: 'right' }
         }, [
           span({
@@ -172,12 +173,13 @@ export default function CollaboratorForm (props) {
           role: 'button',
           onClick: () => props.updateEditState(false)
         },['Cancel']),
-        // Delete Confirmation Modal
-        h(ConfirmationModal, {
-          showConfirmation: showConfirmationModal,
-          closeConfirmation: closeConfirmation,
-          title: 'Delete entry?',
-          message: 'Are you sure you want to delete this entry?',
+        // Delete Modal
+        h(DeleteCollaboratorModal, {
+          showDelete: showDeleteCollaboratorModal,
+          closeDelete: closeDelete,
+          header: 'Delete Entry',
+          title:<div>Are you sure you want to delete <strong>{name}</strong>?</div>,
+          message: <div><i>This action is permanent and cannot be undone.</i></div>,
           onConfirm: () => props.deleteCollaborator(),
         }),
       ]),

--- a/src/pages/dar_application/collaborator/CollaboratorForm.js
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.js
@@ -5,6 +5,7 @@ import { isEmpty, isNil } from 'lodash/fp';
 import { v4 as uuidV4} from 'uuid';
 import { DarValidationMessages } from '../DarValidationMessages';
 import { computeCollaboratorErrors } from '../../../utils/darFormUtils';
+import ConfirmationModal from '/Users/koflaher/Code/duos-ui/src/components/modals/ConfirmationModal.js';
 
 export default function CollaboratorForm (props) {
   const {
@@ -19,6 +20,7 @@ export default function CollaboratorForm (props) {
   const [approverStatus, setApproverStatus] = useState('');
   const [uuid, setUuid] = useState('');
   const [collaboratorValidationErrors, setCollaboratorValidationErrors] = useState([]);
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
 
   useEffect(() => {
     if (!isEmpty(collaborator)) {
@@ -36,6 +38,10 @@ export default function CollaboratorForm (props) {
   const saveUpdate = () => {
     props.saveCollaborator({name, eraCommonsId, title, email, approverStatus, uuid});
     props.updateEditState(false);
+  };
+
+  const closeConfirmation = () => {
+    setShowConfirmationModal(false);
   };
 
   return div({
@@ -132,8 +138,8 @@ export default function CollaboratorForm (props) {
         a({
           id: index+'_deleteMember',
           isRendered: !isNil(props.collaborator) && !props.deleteMode,
-          onClick: () => props.toggleDeleteBool(true),
-          style: { verticalAlign: 'middle', lineHeight: '4rem' }
+          onClick: () => setShowConfirmationModal(true),
+          style: { verticalAlign: 'middle', lineHeight: '4rem', float: 'right' }
         }, [
           span({
             className: 'collaborator-delete-icon glyphicon glyphicon-trash',
@@ -147,24 +153,9 @@ export default function CollaboratorForm (props) {
             }
           }, ['Delete this entry']),
         ]),
-        // Cancel Delete Button
-        div({
-          isRendered: !isNil(props.collaborator) && props.deleteMode,
-          className: 'collaborator-form-cancel-button f-left btn',
-          role: 'button',
-          onClick: () => props.toggleDeleteBool(false),
-        }, ['Cancel']),
-        // Delete Button Confirmation
-        div({
-          id: index+'_confirmDeleteMember',
-          isRendered: !isNil(props.collaborator) && props.deleteMode,
-          className: 'collaborator-form-add-save-button f-left btn',
-          role: 'button',
-          onClick: () => props.deleteCollaborator()
-        },[`Delete`]),
         // Add/Save Button
         div({
-          className: 'collaborator-form-add-save-button f-right btn',
+          className: 'collaborator-form-add-save-button f-left btn',
           role: 'button',
           onClick: () => {
             let newCollaborator = {name, eraCommonsId, title, email, approverStatus, uuid};
@@ -177,10 +168,18 @@ export default function CollaboratorForm (props) {
         [`${isNil(collaborator) ? 'Add' : 'Save'}`]),
         // Cancel Button for Add/Update
         div({
-          className: 'collaborator-form-cancel-button f-right btn',
+          className: 'collaborator-form-cancel-button f-left btn',
           role: 'button',
           onClick: () => props.updateEditState(false)
-        },['Cancel'])
+        },['Cancel']),
+        // Delete Confirmation Modal
+        h(ConfirmationModal, {
+          showConfirmation: showConfirmationModal,
+          closeConfirmation: closeConfirmation,
+          title: 'Delete entry?',
+          message: 'Are you sure you want to delete this entry?',
+          onConfirm: () => props.deleteCollaborator(),
+        }),
       ]),
     ])
   ]);

--- a/src/pages/dar_application/collaborator/CollaboratorForm.js
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.js
@@ -138,7 +138,7 @@ export default function CollaboratorForm (props) {
         a({
           id: index+'_deleteMember',
           isRendered: !isNil(props.collaborator) && !props.deleteMode,
-          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false) },
+          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false); },
           style: { verticalAlign: 'middle', lineHeight: '4rem', float: 'right' }
         }, [
           span({

--- a/src/pages/dar_application/collaborator/CollaboratorForm.js
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.js
@@ -5,7 +5,7 @@ import { isEmpty, isNil } from 'lodash/fp';
 import { v4 as uuidV4} from 'uuid';
 import { DarValidationMessages } from '../DarValidationMessages';
 import { computeCollaboratorErrors } from '../../../utils/darFormUtils';
-import ConfirmationModal from '/Users/koflaher/Code/duos-ui/src/components/modals/ConfirmationModal.js';
+import  ConfirmationModal  from '../../../components/modals/ConfirmationModal';
 
 export default function CollaboratorForm (props) {
   const {

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -1,10 +1,17 @@
-import { a, div, span } from 'react-hyperscript-helpers';
+import { a, h, div, span } from 'react-hyperscript-helpers';
+import { useState } from 'react';
+import ConfirmationModal from '/Users/koflaher/Code/duos-ui/src/components/modals/ConfirmationModal.js';
 
 export const CollaboratorSummary = (props) => {
   const {
     collaborator,
     index
   } = props;
+
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
+  const closeConfirmation = () => {
+    setShowConfirmationModal(false);
+  };
 
   return div({}, [
     div({}, [
@@ -77,7 +84,7 @@ export const CollaboratorSummary = (props) => {
         a({
           id: index+'_deleteMember',
           style: { marginLeft: 10 },
-          onClick: () => props.toggleDeleteBool(true),
+          onClick: () => setShowConfirmationModal(true),
         }, [
           span({
             className: 'glyphicon glyphicon-trash collaborator-delete-icon',
@@ -89,44 +96,14 @@ export const CollaboratorSummary = (props) => {
             }
           }),
         ]),
-      ]),
-      // Delete Confirmation Buttons
-      // Cancel Delete
-      div({
-        className: 'collaborator-summary-confirm-delete-buttons',
-        isRendered: props.deleteMode,
-      }, [
-        a({
-          id: index+'_editCollaborator',
-          style: { marginLeft: 10, marginRight: 10 },
-          onClick: () => props.toggleDeleteBool(false),
-        }, [
-          span({
-            className: 'glyphicon glyphicon-remove caret-margin collaborator-cancel-delete-icon', 'aria-hidden': 'true',
-            'data-tip': 'Edit dataset', 'data-for': 'tip_edit'
-          }),
-          span({
-            style: {
-              marginLeft: '1rem',
-            }
-          }),
-        ]),
-        // Confirm Delete
-        a({
-          id: index+'_confimDeleteMember',
-          style: { marginLeft: 10 },
-          onClick: () => props.deleteCollaborator(),
-        }, [
-          span({
-            className: 'glyphicon glyphicon-trash collaborator-confirm-delete-icon',
-            'aria-hidden': 'true', 'data-tip': 'Delete dataset', 'data-for': 'tip_delete'
-          }),
-          span({
-            style: {
-              marginLeft: '1rem',
-            }
-          }),
-        ]),
+        // Delete Confirmation Modal
+        h(ConfirmationModal, {
+          showConfirmation: showConfirmationModal,
+          closeConfirmation: closeConfirmation,
+          title: 'Delete entry?',
+          message: 'Are you sure you want to delete this entry?',
+          onConfirm: () => props.deleteCollaborator(),
+        })
       ]),
     ]),
   ]);

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -1,6 +1,7 @@
+import React from 'react';
 import { a, h, div, span } from 'react-hyperscript-helpers';
 import { useState } from 'react';
-import ConfirmationModal from '../../../components/modals/ConfirmationModal';
+import DeleteCollaboratorModal from './DeleteCollaboratorModal'
 
 export const CollaboratorSummary = (props) => {
   const {
@@ -8,9 +9,9 @@ export const CollaboratorSummary = (props) => {
     index
   } = props;
 
-  const [showConfirmationModal, setShowConfirmationModal] = useState(false);
-  const closeConfirmation = () => {
-    setShowConfirmationModal(false);
+  const [showDeleteCollaboratorModal, setShowDeleteCollaboratorModal] = useState(false);
+  const closeDelete = () => {
+    setShowDeleteCollaboratorModal(false);
   };
 
   return div({}, [
@@ -84,7 +85,7 @@ export const CollaboratorSummary = (props) => {
         a({
           id: index+'_deleteMember',
           style: { marginLeft: 10 },
-          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false); },
+          onClick: () => { setShowDeleteCollaboratorModal(true), props.toggleDeleteBool(false); },
         }, [
           span({
             className: 'glyphicon glyphicon-trash collaborator-delete-icon',
@@ -96,12 +97,13 @@ export const CollaboratorSummary = (props) => {
             }
           }),
         ]),
-        // Delete Confirmation Modal
-        h(ConfirmationModal, {
-          showConfirmation: showConfirmationModal,
-          closeConfirmation: closeConfirmation,
-          title: 'Delete entry?',
-          message: 'Are you sure you want to delete this entry?',
+        // Delete Modal
+        h(DeleteCollaboratorModal, {
+          showDelete: showDeleteCollaboratorModal,
+          closeDelete: closeDelete,
+          header: 'Delete Entry',
+          title:<div>Are you sure you want to delete <strong>{collaborator.name}</strong>?</div>,
+          message: <div><i>This action is permanent and cannot be undone.</i></div>,
           onConfirm: () => props.deleteCollaborator(),
         })
       ]),

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -84,7 +84,7 @@ export const CollaboratorSummary = (props) => {
         a({
           id: index+'_deleteMember',
           style: { marginLeft: 10 },
-          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false) },
+          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false); },
         }, [
           span({
             className: 'glyphicon glyphicon-trash collaborator-delete-icon',

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -84,7 +84,7 @@ export const CollaboratorSummary = (props) => {
         a({
           id: index+'_deleteMember',
           style: { marginLeft: 10 },
-          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false) },
+          onClick: () => { setShowConfirmationModal(true); props.toggleDeleteBool(false); },
         }, [
           span({
             className: 'glyphicon glyphicon-trash collaborator-delete-icon',

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -1,6 +1,6 @@
 import { a, h, div, span } from 'react-hyperscript-helpers';
 import { useState } from 'react';
-import ConfirmationModal from '/Users/koflaher/Code/duos-ui/src/components/modals/ConfirmationModal.js';
+import ConfirmationModal from '../../../components/modals/ConfirmationModal';
 
 export const CollaboratorSummary = (props) => {
   const {

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -84,7 +84,7 @@ export const CollaboratorSummary = (props) => {
         a({
           id: index+'_deleteMember',
           style: { marginLeft: 10 },
-          onClick: () => setShowConfirmationModal(true),
+          onClick: () => { setShowConfirmationModal(true), props.toggleDeleteBool(false) },
         }, [
           span({
             className: 'glyphicon glyphicon-trash collaborator-delete-icon',

--- a/src/pages/dar_application/collaborator/CollaboratorSummary.js
+++ b/src/pages/dar_application/collaborator/CollaboratorSummary.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { a, h, div, span } from 'react-hyperscript-helpers';
 import { useState } from 'react';
-import DeleteCollaboratorModal from './DeleteCollaboratorModal'
+import DeleteCollaboratorModal from './DeleteCollaboratorModal';
 
 export const CollaboratorSummary = (props) => {
   const {

--- a/src/pages/dar_application/collaborator/DeleteCollaboratorModal.css
+++ b/src/pages/dar_application/collaborator/DeleteCollaboratorModal.css
@@ -1,0 +1,55 @@
+
+.delete-modal {
+    inset: 30% 42%;
+    padding: 2%;
+    display: flex;
+    justify-content: left;
+    position: absolute;
+    height: 208px;
+    width: 480px;
+    border-radius: 4px;
+    background-color: #FFFFFF;
+    box-shadow: 0 2px 6px 0 rgba(0,0,0,0.5);
+  }
+
+.delete-modal-header {
+    height: 24px;
+    width: 150px;
+    color: #333F52;
+    font-family: Montserrat;
+    font-size: 20px;
+    font-weight: bold;
+    line-height: 24px;
+    margin-bottom: 4%;
+    align-items: left;
+  }
+
+.delete-modal-title {
+    height: 28px;
+    width: 365px;
+    color: #333F52;
+    font-family: Montserrat;
+    font-size: 14px;
+    letter-spacing: 0;
+    line-height: 24px;
+    align-items: left;
+  }
+  
+.delete-modal-message {
+    height: 48px;
+    width: 365px;
+    color: #333F52;
+    font-family: Montserrat;
+    font-size: 14px;
+    font-style: italic;
+    letter-spacing: 0;
+    line-height: 24px;
+    align-items: left;
+  }
+
+.delete-modal-actions {
+    display: flex;
+    justify-content: left;
+    height: 41px;
+    width: 89px;
+  }

--- a/src/pages/dar_application/collaborator/DeleteCollaboratorModal.js
+++ b/src/pages/dar_application/collaborator/DeleteCollaboratorModal.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import {div, h} from 'react-hyperscript-helpers';
+import Modal from 'react-modal';
+import CloseIconComponent from '../../../components/CloseIconComponent';
+import './DeleteCollaboratorModal.css';
+import {styled} from '@mui/material/styles';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+
+const DeleteModal = (props) => {
+  const {showDelete, closeDelete, header, title, message, onConfirm, styleOverride = {}} = props;
+  const closeFn = () => closeDelete();
+
+  const duosBlue = '#0948B7';
+  const duosBlueHover = 'rgb(9,72,183)';
+
+  const SecondaryButton = styled(Button)(() => ({
+    fontFamily: 'Montserrat, sans-serif',
+    color: duosBlue,
+    backgroundColor: 'white',
+    borderRadius: '4px',
+    fontSize: '1.45rem',
+    borderColor: duosBlue,
+    '&:hover': {
+      borderColor: duosBlueHover,
+      color: duosBlueHover
+    },
+  }));
+
+  const PrimaryButton = styled(Button)(({theme}) => ({
+    fontFamily: 'Montserrat, sans-serif',
+    color: theme.palette.getContrastText(duosBlue),
+    backgroundColor: duosBlue,
+    borderRadius: '4px',
+    fontSize: '1.45rem',
+    '&:hover': {
+      backgroundColor: duosBlueHover,
+    },
+  }));
+
+  const actionButtons = <Stack spacing={2} direction={'row'}>
+    <PrimaryButton variant={'contained'} className={'delete-modal-primary-button'} onClick={onConfirm}>Delete</PrimaryButton>
+    <SecondaryButton variant={'outlined'} className={'delete-modal-secondary-button'} onClick={closeFn}>Cancel</SecondaryButton>
+  </Stack>;
+
+  return h(Modal, {
+    isOpen: showDelete,
+    onRequestClose: closeFn,
+    shouldCloseOnEsc: true,
+    shouldCloseOnOverlayClick: true,
+    className: 'delete-modal',
+    style: { content: styleOverride }
+  }, [
+    div({}, [
+      h(CloseIconComponent, {closeFn}),
+      div({className: 'delete-modal-header'}, [header]),
+      div({classname: 'delete-modal-title'}, [title]),
+      div({className: 'delete-modal-message'}, [message]),
+      div({className: 'delete-modal-actions'}, [actionButtons])
+    ])
+  ]);
+};
+
+export default DeleteModal;

--- a/src/pages/dar_application/collaborator/DeleteCollaboratorModal.js
+++ b/src/pages/dar_application/collaborator/DeleteCollaboratorModal.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React from 'react';
 import {div, h} from 'react-hyperscript-helpers';
 import Modal from 'react-modal';
 import CloseIconComponent from '../../../components/CloseIconComponent';
@@ -23,7 +23,7 @@ const DeleteModal = (props) => {
     borderColor: duosBlue,
     '&:hover': {
       borderColor: duosBlueHover,
-      color: duosBlueHover
+      color: duosBlueHover,
     },
   }));
 


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2218

On the collaborator edit form, the Add/Save and Cancel buttons are on the bottom left of the form.
On the edit form, the “Delete this entry” button is on the bottom right.
When the Delete button is clicked from either the edit form or the collapsed summary, a modal to confirm removal of the collaborator is generated.

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/91574136/214866588-f96455c8-f8d3-45fb-a2a9-2d275118ff12.png">


<img width="1188" alt="image" src="https://user-images.githubusercontent.com/91574136/214866433-8a199570-d228-4a70-8650-c18efc8ac523.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
