### PR TITLE
[DUOS-2642] Redirect to study edit when dataset is part of study

### DIFF
--- a/src/components/dac_dataset_table/DACDatasetApprovalStatus.js
+++ b/src/components/dac_dataset_table/DACDatasetApprovalStatus.js
@@ -21,7 +21,7 @@ export default function DACDatasetApprovalStatus(props) {
       style={{marginLeft: '15px'}}
       id={`${dataset.dataSetId}_edit`}
       className={'glyphicon glyphicon-pencil'}
-      to={`dataset_registration/${dataset.dataSetId}`}
+      to={props.dataset.study.studyId === undefined ? `dataset_registration/${dataset.dataSetId}` : `study_update/${dataset.study.studyId}`}
     />
   </div>;
 

--- a/src/components/dac_dataset_table/DACDatasetApprovalStatus.js
+++ b/src/components/dac_dataset_table/DACDatasetApprovalStatus.js
@@ -21,7 +21,7 @@ export default function DACDatasetApprovalStatus(props) {
       style={{marginLeft: '15px'}}
       id={`${dataset.dataSetId}_edit`}
       className={'glyphicon glyphicon-pencil'}
-      to={props.dataset.study?.studyId === undefined ? `dataset_registration/${dataset.dataSetId}` : `study_update/${dataset.study.studyId}`}
+      to={dataset.study?.studyId === undefined ? `dataset_registration/${dataset.dataSetId}` : `study_update/${dataset.study.studyId}`}
     />
   </div>;
 

--- a/src/components/dac_dataset_table/DACDatasetApprovalStatus.js
+++ b/src/components/dac_dataset_table/DACDatasetApprovalStatus.js
@@ -21,7 +21,7 @@ export default function DACDatasetApprovalStatus(props) {
       style={{marginLeft: '15px'}}
       id={`${dataset.dataSetId}_edit`}
       className={'glyphicon glyphicon-pencil'}
-      to={props.dataset.study.studyId === undefined ? `dataset_registration/${dataset.dataSetId}` : `study_update/${dataset.study.studyId}`}
+      to={props.dataset.study?.studyId === undefined ? `dataset_registration/${dataset.dataSetId}` : `study_update/${dataset.study.studyId}`}
     />
   </div>;
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2642

### Summary

Redirect to the study edit page when a dataset is part of a study

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
