### PR TITLE
[DUOS-3067] Group GitHub Action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       - "@DataBiosphere/DUOS"
     commit-message:
       prefix: "[DUOS-1740-actions]"
+    groups:
+      action-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     reviewers:
       - "@DataBiosphere/DUOS"
     commit-message:
-      prefix: "[DUOS-1740-dependabot]"
+      prefix: "[DUOS-1740-actions]"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -22,7 +22,7 @@ updates:
       - "dependency"
       - "npm"
     commit-message:
-      prefix: "[DUOS-1740-dependabot]"
+      prefix: "[DUOS-1740-npm]"
     groups:
       npm-dependencies:
         patterns:
@@ -39,7 +39,7 @@ updates:
       - "dependency"
       - "docker"
     commit-message:
-      prefix: "[DUOS-1740-dependabot]"
+      prefix: "[DUOS-1740-docker]"
     groups:
       docker-dependencies:
         patterns:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DUOS-3067

### Summary

To avoid being swamped with GitHub Action updates, group these like we do NPM and Docker updates.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
