### PR TITLE
[DT-1055] Pin version of NodeJS to latest LTS

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.11.0'
       - name: install dependencies
         run: npm ci
       - name: npm audit

--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -8,6 +8,9 @@ jobs:
         run: echo "${{ github.actor }}"
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.11.0'
       - name: NPM Install
         run: npm ci
       - name : Cypress run component tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,9 @@ jobs:
         run: echo "${{ github.actor }}"
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.11.0'
       - name: NPM Install
         run: npm ci
       - name: Copy Configs

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -1,11 +1,11 @@
 # Local Development
 
-1. We use [node@22.6.0](https://github.com/nvm-sh/nvm#installing-and-updating):
+1. We use [node@22.11.0](https://docs.volta.sh/guide/understanding):
 
 ```
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-nvm install 22.6.0
+volta install 22.11.0
 ```
+
 2. Install deps:
 
 ```

--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "engines": {
+    "node": ">=22.11.0"
+  }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1055

### Summary

This will prevent developers from accidentally installing incompatible version of NodeJS for the UI.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
