### PR TITLE
[DUOS-2375][DUOS-2378][risk=no]Long bucket labels overwrite the vote label, RUS Narrative Text Bug

### DIFF
--- a/src/components/CollectionAlgorithmDecision.js
+++ b/src/components/CollectionAlgorithmDecision.js
@@ -40,7 +40,7 @@ export default function CollectionAlgorithmDecision(props) {
         padding: '4%',
         justifyContent: 'space-around',
         fontFamily: 'Montserrat',
-        width: '50%'
+        width: '100%',
       },
       styleOverride
     )
@@ -49,7 +49,7 @@ export default function CollectionAlgorithmDecision(props) {
   return (
     div(containerProps, [
       div({style: {flex: 1, padding: '1%'}}, [
-        h5({id: `collection-${id}-subtitle`, style: {fontFamily: 'Montserrat', fontWeight: 800, fontSize: 17, color: '#333F52', marginTop: '-5%'}}, ['DUOS Algorithm Decision']),
+        h5({id: `collection-${id}-subtitle`, style: {fontFamily: 'Montserrat', fontWeight: 800, fontSize: 17, color: '#333F52'}}, ['DUOS Algorithm Decision']),
         div({style: {fontSize: '1.5rem'}}, [
           span({id: `collection-${id}-decision-label`, style: {paddingRight: '1%', color: '#333F52'}}, ['Decision:']),
           span({id: `collection-${id}-decision-value`, style: {fontWeight: 400}}, [getResult(result)])

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -16,8 +16,9 @@ const styles = {
     marginTop: '-20px'
   },
   question: {
-    marginTop: '-18px',
+    marginTop: '18px',
     fontSize: 17,
+    color: '#333F52',
   },
   content: {
     display: 'flex',

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
@@ -40,10 +40,11 @@ const styles = {
     }
   },
   slabTitle: {
-    display: 'flex'
+    display: 'flex',
+    paddingBottom: '15px',
   },
   slatTitleText: {
-    display: 'fixed',
+    display: 'flex',
     fontSize: 17,
     fontWeight: 800,
     height: '32px',
@@ -51,6 +52,11 @@ const styles = {
     color: '#333F52',
     marginTop: '-5px',
     columnGap: '2rem'
+  },
+  question: {
+    fontSize: 17,
+    color: '#333F52',
+    marginLeft: '30px',
   },
   dataUses: {},
   voteInfo: {},
@@ -107,7 +113,6 @@ export default function MultiDatasetVoteSlab(props) {
         </div>
         <div>
           <CollectionSubmitVoteBox
-            question={'Should data access be granted to this applicant?'}
             votes={currentUserVotes}
             isFinal={isChair}
             isDisabled={adminPage || readOnly || isEmpty(currentUserVotes) || !allOpenElections}
@@ -129,8 +134,15 @@ export default function MultiDatasetVoteSlab(props) {
         <table className={'layout-table'} role='presentation' style={{width:'-webkit-fill-available'}}>
           <tbody>
             <tr>
-              <td style={{width: '50%'}}><DataUseSummary/></td>
-              <td style={{width: '50%', verticalAlign: 'text-top'}}><VoteInfoSubsection/></td>
+              <td style={{width: '50%', verticalAlign: 'text-top',}}>
+                <div style={styles.slabTitle} key={convertLabelToKey(get('key')(bucket))}>
+                  <span style={styles.slatTitleText}>{title}</span>
+                </div>
+                <DataUseSummary/></td>
+              <td style={{width: '50%', verticalAlign: 'text-top'}}>
+                <div style={styles.question}>
+                  <p>Should data access be granted to this applicant?</p>
+                </div><VoteInfoSubsection/></td>
             </tr>
             <tr>
               <td style={{width: '50%', verticalAlign: 'text-top'}}><ChairVoteInfo
@@ -174,9 +186,6 @@ export default function MultiDatasetVoteSlab(props) {
 
   return(
     <div style={styles.baseStyle} data-cy={'dataset-vote-slab'}>
-      <div style={styles.slabTitle} key={convertLabelToKey(get('key')(bucket))}>
-        <span style={styles.slatTitleText}>{title}</span>
-      </div>
       {!isLoading ? <div style={{display:'inline'}}>
         <DatasetDisplayTable/>
         <DatasetsRequested/>

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -153,7 +153,6 @@ export const ChairVoteInfo = ({dacVotes, isChair, adminPage = false}) => {
           style: {
             backgroundColor: '#FFFFFF',
             padding: '1% 0',
-            marginLeft: '-3%',
             marginTop: '10%',
           },
         },


### PR DESCRIPTION
## Addresses
1) https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2375
Fixes overlapping title & data use pills, alignment of titles
<img width="1402" alt="image" src="https://user-images.githubusercontent.com/91574136/224413963-2aadd3e9-a51f-4b94-b258-8341bf5fe447.png">

2) https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2378
Fixes overwritten text on RUS expanded view
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/91574136/224414252-63609fad-29b4-4547-b150-9d212d1877b8.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
