### PR TITLE
[DCJ-378] Fix spread using props

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -362,6 +362,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
   });
 
   it('Renders collapsed row with appended rationales when the same user has same vote but different rationales for multiple elections', function() {
+    cy.viewport(1024, 768);
     mount(
       <MultiDatasetVoteSlab
         title={'GROUP 1'}

--- a/src/components/SimpleButton.jsx
+++ b/src/components/SimpleButton.jsx
@@ -26,6 +26,7 @@ export default function SimpleButton(props) {
   const { onClick, label, disabled, baseColor, additionalStyle, keyProp, hoverStyle = {}} = props;
   const backgroundColor = props.backgroundColor || baseColor || 'rgb(0, 96, 159)';
   const fontColor = props.fontColor || 'white';
+  const keyId = keyProp || `${label}-button`;
   const [style, setStyle] = useState({});
 
   useEffect(() => {
@@ -35,8 +36,6 @@ export default function SimpleButton(props) {
   const getDivAttributes = (disabled) => {
     const baseAttributes = {
       style,
-      key: keyProp || `${label}-button`,
-      id: keyProp || `${label}-button`,
       onClick: () => !disabled && onClick(),
       onMouseEnter: () =>
         !disabled && updateStyle({backgroundColor: hoverStyle.backgroundColor || backgroundColor, fontColor: hoverStyle.color || fontColor, additionalStyle, pointerBool: true, disabled, setStyle}),
@@ -47,7 +46,7 @@ export default function SimpleButton(props) {
   };
 
   return (
-    <button {...getDivAttributes(disabled)}>
+    <button key={keyId} id={keyId} {...getDivAttributes(disabled)}>
       {label}
     </button>
   );

--- a/src/components/TableIconButton.jsx
+++ b/src/components/TableIconButton.jsx
@@ -48,7 +48,7 @@ export default function TableIconButton(props) {
   //NOTE: span wrapper is needed for svg child elements due to flaky behavior onMouseEnter and onMouseLeave
   // https://github.com/facebook/react/issues/4492 --> NOTE: though the issue is from the React repo, the bug is tied to browser specs, NOT React
   return (
-    <span {...attributes}>
+    <span key={keyProp} {...attributes}>
       {isRendered && !isNil(Icon) && (
         <Icon style={appliedStyle} className={classes.root} />
       )}

--- a/src/components/TableTextButton.jsx
+++ b/src/components/TableTextButton.jsx
@@ -28,6 +28,6 @@ export default function TableTextButton(props) {
   const style = setStyle(disabled, baseStyle, 'backgroundColor');
   const divAttributes = setDivAttributes(disabled, onClick, style, dataTip, onMouseEnter, onMouseLeave, keyProp);
   return (
-    <div {...divAttributes}>{label}</div>
+    <div key={keyProp} {...divAttributes}>{label}</div>
   );
 }

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -546,12 +546,12 @@ export const setStyle = (disabled, baseStyle, targetColorAttribute) => {
   }
 };
 
-export const setDivAttributes = (disabled, onClick, style, dataTip, onMouseEnter, onMouseLeave, key) => {
+export const setDivAttributes = (disabled, onClick, style, dataTip, onMouseEnter, onMouseLeave, id) => {
   let attributes;
   if (!disabled) {
-    attributes = {onClick, onMouseEnter, onMouseLeave, style, 'data-tip': dataTip, key, id: key};
+    attributes = {onClick, onMouseEnter, onMouseLeave, style, 'data-tip': dataTip, id};
   } else {
-    attributes = {style, disabled, 'data-tip': dataTip, key};
+    attributes = {style, disabled, 'data-tip': dataTip};
   }
   if (!isEmpty(dataTip)) {
     attributes['data-tip'] = dataTip;


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-378

### Summary

We have a few components where we try to spread `props` that include a `key` onto the component, but this is not valid React. The key should be set directly on the component.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
