### PR TITLE
DCJ-519: Log dar application state changes

### DIFF
--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
@@ -91,7 +91,6 @@ describe('Data Access Request - Validation', () => {
 
   describe('With Library Cards', () => {
     beforeEach(() => {
-      cy.stub(Metrics, 'identify').returns(Promise.resolve('anonymous_identifier'));
       cy.stub(Metrics, 'captureEvent').returns(Promise.resolve());
       cy.stub(User, 'getSOsForCurrentUser').returns(userSigningOfficials);
       cy.stub(DataSet, 'autocompleteDatasets').returns(Promise.resolve(datasets));

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
@@ -5,10 +5,11 @@ import DataAccessRequestApplication from '../../../src/pages/dar_application/Dat
 import { MemoryRouter } from 'react-router-dom';
 import { DAR } from '../../../src/libs/ajax/DAR';
 import { DataSet } from '../../../src/libs/ajax/DataSet';
-import { User } from '../../../src/libs/ajax/User';
-import { Storage } from '../../../src/libs/storage.js';
+import { Metrics } from '../../../src/libs/ajax/Metrics';
 import { Navigation } from '../../../src/libs/utils.js';
 import { NotificationService } from '../../../src/libs/notificationService';
+import { Storage } from '../../../src/libs/storage.js';
+import { User } from '../../../src/libs/ajax/User';
 
 const props = {
   match: {
@@ -90,6 +91,8 @@ describe('Data Access Request - Validation', () => {
 
   describe('With Library Cards', () => {
     beforeEach(() => {
+      cy.stub(Metrics, 'identify').returns(Promise.resolve('anonymous_identifier'));
+      cy.stub(Metrics, 'captureEvent').returns(Promise.resolve());
       cy.stub(User, 'getSOsForCurrentUser').returns(userSigningOfficials);
       cy.stub(DataSet, 'autocompleteDatasets').returns(Promise.resolve(datasets));
       cy.stub(DataSet, 'getDatasetsByIds').returns(Promise.resolve(datasets));

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -19,7 +19,6 @@ export const DAR = {
 
   //v2 update for dar partials
   updateDarDraft: async (dar, referenceId) => {
-    await Metrics.identify(Storage.getAnonymousId());
     await Metrics.captureEvent(eventList.darUpdate);
     const url = `${await getApiUrl()}/api/dar/v2/draft/${referenceId}`;
     const res = await axios.put(url, dar, Config.authOpts());
@@ -28,7 +27,6 @@ export const DAR = {
 
   //api endpoint for v2 draft submission
   postDarDraft: async (dar) => {
-    await Metrics.identify(Storage.getAnonymousId());
     await Metrics.captureEvent(eventList.darDraft);
     const url = `${await getApiUrl()}/api/dar/v2/draft/`;
     const res = await axios.post(url, dar, Config.authOpts());
@@ -44,7 +42,6 @@ export const DAR = {
 
   //v2 endpoint for DAR POST
   postDar: async (dar) => {
-    await Metrics.identify(Storage.getAnonymousId());
     await Metrics.captureEvent(eventList.darSubmit);
     const filteredDar = fp.omit(['createDate', 'sortDate', 'data_access_request_id'])(dar);
     const url = `${await getApiUrl()}/api/dar/v2`;

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -7,7 +7,6 @@ import { isFileEmpty } from '../utils';
 import { getApiUrl, fetchOk, getOntologyUrl, fetchAny } from '../ajax';
 import {Metrics} from './Metrics';
 import eventList from '../events';
-import {Storage} from '../storage';
 
 export const DAR = {
   //v2 get for DARs
@@ -19,7 +18,7 @@ export const DAR = {
 
   //v2 update for dar partials
   updateDarDraft: async (dar, referenceId) => {
-    await Metrics.captureEvent(eventList.darUpdate);
+    await Metrics.captureEvent(eventList.dar, {'action': 'update'});
     const url = `${await getApiUrl()}/api/dar/v2/draft/${referenceId}`;
     const res = await axios.put(url, dar, Config.authOpts());
     return res.data;
@@ -27,7 +26,7 @@ export const DAR = {
 
   //api endpoint for v2 draft submission
   postDarDraft: async (dar) => {
-    await Metrics.captureEvent(eventList.darDraft);
+    await Metrics.captureEvent(eventList.dar, {'action': 'draft'});
     const url = `${await getApiUrl()}/api/dar/v2/draft/`;
     const res = await axios.post(url, dar, Config.authOpts());
     return res.data;
@@ -42,7 +41,7 @@ export const DAR = {
 
   //v2 endpoint for DAR POST
   postDar: async (dar) => {
-    await Metrics.captureEvent(eventList.darSubmit);
+    await Metrics.captureEvent(eventList.dar, {'action': 'submit'});
     const filteredDar = fp.omit(['createDate', 'sortDate', 'data_access_request_id'])(dar);
     const url = `${await getApiUrl()}/api/dar/v2`;
     const res = axios.post(url, filteredDar, Config.authOpts());

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -5,7 +5,9 @@ import { Config } from '../config';
 import axios from 'axios';
 import { isFileEmpty } from '../utils';
 import { getApiUrl, fetchOk, getOntologyUrl, fetchAny } from '../ajax';
-
+import {Metrics} from './Metrics';
+import eventList from '../events';
+import {Storage} from '../storage';
 
 export const DAR = {
   //v2 get for DARs
@@ -17,6 +19,8 @@ export const DAR = {
 
   //v2 update for dar partials
   updateDarDraft: async (dar, referenceId) => {
+    await Metrics.identify(Storage.getAnonymousId());
+    await Metrics.captureEvent(eventList.darUpdate);
     const url = `${await getApiUrl()}/api/dar/v2/draft/${referenceId}`;
     const res = await axios.put(url, dar, Config.authOpts());
     return res.data;
@@ -24,6 +28,8 @@ export const DAR = {
 
   //api endpoint for v2 draft submission
   postDarDraft: async (dar) => {
+    await Metrics.identify(Storage.getAnonymousId());
+    await Metrics.captureEvent(eventList.darDraft);
     const url = `${await getApiUrl()}/api/dar/v2/draft/`;
     const res = await axios.post(url, dar, Config.authOpts());
     return res.data;
@@ -38,6 +44,8 @@ export const DAR = {
 
   //v2 endpoint for DAR POST
   postDar: async (dar) => {
+    await Metrics.identify(Storage.getAnonymousId());
+    await Metrics.captureEvent(eventList.darSubmit);
     const filteredDar = fp.omit(['createDate', 'sortDate', 'data_access_request_id'])(dar);
     const url = `${await getApiUrl()}/api/dar/v2`;
     const res = axios.post(url, filteredDar, Config.authOpts());

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -12,10 +12,7 @@ const eventList = {
     const cleanKey = brand.replaceAll('/', '');
     return `page:view:dataLibrary:${cleanKey}`;
   },
-  darDraft: 'dar:draft',
-  darUpdate: 'dar:update',
-  darAttest: 'dar:attest',
-  darSubmit: 'dar:submit'
+  dar: 'page:view:dar'
 };
 
 export default eventList;

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -3,6 +3,10 @@ const eventList = {
   userSignIn: 'user:signin',
 
   pageView: 'page:view',
+  darDraft: 'dar:draft',
+  darUpdate: 'dar:update',
+  darAttest: 'dar:attest',
+  darSubmit: 'dar:submit'
 };
 
 export default eventList;

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -374,7 +374,6 @@ const DataAccessRequestApplication = (props) => {
     if (isInvalidForm) {
       scrollToFormErrors(validation, eraCommonsIdValid, hasLibraryCard);
     } else {
-      await Metrics.identify(Storage.getAnonymousId());
       await Metrics.captureEvent(eventList.darAttest);
       setIsAttested(true);
       addDucAddendumTab();

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -374,7 +374,7 @@ const DataAccessRequestApplication = (props) => {
     if (isInvalidForm) {
       scrollToFormErrors(validation, eraCommonsIdValid, hasLibraryCard);
     } else {
-      await Metrics.captureEvent(eventList.darAttest);
+      await Metrics.captureEvent(eventList.dar, {'action': 'attest'});
       setIsAttested(true);
       addDucAddendumTab();
       await goToDucAddendum();

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -31,6 +31,8 @@ import { isArray, set } from 'lodash';
 import DucAddendum from './DucAddendum';
 import UsgOmbText from '../../components/UsgOmbText';
 import {DAAUtils} from '../../utils/DAAUtils';
+import {Metrics} from '../../libs/ajax/Metrics';
+import eventList from '../../libs/events';
 const ApplicationTabs = [
   { name: 'Researcher Information' },
   { name: 'Data Access Request' },
@@ -347,7 +349,7 @@ const DataAccessRequestApplication = (props) => {
     }
   }, [goToStep, isAttested]);
 
-  const attemptSubmit = () => {
+  const attemptSubmit = async () => {
     const validation = validateDARFormData({
       formData,
       datasets,
@@ -372,9 +374,11 @@ const DataAccessRequestApplication = (props) => {
     if (isInvalidForm) {
       scrollToFormErrors(validation, eraCommonsIdValid, hasLibraryCard);
     } else {
+      await Metrics.identify(Storage.getAnonymousId());
+      await Metrics.captureEvent(eventList.darAttest);
       setIsAttested(true);
       addDucAddendumTab();
-      goToDucAddendum();
+      await goToDucAddendum();
     }
 
     return !isInvalidForm;


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-519

See also: https://github.com/DataBiosphere/duos-ui/pull/2633

### Summary
This PR adds mixpanel events for all of the major Data Application Request states: create, update, attest, and submit. Events are visible in the [dev mixpanel project](https://mixpanel.com/project/2085496/view/19055/app/events#psxfZXBG7Xdn):

![Screenshot 2024-07-25 at 9 08 31 AM](https://github.com/user-attachments/assets/0beff1aa-ac2f-44a4-b6d0-ba454cf5f370)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
