### PR TITLE
[DUOS-2339][risk=no] Explicitly define peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,19 +47,26 @@
         "voca": "1.4.0"
       },
       "devDependencies": {
+        "@babel/core": "7.18.6",
         "@babel/eslint-parser": "7.19.1",
         "@babel/eslint-plugin": "7.19.1",
         "@babel/plugin-proposal-class-properties": "7.18.6",
+        "@babel/plugin-syntax-flow": "7.18.6",
+        "@babel/plugin-transform-react-jsx": "7.18.6",
         "@babel/preset-react": "7.18.6",
+        "@types/react": "17.0.47",
         "cypress": "12.3.0",
         "eslint": "7.32.0",
         "eslint-plugin-flowtype": "7.0.0",
         "eslint-plugin-react": "7.32.2",
         "google-auth-library": "8.7.0",
         "html-webpack-plugin": "4.5.2",
+        "prop-types": "15.8.1",
         "react-error-overlay": "6.0.9",
         "react-scripts": "5.0.1",
-        "source-map-explorer": "2.5.3"
+        "source-map-explorer": "2.5.3",
+        "typescript": "4.8.3",
+        "webpack": "5.74.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -21082,7 +21089,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -37894,8 +37900,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,19 +53,26 @@
     "cypress:verify": "cypress verify"
   },
   "devDependencies": {
+    "@babel/core": "7.18.6",
     "@babel/eslint-parser": "7.19.1",
     "@babel/eslint-plugin": "7.19.1",
     "@babel/plugin-proposal-class-properties": "7.18.6",
+    "@babel/plugin-syntax-flow": "7.18.6",
+    "@babel/plugin-transform-react-jsx": "7.18.6",
     "@babel/preset-react": "7.18.6",
+    "@types/react": "17.0.47",
     "cypress": "12.3.0",
     "eslint": "7.32.0",
     "eslint-plugin-flowtype": "7.0.0",
     "eslint-plugin-react": "7.32.2",
     "google-auth-library": "8.7.0",
     "html-webpack-plugin": "4.5.2",
+    "prop-types": "15.8.1",
     "react-error-overlay": "6.0.9",
     "react-scripts": "5.0.1",
-    "source-map-explorer": "2.5.3"
+    "source-map-explorer": "2.5.3",
+    "typescript": "4.8.3",
+    "webpack": "5.74.0"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2339

### Summary

Implicitly depending on `peerDependencies` can lead to subtle and hard to debug breakage in package resolution and code. This PR doesn't actually add any new packages as they are already in the `package-lock.json` file, but this makes those dependencies explicit.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
