### PR TITLE
[DUOS-3028][risk=no] Address `key` is not a prop warning

### DIFF
--- a/src/components/collection_voting_slab/DataUsePill.jsx
+++ b/src/components/collection_voting_slab/DataUsePill.jsx
@@ -32,10 +32,10 @@ const styles = {
 };
 
 export const DataUsePill = (props) => {
-  const { dataUse, key } = props;
+  const { dataUse, index } = props;
 
   return (
-    <div key={`data_use_pill_${dataUse.type}_${dataUse.code}_${key}`} style={styles.baseStyle}>
+    <div key={`data_use_pill_${dataUse.type}_${dataUse.code}_${index}`} style={styles.baseStyle}>
       <span style={styles.code}>{!isNil(dataUse) ? [dataUse.code] : []}</span>
       <span style={styles.description}>{!isNil(dataUse) ? [dataUse.description] : []}</span>
     </div>
@@ -49,13 +49,13 @@ export const DataUsePills = (dataUses) => {
   return (
     <div>
       {permissionsUses.map((dataUse, idx) => (
-        <DataUsePill dataUse={dataUse} key={`${dataUse.code}-${idx}`} />
+        <DataUsePill dataUse={dataUse} key={`${dataUse.code}-${idx}`} index={idx} />
       ))}
       {modifierUses.length > 0 && (
         <div>
           <h3 style={styles.subheading}>{ControlledAccessType.modifiers}</h3>
           {modifierUses.map((dataUse, idx) => (
-            <DataUsePill dataUse={dataUse} key={`${dataUse.code}-${idx}`} />
+            <DataUsePill dataUse={dataUse} key={`${dataUse.code}-${idx}`} index={idx} />
           ))}
         </div>
       )}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3028

### Summary
* Minor property rename to address the following warning:
```
Warning: DataUsePill: `key` is not a prop. Trying to access it will result in `undefined` being returned. If you need to access the same value within the child component, you should pass it as a different prop. (https://reactjs.org/link/special-props)
    at DataUsePill (https://local.broadinstitute.org:3000/static/js/bundle.js:10234:5)
    at div
    at div
    at DataUseSummary (https://local.broadinstitute.org:3000/static/js/bundle.js:11221:5)
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
