### PR TITLE
DT-1083: Use global DAA config instead of environment

### DIFF
--- a/src/pages/user_profile/ResearcherStatus.jsx
+++ b/src/pages/user_profile/ResearcherStatus.jsx
@@ -7,7 +7,7 @@ import { DAA } from '../../libs/ajax/DAA';
 import { isNil } from 'lodash';
 import LibraryCard from './LibraryCard';
 import DAAs from './DAAs';
-import { checkEnv, envGroups } from '../../utils/EnvironmentUtils';
+import {DAAUtils} from '../../utils/DAAUtils';
 
 export default function ResearcherStatus(props) {
 
@@ -97,7 +97,7 @@ export default function ResearcherStatus(props) {
     </p>
     <div style={{ marginTop: '15px' }} />
     {hasCard ?
-      (checkEnv(envGroups.DEV) ?
+      (DAAUtils.isEnabled() ?
         (
           <DAAs
             issuedOn={issuedOn}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1083

### Summary
This is another case of a DAA feature that should be using the global config, but is instead using an environment config. See also https://github.com/DataBiosphere/duos-ui/pull/2742 for a similar case.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
