### PR TITLE
DCJ-367: Link to data library instead of old catalog

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -6,7 +6,6 @@ import ManageDac from './pages/manage_dac/ManageDac';
 import ManageEditDac from './pages/manage_dac/ManageEditDac';
 import AdminManageUsers from './pages/AdminManageUsers';
 import DataAccessRequestApplication from './pages/dar_application/DataAccessRequestApplication';
-import DatasetCatalog from './pages/DatasetCatalog';
 import DACDatasets from './pages/DACDatasets';
 import DatasetRegistration from './pages/DatasetRegistration';
 import Home from './pages/Home';
@@ -98,7 +97,6 @@ const Routes = (props) => (
     <AuthenticatedRoute path="/admin_manage_lc/" component={AdminManageLC} props={props} rolesAllowed={[USER_ROLES.admin]} />
     <AuthenticatedRoute path="/admin_manage_dar_collections/" component={AdminManageDarCollections} props={props} rolesAllowed={[USER_ROLES.admin]} />
     {checkEnv(envGroups.NON_STAGING) && <AuthenticatedRoute path="/dataset_catalog/:variant" component={CustomDatasetCatalog} props={props} rolesAllowed={[USER_ROLES.researcher]}/>}
-    <AuthenticatedRoute path="/dataset_catalog" component={DatasetCatalog} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/datalibrary/:query" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/datalibrary" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/dataset/:datasetIdentifier" component={DatasetStatistics} props={props} rolesAllowed={[USER_ROLES.all]} />

--- a/src/assets/DPA.md
+++ b/src/assets/DPA.md
@@ -9,8 +9,8 @@ to Broad’s mission and consistent with its tax-exempt status. Through its Data
 registers and enables widespread access to various types of data and materials, including genomic and imaging data to
 promote global scientific and genomic research. Per these terms and conditions  (this “Agreement”), Broad allows the
 Data Submitter, an institution, to register Data in DUOS and issue permissions to the Data Submitter’s Authorized
-Submission Representatives  (defined below) to register and submit datasets in the DUOS Dataset Catalog (***see***
-**https://duos.broadinstitute.org/dataset_catalog**, the “Application”) at such Authorized Submission Representatives’
+Submission Representatives  (defined below) to register and submit datasets in the DUOS Dataset Library (***see***
+**https://duos.broadinstitute.org/datalibrary**, the “Application”) at such Authorized Submission Representatives’
 discretion and provided further, the Data Submitter is and remains responsible for its compliance with this Agreement
 and for compliance herewith by its Authorized Submission Representatives.\
 \

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -82,7 +82,7 @@ export const headerTabsConfig = [
     link: '/admin_manage_dar_collections',
     children: [
       { label: 'DAR Requests', link: '/admin_manage_dar_collections' },
-      { label: 'Dataset Catalog', link: '/dataset_catalog' },
+      { label: 'Data Library', link: '/datalibrary', search: 'datalibrary' },
       { label: 'DACs', link: '/manage_dac' },
       { label: 'Users', link: '/admin_manage_users' },
       { label: 'Institutions', link: '/admin_manage_institutions' },
@@ -119,16 +119,15 @@ export const headerTabsConfig = [
     search: 'member_console',
     children: [
       { label: 'DAR Requests', link: '/member_console' },
-      { label: 'Datasets', link: '/dataset_catalog' },
+      { label: 'Data Library', link: '/datalibrary', search: 'datalibrary' }
     ],
     isRendered: (user) => user.isMember
   },
   {
     label: 'Researcher Console',
-    link: '/dataset_catalog',
-    search: 'dataset_catalog',
+    link: '/datalibrary',
+    search: 'datalibrary',
     children: [
-      { label: 'Data Catalog', link: '/dataset_catalog' },
       { label: 'Data Library', link: '/datalibrary', search: 'datalibrary' },
       { label: 'DAR Requests', link: '/researcher_console' },
       { label: 'Data Submissions', link: '/dataset_submissions', isRenderedForUser: (user) => user?.isDataSubmitter }

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -101,7 +101,7 @@ export const DatasetUpdate = (props) => {
     multiPartFormData.append('consentGroups', consentGroups);
 
     DataSet.updateDatasetV3(dataset.dataSetId, multiPartFormData).then(() => {
-      history.push('/dataset_catalog');
+      history.push('/datalibrary');
       Notifications.showSuccess({ text: 'Update submitted successfully!' });
     }, () => {
       Notifications.showError({ text: 'Some errors occurred, the dataset was not updated.' });

--- a/src/pages/StudyUpdateForm.jsx
+++ b/src/pages/StudyUpdateForm.jsx
@@ -207,7 +207,7 @@ export const StudyUpdateForm = (props) => {
     const multiPartFormData = createMultiPartFormData(update);
 
     DataSet.updateStudy(studyId, multiPartFormData).then(() => {
-      history.push('/dataset_catalog');
+      history.push('/datalibrary');
       Notifications.showSuccess({ text: 'Submitted succesfully!' });
     }, (e) => {
       Notifications.showError({ text: 'Could not submit: ' + e?.response?.data?.message || e.message });

--- a/src/pages/data_submission/DataSubmissionForm.jsx
+++ b/src/pages/data_submission/DataSubmissionForm.jsx
@@ -150,7 +150,7 @@ export const DataSubmissionForm = (props) => {
     const multiPartFormData = createMultiPartFormData(registration);
 
     DataSet.registerDataset(multiPartFormData).then(() => {
-      history.push('/dataset_catalog');
+      history.push('/datalibrary');
       Notifications.showSuccess({ text: 'Submitted succesfully!' });
     }, (e) => {
       Notifications.showError({ text: 'Could not submit: ' + e?.response?.data?.message || e.message });


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-367

### Summary
Replace all links to the old catalog page to the new data library page
This PR does not remove the older custom dataset catalog functionality. There are no in-app links to that feature but it has been shared with customers. This should be addressed in a separate ticket as a redirect feature.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
