### PR TITLE
[DUOS-2103][risk=low] Hide console if user is only a signing official

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -68,8 +68,8 @@ const styles = {
 };
 
 const isOnlySigningOfficial = (user) => {
-  user.isSigningOfficial && !(user.isAdmin || user.isChairPerson || user.isMember || user.isDataSubmitter)
-}
+  return user.isSigningOfficial && !(user.isAdmin || user.isChairPerson || user.isMember || user.isDataSubmitter);
+};
 
 export const headerTabsConfig = [
   {

--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -67,6 +67,10 @@ const styles = {
   }
 };
 
+const isOnlySigningOfficial = (user) => {
+  user.isSigningOfficial && !(user.isAdmin || user.isChairPerson || user.isMember || user.isDataSubmitter)
+}
+
 export const headerTabsConfig = [
   {
     label: 'Admin Console',
@@ -130,7 +134,7 @@ export const headerTabsConfig = [
       { label: 'Data Catalog', link: '/dataset_catalog' },
       { label: 'DAR Requests', link: '/researcher_console' }
     ],
-    isRendered: (user) => user.isResearcher
+    isRendered: (user) => user.isResearcher && !isOnlySigningOfficial(user)
   }
 ];
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2103

If the user is only a Signing Official and has no other permission (aside from Researcher, which is assigned by default), hide the Researcher console.

### New

<img width="576" alt="Screenshot 2023-01-31 at 5 00 50 PM" src="https://user-images.githubusercontent.com/16434376/215893875-979bb07b-3d41-43d2-abbd-0256e8f56bb1.png">

### Old

<img width="650" alt="Screenshot 2023-01-31 at 5 01 30 PM" src="https://user-images.githubusercontent.com/16434376/215893823-9dec0928-f4ef-4fc8-ace5-cab38cfcc6d7.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
