### PR TITLE
[DUOS-2635] Implemented disabled checkboxes for data submission form

### DIFF
--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -305,6 +305,7 @@ export const EditConsentGroup = (props) => {
           name: 'gso',
           type: FormFieldTypes.CHECKBOX,
           toggleText: 'Genetic studies only (GSO)',
+          disabled: disableFields,
           defaultValue: consentGroup.gso,
           onChange,
           validation: validation.gso,

--- a/src/components/forms/formComponents.js
+++ b/src/components/forms/formComponents.js
@@ -485,6 +485,7 @@ export const FormInputCheckbox = (config) => {
     label({
       className: `regular-checkbox ${!isValid(validation) ? 'errored' : ''}`,
       htmlFor: `${id}`,
+      style: disabled ? { cursor: 'not-allowed' } : null
     }, [toggleText])
   ]);
 };


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2635

### Summary
- Added a non-selection cursor to the checkboxes in the Data Submission Form when the consent group is prefilled (when the checkboxes are disabled)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
