### PR TITLE
[DUOS-2807] Export to terra

### DIFF
--- a/config/base_config.json
+++ b/config/base_config.json
@@ -4,6 +4,7 @@
   "tag": "",
   "apiUrl": "",
   "ontologyApiUrl": "",
+  "terraUrl": "",
   "tdrApiUrl": "",
   "clientId": "",
   "errorApiKey": "",

--- a/config/base_config.json
+++ b/config/base_config.json
@@ -4,6 +4,7 @@
   "tag": "",
   "apiUrl": "",
   "ontologyApiUrl": "",
+  "tdrApiUrl": "",
   "clientId": "",
   "errorApiKey": "",
   "profileUrl": "",

--- a/public/config-example.json
+++ b/public/config-example.json
@@ -4,6 +4,7 @@
   "hash": "dev",
   "apiUrl": "http://localhost:8180/api",
   "ontologyApiUrl": "https://ontologyURL.org/",
+  "tdrApiUrl": "https://tdrApiUrl.org/",
   "clientId": "111111111111-11111111111111111111111111111111.apps.googleusercontent.com",
   "errorApiKey": "example",
   "gaId": "",

--- a/src/components/data_search/DatasetExportButton.js
+++ b/src/components/data_search/DatasetExportButton.js
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { CircularProgress, IconButton, Link } from '@mui/material';
+import { useState } from 'react';
+import IosShareIcon from '@mui/icons-material/IosShare';
+import { TerraDataRepo } from '../../libs/ajax';
+
+export const DatasetExportButton = (props) => {
+  const { snapshot, title } = props;
+  // The exportStatus flow is: initial -> prepping -> ready
+  // TODO: error handling?
+  const [exportStatus, setExportStatus] = useState('initial');
+  const [exportResult, setExportResult] = useState(null);
+
+  // Not a supported export location
+  if (!snapshot) {
+    return null;
+  }
+
+  const prepExportHandler = async () => {
+    setExportStatus('prepping');
+    const job = await TerraDataRepo.prepareExport(snapshot.id);
+    const result = await TerraDataRepo.waitForJob(job.id);
+    setExportResult(result);
+    setExportStatus('ready');
+  };
+
+  if (exportStatus === 'initial') {
+    return (
+      <IconButton aria-label="prepare export to Terra" size="medium" onClick={prepExportHandler}>
+        <IosShareIcon size={15} />
+      </IconButton>
+    );
+  }
+
+  if (exportStatus === 'prepping') {
+    return (
+      <IconButton aria-label="prepare export to Terra" size="medium" onClick={() => ({})} disabled>
+        <CircularProgress size={15} />,
+      </IconButton>
+    );
+  }
+
+  if (exportStatus === 'ready') {
+    return (
+      <Link href={exportResult.terraImportLink} target="_blank" rel="noopener noreferrer" title={title} aria-label={title}>Terra</Link>
+    );
+  }
+
+  return null;
+
+};
+
+export default DatasetExportButton;

--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { Button, Link } from '@mui/material';
+import _ from 'lodash';
+import { Box, Button, Link } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { groupBy, isEmpty } from 'lodash';
 import CollapsibleTable from '../CollapsibleTable';
 import TableHeaderSection from '../TableHeaderSection';
-import { DAR } from '../../libs/ajax';
+import DatasetExportButton from './DatasetExportButton';
+import { DAR, TerraDataRepo } from '../../libs/ajax';
+import { Config } from '../../libs/config';
 import DatasetFilterList from './DatasetFilterList';
-import { Box } from '@mui/material';
 
 const studyTableHeader = [
   'Study Name',
@@ -26,6 +28,7 @@ const datasetTableHeader = [
   'Participants',
   'Data Location',
   'DAC',
+  'Use in Terra',
 ];
 
 export const DatasetSearchTable = (props) => {
@@ -34,6 +37,8 @@ export const DatasetSearchTable = (props) => {
   const [filtered, setFiltered] = useState([]);
   const [tableData, setTableData] = useState({});
   const [selected, setSelected] = useState([]);
+  const [exportableDatasets, setExportableDatasets] = useState({}); // datasetId -> snapshot
+  const [tdrApiUrl, setTdrApiUrl] = useState('');
 
   const isFiltered = (filter) => filters.indexOf(filter) > -1;
 
@@ -94,6 +99,30 @@ export const DatasetSearchTable = (props) => {
     }
 
     setSelected(newSelected);
+  };
+
+  const expandHandler = async (event, data) => {
+    // This method adds the export to Terra button to the subtable rows that have an associated TDR snapshot that the user
+    // has access to.
+
+    setTdrApiUrl(await Config.getTdrApiUrl());
+
+    // Note the dataset id is the first column in subrows.
+    // If columns are ever reordereable, this will need to be updated to be not hardcoded to look for the first column.
+    const datasetIds = data.subtable.rows.map((row) => row.data[0].value);
+    const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIds);
+    if (snapshots.filteredTotal > 0) {
+      const datasetIdToSnapshot = _.chain(snapshots.items)
+        // Ignore any snapshots that a user does not have export (steward or reader) to
+        .filter((snapshot) => _.intersection(snapshots.roleMap[snapshot.id], ['steward', 'reader']).length > 0)
+        .groupBy('duosId')
+        .value();
+      setExportableDatasets(datasetIdToSnapshot);
+    }
+  };
+
+  const collapseHandler = () => {
+    setExportableDatasets({});
   };
 
   const applyForAccess = async () => {
@@ -169,10 +198,34 @@ export const DatasetSearchTable = (props) => {
                     value: dataset.participantCount,
                   },
                   {
-                    value: dataset.url ? <Link href={dataset.url}>{dataset.dataLocation}</Link> : dataset.dataLocation,
+                    value: () => {
+                      const exportableSnapshots = exportableDatasets[dataset.datasetIdentifier] || [];
+                      if (exportableSnapshots.length === 0) {
+                        return dataset.dataLocation;
+                      }
+                      return exportableSnapshots.map((snapshot, i) =>
+                        <Link
+                          key={`${i}`}
+                          href={`${tdrApiUrl}/snapshots/${snapshot.id}`}
+                          target="_blank"
+                        >
+                          {snapshot.name}
+                        </Link>);
+                    }
                   },
                   {
                     value: dataset.dac?.dacName,
+                  },
+                  {
+                    value: () => {
+                      const exportableSnapshots = exportableDatasets[dataset.datasetIdentifier] || [];
+                      return exportableSnapshots
+                        .map((snapshot, i) =>
+                          <DatasetExportButton
+                            key={`${i}`}
+                            snapshot={snapshot}
+                            title={`Export snapshot ${snapshot.name}`} />);
+                    }
                   },
                 ],
               };
@@ -183,7 +236,7 @@ export const DatasetSearchTable = (props) => {
     };
 
     setTableData(table);
-  }, [filtered]);
+  }, [filtered, exportableDatasets, tdrApiUrl]);
 
   useEffect(() => {
     setFiltered(datasets);
@@ -203,7 +256,14 @@ export const DatasetSearchTable = (props) => {
                 <h1>No datasets registered for this library.</h1>
               </Box>
               :
-              <CollapsibleTable data={tableData} selected={selected} selectHandler={selectHandler} summary='faceted study search table' />
+              <CollapsibleTable
+                data={tableData}
+                selected={selected}
+                selectHandler={selectHandler}
+                expandHandler={expandHandler}
+                collapseHandler={collapseHandler}
+                summary='faceted study search table'
+              />
           }
         </Box>
       </Box>

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -778,7 +778,7 @@ export const TerraDataRepo = {
         const finalResult = await axios.get(resultsUrl, Config.authOpts());
         // Add the URL to link to
         finalResult.data.terraImportLink =
-        `${await Config.getTerraUrl()}/#import-data?url=${window.location.origin}&snapshotId=${finalResult.data.snapshot.id}&format=tdrexport&snapshotName=${finalResult.data.snapshot.name}&tdrmanifest=${encodeURIComponent(finalResult.data.format.parquet.manifest)}&tdrSyncPermissions=false`;
+        `${await Config.getTerraUrl()}/#import-data?url=${await Config.getTdrApiUrl()}&snapshotId=${finalResult.data.snapshot.id}&format=tdrexport&snapshotName=${finalResult.data.snapshot.name}&tdrmanifest=${encodeURIComponent(finalResult.data.format.parquet.manifest)}&tdrSyncPermissions=false`;
         return finalResult.data;
       } else if (res.data.job_status === 'failed') {
         return reportError(url, res.data.status_code);

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -11,6 +11,10 @@ export const Config = {
 
   getOntologyApiUrl: async () => (await getConfig()).ontologyApiUrl,
 
+  getTdrApiUrl: async () => (await getConfig()).tdrApiUrl,
+
+  getTerraUrl: async () => (await getConfig()).terraUrl,
+
   getProfileUrl: async () => (await getConfig()).profileUrl,
 
   getNihUrl: async () => (await getConfig()).nihUrl,


### PR DESCRIPTION
### Addresses
Feature to allow exporting TDR snapshots to Terra from DUOS

### Summary
I've added a video of what it looks like in action:

https://github.com/DataBiosphere/duos-ui/assets/5633787/7f5d36f6-8974-4fa1-beed-28d06b27450f

This PR:
- Adds a TDR URL config value that will be needed in all environments
- On expansion of the study, the UI will call TDR to see if any snapshots are available to the current user
   - If so, the user snapshots linked to the datasets will be listed as links that can navigate a user to TDR
   - Also, an export button will be visible that allows a user to prep an export and then export to Terra

This could use testing and some error handling

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
