### PR TITLE
[DCJ-11][risk=no] duos-ui runs all PR checks on Dependabot PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,15 +45,12 @@ jobs:
     - name: Log Github Actor
       run: echo "${{ github.actor }}"
     - name: Auth to GCR
-      if: github.actor != 'dependabot[bot]'
       uses: 'google-github-actions/auth@v1'
       with:
         credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
     - name: Auth Docker for GCR
-      if: github.actor != 'dependabot[bot]'
       run: gcloud auth configure-docker --quiet
     - name: Push Image to GCR
-      if: github.actor != 'dependabot[bot]'
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,6 @@ name: cypress integration tests
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Log Actor
         run: echo "${{ github.actor }}"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-11

### Summary

Dependabot was added to duos-ui before there was a way for Dependabot to access repository secrets. The workaround was to skip UI integration tests in Dependabot PRs, along with any other task requiring secret access.

Once the changes from https://github.com/broadinstitute/terraform-ap-deployments/pull/1486 we can change PR checks so that they all run on Dependabot PRs.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
