### PR TITLE
[DT-949] Disable TDR links in Data Location in DUOS

### DIFF
--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -383,8 +383,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
       cellDataFn: (dataset: DatasetTerm) => {
         let dataLocation;
         if (dataset.dataLocation === 'TDR Location') {
-          dataLocation = dataset.url ?
-            <Link href={dataset.url}>Terra Data Repo</Link> : 'Terra Data Repo';
+          dataLocation = 'Terra Data Repo';
         } else if (dataset.dataLocation === 'Terra Workspace') {
           dataLocation = dataset.url ?
             <Link href={dataset.url}>Terra Workspace</Link> : 'Terra Data Repo';


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-949
### Summary
For all data located in TDR, remove the TDR link and just display the "Terra Data Repo" text

<img width="1501" alt="image" src="https://github.com/user-attachments/assets/ecaa9c1a-fa42-431f-bd0b-a0bf5001a9c8">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
