### PR TITLE
[DUOS-2575] Remove redundant babel plugins

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,6 @@
         "@babel/eslint-parser": "7.21.3",
         "@babel/eslint-plugin": "7.19.1",
         "@babel/plugin-proposal-class-properties": "7.18.6",
-        "@babel/plugin-syntax-flow": "7.21.4",
-        "@babel/plugin-transform-react-jsx": "7.21.0",
         "@babel/preset-react": "7.22.3",
         "@types/react": "18.2.12",
         "ajv-cli": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "@babel/eslint-parser": "7.21.3",
     "@babel/eslint-plugin": "7.19.1",
     "@babel/plugin-proposal-class-properties": "7.18.6",
-    "@babel/plugin-syntax-flow": "7.21.4",
-    "@babel/plugin-transform-react-jsx": "7.21.0",
     "@babel/preset-react": "7.22.3",
     "@types/react": "18.2.12",
     "ajv-cli": "5.0.0",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2575

### Summary

These plugins are causing unnecessary update churn. We don't use flow anywhere in our project and these dependencies aren't needed anymore. `@babel/preset-react` now integrates these dependencies.

Closes #2238 , #2246 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
