### PR TITLE
[WIP][risk=no] Add tests for Schema api

### DIFF
--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -10,6 +10,8 @@ jobs:
         uses: actions/checkout@v4
       - name: NPM Install
         run: npm ci
+      - name: Cypress info
+        run: npx cypress info
       - name : Cypress run component tests
         uses: cypress-io/github-action@v6
         with:

--- a/cypress/component/unit/ajax/Schema.spec.ts
+++ b/cypress/component/unit/ajax/Schema.spec.ts
@@ -1,0 +1,33 @@
+/* eslint-disable no-undef */
+import {Config} from '../../../../src/libs/config';
+import {Schema} from '../../../../src/libs/ajax/Schema';
+
+describe('Schema', () => {
+  beforeEach(() => {
+    cy.stub(Config, 'getApiUrl').resolves('http://localhost');
+  });
+  describe('schemas/schemas/dataset-registration/v1', () => {
+    it('Successfully GETs a dataset registration schema', () => {
+      cy.intercept('GET', '/schemas/dataset-registration/v1', {statusCode: 200, body: '{"schema":true}'}).as('schema');
+      Schema.datasetRegistrationV1();
+      cy.wait('@schema').then((interception) => {
+        expect(interception.request.headers.authorization).to.not.be.null;
+        expect(interception.request.headers['x-app-id']).to.not.be.null;
+        expect(interception.response.statusCode).to.eq(200);
+      });
+    });
+    describe('Error Cases', () => {
+      [400, 404, 500].forEach((code) => {
+        it(`${code}`, () => {
+          cy.intercept('GET', '/schemas/dataset-registration/v1', {statusCode: code}).as('schema');
+          Schema.datasetRegistrationV1().then((response) => {
+            expect(response).to.be.null;
+          }).catch((err) => {
+            expect(err.response.status.to.eq(code));
+            expect(err).to.not.be.null;
+          });
+        });
+      });
+    });
+  });
+});

--- a/cypress/component/unit/ajax/Schema.spec.ts
+++ b/cypress/component/unit/ajax/Schema.spec.ts
@@ -4,7 +4,7 @@ import {Schema} from '../../../../src/libs/ajax/Schema';
 
 describe('Schema', () => {
   beforeEach(() => {
-    cy.stub(Config, 'getApiUrl').resolves('http://localhost:3000/');
+    cy.stub(Config, 'getApiUrl').resolves(Cypress.env().baseUrl);
   });
   describe('Tests for /schemas/dataset-registration/v1', () => {
     it('Successfully GETs a dataset registration schema', () => {

--- a/cypress/component/unit/ajax/Schema.spec.ts
+++ b/cypress/component/unit/ajax/Schema.spec.ts
@@ -4,7 +4,7 @@ import {Schema} from '../../../../src/libs/ajax/Schema';
 
 describe('Schema', () => {
   beforeEach(() => {
-    cy.stub(Config, 'getApiUrl').resolves('http://localhost');
+    cy.stub(Config, 'getApiUrl').resolves('http://127.0.0.1');
   });
   describe('schemas/schemas/dataset-registration/v1', () => {
     it('Successfully GETs a dataset registration schema', () => {

--- a/cypress/component/unit/ajax/Schema.spec.ts
+++ b/cypress/component/unit/ajax/Schema.spec.ts
@@ -4,7 +4,7 @@ import {Schema} from '../../../../src/libs/ajax/Schema';
 
 describe('Schema', () => {
   beforeEach(() => {
-    cy.stub(Config, 'getApiUrl').resolves('http://127.0.0.1');
+    cy.stub(Config, 'getApiUrl').resolves('http://localhost:3000/');
   });
   describe('Tests for /schemas/dataset-registration/v1', () => {
     it('Successfully GETs a dataset registration schema', () => {

--- a/cypress/component/unit/ajax/Schema.spec.ts
+++ b/cypress/component/unit/ajax/Schema.spec.ts
@@ -6,7 +6,7 @@ describe('Schema', () => {
   beforeEach(() => {
     cy.stub(Config, 'getApiUrl').resolves('http://127.0.0.1');
   });
-  describe('schemas/schemas/dataset-registration/v1', () => {
+  describe('Tests for /schemas/dataset-registration/v1', () => {
     it('Successfully GETs a dataset registration schema', () => {
       cy.intercept('GET', '/schemas/dataset-registration/v1', {statusCode: 200, body: '{"schema":true}'}).as('schema');
       Schema.datasetRegistrationV1();


### PR DESCRIPTION
### Addresses
WIP

### Summary
Add tests for the Schema api file

Example of successful local runs:
![Screenshot 2024-05-16 at 9 14 37 AM](https://github.com/DataBiosphere/duos-ui/assets/116679/199891c0-65e5-4192-a87c-e419c089ebcd)

### Debugging Notes

Example failure:
```
  1) Schema
       Tests for /schemas/dataset-registration/v1
         Successfully GETs a dataset registration schema:
     CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms` for the 1st request to the route: `schema`. No request ever occurred.
```

1. Changed `localhost` to `127.0.0.1` based on [this thread](https://github.com/cypress-io/github-action/issues/534), but no luck.
2. Changed `apiUrl` to match `cypress.config.js`: `env.baseUrl`, but no luck.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
