### PR TITLE
[DUOS-2386][risk=no]Data Custodian Email & Data Submitter Name Description

### DIFF
--- a/src/components/data_submission/ds_study_information.js
+++ b/src/components/data_submission/ds_study_information.js
@@ -102,7 +102,7 @@ export default function DataSubmissionStudyInformation(props) {
       isRendered: !isEmpty(user),
       id: 'dataSubmitterName',
       title: 'Data Submitter Name ',
-      helpText: `The individual completing this form will be saved with the study.`,
+      description: `The individual completing this form will be saved with the study.`,
       defaultValue: user?.displayName,
       validation: validation.dataSubmitterName,
       disabled: true,

--- a/src/components/data_submission/ds_study_information.js
+++ b/src/components/data_submission/ds_study_information.js
@@ -122,8 +122,8 @@ export default function DataSubmissionStudyInformation(props) {
     h(FormField, {
       id: 'dataCustodianEmail',
       title: 'Data Custodian Email',
-      helpText: `Insert the email for any individual with the 
-        authority to add/remove users access to this study’s datasets.`,
+      description: `Insert the email for any individual with the 
+      authority to add/remove users access to this study’s datasets.`,
       type: FormFieldTypes.MULTITEXT,
       validators: [
         FormValidators.EMAIL


### PR DESCRIPTION
## Addresses 
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2386
Changes description of Data Custodian Email & Data Submitter Name to be uniform and on one line
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/91574136/227628950-85340ce0-4cd1-4dfc-9671-732f9c32bd98.png">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
