### PR TITLE
[DUOS-2672] Restore a subset of dataset statistics

### DIFF
--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -642,7 +642,11 @@ export default function DatasetCatalog(props) {
                           id: trIndex + '_datasetName', name: 'datasetName',
                           className: `${style['cell-size']} ` + (!isVisible(dataset) ? style['dataset-disabled'] : ''),
                           style: tableBody
-                        }, dataset.name),
+                        }, [
+                          a({
+                            href: `/dataset_statistics/${dataset.dataSetId}`,
+                          }, dataset.name)
+                        ]),
 
                         td({
                           id: trIndex + '_dac', name: 'dac',

--- a/src/pages/DatasetStatistics.js
+++ b/src/pages/DatasetStatistics.js
@@ -122,36 +122,6 @@ export default function DatasetStatistics(props) {
               ])
             ])
           ]),
-          div({style: Styles.SUB_HEADER}, ['Summary of Research Findings to Date']),
-          div({style: {display: 'flex'}}, [
-            div({style: Styles.SQUARE_BOX}, [
-              div({style: {...Styles.MINOR_HEADER, textAlign: 'center'}}, ['Data Access Requests']),
-              LINE,
-              div({style: Styles.JUMBO}, [dars?.length])
-            ]),
-            div({style: Styles.DESCRIPTION_BOX}, [
-              div({style: {...Styles.MINOR_HEADER, paddingLeft:'10px'}}, ['DAR Project Titles:']),
-              LINE,
-              div({style: {fontSize: Theme.font.size.small, padding: '1rem'}}, [
-                dars?.map((dar) => a({style: {display: 'block'}, href: `#${dar.darCode}`}, [dar.projectTitle]))
-              ])
-            ]),
-            div({style: Styles.SQUARE_BOX}, [
-              div({style: {...Styles.MINOR_HEADER, textAlign: 'center'}}, ['DARs Approved']),
-              LINE,
-              div({style: Styles.JUMBO}, [darsApproved?.length])
-            ]),
-            div({style: Styles.SQUARE_BOX}, [
-              div({style: {...Styles.MINOR_HEADER, textAlign: 'center'}}, ['DARs Denied']),
-              LINE,
-              div({style: Styles.JUMBO}, [darsDenied?.length])
-            ]),
-            div({style: Styles.SQUARE_BOX}, [
-              div({style: {...Styles.MINOR_HEADER, textAlign: 'center'}}, ['DARs Open, Canceled, Unreviewed']),
-              LINE,
-              div({style: Styles.JUMBO}, [darsOpen?.length + darsCanceled?.length + darsUnreviewed?.length])
-            ]),
-          ]),
           div({style: Styles.SUB_HEADER}, ['Data Access Requests - Research Statements']),
           dars?.map((dar) =>
             div({style: Styles.READ_MORE, id: `${dar.darCode}` }, [
@@ -173,10 +143,6 @@ export default function DatasetStatistics(props) {
                       div({style: Styles.SMALL_BOLD}, ['Last Updated: ']),
                       div({style: Styles.SMALL_BOLD}, [formatDate(dar.updateDate)]),
                     ]),
-                    div({style: {display: 'flex'}}, [
-                      div({style: Styles.SMALL_BOLD}, ['Status: ']),
-                      div({style: Styles.SMALL_BOLD}, [getDisplayStatusForDar(dar.referenceId)]),
-                    ])
                   ]),
                   div({style: {backgroundColor: 'white'}}, [
                     div({style: Styles.SMALL_BOLD}, ['NonTechnical Summary:']),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2672

### Summary

1. Re-hyperlink dataset names to their statistics page
2. Remove/hide the Summary of Research Findings to Date stats boxes
3. Remove the Status in each DAR box

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
