### PR TITLE
[DUOS-2327][risk=no] Fix search filter on DAC Datasets page

### DIFF
--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -446,24 +446,19 @@ export const getSearchFilterFunctions = () => {
       const loweredTerm = toLower(term);
       const alias = dataset.alias;
       const identifier = dataset.datasetIdentifier;
-      const dataSubmitter = DatasetService.findDatasetPropertyValue(dataset.properties, 'Data Submitter');
       const datasetName = DatasetService.findDatasetPropertyValue(dataset.properties, 'Dataset Name');
-      const dataDepositor = DatasetService.findDatasetPropertyValue(dataset.properties, 'Data Depositor');
-      const dataCustodians = DatasetService.findDatasetPropertyValueList(dataset.properties, 'Data Custodian Email');
+      const allPropValues = dataset.properties.map( p => {return p.propertyValue;}).join('');
       // Approval status
       const status = !isNil(dataset.dacApproval)
         ? dataset.dacApproval
           ? 'accepted'
           : 'rejected'
         : 'yes no';
-      const dataUse = join(', ')(dataset.codeList);
       return includes(loweredTerm, toLower(alias)) ||
           includes(loweredTerm, toLower(identifier)) ||
-          includes(loweredTerm, toLower(dataSubmitter)) ||
           includes(loweredTerm, toLower(datasetName)) ||
-          includes(loweredTerm, toLower(dataDepositor)) ||
-          includes(loweredTerm, toLower(join(' ')(dataCustodians))) ||
-          includes(loweredTerm, toLower(dataUse)) ||
+          includes(loweredTerm, toLower(allPropValues)) ||
+          includes(loweredTerm, toLower(dataset.codeList)) ||
           includes(loweredTerm, toLower(status));
     }, targetList),
   };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -446,8 +446,7 @@ export const getSearchFilterFunctions = () => {
       const loweredTerm = toLower(term);
       const alias = dataset.alias;
       const identifier = dataset.datasetIdentifier;
-      const datasetName = DatasetService.findDatasetPropertyValue(dataset.properties, 'Dataset Name');
-      const allPropValues = dataset.properties.map( p => {return p.propertyValue;}).join('');
+      const allPropValues = dataset.properties.map((p) => p.propertyValue).join('');
       // Approval status
       const status = !isNil(dataset.dacApproval)
         ? dataset.dacApproval
@@ -456,7 +455,6 @@ export const getSearchFilterFunctions = () => {
         : 'yes no';
       return includes(loweredTerm, toLower(alias)) ||
           includes(loweredTerm, toLower(identifier)) ||
-          includes(loweredTerm, toLower(datasetName)) ||
           includes(loweredTerm, toLower(allPropValues)) ||
           includes(loweredTerm, toLower(dataset.codeList)) ||
           includes(loweredTerm, toLower(status));


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2327

Minor fixes to how we get the filterable data per row.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
