### PR TITLE
draft updating public visibility

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -22,8 +22,15 @@ const tableBody = {
   padding: '8px 5px 8px 5px'
 };
 
+// checks the visibility
+// all previous datasets will be visible
+// all future datasets will be dependent on publicVisibility
+const checkPublicVisibility = (dataset) =>{
+  return isNil(dataset.study?.publicVisibility) ? true : dataset.study.publicVisibility;
+};
+
 const canApplyForDataset = (dataset) => {
-  return dataset.active && !isNil(dataset.dacId);
+  return checkPublicVisibility && !isNil(dataset.dacId);
 };
 
 export default function DatasetCatalog(props) {
@@ -252,41 +259,6 @@ export default function DatasetCatalog(props) {
     }
   };
 
-  const dialogHandlerEnable = async(e) => {
-    const answer = getBooleanFromEventHtmlDataValue(e);
-    if (answer) {
-      DataSet.disableDataset(selectedDatasetId, true).then(() => {
-        getDatasets();
-        setShowDatasetEnable(false);
-      }).catch(() => {
-        setShowDatasetEnable(true);
-        setErrorMessage('Please try again later.');
-        setErrorTitle('Something went wrong');
-      });
-    } else {
-      setShowDatasetEnable(false);
-      setErrorMessage(undefined);
-      setErrorTitle(undefined);
-    }
-  };
-
-  const dialogHandlerDisable = async (e) => {
-    const answer = getBooleanFromEventHtmlDataValue(e);
-    if (answer) {
-      DataSet.disableDataset(selectedDatasetId, false).then(() => {
-        getDatasets();
-        setShowDatasetDisable(false);
-      }).catch(() => {
-        setShowDatasetDisable(true);
-        setErrorMessage('Please try again later.');
-        setErrorTitle('Something went wrong');
-      });
-    } else {
-      setShowDatasetDisable(false);
-      setErrorMessage(undefined);
-      setErrorTitle(undefined);
-    }
-  };
 
   const dialogHandlerEdit = async (e) => {
     const answer = getBooleanFromEventHtmlDataValue(e);
@@ -381,7 +353,7 @@ export default function DatasetCatalog(props) {
   };
 
   const inactiveCheckboxStyle = (dataset) => {
-    if (!dataset.active) {
+    if (!checkPublicVisibility) {
       return {cursor: 'default', opacity: '50%'};
     }
     return {};
@@ -648,28 +620,6 @@ export default function DatasetCatalog(props) {
                             ]),
 
                             a({
-                              id: trIndex + '_btnDisable', name: 'btn_disable', isRendered: dataset.active,
-                              onClick: openDisable(dataset.dataSetId),
-                              disabled: !isEditDatasetEnabled(dataset)
-                            }, [
-                              span({
-                                className: `cm-icon-button glyphicon glyphicon-ok-circle caret-margin ${color}-color`, 'aria-hidden': 'true',
-                                'data-tip': 'Disable dataset', 'data-for': 'tip_disable'
-                              })
-                            ]),
-
-                            a({
-                              id: trIndex + '_btnEnable', name: 'btn_enable', isRendered: !dataset.active,
-                              onClick: openEnable(dataset.dataSetId),
-                              disabled: !isEditDatasetEnabled(dataset)
-                            }, [
-                              span({
-                                className: 'cm-icon-button glyphicon glyphicon-ban-circle caret-margin cancel-color', 'aria-hidden': 'true',
-                                'data-tip': 'Enable dataset', 'data-for': 'tip_enable'
-                              })
-                            ]),
-
-                            a({
                               isRendered: currentUser.isAdmin,
                               id: trIndex + '_btnConnect', name: 'btn_connect',
                               onClick: () => openConnectDataset(dataset),
@@ -685,7 +635,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: dataset.datasetIdentifier + '_dataset', name: 'datasetIdentifier',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           dataset['Dataset ID']
@@ -693,39 +643,39 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_datasetName', name: 'datasetName',
-                          className: 'cell-size ' + (!dataset.active ? !!'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? !!'dataset-disabled' : ''),
                           style: tableBody
                         }, [findPropertyValue(dataset, 'Dataset Name')]),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           dataset['Data Access Committee']
                         ]),
 
                         td({
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           getLinkDisplay(dataset, trIndex)
                         ]),
 
                         td({
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           a({
                             id: trIndex + '_linkTranslatedDul', name: 'link_translatedDul',
                             onClick: () => openTranslatedDUL(dataset.dataUse),
-                            className: (!dataset.active ? 'dataset-disabled' : 'enabled')
+                            className: (!checkPublicVisibility ? 'dataset-disabled' : 'enabled')
                           }, dataset.codeList)
                         ]),
 
                         td({
                           id: trIndex + '_dataType', name: 'dataType',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           findPropertyValue(dataset, 'Data Type')
@@ -733,14 +683,14 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_phenotype', name: 'phenotype',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           dataset['Disease Studied']
                         ]),
 
                         td({
-                          id: trIndex + '_pi', name: 'pi', className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          id: trIndex + '_pi', name: 'pi', className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           dataset['Principal Investigator (PI)']
@@ -748,7 +698,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_participants', name: 'participants',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           dataset['# of Participants']
@@ -756,7 +706,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_description', name: 'description',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           findPropertyValue(dataset, 'Description')
@@ -764,7 +714,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_species', name: 'species',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           findPropertyValue(dataset, 'Species')
@@ -772,7 +722,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_depositor', name: 'depositor',
-                          className: 'cell-size ' + (!dataset.active ? 'dataset-disabled' : ''),
+                          className: 'cell-size ' + (!checkPublicVisibility ? 'dataset-disabled' : ''),
                           style: tableBody
                         }, [
                           dataset['Data Custodian']
@@ -837,24 +787,6 @@ export default function DatasetCatalog(props) {
         }, [div({ className: 'dialog-description' }, ['Are you sure you want to delete this Dataset?']),]),
 
         ConfirmationDialog({
-          title: 'Disable Dataset Confirmation?',
-          color: 'dataset',
-          showModal: showDatasetDisable,
-          alertMessage: errorMessage,
-          alertTitle: errorTitle,
-          action: { label: 'Yes', handler: () => dialogHandlerDisable }
-        }, [div({ className: 'dialog-description' }, ['If you disable a Dataset, Researchers won\'t be able to request access on it from now on. New Access elections related to this dataset won\'t be available but opened ones will continue.']),]),
-
-        ConfirmationDialog({
-          title: 'Enable Dataset Confirmation?',
-          color: 'dataset',
-          alertMessage: errorMessage,
-          alertTitle: errorTitle,
-          showModal: showDatasetEnable,
-          action: { label: 'Yes', handler: () => dialogHandlerEnable }
-        }, [div({ className: 'dialog-description' }, ['If you enable a Dataset, Researchers will be able to request access on it from now on.']),]),
-
-        ConfirmationDialog({
           title: 'Edit Dataset Confirmation?',
           color: 'dataset',
           alertMessage: errorMessage,
@@ -872,20 +804,6 @@ export default function DatasetCatalog(props) {
         }),
         h(ReactTooltip, {
           id: 'tip_delete',
-          place: 'right',
-          effect: 'solid',
-          multiline: true,
-          className: 'tooltip-wrapper'
-        }),
-        h(ReactTooltip, {
-          id: 'tip_disable',
-          place: 'right',
-          effect: 'solid',
-          multiline: true,
-          className: 'tooltip-wrapper'
-        }),
-        h(ReactTooltip, {
-          id: 'tip_enable',
           place: 'right',
           effect: 'solid',
           multiline: true,


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?selectedIssue=DUOS-2452
Removes the enable/disable feature on the DAC Chair Console 'Datasets' Tab. All datasets created with the `dataRegistration` form will be enabled and all datasets created with the `dataSubmissionForm` will be enabled/disabled depending on the publicVisibility.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
