### PR TITLE
[DUOS-2420][risk=no] Fix eraCommonsId Required Asterisks

### DIFF
--- a/src/components/eRACommons.js
+++ b/src/components/eRACommons.js
@@ -129,7 +129,14 @@ export const eRACommons = hh(class eRACommons extends React.Component {
         className: this.props.className,
         style: { minHeight: 65, ...this.props.style }
       }, [
-        label({ className: 'control-label', isRendered: this.props.header }, ['NIH eRA Commons ID*']),
+        label(
+          { className: 'control-label', isRendered: this.props.header },
+          [
+            span({}, [
+              'NIH eRA Commons ID',
+              isNil(this.props.required) || this.props.required === true ? '*' : ''
+            ])
+          ]),
         div({
           isRendered: (!this.state.isAuthorized || this.state.expirationCount < 0)
         }, [

--- a/src/pages/dar_application/ResearcherInfo_new.js
+++ b/src/pages/dar_application/ResearcherInfo_new.js
@@ -96,7 +96,8 @@ export default function ResearcherInfo(props) {
               location: location,
               validationError: showNihValidationError,
               readOnly: readOnlyMode,
-              header: true
+              header: true,
+              required: formData.checkCollaborator !== true,
             })
           ]),
           fieldset({ }, [


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2420

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
