### PR TITLE
[DT-688] Disable DUOS sign-in when Sam is down

### DIFF
--- a/cypress/component/SignIn/sign_in_button.spec.js
+++ b/cypress/component/SignIn/sign_in_button.spec.js
@@ -9,6 +9,7 @@ import {Storage} from '../../../src/libs/storage';
 import {Metrics} from '../../../src/libs/ajax/Metrics';
 import {StackdriverReporter} from '../../../src/libs/stackdriverReporter';
 import {ToS} from '../../../src/libs/ajax/ToS';
+import {ServiceStatus} from '../../../src/libs/ajax/ServiceStatus';
 import {mockOidcUser} from '../Auth/mockOidcUser';
 const signInText = 'Sign In';
 
@@ -35,24 +36,35 @@ const userStatus = {
   'tosAccepted': true
 };
 
+const consentStatus = {
+  systems: {
+    sam: {
+      details: {
+        ok: true
+      }
+    }
+  }
+};
+
 const notAcceptedUserStatus = Object.assign({}, userStatus, {'tosAccepted': false});
 
 describe('Sign In: Component Loads', function () {
 
-  // Intercept configuration calls
   beforeEach(() => {
     cy.initApplicationConfig();
+    cy.stub(ServiceStatus, 'getConsentStatus').resolves(consentStatus);
   });
 
   it('Sign In Button Loads', function () {
     cy.viewport(600, 300);
     mount(<SignInButton history={undefined}/>);
     cy.contains(signInText).should('exist');
+    cy.get('button').should('exist').and('not.be.disabled');
   });
 
   it('Sign In: On Success', function () {
     cy.viewport(600, 300);
-    cy.stub(Auth, 'signIn').returns(Promise.resolve(mockOidcUser));
+    cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: duosUser}).as('getMe');
     cy.stub(StackdriverReporter, 'report');
     cy.stub(Metrics, 'identify');
@@ -74,7 +86,7 @@ describe('Sign In: Component Loads', function () {
   it('Sign In: No Roles Error Reporter Is Called', function () {
     const bareUser = {email: 'test@user.com'};
     cy.viewport(600, 300);
-    cy.stub(Auth, 'signIn').returns(Promise.resolve(mockOidcUser));
+    cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: bareUser}).as('getMe');
     cy.stub(StackdriverReporter, 'report');
     cy.stub(Metrics, 'identify');
@@ -90,7 +102,7 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: Redirects to ToS if not accepted', function () {
     cy.viewport(600, 300);
-    cy.stub(Auth, 'signIn').returns(Promise.resolve(mockOidcUser));
+    cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: duosUser}).as('getMe');
     cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus);
     cy.stub(Metrics, 'identify');
@@ -107,7 +119,7 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: Registers user if not found and redirects to ToS', function () {
     cy.viewport(600, 300);
-    cy.stub(Auth, 'signIn').returns(Promise.resolve(mockOidcUser));
+    cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     // Simulate user not found
     cy.stub(User, 'getMe').throws();
     cy.intercept({method: 'POST', url: '**/api/user'}, {statusCode: 200, body: duosUser}).as('registerUser');
@@ -124,4 +136,10 @@ describe('Sign In: Component Loads', function () {
     });
   });
 
+  it('Sign In: Button is disabled when SAM is unhealthy', function () {
+    cy.viewport(600, 300);
+    cy.stub(ServiceStatus, 'isSamHealthy').resolves(false);
+    mount(<SignInButton history={[]}/>);
+    cy.get('button').should('exist').and('be.disabled');
+  });
 });

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -17,6 +17,7 @@ import {DuosUser} from '../types/model';
 import {DuosUserResponse} from '../types/responseTypes';
 import {tooltipStyle} from '../components/Tooltips';
 import {ServiceStatus} from '../libs/ajax/ServiceStatus';
+import '../styles/tooltip.css';
 
 interface SignInButtonProps {
   history: History;
@@ -213,10 +214,13 @@ export const SignInButton = (props: SignInButtonProps) => {
           place={'top'}
           disable={!isSamDown}
           effect={'solid'}
-          scrollHide={true}
           id={'sam-disabled-sign-in-tooltip'}
+          className='interactiveTooltip'
+          delayHide={1000}
         >
-          <div style={tooltipStyle}>{'Sam is currently offline, cannot use DUOS. Please try again later.'}</div>
+          <div style={tooltipStyle}>
+            <span>DUOS is currently unavailable. Please check the <a href="status">status page</a> for more details.</span>
+          </div>
         </ReactTooltip>
         <a
           className='navbar-duos-icon-help'

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -16,7 +16,7 @@ import {OidcUser} from '../libs/auth/oidcBroker';
 import {DuosUser} from '../types/model';
 import {DuosUserResponse} from '../types/responseTypes';
 import {tooltipStyle} from '../components/Tooltips';
-import {isSamHealthy} from '../libs/ajax';
+import {ServiceStatus} from '../libs/ajax/ServiceStatus';
 
 interface SignInButtonProps {
   history: History;
@@ -178,7 +178,7 @@ export const SignInButton = (props: SignInButtonProps) => {
 
   useEffect(() => {
     const init = async () => {
-      setIsSamDown(!(await isSamHealthy()));
+      setIsSamDown(!(await ServiceStatus.isSamHealthy()));
     };
     init();
   }, []);

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {isEmpty, isNil} from 'lodash/fp';
 import {Alert} from './Alert';
 import {Auth} from '../libs/auth/auth';
@@ -15,6 +15,8 @@ import {History} from 'history';
 import {OidcUser} from '../libs/auth/oidcBroker';
 import {DuosUser} from '../types/model';
 import {DuosUserResponse} from '../types/responseTypes';
+import {tooltipStyle} from '../components/Tooltips';
+import {isSamHealthy} from '../libs/ajax';
 
 interface SignInButtonProps {
   history: History;
@@ -38,6 +40,7 @@ export const SignInButton = (props: SignInButtonProps) => {
   const [errorDisplay, setErrorDisplay] = useState<ErrorDisplay>({});
   const {history} = props;
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isSamDown, setIsSamDown] = useState<boolean>(false);
 
   // Utility function called in the normal success case and in the undocumented 409 case
   // Check for ToS Acceptance - redirect user if not set.
@@ -173,27 +176,48 @@ export const SignInButton = (props: SignInButtonProps) => {
     );
   };
 
+  useEffect(() => {
+    const init = async () => {
+      setIsSamDown(!(await isSamHealthy()));
+    };
+    init();
+  }, []);
+
   const signInElement = (): React.JSX.Element => {
     return (
       <div style={{display: 'flex', marginRight: 30}}>
-        <button
-          style={{
-            height: 50,
-            width: 200,
-            fontSize: 18,
-            fontWeight: 500,
-            color: 'rgb(77, 114, 170)',
-            borderRadius: 5
-          }}
-          onClick={async () => {
-            setIsLoading(true);
-            Auth.signIn().then(onSuccess, onFailure);
-            setIsLoading(false);
-          }}
-          disabled={isLoading}
+        <div
+          data-tip='Full details'
+          data-for={'sam-disabled-sign-in-tooltip'}
         >
-          {isLoading ? loadingElement() : 'Sign In'}
-        </button>
+          <button
+            style={{
+              height: 50,
+              width: 200,
+              fontSize: 18,
+              fontWeight: 500,
+              color: 'rgb(77, 114, 170)',
+              borderRadius: 5
+            }}
+            onClick={async () => {
+              setIsLoading(true);
+              Auth.signIn().then(onSuccess, onFailure);
+              setIsLoading(false);
+            }}
+            disabled={isLoading || isSamDown}
+          >
+            {isLoading ? loadingElement() : 'Sign In'}
+          </button>
+        </div>
+        <ReactTooltip
+          place={'top'}
+          disable={!isSamDown}
+          effect={'solid'}
+          scrollHide={true}
+          id={'sam-disabled-sign-in-tooltip'}
+        >
+          <div style={tooltipStyle}>{'Sam is currently offline, cannot use DUOS. Please try again later.'}</div>
+        </ReactTooltip>
         <a
           className='navbar-duos-icon-help'
           style={{color: 'white', height: 16, width: 16, marginLeft: 5}}

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -42,23 +42,6 @@ export const getOntologyUrl = async() => {
   return await Config.getOntologyApiUrl();
 };
 
-export const getConsentStatus = async() => {
-  const url = `${ await getApiUrl() }/status`;
-  const result = await axios.get(url);
-  return result.data;
-}
-
-export const getOntologyStatus = async() => {
-  const url = `${ await getOntologyUrl() }/status`;
-  const result = await axios.get(url);
-  return result.data;
-}
-
-export const isSamHealthy = async() => {
-  const status = await getConsentStatus();
-  return getOr(false)('ok')(status.systems.sam.details);
-}
-
 export const sleep = (ms) => {
   return new Promise(resolve => setTimeout(resolve, ms));
 };

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -42,6 +42,23 @@ export const getOntologyUrl = async() => {
   return await Config.getOntologyApiUrl();
 };
 
+export const getConsentStatus = async() => {
+  const url = `${ await getApiUrl() }/status`;
+  const result = await axios.get(url);
+  return result.data;
+}
+
+export const getOntologyStatus = async() => {
+  const url = `${ await getOntologyUrl() }/status`;
+  const result = await axios.get(url);
+  return result.data;
+}
+
+export const isSamHealthy = async() => {
+  const status = await getConsentStatus();
+  return getOr(false)('ok')(status.systems.sam.details);
+}
+
 export const sleep = (ms) => {
   return new Promise(resolve => setTimeout(resolve, ms));
 };

--- a/src/libs/ajax/ServiceStatus.ts
+++ b/src/libs/ajax/ServiceStatus.ts
@@ -1,0 +1,89 @@
+import axios from 'axios';
+import { getApiUrl, getOntologyUrl } from '../ajax';
+
+interface SystemHealth {
+    healthy: boolean;
+    message?: string;
+    error?: string | null;
+    details?: unknown;
+    time: number;
+    duration: number;
+    timestamp?: string;
+}
+
+interface BaseStatus {
+    ok: boolean;
+    degraded: boolean;
+    systems: Record<string, SystemHealth>;
+}
+
+interface SendGridPage {
+    id: string;
+    name: string;
+    url: string;
+    time_zone: string;
+    updated_at: string;
+}
+
+interface SendGridStatus {
+    indicator: string;
+    description: string;
+}
+
+interface SendGridDetails {
+    page: SendGridPage;
+    status: SendGridStatus;
+}
+
+interface SamSystemStatus {
+    ok: boolean;
+}
+
+interface SamDetails {
+    ok: boolean;
+    systems: {
+        GoogleGroups: SamSystemStatus;
+        GooglePubSub: SamSystemStatus;
+        GoogleIam: SamSystemStatus;
+        Database: SamSystemStatus;
+    };
+}
+
+export interface OntologyStatus extends BaseStatus {
+    systems: {
+        deadlocks: SystemHealth;
+        'elastic-search': SystemHealth;
+        'google-cloud-storage': SystemHealth;
+    };
+}
+
+export interface ConsentStatus extends BaseStatus {
+    systems: {
+        deadlocks: SystemHealth;
+        'elastic-search': SystemHealth;
+        'google-cloud-storage': SystemHealth;
+        ontology: SystemHealth & { details: { ok: boolean; systems: OntologyStatus } };
+        postgresql: SystemHealth;
+        sam: SystemHealth & { details: SamDetails };
+        sendgrid: SystemHealth & { details: SendGridDetails };
+    };
+}
+
+export const ServiceStatus = {
+    getConsentStatus: async (): Promise<ConsentStatus> => {
+        const url = `${await getApiUrl()}/status`;
+        const result = await axios.get(url);
+        return result.data;
+    },
+
+    getOntologyStatus: async (): Promise<OntologyStatus> => {
+        const url = `${await getOntologyUrl()}/status`;
+        const result = await axios.get(url);
+        return result.data;
+    },
+
+    isSamHealthy: async (): Promise<boolean> => {
+        const status = await ServiceStatus.getConsentStatus();
+        return status.systems.sam.details.ok || false;
+    }
+}

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -3,8 +3,7 @@ import { getOr, isNil, map, uniq } from 'lodash/fp';
 import { Component } from 'react';
 import CheckboxMarkedCircleOutline from 'react-material-icon-svg/dist/CheckboxMarkedCircleOutline';
 import DiameterVariant from 'react-material-icon-svg/dist/DiameterVariant';
-import { getApiUrl, getOntologyUrl } from '../libs/ajax';
-
+import { getApiUrl, getConsentStatus, getOntologyStatus } from '../libs/ajax';
 
 class Status extends Component {
 
@@ -12,7 +11,8 @@ class Status extends Component {
     super(props);
     this.state = {
       consentStatus: {},
-      ontologyStatus: {}
+      ontologyStatus: {},
+      samStatus: {}
     };
   }
 
@@ -33,14 +33,11 @@ class Status extends Component {
   };
 
   async componentDidMount() {
-    const consentStatusUrl = `${ await getApiUrl() }/status`;
-    const ontologyStatusUrl = `${ await getOntologyUrl() }/status`;
-    fetch(consentStatusUrl, { method: 'GET' })
-      .then(response => response.json())
-      .then(data => this.setState({ consentStatus: data }));
-    fetch(ontologyStatusUrl, { method: 'GET' })
-      .then(response => response.json())
-      .then(data => this.setState({ ontologyStatus: data }));
+    await getConsentStatus().then(data => {
+      this.setState({ consentStatus: data });
+      this.setState({ samStatus: data.systems.sam.details });
+    });
+    await getOntologyStatus().then(data => this.setState({ ontologyStatus: data }));
   }
 
   render() {
@@ -48,12 +45,14 @@ class Status extends Component {
     const unhealthyState = <DiameterVariant fill={ 'red' } style={ { marginLeft: '2rem', verticalAlign: 'middle', height: '24px' } }/>;
     const consentHealthy = this.isConsentHealthy(this.state.consentStatus) ? healthyState : unhealthyState;
     const ontologyHealthy = this.isOntologyHealthy(this.state.ontologyStatus) ? healthyState : unhealthyState;
+    const samHealthy = this.isConsentHealthy(this.state.samStatus) ? healthyState : unhealthyState;
 
     return (
       <div style={{ margin: '2rem' }}>
         <ul style={{ marginTop: '2rem', listStyle: 'none', fontSize: 'x-large' }}>
           <li><a href="#consent">Consent</a> {consentHealthy}</li>
           <li><a href="#ontology">Ontology</a> {ontologyHealthy}</li>
+          <li><a href="#sam">Sam</a> {samHealthy}</li>
         </ul>
         <hr />
         <h2><a id="consent">Consent Status</a></h2>

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -1,68 +1,61 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { getOr, isNil, map, uniq } from 'lodash/fp';
-import { Component } from 'react';
 import CheckboxMarkedCircleOutline from 'react-material-icon-svg/dist/CheckboxMarkedCircleOutline';
 import DiameterVariant from 'react-material-icon-svg/dist/DiameterVariant';
-import { getApiUrl, getConsentStatus, getOntologyStatus } from '../libs/ajax';
+import { ServiceStatus } from '../libs/ajax/ServiceStatus';
 
-class Status extends Component {
+const Status = () => {
+  const [consentStatus, setConsentStatus] = useState({});
+  const [ontologyStatus, setOntologyStatus] = useState({});
+  const [samStatus, setSamStatus] = useState({});
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      consentStatus: {},
-      ontologyStatus: {},
-      samStatus: {}
-    };
-  }
-
-  isConsentHealthy = (elements) => {
+  const isConsentHealthy = (elements) => {
     return getOr(false)('ok')(elements);
   };
 
-  isOntologyHealthy = (elements) => {
+  const isOntologyHealthy = (elements) => {
     const ok = getOr(undefined)('ok')(elements);
     if (!isNil(ok)) {
-      // return the OK status from ontology if it exists
       return ok;
     } else {
-      // find all values of "healthy" and ensure that they are all true
       const bools = uniq(map('healthy')(elements));
       return bools.length === 1 && bools[0];
     }
   };
 
-  async componentDidMount() {
-    await getConsentStatus().then(data => {
-      this.setState({ consentStatus: data });
-      this.setState({ samStatus: data.systems.sam.details });
-    });
-    await getOntologyStatus().then(data => this.setState({ ontologyStatus: data }));
-  }
+  useEffect(() => {
+    const fetchStatus = async () => {
+      const consentData = await ServiceStatus.getConsentStatus();
+      setConsentStatus(consentData);
+      setSamStatus(consentData.systems.sam.details);
 
-  render() {
-    const healthyState = <CheckboxMarkedCircleOutline fill={ 'green' } style={ { marginLeft: '2rem', verticalAlign: 'middle', height: '24px' } }/>;
-    const unhealthyState = <DiameterVariant fill={ 'red' } style={ { marginLeft: '2rem', verticalAlign: 'middle', height: '24px' } }/>;
-    const consentHealthy = this.isConsentHealthy(this.state.consentStatus) ? healthyState : unhealthyState;
-    const ontologyHealthy = this.isOntologyHealthy(this.state.ontologyStatus) ? healthyState : unhealthyState;
-    const samHealthy = this.isConsentHealthy(this.state.samStatus) ? healthyState : unhealthyState;
+      const ontologyData = await ServiceStatus.getOntologyStatus();
+      setOntologyStatus(ontologyData);
+    };
+    fetchStatus();
+  }, []);
 
-    return (
-      <div style={{ margin: '2rem' }}>
-        <ul style={{ marginTop: '2rem', listStyle: 'none', fontSize: 'x-large' }}>
-          <li><a href="#consent">Consent</a> {consentHealthy}</li>
-          <li><a href="#ontology">Ontology</a> {ontologyHealthy}</li>
-          <li><a href="#sam">Sam</a> {samHealthy}</li>
-        </ul>
-        <hr />
-        <h2><a id="consent">Consent Status</a></h2>
-        <pre>{JSON.stringify(this.state.consentStatus, null, 4)}</pre>
-        <h2><a id="ontology">Ontology Status</a></h2>
-        <pre>{JSON.stringify(this.state.ontologyStatus, null, 4)}</pre>
-      </div>
-    );
-  }
+  const healthyState = <CheckboxMarkedCircleOutline fill={'green'} style={{ marginLeft: '2rem', verticalAlign: 'middle', height: '24px' }} />;
+  const unhealthyState = <DiameterVariant fill={'red'} style={{ marginLeft: '2rem', verticalAlign: 'middle', height: '24px' }} />;
 
+  const consentHealthy = isConsentHealthy(consentStatus) ? healthyState : unhealthyState;
+  const ontologyHealthy = isOntologyHealthy(ontologyStatus) ? healthyState : unhealthyState;
+  const samHealthy = isConsentHealthy(samStatus) ? healthyState : unhealthyState;
+
+  return (
+    <div style={{ margin: '2rem' }}>
+      <ul style={{ marginTop: '2rem', listStyle: 'none', fontSize: 'x-large' }}>
+        <li><a href="#consent">Consent</a> {consentHealthy}</li>
+        <li><a href="#ontology">Ontology</a> {ontologyHealthy}</li>
+        <li><a href="#sam">Sam</a> {samHealthy}</li>
+      </ul>
+      <hr />
+      <h2><a id="consent">Consent Status</a></h2>
+      <pre>{JSON.stringify(consentStatus, null, 4)}</pre>
+      <h2><a id="ontology">Ontology Status</a></h2>
+      <pre>{JSON.stringify(ontologyStatus, null, 4)}</pre>
+    </div>
+  );
 };
 
 export default Status;

--- a/src/styles/tooltip.css
+++ b/src/styles/tooltip.css
@@ -1,0 +1,7 @@
+.interactiveTooltip {
+    pointer-events: auto !important;
+    &:hover {
+        visibility: visible !important;
+        opacity: 1 !important;
+    }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-688

### Summary

Takes the UI design from: https://github.com/DataBiosphere/duos-ui/tree/cc-dt-688-disable-ui-when-sam-down

- Add Sam as a separate item in the status page to see at a glance
- Disable DUOS sign-in when Sam is down

<img width="798" alt="Screenshot 2025-01-09 at 11 16 40 AM" src="https://github.com/user-attachments/assets/1cb61202-eb58-472a-a3ea-99117729a444" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
