### PR TITLE
[DUOS-2264][risk=no]Expand collapsible table width on all DAR tables 

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -28,7 +28,6 @@ export const styles = {
     whiteSpace: 'pre-wrap',
     backgroundColor: 'white',
     border: '1px solid #DEDEDE',
-    borderRadius: '4px',
     margin: '0.5% 0'
   },
   columnStyle: Object.assign({}, Styles.TABLE.HEADER_ROW, {

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -187,10 +187,9 @@ export const Styles = {
       fontFamily: 'Montserrat',
     },
     CARDCONTAINER: {
-      margin: '2rem -12.5%',
+      margin: '-.75rem -12.5%',
       border: '1px solid #979797',
       backgroundColor: 'rgb(184,205,211,0.08)',
-      borderRadius: '5px',
       padding: '1rem 4rem',
       color: '#7B7B7B',
       fontFamily: 'Montserrat',

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -187,11 +187,11 @@ export const Styles = {
       fontFamily: 'Montserrat',
     },
     CARDCONTAINER: {
-      marginTop: '2rem',
+      margin: '2rem -12.5%',
       border: '1px solid #979797',
       backgroundColor: 'rgb(184,205,211,0.08)',
       borderRadius: '5px',
-      padding: '2rem 4rem',
+      padding: '1rem 4rem',
       color: '#7B7B7B',
       fontFamily: 'Montserrat',
     },

--- a/src/libs/theme.js
+++ b/src/libs/theme.js
@@ -187,7 +187,7 @@ export const Styles = {
       fontFamily: 'Montserrat',
     },
     CARDCONTAINER: {
-      margin: '-.75rem -12.5%',
+      margin: '-.75rem -12.5% 2rem',
       border: '1px solid #979797',
       backgroundColor: 'rgb(184,205,211,0.08)',
       padding: '1rem 4rem',


### PR DESCRIPTION
## Adresses 
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2264

- Displays the collapsible DAR ‘Data Use Group’ table with the same width as its parent row on all Console DAR Tables
- Decreases the spacing between the column titles and the first row in both the primary and secondary tables by 50%

**I'm  a little confused about the following instruction, but I think it looks good. Let me know if you think it needs updates: 
- The increased row width should be ~70% allocated to increasing the width of the Datasets column, and ~30% allocated to the Data Use Group column. 

<img width="1395" alt="image" src="https://user-images.githubusercontent.com/91574136/217388477-9c8e8164-8b9b-4e52-a086-012d2ddb6e2b.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
