### PR TITLE
[DUOS-2392][risk=no] Add zero-width spaces to long dataset names

### DIFF
--- a/src/pages/dar_application/DucAddendum.js
+++ b/src/pages/dar_application/DucAddendum.js
@@ -133,7 +133,7 @@ export default function DucAddendum(props) {
             style: columnStyles
           },
           {
-            data: dataset.datasetName.replaceAll("_", "_\u200b"),
+            data: dataset.datasetName.replaceAll('_', '_\u200b'),
             id: dataset.dataSetId,
             style: columnStyles
           },

--- a/src/pages/dar_application/DucAddendum.js
+++ b/src/pages/dar_application/DucAddendum.js
@@ -133,17 +133,17 @@ export default function DucAddendum(props) {
             style: columnStyles
           },
           {
-            data: dataset.datasetName,
+            data: dataset.datasetName.replaceAll("_", "_\u200b"),
             id: dataset.dataSetId,
             style: columnStyles
           },
           {
-            data: 'Unknown',
+            data: '',
             id: dataset.dataSetId,
             style: columnStyles
           },
           {
-            data: 'Unknown',
+            data: '',
             id: dataset.dataSetId,
             style: columnStyles
           }

--- a/src/pages/dar_application/DucAddendum.js
+++ b/src/pages/dar_application/DucAddendum.js
@@ -133,7 +133,7 @@ export default function DucAddendum(props) {
             style: columnStyles
           },
           {
-            data: dataset.datasetName.replaceAll('_', '_\u200b'),
+            data: dataset.datasetName?.replaceAll('_', '_\u200b'),
             id: dataset.dataSetId,
             style: columnStyles
           },


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2392

### Summary

Adds zero-width spaces to long dataset names with underscores.

![Screenshot 2023-03-23 at 10-27-44 Broad Data Use Oversight System](https://user-images.githubusercontent.com/16434376/227235002-53384245-3484-43a3-adb8-0ad8396681b1.png)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
