### PR TITLE
[DCJ-110] Workaround which sets viewport size to avoid error

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -315,6 +315,8 @@ describe('MultiDatasetVoteSlab - Tests', function() {
   });
 
   it('Does not render rows of vote summary table for votes outside of dac for current user', function() {
+    // workaround so that notifications don't overlap the clicked buttons and cause an error
+    cy.viewport(1024, 768);
     mount(
       <MultiDatasetVoteSlab
         title={'GROUP 1'}
@@ -338,6 +340,8 @@ describe('MultiDatasetVoteSlab - Tests', function() {
   });
 
   it('Renders collapsed row of vote summary table when the same user has same vote for multiple elections', function() {
+    // workaround so that notifications don't overlap the clicked buttons and cause an error
+    cy.viewport(1024, 768);
     mount(
       <MultiDatasetVoteSlab
         title={'GROUP 1'}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-110

### Summary

Fixes flaky tests with a workaround which sets the viewport size so that notifications don't overlap the clicked buttons and cause an error.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
