### PR TITLE
DCJ-687: Add dynamic warning for users with no institution

### DIFF
--- a/src/pages/user_profile/AffiliationAndRoles.jsx
+++ b/src/pages/user_profile/AffiliationAndRoles.jsx
@@ -208,6 +208,10 @@ export default function AffiliationAndRole(props) {
       }}
     >
       <p>Institution</p>
+      {!(profile.institutionId) && <div className={'alert-danger alert'} style={{fontWeight: 'normal'}}>
+        Please select an existing Institution. If you don&apos;t see your institution listed, please select the Contact
+        Us link to request that your institution be added.
+      </div>}
       <div style={{ marginTop: '15px' }} />
       {generateInstitutionSelectionDisplay()}
       {formIsValid() ? (


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DCJ-687

## Summary
Adds a user warning to select an institution we know about. There are three cases here:

#### User has selected an institution
![Screenshot 2024-09-24 at 1 11 35 PM](https://github.com/user-attachments/assets/c9a8ba5b-3502-412a-aa37-f0bd236e033f)

#### User has entered a suggested institution
We allow for users to _suggest_ an institution. Currently, there are no backend processes that do anything with this information. At one point, we did, but I believe that has been replaced with the current version when the [AffiliationsAndRole component was first introduced](https://github.com/DataBiosphere/duos-ui/pull/2290). 
![Screenshot 2024-09-24 at 1 12 19 PM](https://github.com/user-attachments/assets/83e3f93f-1ef4-4ed8-bbf9-52820fcbd0ba)

#### User has not yet chosen an institution
![Screenshot 2024-09-24 at 1 11 22 PM](https://github.com/user-attachments/assets/e789fe65-e32e-44c3-96ca-7f1c183d3b30)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
