### PR TITLE
[DT-962] Removes links from the access type column

### DIFF
--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -327,25 +327,16 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
       label: 'Access Type',
       sortable: true,
       cellStyle: makeHeaderStyle(cellWidths.accessType),
-      cellDataFn: (dataset: DatasetTerm) => {
-        let accessType;
-        if (dataset.accessManagement === 'external') {
-          accessType = dataset.url ?
-            <Link href={dataset.url}>External to DUOS</Link> : 'External to DUOS';
-        } else if (dataset.accessManagement === 'open') {
-          accessType = dataset.url ? <Link href={dataset.url}>Open Access</Link> : 'Open Access';
-        } else {
-          accessType = dataset.dac?.dacEmail ? <Link
-            href={'mailto:' + dataset.dac.dacEmail}>{dataset.dac?.dacName}</Link> : dataset.dac?.dacName;
-        }
-        return {
-          data: accessType,
-          value: dataset.accessManagement,
-          id: `${dataset.datasetId}-participant-count`,
-          style: makeRowStyle(cellWidths.accessType),
-          label: `Access Type for dataset ${dataset.datasetId}: ${dataset.accessManagement}`
-        };
-      }
+      cellDataFn: (dataset: DatasetTerm) => ({
+        data: dataset.accessManagement === 'external' ?
+          'External to DUOS' :
+          dataset.accessManagement === 'open' ?
+            'Open Access' : dataset.dac?.dacName,
+        value: dataset.accessManagement,
+        id: `${dataset.datasetId}-participant-count`,
+        style: makeRowStyle(cellWidths.accessType),
+        label: `Access Type for dataset ${dataset.datasetId}: ${dataset.accessManagement}`
+      })
     },
     {
       label: 'Data Type',


### PR DESCRIPTION
### Addresses
Removes links from access type. I decided to move to inlining the ternary because we didn't have a switch utility function - this ideally would be a switch statement.

<img width="1427" alt="Screenshot 2024-11-05 at 4 05 50 PM" src="https://github.com/user-attachments/assets/447de8cd-0090-48c2-8a09-e504cb5e0dfa">

### Summary

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
