### PR TITLE
DCJ-155: Move sign in button from the home page body to the navigation bar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,7 @@ function App() {
     <div className="body">
       <div className="wrap">
         <div className="main">
-          <DuosHeader onSignOut={signOut} />
+          <DuosHeader onSignOut={signOut} onSignIn={signIn} />
           <Spinner name="mainSpinner" group="duos" loadingImage={loadingImage} />
           <Routes onSignOut={signOut} onSignIn={signIn} isLogged={isLoggedIn} env={env} />
         </div>

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -226,7 +226,7 @@ const NavigationTabsComponent = (props) => {
                 {supportrequestModal}
               </ul>
             )
-          };
+          }
         </div>
         {/* Navbar right side */}
         {!isLogged &&

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -224,20 +224,28 @@ const NavigationTabsComponent = (props) => {
                 </li>
                 {contactUsButton}
                 {supportrequestModal}
+                {/* Sign-in button location when window is narrow and menu is vertical */}
+                {!isLogged && orientation === 'vertical' && <li style={{marginRight: 0}}>
+                  <SignInButton
+                    customStyle={undefined}
+                    props={props}
+                    onSignIn={onSignIn}
+                    history={history}/>
+                </li>}
               </ul>
             )
           }
         </div>
         {/* Navbar right side */}
-        {!isLogged &&
+        {/* Sign-in button location when window is wider and menu is not vertical */}
+        {!isLogged && orientation !== 'vertical' &&
           <div
             style={{
               minWidth: '185px',
               display: 'flex',
               alignItems: 'center',
               flexDirection: orientation === 'vertical' ? 'column' : 'row'
-            }}
-          >
+            }}>
             <SignInButton
               customStyle={undefined}
               props={props}

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -18,6 +18,7 @@ import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
 import {isFunction, isNil} from 'lodash/fp';
 import {DAAUtils} from '../utils/DAAUtils';
+import SignInButton from '../components/SignInButton';
 
 const styles = {
   drawerPaper: {
@@ -138,6 +139,8 @@ export const headerTabsConfig = [
 
 const NavigationTabsComponent = (props) => {
   const {
+    onSignIn,
+    history,
     orientation,
     makeNotifications,
     navbarDuosIcon, duosLogoImage, DuosLogo, navbarDuosText,
@@ -226,6 +229,22 @@ const NavigationTabsComponent = (props) => {
           };
         </div>
         {/* Navbar right side */}
+        {!isLogged &&
+          <div
+            style={{
+              minWidth: '185px',
+              display: 'flex',
+              alignItems: 'center',
+              flexDirection: orientation === 'vertical' ? 'column' : 'row'
+            }}
+          >
+            <SignInButton
+              customStyle={undefined}
+              props={props}
+              onSignIn={onSignIn}
+              history={history}/>
+          </div>
+        }
         {isLogged && (
           <div
             style={{ display: 'flex', alignItems: 'center', flexDirection: orientation === 'vertical' ? 'column' : 'row' }}
@@ -310,7 +329,7 @@ const navbarDuosText = {
 };
 
 const DuosHeader = (props) => {
-  const { location, classes } = props;
+  const {location, classes, onSignIn, history} = props;
   const [state, setState] = useState({
     showSupportRequestModal: false,
     hover: false,
@@ -478,6 +497,8 @@ const DuosHeader = (props) => {
         <div className="row no-margin" style={{ width: '100%' }}>
           {/* Standard navbar for medium sized displays and higher (pre-existing navbar) */}
           <NavigationTabsComponent
+            onSignIn={onSignIn}
+            history={history}
             goToLink={goToLink}
             makeNotifications={makeNotifications}
             duosLogoImage={duosLogoImage}
@@ -525,6 +546,8 @@ const DuosHeader = (props) => {
             onClose={() => toggleDrawer(false)}
           >
             <NavigationTabsComponent
+              onSignIn={onSignIn}
+              history={history}
               goToLink={goToLink}
               // Notifications are already displayed underneath the expanded drawer, no need to render them twice.
               makeNotifications={() => {}}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,15 +1,11 @@
 import React from 'react';
-import SignInButton from '../components/SignInButton';
 import { ReadMore } from '../components/ReadMore';
 import homeHeaderBackground from '../images/home_header_background.png';
 import duosLogoImg from '../images/duos_logo.svg';
 import duosDiagram from '../images/DUOS_Homepage_diagram.svg';
 import { Link } from 'react-router-dom';
-import { Storage } from '../libs/storage';
 
 const Home = (props) => {
-  const { onSignIn, history } = props;
-  const isLogged = Storage.userIsLogged();
 
   const homeTitle = {
     color: '#FFFFFF',
@@ -82,22 +78,11 @@ const Home = (props) => {
     display: 'block'
   };
 
-  const signInPositionStyle = {
-    padding: '1em 1em 0 0',
-    alignItems: 'center',
-    position: 'absolute',
-    top: '0',
-    right: '1rem',
-  };
-
   return (
     <div className="row">
       <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12">
         <div className="row" style={{ backgroundColor: 'white', height: '350px', position: 'relative', margin: '-20px auto auto 0' }}>
           <img style={{ height: 'inherit', minWidth: '100%' }} src={homeHeaderBackground} alt="Home header background" />
-          {!isLogged && <div style={signInPositionStyle}>
-            <SignInButton props={props} onSignIn={onSignIn} history={history} />
-          </div>}
           <div style={{ position: 'absolute', width: '100%', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}>
             <img style={duosLogo} alt="DUOS logo" src={duosLogoImg} />
             <h1 style={homeTitle}>Data Use Oversight System</h1>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-155

### Summary
Minor refactor of the sign in button placement from the body of the home page to the navigation bar. There are no functional differences - this is purely a button rearrangement. However, when the window size is reduced, this means that sign-in is now an element in the right-side panel whereas previously, it was hidden, so this PR adds a small degree of functionality.

### Full Screen
The window on top is current dev, the window on the bottom is the new version. 

![Screenshot 2024-08-30 at 7 32 04 AM](https://github.com/user-attachments/assets/1d3791d0-0513-4ab1-8425-b969c3a09393)

### Reduced Window Size
The window on the left is dev, the window on the right is new.

![Screenshot 2024-09-03 at 7 19 39 AM](https://github.com/user-attachments/assets/f5d149bc-631c-4717-8b45-a471157afedb)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
