### PR TITLE
DT-617: Hide spinner after loading failure

### DIFF
--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -298,6 +298,7 @@ export const DatasetSearch = (props) => {
           });
         } catch (error) {
           Notifications.showError({ text: 'Failed to load Elasticsearch index' });
+          setLoading(false);
         }
       }
     };


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-617

### Summary
If the dataset search endpoint fails, this PR closes out the loading spinner.

To test, I started up a local Consent (without a local ES instance) not on the VPN so that it would error out when querying ES. Then point local UI to local Consent and visit the data library page. The loading spinner is closed.

Something I did **_not_** do was to percolate the error down to the table itself. The table just sees an empty list of datasets and thinks there are none for the current library filter. This could be expanded if we would like to see more info in that condition, but since this is a fairly infrequent use case, I didn't pursue this.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
