### PR TITLE
[DUOS-3051][DCJ-94][risk=no] Fix bucket data use logic

### DIFF
--- a/cypress/component/utils/bucket_utils.spec.js
+++ b/cypress/component/utils/bucket_utils.spec.js
@@ -980,8 +980,8 @@ describe('BucketUtils', () => {
     // The provided dar collection should have 1 RP bucket and 3 Data Use buckets
     expect(buckets.length).to.eq(4);
     expect(buckets[0].isRP).to.eq(true);
-    expect(buckets[1].isRP).to.eq(undefined);
     // HMB + Other
+    expect(buckets[1].isRP).to.eq(undefined);
     expect(buckets[1].dataUse.hmbResearch).to.eq(true);
     expect(buckets[1].dataUse.other).to.not.be.empty;
     // General Use

--- a/cypress/component/utils/bucket_utils.spec.js
+++ b/cypress/component/utils/bucket_utils.spec.js
@@ -980,6 +980,17 @@ describe('BucketUtils', () => {
     // The provided dar collection should have 1 RP bucket and 3 Data Use buckets
     expect(buckets.length).to.eq(4);
     expect(buckets[0].isRP).to.eq(true);
+    expect(buckets[1].isRP).to.eq(undefined);
+    // HMB + Other
+    expect(buckets[1].dataUse.hmbResearch).to.eq(true);
+    expect(buckets[1].dataUse.other).to.not.be.empty;
+    // General Use
+    expect(buckets[2].isRP).to.eq(undefined);
+    expect(buckets[2].dataUse.generalUse).to.eq(true);
+    // HMB
+    expect(buckets[3].isRP).to.eq(undefined);
+    expect(buckets[3].dataUse.hmbResearch).to.eq(true);
+    expect(buckets[3].dataUse.other).to.eq(undefined);
   });
 
 });

--- a/cypress/component/utils/bucket_utils.spec.js
+++ b/cypress/component/utils/bucket_utils.spec.js
@@ -589,7 +589,6 @@ describe('BucketUtils', () => {
       {'generalUse': true, 'manualReview': true},
       {'generalUse': true, 'nonBiomedical': true},
       {'generalUse': true, 'other': 'true'},
-      {'generalUse': true, 'otherRestrictions': true},
       {'generalUse': true, 'pediatric': true},
       {'generalUse': true, 'psychologicalTraits': true},
       {'generalUse': true, 'publicationResults': true},

--- a/cypress/component/utils/bucket_utils.spec.js
+++ b/cypress/component/utils/bucket_utils.spec.js
@@ -601,4 +601,385 @@ describe('BucketUtils', () => {
       expect(shouldAbstain(d)).to.eq(true);
     })(dataUses);
   });
+
+  it('correctly buckets data uses when there are similar data use entries', async () => {
+    cy.stub(Match, 'findMatchBatch').returns(match_results);
+    const collection = {
+      'darCollectionId': 1,
+      'darCode': 'DAR-001',
+      'dars': {
+        'dar-reference-id-1': {
+          'id': 1,
+          'referenceId': 'dar-reference-id-1',
+          'collectionId': 1,
+          'elections': {
+            '1': {
+              'electionId': 1,
+              'electionType': 'DataAccess',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 1,
+              'votes': {
+                '1': {
+                  'voteId': 1,
+                  'userId': 1,
+                  'electionId': 1,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '2': {
+                  'voteId': 2,
+                  'userId': 1,
+                  'electionId': 1,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '3': {
+                  'voteId': 3,
+                  'userId': 1,
+                  'electionId': 1,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '2': {
+              'electionId': 2,
+              'electionType': 'RP',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 1,
+              'votes': {
+                '4': {
+                  'voteId': 4,
+                  'userId': 1,
+                  'electionId': 2,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '5': {
+                  'voteId': 5,
+                  'userId': 1,
+                  'electionId': 2,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '6': {
+                  'voteId': 6,
+                  'userId': 1,
+                  'electionId': 2,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '3': {
+              'electionId': 3,
+              'electionType': 'DataAccess',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 2,
+              'votes': {
+                '11': {
+                  'voteId': 11,
+                  'userId': 1,
+                  'electionId': 3,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '22': {
+                  'voteId': 22,
+                  'userId': 1,
+                  'electionId': 3,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '33': {
+                  'voteId': 33,
+                  'userId': 1,
+                  'electionId': 3,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '4': {
+              'electionId': 4,
+              'electionType': 'RP',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 2,
+              'votes': {
+                '44': {
+                  'voteId': 44,
+                  'userId': 1,
+                  'electionId': 4,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '55': {
+                  'voteId': 55,
+                  'userId': 1,
+                  'electionId': 4,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '66': {
+                  'voteId': 66,
+                  'userId': 1,
+                  'electionId': 4,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '5': {
+              'electionId': 5,
+              'electionType': 'DataAccess',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 3,
+              'votes': {
+                '111': {
+                  'voteId': 111,
+                  'userId': 1,
+                  'electionId': 3,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '222': {
+                  'voteId': 222,
+                  'userId': 1,
+                  'electionId': 5,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '333': {
+                  'voteId': 333,
+                  'userId': 1,
+                  'electionId': 5,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '6': {
+              'electionId': 6,
+              'electionType': 'RP',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 3,
+              'votes': {
+                '444': {
+                  'voteId': 444,
+                  'userId': 1,
+                  'electionId': 6,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '555': {
+                  'voteId': 555,
+                  'userId': 1,
+                  'electionId': 6,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '666': {
+                  'voteId': 666,
+                  'userId': 1,
+                  'electionId': 6,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '7': {
+              'electionId': 7,
+              'electionType': 'DataAccess',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 4,
+              'votes': {
+                '1111': {
+                  'voteId': 1111,
+                  'userId': 1,
+                  'electionId': 7,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '2222': {
+                  'voteId': 2222,
+                  'userId': 1,
+                  'electionId': 7,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '3333': {
+                  'voteId': 3333,
+                  'userId': 1,
+                  'electionId': 7,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '8': {
+              'electionId': 8,
+              'electionType': 'RP',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 4,
+              'votes': {
+                '4444': {
+                  'voteId': 4444,
+                  'userId': 1,
+                  'electionId': 8,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '5555': {
+                  'voteId': 5555,
+                  'userId': 1,
+                  'electionId': 8,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '6666': {
+                  'voteId': 6666,
+                  'userId': 1,
+                  'electionId': 8,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '9': {
+              'electionId': 9,
+              'electionType': 'DataAccess',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 5,
+              'votes': {
+                '11111': {
+                  'voteId': 11111,
+                  'userId': 1,
+                  'electionId': 9,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '22222': {
+                  'voteId': 22222,
+                  'userId': 1,
+                  'electionId': 9,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '33333': {
+                  'voteId': 33333,
+                  'userId': 1,
+                  'electionId': 9,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            },
+            '10': {
+              'electionId': 10,
+              'electionType': 'RP',
+              'referenceId': 'dar-reference-id-1',
+              'dataSetId': 5,
+              'votes': {
+                '44444': {
+                  'voteId': 44444,
+                  'userId': 1,
+                  'electionId': 10,
+                  'rationale': '',
+                  'type': 'Chairperson',
+                  'displayName': 'User 1'
+                },
+                '55555': {
+                  'voteId': 55555,
+                  'userId': 1,
+                  'electionId': 10,
+                  'rationale': '',
+                  'type': 'DAC',
+                  'displayName': 'User 1'
+                },
+                '66666': {
+                  'voteId': 66666,
+                  'userId': 1,
+                  'electionId': 10,
+                  'rationale': '',
+                  'type': 'Final',
+                  'displayName': 'User 1'
+                }
+              }
+            }
+          },
+          'datasetIds': [1, 2, 3, 4, 5]
+        }
+      },
+      'datasets': [
+        {
+          'dataSetId': 1,
+          'datasetName': 'ds 1',
+          'datasetIdentifier': 'DUOS-000001',
+          'dataUse': {'hmbResearch': true, 'other': 'Samples and information may not be sold for profit.'},
+          'dacId': 1
+        },
+        {
+          'dataSetId': 2,
+          'datasetName': 'ds 2',
+          'datasetIdentifier': 'DUOS-000002',
+          'dataUse': {'generalUse': true},
+          'dacId': 2
+        },
+        {
+          'dataSetId': 3,
+          'datasetName': 'ds 3',
+          'datasetIdentifier': 'DUOS-000003',
+          'dataUse': {'hmbResearch': true},
+          'dacId': 3
+        },
+        {
+          'dataSetId': 4,
+          'datasetName': 'ds 4',
+          'datasetIdentifier': 'DUOS-000004',
+          'dataUse': {'generalUse': true},
+          'dacId': 4
+        },
+        {
+          'dataSetId': 5,
+          'datasetName': 'ds 5',
+          'datasetIdentifier': 'DUOS-000005',
+          'dataUse': {'hmbResearch': true},
+          'dacId': 5
+        }
+      ],
+    };
+    const buckets = await binCollectionToBuckets(collection);
+    expect(buckets).to.not.be.empty;
+    // The provided dar collection should have 1 RP bucket and 3 Data Use buckets
+    expect(buckets.length).to.eq(4);
+    expect(buckets[0].isRP).to.eq(true);
+  });
+
 });

--- a/src/utils/BucketUtils.js
+++ b/src/utils/BucketUtils.js
@@ -272,10 +272,9 @@ const processV3Abstain = (matchResults) => {
  * @returns boolean
  */
 const isOther = (dataUse) => {
-  const otherRestrictions = getOr(false)('otherRestrictions')(dataUse);
   const primaryOther = !isEmpty(getOr('')('other')(dataUse));
   const secondaryOther = !isEmpty(getOr('')('secondaryOther')(dataUse));
-  return otherRestrictions || primaryOther || secondaryOther;
+  return primaryOther || secondaryOther;
 };
 
 /**

--- a/src/utils/BucketUtils.js
+++ b/src/utils/BucketUtils.js
@@ -2,7 +2,6 @@ import {
   any,
   compact,
   filter,
-  findIndex,
   flatMap,
   flow,
   forEach,
@@ -99,7 +98,7 @@ export const binCollectionToBuckets = async (collection, dacIds = []) => {
 
     // Step 1.b: Populate translated dataUses
     if (dataset.dataUse) {
-      const index = findIndex(dataset.dataUse)(rawDataUses);
+      const index = rawDataUses.findIndex(du => du === dataset.dataUse);
       if (index >= 0 && !isUndefined(flatTranslatedDataUses[index])) {
         bucket.dataUses = flatTranslatedDataUses[index];
       }


### PR DESCRIPTION
### Addresses
* https://broadworkbench.atlassian.net/browse/DUOS-3051
* https://broadworkbench.atlassian.net/browse/DCJ-94

### Summary
Fixes a bug where the bucketing logic would choose an incorrect data use for a bucket when using lodash fp's `findIndex` method. For example, in the production scenario, these are all of the data uses:
```
[
  {"hmbResearch": true, "other": "Samples and information may not be sold for profit."},
  {"generalUse": true},
  {"hmbResearch": true},
  {"generalUse": true},
  {"hmbResearch": true}
]
```
When looking for `{"hmbResearch": true}`, the index returned was `0` which is incorrect. I believe the `findIndex` method was only looking at the first element of the the term instead of fully matching the term against the array elements. The fix here is to use the native `Array.findIndex` method with a full object equality check which returns the correct index, `2`.

Additionally, this PR removes the outdated `otherRestrictions` data use condition which we no longer use.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
