### PR TITLE
[DUOS-2456][risk=no] Do not normalize each data use group

### DIFF
--- a/src/components/dar_dataset_table/DarDatasetTableCellData.js
+++ b/src/components/dar_dataset_table/DarDatasetTableCellData.js
@@ -19,11 +19,6 @@ export function votesCellData({elections, dataUseGroup, label= 'votes'}) {
   let displayValue = '-/-';
   if (!isEmpty(elections)) {
     const darElections = filter(e => e.electionType === 'DataAccess')(elections);
-    const datasetIds = flow(
-      filter(e => e.electionType === 'DataAccess'),
-      map(e => e.dataSetId),
-      uniq
-    )(darElections);
     const memberVotes = flow(
       flatMap(e => values(e.votes)),
       filter(v => v.type === 'DAC')
@@ -32,8 +27,8 @@ export function votesCellData({elections, dataUseGroup, label= 'votes'}) {
       filter(v => !isUndefined(v.vote)),
       map(v => get('vote')(v))
     )(memberVotes);
-    const numerator = voteValues.length / datasetIds.length;
-    const denominator = memberVotes.length / datasetIds.length;
+    const numerator = voteValues.length;
+    const denominator = memberVotes.length;
     displayValue = numerator + '/' + denominator;
   }
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2456

### Summary

This is one potential way to avoid fractional votes.

For example, `DAR-632` has a Data Use Group with 2 datasets. One dataset has 10 DAC members and the other dataset has 5 DAC members. As a result, 15/2 = 7.5, and this ends up with fractional votes.

Avoiding the normalization on the dataset size fixes this issue, but I am not sure it makes sense to display the numbers this way.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
