### PR TITLE
[DUOS-2282][risk=no]GSR explanation box on 'yes'

### DIFF
--- a/src/components/data_submission/NIHAdministrativeInformation.js
+++ b/src/components/data_submission/NIHAdministrativeInformation.js
@@ -122,7 +122,7 @@ export const NIHAdministrativeInformation = (props) => {
     }),
     h(FormField, {
       id: 'controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation',
-      title: 'If no, explain why controlled access is needed for GSR.',
+      title: 'If yes, explain why controlled access is needed for GSR.',
       isRendered: showGSRRequiredExplanation,
       defaultValue: gsrRequiredExplanation,
       validators: [FormValidators.REQUIRED],

--- a/src/components/data_submission/NIHAdministrativeInformation.js
+++ b/src/components/data_submission/NIHAdministrativeInformation.js
@@ -12,8 +12,8 @@ export const NIHAdministrativeInformation = (props) => {
   } = props;
 
   const [showMultiCenterStudy, setShowMultiCenterStudy] = useState(initialFormData?.multiCenterStudy === true || false);
-  const [showGSRNotRequiredExplanation, setShowGSRNotRequiredExplanation] = useState(initialFormData?.controlledAccessRequiredForGenomicSummaryResultsGSR === false || false);
-  const [gsrNotRequiredExplanation, setGSRNotRequiredExplanation] = useState('');
+  const [showGSRRequiredExplanation, setShowGSRRequiredExplanation] = useState(initialFormData?.controlledAccessRequiredForGenomicSummaryResultsGSR === false || false);
+  const [gsrRequiredExplanation, setGSRRequiredExplanation] = useState('');
 
   return div({
     className: 'data-submitter-section',
@@ -112,22 +112,22 @@ export const NIHAdministrativeInformation = (props) => {
       type: FormFieldTypes.YESNORADIOGROUP,
       validators: [FormValidators.REQUIRED],
       onChange: ({key, value}) => {
-        setShowGSRNotRequiredExplanation(!value);
+        setShowGSRRequiredExplanation(value);
         onChange({key, value});
         onChange({
-          key: 'controlledAccessRequiredForGenomicSummaryResultsGSRNotRequiredExplanation',
-          value: (!value ? gsrNotRequiredExplanation : undefined),
+          key: 'controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation',
+          value: (value ? gsrRequiredExplanation : undefined),
         });
       }
     }),
     h(FormField, {
-      id: 'controlledAccessRequiredForGenomicSummaryResultsGSRNotRequiredExplanation',
+      id: 'controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation',
       title: 'If no, explain why controlled access is needed for GSR.',
-      isRendered: showGSRNotRequiredExplanation,
-      defaultValue: gsrNotRequiredExplanation,
+      isRendered: showGSRRequiredExplanation,
+      defaultValue: gsrRequiredExplanation,
       validators: [FormValidators.REQUIRED],
       onChange: ({key, value}) => {
-        setGSRNotRequiredExplanation(value);
+        setGSRRequiredExplanation(value);
         onChange({key, value});
       },
     }),


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2282
Explanation box displayed when 'Yes' selected for GSR question on new DS form.
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/91574136/220760760-4ca548e6-2ed2-4229-93eb-836a4951ed30.png">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
