### PR TITLE
[DUOS-3015][risk=no] Remove register dataset option

### DIFF
--- a/src/pages/user_profile/RequestForm.js
+++ b/src/pages/user_profile/RequestForm.js
@@ -23,10 +23,6 @@ export default function SupportRequestsPage(props) {
   if (props.isRequestRolePage) {
     possibleSupportRequests = [
       {
-        key: 'checkRegisterDataset',
-        label: 'Register a dataset'
-      },
-      {
         key: 'checkSOPermissions',
         label: `I am a Signing Official and I want to issue permissions to my institution's users`
       },
@@ -37,8 +33,6 @@ export default function SupportRequestsPage(props) {
     ];
     hasSupportRequestsCond = false;
     supportRequestsCond = {
-      checkRegisterDataset: false,
-      checkRequestDataAccess: false,
       checkSOPermissions: false,
       checkJoinDac: false,
       extraRequest: undefined
@@ -168,16 +162,6 @@ export default function SupportRequestsPage(props) {
           id={supportRequest.key}
           onChange={handleSupportRequestsChange} />;
       })}
-      {supportRequests.checkRequestDataAccess && (
-        <div
-          style={{
-            border: '1px solid purple',
-            color: 'purple',
-            padding: '10px'
-          }}>
-          Before you can submit a data access request, your Signing Official must register and issue you a Library Card in DUOS
-        </div>
-      )}
       <div style={{ margin: '15px 0 10px' }}>
         Is there anything else you would like to request?
       </div>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3015

### Summary
* Remove the option to request dataset registration
* Minor cleanup of unused `checkRequestDataAccess` condition

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
