### PR TITLE
DCJ-519: Log dataset and study selection/unselection events to Bard

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -177,8 +177,8 @@ export const DatasetSearchTable = (props) => {
         });
       });
     } else if (selector === 'row') {
-      const checkedRowIds = data.subtable.rows.map(row => row.id);
-      const isRowSelected = checkedRowIds.every(id => selected.includes(id));
+      const rowIds = data.subtable.rows.map(row => row.id);
+      const isRowSelected = rowIds.every(id => selected.includes(id));
       isRowSelected ?
         await Metrics.captureEvent(eventList.dataLibraryStudyUnselected) :
         await Metrics.captureEvent(eventList.dataLibraryStudySelected);

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -6,13 +6,15 @@ import { groupBy, isEmpty, concat, compact, map } from 'lodash';
 import CollapsibleTable from '../CollapsibleTable';
 import TableHeaderSection from '../TableHeaderSection';
 import DatasetExportButton from './DatasetExportButton';
-import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo';
 import { DataSet } from '../../libs/ajax/DataSet';
 import { DAR } from '../../libs/ajax/DAR';
+import eventList from '../../libs/events';
 import { Config } from '../../libs/config';
 import DatasetFilterList from './DatasetFilterList';
+import { Metrics } from '../../libs/ajax/Metrics';
 import { Notifications } from '../../libs/utils';
 import { Styles } from '../../libs/theme';
+import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo';
 import isEqual from 'lodash/isEqual';
 import TranslatedDulModal from '../modals/TranslatedDulModal';
 
@@ -166,7 +168,7 @@ export const DatasetSearchTable = (props) => {
 
 
 
-  const selectHandler = (event, data, selector) => {
+  const selectHandler = async (event, data, selector) => {
     let idsToModify = [];
     if (selector === 'all') {
       data.rows.forEach((row) => {
@@ -175,10 +177,18 @@ export const DatasetSearchTable = (props) => {
         });
       });
     } else if (selector === 'row') {
+      const checkedRowIds = data.subtable.rows.map(row => row.id);
+      const isRowSelected = checkedRowIds.every(id => selected.includes(id));
+      isRowSelected ?
+        await Metrics.captureEvent(eventList.dataLibraryStudyUnselected) :
+        await Metrics.captureEvent(eventList.dataLibraryStudySelected);
       data.subtable.rows.forEach((row) => {
         idsToModify.push(row.id);
       });
     } else if (selector === 'subrow') {
+      selected.includes(data.id) ?
+        await Metrics.captureEvent(eventList.dataLibraryDatasetUnselected) :
+        await Metrics.captureEvent(eventList.dataLibraryDatasetSelected);
       idsToModify.push(data.id);
     }
 

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -180,15 +180,15 @@ export const DatasetSearchTable = (props) => {
       const rowIds = data.subtable.rows.map(row => row.id);
       const isRowSelected = rowIds.every(id => selected.includes(id));
       isRowSelected ?
-        await Metrics.captureEvent(eventList.dataLibraryStudyUnselected) :
-        await Metrics.captureEvent(eventList.dataLibraryStudySelected);
+        await Metrics.captureEvent(eventList.dataLibrary, {'action': 'study-unselected'}) :
+        await Metrics.captureEvent(eventList.dataLibrary, {'action': 'study-selected'});
       data.subtable.rows.forEach((row) => {
         idsToModify.push(row.id);
       });
     } else if (selector === 'subrow') {
       selected.includes(data.id) ?
-        await Metrics.captureEvent(eventList.dataLibraryDatasetUnselected) :
-        await Metrics.captureEvent(eventList.dataLibraryDatasetSelected);
+        await Metrics.captureEvent(eventList.dataLibrary, {'action': 'dataset-unselected'}) :
+        await Metrics.captureEvent(eventList.dataLibrary,{'action': 'dataset-selected'});
       idsToModify.push(data.id);
     }
 

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -7,11 +7,15 @@ const eventList = {
   userSignIn: 'user:signin',
 
   pageView: 'page:view',
-  dataLibrary: 'page:view:dataLibrary',
+  dataLibrary: 'page:view:data-library',
   dataLibraryBrand: (brand) => {
     const cleanKey = brand.replaceAll('/', '');
-    return `page:view:dataLibrary:${cleanKey}`;
-  }
+    return `page:view:data-library-${cleanKey}`;
+  },
+  dataLibraryDatasetSelected: 'page:view:data-library-dataset-selected',
+  dataLibraryDatasetUnselected: 'page:view:data-library-dataset-unselected',
+  dataLibraryStudySelected: 'page:view:data-library-study-selected',
+  dataLibraryStudyUnselected: 'page:view:data-library-study-unselected'
 };
 
 export default eventList;

--- a/src/libs/events.js
+++ b/src/libs/events.js
@@ -8,14 +8,6 @@ const eventList = {
 
   pageView: 'page:view',
   dataLibrary: 'page:view:data-library',
-  dataLibraryBrand: (brand) => {
-    const cleanKey = brand.replaceAll('/', '');
-    return `page:view:data-library-${cleanKey}`;
-  },
-  dataLibraryDatasetSelected: 'page:view:data-library-dataset-selected',
-  dataLibraryDatasetUnselected: 'page:view:data-library-dataset-unselected',
-  dataLibraryStudySelected: 'page:view:data-library-study-selected',
-  dataLibraryStudyUnselected: 'page:view:data-library-study-unselected'
 };
 
 export default eventList;

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -252,7 +252,7 @@ export const DatasetSearch = (props) => {
     const init = async () => {
       key === '/datalibrary' ?
         await Metrics.captureEvent(eventList.dataLibrary) :
-        await Metrics.captureEvent(eventList.dataLibraryBrand(key));
+        await Metrics.captureEvent(eventList.dataLibrary, {'brand': key.replaceAll('/', '').toLowerCase()});
     };
     init();
   }, [key]);


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-519

### Summary
This PR adds metrics logging for selecting and unselecting datasets and studies on the data library page. It also slightly modifies the current event names to be more aligned with [existing naming conventions](https://mixpanel.com/project/2085496/view/19055/app/lexicon#transformations).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
