### PR TITLE
[DUOS-2275][risk=no]Add text to new DAR form section 3

### DIFF
--- a/src/pages/dar_application/ResearchPurposeStatement_new.js
+++ b/src/pages/dar_application/ResearchPurposeStatement_new.js
@@ -90,7 +90,7 @@ export default function ResearchPurposeStatement(props) {
           }),
 
           h(ResearchPurposeRow, {
-            title: 'Study variation in the general population.',
+            title: 'Study variation in the general population (e.g. calling variants and/or studying their distribution).',
             id: 'population',
             defaultValue: formData.population,
             onChange,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2275
Adds the following text after “Study variation in the general population” in Step 3 of the DAR form:  “(e.g. calling variants and/or studying their distribution)”
<img width="797" alt="image" src="https://user-images.githubusercontent.com/91574136/215783102-7a95450a-3052-47c1-a582-e4ae5ca46512.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
