### PR TITLE
[DT-995] Add secondary Stanley Center data library link

### DIFF
--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -242,6 +242,15 @@ export const DatasetSearch = (props) => {
       icon: stanleyIcon,
       title: 'Stanley Center Data Library',
     },
+    'stanleycenter': {
+      query: {
+        'match_phrase': {
+          'study.description': 'Stanley Center'
+        }
+      },
+      icon: stanleyIcon,
+      title: 'Stanley Center Data Library',
+    },
     '/custom': {
       query: {
         'bool': {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-995

### Summary

We already have a Stanley Center data library, this creates a secondary link to the same library. If we get many of these in the future it may be worth thinking about how to do duplicate links generally.

See https://github.com/DataBiosphere/duos-ui/pull/2695 for the original.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
