### PR TITLE
[DUOS-2288][risk=new] Fix proxy notifications and placement

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -155,9 +155,9 @@ const NavigationTabsComponent = (props) => {
   return (div({
     className: `navbar-logged ${orientation === 'vertical' ? 'navbar-vertical' : ''}`
   }, [
+    makeNotifications(),
     ul({ className: 'navbar-main' }, [
       div({ style: { width: '100%', display: 'flex', justifyContent: 'flex-start', alignItems: 'center' } }, [
-        makeNotifications(),
         h(Link, {
           isRendered: orientation === 'horizontal',
           id: 'link_logo',

--- a/src/libs/notificationService.js
+++ b/src/libs/notificationService.js
@@ -1,7 +1,7 @@
 import * as fp from 'lodash/fp';
 import { filter } from 'lodash';
 import {Config} from './config';
-import $ from 'jquery';
+import axios from 'axios';
 
 // https://storage.googleapis.com/broad-duos-banners/{{env}}_notifications.json
 const gcs = 'https://storage.googleapis.com/broad-duos-banners';
@@ -15,14 +15,12 @@ export const NotificationService = {
    */
   getBanners: async () => {
     const env = await Config.getEnv();
-    const hash = await Config.getHash();
     const url =
       env === 'local'
-        ? `/broad-duos-banner/${hash}_${bannerFileName}`
+        ? gcs + '/dev_' + bannerFileName
         : gcs + '/' + env + '_' + bannerFileName;
-    return $.getJSON(url, (data) => {
-      return data;
-    });
+    const res = await axios.get(url);
+    return res.data;
   },
 
   /**

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -52,12 +52,4 @@ module.exports = function (app) {
     })
   );
 
-  //Still need to work on this one
-  // app.use(
-  //   '/broad-duos-banner',
-  //   createProxyMiddleware({
-  //     target: 'https://storage.googleapis.com',
-  //     secure: false
-  //   })
-  // );
 };


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2288

This PR fixes two bugs. First, it updates the fetch of notifications when running locally. Second, it fixes the placement of the global notification so it doesn't compress the nav bar. As a bonus, we get the notifications with axios instead of jquery.

### New
<img width="1335" alt="Screenshot 2023-01-31 at 4 21 27 PM" src="https://user-images.githubusercontent.com/116679/215886035-acc6392e-e413-49c6-85e7-137d532aee7d.png">


### Old
<img width="1335" alt="Screenshot 2023-01-31 at 4 21 56 PM" src="https://user-images.githubusercontent.com/116679/215886171-874b4c22-b3c0-4871-b8ae-115b59f2ff87.png">



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
