### PR TITLE
[DT-1096] Update JIRA key to DT instead of DCJ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     open-pull-requests-limit: 10
     target-branch: develop
     commit-message:
-      prefix: "[DCJ-400-actions]"
+      prefix: "[DT-400-actions]"
     groups:
       action-dependencies:
         patterns:
@@ -22,7 +22,7 @@ updates:
       - "dependency"
       - "npm"
     commit-message:
-      prefix: "[DCJ-400-npm]"
+      prefix: "[DT-400-npm]"
     groups:
       npm-dependencies:
         patterns:
@@ -37,7 +37,7 @@ updates:
       - "dependency"
       - "docker"
     commit-message:
-      prefix: "[DCJ-400-docker]"
+      prefix: "[DT-400-docker]"
     groups:
       docker-dependencies:
         patterns:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1096

### Summary

Updates the JIRA key to `DT-` instead of `DCJ-`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
