### PR TITLE
[DUOS-2522][risk=no] Split out initializations into separate useEffects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import './App.css';
 import {Config} from './libs/config';
 import DuosFooter from './components/DuosFooter';
 import DuosHeader from './components/DuosHeader';
-import {useHistory} from 'react-router-dom';
+import {useHistory, useLocation} from 'react-router-dom';
 import loadingImage from './images/loading-indicator.svg';
 
 import {SpinnerComponent as Spinner} from './components/SpinnerComponent';
@@ -19,49 +19,53 @@ function App() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [env, setEnv] = useState('');
   let history = useHistory();
+  let location = useLocation();
 
   const trackPageView = (location) => {
     ReactGA.pageview(location.pathname + location.search);
   };
 
   useEffect(() => {
-    const setUserIsLogged = async () => {
-      const isLogged = await Storage.userIsLogged();
-      setIsLoggedIn(isLogged);
-    };
+    Modal.setAppElement(document.getElementById('modal-root'));
+  });
 
+  useEffect(() => {
+    const setEnvironment = async () => {
+      const environment = await Config.getEnv();
+      setEnv(environment);
+      await Storage.setEnv(environment);
+    };
+    setEnvironment();
+  });
+
+  useEffect(() => {
     const initializeReactGA = async (history) => {
       const gaId = await Config.getGAId();
       ReactGA.initialize(gaId, {
         titleCase: false
       });
       //call trackPageView to register initial page load
-      trackPageView(history.location);
+      trackPageView(location);
       //pass trackPageView as callback function for url change listener
       history.listen(trackPageView);
     };
+    initializeReactGA(history);
+  }, [history, location]);
 
+  useEffect(() => {
     const stackdriverStart = async () => {
       await StackdriverReporter.start();
     };
+    stackdriverStart();
+  });
 
-    const setEnvironment = async () => {
-      const environment = await Config.getEnv();
-      setEnv(environment);
-      Storage.setEnv(environment);
+  useEffect(() => {
+    const setUserIsLogged = async () => {
+      const isLogged = await Storage.userIsLogged();
+      setIsLoggedIn(isLogged);
     };
-
-    const initApp = async () => {
-      Modal.setAppElement(document.getElementById('modal-root'));
-      await initializeReactGA(history);
-      await setUserIsLogged();
-      await setEnvironment();
-      await stackdriverStart();
-    };
-
-    initApp();
-
-  }, [history]);
+    setUserIsLogged();
+  });
 
   const signOut = async () => {
     const clientId = await Config.getGoogleClientId();
@@ -77,14 +81,14 @@ function App() {
   };
 
   return (
-    div({ className: 'body' }, [
-      div({ className: 'wrap' }, [
-        div({ className: 'main' }, [
-          h(DuosHeader, { onSignOut: signOut }),
+    div({className: 'body'}, [
+      div({className: 'wrap'}, [
+        div({className: 'main'}, [
+          h(DuosHeader, {onSignOut: signOut}),
           h(Spinner, {
             name: 'mainSpinner', group: 'duos', loadingImage
           }),
-          h(Routes, { onSignOut: signOut, onSignIn: signIn, isLogged: isLoggedIn, env: env })
+          h(Routes, {onSignOut: signOut, onSignIn: signIn, isLogged: isLoggedIn, env: env})
         ])
       ]),
       DuosFooter()


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2522

### Summary
I'm not sure why this happened, but for some users, not all initialization variables were being stored in local storage. Specifically, the `env` var was not stored for some users, but was stored fine for other users. I theorize that having all initializations in the same useEffect may have caused this. After splitting them out into separate use effects, I was able to get past this error and the problematic user was no longer problematic after the update.

### Testing
I could only reproduce this with one user who had an SO and DO role. If you can reproduce this, look at local storage after logging in and not navigating anywhere. If you can replicate this, then you'll see that there is a missing `env` var in session storage. After this PR, I was able to consistently populate `env`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
