### PR TITLE
[DUOS-2272][risk=no] Allow one of HMB or POA

### DIFF
--- a/src/pages/dar_application/DataAccessRequest_new.js
+++ b/src/pages/dar_application/DataAccessRequest_new.js
@@ -82,13 +82,21 @@ export default function DataAccessRequest(props) {
 
   const primaryChange = ({key, value}) => {
     let newFormData = {
-      diseases: false,
-      hmb: false,
-      poa: false,
-      other: false,
+      diseases: null,
+      hmb: null,
+      poa: null,
+      other: null,
     };
 
-    newFormData[key] = value;
+    // ensure that non visible fields are unselected
+    for (var key0 in newFormData) {
+      if (key === key0) {
+        newFormData[key0] = value;
+        break;
+      } else {
+        newFormData[key0] = false;
+      }
+    }
 
     // if, after updating, 'diseases', 'hmb', and 'poa' are false, then 'other' is true.
     if (newFormData['diseases'] === false && newFormData['hmb'] === false && newFormData['poa'] === false) {
@@ -210,6 +218,7 @@ export default function DataAccessRequest(props) {
             type: FormFieldTypes.YESNORADIOGROUP,
             title: h4({}, 'Is the primary purpose health/medical/biomedical research in nature?'),
             id: 'hmb',
+            orientation: 'horizontal',
             defaultValue: formData.hmb,
             onChange: primaryChange,
           }),
@@ -222,6 +231,7 @@ export default function DataAccessRequest(props) {
             type: FormFieldTypes.YESNORADIOGROUP,
             title: h4({}, 'Is the primary purpose of this research regarding population origins or ancestry?'),
             id: 'poa',
+            orientation: 'horizontal',
             defaultValue: formData.poa,
             onChange: primaryChange,
           }),

--- a/src/pages/dar_application/DataAccessRequest_new.js
+++ b/src/pages/dar_application/DataAccessRequest_new.js
@@ -81,35 +81,21 @@ export default function DataAccessRequest(props) {
   };
 
   const primaryChange = ({key, value}) => {
-    if (key === 'diseases' && value === true) {
-      // in this case, reset all primary data use fields.
-      batchFormFieldChange({
-        diseases: true,
-        hmb: false,
-        poa: false,
-        other: false,
-      });
-      return;
-    }
-
-
-    const newFormData = {
-      ...formData,
-      ...{
-        [key]: value,
-      },
+    let newFormData = {
+      diseases: false,
+      hmb: false,
+      poa: false,
+      other: false,
     };
 
-    // if, after updating, 'hmb', 'diseases', and 'poa' are false, then 'other' is true.
-    if (newFormData['hmb'] === false && newFormData['diseases'] === false && newFormData['poa'] === false) {
-      batchFormFieldChange({
-        [key]: value,
-        other: true,
-      });
-      return;
+    newFormData[key] = value;
+
+    // if, after updating, 'diseases', 'hmb', and 'poa' are false, then 'other' is true.
+    if (newFormData['diseases'] === false && newFormData['hmb'] === false && newFormData['poa'] === false) {
+      newFormData['other'] = true;
     }
 
-    formFieldChange({key, value});
+    batchFormFieldChange(newFormData);
   };
 
   return (

--- a/src/pages/dar_application/DataAccessRequest_new.js
+++ b/src/pages/dar_application/DataAccessRequest_new.js
@@ -225,7 +225,7 @@ export default function DataAccessRequest(props) {
         ]),
 
         div({
-          isRendered: formData.diseases === false && formData.hmb === false,
+          isRendered: formData.hmb === false,
         }, [
           h(FormField, {
             type: FormFieldTypes.YESNORADIOGROUP,
@@ -235,20 +235,19 @@ export default function DataAccessRequest(props) {
             defaultValue: formData.poa,
             onChange: primaryChange,
           }),
-
-          div({
-            isRendered: formData.poa === false && formData.hmb === false,
-          }, [
-            h(FormField, {
-              title: h4({}, 'If none of the above, please describe the primary purpose of your research:'),
-              id: 'otherText',
-              placeholder: 'Please specify...',
-              defaultValue: formData.otherText,
-              onChange,
-            }),
-          ]),
         ]),
 
+        div({
+          isRendered: formData.poa === false,
+        }, [
+          h(FormField, {
+            title: h4({}, 'If none of the above, please describe the primary purpose of your research:'),
+            id: 'otherText',
+            placeholder: 'Please specify...',
+            defaultValue: formData.otherText,
+            onChange,
+          }),
+        ]),
 
         h(FormField, {
           id: 'nonTechRus',

--- a/src/pages/dar_application/DataAccessRequest_new.js
+++ b/src/pages/dar_application/DataAccessRequest_new.js
@@ -219,9 +219,6 @@ export default function DataAccessRequest(props) {
 
         div({
           isRendered: formData.diseases === false,
-          style: {
-            marginBottom: '1.0rem',
-          }
         }, [
           h(FormField, {
             type: FormFieldTypes.YESNORADIOGROUP,
@@ -230,7 +227,11 @@ export default function DataAccessRequest(props) {
             defaultValue: formData.hmb,
             onChange: primaryChange,
           }),
+        ]),
 
+        div({
+          isRendered: formData.diseases === false && formData.hmb === false,
+        }, [
           h(FormField, {
             type: FormFieldTypes.YESNORADIOGROUP,
             title: h4({}, 'Is the primary purpose of this research regarding population origins or ancestry?'),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2272

### Summary

On the new DAR form, ensure that if HMB is on that POA is off and ensure the state is captured correctly.

<img width="582" alt="Screenshot 2023-02-06 at 12 47 43 PM" src="https://user-images.githubusercontent.com/16434376/217046580-2f15cb89-d495-43a8-a49a-4a0031705e8c.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
