### PR TITLE
[DUOS-2402][risk=no] Cleanup Consent Group Validation

### DIFF
--- a/src/components/data_submission/consent_group/ConsentGroupForm.js
+++ b/src/components/data_submission/consent_group/ConsentGroupForm.js
@@ -2,7 +2,8 @@ import { useState } from 'react';
 import { div, h, span, a, button } from 'react-hyperscript-helpers';
 import ConsentGroupSummary from './ConsentGroupSummary';
 import { EditConsentGroup } from './EditConsentGroup';
-import { computeConsentGroupValidationErrors, ConsentGroupErrors } from './ConsentGroupErrors';
+import { computeConsentGroupValidationErrors } from './ConsentGroupErrors';
+import { isEmpty, cloneDeep, set } from 'lodash';
 
 export const ConsentGroupForm = (props) => {
   const {
@@ -10,8 +11,6 @@ export const ConsentGroupForm = (props) => {
     saveConsentGroup,
     updateNihInstitutionalCertificationFile,
     deleteConsentGroup,
-    validation,
-    onValidationChange,
     disableDelete,
   } = props;
 
@@ -47,7 +46,16 @@ export const ConsentGroupForm = (props) => {
   });
 
   const [nihInstitutionalCertificationFile, setNihInstitutionalCertificationFile] = useState(null);
-  const [consentGroupValidationErrors, setConsentGroupValidationErrors] = useState([]);
+  const [validation, setValidation] = useState({});
+
+  const onValidationChange = ({key, validation}) => {
+    setValidation((val) => {
+      const newValidation = cloneDeep(val);
+      set(newValidation, key, validation);
+      return newValidation;
+    });
+  };
+
   const [editMode, setEditMode] = useState(true);
 
   return div({
@@ -59,11 +67,6 @@ export const ConsentGroupForm = (props) => {
     },
     id: idx+'_consentGroupForm'
   }, [
-
-    h(ConsentGroupErrors,
-      {
-        errors: consentGroupValidationErrors,
-      }),
 
     (editMode
       ? h(EditConsentGroup, {
@@ -126,9 +129,9 @@ export const ConsentGroupForm = (props) => {
           isRendered: editMode,
           onClick: () => {
             const errors = computeConsentGroupValidationErrors(consentGroup);
-            const valid = errors.length === 0;
+            const valid = isEmpty(errors);
 
-            setConsentGroupValidationErrors(errors);
+            setValidation(errors);
 
             if (valid) {
               saveConsentGroup({ value: consentGroup, valid: true });

--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -40,17 +40,17 @@ export const EditConsentGroup = (props) => {
     setConsentGroup,
     nihInstitutionalCertificationFile,
     setNihInstitutionalCertificationFile,
-    idx,
-    dacs,
     validation,
     onValidationChange,
+    idx,
+    dacs,
   } = props;
 
   const [showOtherSecondaryText, setShowOtherSecondaryText] = useState(!isNil(consentGroup.otherSecondary));
   const [otherSecondaryText, setOtherSecondaryText] = useState(consentGroup.otherSecondary);
 
   const [showGSText, setShowGSText] = useState(!isNil(consentGroup.gs));
-  const [gsText, setGSText] = useState(consentGroup.gs);
+  const [gsText, setGSText] = useState(consentGroup.gs || '');
 
   const [showOtherPrimaryText, setShowOtherPrimaryText] = useState(!isNil(consentGroup.otherPrimary));
   const [otherPrimaryText, setOtherPrimaryText] = useState(consentGroup.otherPrimary || '');
@@ -59,7 +59,7 @@ export const EditConsentGroup = (props) => {
   const [selectedDiseases, setSelectedDiseases] = useState(consentGroup.diseaseSpecificUse || []);
 
   const [showMORText, setShowMORText] = useState(!isNil(consentGroup.mor));
-  const [morText, setMORText] = useState(consentGroup.mor);
+  const [morText, setMORText] = useState(consentGroup.mor || '');
 
   const onChange = ({ key, value }) => {
     setConsentGroup({
@@ -135,9 +135,9 @@ export const EditConsentGroup = (props) => {
           onChange: ({ value }) => {
             onPrimaryChange({ key: value, value: true });
           },
-          validation: validation.generalResearchUse,
+          validation: validation.primaryConsent,
           onValidationChange: ({ validation }) => {
-            onValidationChange({ key: 'generalResearchUse', validation });
+            onValidationChange({ key: 'primaryConsent', validation });
           },
         }),
 
@@ -151,9 +151,9 @@ export const EditConsentGroup = (props) => {
           onChange: ({ value }) => {
             onPrimaryChange({ key: value, value: true });
           },
-          validation: validation.hmb,
+          validation: validation.primaryConsent,
           onValidationChange: ({ validation }) => {
-            onValidationChange({ key: 'hmb', validation });
+            onValidationChange({ key: 'primaryConsent', validation });
           },
         }),
 
@@ -164,13 +164,16 @@ export const EditConsentGroup = (props) => {
           value: 'diseaseSpecificUse',
           toggleText: 'Disease-Specific Research Use',
           defaultValue: selectedPrimaryGroup(consentGroup),
+          validation: validation.primaryConsent,
+          onValidationChange: ({ validation }) => {
+            onValidationChange({ key: 'primaryConsent', validation });
+          },
           onChange: ({ value }) => {
             onPrimaryChange({
               key: value,
               value: selectedDiseases
             });
           },
-          validation: validation.diseaseSpecificUse,
         }),
 
         div({
@@ -192,7 +195,9 @@ export const EditConsentGroup = (props) => {
             placeholder: 'Please enter one or more diseases',
             defaultValue: selectedDiseases,
             validation: validation.diseaseSpecificUse,
-            onValidationChange,
+            onValidationChange: ({ validation }) => {
+              onValidationChange({ key: 'diseaseSpecificUse', validation });
+            },
             onChange: ({ key, value, isValid }) => {
               setSelectedDiseases(value);
               onChange({
@@ -214,9 +219,9 @@ export const EditConsentGroup = (props) => {
           onChange: ({ value }) => {
             onPrimaryChange({ key: value, value: true });
           },
-          validation: validation.poa,
+          validation: validation.primaryConsent,
           onValidationChange: ({ validation }) => {
-            onValidationChange({ key: 'poa', validation });
+            onValidationChange({ key: 'primaryConsent', validation });
           },
         }),
 
@@ -230,7 +235,10 @@ export const EditConsentGroup = (props) => {
           onChange: ({ value }) => {
             onPrimaryChange({ key: value, value: true });
           },
-          validation: validation.openAccess,
+          validation: validation.primaryConsent,
+          onValidationChange: ({ validation }) => {
+            onValidationChange({ key: 'primaryConsent', validation });
+          },
         }),
 
         h(FormField, {
@@ -243,7 +251,10 @@ export const EditConsentGroup = (props) => {
           onChange: ({ value }) => {
             onPrimaryChange({ key: value, value: otherPrimaryText });
           },
-          validation: validation.otherPrimary,
+          validation: validation.primaryConsent,
+          onValidationChange: ({ validation }) => {
+            onValidationChange({ key: 'primaryConsent', validation });
+          },
         }),
 
         h(FormField, {
@@ -432,6 +443,7 @@ export const EditConsentGroup = (props) => {
       h(FormField, {
         isRendered: consentGroup.openAccess !== true,
         id: idx + 'dataAccessCommitteeId',
+        name: 'dataAccessCommitteeId',
         title: 'Data Access Committee*',
         description: 'Please select which DAC should govern requests for this dataset',
         type: FormFieldTypes.SELECT,
@@ -439,8 +451,11 @@ export const EditConsentGroup = (props) => {
           return { dacId: dac.dacId, displayText: dac.name };
         }),
         onChange: ({ key, value }) => {
-          onChange({ key, value: value.dacId });
-        }
+          onChange({ key, value: value?.dacId });
+        },
+        validators: [FormValidators.REQUIRED],
+        validation: validation.dataAccessCommitteeId,
+        onValidationChange,
       }),
     ]),
 

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -437,11 +437,11 @@ export const FormInputYesNoRadioGroup = (config) => {
 export const FormInputRadioButton = (config) => {
   const {
     id, disabled, value, toggleText,
-    formValue,
+    formValue, validation
   } = config;
 
   return div({
-    className: 'radio-button-container',
+    className: `radio-button-container ${!isValid(validation) ? 'errored' : ''}`,
   }, [
     h(RadioButton, {
       id: id,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2402

Consent groups had a strange way of validation with top-level messages. This removes these top level messages and replaces them with a much cleaner usage of external validation state, which will highlight fields if they are invalid on save, mirroring the rest of the form.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
