### PR TITLE
[DUOS-2043][risk=no] Add "DAC" Column to Admin view of DAR requests page

### DIFF
--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -42,8 +42,8 @@ export const styles = {
     border: 'none'
   }),
   cellWidth: {
-    darCode: '12.5%',
-    dac: '9%',
+    darCode: '11%',
+    dacNames: '9%',
     projectTitle: '14%',
     submissionDate: '10.5%',
     researcher: '10%',
@@ -54,7 +54,7 @@ export const styles = {
   },
   color: {
     darCode: '#000000',
-    dac: '#000000',
+    dacNames: '#000000',
     projectTitle: '#000000',
     submissionDate: '#000000',
     researcher: '#000000',
@@ -65,7 +65,7 @@ export const styles = {
   },
   fontSize: {
     darCode: '1.6rem',
-    dac: '1.4rem',
+    dacNames: '1.4rem',
     projectTitle: '1.4rem',
     submissionDate: '1.4rem',
     researcher: '1.4rem',
@@ -78,7 +78,7 @@ export const styles = {
 
 export const DarCollectionTableColumnOptions = {
   DAR_CODE: 'darCode',
-  DAC: 'dac',
+  DAC: 'dacNames',
   NAME: 'name',
   SUBMISSION_DATE: 'submissionDate',
   RESEARCHER: 'researcher',
@@ -95,9 +95,9 @@ const columnHeaderConfig = {
     cellDataFn: cellData.darCodeCellData,
     sortable: true
   },
-  dac: {
+  dacNames: {
     label: 'DAC',
-    cellStyle: { width: styles.cellWidth.dac },
+    cellStyle: { width: styles.cellWidth.dacNames },
     cellDataFn: cellData.DacCellData
   },
   name: {
@@ -160,7 +160,7 @@ const processCollectionRowData = ({
     return collections.map((collection) => {
       const {
         darCollectionId, darCode, datasetIds,
-        submissionDate, status, actions, dac,
+        submissionDate, status, actions, dacNames,
         researcherName, name, institutionName
       } = collection;
       collectionsSummaryMap[collection.darCollectionId] = collection;
@@ -170,7 +170,7 @@ const processCollectionRowData = ({
           submissionDate, researcherName, institutionName,
           showConfirmationModal, consoleType,
           goToVote, reviewCollection, relevantDatasets,
-          resumeCollection, actions, dac,
+          resumeCollection, actions, dacNames,
           collectionIsExpanded: collectionIsExpanded(darCollectionId),
           updateCollectionIsExpanded: (val) => updateCollectionIsExpandedById(darCollectionId, val),
         });

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -50,6 +50,7 @@ export const styles = {
     datasetCount: '7.5%',
     status: '10%',
     actions: '14.5%',
+    dac: '5%'
   },
   color: {
     darCode: '#000000',
@@ -60,6 +61,7 @@ export const styles = {
     datasetCount: '#354052',
     status: '#000000',
     actions: '#000000',
+    dac: '#000000'
   },
   fontSize: {
     darCode: '1.6rem',
@@ -70,6 +72,7 @@ export const styles = {
     datasetCount: '2.0rem',
     status: '1.6rem',
     actions: '1.6rem',
+    dac: '1.4rem'
   },
 };
 
@@ -81,7 +84,8 @@ export const DarCollectionTableColumnOptions = {
   INSTITUTION: 'institution',
   DATASET_COUNT: 'datasetCount',
   STATUS: 'status',
-  ACTIONS: 'actions'
+  ACTIONS: 'actions',
+  DAC: 'dac'
 };
 
 const columnHeaderConfig = {
@@ -131,6 +135,11 @@ const columnHeaderConfig = {
     label: 'Action',
     cellStyle: { width: styles.cellWidth.actions },
     cellDataFn: cellData.consoleActionsCellData
+  },
+  dac: {
+    label: 'DAC',
+    cellStyle: { width: styles.cellWidth.dac },
+    cellDataFn: cellData.DacCellData
   }
 };
 
@@ -151,7 +160,7 @@ const processCollectionRowData = ({
     return collections.map((collection) => {
       const {
         darCollectionId, darCode, datasetIds,
-        submissionDate, status, actions,
+        submissionDate, status, actions, dac,
         researcherName, name, institutionName
       } = collection;
       collectionsSummaryMap[collection.darCollectionId] = collection;
@@ -161,7 +170,7 @@ const processCollectionRowData = ({
           submissionDate, researcherName, institutionName,
           showConfirmationModal, consoleType,
           goToVote, reviewCollection, relevantDatasets,
-          resumeCollection, actions,
+          resumeCollection, actions, dac,
           collectionIsExpanded: collectionIsExpanded(darCollectionId),
           updateCollectionIsExpanded: (val) => updateCollectionIsExpandedById(darCollectionId, val),
         });

--- a/src/components/dar_collection_table/DarCollectionTable.js
+++ b/src/components/dar_collection_table/DarCollectionTable.js
@@ -43,49 +43,49 @@ export const styles = {
   }),
   cellWidth: {
     darCode: '12.5%',
-    projectTitle: '18%',
-    submissionDate: '12.5%',
+    dac: '9%',
+    projectTitle: '14%',
+    submissionDate: '10.5%',
     researcher: '10%',
     institution: '12.5%',
     datasetCount: '7.5%',
     status: '10%',
-    actions: '14.5%',
-    dac: '5%'
+    actions: '9.5%'
   },
   color: {
     darCode: '#000000',
+    dac: '#000000',
     projectTitle: '#000000',
     submissionDate: '#000000',
     researcher: '#000000',
     institution: '#354052',
     datasetCount: '#354052',
     status: '#000000',
-    actions: '#000000',
-    dac: '#000000'
+    actions: '#000000'
   },
   fontSize: {
     darCode: '1.6rem',
+    dac: '1.4rem',
     projectTitle: '1.4rem',
     submissionDate: '1.4rem',
     researcher: '1.4rem',
     institution: '1.4rem',
     datasetCount: '2.0rem',
     status: '1.6rem',
-    actions: '1.6rem',
-    dac: '1.4rem'
+    actions: '1.6rem'
   },
 };
 
 export const DarCollectionTableColumnOptions = {
   DAR_CODE: 'darCode',
+  DAC: 'dac',
   NAME: 'name',
   SUBMISSION_DATE: 'submissionDate',
   RESEARCHER: 'researcher',
   INSTITUTION: 'institution',
   DATASET_COUNT: 'datasetCount',
   STATUS: 'status',
-  ACTIONS: 'actions',
-  DAC: 'dac'
+  ACTIONS: 'actions'
 };
 
 const columnHeaderConfig = {
@@ -94,6 +94,11 @@ const columnHeaderConfig = {
     cellStyle: { width: styles.cellWidth.darCode },
     cellDataFn: cellData.darCodeCellData,
     sortable: true
+  },
+  dac: {
+    label: 'DAC',
+    cellStyle: { width: styles.cellWidth.dac },
+    cellDataFn: cellData.DacCellData
   },
   name: {
     label: 'Title',
@@ -136,11 +141,6 @@ const columnHeaderConfig = {
     cellStyle: { width: styles.cellWidth.actions },
     cellDataFn: cellData.consoleActionsCellData
   },
-  dac: {
-    label: 'DAC',
-    cellStyle: { width: styles.cellWidth.dac },
-    cellDataFn: cellData.DacCellData
-  }
 };
 
 const defaultColumns = Object.keys(columnHeaderConfig);

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -180,7 +180,7 @@ export function consoleActionsCellData({collection, reviewCollection, goToVote, 
     label: 'table-actions',
     data: actionComponent
   };
-};
+}
 
 export default {
   projectTitleCellData,

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -84,10 +84,9 @@ const dacLinkToCollection = (darCode, status  = '', darCollectionId) => {
 };
 
 export function DacCellData({dacNames, darCollectionId, label = 'dacNames'}) {
-  const dacString = uniq(dacNames).join('\n');
-
+  //const dacString = uniq(dacNames).join('\n');
   return {
-    data: dacString || '- -',
+    data: dacNames || '- -',
     id: darCollectionId,
     style: {
       color: '#354052',

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -1,4 +1,4 @@
-import {includes, isEmpty, isNil, toLower} from 'lodash/fp';
+import {includes, isEmpty, isNil, toLower, uniq} from 'lodash/fp';
 import {formatDate} from '../../libs/utils';
 import {h, div} from 'react-hyperscript-helpers';
 import { ExpandMore, ExpandLess } from '@mui/icons-material';
@@ -84,8 +84,10 @@ const dacLinkToCollection = (darCode, status  = '', darCollectionId) => {
 };
 
 export function DacCellData({dacNames, darCollectionId, label = 'dacNames'}) {
-  return{
-    data: dacNames,
+  const dacString = uniq(dacNames).join('\n');
+
+  return {
+    data: dacString || '- -',
     id: darCollectionId,
     style: {
       color: '#354052',

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -92,7 +92,7 @@ export function DacCellData({dac, collection, label = 'dac'}) {
       fontSize: styles.fontSize.dac,
     },
     label
-  }
+  };
 }
 
 export function submissionDateCellData({submissionDate, darCollectionId, label = 'submission-date'}) {

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -84,9 +84,10 @@ const dacLinkToCollection = (darCode, status  = '', darCollectionId) => {
 };
 
 export function DacCellData({dacNames, darCollectionId, label = 'dacNames'}) {
-  //const dacString = uniq(dacNames).join('\n');
+  const dacString = uniq(dacNames).join('\n');
+  
   return {
-    data: dacNames || '- -',
+    data: dacNames,
     id: darCollectionId,
     style: {
       color: '#354052',

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -6,6 +6,7 @@ import {styles} from './DarCollectionTable';
 import Actions from './Actions';
 import DarCollectionAdminReviewLink from './DarCollectionAdminReviewLink';
 import {Link} from 'react-router-dom';
+import { DAC } from '../../libs/ajax';
 
 export const consoleTypes = {
   ADMIN: 'admin',
@@ -170,6 +171,18 @@ export function consoleActionsCellData({collection, reviewCollection, goToVote, 
   };
 }
 
+export function DacCellData({DAC, collection, label = 'dac'}) {
+  return{
+    data: DAC,
+    id: collection.darCollectionId,
+    style: {
+      color: '#354052',
+      fontSize: styles.fontSize.dac,
+    },
+    label
+  }
+}
+
 export default {
   projectTitleCellData,
   darCodeCellData,
@@ -179,4 +192,5 @@ export default {
   datasetCountCellData,
   statusCellData,
   consoleActionsCellData,
+  DacCellData,
 };

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -85,9 +85,9 @@ const dacLinkToCollection = (darCode, status  = '', darCollectionId) => {
 
 export function DacCellData({dacNames, darCollectionId, label = 'dacNames'}) {
   const dacString = uniq(dacNames).join('\n');
-  
+
   return {
-    data: dacNames,
+    data: dacString,
     id: darCollectionId,
     style: {
       color: '#354052',

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -83,13 +83,13 @@ const dacLinkToCollection = (darCode, status  = '', darCollectionId) => {
   return h(Link, { to: path }, [darCode]);
 };
 
-export function DacCellData({dac, collection, label = 'dac'}) {
+export function DacCellData({dacNames, darCollectionId, label = 'dacNames'}) {
   return{
-    data: dac,
-    id: collection.darCollectionId,
+    data: dacNames,
+    id: darCollectionId,
     style: {
       color: '#354052',
-      fontSize: styles.fontSize.dac,
+      fontSize: styles.fontSize.dacNames,
     },
     label
   };

--- a/src/components/dar_collection_table/DarCollectionTableCellData.js
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.js
@@ -6,7 +6,6 @@ import {styles} from './DarCollectionTable';
 import Actions from './Actions';
 import DarCollectionAdminReviewLink from './DarCollectionAdminReviewLink';
 import {Link} from 'react-router-dom';
-import { DAC } from '../../libs/ajax';
 
 export const consoleTypes = {
   ADMIN: 'admin',
@@ -83,6 +82,18 @@ const dacLinkToCollection = (darCode, status  = '', darCollectionId) => {
 
   return h(Link, { to: path }, [darCode]);
 };
+
+export function DacCellData({dac, collection, label = 'dac'}) {
+  return{
+    data: dac,
+    id: collection.darCollectionId,
+    style: {
+      color: '#354052',
+      fontSize: styles.fontSize.dac,
+    },
+    label
+  }
+}
 
 export function submissionDateCellData({submissionDate, darCollectionId, label = 'submission-date'}) {
   const dateString = isNil(submissionDate) ? '- -' :
@@ -169,22 +180,11 @@ export function consoleActionsCellData({collection, reviewCollection, goToVote, 
     label: 'table-actions',
     data: actionComponent
   };
-}
-
-export function DacCellData({DAC, collection, label = 'dac'}) {
-  return{
-    data: DAC,
-    id: collection.darCollectionId,
-    style: {
-      color: '#354052',
-      fontSize: styles.fontSize.dac,
-    },
-    label
-  }
-}
+};
 
 export default {
   projectTitleCellData,
+  DacCellData,
   darCodeCellData,
   submissionDateCellData,
   researcherCellData,
@@ -192,5 +192,4 @@ export default {
   datasetCountCellData,
   statusCellData,
   consoleActionsCellData,
-  DacCellData,
 };

--- a/src/pages/AdminManageDarCollections.js
+++ b/src/pages/AdminManageDarCollections.js
@@ -85,7 +85,8 @@ export default function AdminManageDarCollections() {
         DarCollectionTableColumnOptions.INSTITUTION,
         DarCollectionTableColumnOptions.DATASET_COUNT,
         DarCollectionTableColumnOptions.STATUS,
-        DarCollectionTableColumnOptions.ACTIONS
+        DarCollectionTableColumnOptions.ACTIONS,
+        DarCollectionTableColumnOptions. DAC,
       ],
       isLoading,
       cancelCollection,

--- a/src/pages/AdminManageDarCollections.js
+++ b/src/pages/AdminManageDarCollections.js
@@ -79,6 +79,7 @@ export default function AdminManageDarCollections() {
       collections: filteredList,
       columns: [
         DarCollectionTableColumnOptions.DAR_CODE,
+        DarCollectionTableColumnOptions. DAC,
         DarCollectionTableColumnOptions.NAME,
         DarCollectionTableColumnOptions.SUBMISSION_DATE,
         DarCollectionTableColumnOptions.RESEARCHER,
@@ -86,7 +87,6 @@ export default function AdminManageDarCollections() {
         DarCollectionTableColumnOptions.DATASET_COUNT,
         DarCollectionTableColumnOptions.STATUS,
         DarCollectionTableColumnOptions.ACTIONS,
-        DarCollectionTableColumnOptions. DAC,
       ],
       isLoading,
       cancelCollection,

--- a/src/pages/AdminManageDarCollections.js
+++ b/src/pages/AdminManageDarCollections.js
@@ -79,7 +79,7 @@ export default function AdminManageDarCollections() {
       collections: filteredList,
       columns: [
         DarCollectionTableColumnOptions.DAR_CODE,
-        DarCollectionTableColumnOptions. DAC,
+        DarCollectionTableColumnOptions.DAC,
         DarCollectionTableColumnOptions.NAME,
         DarCollectionTableColumnOptions.SUBMISSION_DATE,
         DarCollectionTableColumnOptions.RESEARCHER,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/jira/software/c/projects/DUOS/boards/123?modal=detail&selectedIssue=DUOS-2043

### Summary
Add "DAC" Column to Admin view of DAR requests page
<img width="1454" alt="image" src="https://github.com/DataBiosphere/duos-ui/assets/91574136/ba092c79-2803-4b95-b657-6974a0f1a342">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
