### PR TITLE
[DCJ-28][risk=no] Remove Slack notification on develop branch builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,17 +57,6 @@ jobs:
       run: |
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}
-    - name: Notify Slack
-      # only notify for develop branch build
-      if: github.event_name == 'push'
-      uses: broadinstitute/action-slack@v3.15.0
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        status: ${{ job.status }}
-        channel: "#duos-notifications"
-        fields: repo,commit,author,action,eventName,ref,workflow,job,took
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: [tag-build-push]


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-28

### Summary

This was the only Slack alert emitted by the GHAs in this repo.

We get insight into deployment status from an existing [Beehive Slack deploy hook on duos-dev](https://beehive.dsp-devops.broadinstitute.org/environments/dev/chart-releases/duos/deploy-hooks/slack/24), but we should repoint this alert to the DCJ channel.

More complete background: https://github.com/DataBiosphere/jade-data-repo/pull/1654

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
