### PR TITLE
[DUOS-2266][risk=no]Dataset Catalog Button Updates

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -513,7 +513,7 @@ export default function DatasetCatalog(props) {
 
             button({
               id: 'btn_addDataset',
-              isRendered: (currentUser.isAdmin || currentUser.isChairPerson || currentUser.isMember || currentUser.isSigningOfficial ),
+              isRendered: (currentUser.isAdmin || currentUser.isChairPerson ),
               onClick: () => props.history.push({ pathname: 'dataset_registration' }),
               className: `f-right btn-primary ${color}-background search-wrapper`,
               'data-tip': 'Add a new Dataset', 'data-for': 'tip_addDataset'
@@ -818,7 +818,7 @@ export default function DatasetCatalog(props) {
         div({ className: 'col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding' }, [
           button({
             id: 'btn_downloadSelection',
-            isRendered: currentUser.isAdmin || currentUser.isChairPerson,
+            isRendered: (currentUser.isAdmin || currentUser.isChairPerson || currentUser.isMember || currentUser.isSigningOfficial ),
             download: '',
             disabled: selectedDatasets.length === 0,
             onClick: download,

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -513,7 +513,7 @@ export default function DatasetCatalog(props) {
 
             button({
               id: 'btn_addDataset',
-              isRendered: (currentUser.isAdmin || currentUser.isChairPerson),
+              isRendered: (currentUser.isAdmin || currentUser.isChairPerson || currentUser.isMember || currentUser.isSigningOfficial ),
               onClick: () => props.history.push({ pathname: 'dataset_registration' }),
               className: `f-right btn-primary ${color}-background search-wrapper`,
               'data-tip': 'Add a new Dataset', 'data-for': 'tip_addDataset'
@@ -818,6 +818,7 @@ export default function DatasetCatalog(props) {
         div({ className: 'col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding' }, [
           button({
             id: 'btn_downloadSelection',
+            isRendered: currentUser.isAdmin || currentUser.isChairPerson,
             download: '',
             disabled: selectedDatasets.length === 0,
             onClick: download,
@@ -834,7 +835,8 @@ export default function DatasetCatalog(props) {
             disabled: (selectedDatasets.length === 0),
             onClick: () => exportToRequest(),
             className: `btn-primary ${color}-background search-wrapper`,
-            'data-tip': 'Request Access for selected Datasets', 'data-for': 'tip_requestAccess'
+            'data-tip': 'Request Access for selected Datasets', 'data-for': 'tip_requestAccess',
+            style: { marginBottom: '30%'}
           }, ['Apply for Access'])
         ]),
         h(TranslatedDulModal,{

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -513,7 +513,7 @@ export default function DatasetCatalog(props) {
 
             button({
               id: 'btn_addDataset',
-              isRendered: (currentUser.isAdmin || currentUser.isChairPerson ),
+              isRendered: (currentUser.isAdmin || currentUser.isChairPerson),
               onClick: () => props.history.push({ pathname: 'dataset_registration' }),
               className: `f-right btn-primary ${color}-background search-wrapper`,
               'data-tip': 'Add a new Dataset', 'data-for': 'tip_addDataset'
@@ -818,7 +818,7 @@ export default function DatasetCatalog(props) {
         div({ className: 'col-lg-5 col-md-5 col-sm-12 col-xs-12 search-wrapper no-padding' }, [
           button({
             id: 'btn_downloadSelection',
-            isRendered: (currentUser.isAdmin || currentUser.isChairPerson || currentUser.isMember || currentUser.isSigningOfficial ),
+            isRendered: (currentUser.isAdmin || currentUser.isChairPerson || currentUser.isMember || currentUser.isSigningOfficial),
             download: '',
             disabled: selectedDatasets.length === 0,
             onClick: download,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2266

- Removes the ‘Download Dataset List’ button from Researcher views of the Dataset Catalog (i.e. only displays for DAC Chairs, Members, Signing Officials, and Admins)

- Adjusts spacing around the ‘Apply for Access’ button such that there is equal top/bottom spacing between the Catalog table and the black footer.
<img width="1485" alt="image" src="https://user-images.githubusercontent.com/91574136/216675318-dc77e5f5-c135-411d-a8e1-55774150271a.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
