### PR TITLE
[DCJ-179] Completely remove `react-hyperscript-helpers`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "react-dropzone": "14.2.3",
         "react-ga4": "2.1.0",
         "react-google-charts": "4.0.1",
-        "react-hyperscript-helpers": "2.0.0",
         "react-markdown": "9.0.1",
         "react-material-icon-svg": "3.20.0",
         "react-modal": "3.16.1",
@@ -18574,14 +18573,6 @@
         "react-dom": ">=16.3.0"
       }
     },
-    "node_modules/react-hyperscript-helpers": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hyperscript-helpers/-/react-hyperscript-helpers-2.0.0.tgz",
-      "integrity": "sha512-nkWZ7GBDGD4qWnIJo+/gF+tjW9lY6rKMOie/OP03rWYyGNrb1SreiPgcaBsZ2VPQkZ1uUgruKXpRql+LjbsogA==",
-      "peerDependencies": {
-        "react": ">=0.13.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -36298,12 +36289,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.1.tgz",
       "integrity": "sha512-V/hcMcNuBgD5w49BYTUDye+bUKaPmsU5vy/9W/Nj2xEeGn+6/AuH9IvBkbDcNBsY00cV9OeexdmgfI5RFHgsXQ==",
-      "requires": {}
-    },
-    "react-hyperscript-helpers": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hyperscript-helpers/-/react-hyperscript-helpers-2.0.0.tgz",
-      "integrity": "sha512-nkWZ7GBDGD4qWnIJo+/gF+tjW9lY6rKMOie/OP03rWYyGNrb1SreiPgcaBsZ2VPQkZ1uUgruKXpRql+LjbsogA==",
       "requires": {}
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-dropzone": "14.2.3",
     "react-ga4": "2.1.0",
     "react-google-charts": "4.0.1",
-    "react-hyperscript-helpers": "2.0.0",
     "react-markdown": "9.0.1",
     "react-material-icon-svg": "3.20.0",
     "react-modal": "3.16.1",

--- a/src/react-hyperscript-helpers.d.ts
+++ b/src/react-hyperscript-helpers.d.ts
@@ -1,1 +1,0 @@
-declare module 'react-hyperscript-helpers';


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-179

### Summary

Now that https://github.com/DataBiosphere/duos-ui/pull/2582 has gone in, we can completely remove `react-hyperscript-helpers`.

#### Background

This is the final piece of a conversion process that began in November of 2023.

The DUOS (now Data Custodian Journeys, or DCJ) team has been participating in the Terra UI working group meetings and aligning the DUOS UI codebase with Terra UI best practices where feasible. One of the decision taken by the working group was to migrate away from `react-hyperscript-helpers` to using regular JSX. 

The pros and cons of `react-hyperscript-helpers` have been vigorously debated in the Terra UI working group meetings, but in short the main cons were that the library has not been updated since 2018 and it is a relatively niche library, whereas React examples assume use of JSX or TSX.

For the DCJ team, this is especially important since we are a smaller team and have a lot of co-ops with React and JSX experience but not `react-hyperscript-helpers` experience, so this increases onramp time. The removal of outdated libraries from our UI is also important to lower our complexity, dependency churn, and our security upkeep burden.

#### Acknowledgements 

A huge thanks to all the teammates who participated in migrating over these components to JSX, especially @PintoGideon who converted some of our largest and most challenging components.

#### Statistics

By the numbers, this represents:

- 125 components migrated over to JSX
- 22516 total lines converted
- 33 PRs to migrate various components
- 1.02 components migrated per working day

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
