### PR TITLE
[DUOS-2834][risk=no] Use the new Study PI instead of the old dataset property

### DIFF
--- a/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
+++ b/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
@@ -38,12 +38,6 @@ const sampleDataset = {
       'propertyValue': '2',
       'propertyType': 'String'
     },
-    // {
-    //   'dataSetId': 1408,
-    //   'propertyName': 'Principal Investigator(PI)',
-    //   'propertyValue': 'Magnum PI',
-    //   'propertyType': 'String'
-    // },
     {
       'dataSetId': 1408,
       'propertyName': 'Description',

--- a/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
+++ b/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
@@ -38,12 +38,12 @@ const sampleDataset = {
       'propertyValue': '2',
       'propertyType': 'String'
     },
-    {
-      'dataSetId': 1408,
-      'propertyName': 'Principal Investigator(PI)',
-      'propertyValue': 'Magnum PI',
-      'propertyType': 'String'
-    },
+    // {
+    //   'dataSetId': 1408,
+    //   'propertyName': 'Principal Investigator(PI)',
+    //   'propertyValue': 'Magnum PI',
+    //   'propertyType': 'String'
+    // },
     {
       'dataSetId': 1408,
       'propertyName': 'Description',
@@ -86,6 +86,7 @@ const sampleDataset = {
     'name': 'xyz 123',
     'description': 'test',
     'publicVisibility': true,
+    'piName': 'Magnum PI',
     'datasetIds': [
       1408
     ],

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -541,18 +541,6 @@ const dar = {
           'propertyTypeAsString': 'string',
           'propertyValueAsString': 'data_depositor@example.com'
         },
-        // {
-        //   'propertyId': null,
-        //   'dataSetId': 13,
-        //   'propertyKey': null,
-        //   'propertyName': 'Principal Investigator(PI)',
-        //   'propertyValue': 'Lisa Simpson, Betty White',
-        //   'createDate': null,
-        //   'schemaProperty': null,
-        //   'propertyType': 'String',
-        //   'propertyTypeAsString': 'string',
-        //   'propertyValueAsString': 'Lisa Simpson, Betty White'
-        // },
         {
           'propertyId': null,
           'dataSetId': 13,

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -541,18 +541,18 @@ const dar = {
           'propertyTypeAsString': 'string',
           'propertyValueAsString': 'data_depositor@example.com'
         },
-        {
-          'propertyId': null,
-          'dataSetId': 13,
-          'propertyKey': null,
-          'propertyName': 'Principal Investigator(PI)',
-          'propertyValue': 'Lisa Simpson, Betty White',
-          'createDate': null,
-          'schemaProperty': null,
-          'propertyType': 'String',
-          'propertyTypeAsString': 'string',
-          'propertyValueAsString': 'Lisa Simpson, Betty White'
-        },
+        // {
+        //   'propertyId': null,
+        //   'dataSetId': 13,
+        //   'propertyKey': null,
+        //   'propertyName': 'Principal Investigator(PI)',
+        //   'propertyValue': 'Lisa Simpson, Betty White',
+        //   'createDate': null,
+        //   'schemaProperty': null,
+        //   'propertyType': 'String',
+        //   'propertyTypeAsString': 'string',
+        //   'propertyValueAsString': 'Lisa Simpson, Betty White'
+        // },
         {
           'propertyId': null,
           'dataSetId': 13,
@@ -590,7 +590,10 @@ const dar = {
           'propertyValueAsString': 'https://...'
         }
       ],
-      'dacApproval': true
+      'dacApproval': true,
+      'study': {
+        'piName': 'Lisa Simpson, Betty White'
+      }
     }
   ]
 };

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -516,7 +516,7 @@ const DuosHeader = (props) => {
             <NavigationTabsComponent
               goToLink={goToLink}
               // Notifications are already displayed underneath the expanded drawer, no need to render them twice.
-              makeNotifications={() => {}} 
+              makeNotifications={() => {}}
               duosLogoImage={duosLogoImage}
               DuosLogo={DuosLogo}
               navbarDuosIcon={navbarDuosIcon}

--- a/src/components/data_search/DatasetSearchTable.js
+++ b/src/components/data_search/DatasetSearchTable.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import _ from 'lodash';
 import { Box, Button, Link } from '@mui/material';
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { groupBy, isEmpty } from 'lodash';
 import CollapsibleTable from '../CollapsibleTable';
 import TableHeaderSection from '../TableHeaderSection';
@@ -59,30 +59,30 @@ export const DatasetSearchTable = (props) => {
         }
       }
     ];
-  
+
     // do not apply search modifier if there is no searchTerm
     if (searchTerm !== '') {
       const searchModifier = [
         {
-          "multi_match": {
-              "query": searchTerm,
-              "type":"phrase_prefix",
-              "fields": [
-                  "datasetName",
-                  "dataLocation",
-                  "study.description",
-                  "study.studyName",
-                  "study.species",
-                  "study.piName",
-                  "study.dataCustodianEmail",
-                  "study.dataTypes",
-                  "dataUse.primary.code",
-                  "dataUse.secondary.code",
-                  "dac.dacName",
-                  "datasetIdentifier"
-              ]
+          'multi_match': {
+            'query': searchTerm,
+            'type':'phrase_prefix',
+            'fields': [
+              'datasetName',
+              'dataLocation',
+              'study.description',
+              'study.studyName',
+              'study.species',
+              'study.piName',
+              'study.dataCustodianEmail',
+              'study.dataTypes',
+              'dataUse.primary.code',
+              'dataUse.secondary.code',
+              'dac.dacName',
+              'datasetIdentifier'
+            ]
           }
-      }
+        }
       ];
       queryChunks.push(...searchModifier);
     }
@@ -90,26 +90,26 @@ export const DatasetSearchTable = (props) => {
     var filterQuery = {};
     if (filters.length > 0) {
       const shouldTerms = [];
-    
+
       filters.forEach(term => {
         shouldTerms.push({
-          "term": {
-            "accessManagement": term
+          'term': {
+            'accessManagement': term
           }
         });
       });
-    
+
       if (shouldTerms.length > 0) {
         filterQuery = [
           {
-            "bool": {
-              "should": shouldTerms
+            'bool': {
+              'should': shouldTerms
             }
           }
         ];
       }
     }
-    
+
     // do not add filter subquery if no filters are applied
     if (filters.length > 0) {
       return {
@@ -157,7 +157,7 @@ export const DatasetSearchTable = (props) => {
     };
     search();
   };
-  
+
 
 
   const selectHandler = (event, data, selector) => {
@@ -223,7 +223,7 @@ export const DatasetSearchTable = (props) => {
   const clearSearchRef = () => {
     searchRef.current.value = '';
     filterHandler(null, datasets, '', '');
-  }
+  };
 
   useEffect(() => {
     if (isEmpty(filtered)) {
@@ -389,17 +389,17 @@ export const DatasetSearchTable = (props) => {
             if (isEmpty(datasets)) {
               return (
                 <Box sx={{
-                    display: 'flex',
-                    flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                    <h1>No datasets registered for this library.</h1>
+                  display: 'flex',
+                  flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                  <h1>No datasets registered for this library.</h1>
                 </Box>
               );
             } else if (isEmpty(filtered)) {
               return (
                 <Box sx={{
-                    display: 'flex',
-                    flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
-                    <h1>There are no datasets that fit these criteria.</h1>
+                  display: 'flex',
+                  flexDirection: 'column', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                  <h1>There are no datasets that fit these criteria.</h1>
                 </Box>
               );
             } else {

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -5,6 +5,7 @@ import { FormFieldTypes, FormField, FormValidators } from '../forms/forms';
 import { DAC, DAR, DataSet } from '../../libs/ajax';
 import { Notifications } from '../../libs/utils';
 
+// TODO: Deprecated - remove this component when all datasets have been converted to studies
 export const DatasetUpdate = (props) => {
   const { dataset, history } = props;
 
@@ -119,7 +120,7 @@ export const DatasetUpdate = (props) => {
         description: extract('Description'),
         dbGap: extract('dbGAP'),
         dataDepositor: extract('Data Depositor'),
-        principalInvestigator: dataset?.study?.piName,
+        principalInvestigator: dataset?.study?.piName || extract('Principal Investigator(PI)'),
       },
       dataUse: await normalizeDataUse(dataset?.dataUse),
       dac: { ...dac, dacs }

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -119,7 +119,7 @@ export const DatasetUpdate = (props) => {
         description: extract('Description'),
         dbGap: extract('dbGAP'),
         dataDepositor: extract('Data Depositor'),
-        principalInvestigator: extract('Principal Investigator(PI)'),
+        principalInvestigator: dataset?.study?.piName,
       },
       dataUse: await normalizeDataUse(dataset?.dataUse),
       dac: { ...dac, dacs }

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -99,7 +99,7 @@ const DacDatasetsModal = (props) => {
                 <td key={'6_' + dataset.datasetIdentifier}
                   className={'table-items cell-size'}>{getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')}</td>
                 <td key={'7_' + dataset.datasetIdentifier}
-                  className={'table-items cell-size'}>{dataset?.study?.piName || '---'}</td>
+                  className={'table-items cell-size'}>{dataset?.study?.piName || getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')}</td>
                 <td key={'8_' + dataset.datasetIdentifier}
                   className={'table-items cell-size'}>{getPropertyValue(dataset.properties, '# of participants', '---')}</td>
                 <td key={'9_' + dataset.datasetIdentifier}

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -99,7 +99,7 @@ const DacDatasetsModal = (props) => {
                 <td key={'6_' + dataset.datasetIdentifier}
                   className={'table-items cell-size'}>{getPropertyValue(dataset.properties, 'Phenotype/Indication', '---')}</td>
                 <td key={'7_' + dataset.datasetIdentifier}
-                  className={'table-items cell-size'}>{getPropertyValue(dataset.properties, 'Principal Investigator(PI)', '---')}</td>
+                  className={'table-items cell-size'}>{dataset?.study?.piName || '---'}</td>
                 <td key={'8_' + dataset.datasetIdentifier}
                   className={'table-items cell-size'}>{getPropertyValue(dataset.properties, '# of participants', '---')}</td>
                 <td key={'9_' + dataset.datasetIdentifier}

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -105,7 +105,7 @@ export default function DatasetCatalog(props) {
       row['Dataset ID'] = row.datasetIdentifier;
       row['Data Access Committee'] = findDacName(localDacs, row);
       row['Disease Studied'] = findPropertyValue(row, 'Phenotype/Indication');
-      row['Principal Investigator (PI)'] = findPropertyValue(row, 'Principal Investigator(PI)');
+      row['Principal Investigator (PI)'] = row.study?.piName || '';
       row['# of Participants'] = findPropertyValue(row, '# of participants');
       row['Data Custodian'] = findPropertyValue(row, 'Data Depositor');
       return row;

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -105,7 +105,7 @@ export default function DatasetCatalog(props) {
       row['Dataset ID'] = row.datasetIdentifier;
       row['Data Access Committee'] = findDacName(localDacs, row);
       row['Disease Studied'] = findPropertyValue(row, 'Phenotype/Indication');
-      row['Principal Investigator (PI)'] = row.study?.piName || '';
+      row['Principal Investigator (PI)'] = row.study?.piName || findPropertyValue(row, 'Principal Investigator(PI)');
       row['# of Participants'] = findPropertyValue(row, '# of participants');
       row['Data Custodian'] = findPropertyValue(row, 'Data Depositor');
       return row;

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -17,6 +17,7 @@ import addDatasetIcon from '../images/icon_dataset_add.png';
 import { searchOntologies } from '../libs/utils';
 import { OntologyService } from '../libs/ontologyService';
 
+// TODO: Deprecated - remove this component when all datasets have been converted to studies
 class DatasetRegistration extends Component {
 
   constructor(props) {

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -98,13 +98,7 @@ export default function DatasetStatistics(props) {
               <div style={{ display: 'flex' }}>
                 <div style={Styles.SMALL_BOLD}>Principal Investigator: </div>
                 <div style={Styles.SMALL_BOLD}>
-                  {get(
-                    find(dataset?.properties, (p) => {
-                      return p.propertyName === 'Principal Investigator(PI)';
-                    }),
-                    'propertyValue',
-                    ''
-                  )}
+                  {dataset?.study?.piName || ''}
                 </div>
               </div>
               <div style={{ display: 'flex' }}>

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -12,10 +12,10 @@ const LINE = <div style={{ borderTop: '1px solid #BABEC1', height: 0 }} />;
 const extractIdentifier = (params) => {
   let datasetIdentifier = params.datasetIdentifier;
   if (params.duosId) {
-    datasetIdentifier = "DUOS-" + params.duosId;
+    datasetIdentifier = 'DUOS-' + params.duosId;
   }
   return datasetIdentifier.toUpperCase();
-}
+};
 
 export default function DatasetStatistics(props) {
   const datasetIdentifier = extractIdentifier(props.match.params);
@@ -98,7 +98,13 @@ export default function DatasetStatistics(props) {
               <div style={{ display: 'flex' }}>
                 <div style={Styles.SMALL_BOLD}>Principal Investigator: </div>
                 <div style={Styles.SMALL_BOLD}>
-                  {dataset?.study?.piName || ''}
+                  {dataset?.study?.piName || get(
+                    find(dataset?.properties, (p) => {
+                      return p.propertyName === 'Principal Investigator(PI)';
+                    }),
+                    'propertyValue',
+                    ''
+                  )}
                 </div>
               </div>
               <div style={{ display: 'flex' }}>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2834

### Summary
* Use the PI Name on the study before trying to find the the deprecated/duplicated dataset property value
* Address some minor `eslint` warnings for `DatasetSearchTable` and `DuosHeader`
* See also this related back end PR: https://github.com/DataBiosphere/consent/pull/2277


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
