### PR TITLE
[DUOS-2846][risk=no] Non-profit vs Commercial field use changes

### DIFF
--- a/src/components/data_update/DatasetUpdate.js
+++ b/src/components/data_update/DatasetUpdate.js
@@ -350,9 +350,9 @@ export const DatasetUpdate = (props) => {
       }),
       h(FormField, {
         type: FormFieldTypes.CHECKBOX,
-        id: 'nonCommercialUse',
+        id: 'nonProfitUse',
         toggleText: 'Non-profit Use Only (NPU)',
-        defaultValue: formData.dataUse.commercialUse === false,
+        defaultValue: formData.dataUse.nonProfitUse === true,
         disabled: true,
       }),
       h(FormField, {

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -203,6 +203,11 @@ export const consentTranslations = {
     description: 'Use is limited to genetic studies only',
     type: ControlledAccessType.modifiers,
   },
+  commercialUse: {
+    code: 'NPU',
+    description: 'Use is limited to non-profit and non-commercial research',
+    type: ControlledAccessType.modifiers,
+  },
   nonProfitUse: {
     code: 'NPU',
     description: 'Use is limited to non-profit and non-commercial research',
@@ -250,6 +255,14 @@ const getOntologyName = async(urls) => {
 export const processRestrictionStatements = async (key, dataUse) => {
   let resp;
   let value = dataUse[key];
+  /*
+    Due to language used with Data Use Limitations, the description for 'commercialUse' describes non-profit status
+    whereas the actual value represent for-profit status. As such, commercialUse value must be inverted when processing statement
+    in order to accurately reflect description
+  */
+  if (key === 'commercialUse' && !isNil(value)) {
+    value = !value;
+  }
   if (!isNil(value) && value) {
     if (key === 'diseaseRestrictions') {
       //condition for datasets that have ontology labels contained within the dataUse object

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -203,7 +203,7 @@ export const consentTranslations = {
     description: 'Use is limited to genetic studies only',
     type: ControlledAccessType.modifiers,
   },
-  commercialUse: {
+  nonProfitUse: {
     code: 'NPU',
     description: 'Use is limited to non-profit and non-commercial research',
     type: ControlledAccessType.modifiers,
@@ -250,14 +250,6 @@ const getOntologyName = async(urls) => {
 export const processRestrictionStatements = async (key, dataUse) => {
   let resp;
   let value = dataUse[key];
-  /*
-    Due to language used with Data Use Limitations, the description for 'commercialUse' describes non-profit status
-    whereas the actual value represent for-profit status. As such, commercialUse value must be inverted when processing statement
-    in order to accurately reflect description
-  */
-  if (key === 'commercialUse' && !isNil(value)) {
-    value = !value;
-  }
   if (!isNil(value) && value) {
     if (key === 'diseaseRestrictions') {
       //condition for datasets that have ontology labels contained within the dataUse object

--- a/src/pages/ConsentTextGenerator.js
+++ b/src/pages/ConsentTextGenerator.js
@@ -43,7 +43,7 @@ export default function ConsentTextGenerator() {
   const generateHelper = async () => {
     const dataUse = {
       generalUse: general, diseaseRestrictions: ontologies, populationOriginsAncestry: null,
-      hmbResearch: hmb, methodsResearch: nmds, geneticStudiesOnly: gso, commercialUse: npu,
+      hmbResearch: hmb, methodsResearch: nmds, geneticStudiesOnly: gso, nonProfitUse: npu,
       publicationResults: pub, collaboratorRequired: col, ethicsApprovalRequired: irb,
       geographicalRestrictions: gs
     };

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -39,6 +39,7 @@ class DatasetRegistration extends Component {
         ethics: false,
         geographic: false,
         moratorium: false,
+        commercialUse: false,
         nonProfit: false,
         hmb: false,
         npoa: false,
@@ -182,6 +183,7 @@ class DatasetRegistration extends Component {
     let ethics = dataUse.ethicsApprovalRequired;
     let geographic = dataUse.geographicalRestrictions;
     let moratorium = dataUse.publicationMoratorium;
+    let commercialUse = dataUse.commercialUse;
     let nonProfit = dataUse.nonProfitUse;
     let hmb = dataUse.hmbResearch;
     // if the dataset's POA value is set to false, we need to check the NPOA (or NOT POA) option
@@ -202,6 +204,7 @@ class DatasetRegistration extends Component {
       prev.formData.ethics = ethics;
       prev.formData.geographic = geographic;
       prev.formData.moratorium = moratorium;
+      prev.formData.commercialUse = commercialUse;
       prev.formData.nonProfit = nonProfit;
       prev.formData.hmb = hmb;
       prev.formData.npoa = npoa;
@@ -633,6 +636,9 @@ class DatasetRegistration extends Component {
     if (data.npoa) {
       result.populationOriginsAncestry = false;
     }
+    if (data.commercialUse) {
+      result.commercialUse = data.commercialUse;
+    }
     if (data.nonProfit) {
       result.nonProfitUse = data.nonProfit;
     }
@@ -688,6 +694,7 @@ class DatasetRegistration extends Component {
       secondaryOther = false,
       secondaryOtherText = '',
       genetic = false,
+      commercialUse = false,
       nonProfit = false,
       publication = false,
       collaboration = false,

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -182,7 +182,7 @@ class DatasetRegistration extends Component {
     let ethics = dataUse.ethicsApprovalRequired;
     let geographic = dataUse.geographicalRestrictions;
     let moratorium = dataUse.publicationMoratorium;
-    let nonProfit = fp.isNil(dataUse.commercialUse) ? false : !dataUse.commercialUse;
+    let nonProfit = dataUse.nonProfitUse;
     let hmb = dataUse.hmbResearch;
     // if the dataset's POA value is set to false, we need to check the NPOA (or NOT POA) option
     // if the dataset's POA value is set to true, leave this unchecked
@@ -634,7 +634,7 @@ class DatasetRegistration extends Component {
       result.populationOriginsAncestry = false;
     }
     if (data.nonProfit) {
-      result.commercialUse = !data.nonProfit;
+      result.nonProfitUse = data.nonProfit;
     }
     if (data.hmb) {
       result.hmbResearch = data.hmb;

--- a/src/pages/data_submission/DataAccessGovernance.js
+++ b/src/pages/data_submission/DataAccessGovernance.js
@@ -140,7 +140,7 @@ export const DataAccessGovernance = (props) => {
           irb: dataUse.ethicsApprovalRequired,
           gs: dataUse.geographicalRestrictions,
           mor: dataUse.publicationMoratorium,
-          npu: dataUse.commercialUse,
+          npu: dataUse.nonProfitUse,
           otherSecondary: dataUse.secondaryOther,
           url: extract('URL', dataset),
           dataLocation: extract('Data Location', dataset),

--- a/src/utils/BucketUtils.js
+++ b/src/utils/BucketUtils.js
@@ -266,17 +266,16 @@ const processV3Abstain = (matchResults) => {
 };
 
 /**
- * Calculate "Other" status for a data use. Data Uses can have 'otherRestrictions': TRUE|FALSE,
- * or they can have fields populated for 'other': 'other restriction' and 'secondaryOther': 'yet other restriction'
+ * Calculate "Other" status for a data use. Data Uses can have fields populated
+ * for 'other': 'other restriction' and 'secondaryOther': 'yet other restriction'
  * @private
  * @param dataUse
  * @returns boolean
  */
 const isOther = (dataUse) => {
-  const otherRestrictions = getOr(false)('otherRestrictions')(dataUse);
   const primaryOther = !isEmpty(getOr('')('other')(dataUse));
   const secondaryOther = !isEmpty(getOr('')('secondaryOther')(dataUse));
-  return otherRestrictions || primaryOther || secondaryOther;
+  return primaryOther || secondaryOther;
 };
 
 /**
@@ -287,22 +286,22 @@ const isOther = (dataUse) => {
  */
 export const shouldAbstain = (dataUse) => {
   const abstainFields = [
-    'addiction',
     'collaboratorRequired',
     'ethicsApprovalRequired',
     'gender',
     'geneticStudiesOnly',
     'geographicalRestrictions',
     'illegalBehavior',
-    'manualReview',
-    'nonBiomedical',
+    'notHealth',
+    'other',
     'pediatric',
     'psychologicalTraits',
     'publicationResults',
+    'secondaryOther',
     'sexualDiseases',
     'stigmatizeDiseases',
     'vulnerablePopulations'];
-  return isOther(dataUse) || any(f => getOr(false)(f)(dataUse))(abstainFields);
+  return any(f => getOr(false)(f)(dataUse))(abstainFields);
 };
 
 /**
@@ -353,11 +352,12 @@ const createRpVoteStructureFromBuckets = (buckets) => {
 
 /**
  * Constrain the equality check to a limited number of fields. These
- * fields are the ones that are used in algorithm decisions and are what
+ * fields are the ones that are used in V3 algorithm decisions and are what
  * determine whether it falls into a Data Use bucket. We limit the fields
- * because there are quite a few that have no impact on decision-making.
- * Fields like recontactMay and recontactMust, and others, are not relevant
- * to DAC decisions.
+ * to those used in the V3 algorithm checks. There are quite a few legacy
+ * properties that have no impact on current decision-making. Fields like
+ * recontactMay and recontactMust, and others, are not relevant to DAC
+ * decisions.
  *
  * @public
  * @param a Data Use
@@ -365,32 +365,34 @@ const createRpVoteStructureFromBuckets = (buckets) => {
  * @returns {boolean}
  */
 export const isEqualDataUse = (a, b) => {
-  const fields = ['addiction',
-    'aggregateResearch',
+  // alpha sorted list of V3 fields:
+  const fields = [
     'collaboratorRequired',
-    'controlSetOption',
+    'commercialUse',
+    'controls',
+    'diseaseRestrictions',
     'ethicsApprovalRequired',
     'gender',
+    'generalUse',
     'geneticStudiesOnly',
     'geographicalRestrictions',
+    'hmbResearch',
     'illegalBehavior',
-    'manualReview',
     'methodsResearch',
-    'nonBiomedical',
+    'nonProfitUse',
+    'notHealth',
     'other',
-    'otherRestrictions',
     'pediatric',
+    'population',
+    'populationOriginsAncestry',
     'psychologicalTraits',
+    'publicationMoratorium',
     'publicationResults',
     'secondaryOther',
     'sexualDiseases',
     'stigmatizeDiseases',
-    'vulnerablePopulations',
-    'commercialUse',
-    'diseaseRestrictions',
-    'generalUse',
-    'hmbResearch',
-    'populationOriginsAncestry'];
+    'vulnerablePopulations'
+  ];
   const aCopy = pick(fields)(a);
   const bCopy = pick(fields)(b);
   return isEqual(aCopy)(bCopy);


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DUOS-2846

### Summary
* For dataset/study create/update, capture `nonProfitUse` instead of commercial use. The question that captures this field is specifically an NPU question: `Non-profit Use Only (NPU)`
* When calculating the Data Use of a dataset for display in the DAC Voting screens and DAR consoles, ensure that we're displaying NPU if the dataset is marked as such.
* Update BucketUtils so that it is referencing all of the V3 data use fields as described in the [Ontology API](https://consent-ontology.dsde-dev.broadinstitute.org/#/Data%20Use/get_schemas_data_use_v3)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
