### PR TITLE
[DCJ-691] Add filter for primary data use

### DIFF
--- a/src/components/data_search/DatasetFilterList.jsx
+++ b/src/components/data_search/DatasetFilterList.jsx
@@ -8,13 +8,13 @@ import ListItemText from '@mui/material/ListItemText';
 import Divider from '@mui/material/Divider';
 import { Typography } from '@mui/material';
 import { Checkbox } from '@mui/material';
+import { flatten, uniq, compact, capitalize } from 'lodash';
 
 export const DatasetFilterList = (props) => {
-  const { datasets, filters, filterHandler, searchRef } = props;
+  const { datasets, filters, filterHandler, isFiltered, searchRef } = props;
 
-  const accessManagementFilters = ['Controlled', 'Open', 'External'];
-
-  const isFiltered = (filter) => filters.indexOf(filter) > -1;
+  const accessManagementFilters = uniq(compact(datasets.map((dataset) => dataset.accessManagement)));
+  const dataUseFilters = uniq(compact(flatten(datasets.map((dataset) => dataset.dataUse?.primary))).map((dataUse) => dataUse.code));
 
   return (
     <Box sx={{ bgcolor: 'background.paper' }}>
@@ -27,13 +27,35 @@ export const DatasetFilterList = (props) => {
       </Typography>
       <List sx={{ margin: '-0.5em -0.5em'}}>
         {
-          accessManagementFilters.map((filterName) => {
-            const filter = filterName.toLowerCase();
+          accessManagementFilters.map((filter) => {
+            const filterName = capitalize(filter);
+            const category = 'accessManagement';
             return (
               <ListItem disablePadding key={filter}>
-                <ListItemButton sx={{ padding: '0' }} onClick={(event) => filterHandler(event, datasets, filter, searchRef.current.value)}>
+                <ListItemButton sx={{ padding: '0' }} onClick={(event) => filterHandler(event, datasets, category, filter, searchRef.current.value)}>
                   <ListItemIcon>
-                    <Checkbox checked={isFiltered(filter)} />
+                    <Checkbox checked={isFiltered(filter, category)} />
+                  </ListItemIcon>
+                  <ListItemText primary={filterName} sx={{ fontFamily: 'Montserrat', transform: 'scale(1.2)' }} />
+                </ListItemButton>
+              </ListItem>
+            );
+          })
+        }
+      </List>
+      <Typography variant="h6" gutterBottom component="div" sx={{ fontFamily: 'Montserrat', fontWeight: '600' }} marginTop="1em">
+        Primary Data Use
+      </Typography>
+      <List sx={{ margin: '-0.5em -0.5em'}}>
+        {
+          dataUseFilters.map((filter) => {
+            const filterName = filter.toUpperCase();
+            const category = 'dataUse';
+            return (
+              <ListItem disablePadding key={filter}>
+                <ListItemButton sx={{ padding: '0' }} onClick={(event) => filterHandler(event, datasets, category, filter, searchRef.current.value)}>
+                  <ListItemIcon>
+                    <Checkbox checked={isFiltered(filter, category)} />
                   </ListItemIcon>
                   <ListItemText primary={filterName} sx={{ fontFamily: 'Montserrat', transform: 'scale(1.2)' }} />
                 </ListItemButton>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-691

### Summary

Revamps the filtering process to be scalable for many different filters, and adds a filter for primary data use. In general, the filtering works by:

1. Updating the state of the filters based on selections (in `filterHandler`)
2. Constructing a query from the filter terms (in `assembleFullQuery`)
3. Querying elasticsearch for a filtered search (in `search`)
4. Refreshing the view with the new results (done by React)

What was changed here is that previously the selections for the (one and only) filter were hardcoded and added to an array, and then the state and query were constructed from that array. Now instead:

1. The filter selections are dynamically populated from the datasets
2. `filterHandler` also accepts a _category_ of filter, and these are stored in an object that corresponds to the filter category and the selections.
3. The query is assembled slightly differently because `{dataset}.dataUse.primary.code` is a deeply nested JSON object which ElasticSearch has indexed a particular way

In the future, the mechanism to add new filters should be straightforward:

1. Extract the filter selections from the available datasets
2. Create a new UI element for the filter (we could probably create a component for this)
3. Adjust the query to search for those particular filter selections

