### PR TITLE
[DUOS-2835][DUOS-2878][risk=no] Use the url dataset property instead of the dbGap version

### DIFF
--- a/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
+++ b/cypress/component/DacDatasetTable/dac_dataset_table.spec.js
@@ -64,7 +64,7 @@ const sampleDataset = {
     },
     {
       'dataSetId': 1408,
-      'propertyName': 'dbGAP',
+      'propertyName': 'url',
       'propertyValue': 'http://...',
       'propertyType': 'String'
     },

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -581,7 +581,7 @@ const dar = {
           'propertyId': null,
           'dataSetId': 13,
           'propertyKey': null,
-          'propertyName': 'dbGAP',
+          'propertyName': 'url',
           'propertyValue': 'https://...',
           'createDate': null,
           'schemaProperty': null,

--- a/public/DataSetSample.tsv
+++ b/public/DataSetSample.tsv
@@ -1,2 +1,0 @@
-Dataset Name	Data Type	Species	Phenotype/Indication	# of participants	Description	dbGAP	Data Depositor	Principal Investigator(PI)	Sample Collection ID	Consent ID
-(Bucienne Monco) - Muc-1 Kidney Disease	DNA, whole genome	human	muc-1, kidney disease	31	muc-1 patients that developed cancer , 5 weeks after treatment	http://....	John Doe	Mark Smith	SC-20658	

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -87,7 +87,7 @@ export const DatasetUpdate = (props) => {
         asProperty('Phenotype/Indication', formData.properties.phenotype),
         asProperty('# of participants', formData.properties.nrParticipants),
         asProperty('Description', formData.properties.description),
-        asProperty('dbGAP', formData.properties.dbGap),
+        asProperty('URL', formData.properties.url),
         asProperty('Data Depositor', formData.properties.dataDepositor),
         asProperty('Principal Investigator(PI)', formData.properties.principalInvestigator),
       ]
@@ -117,7 +117,7 @@ export const DatasetUpdate = (props) => {
         phenotype: extract('Phenotype/Indication'),
         nrParticipants: extract('# of participants'),
         description: extract('Description'),
-        dbGap: extract('dbGAP'),
+        url: extract('url'),
         dataDepositor: extract('Data Depositor'),
         principalInvestigator: extract('Principal Investigator(PI)'),
       },
@@ -172,12 +172,12 @@ export const DatasetUpdate = (props) => {
         }}
       />
       <FormField
-        id="dbGap"
+        id="url"
         title="Dataset Repository URL"
         validators={[FormValidators.REQUIRED]}
-        defaultValue={formData.properties.dbGap}
+        defaultValue={formData.properties.url}
         onChange={({ value }) => {
-          formData.properties.dbGap = value;
+          formData.properties.url = value;
         }}
       />
       <FormField

--- a/src/components/modals/DacDatasetsModal.js
+++ b/src/components/modals/DacDatasetsModal.js
@@ -34,7 +34,7 @@ const DacDatasetsModal = (props) => {
   };
 
   const getDbGapLinkValue = (properties) => {
-    const href = getPropertyValue(properties, 'dbGAP', '');
+    const href = getPropertyValue(properties, 'url', '');
     return href.length > 0 ?
       <a href={href} target={'_blank'} className={'enabled'} rel="noreferrer">Link</a> :
       <span className={'disabled'}>---</span>;
@@ -72,7 +72,7 @@ const DacDatasetsModal = (props) => {
           <tr key={'dac_datasets_table_head_row'}>
             <th key={'1'} className={'table-titles dataset-color cell-size'}>Dataset Id</th>
             <th key={'2'} className={'table-titles dataset-color cell-size'}>Dataset Name</th>
-            <th key={'3'} className={'table-titles dataset-color cell-size'}>dbGap</th>
+            <th key={'3'} className={'table-titles dataset-color cell-size'}>URL</th>
             <th key={'4'} className={'table-titles dataset-color cell-size'}>Structured Data Use Limitations</th>
             <th key={'5'} className={'table-titles dataset-color cell-size'}>Data Type</th>
             <th key={'6'} className={'table-titles dataset-color cell-size'}>Phenotype/Indication</th>

--- a/src/pages/DatasetCatalog.js
+++ b/src/pages/DatasetCatalog.js
@@ -100,7 +100,7 @@ export default function DatasetCatalog(props) {
       row.checked = false;
       row.ix = index;
       row.dbGapLink =
-        getOr('')('propertyValue')(find({propertyName: 'dbGAP'})(row.properties));
+        getOr('')('propertyValue')(find({propertyName: 'url'})(row.properties));
       // Extracting these fields to make sorting easier
       row['Dataset ID'] = row.datasetIdentifier;
       row['Data Access Committee'] = findDacName(localDacs, row);

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -134,7 +134,7 @@ class DatasetRegistration extends Component {
     let phenotype = fp.find({propertyName: 'Phenotype/Indication'})(dataset.properties);
     let nrParticipants = fp.find({propertyName: '# of participants'})(dataset.properties);
     let description = fp.find({propertyName: 'Description'})(dataset.properties);
-    let datasetRepoUrl = fp.find({propertyName: 'dbGAP'})(dataset.properties);
+    let datasetRepoUrl = fp.find({propertyName: 'url'})(dataset.properties);
     let researcher = fp.find({propertyName: 'Data Depositor'})(dataset.properties);
     let pi = fp.find({propertyName: 'Principal Investigator(PI)'})(dataset.properties);
     let dac = fp.find({dacId: dataset.dacId})(this.state.dacList);
@@ -554,7 +554,7 @@ class DatasetRegistration extends Component {
       properties.push({'propertyName': 'Description', 'propertyValue': formData.description});
     }
     if (formData.datasetRepoUrl) {
-      properties.push({'propertyName': 'dbGAP', 'propertyValue': formData.datasetRepoUrl});
+      properties.push({'propertyName': 'url', 'propertyValue': formData.datasetRepoUrl});
     }
     if (formData.researcher) {
       properties.push({'propertyName': 'Data Depositor', 'propertyValue': formData.researcher});


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2835
https://broadworkbench.atlassian.net/browse/DUOS-2878

### Summary
Use the `url` dataset property of instead of the `dbGap` version. The `url` is meant to replace what we previously stored in `dbGap`.

See also this back end PR: https://github.com/DataBiosphere/consent/pull/2278
This PR is not blocked on ☝🏽 - both can be moved forward independently

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
