### PR TITLE
[DUOS-2352][risk=no] Enable new dar form as default on staging

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -78,16 +78,16 @@ const Routes = (props) => (
       rolesAllowed={[USER_ROLES.researcher]} />
     {/* Order is important for processing links with embedded dataRequestIds */}
     {/*
-        For non-staging/prod (i.e. dev, local, alpha), point existing dar urls (and new url) to new component
+        For non-prod (i.e. dev, local, alpha, staging) point existing dar urls (and new url) to new component
         and point `_old` version of the url to the old component.
         For all environments, point `_old` -> old component and `_new` -> new component.
         TODO: Remove all `_new` and `_old` urls and old component when feature is completely released.
       */}
     <AuthenticatedRoute path="/dar_application/:dataRequestId"
-      component={checkEnv(envGroups.NON_STAGING) ? DataAccessRequestApplication : DataAccessRequestApplication_old}
+      component={checkEnv(envGroups.NON_PROD) ? DataAccessRequestApplication : DataAccessRequestApplication_old}
       props={props} rolesAllowed={[USER_ROLES.researcher]} />
     <AuthenticatedRoute path="/dar_application"
-      component={checkEnv(envGroups.NON_STAGING) ? DataAccessRequestApplication : DataAccessRequestApplication_old}
+      component={checkEnv(envGroups.NON_PROD) ? DataAccessRequestApplication : DataAccessRequestApplication_old}
       props={props} rolesAllowed={[USER_ROLES.researcher]} />
     <AuthenticatedRoute path="/dar_application_new/:dataRequestId" component={DataAccessRequestApplication} props={props} rolesAllowed={[USER_ROLES.researcher]} />
     <AuthenticatedRoute path="/dar_application_new" component={DataAccessRequestApplication} props={props} rolesAllowed={[USER_ROLES.researcher]} />


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2352

Enables the new dar form as default on non-prod envs (i.e. dev, staging, alpha, local)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
