### PR TITLE
[DT-1056] Replace local config interception with `initApplicationConfig`

### DIFF
--- a/cypress/component/Auth/auth.spec.ts
+++ b/cypress/component/Auth/auth.spec.ts
@@ -23,11 +23,7 @@ describe('Auth Failure', function () {
 describe('Auth Success', function () {
   // Intercept configuration calls
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: '/config.json',
-      hostname: 'localhost',
-    }, {'env': 'ci'});
+    cy.initApplicationConfig();
     cy.stub(OAuth2, 'getConfig').returns({
       'authorityEndpoint': Cypress.config().baseUrl,
       'clientId': 'clientId'

--- a/cypress/component/Auth/oidcBroker.spec.ts
+++ b/cypress/component/Auth/oidcBroker.spec.ts
@@ -24,11 +24,7 @@ describe('OidcBroker Failure', function () {
 describe('OidcBroker Success', function () {
   // Intercept configuration calls
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: '/config.json',
-      hostname: 'localhost',
-    }, {'env': 'ci'});
+    cy.initApplicationConfig();
     cy.stub(OAuth2, 'getConfig').returns({
       'authorityEndpoint': Cypress.config().baseUrl,
       'clientId': 'clientId'

--- a/cypress/component/DataSearch/dataset_search_filters.spec.js
+++ b/cypress/component/DataSearch/dataset_search_filters.spec.js
@@ -2,7 +2,6 @@
 
 import { mount } from 'cypress/react';
 import React from 'react';
-import {Storage} from '../../../src/libs/storage';
 import DatasetFilterList from '../../../src/components/data_search/DatasetFilterList';
 
 const duosUser = {
@@ -10,13 +9,8 @@ const duosUser = {
 };
 
 describe('Data Library Filters', () => {
-    // Intercept configuration calls
     beforeEach(() => {
-        cy.intercept({
-            method: 'GET',
-            url: '/config.json',
-            hostname: 'localhost',
-        }, { 'env': 'ci' });
+        cy.initApplicationConfig();
     });
 
     it('Renders the data library filters', () => {

--- a/cypress/component/DataSearch/dataset_search_page.spec.js
+++ b/cypress/component/DataSearch/dataset_search_page.spec.js
@@ -10,13 +10,8 @@ const duosUser = {
 };
 
 describe('Data Library', () => {
-    // Intercept configuration calls
     beforeEach(() => {
-        cy.intercept({
-            method: 'GET',
-            url: '/config.json',
-            hostname: 'localhost',
-        }, { 'env': 'ci' });
+        cy.initApplicationConfig();
     });
 
     it('Renders the data library without a query', () => {

--- a/cypress/component/TermsOfService/tos_acceptance.spec.js
+++ b/cypress/component/TermsOfService/tos_acceptance.spec.js
@@ -20,11 +20,7 @@ const mocks = {
 describe('Terms of Service Acceptance Page', function () {
   // Intercept configuration calls
   beforeEach(async () => {
-    cy.intercept({
-      method: 'GET',
-      url: '/config.json',
-      hostname: 'localhost',
-    }, {'env': 'ci'});
+    cy.initApplicationConfig();
     cy.stub(OAuth2, 'getConfig').returns({
       'authorityEndpoint': 'authorityEndpoint',
       'clientId': 'clientId'

--- a/cypress/component/UserProfile/user_profile.spec.js
+++ b/cypress/component/UserProfile/user_profile.spec.js
@@ -12,13 +12,8 @@ const duosUser = {
 };
 
 describe('User Profile', () => {
-  // Intercept configuration calls
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: '/config.json',
-      hostname: 'localhost',
-    }, {'env': 'ci'});
+    cy.initApplicationConfig();
   });
 
   it('Renders the user profile page', () => {

--- a/cypress/component/utils/metrics.spec.ts
+++ b/cypress/component/utils/metrics.spec.ts
@@ -4,13 +4,8 @@ import eventList from '../../../src/libs/events';
 
 describe('Metrics Tests', function () {
 
-  // Intercept configuration calls
   beforeEach(() => {
-    cy.intercept({
-      method: 'GET',
-      url: '/config.json',
-      hostname: 'localhost',
-    }, {'env': 'ci'});
+    cy.initApplicationConfig();
   });
 
   Cypress._.each(Object.keys(eventList), (eventType) => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1056

### Summary

@rushtong created this method to avoid code duplication in our Cypress tests

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
