### PR TITLE
[DUOS-2187][risk=no] Add form to edit datasets

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -40,6 +40,7 @@ import {ensureSoHasDaaAcknowledgement} from './components/SigningOfficialDaaAgre
 import CustomDatasetCatalog from './pages/dac_dataset_catalog/CustomDatasetCatalog';
 import {AnVILDMSPolicyInfo, NIHDMSPolicyInfo} from './pages/DMSPolicyInfo';
 import {checkEnv, envGroups} from './utils/EnvironmentUtils';
+import { DatasetUpdateForm } from './pages/DatasetUpdateForm';
 
 const Routes = (props) => (
   <Switch>
@@ -83,6 +84,7 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/signing_official_console/dar_requests" component={ensureSoHasDaaAcknowledgement(SigningOfficialDarRequests)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />
     {checkEnv(envGroups.NON_STAGING) && <AuthenticatedRoute path="/signing_official_console/data_submitters" component={ensureSoHasDaaAcknowledgement(SigningOfficialDataSubmitters, true)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />}
     <AuthenticatedRoute path="/dataset_registration/:datasetId" component={DatasetRegistration} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson]} />
+    <AuthenticatedRoute path="/dataset_update/:datasetId" component={DatasetUpdateForm} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/dataset_registration" component={DatasetRegistration} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/admin_manage_lc/" component={AdminManageLC} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_dar_collections/" component={AdminManageDarCollections} props={props} rolesAllowed={[USER_ROLES.admin]} />

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -1,0 +1,394 @@
+import { useCallback, useState, useEffect } from 'react';
+import { button, h, h2, div } from 'react-hyperscript-helpers';
+import { find, isArray, isNil } from 'lodash/fp';
+
+import { FormFieldTypes, FormField, FormValidators } from '../forms/forms';
+import { DAC, DAR, DataSet } from '../../libs/ajax';
+import { Notifications } from '../../libs/utils';
+
+export const DatasetUpdate = (props) => {
+  const { dataset } = props;
+
+  const [formData, setFormData] = useState({ dac: {}, dataUse: {}, properties: {} });
+
+  const searchOntologies = (query, callback) => {
+    let options = [];
+    DAR.getAutoCompleteOT(query).then(
+      items => {
+        options = items.map(function (item) {
+          return item.label;
+        });
+        callback(options);
+      });
+  };
+
+  const getDiseaseLabels = async (ontologyIds) => {
+    let labels = [];
+    if (!isNil(ontologyIds)) {
+      const idList = ontologyIds.join(',');
+      const result = await DAR.searchOntologyIdList(idList);
+      labels = result.map(r => r.label);
+    }
+    return labels;
+  };
+
+  const extract = useCallback((propertyName) => {
+    const property = find({ propertyName })(dataset.properties);
+    return property?.propertyValue;
+  }, [dataset]);
+
+  const asProperty = (propertyName, propertyValue) => {
+    return {
+      propertyName,
+      propertyValue
+    };
+  };
+
+  const normalizeDataUse = useCallback(async (dataUse) => {
+    let du = dataUse;
+    if (!isNil(dataUse.diseaseRestrictions)) {
+      du.hasDiseaseRestrictions = true;
+      du.diseaseLabels = await getDiseaseLabels(dataUse.diseaseRestrictions);
+    }
+    if (!isNil(dataUse.other)) {
+      du.hasPrimaryOther = true;
+    }
+    if (!isNil(dataUse.secondaryOther)) {
+      du.hasSecondaryOther = true;
+    }
+    return du;
+  }, []);
+
+  const submitForm = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const formElement = event.target.form;
+    const submitData = new FormData(formElement);
+    const nihFileData = submitData.get('nihInstitutionalCertification');
+
+    const newDataset = {
+      name: dataset.name,
+      dacId: dataset.dacId,
+      datasetProperties: [
+        asProperty('Dataset Name', formData.properties.datasetName),
+        asProperty('Data Type', formData.properties.dataType),
+        asProperty('Species', formData.properties.species),
+        asProperty('Phenotype/Indication', formData.properties.phenotype),
+        asProperty('# of participants', formData.properties.nrParticipants),
+        asProperty('Description', formData.properties.description),
+        asProperty('dbGAP', formData.properties.dbGap),
+        asProperty('Data Depositor', formData.properties.dataDepositor),
+        asProperty('Principal Investigator(PI)', formData.properties.principalInvestigator),
+      ]
+    };
+
+    DataSet.updateDatasetV3(dataset.dataSetId, newDataset, null, nihFileData).catch(() => {
+      Notifications.showError({ text: 'Some errors occurred, the dataset was not updated.' });
+    });
+  };
+
+  const prefillFormData = useCallback(async (dataset) => {
+    const dac = await DAC.get(dataset?.dacId);
+    setFormData({
+      datasetName: dataset.datasetName,
+      properties: {
+        datasetName: extract('Dataset Name'),
+        dataType: extract('Data Type'),
+        species: extract('Species'),
+        phenotype: extract('Phenotype/Indication'),
+        nrParticipants: extract('# of participants'),
+        description: extract('Description'),
+        dbGap: extract('dbGAP'),
+        dataDepositor: extract('Data Depositor'),
+        principalInvestigator: extract('Principal Investigator(PI)'),
+      },
+      dataUse: await normalizeDataUse(dataset?.dataUse),
+      dac
+    });
+  }, [extract, normalizeDataUse]);
+
+  useEffect(() => {
+    if (isNil(formData.datasetName)) {
+      prefillFormData(dataset);
+    }
+  }, [prefillFormData, dataset, formData]);
+
+  return h(div, {
+    className: 'data-update-section',
+  }, [
+    h2('1. Dataset Information'),
+    h(FormField, {
+      id: 'datasetName',
+      title: 'Dataset Name',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.datasetName,
+      onChange: ({ value }) => {
+        formData.properties.datasetName = value;
+      }
+    }),
+    h(FormField, {
+      id: 'description',
+      title: 'Dataset Description',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.description,
+      onChange: ({ value }) => {
+        formData.properties.description = value;
+      }
+    }),
+    h(FormField, {
+      id: 'dataDepositor',
+      title: 'Data Custodian',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.dataDepositor,
+      onChange: ({ value }) => {
+        formData.properties.dataDepositor = value;
+      }
+    }),
+    h(FormField, {
+      id: 'principalInvestigator',
+      title: 'Principal Investigator (PI)',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.principalInvestigator,
+      onChange: ({ value }) => {
+        formData.properties.principalInvestigator = value;
+      }
+    }),
+    h(FormField, {
+      id: 'dbGap',
+      title: 'Dataset Repository URL',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.dbGap,
+      onChange: ({ value }) => {
+        formData.properties.dbGap = value;
+      }
+    }),
+    h(FormField, {
+      id: 'dataType',
+      title: 'Data Type',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.dataType,
+      onChange: ({ value }) => {
+        formData.properties.dataType = value;
+      }
+    }),
+    h(FormField, {
+      id: 'species',
+      title: 'Species',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.species,
+      onChange: ({ value }) => {
+        formData.properties.species = value;
+      }
+    }),
+    h(FormField, {
+      id: 'phenotype',
+      title: 'Phenotype/Indication',
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.phenotype,
+      onChange: ({ value }) => {
+        formData.properties.phenotype = value;
+      }
+    }),
+    h(FormField, {
+      id: 'nrParticipants',
+      title: '# of Participants',
+      type: FormFieldTypes.NUMBER,
+      validators: [FormValidators.REQUIRED],
+      defaultValue: formData.properties.nrParticipants,
+      onChange: ({ value }) => {
+        formData.properties.nrParticipants = value;
+      }
+    }),
+    h(FormField, {
+      id: 'dac',
+      title: 'Data Access Committee',
+      validators: [FormValidators.REQUIRED],
+      type: FormFieldTypes.SELECT,
+      selectOptions: [], //TODO: list available DACs
+      defaultValue: [
+        { displayText: formData.dac.name, data: formData.dac.dacId },
+      ],
+    }),
+    h2('2. Data Use Terms'),
+    // readonly primary
+    div({}, [
+      h(FormField, {
+        title: 'Primary Data Use Terms*',
+        description: 'Please select one of the following data use permissions for your dataset',
+        type: FormFieldTypes.RADIOBUTTON,
+        id: 'generalUse',
+        toggleText: 'General Research Use',
+        value: 'generalUse',
+        defaultValue: formData.dataUse.generalUse === true ? 'generalUse' : undefined,
+        disabled: true,
+      }),
+      h(FormField, {
+        type: FormFieldTypes.RADIOBUTTON,
+        id: 'hmbResearch',
+        toggleText: 'Health/Medical/Biomedical Research Use',
+        value: 'hmbResearch',
+        defaultValue: formData.dataUse.hmbResearch === true ? 'hmbResearch' : undefined,
+        disabled: true,
+      }),
+      h(FormField, {
+        type: FormFieldTypes.RADIOBUTTON,
+        id: 'diseaseRestrictions',
+        toggleText: 'Disease-Specific Research Use',
+        value: 'diseaseRestrictions',
+        defaultValue: isArray(formData.dataUse.diseaseRestrictions) && formData.dataUse.diseaseRestrictions.length > 0 ? 'diseaseRestrictions' : undefined,
+        disabled: true,
+      }),
+      div({
+        style: {
+          marginBottom: '1.0rem'
+        }
+      }, [
+        h(FormField, {
+          type: FormFieldTypes.SELECT,
+          isMulti: true,
+          isCreatable: true,
+          optionsAreString: true,
+          isAsync: true,
+          id: 'diseaseRestrictionsText',
+          validators: [FormValidators.REQUIRED],
+          placeholder: 'none',
+          loadOptions: searchOntologies,
+          defaultValue: formData.dataUse.diseaseLabels,
+          disabled: true,
+        }),
+      ]),
+      h(FormField, {
+        type: FormFieldTypes.RADIOBUTTON,
+        id: 'otherPrimary',
+        toggleText: 'Other',
+        value: 'otherPrimary',
+        defaultValue: formData.dataUse.otherRestrictions ? 'otherPrimary' : undefined,
+        disabled: true,
+      }),
+      h(FormField, {
+        id: 'otherPrimaryText',
+        validators: [FormValidators.REQUIRED],
+        placeholder: 'none',
+        defaultValue: formData.dataUse.other,
+        disabled: true,
+      }),
+    ]),
+    // secondary
+    div({}, [
+      h(FormField, {
+        title: 'Secondary Data Use Terms',
+        description: 'Please select all applicable data use parameters.',
+        type: FormFieldTypes.CHECKBOX,
+        id: 'methodsResearch',
+        toggleText: 'No methods development or validation studies (NMDS)',
+        defaultValue: formData.dataUse.methodsResearch === true,
+        onChange: ({ value }) => {
+          formData.dataUse.methodsResearch = value;
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'geneticStudiesOnly',
+        toggleText: 'Genetic studies only (GSO)',
+        defaultValue: formData.dataUse.geneticStudiesOnly === true,
+        onChange: ({ value }) => {
+          formData.dataUse.geneticStudiesOnly = value;
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'publicationResults',
+        toggleText: 'Publication Required (PUB)',
+        defaultValue: formData.dataUse.publicationResults === true,
+        onChange: ({ value }) => {
+          formData.dataUse.publicationResults = value;
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'collaboratorRequired',
+        toggleText: 'Collaboration Required (COL)',
+        defaultValue: formData.dataUse.collaboratorRequired === true,
+        onChange: ({ value }) => {
+          formData.dataUse.collaboratorRequired = value;
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'ethicsApprovalRequired',
+        name: 'ethicsApprovalRequired',
+        toggleText: 'Ethics Approval Required (IRB)',
+        defaultValue: formData.dataUse.ethicsApprovalRequired === true,
+        onChange: ({ value }) => {
+          formData.dataUse.ethicsApprovalRequired = value;
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'geographicalRestrictions',
+        toggleText: 'Geographic Restriction (GS-)',
+        defaultValue: formData.dataUse.geographicalRestrictions === 'Yes',
+        onChange: ({ value }) => {
+          formData.dataUse.geographicalRestrictions = value ? 'Yes' : 'No';
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'publicationMoratorium',
+        toggleText: 'Publication Moratorium (MOR)',
+        defaultValue: formData.dataUse.publicationMoratorium === 'true',
+        onChange: ({ value }) => {
+          formData.dataUse.publicationMoratorium = value ? 'true' : 'false';
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'nonCommercialUse',
+        toggleText: 'Non-profit Use Only (NPU)',
+        defaultValue: formData.dataUse.commercialUse === false,
+        onChange: ({ value }) => {
+          formData.dataUse.commercialUse = !value;
+        }
+      }),
+      h(FormField, {
+        type: FormFieldTypes.CHECKBOX,
+        id: 'otherSecondary',
+        toggleText: 'Other',
+        defaultValue: formData.dataUse.hasSecondaryOther,
+        onChange: ({ value }) => {
+          formData.dataUse.hasSecondaryOther = value;
+        }
+      }),
+      h(FormField, {
+        id: 'otherSecondaryText',
+        validators: [FormValidators.REQUIRED],
+        placeholder: 'Please specify',
+        defaultValue: formData.dataUse.secondaryOther,
+        onChange: ({ value }) => {
+          formData.dataUse.secondaryOther = value;
+        }
+      }),
+    ]),
+    h2('3. Data Use Limitations'),
+    h2('4. NIH Certification'),
+    div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'flex-start', alignItems: 'flex-end', marginRight: '30px' } }, [
+      h(FormField, {
+        type: FormFieldTypes.FILE,
+        title: 'NIH Institutional Certification',
+        description: 'If an Institutional Certification for this dataset exists, please upload it here',
+        id: 'nihInstitutionalCertification',
+        placeholder: 'default.txt',
+      }),
+    ]),
+    div({ className: 'flex flex-row', style: { justifyContent: 'flex-end', marginTop: '2rem', marginBottom: '2rem' } }, [
+      button({
+        className: 'button button-white',
+        type: 'submit',
+        onClick: submitForm,
+      }, 'Submit'),
+    ]),
+  ]);
+};
+
+export default DatasetUpdate;

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -228,9 +228,7 @@ export const DatasetUpdate = (props) => {
       defaultValue: [
         { displayText: formData.dac.name, dacId: formData.dac.dacId },
       ],
-      onChange: ({ dacId }) => {
-        formData.dac.dacId = dacId;
-      },
+      disabled: true,
     }),
     h2('2. Data Use Terms'),
     // readonly primary

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -81,7 +81,7 @@ export const DatasetUpdate = (props) => {
     const newDataset = {
       name: dataset.name,
       dacId: formData.dac.dacId,
-      datasetProperties: [
+      properties: [
         asProperty('Dataset Name', formData.properties.datasetName),
         asProperty('Data Type', formData.properties.dataType),
         asProperty('Species', formData.properties.species),

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -283,36 +283,28 @@ export const DatasetUpdate = (props) => {
         id: 'methodsResearch',
         toggleText: 'No methods development or validation studies (NMDS)',
         defaultValue: formData.dataUse.methodsResearch === true,
-        onChange: ({ value }) => {
-          formData.dataUse.methodsResearch = value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'geneticStudiesOnly',
         toggleText: 'Genetic studies only (GSO)',
         defaultValue: formData.dataUse.geneticStudiesOnly === true,
-        onChange: ({ value }) => {
-          formData.dataUse.geneticStudiesOnly = value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'publicationResults',
         toggleText: 'Publication Required (PUB)',
         defaultValue: formData.dataUse.publicationResults === true,
-        onChange: ({ value }) => {
-          formData.dataUse.publicationResults = value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'collaboratorRequired',
         toggleText: 'Collaboration Required (COL)',
         defaultValue: formData.dataUse.collaboratorRequired === true,
-        onChange: ({ value }) => {
-          formData.dataUse.collaboratorRequired = value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
@@ -320,58 +312,45 @@ export const DatasetUpdate = (props) => {
         name: 'ethicsApprovalRequired',
         toggleText: 'Ethics Approval Required (IRB)',
         defaultValue: formData.dataUse.ethicsApprovalRequired === true,
-        onChange: ({ value }) => {
-          formData.dataUse.ethicsApprovalRequired = value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'geographicalRestrictions',
         toggleText: 'Geographic Restriction (GS-)',
         defaultValue: formData.dataUse.geographicalRestrictions === 'Yes',
-        onChange: ({ value }) => {
-          formData.dataUse.geographicalRestrictions = value ? 'Yes' : 'No';
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'publicationMoratorium',
         toggleText: 'Publication Moratorium (MOR)',
         defaultValue: formData.dataUse.publicationMoratorium === 'true',
-        onChange: ({ value }) => {
-          formData.dataUse.publicationMoratorium = value ? 'true' : 'false';
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'nonCommercialUse',
         toggleText: 'Non-profit Use Only (NPU)',
         defaultValue: formData.dataUse.commercialUse === false,
-        onChange: ({ value }) => {
-          formData.dataUse.commercialUse = !value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
         id: 'otherSecondary',
         toggleText: 'Other',
         defaultValue: formData.dataUse.hasSecondaryOther,
-        onChange: ({ value }) => {
-          formData.dataUse.hasSecondaryOther = value;
-        }
+        disabled: true,
       }),
       h(FormField, {
         id: 'otherSecondaryText',
         validators: [FormValidators.REQUIRED],
         placeholder: 'Please specify',
         defaultValue: formData.dataUse.secondaryOther,
-        onChange: ({ value }) => {
-          formData.dataUse.secondaryOther = value;
-        }
+        disabled: true,
       }),
     ]),
-    h2('3. Data Use Limitations'),
-    h2('4. NIH Certification'),
+    h2('3. NIH Certification'),
     div({ style: { display: 'flex', flexDirection: 'row', justifyContent: 'flex-start', alignItems: 'flex-end', marginRight: '30px' } }, [
       h(FormField, {
         type: FormFieldTypes.FILE,

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -7,7 +7,7 @@ import { DAC, DAR, DataSet } from '../../libs/ajax';
 import { Notifications } from '../../libs/utils';
 
 export const DatasetUpdate = (props) => {
-  const { dataset } = props;
+  const { dataset, history } = props;
 
   const [formData, setFormData] = useState({ dac: {}, dataUse: {}, properties: {} });
 
@@ -79,7 +79,7 @@ export const DatasetUpdate = (props) => {
     const consentGroups = [{ nihInstitutionalCertificationFile: nihFileData }];
 
     const newDataset = {
-      name: dataset.name,
+      name: formData.properties.datasetName,
       dacId: formData.dac.dacId,
       properties: [
         asProperty('Dataset Name', formData.properties.datasetName),
@@ -98,7 +98,10 @@ export const DatasetUpdate = (props) => {
     multiPartFormData.append('dataset', JSON.stringify(newDataset));
     multiPartFormData.append('consentGroups', consentGroups);
 
-    DataSet.updateDatasetV3(dataset.dataSetId, multiPartFormData).catch(() => {
+    DataSet.updateDatasetV3(dataset.dataSetId, multiPartFormData).then(() => {
+      history.push('/dataset_catalog');
+      Notifications.showSuccess({ text: 'Update submitted successfully!' });
+    }, () => {
       Notifications.showError({ text: 'Some errors occurred, the dataset was not updated.' });
     });
   };

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -27,10 +27,10 @@ export const DatasetUpdate = (props) => {
     if (!isNil(dacs)) {
       options = dacs.map((dac) => {
         return { displayText: dac.name, dacId: dac.dacId };
-      })
+      });
     }
     return options;
-  }
+  };
 
   const getDiseaseLabels = async (ontologyIds) => {
     let labels = [];
@@ -76,7 +76,7 @@ export const DatasetUpdate = (props) => {
     const formElement = event.target.form;
     const submitData = new FormData(formElement);
     const nihFileData = submitData.get('nihInstitutionalCertificationFile');
-    const consentGroups = [ { nihInstitutionalCertificationFile: nihFileData } ];
+    const consentGroups = [{ nihInstitutionalCertificationFile: nihFileData }];
 
     const newDataset = {
       name: dataset.name,

--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -75,7 +75,8 @@ export const DatasetUpdate = (props) => {
 
     const formElement = event.target.form;
     const submitData = new FormData(formElement);
-    const nihFileData = submitData.get('nihInstitutionalCertification');
+    const nihFileData = submitData.get('nihInstitutionalCertificationFile');
+    const consentGroups = [ { nihInstitutionalCertificationFile: nihFileData } ];
 
     const newDataset = {
       name: dataset.name,
@@ -93,7 +94,11 @@ export const DatasetUpdate = (props) => {
       ]
     };
 
-    DataSet.updateDatasetV3(dataset.dataSetId, newDataset, null, nihFileData).catch(() => {
+    const multiPartFormData = new FormData();
+    multiPartFormData.append('dataset', JSON.stringify(newDataset));
+    multiPartFormData.append('consentGroups', consentGroups);
+
+    DataSet.updateDatasetV3(dataset.dataSetId, multiPartFormData).catch(() => {
       Notifications.showError({ text: 'Some errors occurred, the dataset was not updated.' });
     });
   };
@@ -370,7 +375,7 @@ export const DatasetUpdate = (props) => {
         type: FormFieldTypes.FILE,
         title: 'NIH Institutional Certification',
         description: 'If an Institutional Certification for this dataset exists, please upload it here',
-        id: 'nihInstitutionalCertification',
+        id: 'nihInstitutionalCertificationFile',
         placeholder: 'default.txt',
       }),
     ]),

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -50,7 +50,9 @@ const onFormInputChange = (config, value) => {
   }
 
   if (value !== formValue) {
-    onChange({key: key, value: value, isValid: isValid(validation) });
+    if(!isNil(onChange)) {
+      onChange({key: key, value: value, isValid: isValid(validation) });
+    }
     setFormValue(value);
   }
 };
@@ -67,7 +69,7 @@ const errorMessages = (validation) => {
 //---------------------------------------------
 export const FormInputGeneric = (config) => {
   const {
-    id, title, disabled,
+    id, name, title, disabled,
     placeholder, type,
     inputStyle, ariaDescribedby,
     readOnly,
@@ -77,6 +79,7 @@ export const FormInputGeneric = (config) => {
   return div([
     input({
       id,
+      name: name || id,
       type: type?.inputType || 'text',
       className: `form-control ${!isValid(validation) ? 'errored' : ''}`,
       placeholder: placeholder || title,
@@ -97,7 +100,7 @@ export const FormInputGeneric = (config) => {
 
 export const FormInputTextarea = (config) => {
   const {
-    id, title, type, disabled,
+    id, name, title, type, disabled,
     placeholder,
     inputStyle, ariaDescribedby,
     rows, maxLength,
@@ -107,6 +110,7 @@ export const FormInputTextarea = (config) => {
   return div([
     textarea({
       id,
+      name: name || id,
       type: type || 'text',
       className: `form-control ${!isValid(validation) ? 'errored' : ''}`,
       placeholder: placeholder || title,
@@ -126,7 +130,7 @@ export const FormInputTextarea = (config) => {
 
 export const FormInputMultiText = (config) => {
   const {
-    id, title, disabled,
+    id, name, title, disabled,
     placeholder, ariaDescribedby, validators,
     inputStyle, formValue, validation,
     setValidation
@@ -173,6 +177,7 @@ export const FormInputMultiText = (config) => {
     }, [
       input({
         id,
+        name: name || id,
         type: 'text',
         className: `form-control ${!isValid(validation) || !isValid(inputValidation) ? 'errored' : ''}`,
         placeholder: placeholder || title,
@@ -436,7 +441,7 @@ export const FormInputYesNoRadioGroup = (config) => {
 
 export const FormInputRadioButton = (config) => {
   const {
-    id, disabled, value, toggleText,
+    id, name, disabled, value, toggleText,
     formValue, validation
   } = config;
 
@@ -444,8 +449,8 @@ export const FormInputRadioButton = (config) => {
     className: `radio-button-container ${!isValid(validation) ? 'errored' : ''}`,
   }, [
     h(RadioButton, {
-      id: id,
-      name: id,
+      id,
+      name: name || id,
       defaultChecked: !isNil(formValue) && formValue === value,
       onClick: () => {
         onFormInputChange(config, value);
@@ -462,14 +467,15 @@ export const FormInputRadioButton = (config) => {
 
 export const FormInputCheckbox = (config) => {
   const {
-    id, disabled, validation, toggleText,
+    id, name, disabled, validation, toggleText,
     formValue, ariaDescribedby
   } = config;
 
   return div({ className: 'checkbox' }, [
     input({
       type: 'checkbox',
-      id: `${id}`,
+      id,
+      name: name || id,
       checked: formValue,
       className: 'checkbox-inline',
       'aria-describedby': ariaDescribedby,
@@ -485,14 +491,15 @@ export const FormInputCheckbox = (config) => {
 
 export const FormInputSlider = (config) => {
   const {
-    id, disabled, toggleText, formValue
+    id, name, disabled, toggleText, formValue
   } = config;
 
   return div({ className: 'flex-row', style: { justifyContent: 'unset' } }, [
     label({ className: 'switch', htmlFor: `${id}` }, [
       input({
         type: 'checkbox',
-        id: `${id}`,
+        id,
+        name: name || id,
         checked: formValue,
         className: 'checkbox-inline',
         onChange: (event) => onFormInputChange(config, event.target.checked),
@@ -512,11 +519,13 @@ export const FormInputSlider = (config) => {
 export const FormInputFile = (config) => {
   const {
     id,
+    name,
     formValue,
     uploadText = 'Upload a file',
     hideTextBar = false,
     hideInput = false,
     multiple = false,
+    placeholder = 'Filename.txt',
     accept = '',
     validation,
   } = config;
@@ -534,6 +543,7 @@ export const FormInputFile = (config) => {
     }, [
       input({
         id,
+        name: name || id,
         type: 'file',
         multiple,
         accept,
@@ -569,7 +579,7 @@ export const FormInputFile = (config) => {
     }, [
       h(FormField, {
         id: `${id}_fileName`,
-        placeholder: 'Filename.txt',
+        placeholder,
         validation,
         defaultValue: formValue?.name,
         readOnly: true,

--- a/src/components/forms/forms.js
+++ b/src/components/forms/forms.js
@@ -135,6 +135,7 @@ export const FormFieldTypes = {
     component: FormInputFile,
     requiredProps: [],
     optionalProps: [
+      'placeholder',
       'uploadText',
       'hideTextBar',
       'hideInput',

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -374,9 +374,10 @@ export const DataSet = {
     return await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataSetObject), {method: 'PUT'}]));
   },
 
-  updateDatasetV3: async (datasetId, dataSetObject, alternativeDataSharingData, nihCertificationData) => {
+  updateDatasetV3: async (datasetId, datasetAndFiles) => {
     const url = `${await getApiUrl()}/api/dataset/v3/${datasetId}`;
-    return await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataSetObject), {method: 'PUT'}]));
+    const res = await axios.put(url, datasetAndFiles, Config.multiPartOpts());
+    return res.data;
   },
 
   validateDatasetName: async (name) => {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -254,6 +254,12 @@ export const DAR = {
     return await res.json();
   },
 
+  searchOntologyIdList: async ids => {
+    const url = `${await getOntologyUrl()}/search?id=${ids}`;
+    const res = await fetchOk(url, Config.authOpts());
+    return await res.json();
+  },
+
   getDARDocument: async (referenceId, fileType) => {
     const authOpts = Object.assign(Config.authOpts(), {responseType: 'blob'});
     authOpts.headers = Object.assign(authOpts.headers, {
@@ -365,6 +371,11 @@ export const DataSet = {
 
   updateDataset: async (datasetId, dataSetObject) => {
     const url = `${await getApiUrl()}/api/dataset/${datasetId}`;
+    return await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataSetObject), {method: 'PUT'}]));
+  },
+
+  updateDatasetV3: async (datasetId, dataSetObject, alternativeDataSharingData, nihCertificationData) => {
+    const url = `${await getApiUrl()}/api/dataset/v3/${datasetId}`;
     return await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataSetObject), {method: 'PUT'}]));
   },
 

--- a/src/pages/DatasetUpdateForm.js
+++ b/src/pages/DatasetUpdateForm.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useState, useEffect } from 'react';
+
+import { Notifications } from '../libs/utils';
+import lockIcon from '../images/lock-icon.png';
+import { Styles } from '../libs/theme';
+import DatasetUpdate from '../components/data_update/DatasetUpdate';
+import { DataSet } from '../libs/ajax';
+
+export const DatasetUpdateForm = (props) => {
+  const { datasetId } = props.match.params;
+
+  const [failedInit, setFailedInit] = useState(true);
+  const [dataset, setDataset] = useState({});
+
+  useEffect(() => {
+    const init = async () => {
+      try {
+        setDataset(await DataSet.getDataSetsByDatasetId(datasetId));
+        setFailedInit(false);
+      } catch (error) {
+        Notifications.showError({ text: 'Failed to load dataset' });
+      }
+    };
+    init();
+  }, [datasetId]);
+
+  return !failedInit && <div style={Styles.PAGE} >
+    <div style={{ display: 'flex', justifyContent: 'space-between', width: '112%', marginLeft: '-6%', padding: '0 2.5%' }}>
+      <div className='left-header-section' style={Styles.LEFT_HEADER_SECTION} >
+        <div style={Styles.ICON_CONTAINER}>
+          <img id='lock-icon' src={lockIcon} style={Styles.HEADER_IMG} />
+        </div>
+        <div style={Styles.HEADER_CONTAINER}>
+          <div style={Styles.TITLE}>
+            Dataset Update Form
+            <div style={Styles.MEDIUM_DESCRIPTION}>
+              This is an easy way to update a dataset in DUOS!
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <form style={{ margin: 'auto', maxWidth: 800 }}>
+      <DatasetUpdate dataset={dataset} />
+    </form>
+  </div>;
+};
+
+export default DatasetUpdateForm;

--- a/src/pages/DatasetUpdateForm.js
+++ b/src/pages/DatasetUpdateForm.js
@@ -8,6 +8,7 @@ import DatasetUpdate from '../components/data_update/DatasetUpdate';
 import { DataSet } from '../libs/ajax';
 
 export const DatasetUpdateForm = (props) => {
+  const { history } = props;
   const { datasetId } = props.match.params;
 
   const [failedInit, setFailedInit] = useState(true);
@@ -43,7 +44,7 @@ export const DatasetUpdateForm = (props) => {
     </div>
 
     <form style={{ margin: 'auto', maxWidth: 800 }}>
-      <DatasetUpdate dataset={dataset} />
+      <DatasetUpdate dataset={dataset} history={history} />
     </form>
   </div>;
 };


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2187

### Summary

Add form to edit datasets

![Screenshot 2023-06-16 at 14-00-55 Broad Data Use Oversight System](https://github.com/DataBiosphere/duos-ui/assets/16434376/e24031cb-119d-4ee3-a449-1f08e299e6e9)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
