### PR TITLE
[DUOS-2882][risk=no] Bug fix for component test

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -329,7 +329,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
     cy.get('.table-data').should('not.exist');
-    cy.get('#show-member-vote-dropdown').click();
+    cy.get('#show-member-vote-dropdown').click({force: true});
     const component = cy.get('.table-data');
     component.should('exist');
     component.should('contain', 'test1');


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2882

### Summary
Minor fix for click items that clearly exist, but are for some reason inaccessible without `{force: true}`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
