### PR TITLE
[DT-902] Replace DAC Column with Data Use Column in Data Library Dataset Table

### DIFF
--- a/src/components/dac_dataset_table/DACDatasetTableCellData.jsx
+++ b/src/components/dac_dataset_table/DACDatasetTableCellData.jsx
@@ -71,7 +71,7 @@ export function dataCustodianCellData({dataset, label = 'dataCustodianCellData'}
   };
 }
 
-export function dataUseCellData({dataset, label = 'dataUseCellData'}) {
+export function dataUseCellData({dataset, label = 'dataUseCellData', divClass = style['cell-data'], spanClass = style['data-use'], cellWidth = styles.cellWidths.dataUse, tooltipPlace = 'right'}) {
   const codesAndDescriptions = dataset.dataUse?.primary ? dataset.dataUse.primary.map((dataUse) => {
     if (dataUse.code === 'OTHER') {
       return {'code': `OTH1`, 'description': dataUse.description};
@@ -93,10 +93,10 @@ export function dataUseCellData({dataset, label = 'dataUseCellData'}) {
   }
   const codeList = codesAndDescriptions.map(du => du.code);
   const display =
-    <div className={style['cell-data']}>
-      <span className={style['data-use']} data-tip={true} data-for={`dataset-data-use-${dataset.datasetId}`}>{codeList.join(', ')}</span>
+    <div className={divClass}>
+      <span className={spanClass} data-tip={true} data-for={`dataset-data-use-${dataset.datasetId}`}>{codeList.join(', ')}</span>
       <ReactTooltip
-        place={'right'}
+        place={tooltipPlace}
         effect={'solid'}
         id={`dataset-data-use-${dataset.datasetId}`}>
         <ul>{codesAndDescriptions.map((translation, index) => {
@@ -108,7 +108,7 @@ export function dataUseCellData({dataset, label = 'dataUseCellData'}) {
     data: display,
     value: codeList.join(', '),
     id: `data-use-cell-data-${dataset.datasetId}`,
-    cellStyle: {width: styles.cellWidths.dataUse},
+    cellStyle: {width: cellWidth},
     label
   };
 }

--- a/src/components/data_search/DatasetSearch.css
+++ b/src/components/data_search/DatasetSearch.css
@@ -1,0 +1,5 @@
+.data-use-cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
+}

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -6,6 +6,8 @@ import {OverflowTooltip, tooltipStyle} from '../Tooltips';
 import {SnapshotSummaryModel} from 'src/types/tdrModel';
 import DatasetExportButton from './DatasetExportButton';
 import ReactTooltip from 'react-tooltip';
+import {dataUseCellData} from '../dac_dataset_table/DACDatasetTableCellData';
+import './DatasetSearch.css';
 
 export interface DatasetSearchTableTab<T> {
   key: string;
@@ -406,45 +408,13 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
       sortable: true,
       cellStyle: makeHeaderStyle(cellWidths.dataUse),
       cellDataFn: (dataset: DatasetTerm) => {
-        const codesAndDescriptions = dataset.dataUse?.primary ? dataset.dataUse.primary.map((dataUse) => {
-          if (dataUse.code === 'OTHER') {
-            return {'code': `OTH1`, 'description': dataUse.description};
-          } else if (dataUse.code === 'DS') {
-            const disease = dataUse.description.substring(dataUse.description.indexOf(':') + 2);
-            return {'code': `${dataUse.code} (${disease})`, 'description': dataUse.description};
-          } else {
-            return {'code': dataUse.code, 'description': dataUse.description};
-          }
-        }) : [];
-        if (dataset.dataUse?.secondary) {
-          dataset.dataUse?.secondary.forEach((dataUse) => {
-            if (dataUse.code === 'OTHER') {
-              codesAndDescriptions.push({'code': `OTH2`, 'description': dataUse.description});
-            } else {
-              codesAndDescriptions.push({'code': dataUse.code, 'description': dataUse.description});
-            }
-          });
-        }
-        const codeList = codesAndDescriptions.map(du => du.code);
-        const display =
-            <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
-              <span data-tip={true} data-for={`dataset-data-use-${dataset.datasetId}`}>{codeList.join(', ')}</span>
-              <ReactTooltip
-                place={'top'}
-                effect={'solid'}
-                id={`dataset-data-use-${dataset.datasetId}`}>
-                <ul>{codesAndDescriptions.map((translation, index) => {
-                  return <li key={`${translation.code}_s_${index}`}>{translation.code}: {translation.description}</li>;
-                })}</ul>
-              </ReactTooltip>
-            </div>;
-        return {
-          data: display,
-          value: codeList.join(', '),
-          id: `${dataset.datasetId}-data-use`,
-          style: makeRowStyle(cellWidths.dataUse),
-          label: `Data Use for dataset ${dataset.datasetId}: ${codeList}`
-        };
+        return dataUseCellData({
+          dataset,
+          label: `Data Use for dataset ${dataset.datasetId}: ${dataset}`,
+          divClass: ['data-use-cell'],
+          spanClass: [],
+          cellWidth: cellWidths.dataUse,
+          tooltipPlace: 'top'});
       }
     },
     {

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -230,7 +230,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
     dataType: string;
     donorSize: string;
     dataLocation: string;
-    dac: string;
+    dataUse: string;
     exportToTerra: number;
   }
   const cellWidths: CellWidths = {
@@ -243,7 +243,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
     dataType: '15%',
     donorSize: '7%',
     dataLocation: '13%',
-    dac: '10%',
+    dataUse: '10%',
     exportToTerra: 100,
   };
   const isSelectable = (dataset: DatasetTerm) => dataset.accessManagement != 'open' && dataset.accessManagement != 'external';
@@ -402,18 +402,50 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
       }
     },
     {
-      label: 'DAC',
+      label: 'Data Use',
       sortable: true,
-      cellStyle: makeHeaderStyle(cellWidths.dac),
-      cellDataFn: (dataset: DatasetTerm) => ({
-        data: <OverflowTooltip place={'top'} tooltipText={dataset.dac?.dacName} id={`${dataset.datasetId}-dataset-dac`}>
-          {dataset.dac?.dacName}
-        </OverflowTooltip>,
-        value: dataset.dac?.dacName,
-        id: `${dataset.datasetId}-dac`,
-        style: makeRowStyle(cellWidths.dac),
-        label: `DAC for dataset ${dataset.datasetId}: ${dataset.dac?.dacName}`
-      })
+      cellStyle: makeHeaderStyle(cellWidths.dataUse),
+      cellDataFn: (dataset: DatasetTerm) => {
+        const codesAndDescriptions = dataset.dataUse?.primary ? dataset.dataUse.primary.map((dataUse) => {
+          if (dataUse.code === 'OTHER') {
+            return {'code': `OTH1`, 'description': dataUse.description};
+          } else if (dataUse.code === 'DS') {
+            const disease = dataUse.description.substring(dataUse.description.indexOf(':') + 2);
+            return {'code': `${dataUse.code} (${disease})`, 'description': dataUse.description};
+          } else {
+            return {'code': dataUse.code, 'description': dataUse.description};
+          }
+        }) : [];
+        if (dataset.dataUse?.secondary) {
+          dataset.dataUse?.secondary.forEach((dataUse) => {
+            if (dataUse.code === 'OTHER') {
+              codesAndDescriptions.push({'code': `OTH2`, 'description': dataUse.description});
+            } else {
+              codesAndDescriptions.push({'code': dataUse.code, 'description': dataUse.description});
+            }
+          });
+        }
+        const codeList = codesAndDescriptions.map(du => du.code);
+        const display =
+            <div style={{overflow: 'hidden', textOverflow: 'ellipsis'}}>
+              <span data-tip={true} data-for={`dataset-data-use-${dataset.datasetId}`}>{codeList.join(', ')}</span>
+              <ReactTooltip
+                place={'top'}
+                effect={'solid'}
+                id={`dataset-data-use-${dataset.datasetId}`}>
+                <ul>{codesAndDescriptions.map((translation, index) => {
+                  return <li key={`${translation.code}_s_${index}`}>{translation.code}: {translation.description}</li>;
+                })}</ul>
+              </ReactTooltip>
+            </div>;
+        return {
+          data: display,
+          value: codeList.join(', '),
+          id: `${dataset.datasetId}-data-use`,
+          style: makeRowStyle(cellWidths.dataUse),
+          label: `Data Use for dataset ${dataset.datasetId}: ${codeList}`
+        };
+      }
     },
     {
       label: 'Export to Terra',

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -410,7 +410,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
       cellDataFn: (dataset: DatasetTerm) => {
         return dataUseCellData({
           dataset,
-          label: `Data Use for dataset ${dataset.datasetId}: ${dataset}`,
+          label: `Data Use for dataset ${dataset.datasetId}: ${dataset.dataUse}`,
           divClass: ['data-use-cell'],
           spanClass: [],
           cellWidth: cellWidths.dataUse,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-902
### Summary
Replaces the DAC column in the Data Library Dataset table with a Data Use column
Column displays Data Use codes (primary and secondary) and has a tooltip explaining each code when you hover over that cell in the table

https://github.com/user-attachments/assets/921ec581-7011-47aa-8594-941e15770b83


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
