### PR TITLE
[DUOS-2902] Link DUOS-IDs in Data Library subtables to Dataset Statistics pages

### DIFF
--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -193,7 +193,7 @@ export const DatasetSearchTable = (props) => {
                 id: 'dataset-' + dataset.datasetId,
                 data: [
                   {
-                    value: dataset.datasetIdentifier,
+                    value: <Link key={`dataset.datasetId`} href={`/dataset_statistics/${dataset.datasetId}`}>{dataset.datasetIdentifier}</Link>,
                     increaseWidth: true,
                   },
                   {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2902

### Summary
Links all DUOS-IDs in Data Library to corresponding Dataset Statistics pages, opening in a separate page.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
