### PR TITLE
[DUOS-2565][risk=no] Fix uncontrolled input error due to null

### DIFF
--- a/src/components/data_submission/consent_group/ConsentGroupForm.js
+++ b/src/components/data_submission/consent_group/ConsentGroupForm.js
@@ -42,7 +42,7 @@ export const ConsentGroupForm = (props) => {
     dataLocation: null,
 
     url: '',
-    numberOfParticipants: null,
+    numberOfParticipants: undefined, // numeric
     fileTypes: [{}],
   });
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2565

### Summary

Prevent uncontrolled input error due to null field.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
