### PR TITLE
[DUOS-1740][risk=no] Add Dependabot Groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       - "npm"
     commit-message:
       prefix: "[DUOS-1740-dependabot]"
+    groups:
+      npm-dependencies:
+        patterns: "*"
   - package-ecosystem: docker
     directory: "/"
     schedule:
@@ -26,3 +29,6 @@ updates:
       - "docker"
     commit-message:
       prefix: "[DUOS-1740-dependabot]"
+    groups:
+      docker-dependencies:
+        patterns: "*"


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-1740

### Summary
Add `group` to enable grouped dependabot PRs. See https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/ for more info.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
