### PR TITLE
[DUOS-1442][DUOS-2641][risk=no] Remove unused ajax calls.

### DIFF
--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import CollectionSubmitVoteBox from '../collection_vote_box/CollectionSubmitVoteBox';
 import {
   filter,
-  flatMap,
   flow,
   map,
   isNil,

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.js
@@ -72,18 +72,6 @@ const styles = {
   }
 };
 
-const animationAttributes = {
-  key:'content',
-  initial:'collapsed',
-  animate:'expanded',
-  exit:'collapsed',
-  variants: {
-    collapsed: {opacity: 0, height: 0, y: -50, overflow: 'hidden'},
-    expanded: {opacity: 1, height: 'auto', y: 0, overflow: 'hidden'}
-  },
-  transition:{duration: 0.5, ease: [0.50, 0.62, 0.23, 0.98]}
-};
-
 const highlightedWords = [
   {
     bgColor: 'rgba(0,0,100,.2)',

--- a/src/components/dar_dataset_table/DarDatasetTableCellData.js
+++ b/src/components/dar_dataset_table/DarDatasetTableCellData.js
@@ -1,5 +1,5 @@
 import {styles} from './DarDatasetTable';
-import {filter, flatMap, flow, get, isEmpty, isUndefined, map, uniq, values} from 'lodash/fp';
+import {filter, flatMap, flow, get, isEmpty, isUndefined, map, values} from 'lodash/fp';
 
 export function dataUseGroupCellData({dataUseGroup, label= 'data-use'}) {
   return {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -242,12 +242,6 @@ export const DAR = {
     return await res.data;
   },
 
-  getAutoCompleteDS: async partial => {
-    const url = `${await getApiUrl()}/api/dataset/autocomplete/${partial}`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
-  },
-
   getAutoCompleteOT: async partial => {
     const url = `${await getOntologyUrl()}/autocomplete?q=${partial}`;
     const res = await fetchOk(url, Config.authOpts());

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -254,17 +254,6 @@ export const DAR = {
     return await res.json();
   },
 
-  getDARDocument: async (referenceId, fileType) => {
-    const authOpts = Object.assign(Config.authOpts(), {responseType: 'blob'});
-    authOpts.headers = Object.assign(authOpts.headers, {
-      'Content-Type': 'application/octet-stream',
-      'Accept': 'application/octet-stream'
-    });
-    const url = `${await getApiUrl()}/api/dar/v2/${referenceId}/${fileType}`;
-    const res = await axios.get(url, authOpts);
-    return res.data;
-  },
-
   downloadDARDocument: async (referenceId, fileType, fileName) => {
     const authOpts = Object.assign(Config.authOpts(), {responseType: 'blob'});
     authOpts.headers = Object.assign(authOpts.headers, {
@@ -355,12 +344,6 @@ export const DataSet = {
     const url = `${await getApiUrl()}/api/dataset/${datasetObjectId}`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
     return await res;
-  },
-
-  disableDataset: async (datasetObjectId, active) => {
-    const url = `${await getApiUrl()}/api/dataset/disable/${datasetObjectId}/${active}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
-    return res;
   },
 
   reviewDataSet: async (dataSetId, needsApproval) => {


### PR DESCRIPTION
### Addresses
Partial front end support for:
* https://broadworkbench.atlassian.net/browse/DUOS-1442
* https://broadworkbench.atlassian.net/browse/DUOS-2641

### Summary
This PR removes several unused ajax calls
* `getAutoCompleteDS`: This calls an API that returns a deprecated model object.
* `getDARDocument`: This was used in the old DAR form for documents associated to a DAR. We don't use that any longer so we can remove this call.
* `disableDataset`: This was used to set the active property on a dataset to true/false which used to control visibility. We no longer use that feature for visibility so we can remove this call.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
