### PR TITLE
[DUOS-2805][risk=no] Turn off TS checking for old javascript

### DIFF
--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -5,7 +5,6 @@ import React, {useEffect, useState} from 'react';
 import {BaseModal} from '../BaseModal';
 import {DataUseTranslation} from '../../libs/dataUseTranslation';
 
-// @ts-ignore
 const DacDatasetsModal = (props) => {
 
   const {showModal, onCloseRequest, datasets, dac} = props;
@@ -13,32 +12,27 @@ const DacDatasetsModal = (props) => {
 
   useEffect(() => {
     const init = async () => {
-      // @ts-ignore
       let translationPromises = datasets.map((dataset) =>
         DataUseTranslation.translateDataUseRestrictions(dataset.dataUse));
       const datasetTranslations = await Promise.all(translationPromises);
-      // @ts-ignore
       setTranslatedDatasetRestrictions(datasetTranslations);
     };
 
     init();
   }, [datasets]);
 
-  // @ts-ignore
   const getProperty = (properties, propName) => {
     return find(properties, p => {
       return p.propertyName.toLowerCase() === propName.toLowerCase();
     });
   };
 
-  // @ts-ignore
   const getPropertyValue = (properties, propName, defaultValue) => {
     const prop = getProperty(properties, propName);
     const val = get(prop, 'propertyValue', '');
     return isEmpty(val) ? <span className={'disabled'}>{defaultValue}</span> : val;
   };
 
-  // @ts-ignore
   const getDbGapLinkValue = (properties) => {
     const href = getPropertyValue(properties, 'dbGAP', '');
     return href.length > 0 ?
@@ -46,11 +40,9 @@ const DacDatasetsModal = (props) => {
       <span className={'disabled'}>---</span>;
   };
 
-  // @ts-ignore
   const getStructuredUseRestrictionLink = (index) => {
     if (translatedDatasetRestrictions[index]) {
       const translatedDataUse = translatedDatasetRestrictions[index]
-        // @ts-ignore
         .map((translations) => translations.description)
         .join('\n');
       const shortenedDataUse = translatedDataUse.length >= 75 ?
@@ -63,7 +55,6 @@ const DacDatasetsModal = (props) => {
     }
   };
 
-  // @ts-ignore
   return <BaseModal
     key={'dac_datasets_modal'}
     id={'dacDatasetsModal'}
@@ -94,7 +85,6 @@ const DacDatasetsModal = (props) => {
         </thead>
         <tbody key={'dac_datasets_table_body'}>
           {
-          // @ts-ignore
             datasets.map((dataset, index) => {
               return <tr key={'dac_datasets_table_row_' + index + '_' + dataset.datasetIdentifier}>
                 <td key={'1_' + dataset.datasetIdentifier} className={'table-items cell-size'}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "checkJs": true,
+    "checkJs": false,
     "esModuleInterop": true,
     "jsx": "react-jsx",
     "module": "esnext",


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2805

### Summary
Minor config update so that TypeScript errors are not displayed in JS files

#### Old

![Screenshot 2023-12-14 at 5 05 26 PM](https://github.com/DataBiosphere/duos-ui/assets/116679/edb45547-a9ad-4706-a4d3-1235742c1572)


#### New

![Screenshot 2023-12-14 at 5 05 39 PM](https://github.com/DataBiosphere/duos-ui/assets/116679/d6c7f55b-dc61-4e4e-82a7-073b57923bb6)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
