### PR TITLE
[DUOS-2559][risk=no] Extract catalog styles into a module

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1643,16 +1643,6 @@ input:-webkit-autofill {
   overflow-y: visible;
 }
 
-.table-scroll-admin {
-  overflow-x: scroll;
-  margin: 0 25px 5px 60px !important;
-  overflow-y: visible;
-}
-
-.table-scroll-admin thead, .table-scroll thead {
-  padding: 0 10px 0 10px;
-}
-
 .table {
   margin: 15px 0 !important;
 }
@@ -1675,20 +1665,6 @@ input:-webkit-autofill {
 
 .table-titles label {
   padding-top: 5px;
-}
-
-td:first-child {
-  position: absolute;
-  margin-left: -40px;
-}
-
-td:first-child .checkbox {
-  margin-top: 0px;
-  display: inline;
-}
-
-td:first-child .checkbox label {
-  padding-top: 1px;
 }
 
 .dataset-actions {
@@ -1771,10 +1747,6 @@ td:first-child .checkbox label {
   margin-bottom: 0;
   padding: 0 15px 0 0;
   display: inline;
-}
-
-.dataset-disabled, .dataset-disabled p, .dataset-disabled a {
-  color: #cccccc !important;
 }
 
 .accordion-title {
@@ -1983,11 +1955,6 @@ input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:foc
 
 .noty_type__success {
   background-color: #00928A;
-}
-
-.layout-table td:first-child {
-  position: inherit;
-  margin-left: -40px;
 }
 
 .layout-table th,td {

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -11,13 +11,13 @@ import {SearchBox} from '../components/SearchBox';
 import {DAC, DAR, DataSet} from '../libs/ajax';
 import {Storage} from '../libs/storage';
 import {Theme} from '../libs/theme';
-import datasetIcon from '../images/icon_dataset_.png';
 import {getBooleanFromEventHtmlDataValue, USER_ROLES} from '../libs/utils';
 import {DataUseTranslation} from '../libs/dataUseTranslation';
 import {spinnerService} from '../libs/spinner-service';
 import { ArrowDropUp, ArrowDropDown } from '@mui/icons-material';
 import {isDevEnv} from '../utils/EnvironmentUtils';
 import DuosLogo from '../images/duos-network-logo.svg';
+import style from './DatasetCatalog.module.css';
 
 const tableBody = {
   ...Theme.textTableBody,
@@ -457,13 +457,11 @@ export default function DatasetCatalog(props) {
               })
             ])
           ]),
-          div({
-            className: 'right'
-          }, [
+          div({}, [
             div({ className: 'col-lg-7 col-md-7 col-sm-7 col-xs-7 search-wrapper', style: { display: 'flex' } }, [
               h(SearchBox, { id: 'datasetCatalog', searchHandler: handleSearchDul, pageHandler: handlePageChange, color: 'dataset' }),
               div({
-                className: 'checkbox',
+                className: style['checkbox'],
                 isRendered: isCustomDacDatasetPage,
                 style: {
                   marginLeft: '10px',
@@ -474,7 +472,7 @@ export default function DatasetCatalog(props) {
                   checked: useCustomFilter,
                   type: 'checkbox',
                   'select-all': 'true',
-                  className: 'checkbox-inline',
+                  className: style['checkbox-inline'],
                   id: 'chk_filterDacId',
                   onChange: () => {
                     setUseCustomFilter(!useCustomFilter);
@@ -482,7 +480,7 @@ export default function DatasetCatalog(props) {
                     setCurrentPageAllDatasets(1);
                   },
                 }),
-                label({ className: 'regular-checkbox', htmlFor: 'chk_filterDacId' }, [`Filter to only ${customDacDatasetPage?.dacName} data`]),
+                label({ className: style['regular-checkbox'], htmlFor: 'chk_filterDacId' }, [`Filter to only ${customDacDatasetPage?.dacName} data`]),
               ]),
             ]),
 
@@ -501,7 +499,7 @@ export default function DatasetCatalog(props) {
         div({style: Theme.lightTable}, [
           form({ className: 'pos-relative' }, [
             div({
-              className: 'checkbox display-inline-block',
+              className: style['checkbox display-inline-block'],
               style: {
                 marginLeft: '28px',
                 marginBottom: '0px',
@@ -519,7 +517,7 @@ export default function DatasetCatalog(props) {
             ]),
             // vertical line
             div({
-              className: 'display-inline-block',
+              className: style['display-inline-block'],
               style: {
                 top: '13px',
                 position: 'absolute',
@@ -534,7 +532,7 @@ export default function DatasetCatalog(props) {
             ]),
 
             div({
-              className: 'checkbox display-inline-block',
+              className: style['checkbox display-inline-block'],
               style: {
                 marginLeft: '18px',
                 marginBottom: '0px',
@@ -544,34 +542,33 @@ export default function DatasetCatalog(props) {
                 type: 'checkbox',
                 id: 'chk_onlySelected',
                 checked: filterToOnlySelected,
-                className: 'checkbox-inline',
                 onChange: () => {
                   setFilterToOnlySelected(!filterToOnlySelected);
                 }
               }),
-              label({ id: 'lbl_onlySelected', className: 'regular-checkbox', htmlFor: 'chk_onlySelected' },
+              label({ id: 'lbl_onlySelected', className: style['regular-checkbox'], htmlFor: 'chk_onlySelected' },
                 [`Show ${numDatasetsSelected} Dataset${(numDatasetsSelected != 1?'s':'')} Selected`])
             ]),
           ]),
 
-          div({ className: currentUser.isAdmin ? 'table-scroll-admin' : 'table-scroll' }, [
+          div({ className: currentUser.isAdmin ? style['table-scroll-admin'] : style['table-scroll'] }, [
             table({ className: 'table' }, [
               thead({}, [
                 tr({}, [
                   th(),
-                  th({ isRendered: (currentUser.isAdmin || currentUser.isChairPerson), className: 'cell-size', style: { minWidth: '14rem' }}, ['Actions']),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'datasetIdentifier', label: 'Dataset ID' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Dataset Name' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Data Access Committee' })]),
-                  th({ className: 'cell-size' }, ['Data Source']),
-                  th({ className: 'cell-size' }, ['Data Use Terms']),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Data Type' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Disease Studied' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Principal Investigator (PI)' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: '# of Participants' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Description' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Species' })]),
-                  th({ className: 'cell-size' }, [getSortDisplay({ field: 'Data Custodian' })]),
+                  th({ isRendered: (currentUser.isAdmin || currentUser.isChairPerson), className: style['cell-size'], style: { minWidth: '14rem' }}, ['Actions']),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'datasetIdentifier', label: 'Dataset ID' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Dataset Name' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Data Access Committee' })]),
+                  th({ className: style['cell-size'] }, ['Data Source']),
+                  th({ className: style['cell-size'] }, ['Data Use Terms']),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Data Type' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Disease Studied' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Principal Investigator (PI)' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: '# of Participants' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Description' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Species' })]),
+                  th({ className: style['cell-size'] }, [getSortDisplay({ field: 'Data Custodian' })]),
                 ])
               ]),
 
@@ -579,19 +576,18 @@ export default function DatasetCatalog(props) {
                 datasetsOnPage
                   .map((dataset, trIndex) => {
                     return h(Fragment, { key: trIndex }, [
-                      tr({ className: 'tableRow' }, [
-                        td({ width: '60px' }, [
-                          div({ className: 'checkbox', isRendered: !isNil(dataset.dacId)}, [
+                      tr({}, [
+                        td({ className: style['first-child'], width: '60px' }, [
+                          div({ className: style['checkbox'], isRendered: !isNil(dataset.dacId)}, [
                             input({
                               type: 'checkbox',
                               id: trIndex + '_chkSelect',
                               name: 'chk_select',
                               checked: dataset.checked,
-                              className: 'checkbox-inline user-checkbox',
                               onChange: checkSingleRow(dataset)
                             }),
                             label({
-                              className: 'regular-checkbox rp-choice-questions',
+                              className: style['regular-checkbox'],
                               // Apply additional styling for inactive datasets
                               style: inactiveCheckboxStyle(dataset),
                               htmlFor: trIndex + '_chkSelect' })
@@ -599,7 +595,7 @@ export default function DatasetCatalog(props) {
                         ]),
 
                         td({ isRendered: (currentUser.isAdmin || currentUser.isChairPerson) }, [
-                          div({ className: 'dataset-actions' }, [
+                          div({ className: style['dataset-actions'] }, [
                             a({
                               id: trIndex + '_btnDelete', name: 'btn_delete', onClick: openDelete(dataset.dataSetId),
                               disabled: (!dataset.deletable || !isEditDatasetEnabled(dataset))
@@ -636,7 +632,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: dataset.datasetIdentifier + '_dataset', name: 'datasetIdentifier',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ? style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           dataset['Dataset ID']
@@ -644,39 +640,39 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_datasetName', name: 'datasetName',
-                          className: 'cell-size ' + (!isVisible(dataset) ? !!'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ? !! style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [findPropertyValue(dataset, 'Dataset Name')]),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           dataset['Data Access Committee']
                         ]),
 
                         td({
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           getLinkDisplay(dataset, trIndex)
                         ]),
 
                         td({
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           a({
                             id: trIndex + '_linkTranslatedDul', name: 'link_translatedDul',
                             onClick: () => openTranslatedDUL(dataset.dataUse),
-                            className: (!isVisible(dataset) ? 'dataset-disabled' : 'enabled')
+                            className: (!isVisible(dataset) ?  style['dataset-disabled'] : 'enabled')
                           }, dataset.codeList)
                         ]),
 
                         td({
                           id: trIndex + '_dataType', name: 'dataType',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           findPropertyValue(dataset, 'Data Type')
@@ -684,14 +680,14 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_phenotype', name: 'phenotype',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           dataset['Disease Studied']
                         ]),
 
                         td({
-                          id: trIndex + '_pi', name: 'pi', className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          id: trIndex + '_pi', name: 'pi', className: 'cell-size ' + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           dataset['Principal Investigator (PI)']
@@ -699,7 +695,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_participants', name: 'participants',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           dataset['# of Participants']
@@ -707,7 +703,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_description', name: 'description',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           findPropertyValue(dataset, 'Description')
@@ -715,7 +711,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_species', name: 'species',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           findPropertyValue(dataset, 'Species')
@@ -723,7 +719,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_depositor', name: 'depositor',
-                          className: 'cell-size ' + (!isVisible(dataset) ? 'dataset-disabled' : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ?  style['dataset-disabled'] : ''),
                           style: tableBody
                         }, [
                           dataset['Data Custodian']

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -499,7 +499,7 @@ export default function DatasetCatalog(props) {
         div({style: Theme.lightTable}, [
           form({ className: 'pos-relative' }, [
             div({
-              className: style['checkbox display-inline-block'],
+              className: `${style['checkbox']} ${style['display-inline-block']}`,
               style: {
                 marginLeft: '28px',
                 marginBottom: '0px',
@@ -532,7 +532,7 @@ export default function DatasetCatalog(props) {
             ]),
 
             div({
-              className: style['checkbox display-inline-block'],
+              className: `${style['checkbox']} ${style['display-inline-block']}`,
               style: {
                 marginLeft: '18px',
                 marginBottom: '0px',

--- a/src/pages/DatasetCatalog.module.css
+++ b/src/pages/DatasetCatalog.module.css
@@ -1,0 +1,111 @@
+.first-child {
+  position: absolute;
+  margin-left: -40px;
+}
+
+.checkbox {
+  margin-top: 0;
+  display: inline;
+}
+
+.checkbox label {
+  padding-top: 1px;
+}
+
+.checkbox[disabled] .regular-checkbox {
+  cursor: not-allowed !important;
+  opacity: 0.65;
+}
+
+.checkbox[disabled] .regular-checkbox:before  {
+  background-color: #eee;
+  border: 1px solid #ccc;
+}
+
+.regular-checkbox {
+  cursor: pointer;
+  position: relative;
+  padding-left: 25px !important;
+  margin-right: 15px;
+  font-size: 13px;
+}
+
+.regular-checkbox.normal {
+  font-weight: normal;
+  font-size: 15px;
+  color: #777777;
+}
+
+.regular-checkbox:before {
+  content: "";
+  width: 18px;
+  height: 18px;
+  margin-right: 10px;
+  position: absolute;
+  left: 0;
+  background-color: #ffffff;
+  border-radius: 3px;
+}
+
+.form-control, .regular-checkbox:before {
+  border: 1px solid #999999;
+}
+
+.cell-size {
+  white-space: nowrap;
+  overflow: hidden;
+  width: 1%;
+}
+
+.cell-size p {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 400px!important;
+}
+
+.table-scroll {
+  overflow-x: scroll;
+  margin: 0 25px 5px 60px;
+  overflow-y: visible;
+}
+
+.table-scroll-admin {
+  overflow-x: scroll;
+  margin: 0 25px 5px 60px !important;
+  overflow-y: visible;
+}
+
+.table-scroll-admin thead, .table-scroll thead {
+  padding: 0 10px 0 10px;
+}
+
+.display-inline-block {
+  display: inline-block !important;
+}
+
+.dataset-actions {
+  display: inline !important;
+  margin: 0;
+  padding-right: 10px;
+}
+
+.dataset-actions a {
+  display: inline !important;
+  margin: 0 5px 0 0;
+}
+
+.dataset-actions a:hover span {
+  color: #2FA4E7 !important;
+}
+
+.dataset-actions a .glyphicon {
+  text-shadow: 1px 1px 0 #ffffff !important;
+  padding: 0;
+  vertical-align: bottom;
+  font-size: 1.15em;
+}
+
+.dataset-disabled, .dataset-disabled p, .dataset-disabled a {
+  color: #cccccc !important;
+}


### PR DESCRIPTION
### Addresses
Partial support for https://broadworkbench.atlassian.net/browse/DUOS-2559

### Summary
Pull a bunch of problematic global styles into a css module for the Dataset Catalog. This PR doesn't try to pull ALL styles into the module, just as many of the problematic ones as possible.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
