### PR TITLE
[DUOS-2815] Make Libraries subtitle a single line in /datalibrary page

### DIFF
--- a/src/components/TableHeaderSection.js
+++ b/src/components/TableHeaderSection.js
@@ -34,6 +34,7 @@ export const TableHeaderSection = (props) => {
               style: {
                 fontFamily: 'Montserrat',
                 fontSize: '1.4rem',
+                width: '150%' 
               },
             },
             [description]


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2815

### Summary
<img width="754" alt="Screenshot 2023-12-04 at 2 17 49 PM" src="https://github.com/DataBiosphere/duos-ui/assets/36281103/59ca50d1-fc5a-4f89-8e6b-b8ed9453809f">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
