### PR TITLE
[DUOS-2374][risk-no] Show member/chair tab only if you have member/chair votes

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -628,7 +628,7 @@ const props = {
 };
 
 const user = {
-  userId: 1,
+  userId: 11111,
   roles: [
     {
       dacId: 1,

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -629,11 +629,12 @@ const props = {
 
 const user = {
   userId: 11111,
+  displayName: 'Ted Lasso',
   roles: [
     {
       dacId: 1,
       userRoleId: 586,
-      userId: 1,
+      userId: 11111,
       roleId: 2,
       name: 'Chairperson'
     }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2374

Conditionally render the member/chair tabs based on whether the user has votes in those tabs.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
