### PR TITLE
[DUOS-2426][risk=no] Fix duplicated navbar

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -529,7 +529,7 @@ class DuosHeader extends Component {
       //Hard to make that navbar flexible with material-ui's syntax
       //For now I will use material-ui's hidden element to selectively render the two different navbars
       //I'll look into rewriting the large navbar on a later PR
-      h(Hidden, { lgUp: true }, [
+      h(Hidden, { mdUp: true }, [
         this.makeNotifications(),
         div(
           {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2426

Simple problem, simple fix, but a bit tricky to find.

In order to test: go to landing page and shrink the screen - the navbar should smoothly change to the "condensed" version without "duplicating" into two navbars on top of each other as in the ticket photo.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
