### PR TITLE
[DUOS-3057][risk=no] Typo in the DUOS Header Component

### DIFF
--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -160,7 +160,7 @@ const NavigationTabsComponent = (props) => {
       <ul className="navbar-main">
         <div style={{ width: '100%', display: 'flex', justifyContent: 'flex-start', alignItems: 'center' }}>
           {
-            orientation === 'horizonal' && (
+            orientation === 'horizontal' && (
               <Link
                 id="link_logo"
                 to="/home"


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-3057

### Summary

- Fixes a typo in the DUOS Header Component.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
