### PR TITLE
[DUOS-2526][risk=no] Fix Data Access Committee

### DIFF
--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -444,7 +444,7 @@ export const EditConsentGroup = (props) => {
         isRendered: consentGroup.openAccess !== true,
         id: idx + 'dataAccessCommitteeId',
         name: 'dataAccessCommitteeId',
-        title: 'Data Access Committee*',
+        title: 'Data Access Committee',
         description: 'Please select which DAC should govern requests for this dataset',
         type: FormFieldTypes.SELECT,
         selectOptions: dacs.map((dac) => {
@@ -455,6 +455,9 @@ export const EditConsentGroup = (props) => {
         },
         validators: [FormValidators.REQUIRED],
         validation: validation.dataAccessCommitteeId,
+        defaultValue: dacs.map((dac) => {
+          return { dacId: dac.dacId, displayText: dac.name };
+        }).find((dac) => dac.dacId === consentGroup.dataAccessCommitteeId),
         onValidationChange,
       }),
     ]),
@@ -545,6 +548,7 @@ export const EditConsentGroup = (props) => {
         type: FormFieldTypes.NUMBER,
         validators: [FormValidators.REQUIRED],
         defaultValue: consentGroup.numberOfParticipants,
+        validation: validation.numberOfParticipants,
         onChange,
       }),
     ]),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2526

### Summary

Fixes a couple minor bugs
1. Data access committee was not being preserved if you save and then re-open
2. Number of participants didn't light up red if it wasn't filled out but you hit save

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
