### PR TITLE
[DUOS-2918] Re-enable Data Catalog for Researchers

### DIFF
--- a/src/components/DuosHeader.js
+++ b/src/components/DuosHeader.js
@@ -118,15 +118,17 @@ export const headerTabsConfig = [
     link: '/member_console',
     search: 'member_console',
     children: [
-      { label: 'DAR Requests', link: '/member_console' }
+      { label: 'DAR Requests', link: '/member_console' },
+      { label: 'Datasets', link: '/dataset_catalog' },
     ],
     isRendered: (user) => user.isMember
   },
   {
     label: 'Researcher Console',
-    link: '/datalibrary',
-    search: 'datalibrary',
+    link: '/dataset_catalog',
+    search: 'dataset_catalog',
     children: [
+      { label: 'Data Catalog', link: '/dataset_catalog' },
       { label: 'Data Library', link: '/datalibrary', search: 'datalibrary' },
       { label: 'DAR Requests', link: '/researcher_console' },
       { label: 'Data Submissions', link: '/dataset_submissions', isRenderedForUser: (user) => user?.isDataSubmitter }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2918
### Summary
Re-enables the Data Catalog for the Researcher Console & makes it the default opened tab when on Researcher Console.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
