### PR TITLE
[DUOS-2669][risk=no] Fix dataset selection bug

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -25,7 +25,7 @@ const tableBody = {
 };
 
 const canApplyForDataset = (dataset) => {
-  return dataset.active && !isNil(dataset.dacId);
+  return !isNil(dataset.dacId);
 };
 
 const extractDatasetProp = (propertyName, dataset) => {
@@ -335,6 +335,7 @@ export default function DatasetCatalog(props) {
   };
 
   const checkSingleRow = (dataset) => (e) => {
+    console.log(dataset);
     const checked = isNil(e.target.checked) ? false : e.target.checked;
     const selectedDatasets = map(row => {
       if (row.dataSetId === dataset.dataSetId) {
@@ -346,6 +347,7 @@ export default function DatasetCatalog(props) {
     })(datasetList);
 
     // Update state
+    console.log(e.target);
     setDatasetList(selectedDatasets);
   };
 

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -25,7 +25,7 @@ const tableBody = {
 };
 
 const canApplyForDataset = (dataset) => {
-  return !isNil(dataset.dacId);
+  return !isNil(dataset.dacId) && dataset.dacApproval;
 };
 
 const extractDatasetProp = (propertyName, dataset) => {

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -335,7 +335,6 @@ export default function DatasetCatalog(props) {
   };
 
   const checkSingleRow = (dataset) => (e) => {
-    console.log(dataset);
     const checked = isNil(e.target.checked) ? false : e.target.checked;
     const selectedDatasets = map(row => {
       if (row.dataSetId === dataset.dataSetId) {
@@ -347,7 +346,6 @@ export default function DatasetCatalog(props) {
     })(datasetList);
 
     // Update state
-    console.log(e.target);
     setDatasetList(selectedDatasets);
   };
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2669

### Summary
Fix fallout from deprecating the active check on datasets. Active is no longer a usable field.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
