### PR TITLE
[DUOS-2286][risk=no]New DS Form Consent Group sub-section updates

### DIFF
--- a/cypress/component/DataSubmission/data_access_governance.spec.js
+++ b/cypress/component/DataSubmission/data_access_governance.spec.js
@@ -24,13 +24,13 @@ beforeEach(() => {
 });
 
 describe('Data Access Governance', function () {
-  it('Only renders consent group info if closed access', function () {
+  it('Only renders consent group info if controlled access', function () {
     mount(<DataSubmissionForm />);
 
     cy.get('#btn_addConsentGroup').should('not.exist');
     cy.get('#dataAccessCommitteeId').should('not.exist');
 
-    cy.get('#dataSharingPlan_closed_access').check();
+    cy.get('#dataSharingPlan_controlled_access').check();
 
 
     cy.get('#btn_addConsentGroup').should('exist');
@@ -49,7 +49,7 @@ describe('Data Access Governance', function () {
   it('Adds multiple consent groups', function () {
     mount(<DataSubmissionForm />);
 
-    cy.get('#dataSharingPlan_closed_access').check();
+    cy.get('#dataSharingPlan_controlled_access').check();
 
     cy.get('#0_consentGroupForm').should('not.exist');
     cy.get('#1_consentGroupForm').should('not.exist');
@@ -75,7 +75,7 @@ describe('Data Access Governance', function () {
   it('Delete consent group works', function () {
     mount(<DataSubmissionForm />);
 
-    cy.get('#dataSharingPlan_closed_access').check();
+    cy.get('#dataSharingPlan_controlled_access').check();
 
     cy.get('#btn_addConsentGroup').click();
     cy.get('#btn_addConsentGroup').click();

--- a/src/components/data_submission/DataAccessGovernance.js
+++ b/src/components/data_submission/DataAccessGovernance.js
@@ -1,24 +1,24 @@
 import ConsentGroupForm from './consent_group/ConsentGroupForm';
 import { useEffect, useState, useCallback } from 'react';
 import { isNil, every, cloneDeep } from 'lodash/fp';
-import { div, h, h2, a, span } from 'react-hyperscript-helpers';
+import { div, h, h2, h3, a, span } from 'react-hyperscript-helpers';
 import { DAC } from '../../libs/ajax';
 import { FormFieldTypes, FormField } from '../forms/forms';
 
 import './ds_common.css';
 
 const OPEN_ACCESS = 'Open Access';
-const CLOSED_ACCESS = 'Controlled Access';
+const CONTROLLED_ACCESS = 'Controlled Access';
 
-const openClosedRadioOptions =     [
+const openControlledRadioOptions =     [
   {
     id: 'open_access',
     name: OPEN_ACCESS,
     text: 'Open Access'
   },
   {
-    id: 'closed_access',
-    name: CLOSED_ACCESS,
+    id: 'controlled_access',
+    name: CONTROLLED_ACCESS,
     text: 'Controlled Access',
   }
 ];
@@ -30,7 +30,7 @@ export const DataAccessGovernance = (props) => {
 
   const [consentGroupsState, setConsentGroupsState] = useState([]);
   const [dacs, setDacs] = useState([]);
-  const [isClosedAccess, setIsClosedAccess] = useState(false);
+  const [isControlledAccess, setIsControlledAccess] = useState(false);
 
   useEffect(() => {
     DAC.list(false).then((dacList) => {
@@ -118,7 +118,7 @@ export const DataAccessGovernance = (props) => {
           type: FormFieldTypes.RADIOGROUP,
           id: 'dataSharingPlan',
           title: 'Does the data need to be managed under Controlled or Open Access?',
-          options: openClosedRadioOptions,
+          options: openControlledRadioOptions,
           onChange: ({ value, isValid }) => {
             onChange({
               key: 'alternativeDataSharingPlanControlledOpenAccess',
@@ -126,13 +126,13 @@ export const DataAccessGovernance = (props) => {
               isValid: isValid,
             });
 
-            setIsClosedAccess(value === CLOSED_ACCESS);
+            setIsControlledAccess(value === CONTROLLED_ACCESS);
           },
         }
       ),
 
       div({
-        isRendered: isClosedAccess,
+        isRendered: isControlledAccess,
       },
       [
         h(FormField, {
@@ -148,6 +148,7 @@ export const DataAccessGovernance = (props) => {
           }
         }),
 
+        h3(['Consent Group Information']),
 
         // add consent group
         div({

--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -91,9 +91,6 @@ export const EditConsentGroup = (props) => {
         width: '70%'
       }
     }, [
-
-      h3(['Consent Group Information']),
-
       // name
       h(FormField, {
         id: idx+'_consentGroupName',


### PR DESCRIPTION
## Addresses 
https://broadworkbench.atlassian.net/browse/DUOS-2286

- Changes 'Closed Access' to 'Controlled Access'
- Moves 'Consent Group' above the ‘Add Consent Group’ button

<img width="1130" alt="image" src="https://user-images.githubusercontent.com/91574136/218858847-840e380c-37a8-45b3-ba88-5eea783a830e.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
