### PR TITLE
[DUOS-3014] Replace 'Request a Library Card' button with text guidance

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -65,7 +65,7 @@ const Routes = (props) => (
     <Route path="/nih_dms_policy" component={NIHDMSPolicyInfo} />
     <Route path="/anvil_dms_policy" component={AnVILDMSPolicyInfo} />
     <AuthenticatedRoute path="/profile" component={UserProfile} props={props} rolesAllowed={[USER_ROLES.all]} />
-    <AuthenticatedRoute path="/request_role" component={RequestForm} props={Object.assign({}, props, {isRequestRolePage: true})} rolesAllowed={[USER_ROLES.all]} />
+    <AuthenticatedRoute path="/request_role" component={RequestForm} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/admin_review_collection/:collectionId" component={DarCollectionReview} props={Object.assign({adminPage: true}, props)} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_users" component={AdminManageUsers} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_edit_user/:userId" component={AdminEditUser} props={props} rolesAllowed={[USER_ROLES.admin]} />

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -66,7 +66,6 @@ const Routes = (props) => (
     <Route path="/anvil_dms_policy" component={AnVILDMSPolicyInfo} />
     <AuthenticatedRoute path="/profile" component={UserProfile} props={props} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/request_role" component={RequestForm} props={Object.assign({}, props, {isRequestRolePage: true})} rolesAllowed={[USER_ROLES.all]} />
-    <AuthenticatedRoute path="/request_lc" component={RequestForm} props={Object.assign({}, props, {isRequestLCPage: true})} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/admin_review_collection/:collectionId" component={DarCollectionReview} props={Object.assign({adminPage: true}, props)} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_users" component={AdminManageUsers} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_edit_user/:userId" component={AdminEditUser} props={props} rolesAllowed={[USER_ROLES.admin]} />

--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -16,7 +16,7 @@ export default function SupportRequestsPage(props) {
     marginBottom: '1rem'
   };
 
-  var possibleSupportRequests = [
+  const possibleSupportRequests = [
     {
       key: 'checkRegisterDataset',
       label: 'Register a dataset'
@@ -30,8 +30,8 @@ export default function SupportRequestsPage(props) {
       label: 'I am looking to join a DAC'
     }
   ];
-  var hasSupportRequestsCond = false;
-  var supportRequestsCond = {
+  const hasSupportRequestsCond = false;
+  const supportRequestsCond = {
     checkRegisterDataset: false,
     checkRequestDataAccess: false,
     checkSOPermissions: false,

--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -8,7 +8,6 @@ import { FormField, FormFieldTypes } from '../../components/forms/forms';
 export default function SupportRequestsPage(props) {
 
   const profile = props.location.state?.data || undefined;
-
   const headerStyle = {
     fontWeight: 'bold',
     color: '#333F52',
@@ -37,19 +36,6 @@ export default function SupportRequestsPage(props) {
       checkSOPermissions: false,
       checkJoinDac: false,
       extraRequest: undefined
-    };
-  }
-  else if (props.isRequestLCPage) {
-    possibleSupportRequests = [
-      {
-        key: 'requestNewLC',
-        label: 'Request a new library card',
-        isDefaultOption: true,
-      }
-    ];
-    hasSupportRequestsCond = true;
-    supportRequestsCond = {
-      requestNewLC: true,
     };
   }
   else {
@@ -140,7 +126,7 @@ export default function SupportRequestsPage(props) {
         fontWeight: '600',
         marginTop: 10
       }}>
-      {props.isRequestRolePage ? 'Request a New Role' : (props.isRequestLCPage ? 'Request Library Card' : '')}
+      {props.isRequestRolePage ? 'Request a New Role'  : ''}
     </p>
     <div
       style={{

--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -16,33 +16,28 @@ export default function SupportRequestsPage(props) {
     marginBottom: '1rem'
   };
 
-  var possibleSupportRequests;
-  var hasSupportRequestsCond;
-  var supportRequestsCond;
-
-  if (props.isRequestRolePage) {
-    possibleSupportRequests = [
-      {
-        key: 'checkSOPermissions',
-        label: `I am a Signing Official and I want to issue permissions to my institution's users`
-      },
-      {
-        key: 'checkJoinDac',
-        label: 'I am looking to join a DAC'
-      }
-    ];
-    hasSupportRequestsCond = false;
-    supportRequestsCond = {
-      checkSOPermissions: false,
-      checkJoinDac: false,
-      extraRequest: undefined
-    };
-  }
-  else {
-    possibleSupportRequests = [];
-    hasSupportRequestsCond = false;
-    supportRequestsCond = {};
-  }
+  var possibleSupportRequests = [
+    {
+      key: 'checkRegisterDataset',
+      label: 'Register a dataset'
+    },
+    {
+      key: 'checkSOPermissions',
+      label: `I am a Signing Official and I want to issue permissions to my institution's users`
+    },
+    {
+      key: 'checkJoinDac',
+      label: 'I am looking to join a DAC'
+    }
+  ];
+  var hasSupportRequestsCond = false;
+  var supportRequestsCond = {
+    checkRegisterDataset: false,
+    checkRequestDataAccess: false,
+    checkSOPermissions: false,
+    checkJoinDac: false,
+    extraRequest: undefined
+  };
 
   const [hasSupportRequests, setHasSupportRequests] = useState(hasSupportRequestsCond);
   const [supportRequests, setSupportRequests] = useState(supportRequestsCond);
@@ -65,7 +60,6 @@ export default function SupportRequestsPage(props) {
       await sendSupportRequests();
     }
   };
-
 
   const processSupportRequests =
     () => {
@@ -126,7 +120,7 @@ export default function SupportRequestsPage(props) {
         fontWeight: '600',
         marginTop: 10
       }}>
-      {props.isRequestRolePage ? 'Request a New Role'  : ''}
+      Request a New Role
     </p>
     <div
       style={{

--- a/src/pages/user_profile/ResearcherStatus.jsx
+++ b/src/pages/user_profile/ResearcherStatus.jsx
@@ -11,20 +11,13 @@ export default function ResearcherStatus(props) {
   const {
     user,
     pageProps,
-    profile
   } = props;
 
   const [issuedOn, setIssuedOn] = useState('');
   const [issuedBy, setIssuedBy] = useState('');
   const [hasCard, setHasCard] = useState(true);
 
-  const goToRequestRole = () => {
-    pageProps.history.push({
-      pathname: '/request_lc',
-      state: { data: profile }
-    });
-  };
-
+  
   useEffect(() => {
     const init = async () => {
       try {

--- a/src/pages/user_profile/ResearcherStatus.jsx
+++ b/src/pages/user_profile/ResearcherStatus.jsx
@@ -100,15 +100,10 @@ export default function ResearcherStatus(props) {
     ) : (
       <div>
         <p>No Library Card Found</p>
-        <button
-          className='f-left btn-primary common-background'
-          onClick={goToRequestRole}
-          style={{
-            marginTop: '10px',
-            marginBottom: '50px'
-          }} >
-          Request a Library Card
-        </button>
+        <p style={{
+          marginTop: '10px',
+          marginBottom:'50px'
+        }}>You must have a Library Card to submit a data access request. To obtain one, your Institutional Signing Official must register in DUOS, request and receive Signing Official permissions, and issue you a Library Card.</p>
       </div>
     )}
   </div>;


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-3014

### Summary

If the user does not have any library cards, replace the button to request a card with some textual guidance.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
