### PR TITLE
[DUOS-2389][risk=no] Rename vote dacUserId -> userId

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -308,7 +308,7 @@ const dar = {
             '8675': {
               'voteId': 8675,
               'vote': true,
-              'dacUserId': 4444,
+              'userId': 4444,
               'createDate': 1669062648000,
               'updateDate': 1669120753000,
               'electionId': 8888,
@@ -318,7 +318,7 @@ const dar = {
             },
             '8676': {
               'voteId': 8676,
-              'dacUserId': 11111,
+              'userId': 11111,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'DAC',
@@ -326,7 +326,7 @@ const dar = {
             },
             '8677': {
               'voteId': 8677,
-              'dacUserId': 11111,
+              'userId': 11111,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'Chairperson',
@@ -334,7 +334,7 @@ const dar = {
             },
             '8678': {
               'voteId': 8678,
-              'dacUserId': 11111,
+              'userId': 11111,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'FINAL',
@@ -342,7 +342,7 @@ const dar = {
             },
             '8679': {
               'voteId': 8679,
-              'dacUserId': 11111,
+              'userId': 11111,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'AGREEMENT',
@@ -350,7 +350,7 @@ const dar = {
             },
             '8680': {
               'voteId': 8680,
-              'dacUserId': 9988,
+              'userId': 9988,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'DAC',
@@ -358,7 +358,7 @@ const dar = {
             },
             '8681': {
               'voteId': 8681,
-              'dacUserId': 9988,
+              'userId': 9988,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'Chairperson',
@@ -366,7 +366,7 @@ const dar = {
             },
             '8682': {
               'voteId': 8682,
-              'dacUserId': 9988,
+              'userId': 9988,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'FINAL',
@@ -374,7 +374,7 @@ const dar = {
             },
             '8683': {
               'voteId': 8683,
-              'dacUserId': 9988,
+              'userId': 9988,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'AGREEMENT',
@@ -382,7 +382,7 @@ const dar = {
             },
             '8684': {
               'voteId': 8684,
-              'dacUserId': 4585,
+              'userId': 4585,
               'createDate': 1669062648000,
               'electionId': 8888,
               'type': 'DAC',
@@ -400,7 +400,7 @@ const dar = {
           'votes': {
             '8688': {
               'voteId': 8688,
-              'dacUserId': 9988,
+              'userId': 9988,
               'createDate': 1669062648000,
               'electionId': 1776,
               'type': 'DAC',
@@ -408,7 +408,7 @@ const dar = {
             },
             '8689': {
               'voteId': 8689,
-              'dacUserId': 9988,
+              'userId': 9988,
               'createDate': 1669062648000,
               'electionId': 1776,
               'type': 'Chairperson',
@@ -416,7 +416,7 @@ const dar = {
             },
             '8690': {
               'voteId': 8690,
-              'dacUserId': 4585,
+              'userId': 4585,
               'createDate': 1669062648000,
               'electionId': 1776,
               'type': 'DAC',
@@ -424,7 +424,7 @@ const dar = {
             },
             '8685': {
               'voteId': 8685,
-              'dacUserId': 4444,
+              'userId': 4444,
               'createDate': 1669062648000,
               'electionId': 1776,
               'type': 'DAC',
@@ -432,7 +432,7 @@ const dar = {
             },
             '8686': {
               'voteId': 8686,
-              'dacUserId': 11111,
+              'userId': 11111,
               'createDate': 1669062648000,
               'electionId': 1776,
               'type': 'DAC',
@@ -440,7 +440,7 @@ const dar = {
             },
             '8687': {
               'voteId': 8687,
-              'dacUserId': 11111,
+              'userId': 11111,
               'createDate': 1669062648000,
               'electionId': 1776,
               'type': 'Chairperson',

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -14,7 +14,6 @@ const dar = {
   'createDate': 1669229413840,
   'createUser': {
     'userId': 7,
-    'dacUserId': 7,
     'email': 'Bob.Jones@prodigy.com',
     'displayName': 'Bob Jones',
     'createDate': 1668229413840,
@@ -643,7 +642,6 @@ const user = {
 
 const researcher = {
   'userId': 7,
-  'dacUserId': 7,
   'email': 'Bob.Jones@prodigy.com',
   'displayName': 'Bob Jones',
   'createDate': 1668229413840,

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
@@ -16,7 +16,6 @@ const props = {
 
 const user = {
   userId: 5,
-  dacUserId: 3,
   displayName: 'Jane Doe',
   email: 'janedoe@gmail.com',
   eraCommonsId: 'asdg',
@@ -50,13 +49,11 @@ const datasets = [
 const userSigningOfficials = [
   {
     userId: 6,
-    dacUserId: 4,
     displayName: 'SO 1',
     email: 'so1@gmail.com'
   },
   {
     userId: 7,
-    dacUserId: 5,
     displayName: 'SO 2',
     email: 'so2@gmail.com'
   }

--- a/cypress/component/DataAccessRequest/researcher_info_new.spec.js
+++ b/cypress/component/DataAccessRequest/researcher_info_new.spec.js
@@ -71,7 +71,6 @@ const WrappedResearcherInfo = (props) => {
 
 const user = {
   userId: 1,
-  dacUserId: 2,
   displayName: 'Cindy Crawford',
   email: 'cc@c.com'
 };

--- a/cypress/component/DataSubmission/data_access_governance.spec.js
+++ b/cypress/component/DataSubmission/data_access_governance.spec.js
@@ -21,7 +21,7 @@ const user = {
 beforeEach(() => {
   cy.stub(DAC, 'list').returns(Promise.resolve(dacs));
   cy.stub(User, 'getMe').returns(user);
-  cy.stub(Institution, 'list').returns([{name: 'Test Instituion'}]);
+  cy.stub(Institution, 'list').returns([{name: 'Test Institution'}]);
   cy.stub(Schema, 'datasetRegistrationV1').returns({});
 });
 

--- a/cypress/component/DataSubmission/data_access_governance.spec.js
+++ b/cypress/component/DataSubmission/data_access_governance.spec.js
@@ -13,7 +13,6 @@ const dacs = [
 
 const user = {
   userId: 1,
-  dacUserId: 2,
   displayName: 'Cindy Crawford',
   email: 'cc@c.com'
 };

--- a/cypress/component/DataSubmission/ds_study_information.spec.js
+++ b/cypress/component/DataSubmission/ds_study_information.spec.js
@@ -8,7 +8,6 @@ import DataSubmissionStudyInformation from '../../../src/components/data_submiss
 let propCopy;
 const user = {
   userId: 1,
-  dacUserId: 2,
   displayName: 'Cindy Crawford',
   email: 'cc@c.com'
 };

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -25,15 +25,15 @@ const closedElection =  [
 const votesForOpenElection1 = {
   dataAccess: {
     finalVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
     ],
     chairpersonVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
     ],
     memberVotes: [
-      {dacUserId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1},
-      {dacUserId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
-      {dacUserId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
+      {userId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
     ]
   }
 };
@@ -41,15 +41,15 @@ const votesForOpenElection1 = {
 const votesForOpenElection2 = {
   dataAccess: {
     finalVotes: [
-      {dacUserId: 200, displayName: 'Sarah',  vote: true, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: true, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
     ],
     chairpersonVotes: [
-      {dacUserId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
     ],
     memberVotes: [
-      {dacUserId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2},
-      {dacUserId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
-      {dacUserId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6}
+      {userId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6}
     ]
   }
 };
@@ -57,14 +57,14 @@ const votesForOpenElection2 = {
 const votesForClosedElection = {
   dataAccess: {
     finalVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
     ],
     chairpersonVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
     ],
     memberVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
-      {dacUserId: 300, displayName: 'Matt', vote: true, rationale: 'test3', electionId: 103, voteId: 8}
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 300, displayName: 'Matt', vote: true, rationale: 'test3', electionId: 103, voteId: 8}
     ]
   }
 };

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -23,28 +23,28 @@ const bucket1 = {
     {
       rp: {
         finalVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true, createDate: 1},
+          {userId: 200, displayName: 'Sarah', vote: true, createDate: 1},
         ],
         chairpersonVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true, createDate: 1},
+          {userId: 200, displayName: 'Sarah', vote: true, createDate: 1},
         ],
         memberVotes: [
-          {dacUserId: 100, displayName: 'Joe', electionId: 100, voteId: 1, createDate: 1},
-          {dacUserId: 200, displayName: 'Sarah', vote: true, electionId: 100, voteId: 2, createDate: 1},
-          {dacUserId: 300, displayName: 'Matt', vote: true, electionId: 100, voteId: 3, createDate: 1}
+          {userId: 100, displayName: 'Joe', electionId: 100, voteId: 1, createDate: 1},
+          {userId: 200, displayName: 'Sarah', vote: true, electionId: 100, voteId: 2, createDate: 1},
+          {userId: 300, displayName: 'Matt', vote: true, electionId: 100, voteId: 3, createDate: 1}
         ]
       },
       dataAccess: {
         finalVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: false},
+          {userId: 200, displayName: 'Sarah', vote: false},
         ],
         chairpersonVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: false},
+          {userId: 200, displayName: 'Sarah', vote: false},
         ],
         memberVotes: [
-          {dacUserId: 100, displayName: 'Joe', rationale: 'test', electionId: 101, voteId: 1, createDate: 1},
-          {dacUserId: 200, displayName: 'Sarah', vote: false, rationale: 'rationale', electionId: 101, voteId: 2, createDate: 1},
-          {dacUserId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
+          {userId: 100, displayName: 'Joe', rationale: 'test', electionId: 101, voteId: 1, createDate: 1},
+          {userId: 200, displayName: 'Sarah', vote: false, rationale: 'rationale', electionId: 101, voteId: 2, createDate: 1},
+          {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
         ]
       }
     },
@@ -66,26 +66,26 @@ const bucket2 = {
     {
       rp: {
         finalVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true, createDate: 1},
+          {userId: 200, displayName: 'Sarah', vote: true, createDate: 1},
         ],
         chairpersonVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true, createDate: 1},
+          {userId: 200, displayName: 'Sarah', vote: true, createDate: 1},
         ],
         memberVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true, electionId: 100, voteId: 2, createDate: 1},
-          {dacUserId: 300, displayName: 'Matt', vote: true, electionId: 100, voteId: 3, createDate: 1}
+          {userId: 200, displayName: 'Sarah', vote: true, electionId: 100, voteId: 2, createDate: 1},
+          {userId: 300, displayName: 'Matt', vote: true, electionId: 100, voteId: 3, createDate: 1}
         ]
       },
       dataAccess: {
         finalVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true},
+          {userId: 200, displayName: 'Sarah', vote: true},
         ],
         chairpersonVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true},
+          {userId: 200, displayName: 'Sarah', vote: true},
         ],
         memberVotes: [
-          {dacUserId: 200, displayName: 'Sarah', vote: true, rationale: 'rationale2', electionId: 102, voteId: 4, createDate: 1},
-          {dacUserId: 300, displayName: 'Matt', electionId: 102, voteId: 5, createDate: 1}
+          {userId: 200, displayName: 'Sarah', vote: true, rationale: 'rationale2', electionId: 102, voteId: 4, createDate: 1},
+          {userId: 300, displayName: 'Matt', electionId: 102, voteId: 5, createDate: 1}
         ]
       }
     },

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.js
@@ -29,15 +29,15 @@ const collapseSlabLinkText = 'Hide Research Use Statement (Narrative)';
 const votesForElection1 = {
   rp: {
     finalVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
     ],
     chairpersonVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
     ],
     memberVotes: [
-      {dacUserId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1},
-      {dacUserId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
-      {dacUserId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
+      {userId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
     ]
   }
 };
@@ -45,15 +45,15 @@ const votesForElection1 = {
 const votesForElection2 = {
   rp: {
     finalVotes: [
-      {dacUserId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
     ],
     chairpersonVotes: [
-      {dacUserId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
     ],
     memberVotes: [
-      {dacUserId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2},
-      {dacUserId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
-      {dacUserId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6}
+      {userId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6}
     ]
   }
 };
@@ -61,14 +61,14 @@ const votesForElection2 = {
 const votesForElection3 = {
   rp: {
     finalVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
     ],
     chairpersonVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: true, electionId: 103, voteId: 7},
+      {userId: 200, displayName: 'Sarah', vote: true, electionId: 103, voteId: 7},
     ],
     memberVotes: [
-      {dacUserId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
-      {dacUserId: 300, displayName: 'Matt', vote: true, rationale: 'test3', electionId: 103, voteId: 8}
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 300, displayName: 'Matt', vote: true, rationale: 'test3', electionId: 103, voteId: 8}
     ]
   }
 };

--- a/cypress/component/utils/bucket_utils.spec.js
+++ b/cypress/component/utils/bucket_utils.spec.js
@@ -20,7 +20,7 @@ const dar_collection = {
           'votes': {
             '1': {
               'voteId': 1,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 1,
               'rationale': '',
               'type': 'Chairperson',
@@ -28,7 +28,7 @@ const dar_collection = {
             },
             '2': {
               'voteId': 2,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 1,
               'rationale': '',
               'type': 'DAC',
@@ -36,7 +36,7 @@ const dar_collection = {
             },
             '3': {
               'voteId': 3,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 1,
               'rationale': '',
               'type': 'Final',
@@ -52,7 +52,7 @@ const dar_collection = {
           'votes': {
             '4': {
               'voteId': 4,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 2,
               'rationale': '',
               'type': 'Chairperson',
@@ -60,7 +60,7 @@ const dar_collection = {
             },
             '5': {
               'voteId': 5,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 2,
               'rationale': '',
               'type': 'DAC',
@@ -68,7 +68,7 @@ const dar_collection = {
             },
             '6': {
               'voteId': 6,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 2,
               'rationale': '',
               'type': 'Final',
@@ -84,7 +84,7 @@ const dar_collection = {
           'votes': {
             '11': {
               'voteId': 11,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 3,
               'rationale': '',
               'type': 'Chairperson',
@@ -92,7 +92,7 @@ const dar_collection = {
             },
             '22': {
               'voteId': 22,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 3,
               'rationale': '',
               'type': 'DAC',
@@ -100,7 +100,7 @@ const dar_collection = {
             },
             '33': {
               'voteId': 33,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 3,
               'rationale': '',
               'type': 'Final',
@@ -116,7 +116,7 @@ const dar_collection = {
           'votes': {
             '44': {
               'voteId': 44,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 4,
               'rationale': '',
               'type': 'Chairperson',
@@ -124,7 +124,7 @@ const dar_collection = {
             },
             '55': {
               'voteId': 55,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 4,
               'rationale': '',
               'type': 'DAC',
@@ -132,7 +132,7 @@ const dar_collection = {
             },
             '66': {
               'voteId': 66,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 4,
               'rationale': '',
               'type': 'Final',
@@ -148,7 +148,7 @@ const dar_collection = {
           'votes': {
             '111': {
               'voteId': 111,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 3,
               'rationale': '',
               'type': 'Chairperson',
@@ -156,7 +156,7 @@ const dar_collection = {
             },
             '222': {
               'voteId': 222,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 5,
               'rationale': '',
               'type': 'DAC',
@@ -164,7 +164,7 @@ const dar_collection = {
             },
             '333': {
               'voteId': 333,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 5,
               'rationale': '',
               'type': 'Final',
@@ -180,7 +180,7 @@ const dar_collection = {
           'votes': {
             '444': {
               'voteId': 444,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 6,
               'rationale': '',
               'type': 'Chairperson',
@@ -188,7 +188,7 @@ const dar_collection = {
             },
             '555': {
               'voteId': 555,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 6,
               'rationale': '',
               'type': 'DAC',
@@ -196,7 +196,7 @@ const dar_collection = {
             },
             '666': {
               'voteId': 666,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 6,
               'rationale': '',
               'type': 'Final',
@@ -212,7 +212,7 @@ const dar_collection = {
           'votes': {
             '1111': {
               'voteId': 1111,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 7,
               'rationale': '',
               'type': 'Chairperson',
@@ -220,7 +220,7 @@ const dar_collection = {
             },
             '2222': {
               'voteId': 2222,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 7,
               'rationale': '',
               'type': 'DAC',
@@ -228,7 +228,7 @@ const dar_collection = {
             },
             '3333': {
               'voteId': 3333,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 7,
               'rationale': '',
               'type': 'Final',
@@ -244,7 +244,7 @@ const dar_collection = {
           'votes': {
             '4444': {
               'voteId': 4444,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 8,
               'rationale': '',
               'type': 'Chairperson',
@@ -252,7 +252,7 @@ const dar_collection = {
             },
             '5555': {
               'voteId': 5555,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 8,
               'rationale': '',
               'type': 'DAC',
@@ -260,7 +260,7 @@ const dar_collection = {
             },
             '6666': {
               'voteId': 6666,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 8,
               'rationale': '',
               'type': 'Final',
@@ -276,7 +276,7 @@ const dar_collection = {
           'votes': {
             '11111': {
               'voteId': 11111,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 9,
               'rationale': '',
               'type': 'Chairperson',
@@ -284,7 +284,7 @@ const dar_collection = {
             },
             '22222': {
               'voteId': 22222,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 9,
               'rationale': '',
               'type': 'DAC',
@@ -292,7 +292,7 @@ const dar_collection = {
             },
             '33333': {
               'voteId': 33333,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 9,
               'rationale': '',
               'type': 'Final',
@@ -308,7 +308,7 @@ const dar_collection = {
           'votes': {
             '44444': {
               'voteId': 44444,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 10,
               'rationale': '',
               'type': 'Chairperson',
@@ -316,7 +316,7 @@ const dar_collection = {
             },
             '55555': {
               'voteId': 55555,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 10,
               'rationale': '',
               'type': 'DAC',
@@ -324,7 +324,7 @@ const dar_collection = {
             },
             '66666': {
               'voteId': 66666,
-              'dacUserId': 1,
+              'userId': 1,
               'electionId': 10,
               'rationale': '',
               'type': 'Final',

--- a/cypress/component/utils/dar_collection_utils.spec.js
+++ b/cypress/component/utils/dar_collection_utils.spec.js
@@ -97,12 +97,12 @@ describe('openCollectionFn', () => {
 });
 
 describe('extractDacDataAccessVotesFromBucket', () => {
-  it('returns empty list if data access votes in this bucket do not have the dacUserId of the given user', () => {
+  it('returns empty list if data access votes in this bucket do not have the userId of the given user', () => {
     const bucket = {
       votes: [
         {
           dataAccess: {
-            memberVotes: [{dacUserId: 2}, {dacUserId: 3}]
+            memberVotes: [{userId: 2}, {userId: 3}]
           }
         }
       ]
@@ -118,19 +118,19 @@ describe('extractDacDataAccessVotesFromBucket', () => {
       votes: [
         {
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}, {dacUserId: 3}],
+            memberVotes: [{userId: 1}, {vote: false, userId: 2}, {userId: 3}],
           }
         },
         {
           dataAccess: {
             memberVotes: [
-              {vote: true, dacUserId: 4},
-              {vote: false, rationale: 'rationale', dacUserId: 1}],
+              {vote: true, userId: 4},
+              {vote: false, rationale: 'rationale', userId: 1}],
           }
         },
         {
           dataAccess: {
-            memberVotes: [{vote: true, dacUserId: 5}, {dacUserId: 6}],
+            memberVotes: [{vote: true, userId: 5}, {userId: 6}],
           }
         }
       ]
@@ -139,13 +139,13 @@ describe('extractDacDataAccessVotesFromBucket', () => {
 
     const votes = extractDacDataAccessVotesFromBucket(bucket, user);
     expect(votes).to.have.lengthOf(5);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: false, dacUserId: 2});
-    expect(votes).to.deep.include({dacUserId: 3});
-    expect(votes).to.deep.include({vote: true, dacUserId: 4});
-    expect(votes).to.deep.include({vote: false, rationale: 'rationale', dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 5});
-    expect(votes).to.not.deep.include({dacUserId: 6});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: false, userId: 2});
+    expect(votes).to.deep.include({userId: 3});
+    expect(votes).to.deep.include({vote: true, userId: 4});
+    expect(votes).to.deep.include({vote: false, rationale: 'rationale', userId: 1});
+    expect(votes).to.not.deep.include({vote: true, userId: 5});
+    expect(votes).to.not.deep.include({userId: 6});
   });
 
   it('only returns data access votes', () => {
@@ -153,10 +153,10 @@ describe('extractDacDataAccessVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{vote: true, dacUserId: 1}, {dacUserId: 2}],
+            memberVotes: [{vote: true, userId: 1}, {userId: 2}],
           },
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 3}],
+            memberVotes: [{userId: 1}, {vote: false, userId: 3}],
           }
         },
       ]
@@ -165,10 +165,10 @@ describe('extractDacDataAccessVotesFromBucket', () => {
 
     const votes = extractDacDataAccessVotesFromBucket(bucket, user);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: false, dacUserId: 3});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({dacUserId: 2});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: false, userId: 3});
+    expect(votes).to.not.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({userId: 2});
   });
 
   it('only returns member votes', () => {
@@ -176,8 +176,8 @@ describe('extractDacDataAccessVotesFromBucket', () => {
       votes: [
         {
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 3}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 2}],
+            memberVotes: [{userId: 1}, {vote: false, userId: 3}],
+            chairpersonVotes: [{vote: true, userId: 1}, {userId: 2}],
           }
         },
       ]
@@ -186,20 +186,20 @@ describe('extractDacDataAccessVotesFromBucket', () => {
 
     const votes = extractDacDataAccessVotesFromBucket(bucket, user);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: false, dacUserId: 3});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({dacUserId: 2});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: false, userId: 3});
+    expect(votes).to.not.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({userId: 2});
   });
 });
 
 describe('extractDacRPVotesFromBucket', () => {
-  it('returns empty list if rp votes in this bucket do not have the dacUserId of the given user', () => {
+  it('returns empty list if rp votes in this bucket do not have the userId of the given user', () => {
     const bucket = {
       votes: [
         {
           rp: {
-            memberVotes: [{dacUserId: 2}, {dacUserId: 3}]
+            memberVotes: [{userId: 2}, {userId: 3}]
           }
         }
       ]
@@ -215,19 +215,19 @@ describe('extractDacRPVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}, {dacUserId: 3}],
+            memberVotes: [{userId: 1}, {vote: false, userId: 2}, {userId: 3}],
           }
         },
         {
           rp: {
             memberVotes: [
-              {vote: true, dacUserId: 4},
-              {vote: false, rationale: 'rationale', dacUserId: 1}],
+              {vote: true, userId: 4},
+              {vote: false, rationale: 'rationale', userId: 1}],
           }
         },
         {
           rp: {
-            memberVotes: [{vote: true, dacUserId: 5}, {dacUserId: 6}],
+            memberVotes: [{vote: true, userId: 5}, {userId: 6}],
           }
         }
       ]
@@ -236,13 +236,13 @@ describe('extractDacRPVotesFromBucket', () => {
 
     const votes = extractDacRPVotesFromBucket(bucket, user);
     expect(votes).to.have.lengthOf(5);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: false, dacUserId: 2});
-    expect(votes).to.deep.include({dacUserId: 3});
-    expect(votes).to.deep.include({vote: true, dacUserId: 4});
-    expect(votes).to.deep.include({vote: false, rationale: 'rationale', dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 5});
-    expect(votes).to.not.deep.include({dacUserId: 6});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: false, userId: 2});
+    expect(votes).to.deep.include({userId: 3});
+    expect(votes).to.deep.include({vote: true, userId: 4});
+    expect(votes).to.deep.include({vote: false, rationale: 'rationale', userId: 1});
+    expect(votes).to.not.deep.include({vote: true, userId: 5});
+    expect(votes).to.not.deep.include({userId: 6});
   });
 
   it('only returns rp votes', () => {
@@ -250,10 +250,10 @@ describe('extractDacRPVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{vote: true, dacUserId: 1}, {dacUserId: 2}],
+            memberVotes: [{vote: true, userId: 1}, {userId: 2}],
           },
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 3}],
+            memberVotes: [{userId: 1}, {vote: false, userId: 3}],
           }
         },
       ]
@@ -262,10 +262,10 @@ describe('extractDacRPVotesFromBucket', () => {
 
     const votes = extractDacRPVotesFromBucket(bucket, user);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.not.deep.include({dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: false, dacUserId: 3});
-    expect(votes).to.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.deep.include({dacUserId: 2});
+    expect(votes).to.not.deep.include({userId: 1});
+    expect(votes).to.not.deep.include({vote: false, userId: 3});
+    expect(votes).to.deep.include({vote: true, userId: 1});
+    expect(votes).to.deep.include({userId: 2});
   });
 
   it('only returns member votes', () => {
@@ -273,8 +273,8 @@ describe('extractDacRPVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 3}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 2}],
+            memberVotes: [{userId: 1}, {vote: false, userId: 3}],
+            chairpersonVotes: [{vote: true, userId: 1}, {userId: 2}],
           }
         },
       ]
@@ -283,10 +283,10 @@ describe('extractDacRPVotesFromBucket', () => {
 
     const votes = extractDacRPVotesFromBucket(bucket, user);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: false, dacUserId: 3});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({dacUserId: 2});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: false, userId: 3});
+    expect(votes).to.not.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({userId: 2});
   });
 });
 
@@ -296,15 +296,15 @@ describe('extractUserDataAccessVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{vote: false, dacUserId: 1}],
+            memberVotes: [{vote: false, userId: 1}],
           },
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {dacUserId: 2}],
+            memberVotes: [{userId: 1}, {userId: 2}],
           },
         },
         {
           dataAccess: {
-            memberVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}],
+            memberVotes: [{vote: true, userId: 1}, {userId: 3}],
           },
         },
       ]
@@ -313,10 +313,10 @@ describe('extractUserDataAccessVotesFromBucket', () => {
 
     const votes = extractUserDataAccessVotesFromBucket(bucket, user, false);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({dacUserId: 2});
-    expect(votes).to.not.deep.include({dacUserId: 3});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({userId: 2});
+    expect(votes).to.not.deep.include({userId: 3});
   });
 
   it('only returns member votes if isChair is false', () => {
@@ -324,9 +324,9 @@ describe('extractUserDataAccessVotesFromBucket', () => {
       votes: [
         {
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}],
-            finalVotes: [{vote: true, dacUserId: 1}]
+            memberVotes: [{userId: 1}, {vote: false, userId: 2}],
+            chairpersonVotes: [{vote: true, userId: 1}, {userId: 3}],
+            finalVotes: [{vote: true, userId: 1}]
           },
         },
       ]
@@ -335,10 +335,10 @@ describe('extractUserDataAccessVotesFromBucket', () => {
 
     const votes = extractUserDataAccessVotesFromBucket(bucket, user, false);
     expect(votes).to.have.lengthOf(1);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: false, dacUserId: 2});
-    expect(votes).to.not.deep.include({dacUserId: 3});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.not.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({vote: false, userId: 2});
+    expect(votes).to.not.deep.include({userId: 3});
   });
 
   it('only returns chairperson votes if isChair is true', () => {
@@ -346,9 +346,9 @@ describe('extractUserDataAccessVotesFromBucket', () => {
       votes: [
         {
           dataAccess: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}],
-            finalVotes: [{vote: true, dacUserId: 1}]
+            memberVotes: [{userId: 1}, {vote: false, userId: 2}],
+            chairpersonVotes: [{vote: true, userId: 1}, {userId: 3}],
+            finalVotes: [{vote: true, userId: 1}]
           },
         },
       ]
@@ -357,10 +357,10 @@ describe('extractUserDataAccessVotesFromBucket', () => {
 
     const votes = extractUserDataAccessVotesFromBucket(bucket, user, true);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: false, dacUserId: 2});
-    expect(votes).to.not.deep.include({dacUserId: 3});
+    expect(votes).to.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({userId: 1});
+    expect(votes).to.not.deep.include({vote: false, userId: 2});
+    expect(votes).to.not.deep.include({userId: 3});
   });
 });
 
@@ -370,15 +370,15 @@ describe('extractUserRPVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{dacUserId: 1}, {dacUserId: 2}],
+            memberVotes: [{userId: 1}, {userId: 2}],
           },
           dataAccess: {
-            memberVotes: [{vote: false, dacUserId: 1}],
+            memberVotes: [{vote: false, userId: 1}],
           },
         },
         {
           rp: {
-            memberVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}],
+            memberVotes: [{vote: true, userId: 1}, {userId: 3}],
           },
         },
       ]
@@ -387,10 +387,10 @@ describe('extractUserRPVotesFromBucket', () => {
 
     const votes = extractUserRPVotesFromBucket(bucket, user, false);
     expect(votes).to.have.lengthOf(2);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({dacUserId: 2});
-    expect(votes).to.not.deep.include({dacUserId: 3});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({userId: 2});
+    expect(votes).to.not.deep.include({userId: 3});
   });
 
   it('only returns member votes if isChair is false', () => {
@@ -398,8 +398,8 @@ describe('extractUserRPVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}]
+            memberVotes: [{userId: 1}, {vote: false, userId: 2}],
+            chairpersonVotes: [{vote: true, userId: 1}, {userId: 3}]
           },
         },
       ]
@@ -408,10 +408,10 @@ describe('extractUserRPVotesFromBucket', () => {
 
     const votes = extractUserRPVotesFromBucket(bucket, user, false);
     expect(votes).to.have.lengthOf(1);
-    expect(votes).to.deep.include({dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: true, dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: false, dacUserId: 2});
-    expect(votes).to.not.deep.include({dacUserId: 3});
+    expect(votes).to.deep.include({userId: 1});
+    expect(votes).to.not.deep.include({vote: true, userId: 1});
+    expect(votes).to.not.deep.include({vote: false, userId: 2});
+    expect(votes).to.not.deep.include({userId: 3});
   });
 
   it('only returns chairperson votes if isChair is true', () => {
@@ -419,8 +419,8 @@ describe('extractUserRPVotesFromBucket', () => {
       votes: [
         {
           rp: {
-            memberVotes: [{dacUserId: 1}, {vote: false, dacUserId: 2}],
-            chairpersonVotes: [{vote: true, dacUserId: 1}, {dacUserId: 3}]
+            memberVotes: [{userId: 1}, {vote: false, userId: 2}],
+            chairpersonVotes: [{vote: true, userId: 1}, {userId: 3}]
           },
         },
       ]
@@ -429,51 +429,51 @@ describe('extractUserRPVotesFromBucket', () => {
 
     const votes = extractUserRPVotesFromBucket(bucket, user, true);
     expect(votes).to.have.lengthOf(1);
-    expect(votes).to.not.deep.include({dacUserId: 1});
-    expect(votes).to.not.deep.include({vote: false, dacUserId: 2});
-    expect(votes).to.not.deep.include({dacUserId: 3});
+    expect(votes).to.not.deep.include({userId: 1});
+    expect(votes).to.not.deep.include({vote: false, userId: 2});
+    expect(votes).to.not.deep.include({userId: 3});
   });
 });
 
 describe('collapseVotesByUser', () => {
   it('does not collapse votes by different users', () => {
     const votes = [
-      {dacUserId: 1, displayName: 'John', vote: true, voteId: 1},
-      {dacUserId: 2, displayName: 'John', vote: true, voteId: 2},
-      {dacUserId: 3, displayName: 'Lauren', vote: true, voteId: 3},
+      {userId: 1, displayName: 'John', vote: true, voteId: 1},
+      {userId: 2, displayName: 'John', vote: true, voteId: 2},
+      {userId: 3, displayName: 'Lauren', vote: true, voteId: 3},
     ];
 
     const collapsedVotes = collapseVotesByUser(votes);
     expect(collapsedVotes).to.have.lengthOf(3);
-    expect(collapsedVotes).to.deep.include({dacUserId: 1, voteId: 1, displayName: 'John', vote: true, rationale: null, lastUpdated: null});
-    expect(collapsedVotes).to.deep.include({dacUserId: 2, voteId: 2, displayName: 'John', vote: true, rationale: null, lastUpdated: null});
-    expect(collapsedVotes).to.deep.include({dacUserId: 3, voteId: 3, displayName: 'Lauren', vote: true, rationale: null, lastUpdated: null});
+    expect(collapsedVotes).to.deep.include({userId: 1, voteId: 1, displayName: 'John', vote: true, rationale: null, lastUpdated: null});
+    expect(collapsedVotes).to.deep.include({userId: 2, voteId: 2, displayName: 'John', vote: true, rationale: null, lastUpdated: null});
+    expect(collapsedVotes).to.deep.include({userId: 3, voteId: 3, displayName: 'Lauren', vote: true, rationale: null, lastUpdated: null});
   });
 
   it('does not collapse votes by the same user with different vote values', () => {
     const votes = [
-      {dacUserId: 1, displayName: 'John', vote: true, voteId: 1},
-      {dacUserId: 1, displayName: 'John', vote: false, voteId: 2},
-      {dacUserId: 1, displayName: 'John', voteId: 3},
+      {userId: 1, displayName: 'John', vote: true, voteId: 1},
+      {userId: 1, displayName: 'John', vote: false, voteId: 2},
+      {userId: 1, displayName: 'John', voteId: 3},
     ];
 
     const collapsedVotes = collapseVotesByUser(votes);
     expect(collapsedVotes).to.have.lengthOf(3);
-    expect(collapsedVotes).to.deep.include({dacUserId: 1, voteId: 1, displayName: 'John', vote: true, rationale: null, lastUpdated: null});
-    expect(collapsedVotes).to.deep.include({dacUserId: 1, voteId: 2, displayName: 'John', vote: false, rationale: null, lastUpdated: null});
-    expect(collapsedVotes).to.deep.include({dacUserId: 1, voteId: 3, displayName: 'John', vote: undefined, rationale: null, lastUpdated: null});
+    expect(collapsedVotes).to.deep.include({userId: 1, voteId: 1, displayName: 'John', vote: true, rationale: null, lastUpdated: null});
+    expect(collapsedVotes).to.deep.include({userId: 1, voteId: 2, displayName: 'John', vote: false, rationale: null, lastUpdated: null});
+    expect(collapsedVotes).to.deep.include({userId: 1, voteId: 3, displayName: 'John', vote: undefined, rationale: null, lastUpdated: null});
   });
 
   it('collapses votes by the same user without appending identical dates / rationales', () => {
     const votes = [
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 1},
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 2},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 1},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 2},
     ];
 
     const collapsedVotes = collapseVotesByUser(votes);
     expect(collapsedVotes).to.have.lengthOf(1);
     expect(collapsedVotes).to.deep.include({
-      dacUserId: 1,
+      userId: 1,
       voteId: 1,
       displayName: 'John',
       vote: true,
@@ -484,15 +484,15 @@ describe('collapseVotesByUser', () => {
 
   it('collapses votes by the same user and appends different dates', () => {
     const votes = [
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 1},
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '30000', voteId: 2},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 1},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '30000', voteId: 2},
     ];
     const collapsedVotes = collapseVotesByUser(votes);
     const formattedDate = `${formatDate('20000')}\n${formatDate('30000')}\n`;
 
     expect(collapsedVotes).to.have.lengthOf(1);
     expect(collapsedVotes).to.deep.include({
-      dacUserId: 1,
+      userId: 1,
       voteId: 1,
       displayName: 'John',
       vote: true,
@@ -503,14 +503,14 @@ describe('collapseVotesByUser', () => {
 
   it('collapses votes by the same user and appends different rationales', () => {
     const votes = [
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale1', createDate: '20000', voteId: 1},
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale2', createDate: '20000', voteId: 2},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale1', createDate: '20000', voteId: 1},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale2', createDate: '20000', voteId: 2},
     ];
 
     const collapsedVotes = collapseVotesByUser(votes);
     expect(collapsedVotes).to.have.lengthOf(1);
     expect(collapsedVotes).to.deep.include({
-      dacUserId: 1,
+      userId: 1,
       voteId: 1,
       displayName: 'John',
       vote: true,
@@ -521,14 +521,14 @@ describe('collapseVotesByUser', () => {
 
   it('does not append null dates / rationales', () => {
     const votes = [
-      {dacUserId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 1},
-      {dacUserId: 1, displayName: 'John', vote: true, voteId: 2},
+      {userId: 1, displayName: 'John', vote: true, rationale: 'rationale', createDate: '20000', voteId: 1},
+      {userId: 1, displayName: 'John', vote: true, voteId: 2},
     ];
 
     const collapsedVotes = collapseVotesByUser(votes);
     expect(collapsedVotes).to.have.lengthOf(1);
     expect(collapsedVotes).to.deep.include({
-      dacUserId: 1,
+      userId: 1,
       voteId: 1,
       vote: true,
       displayName: 'John',

--- a/src/pages/dar_collection_review/DarCollectionReview.js
+++ b/src/pages/dar_collection_review/DarCollectionReview.js
@@ -58,13 +58,13 @@ const tabsForUser = (user, buckets, adminPage = false) => {
     flatMap(b => b.votes),
     flatMap(v => v.dataAccess),
     flatMap(da => da.memberVotes),
-    filter(v => v.dacUserId === user.userId)
+    filter(v => v.userId === user.userId)
   )(dataAccessBuckets);
   const myChairVotes = flow(
     flatMap(b => b.votes),
     flatMap(v => v.dataAccess),
     flatMap(da => da.chairpersonVotes),
-    filter(v => v.dacUserId === user.userId)
+    filter(v => v.userId === user.userId)
   )(dataAccessBuckets);
   const updatedTabs = { applicationInformation: 'Application Information' };
   if (!isEmpty(myMemberVotes)) {

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -88,10 +88,10 @@ export const extractDacRPVotesFromBucket = (bucket, user, adminPage) => {
 
 
 // Applies filter to arrays of votes grouped by election and
-// only keeps arrays where at least one vote has the dacUserId of the provided user
+// only keeps arrays where at least one vote has the userId of the provided user
 const filterVoteArraysForUsersDac = (voteArrays = [], user) => {
   const userIdsOfVotes = (votes) => {
-    return map(vote => vote.dacUserId)(votes);
+    return map(vote => vote.userId)(votes);
   };
 
   return filter(
@@ -111,7 +111,7 @@ export const extractUserDataAccessVotesFromBucket = (bucket, user, isChair = fal
       filteredData.memberVotes)
   )(votes);
   return !adminPage ?
-    filter((vote) => vote.dacUserId === user.userId)(output) :
+    filter((vote) => vote.userId === user.userId)(output) :
     filter((vote) => !isNil(vote.vote))(output);
 };
 
@@ -129,14 +129,14 @@ export const extractUserRPVotesFromBucket = (bucket, user, isChair = false, admi
   )(votes);
 
   output = !adminPage ?
-    filter(vote => vote.dacUserId === user.userId)(output) :
+    filter(vote => vote.userId === user.userId)(output) :
     filter(vote => !isNil(vote.vote))(output);
   return output;
 };
 
 //collapses votes by the same user with same vote (true/false) into a singular vote with appended rationales / dates if different
 export const collapseVotesByUser = (votes) => {
-  const votesGroupedByUser = groupBy(vote => vote.dacUserId)(cloneDeep(votes));
+  const votesGroupedByUser = groupBy(vote => vote.userId)(cloneDeep(votes));
   return flatMap(userIdKey => {
     const votesByUser = votesGroupedByUser[userIdKey];
     const collapsedVotes = collapseVotes({votes: votesByUser});
@@ -152,7 +152,7 @@ const collapseVotes = ({votes}) => {
     const lastUpdate = vote.updateDate || vote.createDate;
     if (isNil(matchingVote)) {
       collapsedVotes[`${vote.vote}`] = {
-        dacUserId: vote.dacUserId,
+        userId: vote.userId,
         vote: vote.vote,
         voteId: vote.voteId,
         displayName: vote.displayName,
@@ -176,7 +176,7 @@ const convertToVoteObjects = ({collapsedVotes}) => {
     const collapsedDate = appendAll(map(date => formatDate(date))(collapsedVote.lastUpdates));
 
     return {
-      dacUserId: collapsedVote.dacUserId,
+      userId: collapsedVote.userId,
       vote: collapsedVote.vote,
       voteId: collapsedVote.voteId,
       displayName: collapsedVote.displayName,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2389

On the UI side use the vote `userId` instead of the old `dacUserId`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
