### PR TITLE
[DUOS-2863] Add help text to Contact Us form

### DIFF
--- a/src/components/modals/SupportRequestModal.js
+++ b/src/components/modals/SupportRequestModal.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { div, form, input, label, textarea, hh, h, select, span, option, section, button, p } from 'react-hyperscript-helpers';
+import { div, form, input, label, textarea, hh, h, select, span, option, section, button, p, a } from 'react-hyperscript-helpers';
 import { Support} from '../../libs/ajax';
 import { Storage } from '../../libs/storage';
 import { Notifications, isEmailAddress } from '../../libs/utils';
@@ -264,6 +264,20 @@ export const SupportRequestModal = hh(
                 outline: '0',
               },
             }, [
+              div({className: 'default-color', style: { fontStyle: 'italic', fontSize: '13px' }}, [
+                  p(['Having issues accessing data you were already approved to use?',
+                  div({style: { fontStyle: 'normal'}}, [
+                    'Please contact the dataset\'s Data Custodian listed in the DUOS ',
+                    a({ href: '/datalibrary' }, 'Data Library'),'.'
+                  ])])
+                ]),
+              div({className: 'default-color', style: { fontStyle: 'italic', fontSize: '13px' }}, [
+                p(['Want to ask the data access committee(s) about your request\'s expected turnaround time?',
+                div({style: { fontStyle: 'normal'}}, [
+                  'Please contact the dataset\'s Data Access Committee (DAC) listed in the DUOS ',
+                  a({ href: '/datalibrary' }, 'Data Library'),'.'
+                ])])
+              ]),
               form({
                 className: 'form-horizontal css-form',
                 name: 'zendeskTicketForm',

--- a/src/components/modals/SupportRequestModal.js
+++ b/src/components/modals/SupportRequestModal.js
@@ -272,7 +272,7 @@ export const SupportRequestModal = hh(
                   ])])
                 ]),
               div({className: 'default-color', style: { fontStyle: 'italic', fontSize: '13px' }}, [
-                p(['Want to ask the data access committee(s) about your request\'s expected turnaround time?',
+                p(['Want to ask the data access committee(s) about your requests\' expected turnaround time?',
                 div({style: { fontStyle: 'normal'}}, [
                   'Please contact the dataset\'s Data Access Committee (DAC) listed in the DUOS ',
                   a({ href: '/datalibrary' }, 'Data Library'),'.'


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2863

### Summary
Adds help text to Contact Us form to contact appropriate people, hyperlinking the Data Library where appropriate. 

<img width="433" alt="image" src="https://github.com/DataBiosphere/duos-ui/assets/68303030/3aab2ecc-edb3-4b1f-a9cf-2ddfb3b633ea">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
