### PR TITLE
[DUOS-2265][risk=no] Display to #votes cast over #votes that exist

### DIFF
--- a/src/components/dar_dataset_table/DarDatasetTableCellData.js
+++ b/src/components/dar_dataset_table/DarDatasetTableCellData.js
@@ -1,5 +1,5 @@
 import {styles} from './DarDatasetTable';
-import {filter, flatMap, flow, get, isUndefined, map, uniq} from 'lodash/fp';
+import {filter, flatMap, flow, get, isEmpty, isUndefined, map, uniq} from 'lodash/fp';
 
 export function dataUseGroupCellData({dataUseGroup, label= 'data-use'}) {
   return {
@@ -16,22 +16,25 @@ export function dataUseGroupCellData({dataUseGroup, label= 'data-use'}) {
 }
 
 export function votesCellData({elections, votes, dataUseGroup, label= 'votes'}) {
-  const datasetIds = flow(
-    filter(e => e.electionType === 'DataAccess'),
-    map(e => e.dataSetId),
-    uniq
-  )(elections);
-  const memberVotes = flow(
-    map(v => v.dataAccess),
-    flatMap(v => v.memberVotes)
-  )(votes);
-  const voteValues = flow(
-    filter(v => !isUndefined(v.vote)),
-    map(v => get('vote')(v))
-  )(memberVotes);
-  const numerator = voteValues.length / datasetIds.length;
-  const denominator = memberVotes.length / datasetIds.length;
-  const displayValue = numerator + '/' + denominator;
+  let displayValue = '-/-';
+  if (!isEmpty(elections)) {
+    const datasetIds = flow(
+      filter(e => e.electionType === 'DataAccess'),
+      map(e => e.dataSetId),
+      uniq
+    )(elections);
+    const memberVotes = flow(
+      map(v => v.dataAccess),
+      flatMap(v => v.memberVotes)
+    )(votes);
+    const voteValues = flow(
+      filter(v => !isUndefined(v.vote)),
+      map(v => get('vote')(v))
+    )(memberVotes);
+    const numerator = voteValues.length / datasetIds.length;
+    const denominator = memberVotes.length / datasetIds.length;
+    displayValue = numerator + '/' + denominator;
+  }
 
   return {
     data: displayValue,

--- a/src/components/dar_dataset_table/DarDatasetTableCellData.js
+++ b/src/components/dar_dataset_table/DarDatasetTableCellData.js
@@ -1,5 +1,5 @@
 import {styles} from './DarDatasetTable';
-import {filter, flatMap, flow, get, isEmpty, isUndefined, map, uniq} from 'lodash/fp';
+import {filter, flatMap, flow, get, isEmpty, isUndefined, map, uniq, values} from 'lodash/fp';
 
 export function dataUseGroupCellData({dataUseGroup, label= 'data-use'}) {
   return {
@@ -15,18 +15,19 @@ export function dataUseGroupCellData({dataUseGroup, label= 'data-use'}) {
   };
 }
 
-export function votesCellData({elections, votes, dataUseGroup, label= 'votes'}) {
+export function votesCellData({elections, dataUseGroup, label= 'votes'}) {
   let displayValue = '-/-';
   if (!isEmpty(elections)) {
+    const darElections = filter(e => e.electionType === 'DataAccess')(elections);
     const datasetIds = flow(
       filter(e => e.electionType === 'DataAccess'),
       map(e => e.dataSetId),
       uniq
-    )(elections);
+    )(darElections);
     const memberVotes = flow(
-      map(v => v.dataAccess),
-      flatMap(v => v.memberVotes)
-    )(votes);
+      flatMap(e => values(e.votes)),
+      filter(v => v.type === 'DAC')
+    )(darElections);
     const voteValues = flow(
       filter(v => !isUndefined(v.vote)),
       map(v => get('vote')(v))


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2265

### Before:
Does not account for adjusted bucketing logic (`OTH1, OTH2` should be broken out into 5 separate buckets):
![Screenshot 2023-02-28 at 11 11 58 AM](https://user-images.githubusercontent.com/116679/221911670-082068ba-853c-490a-8845-8db28b0651b9.png)


### After:
Uses adjusted bucketing logic:
![Screenshot 2023-02-28 at 11 11 36 AM](https://user-images.githubusercontent.com/116679/221911649-bd8ab15f-e2e9-46ce-97dd-86da67986901.png)

Unreviewed DARs have no votes so we display those slightly differently:
![Screenshot 2023-02-28 at 4 05 11 PM](https://user-images.githubusercontent.com/116679/221979625-f60cd63b-8cce-4168-8247-46ed231a3714.png)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
