### PR TITLE
[DUOS-2745][risk=no] Fix SO display in profile

### DIFF
--- a/src/pages/user_profile/ResearcherStatus.js
+++ b/src/pages/user_profile/ResearcherStatus.js
@@ -32,9 +32,10 @@ export default function ResearcherStatus(props) {
             setHasCard(false);
           }
           else {
-            const signingOfficialUser = await User.getById(user.libraryCards[0].institution.createUserId);
+            const signingOfficialUsers = await User.getSOsForCurrentUser();
             setIssuedOn(user.libraryCards[0].createDate);
-            setIssuedBy(signingOfficialUser.displayName);
+            const names = signingOfficialUsers.map(so => so.displayName);
+            setIssuedBy(names.join(', '));
           }
         }
       } catch (error) {

--- a/src/pages/user_profile/ResearcherStatus.js
+++ b/src/pages/user_profile/ResearcherStatus.js
@@ -28,7 +28,7 @@ export default function ResearcherStatus(props) {
     const init = async () => {
       try {
         if (!isNil(user) && !isNil(user.libraryCards)) {
-          if (user.libraryCards.length == 0) {
+          if (user.libraryCards.length === 0) {
             setHasCard(false);
           }
           else {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2745

### Summary
Fixes the call to get the SOs for a user

#### Before:
<img width="539" alt="Screenshot 2023-10-19 at 8 32 54 AM" src="https://github.com/DataBiosphere/duos-ui/assets/116679/2b27577c-522e-4974-b3bd-58eb7a989897">


#### After:
<img width="661" alt="Screenshot 2023-10-19 at 8 32 43 AM" src="https://github.com/DataBiosphere/duos-ui/assets/116679/9666908f-3f3f-4c68-8d15-b0de39d9f7cf">



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
