### PR TITLE
[DUOS-2860] Remove duplicate display of profile and lc warning in DAR form

### DIFF
--- a/cypress/component/DataAccessRequest/researcher_info.spec.js
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.js
@@ -87,9 +87,8 @@ describe('Researcher Info', () => {
   it('renders the missing library cards alert correctly', () => {
     const mergedProps = {...props, ...{formData: {...props.formData }}};
     mount(<WrappedResearcherInfo {...mergedProps}/>);
-    cy.get('[dataCy=researcher-info-missing-library-cards]').should('be.visible');
     cy.get('[dataCy=researcher-info-profile-unsubmitted]').should('not.exist');
-    cy.get('[dataCy=researcher-info-profile-submitted]').should('not.exist');
+    cy.get('[dataCy=researcher-info-profile-submitted]').should('be.visible');
   });
 
   it('renders the profile submitted alert', () => {
@@ -97,15 +96,13 @@ describe('Researcher Info', () => {
     mount(<WrappedResearcherInfo {...mergedProps}/>);
     cy.get('[dataCy=researcher-info-profile-submitted]').should('be.visible');
     cy.get('[dataCy=researcher-info-profile-unsubmitted]').should('not.exist');
-    cy.get('[dataCy=researcher-info-missing-library-cards]').should('not.exist');
   });
 
   it('renders the profile unsubmitted alert', () => {
     const mergedProps = {...props, ...{completed: false, researcher: researcherWithLibraryCards}};
     mount(<WrappedResearcherInfo {...mergedProps}/>);
     cy.get('[dataCy=researcher-info-profile-unsubmitted]').should('be.visible');
-    cy.get('[dataCy=researcher-info-profile-submitted]').should('not.exist');
-    cy.get('[dataCy=researcher-info-missing-library-cards]').should('not.exist');
+    cy.get('[dataCy=researcher-info-profile-submitted]').should('be.visible');
   });
 
   it('renders the internal lab staff button and form', () => {

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -34,7 +34,6 @@ export default function ResearcherInfo(props) {
     showValidationMessages,
     validation,
     formValidationChange,
-    isInvalidForm,
     ariaLevel = 2
   } = props;
 

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -51,8 +51,6 @@ export default function ResearcherInfo(props) {
 
   useEffect(() => {
     setLibraryCardReqSatisfied(!isEmpty(get('libraryCards')(researcher)));
-    console.log("library cards", isEmpty(get('libraryCards')(researcher)));
-    console.log(completed);
   }, [researcher]);
 
   return (

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -58,11 +58,11 @@ export default function ResearcherInfo(props) {
       div({ className: 'dar-step-card' }, [
         div({
           datacy: 'researcher-info-profile-submitted',
-          isRendered: (completed === false && libraryCardReqSatisfied === false)}, [
+          isRendered: (completed === false || libraryCardReqSatisfied === false)}, [
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
-            type: 'important',
-            title: span({className: `${libraryCardReqSatisfied === false && showNihValidationError ? 'errored' : 'rp-error' }`},[ 
+            type: 'danger',
+            title: span({className:'errored'},[ 
               `You must submit `, profileLink, ` and obtain a `, libraryCardLink,
               ` from your Signing official before you can submit a Data Access Request.`
             ])

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -13,7 +13,6 @@ const profileLink = h(Link, {to:'/profile', style: linkStyle}, ['Your Profile'])
 const profileUnsubmitted = span(['Please submit ', profileLink, ' to be able to create a Data Access Request']);
 const profileSubmitted = span(['Please make sure ', profileLink, ' is updated as it will be used to pre-populate parts of the Data Access Request']);
 const libraryCardLink = a({href: 'https://broad-duos.zendesk.com/hc/en-us/articles/4402736994971-Researcher-FAQs', style: linkStyle, target: '_blank'}, ['Library Card']);
-const missingLibraryCard = span(['You must submit ', profileLink, ' and obtain a ', libraryCardLink, ' from your Signing Official before you can submit a Data Access Request']);
 
 export default function ResearcherInfo(props) {
   const {
@@ -58,11 +57,12 @@ export default function ResearcherInfo(props) {
       div({ className: 'dar-step-card' }, [
         div({
           datacy: 'researcher-info-profile-submitted',
-          isRendered: (completed === false && libraryCardReqSatisfied === false), className: 'rp-alert' }, [
+          isRendered: (completed === false && libraryCardReqSatisfied === false), 
+          className: `${completed === false ? 'rp-error' : 'errored' }`}, [
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
             type: 'important',
-            title: span([
+            title: span({className: `${completed === false ? 'rp-error' : 'errored' }`},[ 
               `You must submit `, profileLink, ` and obtain a `, libraryCardLink,
               ` from your Signing official before you can submit a Data Access Request.`
             ])
@@ -103,11 +103,6 @@ export default function ResearcherInfo(props) {
             })
           ]),
           fieldset({ }, [
-            div({
-              datacy: 'researcher-info-missing-library-cards',
-              isRendered: libraryCardReqSatisfied === false, className: 'rp-alert' }, [
-              !readOnlyMode && Alert({ id: 'missingLibraryCard', type: 'danger', title: missingLibraryCard })
-            ]),
             div({
               datacy: 'researcher-info-profile-unsubmitted',
               isRendered: (completed === false && libraryCardReqSatisfied === true), className: 'rp-alert' }, [

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -58,11 +58,11 @@ export default function ResearcherInfo(props) {
         div({
           datacy: 'researcher-info-profile-submitted',
           isRendered: (completed === false && libraryCardReqSatisfied === false), 
-          className: `${completed === false ? 'rp-error' : 'errored' }`}, [
+          className: `${completed === false && libraryCardReqSatisfied === false ? 'rp-error' : 'errored' }`}, [
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
             type: 'important',
-            title: span({className: `${completed === false ? 'rp-error' : 'errored' }`},[ 
+            title: span({className: `${completed === false && libraryCardReqSatisfied ? 'rp-error' : 'errored' }`},[ 
               `You must submit `, profileLink, ` and obtain a `, libraryCardLink,
               ` from your Signing official before you can submit a Data Access Request.`
             ])

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -61,7 +61,7 @@ export default function ResearcherInfo(props) {
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
             type: 'danger',
-            title: span({ className: 'errored' },[ 
+            title: span({ className: 'errored' }, [ 
               `You must submit `, profileLink, ` and obtain a `, libraryCardLink,
               ` from your Signing official before you can submit a Data Access Request.`
             ])

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -58,7 +58,7 @@ export default function ResearcherInfo(props) {
         div({
           datacy: 'researcher-info-profile-submitted',
           isRendered: (completed === false && libraryCardReqSatisfied === false), 
-          className: `${completed === false && libraryCardReqSatisfied === false ? 'rp-error' : 'errored' }`}, [
+          className: `${completed === false || libraryCardReqSatisfied === false ? 'rp-error' : 'errored' }`}, [
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
             type: 'important',

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -34,6 +34,7 @@ export default function ResearcherInfo(props) {
     showValidationMessages,
     validation,
     formValidationChange,
+    isInvalidForm,
     ariaLevel = 2
   } = props;
 
@@ -50,6 +51,8 @@ export default function ResearcherInfo(props) {
 
   useEffect(() => {
     setLibraryCardReqSatisfied(!isEmpty(get('libraryCards')(researcher)));
+    console.log("library cards", isEmpty(get('libraryCards')(researcher)));
+    console.log(completed);
   }, [researcher]);
 
   return (
@@ -57,12 +60,11 @@ export default function ResearcherInfo(props) {
       div({ className: 'dar-step-card' }, [
         div({
           datacy: 'researcher-info-profile-submitted',
-          isRendered: (completed === false && libraryCardReqSatisfied === false), 
-          className: `${completed === false || libraryCardReqSatisfied === false ? 'rp-error' : 'errored' }`}, [
+          isRendered: (completed === false && libraryCardReqSatisfied === false)}, [
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
             type: 'important',
-            title: span({className: `${completed === false && libraryCardReqSatisfied ? 'rp-error' : 'errored' }`},[ 
+            title: span({className: `${libraryCardReqSatisfied === false && showNihValidationError ? 'errored' : 'rp-error' }`},[ 
               `You must submit `, profileLink, ` and obtain a `, libraryCardLink,
               ` from your Signing official before you can submit a Data Access Request.`
             ])

--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -61,7 +61,7 @@ export default function ResearcherInfo(props) {
           !readOnlyMode && Alert({
             id: 'profileSubmitted',
             type: 'danger',
-            title: span({className:'errored'},[ 
+            title: span({ className: 'errored' },[ 
               `You must submit `, profileLink, ` and obtain a `, libraryCardLink,
               ` from your Signing official before you can submit a Data Access Request.`
             ])


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2860

### Summary
Removes duplicate profile & library card warning & changes styling for warning that is kept to alert users from the start if those requirements aren't met. 

<img width="1400" alt="Screenshot 2024-01-22 at 4 16 23 PM" src="https://github.com/DataBiosphere/duos-ui/assets/68303030/83bc1f05-cbee-4300-bedb-cae5a2b99140">


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
