### PR TITLE
[DUOS-2636][risk=no] Deprecate active and needs approval in UI

### DIFF
--- a/src/components/manage_dac_table/ManageDacTable.js
+++ b/src/components/manage_dac_table/ManageDacTable.js
@@ -195,9 +195,11 @@ export const ManageDacTable = function ManageDacTable(props) {
 
   const viewDatasets = useCallback(async (selectedDac) => {
     const datasets = await DAC.datasets(selectedDac.dacId);
+    const approvedDatasets = filter({ dacApproval: true })(datasets);
+
     setShowDatasetsModal(true);
     setSelectedDac(selectedDac);
-    setSelectedDatasets(datasets);
+    setSelectedDatasets(approvedDatasets);
   }, [setShowDatasetsModal, setSelectedDac, setSelectedDatasets]);
 
   const changeTableSize = useCallback((value) => {

--- a/src/components/manage_dac_table/ManageDacTable.js
+++ b/src/components/manage_dac_table/ManageDacTable.js
@@ -196,7 +196,6 @@ export const ManageDacTable = function ManageDacTable(props) {
   const viewDatasets = useCallback(async (selectedDac) => {
     const datasets = await DAC.datasets(selectedDac.dacId);
     const approvedDatasets = filter({ dacApproval: true })(datasets);
-
     setShowDatasetsModal(true);
     setSelectedDac(selectedDac);
     setSelectedDatasets(approvedDatasets);

--- a/src/components/manage_dac_table/ManageDacTable.js
+++ b/src/components/manage_dac_table/ManageDacTable.js
@@ -195,11 +195,9 @@ export const ManageDacTable = function ManageDacTable(props) {
 
   const viewDatasets = useCallback(async (selectedDac) => {
     const datasets = await DAC.datasets(selectedDac.dacId);
-    const activeDatasets = filter({ active: true })(datasets);
-
     setShowDatasetsModal(true);
     setSelectedDac(selectedDac);
-    setSelectedDatasets(activeDatasets);
+    setSelectedDatasets(datasets);
   }, [setShowDatasetsModal, setSelectedDac, setSelectedDatasets]);
 
   const changeTableSize = useCallback((value) => {

--- a/src/components/modals/ConnectDatasetModal.js
+++ b/src/components/modals/ConnectDatasetModal.js
@@ -60,7 +60,8 @@ export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Componen
   createOrUpdateAssociations = () => {
     const usersId = [];
     this.state.selectedclients.forEach(user => {
-      usersId.push(JSON.parse(user.id));
+      const userId = user.id.replace(/'/g, '');
+      usersId.push(userId);
     });
 
     if (this.state.isUpdate) {

--- a/src/components/modals/ConnectDatasetModal.js
+++ b/src/components/modals/ConnectDatasetModal.js
@@ -1,8 +1,8 @@
 import { Component, Fragment } from 'react';
-import { div, h, form, input, label, select, hh, option } from 'react-hyperscript-helpers';
+import { div, h, form, input, select, hh, option } from 'react-hyperscript-helpers';
 import { BaseModal } from '../BaseModal';
 import { Alert } from '../Alert';
-import { DatasetAssociation, DataSet } from '../../libs/ajax';
+import { DatasetAssociation } from '../../libs/ajax';
 import datasetLinkIcon from '../../images/icon_dataset_link.png';
 
 export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Component {
@@ -14,15 +14,11 @@ export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Componen
       selected: [],
       availableclients: [],
       selectedclients: [],
-      needsApproval: props.dataset.needsApproval,
       updatedInfoModal: false,
-      needsApprovalModified: false,
       showError: false,
       alert: {},
       isUpdate: false,
     };
-
-    this.handleNeedsApprovalChange = this.handleNeedsApprovalChange.bind(this);
 
     this.closeHandler = this.closeHandler.bind(this);
     this.OKHandler = this.OKHandler.bind(this);
@@ -58,18 +54,7 @@ export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Componen
   }
 
   OKHandler() {
-    if (this.state.needsApprovalModified) {
-      DataSet.reviewDataSet(this.state.datasetId, this.state.needsApproval).then(() => {
-        this.createOrUpdateAssociations();
-      }, () => {
-        this.setState(prev => {
-          prev.showError = true;
-          return prev;
-        });
-      });
-    } else {
-      this.createOrUpdateAssociations();
-    }
+    this.createOrUpdateAssociations();
   }
 
   createOrUpdateAssociations = () => {
@@ -103,15 +88,6 @@ export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Componen
 
   closeHandler() {
     this.props.onCloseRequest();
-  }
-
-  handleNeedsApprovalChange(event) {
-    const checked = event.target.checked;
-    this.setState(prev =>{
-      prev.needsApproval = checked;
-      return prev;
-    },
-    () => this.handleStateSubmit() );
   }
 
   moveLItem = () => {
@@ -171,16 +147,7 @@ export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Componen
   handleStateSubmit = () => {
     const modifiedList = this.isSelectedListModified();
 
-    if (this.props.dataset.needsApproval !== this.state.needsApproval) {
-      this.setState(prev => {
-        prev.needsApprovalModified = true;
-        return prev;
-      });
-    }
-
-    if ((this.props.dataset.needsApproval !== this.state.needsApproval && this.state.selectedclients.length > 0) ||
-      (modifiedList && this.state.selectedclients.length > 0) ||
-      (modifiedList && this.state.needsApproval === false && this.state.selectedclients.length === 0) ) {
+    if ((this.state.selectedclients.length > 0) || (modifiedList && this.state.selectedclients.length > 0)) {
       this.setState({ updatedInfoModal: true });
     } else {
       this.setState({ updatedInfoModal: false });
@@ -300,23 +267,6 @@ export const ConnectDatasetModal = hh(class ConnectDatasetModal extends Componen
               ])
             ]),
 
-          ]),
-
-          div({ className: 'form-group row', style: { 'margin': '10px 0' } }, [
-            div({ className: 'checkbox dataset-label' }, [
-              input({ id: 'chk_needsApproval',
-                onChange: this.handleNeedsApprovalChange,
-                checked: this.state.needsApproval,
-                type: 'checkbox',
-                className: 'checkbox-inline',
-                name: 'needsApproval'
-              }),
-              label({
-                id: 'lbl_needsApproval',
-                className: 'regular-checkbox dataset-label',
-                htmlFor: 'chk_needsApproval'
-              }, ['Needs Data Owner\'s approval']),
-            ]),
           ]),
         ]),
         div({ isRendered: this.state.showError}, [

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -363,12 +363,6 @@ export const DataSet = {
     return await res;
   },
 
-  disableDataset: async (datasetObjectId, active) => {
-    const url = `${await getApiUrl()}/api/dataset/disable/${datasetObjectId}/${active}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'DELETE' }]));
-    return res;
-  },
-
   reviewDataSet: async (dataSetId, needsApproval) => {
     const url = `${await getApiUrl()}/api/dataset?dataSetId=${dataSetId}&needsApproval=${needsApproval}`;
     const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'PUT' }]));

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -363,12 +363,6 @@ export const DataSet = {
     return await res;
   },
 
-  reviewDataSet: async (dataSetId, needsApproval) => {
-    const url = `${await getApiUrl()}/api/dataset?dataSetId=${dataSetId}&needsApproval=${needsApproval}`;
-    const res = await fetchOk(url, fp.mergeAll([Config.authOpts(), { method: 'PUT' }]));
-    return res.json();
-  },
-
   updateDataset: async (datasetId, dataSetObject) => {
     const url = `${await getApiUrl()}/api/dataset/${datasetId}`;
     return await fetchOk(url, fp.mergeAll([Config.authOpts(), Config.jsonBody(dataSetObject), {method: 'PUT'}]));

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -35,12 +35,12 @@ const extractDatasetProp = (propertyName, dataset) => {
 
 const isVisible = (dataset) => {
   const openAccess = extractDatasetProp('Open Access', dataset);
-  if(!isNil(openAccess)){
-    // if open Access is false, dac approval required
-    return openAccess ? dataset.study?.publicVisibility : (dataset.dacApproval && dataset.study?.publicVisibility);
-  } else {
-    return true;
-  }
+  const publicVisibility = extractDatasetProp('Public Visibility', dataset);
+  if (!isNil(dataset.dacApproval)) { return dataset.dacApproval; }
+  if (!isNil(publicVisibility)) { return publicVisibility; }
+  if (!isNil(dataset.study?.publicVisibility)) { return dataset.study.publicVisibility; }
+  if (!isNil(openAccess)) { return openAccess; }
+  return true;
 };
 
 export default function DatasetCatalog(props) {

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -519,7 +519,7 @@ export default function DatasetCatalog(props) {
             div({
               className: style['display-inline-block'],
               style: {
-                top: '13px',
+                top: '4px',
                 position: 'absolute',
               }
             }, [

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -347,13 +347,6 @@ export default function DatasetCatalog(props) {
     setDatasetList(selectedDatasets);
   };
 
-  const inactiveCheckboxStyle = (dataset) => {
-    if (!isVisible(dataset)) {
-      return {cursor: 'default', opacity: '50%'};
-    }
-    return {};
-  };
-
   const findPropertyValue = (dataSet, propName, defaultVal) => {
     const defaultValue = isNil(defaultVal) ? '' : defaultVal;
     return getOr(defaultValue)('propertyValue')(find({ propertyName: propName })(dataSet.properties));
@@ -586,8 +579,6 @@ export default function DatasetCatalog(props) {
                             }),
                             label({
                               className: style['regular-checkbox'],
-                              // Apply additional styling for inactive datasets
-                              style: inactiveCheckboxStyle(dataset),
                               htmlFor: trIndex + '_chkSelect' })
                           ])
                         ]),

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -35,12 +35,14 @@ const extractDatasetProp = (propertyName, dataset) => {
 
 const isVisible = (dataset) => {
   const openAccess = extractDatasetProp('Open Access', dataset);
-  const publicVisibility = extractDatasetProp('Public Visibility', dataset);
-  if (!isNil(dataset.dacApproval)) { return dataset.dacApproval; }
-  if (!isNil(publicVisibility)) { return publicVisibility; }
-  if (!isNil(dataset.study?.publicVisibility)) { return dataset.study.publicVisibility; }
-  if (!isNil(openAccess)) { return openAccess; }
-  return true;
+  const publicDataset = extractDatasetProp('Public Visibility', dataset);
+  const publicStudy = !isNil(dataset.study?.publicVisibility) ? dataset.study?.publicVisibility : true;
+
+  const open = !isNil(openAccess) ? openAccess : false;
+  const dacApproved = (!isNil(dataset.dacApproval) && dataset.dacApproval);
+  const publiclyVisible = !isNil(publicDataset) ? publicDataset : publicStudy;
+
+  return open || (dacApproved && publiclyVisible);
 };
 
 export default function DatasetCatalog(props) {

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -39,7 +39,7 @@ const isVisible = (dataset) => {
     // if open Access is false, dac approval required
     return openAccess ? dataset.study?.publicVisibility : (dataset.dacApproval && dataset.study?.publicVisibility);
   } else {
-    return dataset.active;
+    return true;
   }
 };
 
@@ -347,6 +347,13 @@ export default function DatasetCatalog(props) {
     setDatasetList(selectedDatasets);
   };
 
+  const unapprovedStyle = (dataset) => {
+    if (!isVisible(dataset)) {
+      return {cursor: 'default', opacity: '50%'};
+    }
+    return {};
+  };
+
   const findPropertyValue = (dataSet, propName, defaultVal) => {
     const defaultValue = isNil(defaultVal) ? '' : defaultVal;
     return getOr(defaultValue)('propertyValue')(find({ propertyName: propName })(dataSet.properties));
@@ -579,6 +586,8 @@ export default function DatasetCatalog(props) {
                             }),
                             label({
                               className: style['regular-checkbox'],
+                              // Apply additional styling for inactive datasets
+                              style: unapprovedStyle(dataset),
                               htmlFor: trIndex + '_chkSelect' })
                           ])
                         ]),

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -640,7 +640,7 @@ export default function DatasetCatalog(props) {
 
                         td({
                           id: trIndex + '_datasetName', name: 'datasetName',
-                          className: `${style['cell-size']} ` + (!isVisible(dataset) ? !! style['dataset-disabled'] : ''),
+                          className: `${style['cell-size']} ` + (!isVisible(dataset) ? style['dataset-disabled'] : ''),
                           style: tableBody
                         }, dataset.name),
 

--- a/src/pages/DatasetCatalog.module.css
+++ b/src/pages/DatasetCatalog.module.css
@@ -27,6 +27,7 @@
   position: relative;
   padding-left: 25px !important;
   margin-right: 15px;
+  margin-bottom: 15px;
   font-size: 13px;
 }
 

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -63,7 +63,6 @@ class DatasetRegistration extends Component {
         description: '',
         dac: '',
         consentId: '',
-        needsApproval: false,
         isValidName: false
       },
       problemSavingRequest: false,
@@ -138,7 +137,6 @@ class DatasetRegistration extends Component {
     let datasetRepoUrl = fp.find({propertyName: 'dbGAP'})(dataset.properties);
     let researcher = fp.find({propertyName: 'Data Depositor'})(dataset.properties);
     let pi = fp.find({propertyName: 'Principal Investigator(PI)'})(dataset.properties);
-    let needsApproval = dataset.needsApproval;
     let dac = fp.find({dacId: dataset.dacId})(this.state.dacList);
 
     this.setState(prev => {
@@ -152,7 +150,6 @@ class DatasetRegistration extends Component {
       prev.datasetData.datasetRepoUrl = datasetRepoUrl ? datasetRepoUrl.propertyValue : '';
       prev.datasetData.researcher = researcher ? researcher.propertyValue : '';
       prev.datasetData.principalInvestigator = pi ? pi.propertyValue : '';
-      prev.datasetData.needsApproval = needsApproval;
       prev.datasetData.dac = dac;
       prev.selectedDac = dac;
       let validName = this.validateDatasetName(prev.datasetData.datasetName);
@@ -435,13 +432,6 @@ class DatasetRegistration extends Component {
     return !valid;
   };
 
-  setNeedsApproval = (value) => {
-    this.setState(prev => {
-      prev.datasetData.needsApproval = value;
-      return prev;
-    });
-  };
-
   setGeneralUse = () => {
     this.setState(prev => {
       prev.formData.generalUse = true;
@@ -610,8 +600,6 @@ class DatasetRegistration extends Component {
     // The deprecated API this posts to is expecting a `translatedUseRestriction` field
     result.translatedUseRestriction = data.translatedDataUse;
     result.deletable = true;
-    result.active = true;
-    result.needsApproval = data.needsApproval;
     result.isAssociatedToDataOwners = true;
     result.updateAssociationToDataOwnerAllowed = true;
     result.properties = this.createProperties();
@@ -710,7 +698,6 @@ class DatasetRegistration extends Component {
       generalUse = false,
     } = this.state.formData;
     const { ontologies } = this.state.formData;
-    const { needsApproval = false } = this.state.datasetData;
     const { problemSavingRequest, problemLoadingUpdateDataset, showValidationMessages, submissionSuccess } = this.state;
     const isTypeOfResearchInvalid = this.isTypeOfResearchInvalid();
     const isUpdateDataset = (!fp.isEmpty(this.state.updateDataset));
@@ -1448,35 +1435,6 @@ class DatasetRegistration extends Component {
                         span({ className: 'glyphicon glyphicon-download' }),
                         'DUOS Data Provider Agreement'
                       ])
-                    ]),
-                  ]),
-
-                  div({ className: 'row no-margin'}, [
-                    div({ className: 'col-lg-12 col-md-12 col-sm-12 col-xs-12 rp-group' }, [
-                      label({ style: controlLabelStyle, className: 'default-color' },
-                        ['Do you want to make this dataset publicly available in the DUOS dataset catalog and able to receive data access requests under the assigned DAC above?']),
-
-                      div({style: {display: 'flex'}}, [
-                        RadioButton({
-                          id: 'checkNeedsApproval_yes',
-                          name: 'checkNeedsApproval',
-                          value: 'yes',
-                          defaultChecked: !needsApproval,
-                          onClick: () => this.setNeedsApproval(false),
-                          label: 'Yes'
-                        }),
-
-                        div({style: {width: '10%'}}),
-
-                        RadioButton({
-                          id: 'checkNeedsApproval_no',
-                          name: 'checkNeedsApproval',
-                          value: 'no',
-                          defaultChecked: needsApproval,
-                          onClick: () => this.setNeedsApproval(true),
-                          label: 'No'
-                        }),
-                      ]),
                     ]),
                   ]),
 


### PR DESCRIPTION
### Addresses
Front end work for https://broadworkbench.atlassian.net/browse/DUOS-2636

### Summary
* Removes usages of `active` and `needsApproval` in a variety of pages
* Replaces some usages of `active` with `dacApproval`
* Revise the dataset catalog visibility logic somewhat. I don't want to do too much here since we are moving to an ES backed interface in the near future
* Fix some styling and functional bugs found when doing the removal.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
