### PR TITLE
[DT-936] Ensure H3 validation fields have correct styling

### DIFF
--- a/src/components/forms/forms.jsx
+++ b/src/components/forms/forms.jsx
@@ -37,6 +37,7 @@ export const commonOptionalProps = [
   'defaultValue',
   'hideTitle',
   'style',
+  'titleStyle',
   'validators',
   'onChange',
   'type',
@@ -216,6 +217,7 @@ export const FormFieldTitle = (props) => {
     ariaLevel,
     required,
     validation,
+    titleStyle,
   } = props;
 
   return <div>
@@ -223,6 +225,7 @@ export const FormFieldTitle = (props) => {
       <label
         id={`lbl_${formId}`}
         className={`control-label ${isValid(validation) ? '' : 'errored'}`}
+        style={titleStyle}
         htmlFor={`${formId}`}
         aria-level={ariaLevel}>
         {title}
@@ -238,7 +241,7 @@ export const FormField = (config) => {
   const {
     id, name, type = FormFieldTypes.TEXT, ariaLevel,
     title, hideTitle, description, helpText,
-    defaultValue, style, validators,
+    defaultValue, style, titleStyle, validators,
     validation, onValidationChange
   } = config;
 
@@ -288,6 +291,7 @@ export const FormField = (config) => {
       formId={id}
       ariaLevel={ariaLevel}
       validation={getValidation()}
+      titleStyle={titleStyle}
     />
     <type.component
       {...config}

--- a/src/pages/dar_application/DataAccessRequest.jsx
+++ b/src/pages/dar_application/DataAccessRequest.jsx
@@ -13,6 +13,8 @@ import {
 import SelectableDatasets from './SelectableDatasets';
 import {DAAUtils} from '../../utils/DAAUtils';
 
+const titleStyle = { fontSize: '24px', fontWeight: 500, color: '#333333' };
+
 const formatOntologyForSelect = (ontology) => {
   return {
     value: ontology.id,
@@ -144,7 +146,7 @@ export default function DataAccessRequest(props) {
 
         {DAAUtils.isEnabled() ?
           <div>
-            <label style={{ fontSize: '24px', fontWeight: 500, color: '#333333', display: 'block', marginBottom: '0.5rem' }} className="control-label">2.1 Select Dataset(s)</label>
+            <label style={{ ...titleStyle, display: 'block', marginBottom: '0.5rem' }} className="control-label">2.1 Select Dataset(s)</label>
             <p style={{ marginBottom: '1rem' }}>Currently selected datasets:</p>
             <SelectableDatasets
               disabled={readOnlyMode}
@@ -160,7 +162,7 @@ export default function DataAccessRequest(props) {
             isAsync={true}
             isMulti={true}
             title={'2.1 Select Dataset(s)'}
-            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+            titleStyle={titleStyle}
             validators={[FormValidators.REQUIRED]}
             validation={validation.datasetIds}
             onValidationChange={onValidationChange}
@@ -188,7 +190,7 @@ export default function DataAccessRequest(props) {
           id={'projectTitle'}
           key={'projectTitle'}
           title={'2.2 Descriptive Title of Project'}
-          titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+          titleStyle={titleStyle}
           disabled={readOnlyMode}
           validators={[FormValidators.REQUIRED]}
           validation={validation.projectTitle}
@@ -211,7 +213,7 @@ export default function DataAccessRequest(props) {
           disabled={readOnlyMode}
           type={FormFieldTypes.TEXTAREA}
           title={'2.3 Research Use Statement (RUS)'}
-          titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+          titleStyle={titleStyle}
           validators={[FormValidators.REQUIRED]}
           description={
             <>
@@ -329,7 +331,7 @@ export default function DataAccessRequest(props) {
           disabled={readOnlyMode}
           type={FormFieldTypes.TEXTAREA}
           title={'2.4 Non-Technical Summary'}
-          titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+          titleStyle={titleStyle}
           validators={[FormValidators.REQUIRED]}
           description={includeInstructions ? 'Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below).' : ''}
           placeholder={'Please limit your your non-technical summary to 1100 characters'}

--- a/src/pages/dar_application/DataAccessRequest.jsx
+++ b/src/pages/dar_application/DataAccessRequest.jsx
@@ -140,9 +140,11 @@ export default function DataAccessRequest(props) {
     // eslint-disable-next-line react/no-unknown-property
     <div datacy={'data-access-request'}>
       <div className={'dar-step-card'}>
+        <h2>Step 2: Data Access Request</h2>
+
         {DAAUtils.isEnabled() ?
           <div>
-            <label style={{ fontWeight: 'bold', display: 'block', marginBottom: '0.5rem' }} className="control-label">2.1 Select Dataset(s)</label>
+            <label style={{ fontSize: '24px', fontWeight: 500, color: '#333333', display: 'block', marginBottom: '0.5rem' }} className="control-label">2.1 Select Dataset(s)</label>
             <p style={{ marginBottom: '1rem' }}>Currently selected datasets:</p>
             <SelectableDatasets
               disabled={readOnlyMode}
@@ -158,6 +160,7 @@ export default function DataAccessRequest(props) {
             isAsync={true}
             isMulti={true}
             title={'2.1 Select Dataset(s)'}
+            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
             validators={[FormValidators.REQUIRED]}
             validation={validation.datasetIds}
             onValidationChange={onValidationChange}
@@ -185,6 +188,7 @@ export default function DataAccessRequest(props) {
           id={'projectTitle'}
           key={'projectTitle'}
           title={'2.2 Descriptive Title of Project'}
+          titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
           disabled={readOnlyMode}
           validators={[FormValidators.REQUIRED]}
           validation={validation.projectTitle}
@@ -207,6 +211,7 @@ export default function DataAccessRequest(props) {
           disabled={readOnlyMode}
           type={FormFieldTypes.TEXTAREA}
           title={'2.3 Research Use Statement (RUS)'}
+          titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
           validators={[FormValidators.REQUIRED]}
           description={
             <>
@@ -324,6 +329,7 @@ export default function DataAccessRequest(props) {
           disabled={readOnlyMode}
           type={FormFieldTypes.TEXTAREA}
           title={'2.4 Non-Technical Summary'}
+          titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
           validators={[FormValidators.REQUIRED]}
           description={includeInstructions ? 'Please enter below a non-technical summary of your RUS suitable for understanding by the general public (written at a high school reading level or below).' : ''}
           placeholder={'Please limit your your non-technical summary to 1100 characters'}

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -82,6 +82,7 @@ export default function ResearcherInfo(props) {
             id='researcherName'
             placeholder='Enter Firstname Lastname'
             title='1.1 Researcher'
+            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             defaultValue={researcher.displayName}
@@ -150,6 +151,7 @@ export default function ResearcherInfo(props) {
             description='I certify that the principal investigator listed below is aware of this study'
             placeholder='Firstname Lastname'
             title='1.3 Principal Investigator'
+            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             validation={validation.piName}
@@ -209,6 +211,7 @@ export default function ResearcherInfo(props) {
             type={FormFieldTypes.SELECT}
             description='I certify that the individual listed below is my Institutional Signing official'
             title='1.6 Institutional Signing Official'
+            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             defaultValue={formData.signingOfficial}
@@ -231,6 +234,7 @@ export default function ResearcherInfo(props) {
             description='I certify that the individual listed below is my IT Director'
             placeholder='Enter Firstname Lastname'
             title='1.7 Information Technology (IT) Director'
+            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             validation={validation.itDirector}
@@ -247,6 +251,7 @@ export default function ResearcherInfo(props) {
               disabled={readOnlyMode}
               type={FormFieldTypes.RADIOGROUP}
               title='1.8 Cloud Use Statement'
+              titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
               description={[
                 <span key='anvil-use-description'>
                   Will you perform all of your data storage and analysis for this project on the

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -8,6 +8,7 @@ import { FormField, FormValidators, FormFieldTypes } from '../../components/form
 import './dar_application.css';
 
 const linkStyle = {color: '#2FA4E7'};
+const titleStyle = { fontSize: '24px', fontWeight: 500, color: '#333333' };
 const profileLink = <Link to="/profile" style={linkStyle}>Your Profile</Link>;
 const profileUnsubmitted = <span>Please submit {profileLink} to be able to create a Data Access Request</span>;
 const profileSubmitted = <span>Please make sure {profileLink} is updated as it will be used to pre-populate parts of the Data Access Request</span>;
@@ -82,7 +83,7 @@ export default function ResearcherInfo(props) {
             id='researcherName'
             placeholder='Enter Firstname Lastname'
             title='1.1 Researcher'
-            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+            titleStyle={titleStyle}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             defaultValue={researcher.displayName}
@@ -151,7 +152,7 @@ export default function ResearcherInfo(props) {
             description='I certify that the principal investigator listed below is aware of this study'
             placeholder='Firstname Lastname'
             title='1.3 Principal Investigator'
-            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+            titleStyle={titleStyle}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             validation={validation.piName}
@@ -211,7 +212,7 @@ export default function ResearcherInfo(props) {
             type={FormFieldTypes.SELECT}
             description='I certify that the individual listed below is my Institutional Signing official'
             title='1.6 Institutional Signing Official'
-            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+            titleStyle={titleStyle}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             defaultValue={formData.signingOfficial}
@@ -234,7 +235,7 @@ export default function ResearcherInfo(props) {
             description='I certify that the individual listed below is my IT Director'
             placeholder='Enter Firstname Lastname'
             title='1.7 Information Technology (IT) Director'
-            titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+            titleStyle={titleStyle}
             validators={[FormValidators.REQUIRED]}
             ariaLevel={ariaLevel + 1}
             validation={validation.itDirector}
@@ -251,7 +252,7 @@ export default function ResearcherInfo(props) {
               disabled={readOnlyMode}
               type={FormFieldTypes.RADIOGROUP}
               title='1.8 Cloud Use Statement'
-              titleStyle={{ fontSize: '24px', fontWeight: 500, color: '#333333' }}
+              titleStyle={titleStyle}
               description={[
                 <span key='anvil-use-description'>
                   Will you perform all of your data storage and analysis for this project on the


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-936

### Summary

Previously, form fields that were used at the H3 level inherited the default form field styling which lead to inconsistencies in the DAR form styling. I added an optional `titleStyle` field that will allow a developer to set any styling on the title part of the form field so it can match the rest of the styling of the page. This leads to a consistent looking DAR page:

![Screenshot 2024-10-28 at 13-30-43 Broad Data Use Oversight System](https://github.com/user-attachments/assets/ef900c5e-e6ec-4892-8b17-8142ec8f4f85)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
