### PR TITLE
[DUOS-2903][risk=no] Update dataset selection in DAR form

### DIFF
--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
@@ -89,7 +89,7 @@ describe('Data Access Request - Validation', () => {
   describe('With Library Cards', () => {
     beforeEach(() => {
       cy.stub(User, 'getSOsForCurrentUser').returns(userSigningOfficials);
-      cy.stub(DataSet, 'searchDatasets').returns(Promise.resolve(datasets));
+      cy.stub(DataSet, 'autocompleteDatasets').returns(Promise.resolve(datasets));
       cy.stub(DataSet, 'getDatasetsByIds').returns(Promise.resolve(datasets));
       cy.stub(Storage, 'getCurrentUser').returns(user);
       cy.stub(User, 'getMe').returns(user);
@@ -248,7 +248,7 @@ describe('Data Access Request - Validation', () => {
   describe('Without Library Cards', () => {
     beforeEach(() => {
       cy.stub(User, 'getSOsForCurrentUser').returns(userSigningOfficials);
-      cy.stub(DataSet, 'searchDatasets').returns(Promise.resolve(datasets));
+      cy.stub(DataSet, 'autocompleteDatasets').returns(Promise.resolve(datasets));
       cy.stub(DataSet, 'getDatasetsByIds').returns(Promise.resolve(datasets));
       cy.stub(Storage, 'getCurrentUser').returns(userNoLibraryCard);
       cy.stub(User, 'getMe').returns(userNoLibraryCard);

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -281,8 +281,8 @@ export const DataSet = {
     return await res.json();
   },
 
-  searchDatasets: async (query) => {
-    const url = `${await getApiUrl()}/api/dataset/search?query=${query}`;
+  autocompleteDatasets: async (query) => {
+    const url = `${await getApiUrl()}/api/dataset/autocomplete?query=${query}`;
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -52,7 +52,8 @@ const searchDatasets = (query, callback, currentDatasets) => {
         identifier: ds.identifier || ds.datasetIdentifier,
         datasetIdentifier: ds.identifier || ds.datasetIdentifier,
         datasetName: ds.name || ds.datasetName,
-        name: ds.name || ds.datasetName
+        name: ds.name || ds.datasetName,
+        ... ds
       };
     });
     let options = processedDatasets.filter((ds) => !currentDatasetIds.includes(ds.dataSetId)).map(function (item) {

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -38,10 +38,11 @@ const autocompleteOntologies = (query, callback) => {
 };
 
 const searchDatasets = (query, callback, currentDatasets) => {
-  const currentDatasetIds = currentDatasets.map((ds) => ds.id || ds.dataSetId);
+  const currentDatasetIds = currentDatasets.map((ds) => ds.dataSetId);
 
   DataSet.autocompleteDatasets(query).then(items => {
-    let options = items.filter((ds) => !currentDatasetIds.includes(ds.id)).map(function (item) {
+    const mappedDatasets = items.map((ds) => { return {dataSetId: ds.id, datasetIdentifier: ds.identifier, name: ds.name}; });
+    let options = mappedDatasets.filter((ds) => !currentDatasetIds.includes(ds.dataSetId)).map(function (item) {
       return formatSearchDataset(item);
     });
     callback(options);
@@ -50,12 +51,12 @@ const searchDatasets = (query, callback, currentDatasets) => {
 
 const formatSearchDataset = (ds) => {
   return {
-    key: ds.id || ds.datasetId,
-    value: ds.id || ds.datasetId,
+    key: ds.dataSetId,
+    value: ds.dataSetId,
     dataset: ds,
-    displayText: ds.identifier || ds.datasetIdentifier,
+    displayText: ds.datasetIdentifier,
     label: <span>
-      <span style={{fontWeight: 'bold'}}>{ds.identifier || ds.datasetIdentifier}</span> | {ds.name || ds.datasetName}
+      <span style={{fontWeight: 'bold'}}>{ds.datasetIdentifier}</span> | {ds.name}
     </span>
   };
 };
@@ -144,7 +145,7 @@ export default function DataAccessRequest(props) {
           placeholder={'Dataset Name, Sample Collection ID, or PI'}
           onChange={async ({key, value}) => {
             const datasets = value.map((val) => val.dataset);
-            const datasetIds = datasets?.map((ds) => ds.id || ds.dataSetId);
+            const datasetIds = datasets?.map((ds) => ds.dataSetId);
             const fullDatasets = await DataSet.getDatasetsByIds(datasetIds);
             onChange({key, value: datasetIds});
             setDatasets(fullDatasets);

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -38,7 +38,7 @@ const autocompleteOntologies = (query, callback) => {
 };
 
 const searchDatasets = (query, callback, currentDatasets) => {
-  const currentDatasetIds = currentDatasets.map((ds) => ds.id || ds.datasetId);
+  const currentDatasetIds = currentDatasets.map((ds) => ds.id || ds.dataSetId);
 
   DataSet.autocompleteDatasets(query).then(items => {
     let options = items.filter((ds) => !currentDatasetIds.includes(ds.id)).map(function (item) {
@@ -54,8 +54,9 @@ const formatSearchDataset = (ds) => {
     value: ds.id || ds.datasetId,
     dataset: ds,
     displayText: ds.identifier || ds.datasetIdentifier,
-    label: <span><span
-      style={{fontWeight: 'bold'}}>{ds.identifier || ds.datasetIdentifier}</span> | {ds.name}</span>
+    label: <span>
+      <span style={{fontWeight: 'bold'}}>{ds.identifier || ds.datasetIdentifier}</span> | {ds.name || ds.datasetName}
+    </span>
   };
 };
 
@@ -134,8 +135,9 @@ export default function DataAccessRequest(props) {
           description={includeInstructions ? 'Please start typing the Dataset Name, Sample Collection ID, or PI of the dataset(s) for which you would like to request access:' : ''}
           defaultValue={datasets?.map((ds) => formatSearchDataset(ds))}
           selectConfig={{
-            // return string value of dataset
-            // for accessibility / html keys
+            // return custom html for displaying dataset options
+            formatOptionLabel: (opt) => opt.label,
+            // return string value of dataset for accessibility / html keys
             getOptionLabel: (opt) => opt.displayText,
           }}
           loadOptions={(query, callback) => searchDatasets(query, callback, datasets)}

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -41,8 +41,21 @@ const searchDatasets = (query, callback, currentDatasets) => {
   const currentDatasetIds = currentDatasets.map((ds) => ds.dataSetId);
 
   DataSet.autocompleteDatasets(query).then(items => {
-    const mappedDatasets = items.map((ds) => { return {dataSetId: ds.id, datasetIdentifier: ds.identifier, name: ds.name}; });
-    let options = mappedDatasets.filter((ds) => !currentDatasetIds.includes(ds.dataSetId)).map(function (item) {
+    const processedDatasets = items.map((ds) => {
+      // We are working with two different dataset representations, a legacy dataset object and
+      // a simplified auto-complete dataset object. We need to standardize the keys to ensure
+      // legacy functionality is maintained.
+      return {
+        id: ds.id || ds.dataSetId || ds.datasetId,
+        datasetId: ds.id || ds.dataSetId || ds.datasetId,
+        dataSetId: ds.id || ds.dataSetId || ds.datasetId,
+        identifier: ds.identifier || ds.datasetIdentifier,
+        datasetIdentifier: ds.identifier || ds.datasetIdentifier,
+        datasetName: ds.name || ds.datasetName,
+        name: ds.name || ds.datasetName
+      };
+    });
+    let options = processedDatasets.filter((ds) => !currentDatasetIds.includes(ds.dataSetId)).map(function (item) {
       return formatSearchDataset(item);
     });
     callback(options);

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -118,16 +118,16 @@ export default function DataAccessRequest(props) {
 
   return (
   // eslint-disable-next-line react/no-unknown-property
-    <div datacy='data-access-request'>
-      <div className='dar-step-card'>
+    <div datacy={'data-access-request'}>
+      <div className={'dar-step-card'}>
         <FormField
+          id={'datasetIds'}
           key={'datasetIds'}
           type={FormFieldTypes.SELECT}
-          id='datasetIds'
           disabled={readOnlyMode}
           isAsync={true}
           isMulti={true}
-          title='2.1 Select Dataset(s)'
+          title={'2.1 Select Dataset(s)'}
           validators={[FormValidators.REQUIRED]}
           validation={validation.datasetIds}
           onValidationChange={onValidationChange}
@@ -139,7 +139,7 @@ export default function DataAccessRequest(props) {
             getOptionLabel: (opt) => opt.displayText,
           }}
           loadOptions={(query, callback) => searchDatasets(query, callback, datasets)}
-          placeholder='Dataset Name, Sample Collection ID, or PI'
+          placeholder={'Dataset Name, Sample Collection ID, or PI'}
           onChange={async ({key, value}) => {
             const datasets = value.map((val) => val.dataset);
             const datasetIds = datasets?.map((ds) => ds.id || ds.dataSetId);
@@ -150,34 +150,34 @@ export default function DataAccessRequest(props) {
         />
 
         <FormField
+          id={'projectTitle'}
           key={'projectTitle'}
-          id='projectTitle'
-          title='2.2 Descriptive Title of Project'
+          title={'2.2 Descriptive Title of Project'}
           disabled={readOnlyMode}
           validators={[FormValidators.REQUIRED]}
           validation={validation.projectTitle}
           description={includeInstructions ? 'Please note that coordinated requests by External Collaborators should each use the same title.' : ''}
-          placeholder='Project Title'
+          placeholder={'Project Title'}
           defaultValue={formData.projectTitle}
           onChange={onChange}
           onValidationChange={onValidationChange}
         />
 
-        <div className='dar-form-notice-card'>
+        <div className={'dar-form-notice-card'}>
           <span>
                 In sections 2.3, 2.4, and 2.5, you are attesting that your proposed research will remain with the scope of the items selected below, and will be liable for any deviations. Further, it is to your benefit to be as specific as possible in your selections, as it will maximize the data available to you.
           </span>
         </div>
 
         <FormField
+          id={'rus'}
           key={'rus'}
-          id='rus'
           disabled={readOnlyMode}
           type={FormFieldTypes.TEXTAREA}
-          title='2.3 Research Use Statement (RUS)'
+          title={'2.3 Research Use Statement (RUS)'}
           validators={[FormValidators.REQUIRED]}
           description={includeInstructions ? 'A RUS is a brief description of the applicant\'s proposed use of the dataset(s). The RUS will be reviewed by all parties responsible for data covered by this Data Access Request. Please note that if access is approved, you agree that the RUS, along with your name and institution, will be included on this website to describe your research project to the public. Please enter your RUS in the area below. The RUS should be one or two paragraphs in length and include research objectives, the study design, and an analysis plan (including the phenotypic characteristics that will be tested for association with genetic variants). If you are requesting multiple datasets, please describe how you will use them. Examples of RUS can be found at' : ''}
-          placeholder='Please limit your RUS to 2200 characters.'
+          placeholder={'Please limit your RUS to 2200 characters.'}
           rows={6}
           maxLength={2200}
           ariaLevel={ariaLevel + 3}
@@ -188,12 +188,12 @@ export default function DataAccessRequest(props) {
         />
 
         <FormField
+          id={'diseases'}
           key={'diseases'}
-          id='diseases'
-          title='Is the primary purpose of this research to investigate a specific disease(s)?'
+          title={<h4>Is the primary purpose of this research to investigate a specific disease(s)?</h4>}
           disabled={readOnlyMode}
           type={FormFieldTypes.YESNORADIOGROUP}
-          orientation='horizontal'
+          orientation={'horizontal'}
           defaultValue={formData.diseases}
           validation={validation.diseases}
           onValidationChange={onValidationChange}
@@ -206,6 +206,7 @@ export default function DataAccessRequest(props) {
 
         {formData.diseases === false &&
                     <FormField
+                      id={'ontologies'}
                       key={'ontologies'}
                       type={FormFieldTypes.SELECT}
                       disabled={readOnlyMode}
@@ -214,23 +215,35 @@ export default function DataAccessRequest(props) {
                       isAsync={true}
                       optionsAreString={false}
                       loadOptions={autocompleteOntologies}
-                      id='ontologies'
                       validators={[FormValidators.REQUIRED]}
-                      placeholder='Please enter one or more diseases'
+                      placeholder={'Please enter one or more diseases'}
                       defaultValue={formData.ontologies.map(formatOntologyForSelect)}
                       validation={validation.ontologies}
                       onValidationChange={onValidationChange}
                       onChange={({key, value}) => onChange({key, value: value.map(formatOntologyForFormData)})}
                     />}
 
-        {formData.hmb === false &&
+        {formData.diseases === false &&
                     <FormField
+                      id={'hmb'}
+                      key={'hmb'}
                       type={FormFieldTypes.YESNORADIOGROUP}
                       disabled={readOnlyMode}
-                      title='Is the primary purpose of this research regarding population origins or ancestry?'
-                      id='poa'
-                      key='poa'
-                      orientation='horizontal'
+                      title={<h4>Is the primary purpose health/medical/biomedical research in nature?</h4>}
+                      orientation={'horizontal'}
+                      defaultValue={formData.hmb}
+                      validation={validation.hmb}
+                      onValidationChange={onValidationChange}
+                      onChange={primaryChange}
+                    />}
+        {formData.hmb === false &&
+                    <FormField
+                      id={'poa'}
+                      key={'poa'}
+                      type={FormFieldTypes.YESNORADIOGROUP}
+                      disabled={readOnlyMode}
+                      title={<h4>Is the primary purpose of this research regarding population origins or ancestry?</h4>}
+                      orientation={'horizontal'}
                       defaultValue={formData.poa}
                       validation={validation.poa}
                       onValidationChange={onValidationChange}
@@ -239,12 +252,12 @@ export default function DataAccessRequest(props) {
 
         {formData.poa === false &&
                     <FormField
+                      id={'methods'}
+                      key={'methods'}
                       type={FormFieldTypes.YESNORADIOGROUP}
                       disabled={readOnlyMode}
-                      title='Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?'
-                      id='methods'
-                      key='methods'
-                      orientation='horizontal'
+                      title={<h4>Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?</h4>}
+                      orientation={'horizontal'}
                       defaultValue={formData.methods}
                       validation={validation.methods}
                       onValidationChange={onValidationChange}
@@ -254,12 +267,12 @@ export default function DataAccessRequest(props) {
 
         {formData.methods === false &&
                     <FormField
+                      id={'otherText'}
                       key={'otherText'}
                       disabled={readOnlyMode}
-                      title='If none of the above, please describe the primary purpose of your research:'
-                      id='otherText'
-                      orientation='horizontal'
-                      placeholder='Please specify...'
+                      title={<h4>If none of the above, please describe the primary purpose of your research:</h4>}
+                      orientation={'horizontal'}
+                      placeholder={'Please specify...'}
                       defaultValue={formData.other}
                       validation={validation.other}
                       onValidationChange={onValidationChange}
@@ -267,14 +280,14 @@ export default function DataAccessRequest(props) {
         }
 
         <FormField
+          id={'nonTechRus'}
           key={'nonTechRus'}
-          id='nonTechRus'
           disabled={readOnlyMode}
           type={FormFieldTypes.TEXTAREA}
-          title='2.4 Non-Technical Summary'
+          title={'2.4 Non-Technical Summary'}
           validators={[FormValidators.REQUIRED]}
           description={includeInstructions ? 'Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below).' : ''}
-          placeholder='Please limit your your non-technical summary to 1100 characters'
+          placeholder={'Please limit your your non-technical summary to 1100 characters'}
           rows={6}
           maxLength={1100}
           ariaLevel={ariaLevel + 3}
@@ -285,19 +298,20 @@ export default function DataAccessRequest(props) {
         />
 
         <FormFieldTitle
+          id={'dataUseAcknowledgements'}
           key={'dataUseAcknowledgements'}
-          title='2.5 Data Use Acknowledgements'
+          title={'2.5 Data Use Acknowledgements'}
           description={includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : ''}
           isRendered={needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets)}
         />
 
         <FormField
+          id={'gsoAcknowledgement'}
           key={'gsoAcknowledgement'}
-          id='gsoAcknowledgement'
           disabled={readOnlyMode}
           type={FormFieldTypes.CHECKBOX}
           isRendered={needsGsoAcknowledgement(datasets)}
-          toggleText='I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'
+          toggleText={'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'}
           defaultValue={formData.gsoAcknowledgement}
           onChange={onChange}
           validation={validation.gsoAcknowledgement}
@@ -305,12 +319,12 @@ export default function DataAccessRequest(props) {
         />
 
         <FormField
+          id={'pubAcknowledgement'}
           key={'pubAcknowledgement'}
-          id='pubAcknowledgement'
           disabled={readOnlyMode}
           isRendered={needsPubAcknowledgement(datasets)}
           type={FormFieldTypes.CHECKBOX}
-          toggleText='I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'
+          toggleText={'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'}
           defaultValue={formData.pubAcknowledgement}
           validation={validation.pubAcknowledgement}
           onValidationChange={onValidationChange}
@@ -318,12 +332,12 @@ export default function DataAccessRequest(props) {
         />
 
         <FormField
+          id={'dsAcknowledgement'}
           key={'dsAcknowledgement'}
-          id='dsAcknowledgement'
           disabled={readOnlyMode}
           isRendered={needsDsAcknowledgement(dataUseTranslations)}
           type={FormFieldTypes.CHECKBOX}
-          toggleText='I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'
+          toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
           defaultValue={formData.dsAcknowledgement}
           validation={validation.dsAcknowledgement}
           onValidationChange={onValidationChange}
@@ -333,7 +347,6 @@ export default function DataAccessRequest(props) {
         {needsIrbApprovalDocument(datasets) &&
                     <FormFieldTitle
                       key={'irbApprovalDocument'}
-                      title='2.6 IRB Approval Document'
                       description={includeInstructions ? 'One or more of the datasets you selected requires local IRB approval for use. Please upload your local IRB approval(s) here as a single document. When IRB approval is required and Expedited of Full Review is required, it must be completed annually. Determinations of Not Human Subjects Research (NHSR) by IRBs will not be accepted as IRB approval.' : ''}
                     />
         }
@@ -343,7 +356,7 @@ export default function DataAccessRequest(props) {
                         key={'irbDocument'}
                         type={FormFieldTypes.FILE}
                         disabled={readOnlyMode}
-                        id='irbDocument'
+                        id={'irbDocument'}
                         defaultValue={uploadedIrbDocument || {
                           name: formData.irbDocumentName,
                         }}
@@ -354,7 +367,7 @@ export default function DataAccessRequest(props) {
                       <FormField
                         key={'irbProtocolExpiration'}
                         readOnly={true}
-                        id='irbProtocolExpiration'
+                        id={'irbProtocolExpiration'}
                         defaultValue={`IRB Expires on ${irbProtocolExpiration}`}
                       />
                     </div>
@@ -367,10 +380,10 @@ export default function DataAccessRequest(props) {
                       defaultValue={uploadedCollaborationLetter || {
                         name: formData.collaborationLetterName,
                       }}
-                      id='collaborationLetter'
+                      id={'collaborationLetter'}
                       validation={validation.collaborationLetter}
                       onValidationChange={onValidationChange}
-                      description='One or more of the datasets you selected requires collaboration (COL) with the primary study investigators(s) for use. Please upload documentation of your collaboration here.'
+                      description={'One or more of the datasets you selected requires collaboration (COL) with the primary study investigators(s) for use. Please upload documentation of your collaboration here.'}
                       onChange={({value}) => updateCollaborationLetter(value)}
                     />
         }

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -297,52 +297,56 @@ export default function DataAccessRequest(props) {
           onChange={onChange}
         />
 
-        <FormFieldTitle
-          id={'dataUseAcknowledgements'}
-          key={'dataUseAcknowledgements'}
-          title={'2.5 Data Use Acknowledgements'}
-          description={includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : ''}
-          isRendered={needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets)}
-        />
+        {(needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets)) &&
+            <FormFieldTitle
+              id={'dataUseAcknowledgements'}
+              key={'dataUseAcknowledgements'}
+              title={'2.5 Data Use Acknowledgements'}
+              description={includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : ''}
+            />
+        }
 
-        <FormField
-          id={'gsoAcknowledgement'}
-          key={'gsoAcknowledgement'}
-          disabled={readOnlyMode}
-          type={FormFieldTypes.CHECKBOX}
-          isRendered={needsGsoAcknowledgement(datasets)}
-          toggleText={'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'}
-          defaultValue={formData.gsoAcknowledgement}
-          onChange={onChange}
-          validation={validation.gsoAcknowledgement}
-          onValidationChange={onValidationChange}
-        />
+        {needsGsoAcknowledgement(datasets) &&
+            <FormField
+              id={'gsoAcknowledgement'}
+              key={'gsoAcknowledgement'}
+              disabled={readOnlyMode}
+              type={FormFieldTypes.CHECKBOX}
+              toggleText={'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'}
+              defaultValue={formData.gsoAcknowledgement}
+              onChange={onChange}
+              validation={validation.gsoAcknowledgement}
+              onValidationChange={onValidationChange}
+            />
+        }
 
-        <FormField
-          id={'pubAcknowledgement'}
-          key={'pubAcknowledgement'}
-          disabled={readOnlyMode}
-          isRendered={needsPubAcknowledgement(datasets)}
-          type={FormFieldTypes.CHECKBOX}
-          toggleText={'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'}
-          defaultValue={formData.pubAcknowledgement}
-          validation={validation.pubAcknowledgement}
-          onValidationChange={onValidationChange}
-          onChange={onChange}
-        />
+        {needsPubAcknowledgement(datasets) &&
+            <FormField
+              id={'pubAcknowledgement'}
+              key={'pubAcknowledgement'}
+              disabled={readOnlyMode}
+              type={FormFieldTypes.CHECKBOX}
+              toggleText={'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'}
+              defaultValue={formData.pubAcknowledgement}
+              validation={validation.pubAcknowledgement}
+              onValidationChange={onValidationChange}
+              onChange={onChange}
+            />
+        }
 
-        <FormField
-          id={'dsAcknowledgement'}
-          key={'dsAcknowledgement'}
-          disabled={readOnlyMode}
-          isRendered={needsDsAcknowledgement(dataUseTranslations)}
-          type={FormFieldTypes.CHECKBOX}
-          toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
-          defaultValue={formData.dsAcknowledgement}
-          validation={validation.dsAcknowledgement}
-          onValidationChange={onValidationChange}
-          onChange={onChange}
-        />
+        {needsDsAcknowledgement(dataUseTranslations) &&
+            <FormField
+              id={'dsAcknowledgement'}
+              key={'dsAcknowledgement'}
+              disabled={readOnlyMode}
+              type={FormFieldTypes.CHECKBOX}
+              toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
+              defaultValue={formData.dsAcknowledgement}
+              validation={validation.dsAcknowledgement}
+              onValidationChange={onValidationChange}
+              onChange={onChange}
+            />
+        }
 
         {needsIrbApprovalDocument(datasets) &&
                     <FormFieldTitle

--- a/src/pages/dar_application/DataAccessRequest.js
+++ b/src/pages/dar_application/DataAccessRequest.js
@@ -1,6 +1,6 @@
-import { a, div, h, h4, span, p } from 'react-hyperscript-helpers';
-import { DataSet, DAR } from '../../libs/ajax';
-import { FormField, FormFieldTitle, FormFieldTypes, FormValidators } from '../../components/forms/forms';
+import React from 'react';
+import {DataSet, DAR} from '../../libs/ajax';
+import {FormField, FormFieldTitle, FormFieldTypes, FormValidators} from '../../components/forms/forms';
 import {
   needsDsAcknowledgement,
   needsPubAcknowledgement,
@@ -38,10 +38,10 @@ const autocompleteOntologies = (query, callback) => {
 };
 
 const searchDatasets = (query, callback, currentDatasets) => {
-  const currentDatasetIds = currentDatasets.map((ds) => ds.dataSetId);
+  const currentDatasetIds = currentDatasets.map((ds) => ds.id || ds.datasetId);
 
-  DataSet.searchDatasets(query).then(items => {
-    let options = items.filter((ds) => !currentDatasetIds.includes(ds.dataSetId)).map(function (item) {
+  DataSet.autocompleteDatasets(query).then(items => {
+    let options = items.filter((ds) => !currentDatasetIds.includes(ds.id)).map(function (item) {
       return formatSearchDataset(item);
     });
     callback(options);
@@ -50,12 +50,12 @@ const searchDatasets = (query, callback, currentDatasets) => {
 
 const formatSearchDataset = (ds) => {
   return {
-    key: ds.dataSetId.toString(),
-    value: ds.dataSetId,
+    key: ds.id || ds.datasetId,
+    value: ds.id || ds.datasetId,
     dataset: ds,
-    displayText: ds.datasetIdentifier,
-    label: span({}, [
-      span({style: {fontWeight: 'bold'}}, [ds.datasetIdentifier]), ' | ', ds.name]),
+    displayText: ds.identifier || ds.datasetIdentifier,
+    label: <span><span
+      style={{fontWeight: 'bold'}}>{ds.identifier || ds.datasetIdentifier}</span> | {ds.name}</span>
   };
 };
 
@@ -117,300 +117,266 @@ export default function DataAccessRequest(props) {
   };
 
   return (
-    div({ datacy: 'data-access-request' }, [
-      div({ className: 'dar-step-card' }, [
-        // dataset searchbar:
-        // async select with custom inner render
-        // to look like the mock
-
-        h(FormField, {
-          type: FormFieldTypes.SELECT,
-          id: 'datasetIds',
-          disabled: readOnlyMode,
-          isAsync: true,
-          isMulti: true,
-          title: '2.1 Select Dataset(s)',
-          validators: [FormValidators.REQUIRED],
-          validation: validation.datasetIds,
-          onValidationChange,
-          description: includeInstructions ? 'Please start typing the Dataset Name, Sample Collection ID, or PI of the dataset(s) for which you would like to request access:' : '',
-          defaultValue: datasets?.map((ds) => formatSearchDataset(ds)),
-          selectConfig: {
-            // return custom html for displaying
-            // dataset options
-            formatOptionLabel: (opt) => opt.label,
+  // eslint-disable-next-line react/no-unknown-property
+    <div datacy='data-access-request'>
+      <div className='dar-step-card'>
+        <FormField
+          key={'datasetIds'}
+          type={FormFieldTypes.SELECT}
+          id='datasetIds'
+          disabled={readOnlyMode}
+          isAsync={true}
+          isMulti={true}
+          title='2.1 Select Dataset(s)'
+          validators={[FormValidators.REQUIRED]}
+          validation={validation.datasetIds}
+          onValidationChange={onValidationChange}
+          description={includeInstructions ? 'Please start typing the Dataset Name, Sample Collection ID, or PI of the dataset(s) for which you would like to request access:' : ''}
+          defaultValue={datasets?.map((ds) => formatSearchDataset(ds))}
+          selectConfig={{
             // return string value of dataset
             // for accessibility / html keys
             getOptionLabel: (opt) => opt.displayText,
-          },
-          loadOptions: (query, callback) => searchDatasets(query, callback, datasets),
-          placeholder: 'Dataset Name, Sample Collection ID, or PI',
-          onChange: ({key, value}) => {
+          }}
+          loadOptions={(query, callback) => searchDatasets(query, callback, datasets)}
+          placeholder='Dataset Name, Sample Collection ID, or PI'
+          onChange={async ({key, value}) => {
             const datasets = value.map((val) => val.dataset);
-            onChange({key, value: datasets?.map((ds) => ds.dataSetId)});
-            setDatasets(datasets);
-          },
-        }),
+            const datasetIds = datasets?.map((ds) => ds.id || ds.dataSetId);
+            const fullDatasets = await DataSet.getDatasetsByIds(datasetIds);
+            onChange({key, value: datasetIds});
+            setDatasets(fullDatasets);
+          }}
+        />
 
-        h(FormField, {
-          title: '2.2 Descriptive Title of Project',
-          disabled: readOnlyMode,
-          validators: [FormValidators.REQUIRED],
-          validation: validation.projectTitle,
-          description: includeInstructions ? 'Please note that coordinated requests by External Collaborators should each use the same title.' : '',
-          id: 'projectTitle',
-          placeholder: 'Project Title',
-          defaultValue: formData.projectTitle,
-          onChange,
-          onValidationChange,
-        }),
+        <FormField
+          key={'projectTitle'}
+          id='projectTitle'
+          title='2.2 Descriptive Title of Project'
+          disabled={readOnlyMode}
+          validators={[FormValidators.REQUIRED]}
+          validation={validation.projectTitle}
+          description={includeInstructions ? 'Please note that coordinated requests by External Collaborators should each use the same title.' : ''}
+          placeholder='Project Title'
+          defaultValue={formData.projectTitle}
+          onChange={onChange}
+          onValidationChange={onValidationChange}
+        />
 
-        div({
-          className: 'dar-form-notice-card',
-        }, [
-          span({}, [
-            'In sections 2.3, 2.4, and 2.5, you are attesting that your proposed research will remain with the scope of the items selected below, and will be liable for any deviations. Further, it is to your benefit to be as specific as possible in your selections, as it will maximize the data available to you.'
-          ])
-        ]),
+        <div className='dar-form-notice-card'>
+          <span>
+                In sections 2.3, 2.4, and 2.5, you are attesting that your proposed research will remain with the scope of the items selected below, and will be liable for any deviations. Further, it is to your benefit to be as specific as possible in your selections, as it will maximize the data available to you.
+          </span>
+        </div>
 
-        h(FormField, {
-          id: 'rus',
-          disabled: readOnlyMode,
-          type: FormFieldTypes.TEXTAREA,
-          title: '2.3 Research Use Statement (RUS)',
-          validators: [FormValidators.REQUIRED],
-          description: p({}, [
-            'A RUS is a brief description of the applicant\'s proposed use of the dataset(s). The RUS will be reviewed by all parties responsible for data covered by this Data Access Request. Please note that if access is approved, you agree that the RUS, along with your name and institution, will be included on this website to describe your research project to the public.',
-            span({},
-              ['Please enter your RUS in the area below. The RUS should be one or two paragraphs in length and include research objectives, the study design, and an analysis plan (including the phenotypic characteristics that will be tested for association with genetic variants). If you are requesting multiple datasets, please describe how you will use them. Examples of RUS can be found at ',
-                a({
+        <FormField
+          key={'rus'}
+          id='rus'
+          disabled={readOnlyMode}
+          type={FormFieldTypes.TEXTAREA}
+          title='2.3 Research Use Statement (RUS)'
+          validators={[FormValidators.REQUIRED]}
+          description={includeInstructions ? 'A RUS is a brief description of the applicant\'s proposed use of the dataset(s). The RUS will be reviewed by all parties responsible for data covered by this Data Access Request. Please note that if access is approved, you agree that the RUS, along with your name and institution, will be included on this website to describe your research project to the public. Please enter your RUS in the area below. The RUS should be one or two paragraphs in length and include research objectives, the study design, and an analysis plan (including the phenotypic characteristics that will be tested for association with genetic variants). If you are requesting multiple datasets, please describe how you will use them. Examples of RUS can be found at' : ''}
+          placeholder='Please limit your RUS to 2200 characters.'
+          rows={6}
+          maxLength={2200}
+          ariaLevel={ariaLevel + 3}
+          defaultValue={formData.rus}
+          validation={validation.rus}
+          onValidationChange={onValidationChange}
+          onChange={onChange}
+        />
 
-                }, 'here'),
-                '.'
-              ]),
-          ]),
-          placeholder: 'Please limit your RUS to 2200 characters.',
-          rows: 6,
-          maxLength: 2200,
-          ariaLevel: ariaLevel + 3,
-          defaultValue: formData.rus,
-          validation: validation.rus,
-          onValidationChange,
-          onChange,
-        }),
+        <FormField
+          key={'diseases'}
+          id='diseases'
+          title='Is the primary purpose of this research to investigate a specific disease(s)?'
+          disabled={readOnlyMode}
+          type={FormFieldTypes.YESNORADIOGROUP}
+          orientation='horizontal'
+          defaultValue={formData.diseases}
+          validation={validation.diseases}
+          onValidationChange={onValidationChange}
+          onChange={primaryChange}
+        />
 
-        h(FormField, {
-          title: h4({}, 'Is the primary purpose of this research to investigate a specific disease(s)?'),
-          id: 'diseases',
-          disabled: readOnlyMode,
-          type: FormFieldTypes.YESNORADIOGROUP,
-          orientation: 'horizontal',
-          defaultValue: formData.diseases,
-          validation: validation.diseases,
-          onValidationChange,
-          onChange: primaryChange,
-        }),
+        {formData.diseases === true &&
+                    <div style={{marginTop: '2.0rem', marginBottom: '1.0rem'}}></div>
+        }
 
-        div({
-          isRendered: formData.diseases === true,
-          style: {
-            marginTop: '2.0rem',
-            marginBottom: '1.0rem'
-          }
-        }, [
-          h(FormField, {
-            type: FormFieldTypes.SELECT,
-            disabled: readOnlyMode,
-            isMulti: true,
-            isCreatable: false,
-            isAsync: true,
-            optionsAreString: false,
-            loadOptions: autocompleteOntologies,
-            id: 'ontologies',
-            validators: [FormValidators.REQUIRED],
-            placeholder: 'Please enter one or more diseases',
-            defaultValue: formData.ontologies.map(formatOntologyForSelect),
-            validation: validation.ontologies,
-            onValidationChange,
-            onChange: ({key, value}) => onChange({key, value: value.map(formatOntologyForFormData)}),
-          }),
-        ]),
+        {formData.diseases === false &&
+                    <FormField
+                      key={'ontologies'}
+                      type={FormFieldTypes.SELECT}
+                      disabled={readOnlyMode}
+                      isMulti={true}
+                      isCreatable={false}
+                      isAsync={true}
+                      optionsAreString={false}
+                      loadOptions={autocompleteOntologies}
+                      id='ontologies'
+                      validators={[FormValidators.REQUIRED]}
+                      placeholder='Please enter one or more diseases'
+                      defaultValue={formData.ontologies.map(formatOntologyForSelect)}
+                      validation={validation.ontologies}
+                      onValidationChange={onValidationChange}
+                      onChange={({key, value}) => onChange({key, value: value.map(formatOntologyForFormData)})}
+                    />}
 
-        div({
-          isRendered: formData.diseases === false,
-        }, [
-          h(FormField, {
-            type: FormFieldTypes.YESNORADIOGROUP,
-            disabled: readOnlyMode,
-            title: h4({}, 'Is the primary purpose health/medical/biomedical research in nature?'),
-            id: 'hmb',
-            orientation: 'horizontal',
-            defaultValue: formData.hmb,
-            validation: validation.hmb,
-            onValidationChange,
-            onChange: primaryChange,
-          }),
-        ]),
+        {formData.hmb === false &&
+                    <FormField
+                      type={FormFieldTypes.YESNORADIOGROUP}
+                      disabled={readOnlyMode}
+                      title='Is the primary purpose of this research regarding population origins or ancestry?'
+                      id='poa'
+                      key='poa'
+                      orientation='horizontal'
+                      defaultValue={formData.poa}
+                      validation={validation.poa}
+                      onValidationChange={onValidationChange}
+                      onChange={primaryChange}
+                    />}
 
-        div({
-          isRendered: formData.hmb === false,
-        }, [
-          h(FormField, {
-            type: FormFieldTypes.YESNORADIOGROUP,
-            disabled: readOnlyMode,
-            title: h4({}, 'Is the primary purpose of this research regarding population origins or ancestry?'),
-            id: 'poa',
-            orientation: 'horizontal',
-            defaultValue: formData.poa,
-            validation: validation.poa,
-            onValidationChange,
-            onChange: primaryChange,
-          }),
-        ]),
+        {formData.poa === false &&
+                    <FormField
+                      type={FormFieldTypes.YESNORADIOGROUP}
+                      disabled={readOnlyMode}
+                      title='Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?'
+                      id='methods'
+                      key='methods'
+                      orientation='horizontal'
+                      defaultValue={formData.methods}
+                      validation={validation.methods}
+                      onValidationChange={onValidationChange}
+                      onChange={primaryChange}
+                    />
+        }
 
-        div({
-          isRendered: formData.poa === false,
-        }, [
-          h(FormField, {
-            type: FormFieldTypes.YESNORADIOGROUP,
-            disabled: readOnlyMode,
-            title: h4({}, 'Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?'),
-            id: 'methods',
-            orientation: 'horizontal',
-            defaultValue: formData.methods,
-            validation: validation.methods,
-            onValidationChange,
-            onChange: primaryChange,
-          }),
-        ]),
+        {formData.methods === false &&
+                    <FormField
+                      key={'otherText'}
+                      disabled={readOnlyMode}
+                      title='If none of the above, please describe the primary purpose of your research:'
+                      id='otherText'
+                      orientation='horizontal'
+                      placeholder='Please specify...'
+                      defaultValue={formData.other}
+                      validation={validation.other}
+                      onValidationChange={onValidationChange}
+                      onChange={primaryChange}/>
+        }
 
-        div({
-          isRendered: formData.methods === false,
-        }, [
-          h(FormField, {
-            title: h4({}, 'If none of the above, please describe the primary purpose of your research:'),
-            disabled: readOnlyMode,
-            id: 'otherText',
-            placeholder: 'Please specify...',
-            defaultValue: formData.otherText,
-            validation: validation.otherText,
-            onValidationChange,
-            onChange,
-          }),
-        ]),
+        <FormField
+          key={'nonTechRus'}
+          id='nonTechRus'
+          disabled={readOnlyMode}
+          type={FormFieldTypes.TEXTAREA}
+          title='2.4 Non-Technical Summary'
+          validators={[FormValidators.REQUIRED]}
+          description={includeInstructions ? 'Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below).' : ''}
+          placeholder='Please limit your your non-technical summary to 1100 characters'
+          rows={6}
+          maxLength={1100}
+          ariaLevel={ariaLevel + 3}
+          defaultValue={formData.nonTechRus}
+          validation={validation.nonTechRus}
+          onValidationChange={onValidationChange}
+          onChange={onChange}
+        />
 
-        h(FormField, {
-          id: 'nonTechRus',
-          disabled: readOnlyMode,
-          type: FormFieldTypes.TEXTAREA,
-          title: '2.4 Non-Technical Summary',
-          validators: [FormValidators.REQUIRED],
-          description: includeInstructions ? 'Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below).' : '',
-          placeholder: 'Please limit your your non-technical summary to 1100 characters',
-          rows: 6,
-          maxLength: 1100,
-          ariaLevel: ariaLevel + 3,
-          defaultValue: formData.nonTechRus,
-          validation: validation.nonTechRus,
-          onValidationChange,
-          onChange,
-        }),
+        <FormFieldTitle
+          key={'dataUseAcknowledgements'}
+          title='2.5 Data Use Acknowledgements'
+          description={includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : ''}
+          isRendered={needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets)}
+        />
 
-        h(FormFieldTitle, {
-          title: '2.5 Data Use Acknowledgements',
-          description: includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : '',
-          isRendered: needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets),
-        }),
+        <FormField
+          key={'gsoAcknowledgement'}
+          id='gsoAcknowledgement'
+          disabled={readOnlyMode}
+          type={FormFieldTypes.CHECKBOX}
+          isRendered={needsGsoAcknowledgement(datasets)}
+          toggleText='I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'
+          defaultValue={formData.gsoAcknowledgement}
+          onChange={onChange}
+          validation={validation.gsoAcknowledgement}
+          onValidationChange={onValidationChange}
+        />
 
-        h(FormField, {
-          id: 'gsoAcknowledgement',
-          disabled: readOnlyMode,
-          type: FormFieldTypes.CHECKBOX,
-          isRendered: needsGsoAcknowledgement(datasets),
-          toggleText: 'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.',
-          defaultValue: formData.gsoAcknowledgement,
-          onChange,
-          validation: validation.gsoAcknowledgement,
-          onValidationChange,
-        }),
+        <FormField
+          key={'pubAcknowledgement'}
+          id='pubAcknowledgement'
+          disabled={readOnlyMode}
+          isRendered={needsPubAcknowledgement(datasets)}
+          type={FormFieldTypes.CHECKBOX}
+          toggleText='I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'
+          defaultValue={formData.pubAcknowledgement}
+          validation={validation.pubAcknowledgement}
+          onValidationChange={onValidationChange}
+          onChange={onChange}
+        />
 
-        h(FormField, {
-          id: 'pubAcknowledgement',
-          disabled: readOnlyMode,
-          isRendered: needsPubAcknowledgement(datasets),
-          type: FormFieldTypes.CHECKBOX,
-          toggleText: 'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.',
-          defaultValue: formData.pubAcknowledgement,
-          validation: validation.pubAcknowledgement,
-          onValidationChange,
-          onChange,
-        }),
+        <FormField
+          key={'dsAcknowledgement'}
+          id='dsAcknowledgement'
+          disabled={readOnlyMode}
+          isRendered={needsDsAcknowledgement(dataUseTranslations)}
+          type={FormFieldTypes.CHECKBOX}
+          toggleText='I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'
+          defaultValue={formData.dsAcknowledgement}
+          validation={validation.dsAcknowledgement}
+          onValidationChange={onValidationChange}
+          onChange={onChange}
+        />
 
-        h(FormField, {
-          id: 'dsAcknowledgement',
-          disabled: readOnlyMode,
-          isRendered: needsDsAcknowledgement(dataUseTranslations),
-          type: FormFieldTypes.CHECKBOX,
-          toggleText: 'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum',
-          defaultValue: formData.dsAcknowledgement,
-          validation: validation.dsAcknowledgement,
-          onValidationChange,
-          onChange,
-        }),
+        {needsIrbApprovalDocument(datasets) &&
+                    <FormFieldTitle
+                      key={'irbApprovalDocument'}
+                      title='2.6 IRB Approval Document'
+                      description={includeInstructions ? 'One or more of the datasets you selected requires local IRB approval for use. Please upload your local IRB approval(s) here as a single document. When IRB approval is required and Expedited of Full Review is required, it must be completed annually. Determinations of Not Human Subjects Research (NHSR) by IRBs will not be accepted as IRB approval.' : ''}
+                    />
+        }
+        {needsIrbApprovalDocument(datasets) &&
+                    <div style={{display: 'flex', justifyContent: 'space-between'}}>
+                      <FormField
+                        key={'irbDocument'}
+                        type={FormFieldTypes.FILE}
+                        disabled={readOnlyMode}
+                        id='irbDocument'
+                        defaultValue={uploadedIrbDocument || {
+                          name: formData.irbDocumentName,
+                        }}
+                        validation={validation.irbDocument}
+                        onValidationChange={onValidationChange}
+                        onChange={({value}) => updateUploadedIrbDocument(value, irbProtocolExpiration)}
+                      />
+                      <FormField
+                        key={'irbProtocolExpiration'}
+                        readOnly={true}
+                        id='irbProtocolExpiration'
+                        defaultValue={`IRB Expires on ${irbProtocolExpiration}`}
+                      />
+                    </div>
+        }
 
+        {needsCollaborationLetter(datasets) &&
+                    <FormField
+                      type={FormFieldTypes.FILE}
+                      disabled={readOnlyMode}
+                      defaultValue={uploadedCollaborationLetter || {
+                        name: formData.collaborationLetterName,
+                      }}
+                      id='collaborationLetter'
+                      validation={validation.collaborationLetter}
+                      onValidationChange={onValidationChange}
+                      description='One or more of the datasets you selected requires collaboration (COL) with the primary study investigators(s) for use. Please upload documentation of your collaboration here.'
+                      onChange={({value}) => updateCollaborationLetter(value)}
+                    />
+        }
 
-        h(FormFieldTitle, {
-          description: 'One or more of the datasets you selected requires local IRB approval for use. Please upload your local IRB approval(s) here as a single document. When IRB approval is required and Expedited of Full Review is required, it must be completed annually. Determinations of Not Human Subjects Research (NHSR) by IRBs will not be accepted as IRB approval.',
-          isRendered: needsIrbApprovalDocument(datasets),
-        }),
-        div({
-          isRendered: needsIrbApprovalDocument(datasets),
-          style: {
-            display: 'flex',
-            justifyContent: 'space-between',
-          }
-        }, [
-          div({}, [
-            h(FormField, {
-              type: FormFieldTypes.FILE,
-              disabled: readOnlyMode,
-              id: 'irbDocument',
-              defaultValue: uploadedIrbDocument || {
-                name: formData.irbDocumentName,
-              },
-              validation: validation.irbDocument,
-              onValidationChange,
-              onChange: ({value}) => updateUploadedIrbDocument(value, irbProtocolExpiration),
-            }),
-          ]),
+      </div>
+    </div>
 
-          div({
-            style: {
-              width: '250px',
-            }
-          }, [
-            h(FormField, {
-              readOnly: true,
-              id: 'irbProtocolExpiration',
-              defaultValue: `IRB Expires on ${irbProtocolExpiration}`,
-            }),
-          ]),
-        ]),
-
-        h(FormField, {
-          type: FormFieldTypes.FILE,
-          disabled: readOnlyMode,
-          isRendered: needsCollaborationLetter(datasets),
-          defaultValue: uploadedCollaborationLetter ||{
-            name: formData.collaborationLetterName,
-          },
-          id: 'collaborationLetter',
-          validation: validation.collaborationLetter,
-          onValidationChange,
-          description: 'One or more of the datasets you selected requires collaboration (COL) with the primary study investigators(s) for use. Please upload documentation of your collaboration here.',
-          onChange: ({value}) => updateCollaborationLetter(value),
-        }),
-      ]),
-    ])
   );
 }

--- a/src/pages/dar_application/DataAccessRequestApplication.js
+++ b/src/pages/dar_application/DataAccessRequestApplication.js
@@ -32,11 +32,12 @@ const ApplicationTabs = [
 ];
 
 const fetchAllDatasets = async (dsIds) => {
-  if (isEmpty(dsIds)) {
+  const filteredDatasetIds = dsIds.filter((id) => !isNil(id) && Number.isInteger(id) && id > 0);
+  if (isEmpty(filteredDatasetIds)) {
     return [];
   }
   // filter just for safety
-  return DataSet.getDatasetsByIds(dsIds);//.filter((id) => !isNil(id) && isNumber(id)));
+  return DataSet.getDatasetsByIds(filteredDatasetIds);
 };
 
 const validationFailed = (validation) => {
@@ -260,7 +261,7 @@ const DataAccessRequestApplication = (props) => {
       const { dars, datasets } = collection;
       const darReferenceId = head(keys(dars));
       formData = await DAR.getPartialDarRequest(darReferenceId);
-      formData.datasetIds = map(ds => get('dataSetId')(ds))(datasets);
+      formData.datasetIds = map(ds => get(['dataSetId', 'id'])(ds))(datasets);
     }
     else if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id

--- a/src/pages/dar_application/DataAccessRequestApplication.js
+++ b/src/pages/dar_application/DataAccessRequestApplication.js
@@ -261,7 +261,8 @@ const DataAccessRequestApplication = (props) => {
       const { dars, datasets } = collection;
       const darReferenceId = head(keys(dars));
       formData = await DAR.getPartialDarRequest(darReferenceId);
-      formData.datasetIds = map(ds => get(['dataSetId', 'id'])(ds))(datasets);
+      // This is a collection, so we need to get the datasets and dataSetIds from the collection
+      formData.datasetIds = map(ds => get('dataSetId')(ds))(datasets);
     }
     else if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2903

### Summary
* Convert from hyperscript to jsx
* Use new dataset autocomplete API instead of slower search API
  * Note that the new API returns data in a slightly different form since it is not a full dataset object. For that reason, in several places in the code, we look for one of two property names like `id` and `dataSetId` or `identifier` and `datasetIdentifier` due to the different models.
* Update the population and selection of dataset objects when populating the form
* Ensure that we're not querying for invalid/null dataset ids

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
