### PR TITLE
[DUOS-2341][risk=no] Make TOS page extend to bottom

### DIFF
--- a/src/libs/tosService.js
+++ b/src/libs/tosService.js
@@ -11,9 +11,10 @@ export const TosService = {
     return {
       marginTop: '-50px',
       paddingTop: '25px',
-      minHeight: '700px',
+      minHeight: '900px',
       backgroundImage: `linear-gradient(to right, transparent, white 50%), url(${homeHeaderBackground})`,
-      backgroundRepeat: 'no-repeat'
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: 'cover'
     };
   },
 
@@ -22,6 +23,7 @@ export const TosService = {
       margin: '50px',
       maxWidth: '800px',
       padding: '1.5rem',
+      height: '100%',
       backgroundColor: 'white',
       boxShadow: 'rgb(0 0 0 / 12%) 0 3px 2px 1px',
       borderRadius: '5px',


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2341

It turns out the way the page is laid out is pretty weird - the page is a little bit more than one screen's height, and for some reason with a height attribute of '100%' the page didn't reach to the bottom. I tried reorganizing a bunch of things to make it more relative, but ended up discovering that it was good enough to keep things as is and hardcore a minimum height - seemed to be responsive enough to small and big displays.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
