### PR TITLE
[DUOS-2609][risk=no] Specify Icon Size

### DIFF
--- a/src/components/LibraryCardAgreementTermsDownload.js
+++ b/src/components/LibraryCardAgreementTermsDownload.js
@@ -3,7 +3,7 @@ import DownloadIcon from 'react-material-icon-svg/dist/Download';
 import {a, div} from 'react-hyperscript-helpers';
 import React from 'react';
 
-const downloadIcon = <DownloadIcon fill={'black'} style={{verticalAlign: 'middle'}}/>;
+const downloadIcon = <DownloadIcon fill={'black'} style={{verticalAlign: 'middle', height: '24px'}}/>;
 export const LibraryCardAgreementTermsDownload =
   div({}, [
     'I agree to the terms of the Library Card Agreement',


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2609

### Summary
Minor fix for the download icon to specify size.

#### With fix:
![Screenshot 2023-07-17 at 7 30 34 AM](https://github.com/DataBiosphere/duos-ui/assets/116679/68d284b4-5f6a-4c9c-b58a-e576255e61a3)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
