### PR TITLE
[DCJ-702] Switch to datasetId everywhere

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.js
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.js
@@ -303,7 +303,7 @@ const dar = {
           'status': 'Open',
           'createDate': 1669062648000,
           'referenceId': 'dars-id-123',
-          'dataSetId': 13,
+          'datasetId': 13,
           'votes': {
             '8675': {
               'voteId': 8675,
@@ -396,7 +396,7 @@ const dar = {
           'status': 'Open',
           'createDate': 1669062648000,
           'referenceId': 'dars-id-123',
-          'dataSetId': 13,
+          'datasetId': 13,
           'votes': {
             '8688': {
               'voteId': 8688,
@@ -456,7 +456,7 @@ const dar = {
   },
   'datasets': [
     {
-      'dataSetId': 13,
+      'datasetId': 13,
       'objectId': null,
       'name': 'Sleep Apnea',
       'datasetName': 'Sleep Apnea',
@@ -483,7 +483,7 @@ const dar = {
       'properties': [
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': '# of participants',
           'propertyValue': 17,
@@ -495,7 +495,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'Dataset Name',
           'propertyValue': 'Sleep Apnea',
@@ -507,7 +507,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'Description',
           'propertyValue': 'Single cell RNA-sequence',
@@ -519,7 +519,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'Data Type',
           'propertyValue': 'RNA-seq',
@@ -531,7 +531,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'Data Depositor',
           'propertyValue': 'data_depositor@example.com',
@@ -543,7 +543,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'Species',
           'propertyValue': 'Human',
@@ -555,7 +555,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'Phenotype/Indication',
           'propertyValue': 'sleep apnea',
@@ -567,7 +567,7 @@ const dar = {
         },
         {
           'propertyId': null,
-          'dataSetId': 13,
+          'datasetId': 13,
           'propertyKey': null,
           'propertyName': 'url',
           'propertyValue': 'https://...',
@@ -658,7 +658,7 @@ const matchResponse = [
 const dacDatasets = [{
   'datasetName': null,
   'dacId': 3,
-  'dataSetId': 13,
+  'datasetId': 13,
   'consentId': 'B177D3C2-CDD8-4153-9CBF-AE4F0C34609A',
   'translatedDataUse': '',
   'deletable': null,

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.js
@@ -64,7 +64,7 @@ const userNoLibraryCard = {
 
 const datasets = [
   {
-    dataSetId: 123456,
+    datasetId: 123456,
     datasetIdentifier: `DUOS-123456`,
     name: 'Some Dataset',
     dataUse: {

--- a/cypress/component/DataAccessRequest/selectable_datasets.spec.js
+++ b/cypress/component/DataAccessRequest/selectable_datasets.spec.js
@@ -6,22 +6,22 @@ import SelectableDatasets from '../../../src/pages/dar_application/SelectableDat
 
 const datasets = [
   {
-    dataSetId: 123456,
+    datasetId: 123456,
     datasetIdentifier: `DUOS-123456`,
     datasetName: 'Some Dataset 1'
   },
   {
-    dataSetId: 234567,
+    datasetId: 234567,
     datasetIdentifier: `DUOS-234567`,
     datasetName: 'Some Dataset 2'
   },
   {
-    dataSetId: 345678,
+    datasetId: 345678,
     datasetIdentifier: `DUOS-345678`,
     datasetName: 'Some Dataset 3'
   },
   {
-    dataSetId: 456789,
+    datasetId: 456789,
     datasetIdentifier: `DUOS-456789`,
     datasetName: 'Some Dataset 4'
   },

--- a/cypress/component/MultiDatasetVoteTab/datasets_requested.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/datasets_requested.spec.js
@@ -5,7 +5,7 @@ import DatasetsRequestedPanel from '../../../src/components/collection_voting_sl
 
 const dataset = (id) => {
   return {
-    dataSetId: id,
+    datasetId: id,
     datasetIdentifier: `DUOS-${id}`,
     name: `Dataset ${id}`
   };
@@ -182,7 +182,7 @@ describe('DatasetsRequestedPanel - Tests', function () {
       <DatasetsRequestedPanel
         bucketDatasets={[
           {
-            dataSetId: 1,
+            datasetId: 1,
             name: 'Dataset 1'
           }
         ]}
@@ -199,7 +199,7 @@ describe('DatasetsRequestedPanel - Tests', function () {
       <DatasetsRequestedPanel
         bucketDatasets={[
           {
-            dataSetId: 1,
+            datasetId: 1,
             datasetIdentifier: 'DUOS-1'
           }
         ]}

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.js
@@ -7,11 +7,11 @@ import { Votes } from '../../../src/libs/ajax/Votes';
 import {votingColors} from '../../../src/pages/dar_collection_review/MultiDatasetVotingTab';
 import {ControlledAccessType} from '../../../src/libs/dataUseTranslation';
 
-const openElection1 = {dataSetId: 10, electionId: 101, status: 'Open', electionType: 'DataAccess'};
+const openElection1 = {datasetId: 10, electionId: 101, status: 'Open', electionType: 'DataAccess'};
 
-const openElection2 = {dataSetId: 20, electionId: 102, status: 'Open', electionType: 'DataAccess'};
+const openElection2 = {datasetId: 20, electionId: 102, status: 'Open', electionType: 'DataAccess'};
 
-const closedElection = {dataSetId: 30, electionId: 103, status: 'Closed', electionType: 'DataAccess'};
+const closedElection = {datasetId: 30, electionId: 103, status: 'Closed', electionType: 'DataAccess'};
 
 const votesForOpenElection1 = {
   dataAccess: {

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.js
@@ -15,7 +15,7 @@ const bucket1 = {
   key: 'bucket1',
   elections: [
     [
-      {dataSetId: 300, electionId: 101, status: 'Open', electionType: 'DataAccess'},
+      {datasetId: 300, electionId: 101, status: 'Open', electionType: 'DataAccess'},
       {electionId: 100, electionType: 'RP Vote'}
     ],
   ],
@@ -58,7 +58,7 @@ const bucket2 = {
   key: 'bucket2',
   elections: [
     [
-      {dataSetId: 400, electionId: 101, status: 'Open', electionType: 'DataAccess'},
+      {datasetId: 400, electionId: 101, status: 'Open', electionType: 'DataAccess'},
       {electionId: 100, electionType: 'RP Vote'}
     ],
   ],
@@ -97,8 +97,8 @@ const bucket2 = {
 
 const collection = {
   datasets: [
-    {dataSetId: 300},
-    {dataSetId: 400}
+    {datasetId: 300},
+    {datasetId: 400}
   ],
   createUser: {
     libraryCards: [{id: 1}]
@@ -107,7 +107,7 @@ const collection = {
 
 const collectionMissingLibraryCard = {
   datasets: [
-    {dataSetId: 300}
+    {datasetId: 300}
   ],
   createUser: {
     libraryCards: []
@@ -116,7 +116,7 @@ const collectionMissingLibraryCard = {
 
 beforeEach(() => {
   cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
-  cy.stub(User, 'getUserRelevantDatasets').returns([{dataSetId: 300}, {dataSetId: 400}]);
+  cy.stub(User, 'getUserRelevantDatasets').returns([{datasetId: 300}, {datasetId: 400}]);
 });
 
 describe('MultiDatasetVoteTab - Tests', function() {

--- a/cypress/component/utils/bucket_utils.spec.js
+++ b/cypress/component/utils/bucket_utils.spec.js
@@ -16,7 +16,7 @@ const dar_collection = {
           'electionId': 1,
           'electionType': 'DataAccess',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 1,
+          'datasetId': 1,
           'votes': {
             '1': {
               'voteId': 1,
@@ -48,7 +48,7 @@ const dar_collection = {
           'electionId': 2,
           'electionType': 'RP',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 1,
+          'datasetId': 1,
           'votes': {
             '4': {
               'voteId': 4,
@@ -80,7 +80,7 @@ const dar_collection = {
           'electionId': 3,
           'electionType': 'DataAccess',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 2,
+          'datasetId': 2,
           'votes': {
             '11': {
               'voteId': 11,
@@ -112,7 +112,7 @@ const dar_collection = {
           'electionId': 4,
           'electionType': 'RP',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 2,
+          'datasetId': 2,
           'votes': {
             '44': {
               'voteId': 44,
@@ -144,7 +144,7 @@ const dar_collection = {
           'electionId': 5,
           'electionType': 'DataAccess',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 3,
+          'datasetId': 3,
           'votes': {
             '111': {
               'voteId': 111,
@@ -176,7 +176,7 @@ const dar_collection = {
           'electionId': 6,
           'electionType': 'RP',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 3,
+          'datasetId': 3,
           'votes': {
             '444': {
               'voteId': 444,
@@ -208,7 +208,7 @@ const dar_collection = {
           'electionId': 7,
           'electionType': 'DataAccess',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 4,
+          'datasetId': 4,
           'votes': {
             '1111': {
               'voteId': 1111,
@@ -240,7 +240,7 @@ const dar_collection = {
           'electionId': 8,
           'electionType': 'RP',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 4,
+          'datasetId': 4,
           'votes': {
             '4444': {
               'voteId': 4444,
@@ -272,7 +272,7 @@ const dar_collection = {
           'electionId': 9,
           'electionType': 'DataAccess',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 5,
+          'datasetId': 5,
           'votes': {
             '11111': {
               'voteId': 11111,
@@ -304,7 +304,7 @@ const dar_collection = {
           'electionId': 10,
           'electionType': 'RP',
           'referenceId': 'dar-reference-id-1',
-          'dataSetId': 5,
+          'datasetId': 5,
           'votes': {
             '44444': {
               'voteId': 44444,
@@ -338,35 +338,35 @@ const dar_collection = {
   },
   'datasets': [
     {
-      'dataSetId': 1,
+      'datasetId': 1,
       'datasetName': 'ds 1',
       'datasetIdentifier': 'DUOS-000001',
       'dataUse': {'generalUse': true},
       'dacId': 1
     },
     {
-      'dataSetId': 2,
+      'datasetId': 2,
       'datasetName': 'ds 2',
       'datasetIdentifier': 'DUOS-000002',
       'dataUse': {'generalUse': true},
       'dacId': 2
     },
     {
-      'dataSetId': 3,
+      'datasetId': 3,
       'datasetName': 'ds 3',
       'datasetIdentifier': 'DUOS-000003',
       'dataUse': {'generalUse': false, 'other': 'other restrictions'},
       'dacId': 3
     },
     {
-      'dataSetId': 4,
+      'datasetId': 4,
       'datasetName': 'ds 4',
       'datasetIdentifier': 'DUOS-000004',
       'dataUse': {'generalUse': false, 'secondaryOther': 'secondary other restrictions'},
       'dacId': 4
     },
     {
-      'dataSetId': 5,
+      'datasetId': 5,
       'datasetName': 'ds 5',
       'datasetIdentifier': 'DUOS-000005',
       'dacId': 5
@@ -465,7 +465,7 @@ describe('BucketUtils', () => {
     expect(dataAccessBuckets[0].datasetIds.length).to.eq(1);
     forEach(b => {
       forEach(e => {
-        expect(b.datasetIds).to.contain(e.dataSetId);
+        expect(b.datasetIds).to.contain(e.datasetId);
       })(b.elections);
     })(buckets);
   });
@@ -478,7 +478,7 @@ describe('BucketUtils', () => {
     expect(dataAccessBuckets.length).to.eq(2);
     forEach(b => {
       forEach(e => {
-        expect(b.datasetIds).to.contain(e.dataSetId);
+        expect(b.datasetIds).to.contain(e.datasetId);
       })(b.elections);
     })(buckets);
   });
@@ -617,7 +617,7 @@ describe('BucketUtils', () => {
               'electionId': 1,
               'electionType': 'DataAccess',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 1,
+              'datasetId': 1,
               'votes': {
                 '1': {
                   'voteId': 1,
@@ -649,7 +649,7 @@ describe('BucketUtils', () => {
               'electionId': 2,
               'electionType': 'RP',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 1,
+              'datasetId': 1,
               'votes': {
                 '4': {
                   'voteId': 4,
@@ -681,7 +681,7 @@ describe('BucketUtils', () => {
               'electionId': 3,
               'electionType': 'DataAccess',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 2,
+              'datasetId': 2,
               'votes': {
                 '11': {
                   'voteId': 11,
@@ -713,7 +713,7 @@ describe('BucketUtils', () => {
               'electionId': 4,
               'electionType': 'RP',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 2,
+              'datasetId': 2,
               'votes': {
                 '44': {
                   'voteId': 44,
@@ -745,7 +745,7 @@ describe('BucketUtils', () => {
               'electionId': 5,
               'electionType': 'DataAccess',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 3,
+              'datasetId': 3,
               'votes': {
                 '111': {
                   'voteId': 111,
@@ -777,7 +777,7 @@ describe('BucketUtils', () => {
               'electionId': 6,
               'electionType': 'RP',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 3,
+              'datasetId': 3,
               'votes': {
                 '444': {
                   'voteId': 444,
@@ -809,7 +809,7 @@ describe('BucketUtils', () => {
               'electionId': 7,
               'electionType': 'DataAccess',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 4,
+              'datasetId': 4,
               'votes': {
                 '1111': {
                   'voteId': 1111,
@@ -841,7 +841,7 @@ describe('BucketUtils', () => {
               'electionId': 8,
               'electionType': 'RP',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 4,
+              'datasetId': 4,
               'votes': {
                 '4444': {
                   'voteId': 4444,
@@ -873,7 +873,7 @@ describe('BucketUtils', () => {
               'electionId': 9,
               'electionType': 'DataAccess',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 5,
+              'datasetId': 5,
               'votes': {
                 '11111': {
                   'voteId': 11111,
@@ -905,7 +905,7 @@ describe('BucketUtils', () => {
               'electionId': 10,
               'electionType': 'RP',
               'referenceId': 'dar-reference-id-1',
-              'dataSetId': 5,
+              'datasetId': 5,
               'votes': {
                 '44444': {
                   'voteId': 44444,
@@ -939,35 +939,35 @@ describe('BucketUtils', () => {
       },
       'datasets': [
         {
-          'dataSetId': 1,
+          'datasetId': 1,
           'datasetName': 'ds 1',
           'datasetIdentifier': 'DUOS-000001',
           'dataUse': {'hmbResearch': true, 'other': 'Samples and information may not be sold for profit.'},
           'dacId': 1
         },
         {
-          'dataSetId': 2,
+          'datasetId': 2,
           'datasetName': 'ds 2',
           'datasetIdentifier': 'DUOS-000002',
           'dataUse': {'generalUse': true},
           'dacId': 2
         },
         {
-          'dataSetId': 3,
+          'datasetId': 3,
           'datasetName': 'ds 3',
           'datasetIdentifier': 'DUOS-000003',
           'dataUse': {'hmbResearch': true},
           'dacId': 3
         },
         {
-          'dataSetId': 4,
+          'datasetId': 4,
           'datasetName': 'ds 4',
           'datasetIdentifier': 'DUOS-000004',
           'dataUse': {'generalUse': true},
           'dacId': 4
         },
         {
-          'dataSetId': 5,
+          'datasetId': 5,
           'datasetName': 'ds 5',
           'datasetIdentifier': 'DUOS-000005',
           'dataUse': {'hmbResearch': true},

--- a/cypress/component/utils/utils.spec.js
+++ b/cypress/component/utils/utils.spec.js
@@ -11,7 +11,7 @@ const collectionWithMixedElectionStatuses = {
         0: {
           status: 'Closed',
           electionType: 'DataAccess',
-          dataSetId: 100
+          datasetId: 100
         }
       }
     },
@@ -20,7 +20,7 @@ const collectionWithMixedElectionStatuses = {
         1: {
           status: 'Open',
           electionType: 'DataAccess',
-          dataSetId: 200,
+          datasetId: 200,
           votes: {0: {type: 'DAC'}}
         }
       }
@@ -35,7 +35,7 @@ const collectionWithSameElectionStatus = {
         0: {
           status: 'Closed',
           electionType: 'DataAccess',
-          dataSetId: 100
+          datasetId: 100
         }
       }
     },
@@ -44,7 +44,7 @@ const collectionWithSameElectionStatus = {
         1: {
           status: 'Closed',
           electionType: 'DataAccess',
-          dataSetId: 200
+          datasetId: 200
         }
       }
     }
@@ -362,7 +362,7 @@ describe('Dar Collection determineCollectionStatus', () => {
         0: {data: {datasetIds: [100]}}
       }
     };
-    const relevantDatasets = [{dataSetId: 100}];
+    const relevantDatasets = [{datasetId: 100}];
     const status = determineCollectionStatus(collection, relevantDatasets);
     expect(toLower(status)).equals('unreviewed');
   });
@@ -388,12 +388,12 @@ describe('Dar Collection determineCollectionStatus', () => {
             0: {
               status: 'Closed',
               electionType: 'DataAccess',
-              dataSetId: 100
+              datasetId: 100
             },
             1: {
               status: 'Open',
               electionType: 'RP',
-              dataSetId: 100
+              datasetId: 100
             },
           }
         }
@@ -411,24 +411,24 @@ describe('Dar Collection determineCollectionStatus', () => {
             0: {
               status: 'Closed',
               electionType: 'DataAccess',
-              dataSetId: 100
+              datasetId: 100
             },
             1: {
               status: 'Open',
               electionType: 'RP',
-              dataSetId: 100
+              datasetId: 100
             },
           }
         }
       }
     };
-    const relevantDatasets = [{dataSetId: 100}, {dataSetId: 200}];
+    const relevantDatasets = [{datasetId: 100}, {datasetId: 200}];
     const status = determineCollectionStatus(collection, relevantDatasets);
     expect(toLower(status)).equals('denied');
   });
 
   it('Only considers DARs for relevant datasets when determining collection status', () => {
-    const relevantDatasets = [{dataSetId: 100}];
+    const relevantDatasets = [{datasetId: 100}];
     const status = determineCollectionStatus(collectionWithMixedElectionStatuses, relevantDatasets);
     expect(toLower(status)).equals('denied');
   });
@@ -444,13 +444,13 @@ describe('Dar Collection determineCollectionStatus', () => {
   });
 
   it('Appends together statuses when relevant datasets is non-null and elections have different statuses', () => {
-    const relevantDatasets = [{dataSetId: 100}, {dataSetId: 200}];
+    const relevantDatasets = [{datasetId: 100}, {datasetId: 200}];
     const status = determineCollectionStatus(collectionWithMixedElectionStatuses, relevantDatasets);
     expect(toLower(status)).equals('denied, open');
   });
 
   it('Only returns unique statuses when relevant datasets is non-null and multiple elections have the same status', () => {
-    const relevantDatasets = [{dataSetId: 100}, {dataSetId: 200}];
+    const relevantDatasets = [{datasetId: 100}, {datasetId: 200}];
     const status = determineCollectionStatus(collectionWithSameElectionStatus, relevantDatasets);
     expect(toLower(status)).equals('denied');
   });

--- a/src/components/collection_voting_slab/DatasetsRequestedPanel.jsx
+++ b/src/components/collection_voting_slab/DatasetsRequestedPanel.jsx
@@ -51,8 +51,8 @@ export default function DatasetsRequestedPanel(props) {
     const datasets = adminPage ?
       bucketDatasets :
       filter(dataset => {
-        const { dataSetId } = dataset;
-        return includes(dataSetId)(dacDatasetIds);
+        const { datasetId } = dataset;
+        return includes(datasetId)(dacDatasetIds);
       })(bucketDatasets);
 
     setFilteredDatasets(datasets);
@@ -84,7 +84,7 @@ export default function DatasetsRequestedPanel(props) {
   const DatasetList = () => {
     const datasetRows = map(dataset => {
       return (
-        <div style={{display: 'flex'}} key={dataset.dataSetId} className="dataset-list-item">
+        <div style={{display: 'flex'}} key={dataset.datasetId} className="dataset-list-item">
           <div style={{width: '12.5%'}}>{datasetId(dataset)}</div>
           <div style={{width: '75%'}}>{datasetName(dataset)}</div>
         </div>

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -100,7 +100,7 @@ export const DatasetUpdate = (props) => {
     multiPartFormData.append('dataset', JSON.stringify(newDataset));
     multiPartFormData.append('consentGroups', consentGroups);
 
-    DataSet.updateDatasetV3(dataset.dataSetId, multiPartFormData).then(() => {
+    DataSet.updateDatasetV3(dataset.datasetId, multiPartFormData).then(() => {
       history.push('/datalibrary');
       Notifications.showSuccess({ text: 'Update submitted successfully!' });
     }, () => {

--- a/src/libs/ajax/DataSet.js
+++ b/src/libs/ajax/DataSet.js
@@ -41,8 +41,8 @@ export const DataSet = {
     return res.data;
   },
 
-  getDataSetsByDatasetId: async (dataSetId) => {
-    const url = `${await getApiUrl()}/api/dataset/v2/${dataSetId}`;
+  getDataSetsByDatasetId: async (datasetId) => {
+    const url = `${await getApiUrl()}/api/dataset/v2/${datasetId}`;
     const res = await fetchOk(url, Config.authOpts());
     return await res.json();
   },

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -56,8 +56,8 @@ export const darCollectionUtils = {
             if (isNil(relevantDatasets)) {
               return electionArr;
             } else {
-              const relevantIds = map(dataset => dataset.dataSetId)(relevantDatasets);
-              return filter(election => includes(election.dataSetId, relevantIds))(electionArr);
+              const relevantIds = map(dataset => dataset.datasetId)(relevantDatasets);
+              return filter(election => includes(election.datasetId, relevantIds))(electionArr);
             }
           }
         }),

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -26,7 +26,7 @@ export default function DatasetStatistics(props) {
 
   useEffect(() => {
     DataSet.getDatasetByDatasetIdentifier(datasetIdentifier).then((dataset) => {
-      setData(dataset.dataSetId);
+      setData(dataset.datasetId);
     }).catch(() => {
       Notifications.showError({ text: 'Error: Unable to retrieve dataset from server' });
     });

--- a/src/pages/dar_application/DataAccessRequest.jsx
+++ b/src/pages/dar_application/DataAccessRequest.jsx
@@ -41,7 +41,7 @@ const autocompleteOntologies = (query, callback) => {
 };
 
 const searchDatasets = (query, callback, currentDatasets) => {
-  const currentDatasetIds = currentDatasets.map((ds) => ds.dataSetId);
+  const currentDatasetIds = currentDatasets.map((ds) => ds.datasetId);
 
   DataSet.autocompleteDatasets(query).then(items => {
     const processedDatasets = items.map((ds) => {
@@ -49,9 +49,9 @@ const searchDatasets = (query, callback, currentDatasets) => {
       // a simplified auto-complete dataset object. We need to standardize the keys to ensure
       // legacy functionality is maintained.
       return {
-        id: ds.id || ds.dataSetId || ds.datasetId,
-        datasetId: ds.id || ds.dataSetId || ds.datasetId,
-        dataSetId: ds.id || ds.dataSetId || ds.datasetId,
+        id: ds.id || ds.datasetId,
+        datasetId: ds.id || ds.datasetId,
+        datasetId: ds.id || ds.datasetId,
         identifier: ds.identifier || ds.datasetIdentifier,
         datasetIdentifier: ds.identifier || ds.datasetIdentifier,
         datasetName: ds.name || ds.datasetName,
@@ -59,7 +59,7 @@ const searchDatasets = (query, callback, currentDatasets) => {
         ... ds
       };
     });
-    let options = processedDatasets.filter((ds) => !currentDatasetIds.includes(ds.dataSetId)).map(function (item) {
+    let options = processedDatasets.filter((ds) => !currentDatasetIds.includes(ds.datasetId)).map(function (item) {
       return formatSearchDataset(item);
     });
     callback(options);
@@ -68,8 +68,8 @@ const searchDatasets = (query, callback, currentDatasets) => {
 
 const formatSearchDataset = (ds) => {
   return {
-    key: ds.dataSetId,
-    value: ds.dataSetId,
+    key: ds.datasetId,
+    value: ds.datasetId,
     dataset: ds,
     displayText: ds.datasetIdentifier,
     label: <span>
@@ -174,7 +174,7 @@ export default function DataAccessRequest(props) {
             placeholder={'Dataset Name, Sample Collection ID, or PI'}
             onChange={async ({key, value}) => {
               const datasets = value.map((val) => val.dataset);
-              const datasetIds = datasets?.map((ds) => ds.dataSetId);
+              const datasetIds = datasets?.map((ds) => ds.datasetId);
               const fullDatasets = await DataSet.getDatasetsByIds(datasetIds);
               onChange({key, value: datasetIds});
               setDatasets(fullDatasets);

--- a/src/pages/dar_application/DataAccessRequest.jsx
+++ b/src/pages/dar_application/DataAccessRequest.jsx
@@ -51,7 +51,6 @@ const searchDatasets = (query, callback, currentDatasets) => {
       return {
         id: ds.id || ds.datasetId,
         datasetId: ds.id || ds.datasetId,
-        datasetId: ds.id || ds.datasetId,
         identifier: ds.identifier || ds.datasetIdentifier,
         datasetIdentifier: ds.identifier || ds.datasetIdentifier,
         datasetName: ds.name || ds.datasetName,

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -270,8 +270,8 @@ const DataAccessRequestApplication = (props) => {
       const { dars, datasets } = collection;
       const darReferenceId = head(keys(dars));
       formData = await DAR.getPartialDarRequest(darReferenceId);
-      // This is a collection, so we need to get the datasets and dataSetIds from the collection
-      formData.datasetIds = map(ds => get('dataSetId')(ds))(datasets);
+      // This is a collection, so we need to get the datasets and datasetIds from the collection
+      formData.datasetIds = map(ds => get('datasetId')(ds))(datasets);
     }
     else if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
@@ -449,7 +449,7 @@ const DataAccessRequestApplication = (props) => {
     let formattedFormData = cloneDeep(formData);
     // DAR datasetIds needs to be a list of ids
     if (DAAUtils.isEnabled()) {
-      formattedFormData.datasetIds = selectedDatasets.map(d => d.dataSetId);
+      formattedFormData.datasetIds = selectedDatasets.map(d => d.datasetId);
     }
 
     // Make sure we navigate back to the current DAR after saving.

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -129,22 +129,22 @@ export default function DucAddendum(props) {
         return [
           {
             data: dataset.datasetIdentifier,
-            id: dataset.dataSetId,
+            id: dataset.datasetId,
             style: columnStyles
           },
           {
             data: dataset.datasetName?.replaceAll('_', '_\u200b'),
-            id: dataset.dataSetId,
+            id: dataset.datasetId,
             style: columnStyles
           },
           {
             data: '',
-            id: dataset.dataSetId,
+            id: dataset.datasetId,
             style: columnStyles
           },
           {
             data: '',
-            id: dataset.dataSetId,
+            id: dataset.datasetId,
             style: columnStyles
           }
         ];

--- a/src/pages/dar_application/SelectableDatasets.jsx
+++ b/src/pages/dar_application/SelectableDatasets.jsx
@@ -9,15 +9,15 @@ export default function SelectableDatasets(props) {
 
   useEffect(() => {
     // Populate parent state with the current state of datasets to be saved to the DAR
-    const newSelectedDatasets = datasets.filter(ds => !removedIds.includes(ds.dataSetId));
+    const newSelectedDatasets = datasets.filter(ds => !removedIds.includes(ds.datasetId));
     setSelectedDatasets(newSelectedDatasets);
   }, [removedIds, datasets, setSelectedDatasets]);
 
   const updateLocalState = (ds) => {
-    if (removedIds.includes(ds.dataSetId)) {
-      setRemovedIds(removedIds.toSpliced(removedIds.indexOf(ds.dataSetId), 1));
+    if (removedIds.includes(ds.datasetId)) {
+      setRemovedIds(removedIds.toSpliced(removedIds.indexOf(ds.datasetId), 1));
     } else {
-      setRemovedIds(removedIds.concat(ds.dataSetId));
+      setRemovedIds(removedIds.concat(ds.datasetId));
     }
   };
 
@@ -34,22 +34,22 @@ export default function SelectableDatasets(props) {
     const isDeletable = removedIds.length < datasets.length - 1;
     const clickable = isDeletable && !disabled;
     return <div
-      key={'selectable_dataset_' + ds.dataSetId}
+      key={'selectable_dataset_' + ds.datasetId}
       id={ds.datasetIdentifier + '_summary'}
       className="collaborator-summary-card"
       style={disabled ? {} : {cursor: 'pointer'}}
       {...(clickable ? {onClick: () => updateLocalState(ds)} : {})}>
       {datasetDescriptionDiv(ds)}
-      <span id={'remove_dataset_' + ds.dataSetId} style={{marginLeft: 10}}>
+      <span id={'remove_dataset_' + ds.datasetId} style={{marginLeft: 10}}>
         <>
           {!disabled && <DeleteIcon
             data-tip="Delete dataset"
-            data-for={removedIds.length === (datasets.length - 1) && !removedIds.includes(ds.dataSetId) ? 'tip_last' : ''}
+            data-for={removedIds.length === (datasets.length - 1) && !removedIds.includes(ds.datasetId) ? 'tip_last' : ''}
             style={{
               color: '#0948B7',
               fontSize: '2.3rem',
               verticalAlign: 'middle',
-              opacity: removedIds.length === (datasets.length - 1) && !removedIds.includes(ds.dataSetId) ? 0.5 : 1
+              opacity: removedIds.length === (datasets.length - 1) && !removedIds.includes(ds.datasetId) ? 0.5 : 1
             }}
           />}
           {!isDeletable &&
@@ -67,13 +67,13 @@ export default function SelectableDatasets(props) {
       {backgroundColor: 'lightgray', opacity: .5} :
       {backgroundColor: 'lightgray', opacity: .5, cursor: 'pointer'};
     return <div
-      key={'selectable_dataset_' + ds.dataSetId}
+      key={'selectable_dataset_' + ds.datasetId}
       id={ds.datasetIdentifier + '_summary'}
       className="collaborator-summary-card"
       style={style}
       {...(disabled ? {} : {onClick: () => updateLocalState(ds)})}>
       {datasetDescriptionDiv(ds)}
-      <span id={'restore_dataset_' + ds.dataSetId} style={{marginLeft: 10}}>
+      <span id={'restore_dataset_' + ds.datasetId} style={{marginLeft: 10}}>
         {!disabled && <RestoreFromTrashIcon style={{color: '#0948B7', fontSize: '2.3rem', verticalAlign: 'middle'}}/>}
         <span style={{marginLeft: '1rem'}}></span>
       </span>
@@ -82,7 +82,7 @@ export default function SelectableDatasets(props) {
 
   const datasetList = () => {
     return datasets.map((ds) => {
-      return removedIds.includes(ds.dataSetId) ?
+      return removedIds.includes(ds.datasetId) ?
         unDeletableStyled(ds) :
         deletableStyled(ds);
     });

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
@@ -50,7 +50,7 @@ export default function MultiDatasetVotingTab(props) {
     const init = async () => {
       const dacDatasets = adminPage ? [] : await User.getUserRelevantDatasets();
       const datasetIds = flow(
-        map(dataset => get('dataSetId')(dataset)),
+        map(dataset => get('datasetId')(dataset)),
         filter(datasetId => !isNil(datasetId))
       )(dacDatasets);
       setDacDatasetIds(datasetIds);

--- a/src/pages/data_submission/DataAccessGovernance.jsx
+++ b/src/pages/data_submission/DataAccessGovernance.jsx
@@ -121,7 +121,7 @@ export const DataAccessGovernance = (props) => {
 
       return {
         consentGroup: {
-          datasetId: dataset.dataSetId,
+          datasetId: dataset.datasetId,
           consentGroupName: dataset.name,
 
           // primary

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -95,7 +95,7 @@ export interface Institution {
 export interface Dataset {
   name: string;
   datasetName: string;
-  dataSetId: number;
+  datasetId: number;
   createUserId: number;
   createUser: DuosUserResponse;
   dacId: string;

--- a/src/utils/BucketUtils.js
+++ b/src/utils/BucketUtils.js
@@ -71,7 +71,7 @@ export const binCollectionToBuckets = async (collection, dacIds = []) => {
       key: '',
       label: '',
       datasets: [dataset],
-      datasetIds: [dataset.dataSetId],
+      datasetIds: [dataset.datasetId],
       dataUse: dataset.dataUse,
       dataUses: [],
       elections: [],
@@ -87,7 +87,7 @@ export const binCollectionToBuckets = async (collection, dacIds = []) => {
       forEach(b => {
         if (isEqualDataUse(b.dataUse, dataset.dataUse)) {
           b.datasets.push(dataset);
-          b.datasetIds.push(dataset.dataSetId);
+          b.datasetIds.push(dataset.datasetId);
           added = true;
         }
       })(buckets);
@@ -166,7 +166,7 @@ const findElectionsForDatasets = (collection, datasetIds) => {
     values, // List of DARs
     flatMap(dar => get('elections')(dar)), // List of maps of election id -> election
     flatMap(eMap => values(eMap)), // List of election objects
-    filter(e => includes(get('dataSetId')(e))(datasetIds))
+    filter(e => includes(get('datasetId')(e))(datasetIds))
   )(darMap);
 };
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DCJ-702

### Summary

Needs to go in with https://github.com/DataBiosphere/consent/pull/2411 . Consolidates use of `dataSetId` and `datasetId`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
