### PR TITLE
[DCJ-627][risk=low] Remove deprecated Dataset needsApproval and active state attributes.

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -78,7 +78,7 @@ run in GitHub Actions. Create a `cypress.env.json` file in the root of your
 local repo that looks like this:
 ```json
 {
-  "baseUrl": "https://local.dsde-dev,broadinstitute.org:3000/"
+  "baseUrl": "https://local.dsde-dev.broadinstitute.org:3000/"
 }
 ```
 Cypress will use these values in `cypress.config.js` and `cypress/support/commands.js`

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -464,9 +464,7 @@ const dar = {
       'createUserId': null,
       'updateDate': 1643730658770,
       'updateUserId': 11111,
-      'active': true,
       'consentName': null,
-      'needsApproval': null,
       'alias': 999,
       'datasetIdentifier': 'DUOS-00999',
       'dataUse': {
@@ -670,8 +668,6 @@ const dacDatasets = [{
       'propertyValue': 'Sleep Apnea'
     }
   ],
-  'active': true,
-  'needsApproval': true,
   'isAssociatedToDataOwners': null,
   'updateAssociationToDataOwnerAllowed': null,
   'alias': 999,

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -104,8 +104,6 @@ export interface Dataset {
   deletable: boolean;
   properties: DatasetProperty[];
   study: Study;
-  active: boolean;
-  needsApproval: boolean;
   alias: string;
   datasetIdentifier: string;
   objectId: string;


### PR DESCRIPTION
### Addresses

Addresses the UI portion of [removing deprecated Dataset properties](https://broadworkbench.atlassian.net/browse/DCJ-627?atlOrigin=eyJpIjoiMjYxZTkxODc0MWFiNDBmMTg0ZDBiODA5Y2FmNDEzMjAiLCJwIjoiaiJ9)

### Summary

Removing needsApproval and active Dataset interface properties that are marked deprecated in consent.  Drive by fix of punctuation in the DEVNOTES.md that was discovered while tooling my local dev environment.

These properties were already (largely) ignored by the frontend code.

### See also
https://github.com/DataBiosphere/consent/pull/2399
