### PR TITLE
[DUOS-2268][risk=no]Dataset catalog column updates

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -73,7 +73,7 @@ export default function DatasetCatalog(props) {
       row.dbGapLink =
         getOr('')('propertyValue')(find({propertyName: 'dbGAP'})(row.properties));
       // Extracting these fields to make sorting easier
-      row['Dataset Id'] = row.alias;
+      row['Dataset ID'] = row.alias;
       row['Data Access Committee'] = findDacName(localDacs, row);
       row['Disease Studied'] = findPropertyValue(row, 'Phenotype/Indication');
       row['Principal Investigator (PI)'] = findPropertyValue(row, 'Principal Investigator(PI)');
@@ -173,9 +173,6 @@ export default function DatasetCatalog(props) {
     return (filterToOnlySelected ? currentPageOnlySelected : currentPageAllDatasets);
   };
 
-  const downloadList = (dataset) => {
-    Files.getApprovedUsersFile(dataset.dataSetId + '-ApprovedRequestors.tsv', dataset.dataSetId);
-  };
 
   const exportToRequest = async () => {
     let datasets = [];
@@ -585,11 +582,11 @@ export default function DatasetCatalog(props) {
                 tr({}, [
                   th(),
                   th({ isRendered: (currentUser.isAdmin || currentUser.isChairPerson), className: 'cell-size', style: { minWidth: '14rem' }}, ['Actions']),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'alias', label: 'Dataset Id' })]),
+                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'alias', label: 'Dataset ID' })]),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Dataset Name' })]),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Data Access Committee' })]),
                   th({ className: 'cell-size' }, ['Data Source']),
-                  th({ className: 'cell-size' }, ['Structured Data Use Limitations']),
+                  th({ className: 'cell-size' }, ['Data Use Terms']),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Data Type' })]),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Disease Studied' })]),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Principal Investigator (PI)' })]),
@@ -597,9 +594,6 @@ export default function DatasetCatalog(props) {
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Description' })]),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Species' })]),
                   th({ className: 'cell-size' }, [getSortDisplay({ field: 'Data Custodian' })]),
-                  th({ className: 'cell-size' }, ['Consent ID']),
-                  th({ className: 'cell-size' }, ['SC-ID']),
-                  th({ className: 'cell-size' }, ['Approved Requestors'])
                 ])
               ]),
 
@@ -689,7 +683,7 @@ export default function DatasetCatalog(props) {
                           className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
-                          dataset['Dataset Id']
+                          dataset['Dataset ID']
                         ]),
 
                         td({
@@ -779,25 +773,6 @@ export default function DatasetCatalog(props) {
                           dataset['Data Custodian']
                         ]),
 
-                        td({
-                          id: trIndex + '_consentId', name: 'consentId',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
-                          style: tableBody
-                        }, [dataset.consentId]),
-
-                        td({
-                          id: trIndex + '_scid', name: 'sc-id', className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
-                          style: tableBody
-                        }, [
-                          findPropertyValue(dataset, 'Sample Collection ID', '---')
-                        ]),
-
-                        td({ className: 'cell-size', style: tableBody }, [
-                          a({
-                            id: trIndex + '_linkDownloadList', name: 'link_downloadList', onClick: () => downloadList(dataset),
-                            className: 'enabled'
-                          }, ['Download List'])
-                        ])
                       ])
                     ]);
                   })


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2268
Updates “Dataset Id” to “Dataset ID” and “Structured Data Use Limitations” to “Data Use Terms”.
Removes the Consent ID, SC-ID, Approved Requestors columns.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
