### PR TITLE
DT-903: Change export button to link directly to terra-ui import page

### DIFF
--- a/src/components/data_search/DatasetExportButton.jsx
+++ b/src/components/data_search/DatasetExportButton.jsx
@@ -1,53 +1,22 @@
 import * as React from 'react';
-import { CircularProgress, IconButton, Link } from '@mui/material';
-import { useState } from 'react';
-import IosShareIcon from '@mui/icons-material/IosShare';
-import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo';
+import {useEffect, useState} from 'react';
+import {Link} from '@mui/material';
+import {Config} from '../../libs/config';
 
 export const DatasetExportButton = (props) => {
-  const { snapshot, title } = props;
-  // The exportStatus flow is: initial -> prepping -> ready
-  // TODO: error handling?
-  const [exportStatus, setExportStatus] = useState('initial');
-  const [exportResult, setExportResult] = useState(null);
+  const {snapshot, title} = props;
 
-  // Not a supported export location
-  if (!snapshot) {
-    return null;
-  }
+  const [terraUrl, setTerraUrl] = useState('');
 
-  const prepExportHandler = async () => {
-    setExportStatus('prepping');
-    const job = await TerraDataRepo.prepareExport(snapshot.id);
-    const result = await TerraDataRepo.waitForJob(job.id);
-    setExportResult(result);
-    setExportStatus('ready');
-  };
+  useEffect(() => {
+    (async () => {
+      setTerraUrl(await Config.getTerraUrl());
+    })();
+  }, []);
 
-  if (exportStatus === 'initial') {
-    return (
-      <IconButton aria-label="prepare export to Terra" size="medium" onClick={prepExportHandler}>
-        <IosShareIcon size={15} />
-      </IconButton>
-    );
-  }
+  const link = `${terraUrl}/#import-data?snapshotId=${snapshot.id}&format=tdrexport&tdrSyncPermissions=false`;
 
-  if (exportStatus === 'prepping') {
-    return (
-      <IconButton aria-label="prepare export to Terra" size="medium" onClick={() => ({})} disabled>
-        <CircularProgress size={15} />,
-      </IconButton>
-    );
-  }
-
-  if (exportStatus === 'ready') {
-    return (
-      <Link href={exportResult.terraImportLink} target="_blank" rel="noopener noreferrer" title={title} aria-label={title}>Export</Link>
-    );
-  }
-
-  return null;
-
+  return <Link href={link} target="_blank" rel="noopener noreferrer" title={title} aria-label={title}>Export</Link>;
 };
 
 export default DatasetExportButton;

--- a/src/components/data_search/DatasetExportButton.jsx
+++ b/src/components/data_search/DatasetExportButton.jsx
@@ -16,7 +16,7 @@ export const DatasetExportButton = (props) => {
 
   const link = `${terraUrl}/#import-data?snapshotId=${snapshot.id}&format=tdrexport&tdrSyncPermissions=false`;
 
-  return <Link href={link} target="_blank" rel="noopener noreferrer" title={title} aria-label={title}>Export</Link>;
+  return <Link style={{marginRight: '5px'}} href={link} target="_blank" rel="noopener noreferrer" title={title} aria-label={title}>Export</Link>;
 };
 
 export default DatasetExportButton;

--- a/src/libs/ajax/TerraDataRepo.js
+++ b/src/libs/ajax/TerraDataRepo.js
@@ -1,6 +1,5 @@
 import { Config } from '../config';
 import axios from 'axios';
-import { sleep, reportError } from '../ajax';
 
 
 export const TerraDataRepo = {
@@ -9,32 +8,5 @@ export const TerraDataRepo = {
     const url = `${await Config.getTdrApiUrl()}/api/repository/v1/snapshots?duosDatasetIds=${identifiers.join('&duosDatasetIds=')}`;
     const res = await axios.get(url, Config.authOpts());
     return res.data;
-  },
-
-  prepareExport: async (snapshotId) => {
-    const url = `${await Config.getTdrApiUrl()}/api/repository/v1/snapshots/${snapshotId}/export`;
-    const res = await axios.get(url, Config.authOpts());
-    return res.data;
-  },
-
-  waitForJob: async (jobId) => {
-    const url = `${await Config.getTdrApiUrl()}/api/repository/v1/jobs/${jobId}`;
-    const resultsUrl = `${await Config.getTdrApiUrl()}/api/repository/v1/jobs/${jobId}/result`;
-
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const res = await axios.get(url, Config.authOpts());
-      if (res.data.job_status === 'running') {
-        await sleep(1000);
-      } else if (res.data.job_status === 'succeeded') {
-        const finalResult = await axios.get(resultsUrl, Config.authOpts());
-        // Add the URL to link to
-        finalResult.data.terraImportLink =
-          `${await Config.getTerraUrl()}/#import-data?url=${window.location.origin}&snapshotId=${finalResult.data.snapshot.id}&format=tdrexport&snapshotName=${finalResult.data.snapshot.name}&tdrmanifest=${encodeURIComponent(finalResult.data.format.parquet.manifest)}&tdrSyncPermissions=false`;
-        return finalResult.data;
-      } else if (res.data.job_status === 'failed') {
-        return reportError(url, res.data.status_code);
-      }
-    }
   },
 };


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-903

Instead of performing a two-step operation in the duos UI, use the new TDR import link to have terra-ui perform the TDR export step. The same APIs are called in both cases, so other than the UX differences there is no difference in behavior.

### Summary

Video clip showing behavior, note that this is trying to export an azure dataset so the final step is blocked, but everything else is working correctly.

https://github.com/user-attachments/assets/859bb8dd-171e-4b4e-91ca-51961eded4b3
