### PR TITLE
[DUOS-2280][risk=no]New Data Submission Form - NIH/AnVIL double ‘No’ removes 2 sections

### DIFF
--- a/cypress/component/DataSubmission/ds_nih_anvil_use.spec.js
+++ b/cypress/component/DataSubmission/ds_nih_anvil_use.spec.js
@@ -10,6 +10,7 @@ const props = {
   onChange: () => {},
   validation: {},
   onValidationChange: () => {},
+  updateParentRenderState: () => {},
 };
 
 beforeEach(() => {

--- a/src/components/data_submission/NIHAdministrativeInformation.js
+++ b/src/components/data_submission/NIHAdministrativeInformation.js
@@ -11,6 +11,7 @@ export const NIHAdministrativeInformation = (props) => {
     institutions,
     validation,
     onValidationChange,
+    nihAdminRendered,
   } = props;
 
   const [showMultiCenterStudy, setShowMultiCenterStudy] = useState(initialFormData?.multiCenterStudy === true || false);
@@ -18,6 +19,7 @@ export const NIHAdministrativeInformation = (props) => {
   const [gsrRequiredExplanation, setGSRRequiredExplanation] = useState('');
 
   return div({
+    isRendered: nihAdminRendered === true,
     className: 'data-submitter-section',
   }, [
     h2('NIH Administrative Information'),

--- a/src/components/data_submission/NIHDataManagement.js
+++ b/src/components/data_submission/NIHDataManagement.js
@@ -21,7 +21,7 @@ export const NIHDataManagement = (props) => {
     onFileChange,
     validation,
     onValidationChange,
-    NIHDataManagementRendered,
+    nihDataManagementRendered,
   } = props;
 
   const [showAlternativeDataSharingPlan, setShowAlternativeDataSharingPlan] = useState(initialFormData?.alternativeDataSharingPlan === true || false);
@@ -57,7 +57,7 @@ export const NIHDataManagement = (props) => {
   };
 
   return div({
-    isRendered: NIHDataManagementRendered === true,
+    isRendered: nihDataManagementRendered === true,
     className: 'data-submitter-section',
   }, [
     h2('NIH Data Management & Sharing Policy Details'),

--- a/src/components/data_submission/NIHDataManagement.js
+++ b/src/components/data_submission/NIHDataManagement.js
@@ -21,6 +21,7 @@ export const NIHDataManagement = (props) => {
     onFileChange,
     validation,
     onValidationChange,
+    NIHDataManagementRendered,
   } = props;
 
   const [showAlternativeDataSharingPlan, setShowAlternativeDataSharingPlan] = useState(initialFormData?.alternativeDataSharingPlan === true || false);
@@ -56,6 +57,7 @@ export const NIHDataManagement = (props) => {
   };
 
   return div({
+    isRendered: NIHDataManagementRendered === true,
     className: 'data-submitter-section',
   }, [
     h2('NIH Data Management & Sharing Policy Details'),

--- a/src/components/data_submission/NihAnvilUse.js
+++ b/src/components/data_submission/NihAnvilUse.js
@@ -55,7 +55,7 @@ export default function NihAnvilUse(props) {
         const value = nihAnvilUseLabels[config.value];
         onChange({key: config.key, value: [value], isValid: config.isValid});
         setNihAnvilUse(value);
-        updateParentRenderState({key: config.key, value: [value], isValid: config.isValid});
+        updateParentRenderState({key: config.key, value: [value]});
       },
       validation: validation.nihAnvilUse,
       onValidationChange,

--- a/src/components/data_submission/NihAnvilUse.js
+++ b/src/components/data_submission/NihAnvilUse.js
@@ -7,7 +7,7 @@ export const YES_NHGRI_NO_PHS_ID = 'I am NHGRI funded and I do not have a dbGaP 
 export const NO_NHGRI_YES_ANVIL = 'I am not NHGRI funded but I am seeking to submit data to AnVIL';
 export const NO_NHGRI_NO_ANVIL = 'I am not NHGRI funded and do not plan to store data in AnVIL';
 
-export const nihAnvilUseLabels = {
+const nihAnvilUseLabels = {
   yes_nhgri_yes_phs_id: YES_NHGRI_YES_PHS_ID,
   yes_nhgri_no_phs_id: YES_NHGRI_NO_PHS_ID,
   no_nhgri_yes_anvil: NO_NHGRI_YES_ANVIL,
@@ -27,6 +27,7 @@ export default function NihAnvilUse(props) {
     initialFormData,
     validation,
     onValidationChange,
+    updateParentRenderState,
   } = props;
   const [nihAnvilUse, setNihAnvilUse] = useState(initialFormData?.nihAnvilUse || null);
 
@@ -54,6 +55,7 @@ export default function NihAnvilUse(props) {
         const value = nihAnvilUseLabels[config.value];
         onChange({key: config.key, value: [value], isValid: config.isValid});
         setNihAnvilUse(value);
+        updateParentRenderState({key: config.key, value: [value], isValid: config.isValid});
       },
       validation: validation.nihAnvilUse,
       onValidationChange,

--- a/src/components/data_submission/NihAnvilUse.js
+++ b/src/components/data_submission/NihAnvilUse.js
@@ -2,12 +2,12 @@ import {div, h, h2} from 'react-hyperscript-helpers';
 import {useState} from 'react';
 import {FormField, FormFieldTypes, FormValidators} from '../forms/forms';
 
-const YES_NHGRI_YES_PHS_ID = 'I am NHGRI funded and I have a dbGaP PHS ID already';
-const YES_NHGRI_NO_PHS_ID = 'I am NHGRI funded and I do not have a dbGaP PHS ID';
-const NO_NHGRI_YES_ANVIL = 'I am not NHGRI funded but I am seeking to submit data to AnVIL';
-const NO_NHGRI_NO_ANVIL = 'I am not NHGRI funded and do not plan to store data in AnVIL';
+export const YES_NHGRI_YES_PHS_ID = 'I am NHGRI funded and I have a dbGaP PHS ID already';
+export const YES_NHGRI_NO_PHS_ID = 'I am NHGRI funded and I do not have a dbGaP PHS ID';
+export const NO_NHGRI_YES_ANVIL = 'I am not NHGRI funded but I am seeking to submit data to AnVIL';
+export const NO_NHGRI_NO_ANVIL = 'I am not NHGRI funded and do not plan to store data in AnVIL';
 
-const nihAnvilUseLabels = {
+export const nihAnvilUseLabels = {
   yes_nhgri_yes_phs_id: YES_NHGRI_YES_PHS_ID,
   yes_nhgri_no_phs_id: YES_NHGRI_NO_PHS_ID,
   no_nhgri_yes_anvil: NO_NHGRI_YES_ANVIL,

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -13,7 +13,7 @@ import DataSubmissionStudyInformation from '../components/data_submission/ds_stu
 import NIHAdministrativeInformation from '../components/data_submission/NIHAdministrativeInformation';
 import NIHDataManagement from '../components/data_submission/NIHDataManagement';
 import NihAnvilUse from '../components/data_submission/NihAnvilUse';
-import { YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL, NO_NHGRI_NO_ANVIL } from '../components/data_submission/NihAnvilUse';
+import { YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL } from '../components/data_submission/NihAnvilUse';
 import { set } from 'lodash';
 
 

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -98,15 +98,7 @@ export const DataSubmissionForm = () => {
     formData[key] = value;
     if (key === 'nihAnvilUse') {
       const val = isArray(value) ? value[0] : value;
-      if (includes(val)([YES_NHGRI_YES_PHS_ID])) {
-        setNihAdminRendered(true);
-        setNihDataManagementRendered(true);
-      }
-      if (includes(val)([YES_NHGRI_NO_PHS_ID])) {
-        setNihAdminRendered(true);
-        setNihDataManagementRendered(true);
-      }
-      if (includes(val)([NO_NHGRI_YES_ANVIL])) {
+      if (includes(val)([YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL])) {
         setNihAdminRendered(true);
         setNihDataManagementRendered(true);
       }

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { cloneDeep, isNil, includes, isArray } from 'lodash/fp';
+import { cloneDeep, isNil, includes, isArray, isEmpty } from 'lodash/fp';
 import { useState, useEffect } from 'react';
 import { Institution, DataSet } from '../libs/ajax';
 import { Notifications } from '../libs/utils';
@@ -96,8 +96,11 @@ export const DataSubmissionForm = () => {
 
   const onChange = ({ key, value }) => {
     formData[key] = value;
+  }
+
+  const updateParentRenderState = ({ key, value }) => {
     if (key === 'nihAnvilUse') {
-      const val = isArray(value) ? value[0] : value;
+      const val = (isArray(value) && !isEmpty(value)) ? value[0] : value;
       if (includes(val)([YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL])) {
         setNihAdminRendered(true);
         setNihDataManagementRendered(true);
@@ -141,7 +144,7 @@ export const DataSubmissionForm = () => {
 
 
       <DataSubmissionStudyInformation onChange={onChange} validation={formValidation} onValidationChange={onValidationChange} />
-      <NihAnvilUse onChange={onChange} initialFormData={formData} validation={formValidation} onValidationChange={onValidationChange} />
+      <NihAnvilUse onChange={onChange} initialFormData={formData} validation={formValidation} onValidationChange={onValidationChange} updateParentRenderState={updateParentRenderState}/>
       <NIHAdministrativeInformation nihAdminRendered={nihAdminRendered} initialFormData={formData} onChange={onChange} institutions={institutions} validation={formValidation} onValidationChange={onValidationChange} />
       <NIHDataManagement nihDataManagementRendered={nihDataManagementRendered} initialFormData={formData} onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} />
       <DataAccessGovernance onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} />

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -96,7 +96,7 @@ export const DataSubmissionForm = () => {
     formData[key] = value;
     if (key === 'nihAnvilUse') {
       if (includes(value)(['yes_nhgri_yes_phs_id'])) {
-      setNihAdminRendered(true);
+        setNihAdminRendered(true);
       setNihDataManagementRendered(true);
       }
       if (includes(value)(['yes_nhgri_no_phs_id'])) {

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -97,7 +97,7 @@ export const DataSubmissionForm = () => {
     if (key === 'nihAnvilUse') {
       if (includes(value)(['yes_nhgri_yes_phs_id'])) {
         setNihAdminRendered(true);
-      setNihDataManagementRendered(true);
+        setNihDataManagementRendered(true);
       }
       if (includes(value)(['yes_nhgri_no_phs_id'])) {
         setNihAdminRendered(true);

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { cloneDeep, isNil } from 'lodash/fp';
+import { cloneDeep, isNil, includes } from 'lodash/fp';
 import { useState, useEffect } from 'react';
 import { Institution, DataSet } from '../libs/ajax';
 import { Notifications } from '../libs/utils';
@@ -20,6 +20,9 @@ export const DataSubmissionForm = () => {
 
   const [institutions, setInstitutions] = useState([]);
   const [failedInit, setFailedInit] = useState(false);
+  const [nihAdminRendered, setNihAdminRendered] = useState(false);
+  const [nihDataManagementRendered, setNihDataManagementRendered]  = useState(false);
+
 
   useEffect(() => {
     const getAllInstitutions = async() => {
@@ -91,6 +94,20 @@ export const DataSubmissionForm = () => {
 
   const onChange = ({ key, value }) => {
     formData[key] = value;
+    if (key === 'nihAnvilUse') {
+      if (includes(value)(['yes_nhgri_yes_phs_id'])) {
+      setNihAdminRendered(true);
+      setNihDataManagementRendered(true);
+      }
+      if (includes(value)(['yes_nhgri_no_phs_id'])) {
+        setNihAdminRendered(true);
+        setNihDataManagementRendered(true);
+      }
+      if (includes(value)(['no_nhgri_yes_anvil'])) {
+        setNihAdminRendered(true);
+        setNihDataManagementRendered(true);
+      }
+    }
   };
 
   const onFileChange = ({ key, value }) => {
@@ -126,8 +143,8 @@ export const DataSubmissionForm = () => {
 
       <DataSubmissionStudyInformation onChange={onChange} validation={formValidation} onValidationChange={onValidationChange} />
       <NihAnvilUse onChange={onChange} initialFormData={formData} validation={formValidation} onValidationChange={onValidationChange} />
-      <NIHAdministrativeInformation initialFormData={formData} onChange={onChange} institutions={institutions} validation={formValidation} onValidationChange={onValidationChange} />
-      <NIHDataManagement initialFormData={formData} onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} />
+      <NIHAdministrativeInformation nihAdminRendered={nihAdminRendered} initialFormData={formData} onChange={onChange} institutions={institutions} validation={formValidation} onValidationChange={onValidationChange} />
+      <NIHDataManagement nihDataManagementRendered={nihDataManagementRendered} initialFormData={formData} onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} />
       <DataAccessGovernance onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} />
 
       <div className='flex flex-row' style={{justifyContent: 'flex-end', marginBottom: '2rem'}}>

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -105,7 +105,7 @@ export const DataSubmissionForm = () => {
         setNihAdminRendered(true);
         setNihDataManagementRendered(true);
       }
-      if (includes(val)([NO_NHGRI_NO_ANVIL])) {
+      else {
         setNihAdminRendered(false);
         setNihDataManagementRendered(false);
       }

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { cloneDeep, isNil, includes } from 'lodash/fp';
+import { cloneDeep, isNil, includes, isArray } from 'lodash/fp';
 import { useState, useEffect } from 'react';
 import { Institution, DataSet } from '../libs/ajax';
 import { Notifications } from '../libs/utils';
@@ -13,6 +13,7 @@ import DataSubmissionStudyInformation from '../components/data_submission/ds_stu
 import NIHAdministrativeInformation from '../components/data_submission/NIHAdministrativeInformation';
 import NIHDataManagement from '../components/data_submission/NIHDataManagement';
 import NihAnvilUse from '../components/data_submission/NihAnvilUse';
+import { YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL, NO_NHGRI_NO_ANVIL } from '../components/data_submission/NihAnvilUse';
 import { set } from 'lodash';
 
 
@@ -21,7 +22,8 @@ export const DataSubmissionForm = () => {
   const [institutions, setInstitutions] = useState([]);
   const [failedInit, setFailedInit] = useState(false);
   const [nihAdminRendered, setNihAdminRendered] = useState(false);
-  const [nihDataManagementRendered, setNihDataManagementRendered]  = useState(false);
+  const [nihDataManagementRendered, setNihDataManagementRendered] = useState(false);
+
 
 
   useEffect(() => {
@@ -95,17 +97,22 @@ export const DataSubmissionForm = () => {
   const onChange = ({ key, value }) => {
     formData[key] = value;
     if (key === 'nihAnvilUse') {
-      if (includes(value)(['yes_nhgri_yes_phs_id'])) {
-      setNihAdminRendered(true);
-      setNihDataManagementRendered(true);
-      }
-      if (includes(value)(['yes_nhgri_no_phs_id'])) {
+      const val = isArray(value) ? value[0] : value;
+      if (includes(val)([YES_NHGRI_YES_PHS_ID])) {
         setNihAdminRendered(true);
         setNihDataManagementRendered(true);
       }
-      if (includes(value)(['no_nhgri_yes_anvil'])) {
+      if (includes(val)([YES_NHGRI_NO_PHS_ID])) {
         setNihAdminRendered(true);
         setNihDataManagementRendered(true);
+      }
+      if (includes(val)([NO_NHGRI_YES_ANVIL])) {
+        setNihAdminRendered(true);
+        setNihDataManagementRendered(true);
+      }
+      if (includes(val)([NO_NHGRI_NO_ANVIL])) {
+        setNihAdminRendered(false);
+        setNihDataManagementRendered(false);
       }
     }
   };

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -96,7 +96,7 @@ export const DataSubmissionForm = () => {
 
   const onChange = ({ key, value }) => {
     formData[key] = value;
-  }
+  };
 
   const updateParentRenderState = ({ key, value }) => {
     if (key === 'nihAnvilUse') {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2280
Data Submission Form
'NIH Administrative Information' and 'NIH Data Management & Sharing Policy Details' sections displayed when:
- > I am NHGRI funded and I have a dbGaP PHS ID already
- > I am NHGRI funded and I do not have a dbGaP PHS ID
- > I am not NHGRI funded but I am seeking to submit data to AnVIL

Sections hidden when:
- page loads 
- > I am not NHGRI funded and do not plan to store data in AnVIL

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
