### PR TITLE
[DUOS-2640][risk=no] Ensure DAC Id is Submitted on Study Update

### DIFF
--- a/src/pages/StudyUpdateForm.js
+++ b/src/pages/StudyUpdateForm.js
@@ -159,7 +159,7 @@ export const StudyUpdateForm = (props) => {
     }
 
     formData?.consentGroups?.forEach((cg) => {
-      const validCgFields = [cg.dataLocation, cg.url, cg.fileTypes, cg.numberOfParticipants];
+      const validCgFields = [cg.dataLocation, cg.url, cg.fileTypes, cg.numberOfParticipants, cg.dataAccessCommitteeId];
 
       if(!isNil(cg.datasetId)){
         for (const key of Object.keys(cg)) {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2640

### Summary
Minor bug fix - the dac id, even though selected, was filtered out of the submitted entity

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
