### PR TITLE
DT-688: Bug fix for missing tooltip style

### DIFF
--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -15,7 +15,6 @@ import {History} from 'history';
 import {OidcUser} from '../libs/auth/oidcBroker';
 import {DuosUser} from '../types/model';
 import {DuosUserResponse} from '../types/responseTypes';
-import {tooltipStyle} from '../components/Tooltips';
 import {ServiceStatus} from '../libs/ajax/ServiceStatus';
 import '../styles/tooltip.css';
 
@@ -176,6 +175,8 @@ export const SignInButton = (props: SignInButtonProps) => {
       </span>
     );
   };
+
+  const tooltipStyle: React.CSSProperties = {maxWidth: '30vw', textWrap: 'wrap'};
 
   useEffect(() => {
     const init = async () => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-688

### Summary
There were two competing PRs that caused this, one that removed the style, and a concurrent one that depended on it:
* https://github.com/DataBiosphere/duos-ui/pull/2764/files#diff-2ad494007e443b431af3317668072686621ed5a3fb76493f4f59cc694798b09eL8
* https://github.com/DataBiosphere/duos-ui/pull/2763/files#diff-953fe2370f0a9fdd434a0ed7f1850398981d2738e4ce8686520cfb611a1cceafR18

This PR just copies the missing style back to where it was being used.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
