### PR TITLE
DCJ-516: Use Workload Identity

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
     - id: 'auth'
       if: github.actor != 'dependabot[bot]'
       name: 'Authenticate to Google Cloud'
-      uses: 'google-github-actions/auth@v0'
+      uses: 'google-github-actions/auth@v2'
       with:
         # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
         workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,11 +44,12 @@ jobs:
         .
     - name: Log Github Actor
       run: echo "${{ github.actor }}"
-    - name: Auth to GCR
+    - name: Auth to GCP
       if: github.actor != 'dependabot[bot]'
-      uses: 'google-github-actions/auth@v2'
+      uses: google-github-actions/auth@v2
       with:
-        credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
+        workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+        service_account: 'gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com'
     - name: Auth Docker for GCR
       if: github.actor != 'dependabot[bot]'
       run: gcloud auth configure-docker --quiet

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       sherlock-version: ${{ steps.short-sha.outputs.sha }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -44,12 +47,14 @@ jobs:
         .
     - name: Log Github Actor
       run: echo "${{ github.actor }}"
-    - name: Auth to GCP
+    - id: 'auth'
       if: github.actor != 'dependabot[bot]'
-      uses: google-github-actions/auth@v2
+      name: 'Authenticate to Google Cloud'
+      uses: 'google-github-actions/auth@v0'
       with:
+        # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
         workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-        service_account: 'gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com'
+        service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
     - name: Auth Docker for GCR
       if: github.actor != 'dependabot[bot]'
       run: gcloud auth configure-docker --quiet

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,12 +55,10 @@ jobs:
         # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
         workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
         service_account: 'gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com'
-    - name: Auth Docker for GCR
-      if: github.actor != 'dependabot[bot]'
-      run: gcloud auth configure-docker --quiet
     - name: Push Image to GCR
       if: github.actor != 'dependabot[bot]'
       run: |
+        gcloud auth configure-docker --quiet
         docker push ${{ steps.construct-tags.outputs.sha-tag }}
         docker push ${{ steps.construct-tags.outputs.environment-tag }}
   report-to-sherlock:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
       with:
         # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
         workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
-        service_account: 'gha-iap-accessor@dsp-devops-super-prod.iam.gserviceaccount.com'
+        service_account: 'gcr-publish@broad-dsp-gcr-public.iam.gserviceaccount.com'
     - name: Auth Docker for GCR
       if: github.actor != 'dependabot[bot]'
       run: gcloud auth configure-docker --quiet

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ ca-bundle.crt
 server.crt
 server.key
 site.conf
+
+## GHA Credentials
+gha-creds-*.json


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-516

### Summary
Use Workload Identity to auth to GCR instead of GH secrets

See also:
* https://github.com/DataBiosphere/consent-ontology/pull/975
* https://github.com/DataBiosphere/consent/pull/2361
* https://github.com/broadinstitute/terraform-ap-deployments/pull/1648

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
