### PR TITLE
[DUOS-2274][risk=no]Removing methods

### DIFF
--- a/src/pages/dar_application/ResearchPurposeStatement_new.js
+++ b/src/pages/dar_application/ResearchPurposeStatement_new.js
@@ -76,13 +76,6 @@ export default function ResearchPurposeStatement(props) {
           h4({}, ['I am proposing to:']),
 
           h(ResearchPurposeRow, {
-            title: 'Develop or validate new methods for analysing/interpreting data.',
-            id: 'methods',
-            defaultValue: formData.methods,
-            onChange,
-          }),
-
-          h(ResearchPurposeRow, {
             title: 'Increase controls available for a comparison group (e.g. a case-control study).',
             id: 'controls',
             defaultValue: formData.controls,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2274
Removes the question and answer option for methods in Step 3 of the DAR form.
<img width="829" alt="image" src="https://user-images.githubusercontent.com/91574136/215793816-c5bfbbe3-0e86-430d-813c-2d61295a2715.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
