### PR TITLE
[dt-741] Fix default value for exportable datasets

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -38,7 +38,7 @@ const defaultFilters = {
 
 export const DatasetSearchTable = (props) => {
   const { datasets, history, icon, title } = props;
-  const [exportableDatasets, setExportableDatasets] = useState();
+  const [exportableDatasets, setExportableDatasets] = useState({});
   const [filters, setFilters] = useState(defaultFilters);
   const [filtered, setFiltered] = useState([]);
   const [selected, setSelected] = useState([]);


### PR DESCRIPTION
### Addresses
Fixes the default value for `exportableDatasets` to be an empty object so we don't error out before getting snapshots - we just can't export till we do. (Ideally we would have a loading spinner, but since this isn't the long term home for export I figured this was a good low effort fix)
### Summary

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
