### PR TITLE
DCJ-619: Simplify/fix useEffect infinite reload problem

### DIFF
--- a/src/pages/manage_dac/ManageDac.jsx
+++ b/src/pages/manage_dac/ManageDac.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ManageDacTable from '../../components/manage_dac_table/ManageDacTable';
-import {useState, useEffect, useCallback} from 'react';
+import {useState, useEffect} from 'react';
 import { Styles } from '../../libs/theme';
 import lockIcon from '../../images/lock-icon.png';
 import { DAC } from '../../libs/ajax/DAC';


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-619

### Summary
This PR does a few of things that hopefully clarify and simplify the intended functionality behind this page.

1. Move all initialization logic into a single method
2. Load DACs based on the user role. Here, we check state to see if the user is Admin before loading all DACs on the page. This prevents a flash of seeing all DACs before they get filtered by role and instead, only become visible once state has loaded and we know which role the user is accessing DACs for.
3. Clean up usages of lodash to use native javascript filter/map/includes functionality
4. Reduce the `useEffect` dependencies to an empty array

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
