### PR TITLE
[DUOS-2385][risk=no] Data Location Updates

### DIFF
--- a/src/components/data_submission/consent_group/ConsentGroupErrors.js
+++ b/src/components/data_submission/consent_group/ConsentGroupErrors.js
@@ -12,7 +12,7 @@ export const computeConsentGroupValidationErrors = (consentGroup) => {
     errors.push('Please select a primary consent group.');
   }
 
-  if (isNil(consentGroup.url) || consentGroup.url === '') {
+  if ((isNil(consentGroup.url) || consentGroup.url === '') && consentGroup.dataLocation !== 'Not Determined') {
     errors.push('Please specify the URL of the data.');
   } else {
     try {
@@ -26,7 +26,7 @@ export const computeConsentGroupValidationErrors = (consentGroup) => {
     errors.push('Please specify the name of the consent group');
   }
 
-  if (isNil(consentGroup.dataLocation) || consentGroup.dataLocation.length === 0) {
+  if (isNil(consentGroup.dataLocation) || consentGroup.dataLocation === '') {
     errors.push('Please specify data location (or specify \'Not Determined\')');
   }
 
@@ -36,6 +36,10 @@ export const computeConsentGroupValidationErrors = (consentGroup) => {
 
   if (!isNil(consentGroup.otherPrimary) && consentGroup.otherPrimary == '') {
     errors.push('Please specify the \'Other\' primary consent.');
+  }
+
+  if (isNil(consentGroup.dataAccessCommitteeId) && consentGroup.openAccess !== true) {
+    errors.push('Please specify the DAC ID');
   }
 
   if (!isNil(consentGroup.otherSecondary) && consentGroup.otherSecondary == '') {
@@ -48,6 +52,12 @@ export const computeConsentGroupValidationErrors = (consentGroup) => {
 
   if (isNil(consentGroup.fileTypes) || isEmpty(consentGroup.fileTypes)) {
     errors.push('Please specify the file type.');
+  } else {
+    consentGroup.fileTypes.forEach((ft) => {
+      if (isNil(ft.numberOfParticipants)) {
+        errors.push('Please specify the number of participants.')
+      }
+    })
   }
 
   return errors;

--- a/src/components/data_submission/consent_group/ConsentGroupErrors.js
+++ b/src/components/data_submission/consent_group/ConsentGroupErrors.js
@@ -55,9 +55,9 @@ export const computeConsentGroupValidationErrors = (consentGroup) => {
   } else {
     consentGroup.fileTypes.forEach((ft) => {
       if (isNil(ft.numberOfParticipants)) {
-        errors.push('Please specify the number of participants.')
+        errors.push('Please specify the number of participants.');
       }
-    })
+    });
   }
 
   return errors;

--- a/src/components/data_submission/consent_group/ConsentGroupForm.js
+++ b/src/components/data_submission/consent_group/ConsentGroupForm.js
@@ -39,7 +39,7 @@ export const ConsentGroupForm = (props) => {
     // dataLocation is one of:
     // "AnVIL Workspace", "Terra Workspace",
     // "TDR Location", "Not Determined"
-    dataLocation: [],
+    dataLocation: null,
 
     url: '',
     fileTypes: [{}],

--- a/src/components/data_submission/consent_group/ConsentGroupSummary.js
+++ b/src/components/data_submission/consent_group/ConsentGroupSummary.js
@@ -201,7 +201,7 @@ export const ConsentGroupSummary = (props) => {
           }
         }, 'Data Location'),
         p({}, [
-          (!isNil(consentGroup.dataLocation)? consentGroup.dataLocation.join(', ') : ''),
+          consentGroup.dataLocation,
         ]),
         input({
           disabled: true,

--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { div, h } from 'react-hyperscript-helpers';
 import { isNil, isString } from 'lodash/fp';
 import { FormFieldTypes, FormField, FormTable, FormValidators, FormFieldTitle } from '../../forms/forms';
@@ -61,13 +61,6 @@ export const EditConsentGroup = (props) => {
   const [showMORText, setShowMORText] = useState(!isNil(consentGroup.mor));
   const [morText, setMORText] = useState(consentGroup.mor);
 
-
-  useEffect(() => {
-    console.log(consentGroup.dataLocation);
-  }, [consentGroup.dataLocation]);
-  useEffect(() => {
-    console.log(consentGroup);
-  }, [consentGroup])
   const onChange = ({ key, value }) => {
     setConsentGroup({
       ...consentGroup,
@@ -86,8 +79,8 @@ export const EditConsentGroup = (props) => {
       });
 
       return consentGroup;
-    })
-  }
+    });
+  };
 
   const onPrimaryChange = ({ key, value }) => {
     setConsentGroup({
@@ -480,7 +473,7 @@ export const EditConsentGroup = (props) => {
           if (value === 'Not Determined') {
             // if not determined, clear url field as well.
             // must do in one batch call, otherwise react gets confused.
-            onBatchChange({ key, value }, {key: 'url', value: ''})
+            onBatchChange({ key, value }, {key: 'url', value: ''});
           } else {
             onChange({key, value, isValid});
           }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2385

I also fixed some bugs in how the consent group was calculating errors. More cleanup is needed - I made another ticket (DUOS-2402) for cleaning them up & making consent errors look like the rest of the form.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
