### PR TITLE
[DUOS-2803] Return item label and DOID

### DIFF
--- a/src/pages/data_submission/consent_group/EditConsentGroup.js
+++ b/src/pages/data_submission/consent_group/EditConsentGroup.js
@@ -26,7 +26,7 @@ const searchOntologies = (query, callback) => {
   DAR.getAutoCompleteOT(query).then(
     items => {
       options = items.map(function (item) {
-        return item.label;
+        return { displayText: item.label, id: item.id };
       });
       callback(options);
     });
@@ -240,7 +240,6 @@ export const EditConsentGroup = (props) => {
             isMulti: true,
             isCreatable: true,
             isAsync: true,
-            optionsAreString: true,
             loadOptions: searchOntologies,
             id: idx + '_diseaseSpecificUseText',
             name: 'diseaseSpecificUse',
@@ -253,10 +252,11 @@ export const EditConsentGroup = (props) => {
               onValidationChange({ key: 'diseaseSpecificUse', validation });
             },
             onChange: ({ key, value, isValid }) => {
+              const doids = value.map((v) => v.id);
               setSelectedDiseases(value);
               onChange({
                 key: key,
-                value: value,
+                value: doids,
                 isValid: isValid
               });
             },


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2803

### Summary

Return DOID instead of the disease when Disease Restriction is selected.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
