### PR TITLE
[DUOS-2912][risk=no] Add safety check to error reports

### DIFF
--- a/src/libs/stackdriverReporter.js
+++ b/src/libs/stackdriverReporter.js
@@ -45,7 +45,7 @@ export const StackdriverReporter = {
     try {
       await errorHandler.report(formattedMsg);
     } catch (error) {
-      //
+      // swallow error to avoid user visible errors
     }
   },
 

--- a/src/libs/stackdriverReporter.js
+++ b/src/libs/stackdriverReporter.js
@@ -42,7 +42,11 @@ export const StackdriverReporter = {
     const user = Storage.getCurrentUser();
     const formattedMsg = await StackdriverReporter.format(msg);
     errorHandler.setUser(ld.get(user, 'email', 'anonymous'));
-    errorHandler.report(formattedMsg);
+    try {
+      await errorHandler.report(formattedMsg);
+    } catch (error) {
+      //
+    }
   },
 
   format: async (msg) => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DUOS-2912

### Summary
Minor update to prevent UI errors when the sending of a stackdriver error report fails.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
