### PR TITLE
[DUOS-2900][risk=no] Update to GA4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-dropzone": "14.2.3",
-        "react-ga": "3.3.1",
+        "react-ga4": "2.1.0",
         "react-google-charts": "4.0.1",
         "react-hyperscript-helpers": "2.0.0",
         "react-markdown": "9.0.1",
@@ -18020,14 +18020,10 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
-    "node_modules/react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
-      }
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-google-charts": {
       "version": "4.0.1",
@@ -35595,11 +35591,10 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==",
       "dev": true
     },
-    "react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "requires": {}
+    "react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "react-google-charts": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "14.2.3",
-    "react-ga": "3.3.1",
+    "react-ga4": "2.1.0",
     "react-google-charts": "4.0.1",
     "react-hyperscript-helpers": "2.0.0",
     "react-markdown": "9.0.1",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
 import Modal from 'react-modal';
 import './App.css';
 import {Config} from './libs/config';


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2900

### Summary
Update to the latest react-ga4 library for GA4 functionality ([docs](https://www.npmjs.com/package/react-ga4))
See also: https://github.com/broadinstitute/terra-helmfile/pull/5051

### Testing
1. Update your local config with a value in the helm-file PR ☝🏽 (preferably the dev value)
2. Run, log in, and visit the corresponding GA page ([dev](https://analytics.google.com/analytics/web/?utm_source=marketingplatform.google.com&utm_medium=et&utm_campaign=marketingplatform.google.com%2Fabout%2Fanalytics%2F#/p385349167/realtime/overview?params=_u..nav%3Dmaui))
3. You should see real time changes in page views when logging in, out, and back in again

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
