### PR TITLE
[DUOS-2688] Add loading indicator and details when no items

### DIFF
--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -188,13 +188,23 @@ export const DatasetSearchTable = (props) => {
           <DatasetFilterList datasets={datasets} filters={filters} filterHandler={filterHandler} />
         </Box>
         <Box sx={{ width: '85%', padding: '0 1em' }}>
-          <CollapsibleTable data={tableData} selected={selected} selectHandler={selectHandler} summary='faceted study search table' />
+          {
+            isEmpty(datasets) ?
+              <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                <h1>No datasets registered for this library.</h1>
+              </Box>
+              :
+              <CollapsibleTable data={tableData} selected={selected} selectHandler={selectHandler} summary='faceted study search table' />
+          }
         </Box>
       </Box>
       <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', padding: '2em 4em' }}>
-        <Button variant="contained" onClick={applyForAccess} sx={{ transform: 'scale(1.5)' }} >
+        {
+          !isEmpty(datasets) &&
+          <Button variant="contained" onClick={applyForAccess} sx={{ transform: 'scale(1.5)' }} >
             Apply for Access
-        </Button>
+          </Button>
+        }
       </Box>
     </Box>
   );

--- a/src/pages/DatasetSearch.js
+++ b/src/pages/DatasetSearch.js
@@ -8,6 +8,8 @@ import duosIcon from '../images/duos-network-logo.svg';
 import mgbIcon from '../images/mass-general-brigham-logo.svg';
 import elwaziIcon from '../images/elwazi-logo-color.svg';
 import { Storage } from '../libs/storage';
+import { isEmpty, isNil } from 'lodash';
+import { Box, CircularProgress } from '@mui/material';
 
 const signingOfficialQuery = (user) => {
   return {
@@ -51,6 +53,7 @@ const myInstitutionQuery = (user) => {
 export const DatasetSearch = (props) => {
   const { location } = props;
   const [datasets, setDatasets] = useState([]);
+  const [loading, setLoading] = useState(true);
   const user = Storage.getCurrentUser();
 
   // branded study table versions
@@ -143,6 +146,7 @@ export const DatasetSearch = (props) => {
       try {
         await DataSet.searchDatasetIndex(query).then((datasets) => {
           setDatasets(datasets);
+          setLoading(false);
         });
       } catch (error) {
         Notifications.showError({ text: 'Failed to load Elasticsearch index' });
@@ -152,7 +156,12 @@ export const DatasetSearch = (props) => {
   }, []);
 
   return (
-    <DatasetSearchTable {...props} datasets={datasets} icon={version.icon} title={version.title} />
+    loading ?
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+        <CircularProgress />
+      </Box>
+      :
+      <DatasetSearchTable {...props} datasets={datasets} icon={version.icon} title={version.title} />
   );
 };
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2688

### Summary

Adds a loading indicator and shows 'No datasets registered for this Library' if there are no results to display.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
