### PR TITLE
[DUOS-2752][risk=no] Remove unused header

### DIFF
--- a/conf/conf.d/default.conf
+++ b/conf/conf.d/default.conf
@@ -12,7 +12,6 @@ server {
   server_tokens off;
   listen 8080;
   expires $expires;
-  add_header Content-Security-Policy "default-src 'self' accounts.google.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' apis.google.com *.google-analytics.com www.gstatic.com accounts.google.com; connect-src 'self' *.firecloud.org *.broadinstitute.org *.googleapis.com *.google-analytics.com profile-dot-broad-shibboleth-prod.appspot.com broadinstitute.zendesk.com; img-src 'self' data: *.google-analytics.com; style-src 'self' 'unsafe-inline' www.gstatic.com; base-uri 'self'; form-action 'self'; font-src 'self' fonts.gstatic.com; frame-ancestors 'self';";
   error_page 400 401 403 404 /;
   location / {
     root   /usr/share/nginx/html;


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2752

### Summary
Removes unused header setting
This is now controlled in the proxy
See also: https://github.com/broadinstitute/terra-helmfile/pull/4719

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
