### PR TITLE
[DUOS-2795][risk=no] Only run init once on mount

### DIFF
--- a/src/pages/DatasetSearch.js
+++ b/src/pages/DatasetSearch.js
@@ -184,7 +184,7 @@ export const DatasetSearch = (props) => {
       }
     };
     init();
-  });
+  }, []);
 
   return (
     loading ?


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2795

### Summary

Only run init once on mount to prevent infinite loop with loading the index.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
