### PR TITLE
[DUOS-2933][risk=no] Update to use V4 algorithm

### DIFF
--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -345,9 +345,9 @@ export const DatasetUpdate = (props) => {
         />
         <FormField
           type={FormFieldTypes.CHECKBOX}
-          id="nonCommercialUse"
+          id="nonProfitUse"
           toggleText="Non-profit Use Only (NPU)"
-          defaultValue={formData.dataUse.commercialUse === false}
+          defaultValue={formData.dataUse.nonProfitUse === true}
           disabled={true}
         />
         <FormField

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -203,7 +203,7 @@ export const consentTranslations = {
     description: 'Use is limited to genetic studies only',
     type: ControlledAccessType.modifiers,
   },
-  commercialUse: {
+  nonProfitUse: {
     code: 'NPU',
     description: 'Use is limited to non-profit and non-commercial research',
     type: ControlledAccessType.modifiers,
@@ -250,14 +250,6 @@ const getOntologyName = async(urls) => {
 export const processRestrictionStatements = async (key, dataUse) => {
   let resp;
   let value = dataUse[key];
-  /*
-    Due to language used with Data Use Limitations, the description for 'commercialUse' describes non-profit status
-    whereas the actual value represent for-profit status. As such, commercialUse value must be inverted when processing statement
-    in order to accurately reflect description
-  */
-  if (key === 'commercialUse' && !isNil(value)) {
-    value = !value;
-  }
   if (!isNil(value) && value) {
     if (key === 'diseaseRestrictions') {
       //condition for datasets that have ontology labels contained within the dataUse object

--- a/src/pages/ConsentTextGenerator.jsx
+++ b/src/pages/ConsentTextGenerator.jsx
@@ -43,7 +43,7 @@ export default function ConsentTextGenerator() {
   const generateHelper = async () => {
     const dataUse = {
       generalUse: general, diseaseRestrictions: ontologies, populationOriginsAncestry: null,
-      hmbResearch: hmb, methodsResearch: nmds, geneticStudiesOnly: gso, commercialUse: npu,
+      hmbResearch: hmb, methodsResearch: nmds, geneticStudiesOnly: gso, nonProfitUse: npu,
       publicationResults: pub, collaboratorRequired: col, ethicsApprovalRequired: irb,
       geographicalRestrictions: gs
     };

--- a/src/pages/DatasetRegistration.js
+++ b/src/pages/DatasetRegistration.js
@@ -183,7 +183,7 @@ class DatasetRegistration extends Component {
     let ethics = dataUse.ethicsApprovalRequired;
     let geographic = dataUse.geographicalRestrictions;
     let moratorium = dataUse.publicationMoratorium;
-    let nonProfit = fp.isNil(dataUse.commercialUse) ? false : !dataUse.commercialUse;
+    let nonProfit = dataUse.nonProfitUse;
     let hmb = dataUse.hmbResearch;
     // if the dataset's POA value is set to false, we need to check the NPOA (or NOT POA) option
     // if the dataset's POA value is set to true, leave this unchecked
@@ -635,7 +635,7 @@ class DatasetRegistration extends Component {
       result.populationOriginsAncestry = false;
     }
     if (data.nonProfit) {
-      result.commercialUse = !data.nonProfit;
+      result.nonProfitUse = data.nonProfit;
     }
     if (data.hmb) {
       result.hmbResearch = data.hmb;

--- a/src/pages/data_submission/DataAccessGovernance.js
+++ b/src/pages/data_submission/DataAccessGovernance.js
@@ -140,7 +140,7 @@ export const DataAccessGovernance = (props) => {
           irb: dataUse.ethicsApprovalRequired,
           gs: dataUse.geographicalRestrictions,
           mor: dataUse.publicationMoratorium,
-          npu: dataUse.commercialUse,
+          npu: dataUse.nonProfitUse,
           otherSecondary: dataUse.secondaryOther,
           url: extract('URL', dataset),
           dataLocation: extract('Data Location', dataset),

--- a/src/utils/BucketUtils.js
+++ b/src/utils/BucketUtils.js
@@ -353,11 +353,9 @@ const createRpVoteStructureFromBuckets = (buckets) => {
 
 /**
  * Constrain the equality check to a limited number of fields. These
- * fields are the ones that are used in algorithm decisions and are what
+ * fields are the ones that are used in the v4 algorithm decisions and are what
  * determine whether it falls into a Data Use bucket. We limit the fields
- * because there are quite a few that have no impact on decision-making.
- * Fields like recontactMay and recontactMust, and others, are not relevant
- * to DAC decisions.
+ * because there are several captured values that have no impact on decision-making.
  *
  * @public
  * @param a Data Use
@@ -365,32 +363,32 @@ const createRpVoteStructureFromBuckets = (buckets) => {
  * @returns {boolean}
  */
 export const isEqualDataUse = (a, b) => {
-  const fields = ['addiction',
-    'aggregateResearch',
-    'collaboratorRequired',
-    'controlSetOption',
-    'ethicsApprovalRequired',
-    'gender',
-    'geneticStudiesOnly',
-    'geographicalRestrictions',
-    'illegalBehavior',
-    'manualReview',
+  const fields = [
+    'generalUse',
+    'hmbResearch',
+    'diseaseRestrictions',
+    'populationOriginsAncestry',
     'methodsResearch',
-    'nonBiomedical',
+    'nonProfitUse',
     'other',
-    'otherRestrictions',
-    'pediatric',
-    'psychologicalTraits',
-    'publicationResults',
     'secondaryOther',
+    'ethicsApprovalRequired',
+    'collaboratorRequired',
+    'geographicalRestrictions',
+    'geneticStudiesOnly',
+    'publicationResults',
+    'publicationMoratorium',
+    'controls',
+    'gender',
+    'pediatric',
+    'population',
+    'illegalBehavior',
     'sexualDiseases',
     'stigmatizeDiseases',
     'vulnerablePopulations',
-    'commercialUse',
-    'diseaseRestrictions',
-    'generalUse',
-    'hmbResearch',
-    'populationOriginsAncestry'];
+    'psychologicalTraits',
+    'notHealth'
+  ];
   const aCopy = pick(fields)(a);
   const bCopy = pick(fields)(b);
   return isEqual(aCopy)(bCopy);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2933

### Summary
* Remove usages of commercial use
* Replace with non profit use where appropriate
* Use [V4 algorithm](https://github.com/DataBiosphere/consent-ontology/blob/develop/docs/Algorithms.md#version-4) fields for data use bucketing purposes
* See also this back end PR: https://github.com/DataBiosphere/consent/pull/2286

### Testing Notes
Testing this is a bit challenging as there are no NPU datasets in dev. I suggest the following steps:
1. Find a DAR that hits multiple datasets
2. Use the **PUT** `/api/dataset/{id}/datause` endpoint to modify your selected datasets with a data use that looks like this: `{ "generalUse": true, "nonProfitUse": true }`
3. Use the **POST** `/api/match/reprocess/purpose/{purposeId}` endpoint with your DAR reference id to reprocess the algorithm decisions for the new data uses on the modified datasets
4. View the dar collection in the admin or chairperson view to see the data use buckets. They should appropriately show NPU for the modified datasets.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
