### PR TITLE
[DUOS-2925] Only disable 'Add Dataset' button if user's role not Data Submitter

### DIFF
--- a/src/pages/researcher_console/DatasetSubmissions.jsx
+++ b/src/pages/researcher_console/DatasetSubmissions.jsx
@@ -103,7 +103,7 @@ export default function DatasetSubmissions(props) {
     marginTop: 10
   };
 
-  const addDatasetButton = (currentUser.libraryCards?.length > 0)
+  const addDatasetButton = (currentUser.isDataSubmitter)
     ? <button style={addDatasetButtonStyle}>
       <AddCircleOutlineIcon/><Link to={'/data_submission_form'} style={{marginLeft: 5}}>Add Dataset</Link>
     </button>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2925

### Summary
Changes logic so that 'Add Dataset' button disabling is dependent on user's role & not their number of library cards.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
