### PR TITLE
[DUOS-2787] Ensure package-lock.json is copied into build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PATH /usr/src/app/node_modules/.bin:$PATH
 COPY src /usr/src/app/src
 COPY public /usr/src/app/public
 COPY package.json /usr/src/app/package.json
+COPY package-lock.json /usr/src/app/package-lock.json
 COPY config/base_config.json /usr/src/app/public/config.json
 RUN npm config set update-notifier false
 RUN npm install --silent


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2787

### Summary

Ensure `package-lock.json` is copied into build container to fix issues with `dataset_catalog` not loading.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
