### PR TITLE
[DUOS-2388][risk=no]Make Public Visibility a Radio Button

### DIFF
--- a/src/components/data_submission/ds_study_information.js
+++ b/src/components/data_submission/ds_study_information.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { h, h2, div, span } from 'react-hyperscript-helpers';
+import { h, h2, div } from 'react-hyperscript-helpers';
 import { isEmpty } from 'lodash/fp';
 
 import { Notifications } from '../../libs/utils';
@@ -171,18 +171,17 @@ export default function DataSubmissionStudyInformation(props) {
       id: 'publicVisibility',
       title: 'Public Visibility',
       validators: [FormValidators.REQUIRED],
-      type: FormFieldTypes.SLIDER,
+      type: FormFieldTypes.RADIOGROUP,
       defaultValue: true,
-      description: `Please select if you would like your dataset
-        to be publicly visible for the requesters to see and select
-        for an access request`,
-      toggleText: span({ style: {
-        fontWeight: 'normal',
-        fontStyle: 'italic'
-      }}, ['Visible']),
+      description: 'Please select one of the following data use permissions for your dataset',
+      name: 'publicVisibility',
+      options: [
+        { name: 'yes', text: 'Yes, I want my dataset info to be visible and available for requests' },
+        { name: 'no', text: 'No, I do not want my dataset info to be visible and available for requests' }
+      ],
       onChange,
       validation: validation.publicVisibility,
       onValidationChange
-    })
+    }),
   ]);
 }


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2388
Makes "public visibility" section on DS form a radio button.
<img width="687" alt="image" src="https://user-images.githubusercontent.com/91574136/227620923-68572375-6a79-47f0-ad35-83227540e8e6.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
