### PR TITLE
[DUOS-2832][risk=no] Use legacy # of participants property

### DIFF
--- a/src/pages/data_submission/DataAccessGovernance.js
+++ b/src/pages/data_submission/DataAccessGovernance.js
@@ -144,7 +144,7 @@ export const DataAccessGovernance = (props) => {
           otherSecondary: dataUse.secondaryOther,
           url: extract('URL', dataset),
           dataLocation: extract('Data Location', dataset),
-          numberOfParticipants: extract('Number Of Participants', dataset),
+          numberOfParticipants: extract('# of participants', dataset),
           fileTypes: extractFileTypes('File Types', dataset),
           dataAccessCommitteeId: dac?.dacId,
         },


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2832

### Summary
* Use the legacy `# of participants` property instead of the newer, duplicate one.
* See also: https://github.com/DataBiosphere/consent/pull/2244

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
