### PR TITLE
[DUOS-2387][risk=no]Remove duplicate PI Name Field

### DIFF
--- a/src/components/data_submission/NIHAdministrativeInformation.js
+++ b/src/components/data_submission/NIHAdministrativeInformation.js
@@ -24,15 +24,6 @@ export const NIHAdministrativeInformation = (props) => {
   }, [
     h2('NIH Administrative Information'),
     h(FormField, {
-      id: 'piName',
-      title: 'Principal Investigator Name',
-      validators: [FormValidators.REQUIRED],
-      onChange,
-      defaultValue: initialFormData?.piName,
-      validation: validation.piName,
-      onValidationChange,
-    }),
-    h(FormField, {
       id: 'piInstitution',
       title: 'Principal Investigator Institution',
       isRendered: !isEmpty(institutions),

--- a/src/components/data_submission/ds_study_information.js
+++ b/src/components/data_submission/ds_study_information.js
@@ -94,6 +94,7 @@ export default function DataSubmissionStudyInformation(props) {
     h(FormField, {
       id: 'piName',
       title: 'Principal Investigator Name',
+      validators: [FormValidators.REQUIRED],
       validation: validation.piName,
       onChange,
       onValidationChange


### PR DESCRIPTION
## Addresses 
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2387
Updates PI name fields DS Form
Study Info Section:
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/91574136/227624908-169e020b-9eb5-4a9c-87de-619f739a31cb.png">

NIH Adminstrative Info section:
<img width="960" alt="image" src="https://user-images.githubusercontent.com/91574136/227625158-2bac7e21-9d24-4ec2-a833-8f59e1cb7b23.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
