### PR TITLE
[DT-997] Move the Donor Size Header in DUOS further left so it aligns with the rest of the table

### DIFF
--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -243,7 +243,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
     duosId: '10%',
     accessType: '10%',
     dataType: '15%',
-    donorSize: '7%',
+    donorSize: '10%',
     dataLocation: '13%',
     dataUse: '10%',
     exportToTerra: 100,

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -25,6 +25,7 @@ interface DatasetSearchTableTabs {
 
 const makeHeaderStyle = (width: string | number): React.CSSProperties => ({
   width,
+  marginRight: 5
 });
 
 const makeRowStyle = (width: string | number): React.CSSProperties => ({
@@ -32,7 +33,7 @@ const makeRowStyle = (width: string | number): React.CSSProperties => ({
   textOverflow: 'ellipsis',
   textWrap: 'nowrap',
   overflow: 'hidden',
-  paddingRight: 5
+  marginRight: 5
 });
 
 const trimNewlineCharacters = (str: string): string => str?.replace( /[\r\n]+/gm, '');


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-997
### Summary
Increase the spacing between the Donor Size and the Data Location columns in the Dataset table in the Data Library
<img width="1507" alt="image" src="https://github.com/user-attachments/assets/a11ea212-85b1-4145-bff1-730db46fb298">

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
