### PR TITLE
[DUOS-2721] Inherit all data libraries from base url

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -99,11 +99,6 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/dataset_catalog" component={DatasetCatalog} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/datalibrary/:query" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/datalibrary" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
-    <AuthenticatedRoute path="/datalibrary_broad" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
-    <AuthenticatedRoute path="/datalibrary_mgb" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
-    <AuthenticatedRoute path="/datalibrary_elwazi" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
-    <AuthenticatedRoute path="/datalibrary_myinstitution" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
-    <AuthenticatedRoute path="/datalibrary_nhgri" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/dataset_statistics/:datasetId" component={DatasetStatistics} props={props}
       rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/dac_datasets" component={DACDatasets} props={props} rolesAllowed={[USER_ROLES.chairperson]} />

--- a/src/pages/DatasetSearch.js
+++ b/src/pages/DatasetSearch.js
@@ -41,7 +41,6 @@ const myInstitutionQuery = (user) => {
 }
 
 export const DatasetSearch = (props) => {
-  const { location } = props;
   const { match: { params: { query } } } = props;
   const [datasets, setDatasets] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -54,7 +53,7 @@ export const DatasetSearch = (props) => {
       icon: duosIcon,
       title: 'DUOS Data Library',
     },
-    '/datalibrary_broad': {
+    'broad': {
       query: {
         'match_phrase': {
           'submitter.institution.name': 'The Broad Institute of MIT and Harvard'
@@ -63,7 +62,7 @@ export const DatasetSearch = (props) => {
       icon: broadIcon,
       title: 'Broad Data Library',
     },
-    '/datalibrary_mgb': {
+    'mgb': {
       query: {
         'bool': {
           'should': [
@@ -93,7 +92,7 @@ export const DatasetSearch = (props) => {
       icon: mgbIcon,
       title: 'Mass General Brigham Data Library',
     },
-    '/datalibrary_elwazi': {
+    'elwazi': {
       query: {
         'match_phrase': {
           'study.description': 'elwazi'
@@ -102,12 +101,12 @@ export const DatasetSearch = (props) => {
       icon: elwaziIcon,
       title: 'eLwazi Data Library',
     },
-    '/datalibrary_myinstitution': {
+    'myinstitution': {
       query: user.isSigningOfficial ? signingOfficialQuery(user) : myInstitutionQuery(user),
       icon: null,
       title: user.institution.name + ' Data Library',
     },
-    '/datalibrary_nhgri': {
+    'nhgri': {
       query: {
         'match_phrase': {
           'study.description': 'anvil'
@@ -116,7 +115,7 @@ export const DatasetSearch = (props) => {
       icon: nhgriIcon,
       title: 'NHGRI Data Library',
     },
-    'custom': {
+    '/custom': {
       query: {
         'bool': {
           'should': [
@@ -138,7 +137,8 @@ export const DatasetSearch = (props) => {
     }
   }
 
-  const version = query === undefined ? versions[location.pathname] : versions['custom'];
+  const key = query === undefined ? '/datalibrary' : query;
+  const version = versions[key] === undefined ? versions['/custom'] : versions[key];
 
   useEffect(() => {
     const init = async () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2721

### Summary

Refactors data libraries so that are all available at `/datalibrary/<name>`. 

Advantages of this approach include:

- Not having to create a new route in code every time
- All data libraries inherit from a standardized url scheme
- Easier to add more data libraries in the future
- Falls back to instant data libraries if the path doesn't exist

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
