### PR TITLE
[DUOS-2861] Return undefined instead of error when no data custodian

### DIFF
--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -148,7 +148,7 @@ export const DatasetSearchTable = (props) => {
               truncate: true,
             },
             {
-              value: entry[0].study.dataCustodianEmail.join(', '),
+              value: entry[0].study.dataCustodianEmail?.join(', '),
               truncate: true,
             },
           ],


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2861

### Summary

Return undefined instead of error when no data custodian

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
