### PR TITLE
DT-969: Show server errors when creating a draft DAR

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -187,8 +187,18 @@ export const DatasetSearchTable = (props) => {
     doSearch();
   };
   const applyForAccess = async () => {
-    const darDraft = await DAR.postDarDraft({ datasetId: selected });
-    history.push(`/dar_application/${darDraft.referenceId}`);
+    try {
+      const draftResponse = await DAR.postDarDraft({ datasetId: selected  });
+      if (draftResponse.referenceId) {
+        history.push(`/dar_application/${draftResponse.referenceId}`);
+      } else if (draftResponse.message) {
+        Notifications.showError({ text: draftResponse.message + ' Please contact customer support for help.' });
+      } else {
+        Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
+      }
+    } catch (error) {
+      Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
+    }
   };
 
   useEffect(() => {

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -217,11 +217,11 @@ export const DatasetSearchTable = (props) => {
       <Box sx={{ display: 'flex', flexDirection: 'column' }}>
         <TableHeaderSection icon={icon} title={title} description="Search, filter, and select datasets, then click 'Apply for Access' to request access" />
         <Box sx={{paddingTop: '2em', paddingLeft: '2em'}}>
-          <div className="right-header-section" style={Styles.RIGHT_HEADER_SECTION}>
+          <div className='right-header-section' style={Styles.RIGHT_HEADER_SECTION}>
             <input
-              data-cy="search-bar"
-              type="text"
-              placeholder="Enter search terms"
+              data-cy='search-bar'
+              type='text'
+              placeholder='Enter search terms'
               style={{
                 width: '100%',
                 border: '1px solid #cecece',
@@ -237,7 +237,7 @@ export const DatasetSearchTable = (props) => {
             />
             <div/>
             <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', paddingLeft: '1em', height: '4rem' }}>
-              <Button variant="contained" onClick={() => {filterHandler(null, datasets, 'search', '')}} sx={{ width: '100px' }}>
+              <Button variant='contained' onClick={() => {filterHandler(null, datasets, 'search', '');}} sx={{ width: '100px' }}>
                 Clear Search
               </Button>
             </Box>
@@ -284,7 +284,7 @@ export const DatasetSearchTable = (props) => {
         <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', padding: '2em 4em' }}>
           {
             !isEmpty(datasets) &&
-          <Button variant="contained" onClick={applyForAccess} sx={{ transform: 'scale(1.5)' }} >
+          <Button variant='contained' onClick={applyForAccess} sx={{ transform: 'scale(1.5)' }} >
             Apply for Access
           </Button>
           }

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -33,7 +33,7 @@ export const DAR = {
     const url = DAAUtils.isEnabled() ?
       `${await getApiUrl()}/api/dar/v3/draft` :
       `${await getApiUrl()}/api/dar/v2/draft`;
-    const res = await axios.post(url, dar, Config.authOpts());
+    const res = await axios.post(url, dar, Object.assign({}, Config.authOpts(), {validateStatus: () => true}));
     return res.data;
   },
 

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -79,7 +79,7 @@ export default function DatasetStatistics(props) {
               </div>
             </div>
             <div style={{ paddingTop: '20px', paddingLeft: '30px' }}>
-              <Button variant="contained" onClick={applyForAccess} sx={{ transform: 'scale(1.5)' }} >
+              <Button variant='contained' onClick={applyForAccess} sx={{ transform: 'scale(1.5)' }} >
                 Apply for Access
               </Button>
             </div>
@@ -119,8 +119,8 @@ export default function DatasetStatistics(props) {
             <div style={Styles.READ_MORE} id={`${dar.darCode}`} key={`${dar.darCode}`}>
               <ReadMore
                 props={props}
-                readLessText="Show less"
-                readMoreText="Show More"
+                readLessText='Show less'
+                readMoreText='Show More'
                 readStyle={{ fontWeight: 500, margin: '20px', height: 0 }}
                 content={[
                   <div key='dar' style={{ display: 'flex' }}>

--- a/src/pages/DatasetStatistics.jsx
+++ b/src/pages/DatasetStatistics.jsx
@@ -20,8 +20,18 @@ export default function DatasetStatistics(props) {
   const [isLoading, setIsLoading] = useState(true);
 
   const applyForAccess = async () => {
-    const darDraft = await DAR.postDarDraft({ datasetId: [datasetId]  });
-    history.push(`/dar_application/${darDraft.referenceId}`);
+    try {
+      const draftResponse = await DAR.postDarDraft({ datasetId: [datasetId]  });
+      if (draftResponse.referenceId) {
+        history.push(`/dar_application/${draftResponse.referenceId}`);
+      } else if (draftResponse.message) {
+        Notifications.showError({ text: draftResponse.message + ' Please contact customer support for help.' });
+      } else {
+        Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
+      }
+    } catch (error) {
+      Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-969

### Summary
If there are server errors when submitting a draft dar, they are swallowed by the UI. This PR shows them in the two cases where one can apply for access to a dataset(s).

### Data Library View
https://github.com/user-attachments/assets/43b8378b-ea85-4d50-9d59-7f5c5a317e2f

### Dataset View
https://github.com/user-attachments/assets/e3072377-101c-4594-9840-223aac56df3e


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
