### PR TITLE
[DUOS-2390][risk=no]DS Form: NIH Anvil Use Cleanup

### DIFF
--- a/cypress/component/DataSubmission/ds_nih_anvil_use.spec.js
+++ b/cypress/component/DataSubmission/ds_nih_anvil_use.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import { cloneDeep } from 'lodash/fp';
-import NihAnvilUse from '../../../src/components/data_submission/NihAnvilUse';
+import NihAnvilUse, { YES_NHGRI_YES_PHS_ID } from '../../../src/components/data_submission/NihAnvilUse';
 
 let propCopy;
 
@@ -11,6 +11,7 @@ const props = {
   validation: {},
   onValidationChange: () => {},
   updateParentRenderState: () => {},
+  formData: {}
 };
 
 beforeEach(() => {
@@ -19,7 +20,6 @@ beforeEach(() => {
 
 describe('NihAnvilUse - Tests', () => {
   it('should mount with only the nihAnvilUse form field displayed', () => {
-    propCopy.formData = {};
     mount(<NihAnvilUse {...propCopy}/>);
     const formFields = cy.get('.formField-container');
     formFields.should('exist');
@@ -32,6 +32,7 @@ describe('NihAnvilUse - Tests', () => {
   });
 
   it('should show dbGaP form fields if NHGRI funded and has dbGaP ID', () => {
+    propCopy.formData.nihAnvilUse = YES_NHGRI_YES_PHS_ID;
     mount(<NihAnvilUse {...propCopy}/>);
     cy.get('#nihAnvilUse_yes_nhgri_yes_phs_id').click();
 

--- a/src/components/data_submission/NihAnvilUse.js
+++ b/src/components/data_submission/NihAnvilUse.js
@@ -24,12 +24,11 @@ const allNihAnvilUseFields = [
 export default function NihAnvilUse(props) {
   const {
     onChange,
-    initialFormData,
+    formData,
     validation,
     onValidationChange,
     updateParentRenderState,
   } = props;
-  const [nihAnvilUse, setNihAnvilUse] = useState(initialFormData?.nihAnvilUse || null);
 
   const clearFormValues = () => {
     allNihAnvilUseFields.forEach((field) => onChange({key: field, value: undefined, isValid: true}));
@@ -54,19 +53,19 @@ export default function NihAnvilUse(props) {
         clearFormValues();
         const value = nihAnvilUseLabels[config.value];
         onChange({key: config.key, value: [value], isValid: config.isValid});
-        setNihAnvilUse(value);
         updateParentRenderState({key: config.key, value: [value]});
       },
       validation: validation.nihAnvilUse,
       onValidationChange,
     }),
 
-    div({ isRendered: nihAnvilUse === YES_NHGRI_YES_PHS_ID }, [
+    div({ isRendered: formData.nihAnvilUse === YES_NHGRI_YES_PHS_ID }, [
       h(FormField, {
         id: 'dbGaPPhsID',
         title: 'dbGaP phs ID',
         placeholder: 'Firstname Lastname',
         validators: [FormValidators.REQUIRED],
+        defaultValue: formData.dbGaPPhsID,
         onChange,
         validation: validation.dbGaPPhsID,
         onValidationChange,
@@ -76,6 +75,7 @@ export default function NihAnvilUse(props) {
         title: 'dbGaP Study Registration Name',
         placeholder: 'Name',
         validators: [FormValidators.REQUIRED],
+        defaultValue: formData.dbGaPStudyRegistrationName,
         onChange,
         validation: validation.dbGaPStudyRegistrationName,
         onValidationChange,
@@ -86,6 +86,7 @@ export default function NihAnvilUse(props) {
         title: 'Embargo Release Date',
         placeholder: 'YYYY-MM-DD',
         validators: [FormValidators.REQUIRED, FormValidators.DATE],
+        defaultValue: formData.embargoReleaseDate,
         onChange,
         validation: validation.embargoReleaseDate,
         onValidationChange,
@@ -95,6 +96,7 @@ export default function NihAnvilUse(props) {
         title: 'Sequencing Center',
         placeholder: 'Name',
         validators: [FormValidators.REQUIRED],
+        defaultValue: formData.sequencingCenter,
         onChange,
         validation: validation.sequencingCenter,
         onValidationChange,

--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -189,7 +189,7 @@ export const DataSubmissionForm = () => {
 
 
       <DataSubmissionStudyInformation onChange={onChange} validation={formValidation} onValidationChange={onValidationChange} />
-      <NihAnvilUse onChange={onChange} initialFormData={formData} validation={formValidation} onValidationChange={onValidationChange} updateParentRenderState={updateParentRenderState}/>
+      <NihAnvilUse onChange={onChange} formData={formData} validation={formValidation} onValidationChange={onValidationChange} updateParentRenderState={updateParentRenderState}/>
       <NIHAdministrativeInformation nihAdminRendered={nihAdminRendered} initialFormData={formData} onChange={onChange} institutions={institutions} validation={formValidation} onValidationChange={onValidationChange} />
       <NIHDataManagement nihDataManagementRendered={nihDataManagementRendered} initialFormData={formData} onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} />
       <DataAccessGovernance onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} setAllConsentGroupsSaved={setAllConsentGroupsSaved} />


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2390

### Summary

- Saves input data after you change your NIH Anvil Use selection
- Updates rendering of NihAnvilUse

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
