### PR TITLE
[DUOS-3038][risk=no]Added divKey to pass key to notification component

### DIFF
--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -365,7 +365,7 @@ const DuosHeader = (props) => {
   };
 
   const makeNotifications = () => {
-    return state.notificationData.map((d, index) => <Notification notificationData={d} key={index} />);
+    return state.notificationData.map((d, index) => <Notification notificationData={d} key={index} divKey={index} />);
   };
 
   const toggleDrawer = (boolVal) => {

--- a/src/components/Notification.js
+++ b/src/components/Notification.js
@@ -8,8 +8,8 @@ import ReportIcon from '@mui/icons-material/Report';
 import style from './Notification.module.css';
 
 export const Notification = (props) => {
-  const {notificationData, key} = props;
-  let notificationDiv = <div key={key} style={{display: 'none'}}/>;
+  const {notificationData, divKey} = props;
+  let notificationDiv = <div key={divKey} style={{display: 'none'}}/>;
 
   if (!isEmpty(notificationData)) {
     const iconStyle = {
@@ -40,7 +40,7 @@ export const Notification = (props) => {
     // eslint-disable-next-line react/no-children-prop
     const content = <ReactMarkdown children={notificationData.message} className={style['underlined']}/>;
     notificationDiv = <div
-      key={key}
+      key={divKey}
       className={'row no-margin alert alert-' + notificationData.level}>
       <div style={{float: 'left'}}>{icon}</div>
       <div>{content}</div>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-3038

### Summary
This react warning was introduced in https://github.com/DataBiosphere/duos-ui/pull/2511 . This PR fixes that warning and passes the `key` value to the child components through `divKey`.
![image](https://github.com/DataBiosphere/duos-ui/assets/56648914/80f5050b-4f98-448f-b5a0-9a3b221bcf5b)
