### PR TITLE
[DUOS-2553][risk=no] Remove editing for datasets that are part of studies

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -1,4 +1,4 @@
-import {filter, find, flow, getOr, includes, isEmpty, isNil, map, isFunction} from 'lodash/fp';
+import {filter, find, flow, getOr, includes, isEmpty, isNil, isNull, map, isFunction} from 'lodash/fp';
 import {Fragment, useEffect, useState, useCallback } from 'react';
 import {a, button, div, form, h, input, label, span, table, tbody, td, th, thead, tr, img} from 'react-hyperscript-helpers';
 import ReactTooltip from 'react-tooltip';
@@ -432,6 +432,10 @@ export default function DatasetCatalog(props) {
   };
 
   const isEditDatasetEnabled = (dataset) => {
+    // Study editing is not currently supported through existing edit page.
+    if (!isNull(getOr(null)('study.studyId')(dataset))) {
+      return false;
+    }
     if (currentUser.isAdmin) {
       return true;
     }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2553

### Summary
Datasets that are part of a study cannot be edited with the existing edit dataset page so we're turning that off on the catalog page.

## Testing
`DUOS-000622` is a study dataset on dev. There are others - inspect the raw response to find datasets that have a non-null study id.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
