### PR TITLE
[DUOS-2258][risk=no]Changing Request Help to Contact Us

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -242,7 +242,7 @@ const NavigationTabsComponent = (props) => {
           style: styles.navButton
         }, [
           div({ id: 'help', style: { whiteSpace: 'nowrap' } }, [
-            'Request Help'
+            'Contact Us'
           ])
         ]),
         supportrequestModal,
@@ -424,7 +424,7 @@ class DuosHeader extends Component {
 
     const contactUsSource = this.state.hover ? contactUsHover : contactUsStandard;
     const contactUsIcon = isLogged ? '' : img({src: contactUsSource, style: {display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline'}});
-    const contactUsText = isLogged ? 'Request Help': span({ style: navbarDuosText }, ['Request Help']);
+    const contactUsText = isLogged ? 'Contact Us': span({ style: navbarDuosText }, ['Contact Us']);
     const contactUsButton = button({
       id: 'btn_applyAcces',
       style: {

--- a/src/components/modals/SupportRequestModal.js
+++ b/src/components/modals/SupportRequestModal.js
@@ -254,7 +254,7 @@ export const SupportRequestModal = hh(
                 id: 'SupportRequestModal',
                 imgSrc: addHelpIcon,
                 color: 'common',
-                title: 'Request Help',
+                title: 'Contact Us',
               }),
             ]),
             div({


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2258

Changes 'Request Help' to 'Contact Us'

<img width="1488" alt="Screen Shot 2023-01-31 at 8 05 36 AM" src="https://user-images.githubusercontent.com/91574136/215767844-c548a0f3-bbea-485f-aad1-993e2c8d6ac6.png">

<img width="393" alt="image" src="https://user-images.githubusercontent.com/91574136/215767968-1729a4ef-2867-425f-81a7-05e520c4dee9.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
