### PR TITLE
[DUOS-2883] Switch eRA commons link to working location

### DIFF
--- a/src/pages/dar_application/ResearcherInfo.js
+++ b/src/pages/dar_application/ResearcherInfo.js
@@ -86,7 +86,7 @@ export default function ResearcherInfo(props) {
           h3('1.2 Researcher Identification' + (formData.checkCollaborator ? ' (optional)' : '')),
           !readOnlyMode && span({ className: `${showNihValidationError ? 'errored' : 'default-color'}`, isRendered: formData.checkCollaborator !== true }, [
             'Please authenticate with ',
-            a({ target: '_blank', href: 'https://era.nih.gov/reg-accounts/register-commons.htm' }, ['eRA Commons']), ' in order to proceed.'
+            a({ target: '_blank', href: 'https://www.era.nih.gov/register-accounts/create-and-edit-an-account.htm' }, ['eRA Commons']), ' in order to proceed.'
           ]),
           div({ className: 'flex-row', style: { justifyContent: 'flex-start', alignItems: 'flex-start' } }, [
             h4({ style: { marginRight: 30, marginTop: 30 } }, '1.2.1'),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2883

### Summary

Fix eRA commons link on DAR Application to the correct location. I'll refactor this page to use JSX in a separate PR.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
