### PR TITLE
[DUOS-2354][risk=no] Update data use code translations for OTHER and additional match fields.

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -151,7 +151,7 @@ export const srpTranslations = {
  * It is intended to map codes and descriptions for easier viewing.
  */
 export const consentTranslations = {
-  nRes: {
+  noRestrictions: {
     code: 'NRES',
     description: 'No restrictions on data use',
     type: ControlledAccessType.permissions,

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -7,6 +7,11 @@ export const ControlledAccessType = {
   modifiers: 'Modifiers'
 };
 
+/**
+ * Primary source of truth for Data Access Request (purpose) data use translations
+ * This constant holds all potential DUO codes that a dar might contain.
+ * It is intended to map codes and descriptions for easier viewing.
+ */
 export const srpTranslations = {
   hmb: {
     code: 'HMB',
@@ -140,7 +145,17 @@ export const srpTranslations = {
   }
 };
 
+/**
+ * Primary source of truth for Dataset translations
+ * This constant holds all potential DUO codes that a dataset might contain.
+ * It is intended to map codes and descriptions for easier viewing.
+ */
 export const consentTranslations = {
+  nRes: {
+    code: 'NRES',
+    description: 'No restrictions on data use',
+    type: ControlledAccessType.permissions,
+  },
   generalUse: {
     code: 'GRU',
     description: 'Use is permitted for any research purpose',
@@ -171,6 +186,16 @@ export const consentTranslations = {
   methodsResearch: {
     code: 'NMDS',
     description: 'Use for methods development research (e.g., development of software or algorithms) only within the bounds of other use limitations',
+    type: ControlledAccessType.modifiers,
+  },
+  controlSetOption: {
+    code: 'NCTRL',
+    description: 'Future use as a control set for diseases other than those specified is prohibited',
+    type: ControlledAccessType.modifiers,
+  },
+  aggregateResearch: {
+    code: 'NAGR',
+    description: 'Future use of aggregate-level data for general research purposes is prohibited',
     type: ControlledAccessType.modifiers,
   },
   geneticStudiesOnly: {
@@ -281,11 +306,12 @@ export const processDefinedLimitations = (
 //Helper function to handle OTHER attribute translations in dataUse
 const processOtherInDataUse = (dataUse, restrictionStatements) => {
   //Wrapping the statements in a Promise.resolve before adding it to the array allows the restrictionStatements to be compatible with future Promise.all calls
-  if ((dataUse.otherRestrictions === true || (!isNil(dataUse.generalUse) && dataUse.generalUse === false)) && !isNil(dataUse.other)) {
+  if (dataUse.otherRestrictions === true || !isNil(dataUse.other)) {
     restrictionStatements.push(
       Promise.resolve({
         code: 'OTH1',
         description: `Primary Other: ${isEmpty(dataUse.other) ? 'Not provided' : dataUse.other}`,
+        type: ControlledAccessType.modifiers,
       })
     );
   }
@@ -294,6 +320,7 @@ const processOtherInDataUse = (dataUse, restrictionStatements) => {
       Promise.resolve({
         code: 'OTH2',
         description: `Secondary Other: ${isEmpty(dataUse.secondaryOther) ? 'Not provided' : dataUse.secondaryOther}`,
+        type: ControlledAccessType.modifiers,
       })
     );
   }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2354

Fixes:
1. Always calculate the other condition for display as a code
2. Allow for other codes to display as a pill in dataset bucket slabs
3. Docs on what codes mean
4. Additional code for NRES for future work
5. Additional codes for fields that the algorithm is using for match purposes

References:
* https://github.com/DataBiosphere/consent-ontology/blob/develop/docs/Algorithms.md#version-2
* https://github.com/EBISPOT/DUO#research-purpose--data-use-limitation-matching
* https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005772#pgen-1005772-t001

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
