### PR TITLE
[DUOS-2986] Allow DUOS-000000 in URLs for datasets

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -97,8 +97,8 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/dataset_catalog" component={DatasetCatalog} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/datalibrary/:query" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/datalibrary" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
-    <AuthenticatedRoute path="/dataset_statistics/:datasetId" component={DatasetStatistics} props={props}
-      rolesAllowed={[USER_ROLES.all]} />
+    <AuthenticatedRoute path="/dataset/:datasetIdentifier" component={DatasetStatistics} props={props} rolesAllowed={[USER_ROLES.all]} />
+    <AuthenticatedRoute path="/duos-:duosId" component={DatasetStatistics} props={props} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/dac_datasets" component={DACDatasets} props={props} rolesAllowed={[USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/tos_acceptance" component={TermsOfServiceAcceptance} props={props} rolesAllowed={[USER_ROLES.all]} />
     {checkEnv(envGroups.NON_PROD) && <AuthenticatedRoute path="/translate" component={Translator} props={props} rolesAllowed={[USER_ROLES.researcher]}/>}

--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -283,7 +283,7 @@ export const DatasetSearchTable = (props) => {
                 datasetIdentifier: dataset.datasetIdentifier,
                 data: [
                   {
-                    value: <Link key={`dataset.datasetId`} href={`/dataset_statistics/${dataset.datasetId}`}>{dataset.datasetIdentifier}</Link>,
+                    value: <Link key={`dataset.datasetId`} href={`/dataset/${dataset.datasetIdentifier}`}>{dataset.datasetIdentifier}</Link>,
                     increaseWidth: true,
                   },
                   {

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -359,8 +359,8 @@ export const DataSet = {
 
   getDatasetByDatasetIdentifier: async datasetIdentifier => {
     const url = `${await getApiUrl()}/api/tdr/${datasetIdentifier}`;
-    const res = await fetchOk(url, Config.authOpts());
-    return await res.json();
+    const res = await axios.get(url, Config.authOpts());
+    return res.data;
   }
 };
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -356,6 +356,12 @@ export const DataSet = {
     const url = `${await getApiUrl()}/api/dataset/study/${studyId}`;
     return await axios.put(url, studyObject, Config.multiPartOpts());
   },
+
+  getDatasetByDatasetIdentifier: async datasetIdentifier => {
+    const url = `${await getApiUrl()}/api/tdr/${datasetIdentifier}`;
+    const res = await fetchOk(url, Config.authOpts());
+    return await res.json();
+  }
 };
 
 export const Study = {

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -624,7 +624,7 @@ export default function DatasetCatalog(props) {
                           style: tableBody
                         }, [
                           a({
-                            href: `/dataset_statistics/${dataset.dataSetId}`,
+                            href: `/dataset/${dataset.datasetIdentifier}`,
                           }, dataset.name)
                         ]),
 

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
-import { Metrics } from '../libs/ajax';
+import { DataSet, Metrics } from '../libs/ajax';
 import { Notifications } from '../libs/utils';
 import { Styles, Theme } from '../libs/theme';
 import { get, find } from 'lodash';
@@ -9,15 +9,25 @@ import { formatDate } from '../libs/utils';
 
 const LINE = <div style={{ borderTop: '1px solid #BABEC1', height: 0 }} />;
 
+const extractIdentifier = (params) => {
+  let datasetIdentifier = params.datasetIdentifier;
+  if (params.duosId) {
+    datasetIdentifier = "DUOS-" + params.duosId;
+  }
+  return datasetIdentifier.toUpperCase();
+}
+
 export default function DatasetStatistics(props) {
-  const datasetId = props.match.params.datasetId;
+  const datasetIdentifier = extractIdentifier(props.match.params);
   const [dataset, setDataset] = useState();
   const [dars, setDars] = useState();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    setData(datasetId);
-  }, [datasetId]);
+    DataSet.getDatasetByDatasetIdentifier(datasetIdentifier).then((dataset) => {
+      setData(dataset.dataSetId);
+    });
+  }, [datasetIdentifier]);
 
   const setData = async (datasetId) => {
     try {

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -26,6 +26,8 @@ export default function DatasetStatistics(props) {
   useEffect(() => {
     DataSet.getDatasetByDatasetIdentifier(datasetIdentifier).then((dataset) => {
       setData(dataset.dataSetId);
+    }).catch(() => {
+      Notifications.showError({ text: 'Error: Unable to retrieve dataset from server' });
     });
   }, [datasetIdentifier]);
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-2986

### Summary

Allow DUOS-000000 in URLs for datasets. BONUS: Enables a dataset short link which lives at duos.org/duos-000000

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
