### PR TITLE
[DUOS-2523][risk=no] Switch multitext to tag inputs

### DIFF
--- a/src/components/data_submission/ds_study_information.js
+++ b/src/components/data_submission/ds_study_information.js
@@ -76,7 +76,22 @@ export default function DataSubmissionStudyInformation(props) {
       title: 'Data Types',
       placeholder: 'Type',
       validators: [FormValidators.REQUIRED],
-      type: FormFieldTypes.MULTITEXT,
+      type: FormFieldTypes.SELECT,
+      isCreatable: true,
+      isMulti: true,
+      optionsAreString: true,
+      // The top properties were extracted from the prod database and deduplicated using the query:
+      // SELECT property_value, COUNT(*) FROM dataset_property WHERE property_key = 2 GROUP BY property_value ORDER BY COUNT(*) DESC;
+      selectOptions: [
+        'CITE-seq',
+        'Hybrid Capture',
+        'RNA-Seq',
+        'scRNA-Seq',
+        'Spatial Transcriptomics',
+        'snRNA-Seq',
+        'Whole Genome (WGS)',
+        'Whole Exome (WES)',
+      ],
       validation: validation.dataTypes,
       onChange,
       onValidationChange
@@ -129,10 +144,21 @@ export default function DataSubmissionStudyInformation(props) {
       title: 'Data Custodian Email',
       description: `Insert the email for any individual with the 
       authority to add/remove users access to this study’s datasets.`,
-      type: FormFieldTypes.MULTITEXT,
+      type: FormFieldTypes.SELECT,
       validators: [
         FormValidators.EMAIL
       ],
+      selectOptions: [],
+      isCreatable: true,
+      isMulti: true,
+      optionsAreString: true,
+      selectConfig: {
+        components: {
+          DropdownIndicator: null,
+          Menu: () => null,
+        },
+      },
+      placeholder: 'Add one or more emails',
       validation: validation.dataCustodianEmail,
       onChange,
       onValidationChange


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2523

### Summary

Switch multitext to tag inputs and add a default list for data types based on the most commonly used data types. Custom data types can be entered as well.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
