### PR TITLE
[DUOS-2979] Remove git-secrets from getting started docs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,10 +81,6 @@ gcloud auth login
 gcloud auth application-default login
 gcloud auth configure-docker
 
-# ensure that git-secrets patterns are installed
-git clone https://github.com/broadinstitute/dsp-appsec-gitsecrets-client.git
-./dsp-appsec-gitsecrets-client/gitsecrets.sh
-
 # install the appropriate version of nodejs and its dependencies
 NODE_VERSION=$(curl -L https://raw.githubusercontent.com/DataBiosphere/duos-ui/develop/Dockerfile | awk 'NR==2 {gsub(":","@",$2); print $2}')
 volta setup && volta install ${NODE_VERSION}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2979

### Summary

Remove git-secrets from getting started docs, this is automatically installed by appsec

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
