### PR TITLE
[DUOS-2276][risk=no]Adding message to 1.4 DAR form

### DIFF
--- a/src/pages/dar_application/ResearcherInfo_new.js
+++ b/src/pages/dar_application/ResearcherInfo_new.js
@@ -151,7 +151,8 @@ export default function ResearcherInfo(props) {
             `Please add internal Lab Staff here. Internal Lab Staff are defined as users of data from
             this data access request, including any that are downloaded or utilized in the cloud. 
             please do not list External Collaborators or Internal Collaborators at a PI or equivalent 
-            level here.`
+            level here. If your DAR is approved, you will be responsible for the appropriate use of the 
+            data by each individual listed in this section.`
           ),
           h(CollaboratorList_new, {
             formFieldChange,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2276
Adds additional message to section 1.4 of the new DAR form. 
<img width="908" alt="image" src="https://user-images.githubusercontent.com/91574136/215770276-cbb1ed76-7f2d-4382-864f-1c11048b134c.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
