### PR TITLE
[DUOS-2423][risk=no] Fix failing test

### DIFF
--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
@@ -30,7 +30,7 @@ const user = {
       propertyId: 10351,
       userId: 5,
       propertyKey: 'eraExpiration',
-      propertyValue: '1680741397751'
+      propertyValue: '999980741397751'
     },
   ],
 };


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2423

All new tests are failing because the expiration date of the test user's eraCommonsId passed. Extended it to many many thousands of years from now.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
