### PR TITLE
[DUOS-2358][risk=no] Remove unused `react-router-bootstrap` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "react-modal": "3.16.1",
         "react-paginating": "1.4.0",
         "react-protected-mailto": "1.0.3",
-        "react-router-bootstrap": "0.25.0",
         "react-router-dom": "5.3.0",
         "react-select": "5.7.0",
         "react-tooltip": "4.5.1",
@@ -17933,18 +17932,6 @@
         "react": ">=15"
       }
     },
-    "node_modules/react-router-bootstrap": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
-      "integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
-      "dependencies": {
-        "prop-types": "^15.5.10"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0",
-        "react-router-dom": ">=4.0.0"
-      }
-    },
     "node_modules/react-router-dom": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
@@ -35390,14 +35377,6 @@
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
           "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
-      }
-    },
-    "react-router-bootstrap": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/react-router-bootstrap/-/react-router-bootstrap-0.25.0.tgz",
-      "integrity": "sha512-/22eqxjn6Zv5fvY2rZHn57SKmjmJfK7xzJ6/G1OgxAjLtKVfWgV5sn41W2yiqzbtV5eE4/i4LeDLBGYTqx7jbA==",
-      "requires": {
-        "prop-types": "^15.5.10"
       }
     },
     "react-router-dom": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react-modal": "3.16.1",
     "react-paginating": "1.4.0",
     "react-protected-mailto": "1.0.3",
-    "react-router-bootstrap": "0.25.0",
     "react-router-dom": "5.3.0",
     "react-select": "5.7.0",
     "react-tooltip": "4.5.1",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2358

### Summary

While working on updating `react-router-dom` to 6.8.1, I noticed that we don't seem to use `react-router-bootstrap` anywhere, and there are no occurrences of `LinkContainer` in the codebase. I `git blame`d the history and I saw it was pulled in when the project was converted to React.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
