### PR TITLE
[DUOS-2493][risk=no] Remove popper.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "mixin-deep": "2.0.1",
         "moment": "2.29.4",
         "noty": "3.2.0-beta",
-        "popper.js": "1.16.1",
         "query-string": "^7.1.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -15914,16 +15913,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/postcss": {
@@ -33910,11 +33899,6 @@
           "dev": true
         }
       }
-    },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "postcss": {
       "version": "8.4.16",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "mixin-deep": "2.0.1",
     "moment": "2.29.4",
     "noty": "3.2.0-beta",
-    "popper.js": "1.16.1",
     "query-string": "^7.1.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
 
-// import $ from 'jquery';
-// import Popper from 'popper.js';
+// jquery is needed for bootstrap
 import 'jquery/src/jquery';
-
 import 'bootstrap/dist/js/bootstrap.min';
 
 import React from 'react';


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2493

### Summary

We don't use this package anywhere.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
