### PR TITLE
DT-781: Use logical AND to combine filters in the DUOS UI

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -104,12 +104,12 @@ export const DatasetSearchTable = (props) => {
       queryChunks.push(...searchModifier);
     }
 
-    var filterQuery = {};
+    let filterQuery = {};
     if (numSelectedFilters(filters) > 0) {
-      const shouldTerms = [];
+      const filterTerms = [];
 
       filters.accessManagement.forEach(term => {
-        shouldTerms.push({
+        filterTerms.push({
           'term': {
             'accessManagement': term
           }
@@ -117,47 +117,35 @@ export const DatasetSearchTable = (props) => {
       });
 
       filters.dataUse.forEach(term => {
-        shouldTerms.push({
+        filterTerms.push({
           'match': {
             'dataUse.primary.code': term
           }
         });
       });
 
-      if (shouldTerms.length > 0) {
+      if (filterTerms.length > 0) {
         filterQuery = [
           {
             'bool': {
-              'should': shouldTerms
+              'must': filterTerms
             }
           }
         ];
       }
     }
 
-    // do not add filter subquery if no filters are applied
-    if (numSelectedFilters(filters) > 0) {
-      return {
-        'from': 0,
-        'size': 10000,
-        'query': {
-          'bool': {
-            'must': queryChunks,
-            'filter': filterQuery
-          }
+    return {
+      'from': 0,
+      'size': 10000,
+      'query': {
+        'bool': {
+          'must': queryChunks,
+          // do not add filter subquery if no filters are applied
+          ...(Object.keys(filterQuery).length > 0 && { 'filter': filterQuery })
         }
-      };
-    } else {
-      return {
-        'from': 0,
-        'size': 10000,
-        'query': {
-          'bool': {
-            'must': queryChunks
-          }
-        }
-      };
-    }
+      }
+    };
   };
 
   const filterHandler = (event, data, category, filter) => {

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -141,7 +141,7 @@ export const DatasetSearchTable = (props) => {
       'query': {
         'bool': {
           'must': queryChunks,
-          // do not add filter subquery if no filters are applied
+          // Only add filter subquery when filters are applied.
           ...(Object.keys(filterQuery).length > 0 && { 'filter': filterQuery })
         }
       }

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -108,20 +108,26 @@ export const DatasetSearchTable = (props) => {
     if (numSelectedFilters(filters) > 0) {
       const filterTerms = [];
 
-      filters.accessManagement.forEach(term => {
-        filterTerms.push({
-          'term': {
-            'accessManagement': term
-          }
-        });
+      filterTerms.push({
+        'bool': {
+          'should':
+              filters.accessManagement.map(term => ({
+                'term': {
+                  'accessManagement': term
+                }
+              }))
+        }
       });
 
-      filters.dataUse.forEach(term => {
-        filterTerms.push({
-          'match': {
-            'dataUse.primary.code': term
-          }
-        });
+      filterTerms.push({
+        'bool': {
+          'should':
+              filters.dataUse.map(term => ({
+                'match': {
+                  'dataUse.primary.code': term
+                }
+              }))
+        }
       });
 
       if (filterTerms.length > 0) {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-781

Users would like filters in the DUOS UI to combine as a set intersection operation, so an item is only shown if it's valid for all selected filters.

### Summary

By changing the root node of filter query to use `must` instead of `should`, the filters are combined using logical `AND` instead of `OR`.

Video of feature in action

https://github.com/user-attachments/assets/e401d739-9c74-4067-81f5-9920a0c69da6

