### PR TITLE
[DUOS-2758][risk=no] Minor updates related to DAC Name and Email displays

### DIFF
--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -163,7 +163,7 @@ export const DatasetSearchTable = (props) => {
                     value: dataset.dataLocation,
                   },
                   {
-                    value: dataset.dacName,
+                    value: dataset.dac?.dacName,
                   },
                 ],
               };

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -480,7 +480,8 @@ export const getSearchFilterFunctions = () => {
       const custodians = join(', ')(datasetTerm.study?.dataCustodianEmail);
       return includes(loweredTerm, toLower(datasetTerm.datasetName)) ||
         includes(loweredTerm, toLower(datasetTerm.datasetIdentifier)) ||
-        includes(loweredTerm, toLower(datasetTerm.dacName)) ||
+        includes(loweredTerm, toLower(datasetTerm.dac?.dacName)) ||
+        includes(loweredTerm, toLower(datasetTerm.dac?.dacEmail)) ||
         includes(loweredTerm, toLower(datasetTerm.dataLocation)) ||
         includes(loweredTerm, toLower(codes)) ||
         includes(loweredTerm, toLower(datasetTerm.createUserDisplayName)) ||

--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -91,7 +91,7 @@ export default function DatasetSubmissionsTable(props) {
         datasetName: term.datasetName,
         dataSubmitter: term.createUserDisplayName,
         datasetCustodians: custodians,
-        dac: term.dacName,
+        dac: term.dac?.dacName,
         dataUse: join(', ')(concat(primaryCodes)(secondaryCodes)),
         status: status,
         actions: editButton


### PR DESCRIPTION
### Addresses
Related updates for https://broadworkbench.atlassian.net/browse/DUOS-2758

### Summary
* Migrate from `term.dacName` to `term.dac.dacName`
* Add `term.dac.dacEmail` to filter to prep for changes in https://github.com/DataBiosphere/consent/pull/2186

### Testing
You can find studies that are not in use with this query:
```
select distinct d.study_id
from dataset d
where d.dataset_id not in (select distinct dataset_id from dar_dataset);
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
