### PR TITLE
[DUOS-2260][risk=no]Updating SO Console subtabs

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -84,11 +84,12 @@ export const headerTabsConfig = [
   },
   {
     label: 'SO Console',
-    link: '/signing_official_console/data_submitters',
+    link: '/signing_official_console/researchers',
     children: [
-      { label: 'Data Submitters', link: '/signing_official_console/data_submitters' },
+      { label: 'Researchers', link: '/signing_official_console/researchers' },
       { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },
-      { label: 'Researchers', link: '/signing_official_console/researchers' }
+      { label: 'Data Submitters', link: '/signing_official_console/data_submitters' },
+      { label: 'My Datasets', link: '/dataset_catalog'}
     ],
     isRendered: (user) => user.isSigningOfficial
   },


### PR DESCRIPTION
## Addresses 
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2260

- Adds new tab "My Datasets" which links to dataset catalog
- Reorders subtabs to Researchers, DAR Requests, Data Submitters, My Datasets
** An error occurs on my local environment: "Warning: Each child in a list should have a unique "key" prop." Let me know if you have any thoughts or a solution!

<img width="1499" alt="image" src="https://user-images.githubusercontent.com/91574136/216641554-ba1ee98c-9e7f-4541-b3a2-1725c815c92c.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
