### PR TITLE
[DUOS-2273][risk=no] Add methods as primary option to new DAR form

### DIFF
--- a/src/pages/dar_application/DataAccessRequest_new.js
+++ b/src/pages/dar_application/DataAccessRequest_new.js
@@ -85,6 +85,7 @@ export default function DataAccessRequest(props) {
       diseases: null,
       hmb: null,
       poa: null,
+      methods: null,
       other: null,
     };
 
@@ -98,8 +99,8 @@ export default function DataAccessRequest(props) {
       }
     }
 
-    // if, after updating, 'diseases', 'hmb', and 'poa' are false, then 'other' is true.
-    if (newFormData['diseases'] === false && newFormData['hmb'] === false && newFormData['poa'] === false) {
+    // if, after updating, 'diseases', 'hmb', 'poa', and 'methods' are false, then 'other' is true.
+    if (newFormData['diseases'] === false && newFormData['hmb'] === false && newFormData['poa'] === false && newFormData['methods'] === false) {
       newFormData['other'] = true;
     }
 
@@ -239,6 +240,19 @@ export default function DataAccessRequest(props) {
 
         div({
           isRendered: formData.poa === false,
+        }, [
+          h(FormField, {
+            type: FormFieldTypes.YESNORADIOGROUP,
+            title: h4({}, 'Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?'),
+            id: 'methods',
+            orientation: 'horizontal',
+            defaultValue: formData.methods,
+            onChange: primaryChange,
+          }),
+        ]),
+
+        div({
+          isRendered: formData.methods === false,
         }, [
           h(FormField, {
             title: h4({}, 'If none of the above, please describe the primary purpose of your research:'),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2273

### Summary

Add methods as primary option to new DAR form

<img width="582" alt="Screenshot 2023-02-06 at 12 46 17 PM" src="https://user-images.githubusercontent.com/16434376/217046690-0c409e6c-7730-4e38-a3d2-a00a0792db7d.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
