### PR TITLE
[DUOS-2453][risk=no] Dataset Submission Redirects on Success

### DIFF
--- a/src/pages/DataSubmissionForm.js
+++ b/src/pages/DataSubmissionForm.js
@@ -19,7 +19,10 @@ import NihAnvilUse from '../components/data_submission/NihAnvilUse';
 import validateSchema from '../assets/schemas/DataRegistrationV1Validation';
 import { set } from 'lodash';
 
-export const DataSubmissionForm = () => {
+export const DataSubmissionForm = (props) => {
+  const {
+    history
+  } = props;
 
   const [institutions, setInstitutions] = useState([]);
   const [failedInit, setFailedInit] = useState(false);
@@ -116,7 +119,10 @@ export const DataSubmissionForm = () => {
     // no validation issues, matches json schema: continue to submission
     const multiPartFormData = createMultiPartFormData(registration);
 
-    DataSet.registerDataset(multiPartFormData).catch((e) => {
+    DataSet.registerDataset(multiPartFormData).then(() => {
+      history.push('/dataset_catalog');
+      Notifications.showSuccess({ text: 'Submitted succesfully!' });
+    }, (e) => {
       Notifications.showError({ text: 'Could not submit: ' + e?.response?.data?.message || e.message });
     });
   };


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2453

### Summary

When you click submit on dataset submission, it should redirect you back to the dataset catalog and display a success toast.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
