### PR TITLE
[DUOS-2788][risk=no] Fix edit button styling

### DIFF
--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -5,7 +5,6 @@ import loadingIndicator from '../../images/loading-indicator.svg';
 import SortableTable from '../../components/sortable_table/SortableTable';
 import {concat, isNil, join} from 'lodash/fp';
 import Button from '@mui/material/Button';
-import styles from './DatasetTerms.module.css';
 
 
 export default function DatasetSubmissionsTable(props) {

--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -81,7 +81,12 @@ export default function DatasetSubmissionsTable(props) {
         <div>
           <Button
             href={editLink}
-            className={styles['action-button']}>
+            sx={{
+              fontSize: '1.25rem',
+              border: '1px solid #0948B7',
+              borderRadius: 1,
+              height: 25
+            }}>
             Edit
           </Button>
         </div>;

--- a/src/pages/researcher_console/DatasetTerms.module.css
+++ b/src/pages/researcher_console/DatasetTerms.module.css
@@ -17,12 +17,3 @@
     display: flex;
     justify-content: flex-end;
 }
-
-.action-button {
-    font-size: 14px;
-    border: 1px solid #0948B7;
-    border-radius: 4px;
-    height: 25px;
-    cursor: pointer;
-    color: #0948B7;
-}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2788

### Summary
Minor style update for the edit button on the "Data Submissions" page

#### Before:
<img width="1535" alt="Screenshot 2023-11-09 at 7 50 18 AM" src="https://github.com/DataBiosphere/duos-ui/assets/116679/c201627a-404f-4c9d-afe1-e8dd01172850">

#### After:
<img width="1533" alt="Screenshot 2023-11-09 at 7 50 41 AM" src="https://github.com/DataBiosphere/duos-ui/assets/116679/7ff4d6c3-c85a-47b1-9439-ae50b6b94cf3">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
