### PR TITLE
[DUOS-2283][risk=no]Moving target delivery/release date new DS form

### DIFF
--- a/cypress/component/DataSubmission/ds_study_information.spec.js
+++ b/cypress/component/DataSubmission/ds_study_information.spec.js
@@ -26,7 +26,7 @@ describe('DataSubmissionStudyInformation - Tests', () => {
   it('should mount with all the fields', () => {
     mount(<DataSubmissionStudyInformation {...propCopy}/>);
     const formFields = cy.get('.formField-container');
-    formFields.should('have.length', 11);
+    formFields.should('have.length', 13);
 
     cy.get('.formField-studyName').should('have.length', 1);
     cy.get('.formField-studyType').should('have.length', 1);
@@ -38,6 +38,8 @@ describe('DataSubmissionStudyInformation - Tests', () => {
     cy.get('.formField-dataSubmitterName').should('have.length', 1);
     cy.get('.formField-dataSubmitterEmail').should('have.length', 1);
     cy.get('.formField-dataCustodianEmail').should('have.length', 1);
+    cy.get('#alternativeDataSharingPlanTargetDeliveryDate').should('exist');
+    cy.get('#alternativeDataSharingPlanTargetPublicReleaseDate').should('exist');
     cy.get('.formField-publicVisibility').should('have.length', 1);
   });
 

--- a/src/components/data_submission/NIHDataManagement.js
+++ b/src/components/data_submission/NIHDataManagement.js
@@ -182,38 +182,6 @@ export const NIHDataManagement = (props) => {
         title: 'Data to be released will meet the timeframes specified in the NHGRI Guidance for Data Submission and Data Release',
         onChange,
       }),
-
-      div({
-        style: {
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-        },
-      }, [
-
-        h(FormField, {
-          id: 'alternativeDataSharingPlanTargetDeliveryDate',
-          style: {
-            width: '45%',
-          },
-          defaultValue: initialFormData?.alternativeDataSharingPlanTargetDeliveryDate,
-          title: 'Target Delivery Date',
-          placeholder: 'Please enter date (YYYY-MM-DD)',
-          validators: [FormValidators.DATE],
-          onChange,
-        }),
-        h(FormField, {
-          id: 'alternativeDataSharingPlanTargetPublicReleaseDate',
-          style: {
-            width: '45%',
-          },
-          defaultValue: initialFormData?.alternativeDataSharingPlanTargetPublicReleaseDate,
-          title: 'Target Public Release Date',
-          placeholder: 'Please enter date (YYYY-MM-DD)',
-          validators: [FormValidators.DATE],
-          onChange,
-        }),
-      ]),
     ]),
 
   ]);

--- a/src/components/data_submission/ds_study_information.js
+++ b/src/components/data_submission/ds_study_information.js
@@ -5,6 +5,7 @@ import { isEmpty } from 'lodash/fp';
 import { Notifications, isEmailAddress } from '../../libs/utils';
 import { User } from '../../libs/ajax';
 import { FormFieldTypes, FormField, FormValidators } from '../forms/forms';
+import initialFormData from './NIHDataManagement';
 
 import './ds_common.css';
 
@@ -110,6 +111,37 @@ export default function DataSubmissionStudyInformation(props) {
       ],
       onChange
     }),
+    div({
+      style: {
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+      },
+    }, [
+
+      h(FormField, {
+        id: 'alternativeDataSharingPlanTargetDeliveryDate',
+        style: {
+          width: '45%',
+        },
+        defaultValue: initialFormData?.alternativeDataSharingPlanTargetDeliveryDate,
+        title: 'Target Delivery Date',
+        placeholder: 'Please enter date (YYYY-MM-DD)',
+        validators: [FormValidators.DATE],
+        onChange,
+      }),
+      h(FormField, {
+        id: 'alternativeDataSharingPlanTargetPublicReleaseDate',
+        style: {
+          width: '45%',
+        },
+        defaultValue: initialFormData?.alternativeDataSharingPlanTargetPublicReleaseDate,
+        title: 'Target Public Release Date',
+        placeholder: 'Please enter date (YYYY-MM-DD)',
+        validators: [FormValidators.DATE],
+        onChange,
+      }),
+    ]),
     h(FormField, {
       id: 'publicVisibility',
       title: 'Public Visibility',


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2283
Moves target delivery/release date to first section of the new DS form
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/91574136/220675040-a6621247-477d-4291-8c27-ccd4690464cf.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
