### PR TITLE
[DCJ-666] Update links to DUOS documentation to point to new location

### DIFF
--- a/cypress/e2e/about.cy.js
+++ b/cypress/e2e/about.cy.js
@@ -9,7 +9,7 @@ describe('About', function() {
     cy.get('#link_about').should(
       'have.attr',
       'href',
-      'https://broad-duos.zendesk.com/hc/en-us/articles/360060400311-About-DUOS'
+      'https://support.terra.bio/hc/en-us/articles/28485372215579-About-DUOS'
     );
   });
 
@@ -20,7 +20,7 @@ describe('About', function() {
     cy.get('#link_about').should(
       'have.attr',
       'href',
-      'https://broad-duos.zendesk.com/hc/en-us/articles/360060400311-About-DUOS'
+      'https://support.terra.bio/hc/en-us/articles/28485372215579-About-DUOS'
     );
   });
 });

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -12,21 +12,21 @@ describe('Home', function() {
     cy.contains('Looking for data');
     cy.contains('Overview of DUOS');
     cy.contains('Machine Readable Consent Guidance.');
-    cy.get('#zendesk-dac-link').should(
+    cy.get('#terra-support-dac-link').should(
       'have.attr',
       'href',
-      'https://broad-duos.zendesk.com/hc/en-us/articles/360060401131-Data-Access-Committee-User-Guide'
+      'https://support.terra.bio/hc/en-us/articles/28513346337179-Overview-DUOS-for-Data-Access-Committees-DACs'
     );
-    cy.get('#zendesk-so-link').should(
+    cy.get('#terra-support-so-link').should(
       'have.attr',
       'href',
-      'https://broad-duos.zendesk.com/hc/en-us/articles/360060402751-Signing-Official-User-Guide'
+      'https://support.terra.bio/hc/en-us/articles/28512587249051-How-to-Pre-Authorize-Researchers-to-Submit-Data-Access-Requests-in-DUOS'
     );
 
-    cy.get('#zendesk-researcher-link').should(
+    cy.get('#terra-support-researcher-link').should(
       'have.attr',
       'href',
-      'https://broad-duos.zendesk.com/hc/en-us/articles/360060402551-Researcher-User-Guide'
+      'https://support.terra.bio/hc/en-us/articles/28510385779099-Overview-DUOS-for-Researchers'
     );
   });
 

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -203,7 +203,7 @@ const NavigationTabsComponent = (props) => {
                   <a
                     id="link_about"
                     className="navbar-duos-link"
-                    href="https://broad-duos.zendesk.com/hc/en-us/articles/360060400311-About-DUOS"
+                    href="https://support.terra.bio/hc/en-us/articles/28485372215579-About-DUOS"
                     target="_blank"
                     rel="noreferrer"
                   >
@@ -215,7 +215,7 @@ const NavigationTabsComponent = (props) => {
                   <a
                     id="link_help"
                     className="navbar-duos-link"
-                    href="https://broad-duos.zendesk.com/hc/en-us/articles/360059957092-Frequently-Asked-Questions-FAQs-"
+                    href="https://support.terra.bio/hc/en-us/articles/28486067349531-Frequently-Asked-Questions-about-DUOS"
                     target="_blank" rel="noreferrer"
                   >
                     <div className="navbar-duos-icon-help" style={navbarDuosIcon}></div>
@@ -251,13 +251,20 @@ const NavigationTabsComponent = (props) => {
         }
         {isLogged && (
           <div
-            style={{ display: 'flex', alignItems: 'center', flexDirection: orientation === 'vertical' ? 'column' : 'row' }}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              flexDirection: orientation === 'vertical' ? 'column' : 'row'
+            }}
           >
+            <a href="https://support.terra.bio/hc/en-us/categories/28485138480539-Managing-Data-Access-with-DUOS"
+              id="terra-support-docs-link" target="_blank" rel="noreferrer"
+              style={{color: 'white', paddingTop: 30, paddingBottom: 30, paddingLeft: 2, paddingRight: 2, marginRight: 20}}>Help</a>
             <button onClick={showRequestModal} style={styles.navButton}>
-              <div id="help" style={{ whiteSpace: 'nowrap' }}>Contact Us</div>
+              <div id="help" style={{whiteSpace: 'nowrap'}}>Contact Us</div>
             </button>
             {supportrequestModal}
-            <li className="dropdown user-li" onClick={showProfileLinks} style={{ listStyleType: 'none' }}>
+            <li className="dropdown user-li" onClick={showProfileLinks} style={{listStyleType: 'none'}}>
               <a id="sel_user" role="button" className="dropdown-toggle" data-toggle="dropdown">
                 <div id="dacUser">
                   {currentUser.displayName}
@@ -265,7 +272,10 @@ const NavigationTabsComponent = (props) => {
                 </div>
                 <small id="dacUserMail">{currentUser.email}</small>
               </a>
-              <ul className="dropdown-menu navbar-dropdown" role="menu" style={{ display: `${profileState ? 'block': 'none'}`, top: orientation === 'vertical' ? '-100%' : '100%' }}>
+              <ul className="dropdown-menu navbar-dropdown" role="menu" style={{
+                display: `${profileState ? 'block' : 'none'}`,
+                top: orientation === 'vertical' ? '-100%' : '100%'
+              }}>
                 <li>
                   <Link id="link_profile" to="/profile" onClick={onSubtabChange}>Your Profile</Link>
                 </li>

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -186,7 +186,7 @@ export const SignInButton = (props: SignInButtonProps) => {
         <a
           className='navbar-duos-icon-help'
           style={{color: 'white', height: 16, width: 16, marginLeft: 5}}
-          href='https://broad-duos.zendesk.com/hc/en-us/articles/6160103983771-How-to-Create-a-Google-Account-with-a-Non-Google-Email'
+          href='https://support.terra.bio/hc/en-us/articles/28504837523995-How-to-Register-for-DUOS'
           data-for="tip_google-help"
           data-tip="Need account help? Click here!"
         />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -107,21 +107,21 @@ const Home = (props) => {
             <p style={header}>DUOS for DACs</p>
             <p style={description}>DACs can swiftly manage data access requests <br /> and clearly track data use compliance.</p>
             <div className="row" style={{ display: 'flex', justifyContent: 'center' }}>
-              <a id="zendesk-dac-link" href="https://broad-duos.zendesk.com/hc/en-us/articles/360060401131-Data-Access-Committee-User-Guide" target="_blank" rel="noreferrer" style={{ color: '#1F3B50', fontSize: '16px', fontWeight: 500 }}>LEARN MORE</a>
+              <a id="terra-support-dac-link" href="https://support.terra.bio/hc/en-us/articles/28513346337179-Overview-DUOS-for-Data-Access-Committees-DACs" target="_blank" rel="noreferrer" style={{ color: '#1F3B50', fontSize: '16px', fontWeight: 500 }}>LEARN MORE</a>
             </div>
           </div>
           <div className="col-lg-4 col-md-4 ">
             <p style={header}>Institutional Oversight</p>
             <p style={description}>DUOS reduces repetitive work for Signing Officials and expedites data sharing through our innovative Library Card-style agreements.</p>
             <div className="row" style={{ display: 'flex', justifyContent: 'center' }}>
-              <a href="https://broad-duos.zendesk.com/hc/en-us/articles/360060402751-Signing-Official-User-Guide" target="_blank" rel="noreferrer" id="zendesk-so-link" style={{ color: '#1F3B50', fontSize: '16px', fontWeight: 500 }}>LEARN MORE</a>
+              <a href="https://support.terra.bio/hc/en-us/articles/28512587249051-How-to-Pre-Authorize-Researchers-to-Submit-Data-Access-Requests-in-DUOS" target="_blank" rel="noreferrer" id="terra-support-so-link" style={{ color: '#1F3B50', fontSize: '16px', fontWeight: 500 }}>LEARN MORE</a>
             </div>
           </div>
           <div className="col-lg-4 col-md-4">
             <p style={header}>Looking for data?</p>
             <p style={description}>DUOS helps researchers request and access data from multiple sources with a single application.</p>
             <div className="row" style={{ display: 'flex', justifyContent: 'center' }}>
-              <a href="https://broad-duos.zendesk.com/hc/en-us/articles/360060402551-Researcher-User-Guide" id="zendesk-researcher-link" target="_blank" rel="noreferrer" style={{ color: '#1F3B50', fontSize: '16px', fontWeight: 500 }}>LEARN MORE</a>
+              <a href="https://support.terra.bio/hc/en-us/articles/28510385779099-Overview-DUOS-for-Researchers" id="terra-support-researcher-link" target="_blank" rel="noreferrer" style={{ color: '#1F3B50', fontSize: '16px', fontWeight: 500 }}>LEARN MORE</a>
             </div>
           </div>
         </div>

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -11,7 +11,7 @@ const linkStyle = {color: '#2FA4E7'};
 const profileLink = <Link to="/profile" style={linkStyle}>Your Profile</Link>;
 const profileUnsubmitted = <span>Please submit {profileLink} to be able to create a Data Access Request</span>;
 const profileSubmitted = <span>Please make sure {profileLink} is updated as it will be used to pre-populate parts of the Data Access Request</span>;
-const libraryCardLink = <a href="https://broad-duos.zendesk.com/hc/en-us/articles/4402736994971-Researcher-FAQs" style={linkStyle} target="_blank" rel="noopener noreferrer">Library Card</a>;
+const libraryCardLink = <a href="https://support.terra.bio/hc/en-us/articles/28510945983003-How-to-Submit-a-Data-Access-Request-DAR-in-DUOS" style={linkStyle} target="_blank" rel="noopener noreferrer">Library Card</a>;
 
 
 export default function ResearcherInfo(props) {

--- a/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
@@ -189,7 +189,9 @@ export default function ManageResearcherDAAsTable(props) {
               fontSize: '16px',
               maxWidth: '60%',
             })}>
-              The table below allows you to pre-authorize your Institution&apos;s users to request access to datasets,
+              The table below allows you to
+              <a href="https://support.terra.bio/hc/en-us/articles/28512587249051-How-to-Pre-Authorize-Researchers-to-Submit-Data-Access-Requests-in-DUOS"
+                id="terra-support-pre-auth-link" target="_blank" rel="noreferrer"> pre-authorize </a> your Institution&apos;s users to request access to datasets,
               known as issuing them a Library Card. Issuing a checkmark in a cell for a researcher issues them a Library
               Card for that DAA and denotes your approval of that researcher to request data from DACs operating under the respective DAA(s).
             </div>

--- a/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
@@ -189,9 +189,8 @@ export default function ManageResearcherDAAsTable(props) {
               fontSize: '16px',
               maxWidth: '60%',
             })}>
-              The table below allows you to
-              <a href="https://support.terra.bio/hc/en-us/articles/28512587249051-How-to-Pre-Authorize-Researchers-to-Submit-Data-Access-Requests-in-DUOS"
-                id="terra-support-pre-auth-link" target="_blank" rel="noreferrer"> pre-authorize </a> your Institution&apos;s users to request access to datasets,
+              The table below allows you to <a href="https://support.terra.bio/hc/en-us/articles/28512587249051-How-to-Pre-Authorize-Researchers-to-Submit-Data-Access-Requests-in-DUOS"
+                id="terra-support-pre-auth-link" target="_blank" rel="noreferrer">pre-authorize</a> your Institution&apos;s users to request access to datasets,
               known as issuing them a Library Card. Issuing a checkmark in a cell for a researcher issues them a Library
               Card for that DAA and denotes your approval of that researcher to request data from DACs operating under the respective DAA(s).
             </div>

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -399,7 +399,7 @@ export default function SigningOfficialTable(props) {
               Issue or Remove Library Card privileges to allow researchers to submit DARs.
               <a
                 rel="noopener noreferrer"
-                href="https://broad-duos.zendesk.com/hc/en-us/articles/360060402751-Signing-Official-User-Guide"
+                href="https://support.terra.bio/hc/en-us/articles/28512587249051-How-to-Pre-Authorize-Researchers-to-Submit-Data-Access-Requests-in-DUOS"
                 target="_blank"
                 id="so-console-info-link"
                 style={{ verticalAlign: 'super' }}>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DCJ-666
### Summary
- Updated old zendesk documentation links to point to new Terra Support site articles and added a couple new links
- Updated a couple of tests to match the link changes
- Changes based on [this spreadsheet](https://docs.google.com/spreadsheets/d/1TC-qUTJL_eigPXXI7DocwQpAlJYO92c4e4Dw2EYUmMM/edit?gid=0#gid=0) and [this search](https://github.com/search?q=repo%3ADataBiosphere%2Fduos-ui%20zendesk&type=code)
- **Note** - ~~I'm not exactly sure what the zendesk links in /ajax/Support.js (see search) are for and I couldn't find or access them on the UI so I didn't replace those. Every other instance of a zendesk link should be replaced though~~ Never mind, they're API calls and not documentation links, so they won't be replaced
- I also might've missed updating some tests, I'm not super familiar with the DUOs testings
### Visual Aids
New "Help" and "pre-authorize" links: 

https://github.com/user-attachments/assets/62cf61d4-c9ff-4e51-a707-1f000bb09a9b

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
