### PR TITLE
[DUOS-2284][risk=no] Refactor DAR table action states

### DIFF
--- a/src/components/dar_collection_table/Actions.js
+++ b/src/components/dar_collection_table/Actions.js
@@ -5,6 +5,7 @@ import { Block, Delete } from '@mui/icons-material';
 import SimpleButton from '../SimpleButton';
 import { useHistory } from 'react-router-dom';
 import { Notifications } from '../../libs/utils';
+import { includes, toLower } from 'lodash/fp';
 
 const duosBlue = '#0948B7';
 const cancelGray = '#333F52';
@@ -40,7 +41,7 @@ const resumeDARApplication = (referenceId, history) => {
 };
 
 export default function Actions(props) {
-  const { showConfirmationModal, collection, goToVote, consoleType, actions = [] } = props;
+  const { showConfirmationModal, collection, goToVote, consoleType, actions = [], status } = props;
   const collectionId = collection.darCollectionId;
   const uniqueId = (collectionId ? collectionId : collection.referenceIds[0]);
 
@@ -48,7 +49,7 @@ export default function Actions(props) {
 
   const openButtonAttributes = {
     keyProp: `${consoleType}-open-${uniqueId}`,
-    label: 'Open',
+    label: includes(toLower(status), ['complete', 'canceled']) ? 'Re-Open' : 'Open',
     isRendered: actions.includes('Open'),
     onClick: () => showConfirmationModal(collection, 'open'),
     baseColor: duosBlue,

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -148,14 +148,14 @@ export function statusCellData({status = '- -', darCollectionId, label = 'status
   };
 }
 
-export function consoleActionsCellData({collection, reviewCollection, goToVote, showConfirmationModal, consoleType, resumeCollection, actions}) {
+export function consoleActionsCellData({collection, reviewCollection, goToVote, showConfirmationModal, consoleType, resumeCollection, actions, status}) {
   let actionComponent;
 
   actionComponent = h(Actions, {
     collection, consoleType,
     showConfirmationModal, goToVote,
     reviewCollection, resumeCollection,
-    actions
+    actions, status
   });
 
   return {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2284

### Summary

Show reopen button instead of open when status is in the completed or canceled state.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
