### PR TITLE
DCJ-519: Log data library page views

### DIFF
--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -1,8 +1,17 @@
+/*
+ * NOTE: See the Mixpanel guide in the terra-ui GitHub Wiki for more details:
+ *   https://github.com/DataBiosphere/terra-ui/wiki/Mixpanel
+ */
 const eventList = {
   userRegister: 'user:register',
   userSignIn: 'user:signin',
 
   pageView: 'page:view',
+  dataLibrary: 'page:view:dataLibrary',
+  dataLibraryBrand: (brand) => {
+    const cleanKey = brand.replaceAll('/', '');
+    return `page:view:dataLibrary:${cleanKey}`;
+  }
 };
 
 export default eventList;

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -18,6 +18,8 @@ import homeIcon from '../images/icon_dataset_.png';
 import { Storage } from '../libs/storage';
 import { Box, CircularProgress } from '@mui/material';
 import { toLower } from 'lodash';
+import {Metrics} from '../libs/ajax/Metrics';
+import eventList from '../libs/events';
 
 const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery) => {
   const queryChunks = [
@@ -245,6 +247,16 @@ export const DatasetSearch = (props) => {
   const isInstitutionSet = institutionId === undefined && isInstitutionQuery;
 
   const hasChangedPage = query !== queryState;
+
+  useEffect(() => {
+    const init = async () => {
+      await Metrics.identify(Storage.getAnonymousId());
+      key === '/datalibrary' ?
+        await Metrics.captureEvent(eventList.dataLibrary) :
+        await Metrics.captureEvent(eventList.dataLibraryBrand(key));
+    };
+    init();
+  }, [key]);
 
   useEffect(() => {
     const init = async () => {

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -250,7 +250,6 @@ export const DatasetSearch = (props) => {
 
   useEffect(() => {
     const init = async () => {
-      await Metrics.identify(Storage.getAnonymousId());
       key === '/datalibrary' ?
         await Metrics.captureEvent(eventList.dataLibrary) :
         await Metrics.captureEvent(eventList.dataLibraryBrand(key));


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-519

See also: https://github.com/DataBiosphere/duos-ui/pull/2634

### Summary
When visiting the Data Library page, log mix panel events. This will create a different event for each branded view the user visits. When testing, navigate to any of the various flavors of the data library and you should see network calls go out to terra-bard. The events are logged in the [dev mixpanel project here](https://mixpanel.com/project/2085496/view/19055/app/events#psxfZXBG7Xdn). 

![Screenshot 2024-07-25 at 7 58 24 AM](https://github.com/user-attachments/assets/fe84f82c-1e39-4e70-bfa3-da032264fa0d)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
