### PR TITLE
[DT-980] Fix the enumerate snapshots to get more snapshots than the first 10

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -1,8 +1,9 @@
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
+import useOnMount from '@mui/utils/useOnMount'
 import * as React from 'react';
 import { Box, Button } from '@mui/material';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { isEmpty } from 'lodash';
 import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo';
 import { DatasetSearchTableDisplay } from './DatasetSearchTableDisplay';
@@ -201,12 +202,12 @@ export const DatasetSearchTable = (props) => {
     }
   };
 
-  useEffect(() => {
-    if (isEmpty(filtered)) {
+  useOnMount(() => {
+    if (isEmpty(datasets)) {
       return;
     }
-    getExportableDatasets(filtered);
-  }, [filtered]);
+    getExportableDatasets(datasets);
+  });
 
   useEffect(() => {
     setFiltered(datasets);

--- a/src/libs/ajax/TerraDataRepo.js
+++ b/src/libs/ajax/TerraDataRepo.js
@@ -18,7 +18,8 @@ export const TerraDataRepo = {
     };
     const rootTdrApiUrl = await Config.getTdrApiUrl();
     const snapshotPromises = partitionedIdentifiers.map(sublist => {
-      const url = `${rootTdrApiUrl}/api/repository/v1/snapshots?duosDatasetIds=${sublist.join('&duosDatasetIds=')}`;
+      // 1000 should be safe with only 70 DUOS IDs.
+      const url = `${rootTdrApiUrl}/api/repository/v1/snapshots?limit=1000&duosDatasetIds=${sublist.join('&duosDatasetIds=')}`;
       return axios.get(url, Config.authOpts());
     });
     await Promise.all(snapshotPromises).then(function(responses) {


### PR DESCRIPTION
### Addresses
This makes it so we load snapshots only once to avoid debounce issues and ensure that we have a comprehensive list of what can export always.

It also bumps up the limits on snapshots from 10 (the default) to 1000 - this should be a safe number given that we partition DUOS IDs into 70 at a time.
### Summary

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
