### PR TITLE
[DUOS-2326][risk=no] Restrict Datasets without DAC 

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -1,4 +1,4 @@
-import React, {Component, useEffect, useState} from 'react';
+import {Component, useEffect, useState} from 'react';
 import {a, button, div, h, img, li, nav, small, span, ul} from 'react-hyperscript-helpers';
 import Drawer from '@mui/material/Drawer';
 import Hidden from '@mui/material/Hidden';

--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { div, h, h3 } from 'react-hyperscript-helpers';
+import { div, h } from 'react-hyperscript-helpers';
 import { isNil, isString } from 'lodash/fp';
 import { FormFieldTypes, FormField, FormTable, FormValidators } from '../../forms/forms';
 import { DAR } from '../../../libs/ajax';

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -81,6 +81,7 @@ export default function DatasetCatalog(props) {
       row['Data Custodian'] = findPropertyValue(row, 'Data Depositor');
       return row;
     })(datasets);
+    console.log(datasets)
     applyDatasetSort(sort, datasets);
   }, [applyDatasetSort, sort]);
 
@@ -603,7 +604,7 @@ export default function DatasetCatalog(props) {
                     return h(Fragment, { key: trIndex }, [
                       tr({ className: 'tableRow' }, [
                         td({}, [
-                          div({ className: 'checkbox' }, [
+                          div({ className: 'checkbox', isRendered: !isNil(dataset.dacId)}, [
                             input({
                               type: 'checkbox',
                               id: trIndex + '_chkSelect',

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -22,6 +22,10 @@ const tableBody = {
   padding: '8px 5px 8px 5px'
 };
 
+const canApplyForDataset = (dataset) => {
+  return dataset.active && !isNil(dataset.dacId);
+};
+
 export default function DatasetCatalog(props) {
 
   const {
@@ -81,7 +85,6 @@ export default function DatasetCatalog(props) {
       row['Data Custodian'] = findPropertyValue(row, 'Data Depositor');
       return row;
     })(datasets);
-    console.log(datasets)
     applyDatasetSort(sort, datasets);
   }, [applyDatasetSort, sort]);
 
@@ -333,10 +336,10 @@ export default function DatasetCatalog(props) {
 
   const allOnPageSelected = () => {
 
-    const filteredList = datasetsOnPage;
+    const filteredList = datasetsOnPage.filter(canApplyForDataset);
 
-    return filteredList.length > 0 &&  filteredList.every((row) => {
-      return row.checked || (!row.active);
+    return filteredList.length > 0 && filteredList.every((row) => {
+      return row.checked;
     });
   };
 
@@ -348,7 +351,7 @@ export default function DatasetCatalog(props) {
     });
 
     const modifiedDatasetList = map((row) => {
-      if (row.active) {
+      if (canApplyForDataset(row)) {
         if (datasetIdsToCheck.includes(row.dataSetId)) {
           row.checked = checked;
         }
@@ -365,7 +368,7 @@ export default function DatasetCatalog(props) {
     const checked = isNil(e.target.checked) ? false : e.target.checked;
     const selectedDatasets = map(row => {
       if (row.dataSetId === dataset.dataSetId) {
-        if (row.active) {
+        if (canApplyForDataset(row)) {
           row.checked = checked;
         }
       }
@@ -603,7 +606,7 @@ export default function DatasetCatalog(props) {
                   .map((dataset, trIndex) => {
                     return h(Fragment, { key: trIndex }, [
                       tr({ className: 'tableRow' }, [
-                        td({}, [
+                        td({ width: '60px' }, [
                           div({ className: 'checkbox', isRendered: !isNil(dataset.dacId)}, [
                             input({
                               type: 'checkbox',
@@ -621,7 +624,7 @@ export default function DatasetCatalog(props) {
                           ])
                         ]),
 
-                        td({ isRendered: (currentUser.isAdmin || currentUser.isChairPerson), style: { minWidth: '14rem' } }, [
+                        td({ isRendered: (currentUser.isAdmin || currentUser.isChairPerson) }, [
                           div({ className: 'dataset-actions' }, [
                             a({
                               id: trIndex + '_btnDelete', name: 'btn_delete', onClick: openDelete(dataset.dataSetId),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2326

<img width="1519" alt="image" src="https://user-images.githubusercontent.com/17440010/221434980-b70ae775-7d20-410e-9641-7b4fb1e00cbd.png">

Here, you can see what it looks like with:
- Active datasets with dac (first two)
- Active datasets without dac (second two)
- Inactive datasets (last one) 

Inactive datasets without DAC would look like the last one, with no greyed out button.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
