### PR TITLE
[DT-987]Debounce the dataset search and filter in the Data Library

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -3,7 +3,7 @@ import Tabs from '@mui/material/Tabs';
 import useOnMount from '@mui/utils/useOnMount';
 import * as React from 'react';
 import { Box, Button } from '@mui/material';
-import {useEffect, useRef, useState} from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { isEmpty } from 'lodash';
 import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo';
 import { DatasetSearchTableDisplay } from './DatasetSearchTableDisplay';

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -3,7 +3,7 @@ import Tabs from '@mui/material/Tabs';
 import useOnMount from '@mui/utils/useOnMount';
 import * as React from 'react';
 import { Box, Button } from '@mui/material';
-import { useEffect, useState } from 'react';
+import {useEffect, useRef, useState} from 'react';
 import { isEmpty } from 'lodash';
 import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo';
 import { DatasetSearchTableDisplay } from './DatasetSearchTableDisplay';
@@ -211,13 +211,18 @@ export const DatasetSearchTable = (props) => {
     getExportableDatasets(datasets);
   });
 
-  useEffect(() => {
-    const fullQuery = assembleFullQuery();
-    try {
+  const searchAndFilter = useRef(
+    _.debounce((fullQuery) => {
       DataSet.searchDatasetIndex(fullQuery).then((filteredDatasets) => {
         const newFiltered = datasets.filter(value => filteredDatasets.some(item => _.isEqual(item, value)));
         setFiltered(newFiltered);
       });
+    }, 250));
+
+  useEffect(() => {
+    const fullQuery = assembleFullQuery();
+    try {
+      searchAndFilter.current(fullQuery);
     } catch (error) {
       Notifications.showError({ text: 'Failed to load Elasticsearch index' });
     }  }, [filters, searchTerm]); // eslint-disable-line

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -217,7 +217,7 @@ export const DatasetSearchTable = (props) => {
         const newFiltered = datasets.filter(value => filteredDatasets.some(item => _.isEqual(item, value)));
         setFiltered(newFiltered);
       });
-    }, 250));
+    }, 150));
 
   useEffect(() => {
     const fullQuery = assembleFullQuery();


### PR DESCRIPTION
### Addresses
Jira ticket: https://broadworkbench.atlassian.net/browse/DT-987

### Summary
Add debouncing to the search and filter api call in the data library

### Testing
I tested manually as shown in the video, but I am down to add unit tests if we think that would be beneficial. I just wasn't sure how to unit test the debouncing behavior.

Video shows that the api is not called on every keystroke
https://github.com/user-attachments/assets/345e0696-bcac-4d26-a4c4-07dd44e693fd



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
