### PR TITLE
[DUOS-2806] Fix empty columns for new study datasets

### DIFF
--- a/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
+++ b/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
@@ -80,7 +80,25 @@ const sampleDataset = {
       'propertyValue': 'human',
       'propertyType': 'String'
     }
-  ]
+  ],
+  'study': {
+    'studyId': 1,
+    'name': 'xyz 123',
+    'description': 'test',
+    'publicVisibility': true,
+    'datasetIds': [
+      1408
+    ],
+    'properties': [
+      {
+        'studyPropertyId': 110,
+        'studyId': 17,
+        'key': 'dataCustodianEmail',
+        'type': 'Json',
+        "value": []
+      }
+    ],
+  },
 };
 
 // It's necessary to wrap components that contain `Link` components

--- a/cypress/component/utils/dataset_utils.spec.js
+++ b/cypress/component/utils/dataset_utils.spec.js
@@ -1,0 +1,59 @@
+import { firstNonEmptyPropertyValue } from '../../../src/utils/DatasetUtils';
+
+describe('firstNonEmptyPropertyValue', () => {
+    it('ensure no errors when no study properties', async () => {
+        const dataset = { id: 1, study: { id: 2 }};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'test' ]);
+        expect(result).to.be.empty;
+    });
+    it('ensure no errors when no dataset properties', async () => {
+        const dataset = { id: 1 };
+        const result = firstNonEmptyPropertyValue(dataset, [ 'test' ]);
+        expect(result).to.be.empty;
+    });
+    it('ensure no errors when incorrect properties', async () => {
+        const dataset = { id: 1, study: { id: 2, properties: [ { key: 'hello', value: 'goodbye' } ]}};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'test' ]);
+        expect(result).to.be.empty;
+    });
+    it('ensure no errors when empty study property values', async () => {
+        const dataset = { id: 1, study: { id: 2, properties: [ { key: 'hello' } ]}};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello' ]);
+        expect(result).to.be.empty;
+    });
+    it('ensure no errors when empty dataset property values', async () => {
+        const dataset = { id: 1, properties: [ { propertyName: 'hello' } ]};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello' ]);
+        expect(result).to.be.empty;
+    });
+    it('extract hello property from study', async () => {
+        const dataset = { id: 1, study: { id: 2, properties: [ { key: 'hello', value: 'goodbye' } ]}};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello' ]);
+        expect(result).to.equal('goodbye');
+    });
+    it('extract hello property from dataset', async () => {
+        const dataset = { id: 1, properties: [ { propertyName: 'hello', propertyValue: 'goodbye' } ]};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello' ]);
+        expect(result).to.equal('goodbye');
+    });
+    it('prioritize study property over dataset property', async () => {
+        const dataset = { id: 1, properties: [ { propertyName: 'hello', propertyValue: 'goodbye' } ], study: { id: 2, properties: [ { key: 'hello', value: 'world' } ]}};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello' ]);
+        expect(result).to.equal('world');
+    });
+    it('extract first available property from study', async () => {
+        const dataset = { id: 1, study: { id: 2, properties: [ { key: 'hello', value: 'goodbye' }, { key: 'world', value: 'hello' } ]}};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello', 'world' ]);
+        expect(result).to.equal('goodbye');
+    });
+    it('extract first available property from dataset', async () => {
+        const dataset = { id: 1, properties: [ { propertyName: 'hello', propertyValue: 'goodbye' }, { propertyName: 'world', propertyValue: 'hello' } ]};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'hello', 'world' ]);
+        expect(result).to.equal('goodbye');
+    });
+    it('extract mix of properties from study and dataset', async () => {
+        const dataset = { id: 1, properties: [ { propertyName: 'hello', propertyValue: 'goodbye' } ], study: { id: 2, properties: [ { key: 'world', value: 'hello' } ]}};
+        const result = firstNonEmptyPropertyValue(dataset, [ 'world', 'hello' ]);
+        expect(result).to.equal('hello');
+    });
+});

--- a/src/components/dac_dataset_table/DACDatasetTableCellData.js
+++ b/src/components/dac_dataset_table/DACDatasetTableCellData.js
@@ -5,6 +5,7 @@ import {DatasetService} from '../../utils/DatasetService';
 import DACDatasetApprovalStatus from './DACDatasetApprovalStatus';
 import {isEmpty, map} from 'lodash/fp';
 import ReactTooltip from 'react-tooltip';
+import { firstNonEmptyPropertyValue } from '../../utils/DatasetUtils';
 
 export const consoleTypes = { CHAIR: 'chair' };
 
@@ -43,10 +44,7 @@ export function datasetNameCellData({dataset, label = 'datasetNameCellData'}) {
 export function dataCustodianCellData({dataset, label = 'dataCustodianCellData'}) {
   // Newer datasets have a list of data custodian emails.
   // Older datasets may or may not have a data depositor
-  const datasetCustodians = DatasetService.findDatasetPropertyValueList(dataset, 'Data Custodian Email')?.join(', ');
-  const dataDepositor = DatasetService.findDatasetPropertyValue(dataset, 'Data Depositor');
-  const studyCustodians = DatasetService.findDatasetPropertyValueList(dataset.study, 'dataCustodianEmail')?.join(', ');
-  const displayValue = isEmpty(datasetCustodians) ? (isEmpty(dataDepositor) ? studyCustodians : dataDepositor) : datasetCustodians;
+  const displayValue = firstNonEmptyPropertyValue(dataset, [ 'Data Custodian Email', 'Data Depositor', 'dataCustodianEmail' ]);
   return {
     data: <div className={style['cell-data']}>{displayValue}</div>,
     value: displayValue,

--- a/src/components/dac_dataset_table/DACDatasetTableCellData.js
+++ b/src/components/dac_dataset_table/DACDatasetTableCellData.js
@@ -3,7 +3,7 @@ import style from '../../pages/DACDatasets.module.css';
 import {styles} from './DACDatasetsTable';
 import {DatasetService} from '../../utils/DatasetService';
 import DACDatasetApprovalStatus from './DACDatasetApprovalStatus';
-import {isEmpty, join, map} from 'lodash/fp';
+import {isEmpty, map} from 'lodash/fp';
 import ReactTooltip from 'react-tooltip';
 
 export const consoleTypes = { CHAIR: 'chair' };
@@ -19,14 +19,11 @@ export function duosIdCellData({dataset, label = 'duosIdCellData'}) {
 }
 
 export function dataSubmitterCellData({dataset, label = 'dataSubmitterCellData'}) {
-  // We need an update to the dac-dataset API to get the data submitter value.
-  // The Data Submitter is always pre-populated with the user who originally created the dataset.
-  // See https://broadworkbench.atlassian.net/browse/DUOS-2291 for details
-  // Until that happens, we can rely on the data depositor field.
   const dataDepositor = DatasetService.findDatasetPropertyValue(dataset, 'Data Depositor');
+  const displayValue = isEmpty(dataDepositor) ? dataset.createUser.displayName : dataDepositor;
   return {
-    data: <div className={style['cell-data']}>{dataDepositor}</div>,
-    value: dataDepositor,
+    data: <div className={style['cell-data']}>{displayValue}</div>,
+    value: displayValue,
     id: `data-submitter-cell-data-${dataset.dataSetId}`,
     cellStyle: {width: styles.cellWidths.dataSubmitter},
     label
@@ -46,9 +43,10 @@ export function datasetNameCellData({dataset, label = 'datasetNameCellData'}) {
 export function dataCustodianCellData({dataset, label = 'dataCustodianCellData'}) {
   // Newer datasets have a list of data custodian emails.
   // Older datasets may or may not have a data depositor
-  const dataCustodians = DatasetService.findDatasetPropertyValueList(dataset, 'Data Custodian Email');
+  const datasetCustodians = DatasetService.findDatasetPropertyValueList(dataset, 'Data Custodian Email')?.join(', ');
   const dataDepositor = DatasetService.findDatasetPropertyValue(dataset, 'Data Depositor');
-  const displayValue = isEmpty(dataCustodians) ? dataDepositor : join(', ')(dataCustodians);
+  const studyCustodians = DatasetService.findDatasetPropertyValueList(dataset.study, 'dataCustodianEmail')?.join(', ');
+  const displayValue = isEmpty(datasetCustodians) ? (isEmpty(dataDepositor) ? studyCustodians : dataDepositor) : datasetCustodians;
   return {
     data: <div className={style['cell-data']}>{displayValue}</div>,
     value: displayValue,

--- a/src/utils/DatasetUtils.ts
+++ b/src/utils/DatasetUtils.ts
@@ -1,0 +1,25 @@
+export const firstNonEmptyPropertyValue = (dataset: any, propertyNames: string[]): string => {
+    for (const propertyName of propertyNames) {
+        let propertyValue: string[] = [];
+        if ('study' in dataset && 'properties' in dataset.study) {
+            const property = dataset.study.properties.find((property: any) => property.key === propertyName);
+            const value = property?.value;
+            if (value !== undefined) {
+                const valueAsIterable = typeof value === 'string' ? [value] : value;
+                propertyValue.push(...valueAsIterable);
+            }
+        }
+        if ('properties' in dataset && propertyValue.length === 0) {
+            const property = dataset.properties.find((property: any) => property.propertyName === propertyName);
+            const value = property?.propertyValue;
+            if (value !== undefined) {
+                const valueAsIterable = typeof value === 'string' ? [value] : value;
+                propertyValue.push(...valueAsIterable);
+            }
+        }
+        if (propertyValue.length > 0) {
+            return propertyValue.join(', ');
+        }
+    }
+    return '';
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2806

### Summary

Fix empty columns for new study datasets by trying all available depositor and custodian fields.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
