### PR TITLE
[DUOS-1740][risk=no] Switch dependabot group pattern to array

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,8 @@ updates:
       prefix: "[DUOS-1740-dependabot]"
     groups:
       npm-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"
   - package-ecosystem: docker
     directory: "/"
     schedule:
@@ -31,4 +32,5 @@ updates:
       prefix: "[DUOS-1740-dependabot]"
     groups:
       docker-dependencies:
-        patterns: "*"
+        patterns:
+          - "*"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-1740

### Summary

Dependabot group pattern is required to be an array

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
