### PR TITLE
[DUOS-2693] Ensure that data location url is cleared visually

### DIFF
--- a/src/components/data_submission/consent_group/EditConsentGroup.js
+++ b/src/components/data_submission/consent_group/EditConsentGroup.js
@@ -524,7 +524,8 @@ export const EditConsentGroup = (props) => {
         validators: [FormValidators.URL],
         disabled: consentGroup.dataLocation === 'Not Determined',
         placeholder: 'Enter a URL for your data location here',
-        defaultValue: consentGroup.url,
+        // React doesn't rerender this value when it is undefined, so set it to empty string
+        defaultValue: consentGroup.dataLocation === 'Not Determined' ? '' : consentGroup.url,
         onChange,
         validation: validation.url,
         onValidationChange,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2693

### Summary

The data location URL is cleared in the underlying form value, but setting it to undefined does not cause a rerender.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
