### PR TITLE
[DCJ-235] Remove individual researcher calls to populate DAA IDs

### DIFF
--- a/src/pages/signing_official_console/ManageResearcherDAAs.jsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAs.jsx
@@ -26,15 +26,7 @@ export default function ManageResearcherDAAs() {
         const daaList = await DAA.getDaas();
         const dacList = await DAC.list();
 
-        // the construction of this list is currently a work-around because our endpoint in the backend
-        // does not currently populate the DAA IDs on the each researcher's libary card
-        const researcherObjectList = await Promise.all(
-          researcherList.map(async (researcher) => {
-            return await User.getById(researcher.userId);
-          })
-        );
-
-        setResearchers(researcherObjectList);
+        setResearchers(researcherList);
         setSigningOfficial(soUser);
         setDaas(daaList);
         setDacs(dacList);

--- a/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
@@ -53,14 +53,7 @@ const researcherFilterFunction = getSearchFilterFunctions().signingOfficialResea
 
 const refreshResearchers = async (setResearchers) => {
   const researcherList = await User.list(USER_ROLES.signingOfficial);
-  // the construction of this list is currently a work-around because our endpoint in the backend
-  // does not currently populate the DAA IDs on the each researcher's libary card
-  const researcherObjectList = await Promise.all(
-    researcherList.map(async (researcher) => {
-      return await User.getById(researcher.userId);
-    })
-  );
-  setResearchers(researcherObjectList);
+  setResearchers(researcherList);
 };
 
 const displayNameCell = (displayName, email, id, daas, setResearchers) => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-235

### Summary
Removes the previously implemented work-around to populate the DAA IDs on the researchers now that the backend researcher list endpoint populates those IDs on the researchers itself.

Note: this PR depends on [this corresponding PR](https://github.com/DataBiosphere/consent/pull/2328).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
