### PR TITLE
[DUOS-2451][risk=no] Text changes for consent groups

### DIFF
--- a/src/components/data_submission/consent_group/ConsentGroupSummary.js
+++ b/src/components/data_submission/consent_group/ConsentGroupSummary.js
@@ -166,7 +166,7 @@ export const ConsentGroupSummary = (props) => {
             fontWeight: 'bold',
             fontSize: '16px',
           }
-        }, ['Name']),
+        }, ['Consent Group Name']),
         input({
           disabled: true,
           type: 'text',
@@ -178,14 +178,14 @@ export const ConsentGroupSummary = (props) => {
             fontWeight: 'bold',
             fontSize: '16px',
           }
-        }, ['Primary Group']),
+        }, ['Primary Data Use']),
         summarizePrimaryGroup(),
         p({
           style: {
             fontWeight: 'bold',
             fontSize: '16px',
           }
-        }, 'Secondary Group(s)'),
+        }, 'Secondary Data Use(s)'),
         summarizeSecondaryGroup(),
       ]),
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2451

### Summary

Text changes for consent groups.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
