### PR TITLE
[DUOS-2673] Add hyperlink to NHGRI policy

### DIFF
--- a/src/components/data_submission/NIHDataManagement.js
+++ b/src/components/data_submission/NIHDataManagement.js
@@ -1,4 +1,4 @@
-import {div, h, h2, h3} from 'react-hyperscript-helpers';
+import {div, h, h2, h3, span} from 'react-hyperscript-helpers';
 import { FormFieldTypes, FormField, FormValidators } from '../forms/forms';
 import { useState } from 'react';
 import { YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL  } from './NihAnvilUse';
@@ -69,7 +69,7 @@ export const NIHDataManagement = (props) => {
       type: FormFieldTypes.YESNORADIOGROUP,
       id: 'alternativeDataSharingPlan',
       defaultValue: formData?.alternativeDataSharingPlan,
-      title: 'Are you requesting an Alternative Data Sharing Plan for samples that cannot be shared through a public repository or database?',
+      title: span({ dangerouslySetInnerHTML: { __html: 'Are you requesting an Alternative Data Sharing Plan <a href="https://www.genome.gov/about-nhgri/Policies-Guidance/Data-Sharing-Policies-and-Expectations#genomic-data-sharing">(info)</a> for samples that cannot be shared through a public repository or database?' }}),
       onChange: ({key, value}) => {
         setShowAlternativeDataSharingPlan(value);
         onChange({key, value});

--- a/src/components/data_submission/NIHDataManagement.js
+++ b/src/components/data_submission/NIHDataManagement.js
@@ -1,4 +1,4 @@
-import {div, h, h2, h3, span} from 'react-hyperscript-helpers';
+import {div, h, h2, h3, span, a} from 'react-hyperscript-helpers';
 import { FormFieldTypes, FormField, FormValidators } from '../forms/forms';
 import { useState } from 'react';
 import { YES_NHGRI_YES_PHS_ID, YES_NHGRI_NO_PHS_ID, NO_NHGRI_YES_ANVIL  } from './NihAnvilUse';
@@ -69,7 +69,11 @@ export const NIHDataManagement = (props) => {
       type: FormFieldTypes.YESNORADIOGROUP,
       id: 'alternativeDataSharingPlan',
       defaultValue: formData?.alternativeDataSharingPlan,
-      title: span({ dangerouslySetInnerHTML: { __html: 'Are you requesting an Alternative Data Sharing Plan <a href="https://www.genome.gov/about-nhgri/Policies-Guidance/Data-Sharing-Policies-and-Expectations#genomic-data-sharing">(info)</a> for samples that cannot be shared through a public repository or database?' }}),
+      title: span([
+        'Are you requesting an Alternative Data Sharing Plan ',
+        a({href: 'https://www.genome.gov/about-nhgri/Policies-Guidance/Data-Sharing-Policies-and-Expectations#genomic-data-sharing'}, '(info)'),
+        ' for samples that cannot be shared through a public repository or database?'
+      ]),
       onChange: ({key, value}) => {
         setShowAlternativeDataSharingPlan(value);
         onChange({key, value});


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2673

### Summary

Adds hyperlink to NHGRI policy on Alternate Data Sharing.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
