### PR TITLE
[DUOS-2352][risk=no] Re-add the dar review link

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -74,6 +74,8 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/member_console" component={MemberConsole} props={props} rolesAllowed={[USER_ROLES.member]}/>
     <AuthenticatedRoute path="/dar_vote_review/:collectionId" component={DarCollectionReview} props={Object.assign({readOnly: true}, props)}
       rolesAllowed={[USER_ROLES.chairperson, USER_ROLES.member]}/>
+    <AuthenticatedRoute path="/dar_application_review/:collectionId" component={DataAccessRequestApplication} props={props}
+      rolesAllowed={[USER_ROLES.researcher]} />
     {/* Order is important for processing links with embedded dataRequestIds */}
     {/*
         For non-staging/prod (i.e. dev, local, alpha), point existing dar urls (and new url) to new component


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2352

Fixes a regression introduced in https://github.com/DataBiosphere/duos-ui/pull/2148

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
