### PR TITLE
[DUOS-2075][risk=no] Migrate to translatedDataUse field

### DIFF
--- a/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
+++ b/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
@@ -23,7 +23,7 @@ const sampleDataset = {
   },
   'dacId': 1,
   'consentId': 'dcf14449-ff38-4fc5-8ab1-4e08f91f2521',
-  'translatedUseRestriction': 'Samples are restricted for use under the following conditions:\nData is limited for health/medical/biomedical research. [HMB]\nCommercial use is not prohibited.\nData use for methods development research irrespective of the specified data use limitations is not prohibited.\nRestrictions for use as a control set for diseases other than those defined were not specified.',
+  'translatedDataUse': 'Samples are restricted for use under the following conditions:\nData is limited for health/medical/biomedical research. [HMB]\nCommercial use is not prohibited.\nData use for methods development research irrespective of the specified data use limitations is not prohibited.\nRestrictions for use as a control set for diseases other than those defined were not specified.',
   'deletable': true,
   'properties': [
     {

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -476,7 +476,7 @@ const dar = {
       },
       'dacId': 1,
       'consentId': 'B177D3C2-CDD8-4153-9CBF-AE4F0C34609A',
-      'translatedUseRestriction': 'Samples are restricted for use under the following conditions:\nData use is limited for studying: sleep apnea [DS]\nFuture use for population origins or ancestry research is prohibited. [POA]\nCommercial use is not prohibited.\nData use for methods development research irrespective of the specified data use limitations is not prohibited.\nFuture use as a control set for diseases other than those specified is prohibited. [NCTRL]',
+      'translatedDataUse': 'Samples are restricted for use under the following conditions:\nData use is limited for studying: sleep apnea [DS]\nFuture use for population origins or ancestry research is prohibited. [POA]\nCommercial use is not prohibited.\nData use for methods development research irrespective of the specified data use limitations is not prohibited.\nFuture use as a control set for diseases other than those specified is prohibited. [NCTRL]',
       'deletable': false,
       'sharingPlanDocument': null,
       'sharingPlanDocumentName': null,
@@ -668,7 +668,7 @@ const dacDatasets = [{
   'dacId': 3,
   'dataSetId': 13,
   'consentId': 'B177D3C2-CDD8-4153-9CBF-AE4F0C34609A',
-  'translatedUseRestriction': '',
+  'translatedDataUse': '',
   'deletable': null,
   'properties': [
     {

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -12,7 +12,7 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
   constructor() {
     super();
     this.state = {
-      translatedDatasetRestrictions: [],
+      translatedDataUse: [],
       getStructuredUseRestrictionLink: this.getStructuredUseRestrictionLink.bind(this)
     };
   }
@@ -46,14 +46,14 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
 
   getStructuredUseRestrictionLink = (index) => {
     if(this.state.translatedDatasetRestrictions && this.state.translatedDatasetRestrictions[index]) {
-      const translatedUseRestrictions = this.state.translatedDatasetRestrictions[index]
+      const translatedDataUse = this.state.translatedDatasetRestrictions[index]
         .map((translations) => translations.description)
         .join('\n');
-      if (isEmpty(translatedUseRestrictions)) {
+      if (isEmpty(translatedDataUse)) {
         return span({ className: 'disabled' }, ['---']);
       }
       return ReadMore({
-        content: translatedUseRestrictions,
+        content: translatedDataUse,
         className: 'row no-margin',
         style: { whiteSpace: 'pre-line' },
         charLimit: 30,

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -610,7 +610,8 @@ class DatasetRegistration extends Component {
     result.datasetName = data.datasetName;
     result.dacId = this.state.selectedDac.dacId;
     result.consentId = data.consentId;
-    result.translatedDataUse = data.translatedDataUse;
+    // The deprecated API this posts to is expecting a `translatedUseRestriction` field
+    result.translatedUseRestriction = data.translatedDataUse;
     result.deletable = true;
     result.active = true;
     result.needsApproval = data.needsApproval;

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -610,7 +610,7 @@ class DatasetRegistration extends Component {
     result.datasetName = data.datasetName;
     result.dacId = this.state.selectedDac.dacId;
     result.consentId = data.consentId;
-    result.translatedUseRestriction = data.translatedUseRestriction;
+    result.translatedDataUse = data.translatedDataUse;
     result.deletable = true;
     result.active = true;
     result.needsApproval = data.needsApproval;


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2075

### Summary
Previous PRs created a new field on datasets, `translatedDataUse`, which replaces `translatedUseRestriction`. The new data use translation is calculated on the back end while the old value was provided from external systems. This PR makes use of the new field in the UI so we can deprecate the old field.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
