### PR TITLE
[DT-1122] Apply `zizmor` suggestions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22.11.0'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Get Short Sha
       id: short-sha
       run: echo "sha=$(git rev-parse --short=12 HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,21 +32,22 @@ jobs:
     - name: Construct tags
       id: construct-tags
       run: |
-        SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.short-sha.outputs.sha }}"
+        SHA_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:${SHORT_SHA}"
         ENVIRONMENT_TAG=""
         if ${{ github.event_name == 'pull_request'}}; then
-          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${{ steps.short-sha.outputs.sha }}"
+          ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:pr-${SHORT_SHA}"
         elif ${{github.event_name == 'push' }}; then
           ENVIRONMENT_TAG="${REGISTRY_HOST}/${GOOGLE_PROJECT}/${SERVICE_NAME}:dev"
         fi
         echo "sha-tag=$SHA_TAG" >> $GITHUB_OUTPUT
         echo "environment-tag=$ENVIRONMENT_TAG" >> $GITHUB_OUTPUT
+      env:
+        SHORT_SHA: ${{ steps.short-sha.outputs.sha }}
     - name: Build Image
-      run: |
-        docker build \
-        -t ${{ steps.construct-tags.outputs.sha-tag }} \
-        -t ${{ steps.construct-tags.outputs.environment-tag }} \
-        .
+      run: docker build -t "${SHA_TAG}" -t "${ENVIRONMENT_TAG}" .
+      env:
+        SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
+        ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
     - id: 'auth'
       if: github.actor != 'dependabot[bot]'
       name: 'Authenticate to Google Cloud'
@@ -59,8 +60,11 @@ jobs:
       if: github.actor != 'dependabot[bot]'
       run: |
         gcloud auth configure-docker --quiet
-        docker push ${{ steps.construct-tags.outputs.sha-tag }}
-        docker push ${{ steps.construct-tags.outputs.environment-tag }}
+        docker push "${SHA_TAG}"
+        docker push "${ENVIRONMENT_TAG}"
+      env:
+        SHA_TAG: ${{ steps.construct-tags.outputs.sha-tag }}
+        ENVIRONMENT_TAG: ${{ steps.construct-tags.outputs.environment-tag }}
   report-to-sherlock:
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
     needs: [tag-build-push]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,8 +47,6 @@ jobs:
         -t ${{ steps.construct-tags.outputs.sha-tag }} \
         -t ${{ steps.construct-tags.outputs.environment-tag }} \
         .
-    - name: Log Github Actor
-      run: echo "${{ github.actor }}"
     - id: 'auth'
       if: github.actor != 'dependabot[bot]'
       name: 'Authenticate to Google Cloud'

--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -4,8 +4,6 @@ jobs:
   cypress-run:
     runs-on: ubuntu-latest
     steps:
-      - name: Log Actor
-        run: echo "${{ github.actor }}"
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -8,6 +8,8 @@ jobs:
         run: echo "${{ github.actor }}"
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22.11.0'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,5 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Build Image
         run: docker build .

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,6 +9,8 @@ jobs:
         run: echo "${{ github.actor }}"
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22.11.0'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,8 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
     steps:
-      - name: Log Actor
-        run: echo "${{ github.actor }}"
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -8,5 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          persist-credentials: false
       - uses: broadinstitute/dsp-appsec-trivy-action@v1


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1122

### Summary

* The Github actor is already logged on the action run page
* We should not persist credentials if we don't need to
* Use shell variable expansion instead of [template expansion](https://woodruffw.github.io/zizmor/audits/#template-injection)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
