### PR TITLE
DCJ-654: Standardize metrics token usage

### DIFF
--- a/src/libs/acknowledgements.js
+++ b/src/libs/acknowledgements.js
@@ -12,7 +12,7 @@ const acknowledgementStorageKey = (ackKey) => {
 
 export const hasAccepted = async (...acknowledgements) => {
 
-  // check if the acknowledgements are int he cache
+  // check if the acknowledgements are in the cache
   const allAcknowledgementsInStorage = acknowledgements.every(
     (ackKey) => Storage.getCurrentUserSettings(acknowledgementStorageKey(ackKey)) || false
   );

--- a/src/libs/ajax/Metrics.js
+++ b/src/libs/ajax/Metrics.js
@@ -1,11 +1,13 @@
 import axios from 'axios';
-import { getDefaultProperties } from '@databiosphere/bard-client';
+import {getDefaultProperties} from '@databiosphere/bard-client';
 
-import { Storage } from '../storage';
-import { getBardApiUrl } from '../ajax';
+import {Storage} from '../storage';
+import {getBardApiUrl} from '../ajax';
+import {Token} from '../config';
 
 export const Metrics = {
-  captureEvent: (event, details, signal) => captureEventFn(event, details, signal).catch(() => { }),
+  captureEvent: (event, details, signal) => captureEventFn(event, details, signal).catch(() => {
+  }),
   syncProfile: (signal) => syncProfile(signal),
   identify: (anonId, signal) => identify(anonId, signal),
 };
@@ -42,7 +44,7 @@ const captureEventFn = async (event, details = {}, signal) => {
     method: 'POST',
     url: `${await getBardApiUrl()}/api/event`,
     data: body,
-    headers: isRegistered ? { Authorization: `Bearer ${Storage.getGoogleData()?.accessToken}` } : undefined,
+    headers: isRegistered ? {Authorization: `Bearer ${Token.getToken()}`} : undefined,
     signal,
   };
 
@@ -59,11 +61,12 @@ const syncProfile = async (signal) => {
   const config = {
     method: 'POST',
     url: `${await getBardApiUrl()}/api/syncProfile`,
-    headers: { Authorization: `Bearer ${Storage.getGoogleData()?.accessToken}` },
+    headers: {Authorization: `Bearer ${Token.getToken()}`},
     signal,
   };
 
-  return axios(config).catch(() => { });
+  return axios(config).catch(() => {
+  });
 };
 
 /**
@@ -74,17 +77,18 @@ const syncProfile = async (signal) => {
  * @returns {Promise} - A Promise that resolves when the user is identified.
  */
 const identify = async (anonId, signal) => {
-  const body = { anonId };
+  const body = {anonId};
 
   const config = {
     method: 'POST',
     url: `${await getBardApiUrl()}/api/identify`,
     data: body,
-    headers: { Authorization: `Bearer ${Storage.getGoogleData()?.accessToken}` },
+    headers: {Authorization: `Bearer ${Token.getToken()}`},
     signal,
   };
 
-  return axios(config).catch(() => { });
+  return axios(config).catch(() => {
+  });
 };
 
 

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -27,11 +27,6 @@ export const Config = {
 
   getTag: async () => (await getConfig()).tag,
 
-  getFeatureFlag: async (featureName) => {
-    const feature = _.get(await getConfig(), 'features', {});
-    return _.get(feature, featureName, false);
-  },
-
   getProject: async () => {
     const env = await Config.getEnv();
     switch (env) {
@@ -65,13 +60,6 @@ export const Config = {
     },
   }),
 
-  fileOpts: (token = Token.getToken()) => ({
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: 'application/json',
-    },
-  }),
-
   jsonBody: body => ({
     body: JSON.stringify(body),
     headers: {'Content-Type': 'application/json'},
@@ -82,15 +70,9 @@ export const Config = {
     headers: {'Content-Type': 'application/binary'}
   }),
 
-  fileBody: (token = Token.getToken()) => ({
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: '*/*',
-    },
-  }),
 };
 
-const Token = {
+export const Token = {
   getToken: () => {
     return Storage.getGoogleData() !== null ?
       Storage.getGoogleData().accessToken :


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DCJ-654

### Summary
This PR pulls out a small part of https://github.com/DataBiosphere/duos-ui/pull/2611 to consolidate how we're getting the access token for Metrics (bard) ajax requests. This will simplify the full B2C sign-in PR here: https://github.com/DataBiosphere/duos-ui/pull/2667

Drive-by fixes:
* Typo in `acknowledgements.js`
* Unused `getFeatureFlag` function
* Unused `fileOpts ` function
* Unused `fileBody ` function
* Reformatted with eslint

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
