### PR TITLE
DT-1144: Update Support URLs

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -74,11 +74,6 @@ export const fetchAny = async (...args) => {
   return res;
 };
 
-export const getFileNameFromHttpResponse = (response) => {
-  const respHeaders = response.headers;
-  return respHeaders.get('Content-Disposition').split(';')[1].trim().split('=')[1];
-};
-
 export const reportError = async (url, status) => {
   const msg = 'Error fetching response: '
     .concat(JSON.stringify(url))

--- a/src/libs/ajax/Support.js
+++ b/src/libs/ajax/Support.js
@@ -1,11 +1,10 @@
-import {Config} from '../config';
 import {getApiUrl} from '../ajax';
 import axios from 'axios';
 
 export const Support = {
 
   createTicket: (name, type, email, subject, description, attachmentToken, url) => {
-    return  {
+    return {
       name: name,
       type: type.toUpperCase(),
       email: email,
@@ -18,12 +17,20 @@ export const Support = {
 
   createSupportRequest: async (ticket) => {
     const url = `${await getApiUrl()}/support/request`;
-    return  await axios.post(url, Config.jsonBody(ticket));
+    return await axios.post(url, ticket, {headers: {'Content-Type': 'application/json'}}).catch(
+      function (error) {
+        return Promise.reject(error.response);
+      }
+    );
   },
 
   uploadAttachment: async (file) => {
     const url = `${await getApiUrl()}/support/upload`;
-    return  await axios.post(url, Config.attachmentBody(file));
+    return await axios.post(url, file, {headers: {'Content-Type': 'application/binary'}}).catch(
+      function (error) {
+        return Promise.reject(error.response);
+      }
+    );
   },
 
 };

--- a/src/libs/ajax/Support.js
+++ b/src/libs/ajax/Support.js
@@ -1,40 +1,29 @@
-import * as fp from 'lodash/fp';
-import { Config } from '../config';
-import { fetchAny } from '../ajax';
-
+import {Config} from '../config';
+import {getApiUrl} from '../ajax';
+import axios from 'axios';
 
 export const Support = {
+
   createTicket: (name, type, email, subject, description, attachmentToken, url) => {
-    const ticket = {};
-
-    ticket.request = {
-      requester: { name: name, email: email },
+    return  {
+      name: name,
+      type: type.toUpperCase(),
+      email: email,
       subject: subject,
-      // BEWARE changing the following ids or values! If you change them then you must thoroughly test.
-      custom_fields: [
-        { id: 360012744452, value: type },
-        { id: 360007369412, value: description },
-        { id: 360012744292, value: name },
-        { id: 360012782111, value: email },
-        { id: 360018545031, value: email }
-      ],
-      comment: {
-        body: description + '\n\n------------------\nSubmitted from: ' + url,
-        uploads: attachmentToken
-      },
-      ticket_form_id: 360000669472
+      description: description,
+      url: url,
+      uploads: attachmentToken
     };
-
-    return ticket;
-
   },
+
   createSupportRequest: async (ticket) => {
-    const res = await fetchAny('https://broadinstitute.zendesk.com/api/v2/requests.json', fp.mergeAll([Config.jsonBody(ticket), { method: 'POST' }]));
-    return await res;
+    const url = `${await getApiUrl()}/support/request`;
+    return  await axios.post(url, Config.jsonBody(ticket));
   },
 
   uploadAttachment: async (file) => {
-    const res = await fetchAny('https://broadinstitute.zendesk.com/api/v2/uploads?filename=Attachment', fp.mergeAll([Config.attachmentBody(file), { method: 'POST' }]));
-    return (await res.json()).upload;
+    const url = `${await getApiUrl()}/support/upload`;
+    return  await axios.post(url, Config.attachmentBody(file));
   },
+
 };

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -17,8 +17,6 @@ export const Config = {
 
   getNihUrl: async () => (await getConfig()).nihUrl,
 
-  getGoogleClientId: async () => (await getConfig()).clientId,
-
   getGAId: async () => (await getConfig()).gaId,
 
   getErrorApiKey: async () => (await getConfig()).errorApiKey,
@@ -63,11 +61,6 @@ export const Config = {
   jsonBody: body => ({
     body: JSON.stringify(body),
     headers: {'Content-Type': 'application/json'},
-  }),
-
-  attachmentBody: body => ({
-    body: body,
-    headers: {'Content-Type': 'application/binary'}
   }),
 
 };

--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useState } from 'react';
-import { Support } from '../../libs/ajax/Support';
-import { Notifications } from '../../libs/utils';
-import { isNil } from 'lodash';
-import { FormField, FormFieldTypes } from '../../components/forms/forms';
+import {useState} from 'react';
+import {Support} from '../../libs/ajax/Support';
+import {Notifications} from '../../libs/utils';
+import {isNil} from 'lodash';
+import {FormField, FormFieldTypes} from '../../components/forms/forms';
 
 export default function SupportRequestsPage(props) {
 
@@ -47,8 +47,8 @@ export default function SupportRequestsPage(props) {
     await props.history.push('/profile');
   };
 
-  const handleSupportRequestsChange = ({ key, value }) => {
-    let newSupportRequests = Object.assign({}, supportRequests, { [key]: value });
+  const handleSupportRequestsChange = ({key, value}) => {
+    let newSupportRequests = Object.assign({}, supportRequests, {[key]: value});
     setSupportRequests(newSupportRequests);
     const hasAnyRequests = possibleSupportRequests.some(request => newSupportRequests[request.key]);
     setHasSupportRequests(hasAnyRequests);
@@ -91,7 +91,9 @@ export default function SupportRequestsPage(props) {
       };
 
       const ticket = Support.createTicket(
-        profile.profileName, ticketInfo.type, profile.email,
+        profile.profileName,
+        ticketInfo.type,
+        profile.email,
         ticketInfo.subject,
         ticketInfo.description,
         ticketInfo.attachmentToken,
@@ -101,7 +103,7 @@ export default function SupportRequestsPage(props) {
       const response = await Support.createSupportRequest(ticket);
       if (response.status === 201) {
         Notifications.showSuccess(
-          { text: 'Sent Requests Successfully', layout: 'topRight', timeout: 1500 }
+          {text: 'Sent Requests Successfully', layout: 'topRight', timeout: 1500}
         );
       } else {
         Notifications.showError({
@@ -111,7 +113,7 @@ export default function SupportRequestsPage(props) {
       }
     };
 
-  return <div style={{ padding: '25px 270px 0px 270px' }}>
+  return <div style={{padding: '25px 270px 0px 270px'}}>
     <p
       style={{
         color: '#01549F',
@@ -130,7 +132,7 @@ export default function SupportRequestsPage(props) {
       }}>
       <h2
         id='lbl_supportRequests'
-        style={{ ...headerStyle, marginTop: 0 }}>
+        style={{...headerStyle, marginTop: 0}}>
         Which of the following are you looking to do?*
       </h2>
       {possibleSupportRequests.map((supportRequest) => {
@@ -141,9 +143,9 @@ export default function SupportRequestsPage(props) {
           type={FormFieldTypes.CHECKBOX}
           key={supportRequest.key}
           id={supportRequest.key}
-          onChange={handleSupportRequestsChange} />;
+          onChange={handleSupportRequestsChange}/>;
       })}
-      <div style={{ margin: '15px 0 10px' }}>
+      <div style={{margin: '15px 0 10px'}}>
         Is there anything else you would like to request?
       </div>
       <FormField
@@ -152,13 +154,13 @@ export default function SupportRequestsPage(props) {
         placeholder='Enter your request'
         maxLength='512'
         rows='3'
-        onChange={handleSupportRequestsChange} />
+        onChange={handleSupportRequestsChange}/>
     </div>
     <button
       id='btn_save'
       onClick={goToPrevPage}
       className='f-left btn-primary btn-back'
-      style={{ marginTop: '50px' }}>
+      style={{marginTop: '50px'}}>
       Back
     </button>
     <button


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1144

### Summary
* Requires https://github.com/DataBiosphere/consent/pull/2448
* Updates the support calls to go through Consent instead of directly to Zendesk

### Testing
* TODO

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
