### PR TITLE
[DUOS-2579][risk=no] Bug Fix: Use name on dataset instead of props

### DIFF
--- a/src/components/dac_dataset_table/DACDatasetTableCellData.js
+++ b/src/components/dac_dataset_table/DACDatasetTableCellData.js
@@ -35,8 +35,8 @@ export function dataSubmitterCellData({dataset, label = 'dataSubmitterCellData'}
 
 export function datasetNameCellData({dataset, label = 'datasetNameCellData'}) {
   return {
-    data: <div className={style['cell-data']}>{dataset.datasetName}</div>,
-    value: dataset.datasetName,
+    data: <div className={style['cell-data']}>{dataset.name}</div>,
+    value: dataset.name,
     id: `name-cell-data-${dataset.dataSetId}`,
     cellStyle: {width: styles.cellWidths.datasetName},
     label

--- a/src/components/dac_dataset_table/DACDatasetTableCellData.js
+++ b/src/components/dac_dataset_table/DACDatasetTableCellData.js
@@ -34,10 +34,9 @@ export function dataSubmitterCellData({dataset, label = 'dataSubmitterCellData'}
 }
 
 export function datasetNameCellData({dataset, label = 'datasetNameCellData'}) {
-  const datasetName = DatasetService.findDatasetPropertyValue(dataset, 'Dataset Name');
   return {
-    data: <div className={style['cell-data']}>{datasetName}</div>,
-    value: datasetName,
+    data: <div className={style['cell-data']}>{dataset.datasetName}</div>,
+    value: dataset.datasetName,
     id: `name-cell-data-${dataset.dataSetId}`,
     cellStyle: {width: styles.cellWidths.datasetName},
     label

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -98,7 +98,7 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
             this.props.datasets.map((dataset, index) => {
               return tr({ key: dataset.datasetIdentifier }, [
                 td({ className: 'table-items cell-size', style: { position: 'relative' } }, [dataset.datasetIdentifier]),
-                td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Dataset Name', '---')]),
+                td({ className: 'table-items cell-size' }, [dataset.datasetName]),
                 td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
                 td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(index)]),
                 td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -98,7 +98,7 @@ export const DacDatasetsModal = hh(class DacDatasetsModal extends Component {
             this.props.datasets.map((dataset, index) => {
               return tr({ key: dataset.datasetIdentifier }, [
                 td({ className: 'table-items cell-size', style: { position: 'relative' } }, [dataset.datasetIdentifier]),
-                td({ className: 'table-items cell-size' }, [dataset.datasetName]),
+                td({ className: 'table-items cell-size' }, [dataset.name]),
                 td({ className: 'table-items cell-size' }, [this.getDbGapLinkValue(dataset.properties)]),
                 td({ className: 'table-items cell-size' }, [this.getStructuredUseRestrictionLink(index)]),
                 td({ className: 'table-items cell-size' }, [this.getPropertyValue(dataset.properties, 'Data Type', '---')]),

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -199,13 +199,11 @@ export default function DatasetCatalog(props) {
     let datasetIdList = [];
     selectedDatasets
       .forEach(dataset => {
-        const dsNameProp = find({propertyName: 'Dataset Name'})(dataset.properties);
-        const label = dsNameProp.propertyValue;
         datasets.push({
           key: dataset.dataSetId,
           value: dataset.dataSetId,
-          label: label,
-          concatenation: label,
+          label: dataset.datasetName,
+          concatenation: dataset.datasetName,
         });
         datasetIdList.push(dataset.dataSetId);
       });
@@ -642,7 +640,7 @@ export default function DatasetCatalog(props) {
                           id: trIndex + '_datasetName', name: 'datasetName',
                           className: `${style['cell-size']} ` + (!isVisible(dataset) ? !! style['dataset-disabled'] : ''),
                           style: tableBody
-                        }, [findPropertyValue(dataset, 'Dataset Name')]),
+                        }, dataset.datasetName),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -202,8 +202,8 @@ export default function DatasetCatalog(props) {
         datasets.push({
           key: dataset.dataSetId,
           value: dataset.dataSetId,
-          label: dataset.datasetName,
-          concatenation: dataset.datasetName,
+          label: dataset.name,
+          concatenation: dataset.name,
         });
         datasetIdList.push(dataset.dataSetId);
       });
@@ -640,7 +640,7 @@ export default function DatasetCatalog(props) {
                           id: trIndex + '_datasetName', name: 'datasetName',
                           className: `${style['cell-size']} ` + (!isVisible(dataset) ? !! style['dataset-disabled'] : ''),
                           style: tableBody
-                        }, dataset.datasetName),
+                        }, dataset.name),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -81,7 +81,7 @@ class DatasetRegistration extends Component {
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     const currentUser = await Storage.getCurrentUser();
     const allDatasets =  await DataSet.getDatasets();
-    const allDatasetNames = allDatasets.map(d => d.datasetName);
+    const allDatasetNames = allDatasets.map(d => d.name);
     const dacs = await DAC.list();
     this.setState(prev => {
       prev.notificationData = notificationData;
@@ -128,7 +128,7 @@ class DatasetRegistration extends Component {
 
   // fill out the form fields with old dataset properties if they already exist
   prefillDatasetFields(dataset) {
-    let name = dataset.datasetName;
+    let name = dataset.name;
     let collectionId = fp.find({propertyName: 'Sample Collection ID'})(dataset.properties);
     let dataType = fp.find({propertyName: 'Data Type'})(dataset.properties);
     let species = fp.find({propertyName: 'Species'})(dataset.properties);
@@ -316,7 +316,7 @@ class DatasetRegistration extends Component {
     }
     // if there is a name loaded in because this is an update
     if (!fp.isEmpty(this.state.updateDataset)) {
-      let updateDatasetName = this.state.updateDataset.datasetName;
+      let updateDatasetName = this.state.updateDataset.name;
       if (name === updateDatasetName) {
         return 'form-control';
       }

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -81,10 +81,7 @@ class DatasetRegistration extends Component {
     const notificationData = await NotificationService.getBannerObjectById('eRACommonsOutage');
     const currentUser = await Storage.getCurrentUser();
     const allDatasets =  await DataSet.getDatasets();
-    const allDatasetNames = allDatasets.map(d => {
-      let name = d.properties.find(p => p.propertyName === 'Dataset Name');
-      return name.propertyValue;
-    });
+    const allDatasetNames = allDatasets.map(d => d.datasetName);
     const dacs = await DAC.list();
     this.setState(prev => {
       prev.notificationData = notificationData;
@@ -131,7 +128,7 @@ class DatasetRegistration extends Component {
 
   // fill out the form fields with old dataset properties if they already exist
   prefillDatasetFields(dataset) {
-    let name = fp.find({propertyName: 'Dataset Name'})(dataset.properties);
+    let name = dataset.datasetName;
     let collectionId = fp.find({propertyName: 'Sample Collection ID'})(dataset.properties);
     let dataType = fp.find({propertyName: 'Data Type'})(dataset.properties);
     let species = fp.find({propertyName: 'Species'})(dataset.properties);
@@ -145,7 +142,7 @@ class DatasetRegistration extends Component {
     let dac = fp.find({dacId: dataset.dacId})(this.state.dacList);
 
     this.setState(prev => {
-      prev.datasetData.datasetName = name ? name.propertyValue : '';
+      prev.datasetData.datasetName = name ? name : '';
       prev.datasetData.collectionId = collectionId ? collectionId.propertyValue : '';
       prev.datasetData.dataType = dataType ? dataType.propertyValue : '';
       prev.datasetData.species = species ? species.propertyValue : '';
@@ -319,7 +316,7 @@ class DatasetRegistration extends Component {
     }
     // if there is a name loaded in because this is an update
     if (!fp.isEmpty(this.state.updateDataset)) {
-      let updateDatasetName = fp.find(p => p.propertyName === 'Dataset Name', this.state.updateDataset.properties).propertyValue;
+      let updateDatasetName = this.state.updateDataset.datasetName;
       if (name === updateDatasetName) {
         return 'form-control';
       }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2579

### Summary
* Deprecate the property version of dataset name in favor of the `name` field on `dataset`.
* Bug fix from residual fallout in API change: https://github.com/DataBiosphere/consent/pull/2109

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
