### PR TITLE
DT-1144: Update Support Destination URLs

### DIFF
--- a/cypress/component/Support/RequestForm.spec.js
+++ b/cypress/component/Support/RequestForm.spec.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-undef */
+
+import React from 'react';
+import {mount} from 'cypress/react18';
+import RequestForm from '../../../src/pages/user_profile/RequestForm';
+
+describe('SupportRequestsPage Tests', () => {
+  beforeEach(() => {
+    cy.viewport(1000, 500);
+    cy.initApplicationConfig();
+    mount(<RequestForm
+      location={{
+        state: {
+          data: {
+            profileName: 'name',
+            email: 'user@test.com',
+            id: 1
+          }
+        }
+      }}
+      history={[]}
+    />);
+  });
+
+  it('Renders all form elements', () => {
+    cy.get('[data-cy="supportRequestForm"]').should('exist');
+    // Note that for the following selectors, each one is a `FormField` components that does not allow a data-cy property
+    cy.get('[id="checkRegisterDataset"]').should('exist');
+    cy.get('[id="checkSOPermissions"]').should('exist');
+    cy.get('[id="checkJoinDac"]').should('exist');
+    cy.get('[id="extraRequest"]').should('exist');
+    cy.get('[data-cy="backButton"]').should('be.enabled');
+    cy.get('[data-cy="submitButton"]').should('be.disabled');
+  });
+
+  it('Allows for submission when form is filled out', () => {
+    cy.get('[id="checkRegisterDataset"]').check();
+    cy.get('[data-cy="submitButton"]').should('be.enabled');
+    cy.get('[id="checkRegisterDataset"]').uncheck();
+    cy.get('[data-cy="submitButton"]').should('be.disabled');
+
+    cy.get('[id="checkSOPermissions"]').check();
+    cy.get('[data-cy="submitButton"]').should('be.enabled');
+    cy.get('[id="checkSOPermissions"]').uncheck();
+    cy.get('[data-cy="submitButton"]').should('be.disabled');
+
+    cy.get('[id="checkJoinDac"]').check();
+    cy.get('[data-cy="submitButton"]').should('be.enabled');
+    cy.get('[id="checkJoinDac"]').uncheck();
+    cy.get('[data-cy="submitButton"]').should('be.disabled');
+
+    cy.get('[id="extraRequest"]').type('Extra Request');
+    // Note that the UI currently does not allow submission without a checkbox selected
+    cy.get('[data-cy="submitButton"]').should('be.disabled');
+
+    // Test actual submission
+    cy.intercept({method: 'POST', url: '**/support/request'}, {statusCode: 201}).as('request');
+    cy.get('[id="checkRegisterDataset"]').check();
+    cy.get('[data-cy="submitButton"]').click();
+    cy.wait(['@request']).then((interception) => {
+      expect(interception).to.not.be.null;
+    });
+  });
+
+});

--- a/cypress/component/Support/SupportRequestModal.spec.js
+++ b/cypress/component/Support/SupportRequestModal.spec.js
@@ -62,6 +62,14 @@ describe('Support Request Modal Tests', () => {
       // Form is complete:
       cy.get('[data-cy="supportFormSubmit"]').should('not.be.disabled');
       cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled');
+      cy.intercept({method: 'POST', url: '**/support/request'}, {statusCode: 201}).as('request');
+      cy.intercept({method: 'POST', url: '**/support/upload'}, {statusCode: 201, body: {'token': 'token_string'}}).as('upload');
+      // {force: true} is necessary here due to the surrounding div that covers the input.
+      cy.get('[data-cy="supportFormAttachment"]').selectFile(['cypress/fixtures/example.json'], {force: true});
+      cy.get('[data-cy="supportFormSubmit"]').click();
+      cy.wait(['@request', '@upload']).then((interceptions) => {
+        assert(interceptions.length === 2);
+      });
     });
 
   });
@@ -112,6 +120,14 @@ describe('Support Request Modal Tests', () => {
       // Form is complete:
       cy.get('[data-cy="supportFormSubmit"]').should('not.be.disabled');
       cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled');
+      cy.intercept({method: 'POST', url: '**/support/request'}, {statusCode: 201}).as('request');
+      cy.intercept({method: 'POST', url: '**/support/upload'}, {statusCode: 201, body: {'token': 'token_string'}}).as('upload');
+      // {force: true} is necessary here due to the surrounding div that covers the input.
+      cy.get('[data-cy="supportFormAttachment"]').selectFile(['cypress/fixtures/example.json'], {force: true});
+      cy.get('[data-cy="supportFormSubmit"]').click();
+      cy.wait(['@request', '@upload']).then((interceptions) => {
+        assert(interceptions.length === 2);
+      });
     });
 
   });

--- a/cypress/component/Support/SupportRequestModal.spec.js
+++ b/cypress/component/Support/SupportRequestModal.spec.js
@@ -1,0 +1,150 @@
+/* eslint-disable no-undef */
+
+import React from 'react';
+import {mount} from 'cypress/react18';
+import {SupportRequestModal} from '../../../src/components/modals/SupportRequestModal';
+import {Storage} from '../../../src/libs/storage';
+
+const mockUser = {
+  displayName: 'Display Name',
+  email: 'email@test.com'
+};
+
+const handler = () => {
+};
+
+describe('Support Request Modal Tests', () => {
+
+  beforeEach(() => {
+    cy.viewport(500, 500);
+    cy.initApplicationConfig();
+  });
+
+  describe('When a user is logged in:', () => {
+    beforeEach(() => {
+      cy.stub(Storage, 'userIsLogged').returns(true);
+      cy.stub(Storage, 'getCurrentUser').returns(mockUser);
+    });
+
+    it('Renders form correctly', () => {
+      mount(<SupportRequestModal
+        onCloseRequest={handler}
+        onOKRequest={handler}
+        url={'url'}
+        showModal={true}
+      />);
+      // These fields should exist
+      cy.get('[data-cy="closeButton"]').should('exist');
+      cy.get('[data-cy="supportForm"]').should('exist');
+      cy.get('[data-cy="supportFormEmail"]').should('not.exist');
+      cy.get('[data-cy="supportFormName"]').should('not.exist');
+      cy.get('[data-cy="supportFormType"]').should('exist');
+      cy.get('[data-cy="supportFormSubject"]').should('exist');
+      cy.get('[data-cy="supportFormDescription"]').should('exist');
+      cy.get('[data-cy="supportFormAttachment"]').should('exist');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled');
+    });
+
+    it('Submits properly', () => {
+      mount(<SupportRequestModal
+        onCloseRequest={handler}
+        onOKRequest={handler}
+        url={'url'}
+        showModal={true}
+      />);
+      // Ensure that all required fields are filled out before submit becomes available
+      cy.get('[data-cy="supportFormType"]').select('bug');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormSubject"]').type('Subject');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormDescription"]').type('Description');
+      // Form is complete:
+      cy.get('[data-cy="supportFormSubmit"]').should('not.be.disabled');
+      cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled');
+    });
+
+  });
+
+  describe('When a user is NOT logged in:', () => {
+    beforeEach(() => {
+      cy.stub(Storage, 'userIsLogged').returns(false);
+      cy.stub(Storage, 'getCurrentUser').returns(undefined);
+    });
+
+    it('Renders form correctly', () => {
+      mount(<SupportRequestModal
+        onCloseRequest={handler}
+        onOKRequest={handler}
+        url={'url'}
+        showModal={true}
+      />);
+      // These fields should exist
+      cy.get('[data-cy="closeButton"]').should('exist');
+      cy.get('[data-cy="supportForm"]').should('exist');
+      cy.get('[data-cy="supportFormEmail"]').should('exist');
+      cy.get('[data-cy="supportFormName"]').should('exist');
+      cy.get('[data-cy="supportFormType"]').should('exist');
+      cy.get('[data-cy="supportFormSubject"]').should('exist');
+      cy.get('[data-cy="supportFormDescription"]').should('exist');
+      cy.get('[data-cy="supportFormAttachment"]').should('exist');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled');
+    });
+
+    it('Submits properly', () => {
+      mount(<SupportRequestModal
+        onCloseRequest={handler}
+        onOKRequest={handler}
+        url={'url'}
+        showModal={true}
+      />);
+      // Ensure that all required fields are filled out before submit becomes available
+      cy.get('[data-cy="supportFormName"]').type('Name');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormType"]').select('bug');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormSubject"]').type('Subject');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormDescription"]').type('Description');
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled');
+      cy.get('[data-cy="supportFormEmail"]').type(mockUser.email);
+      // Form is complete:
+      cy.get('[data-cy="supportFormSubmit"]').should('not.be.disabled');
+      cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled');
+    });
+
+  });
+
+  describe('File Attachments', () => {
+    beforeEach(() => {
+      cy.stub(Storage, 'userIsLogged').returns(false);
+      cy.stub(Storage, 'getCurrentUser').returns(undefined);
+    });
+    it('Single attachment displayed', () => {
+      mount(<SupportRequestModal
+        onCloseRequest={handler}
+        onOKRequest={handler}
+        url={'url'}
+        showModal={true}
+      />);
+      // {force: true} is necessary here due to the surrounding div that covers the input.
+      cy.get('[data-cy="supportFormAttachment"]').selectFile(['cypress/fixtures/example.json'], {force: true});
+      const container = cy.get('[data-cy="supportFormAttachmentContainer"]');
+      expect(container.contains('example.json'));
+    });
+
+    it('Multiple attachments displayed', () => {
+      mount(<SupportRequestModal
+        onCloseRequest={handler}
+        onOKRequest={handler}
+        url={'url'}
+        showModal={true}
+      />);
+      // {force: true} is necessary here due to the surrounding div that covers the input.
+      cy.get('[data-cy="supportFormAttachment"]').selectFile(['cypress/fixtures/example.json', 'cypress/fixtures/dataset-registration-schema_v1.json'], {force: true});
+      const container = cy.get('[data-cy="supportFormAttachmentContainer"]');
+      expect(container.contains('2 files selected'));
+    });
+  });
+});

--- a/src/components/modals/SupportRequestModal.jsx
+++ b/src/components/modals/SupportRequestModal.jsx
@@ -64,7 +64,7 @@ export const SupportRequestModal = (props) => {
       for (let i = 0; i < modalState.attachment.length; i++) {
         try {
           const response = await Support.uploadAttachment(modalState.attachment[i]);
-          results.push(response);
+          results.push(response.data);
         } catch (response) {
           Notifications.showError({
             text: `ERROR ${response.status}: Unable to add attachment: ${response.data?.message}`,

--- a/src/components/modals/SupportRequestModal.jsx
+++ b/src/components/modals/SupportRequestModal.jsx
@@ -63,10 +63,11 @@ export const SupportRequestModal = (props) => {
       const results = [];
       for (let i = 0; i < modalState.attachment.length; i++) {
         try {
-          results.push(Support.uploadAttachment(modalState.attachment[i]));
-        } catch (e) {
+          const response = await Support.uploadAttachment(modalState.attachment[i]);
+          results.push(response);
+        } catch (response) {
           Notifications.showError({
-            text: 'Unable to add attachment',
+            text: `ERROR ${response.status}: Unable to add attachment: ${response.data?.message}`,
             layout: 'topRight',
           });
           setModalState({
@@ -99,8 +100,8 @@ export const SupportRequestModal = (props) => {
     if (modalState.validAttachment) {
       const ticket = Support.createTicket(modalState.name, modalState.type, modalState.email,
         modalState.subject, modalState.description, attachmentToken, props.url);
-      const response = await Support.createSupportRequest(ticket);
-      if (response.status === 201) {
+      try {
+        await Support.createSupportRequest(ticket);
         Notifications.showSuccess({ text: 'Sent Successfully', layout: 'topRight', timeout: 1500 });
         setModalState({
           ...modalState,
@@ -110,9 +111,9 @@ export const SupportRequestModal = (props) => {
           attachment: ''
         });
         props.onOKRequest('support');
-      } else {
+      } catch (response) {
         Notifications.showError({
-          text: `ERROR ${response.status} : Unable To Send`,
+          text: `ERROR ${response.status} : Unable To Send: ${response.data?.message}`,
           layout: 'topRight',
         });
       }

--- a/src/components/modals/SupportRequestModal.jsx
+++ b/src/components/modals/SupportRequestModal.jsx
@@ -246,6 +246,7 @@ export const SupportRequestModal = (props) => {
             style={{ position: 'absolute', top: '20px', right: '20px' }}
             className='close'
             onClick={closeHandler}
+            data-cy={'closeButton'}
           >
             <span className='glyphicon glyphicon-remove default-color' />
           </button>
@@ -278,6 +279,7 @@ export const SupportRequestModal = (props) => {
             name = 'zendeskTicketForm'
             noValidate = {true}
             encType= 'multipart/form-data'
+            data-cy={'supportForm'}
           >
             {!modalState.isLogged && (
               <div className='form-group first-form-group'>
@@ -289,6 +291,7 @@ export const SupportRequestModal = (props) => {
                   className='form-control col-lg-12'
                   onChange={nameChangeHandler}
                   required={true}
+                  data-cy={'supportFormName'}
                 />
               </div>
             )}
@@ -301,6 +304,7 @@ export const SupportRequestModal = (props) => {
                 value={modalState.type}
                 onChange={typeChangeHandler}
                 required={true}
+                data-cy={'supportFormType'}
               >
                 <option value='question'>Question</option>
                 <option value='bug'>Bug</option>
@@ -313,10 +317,10 @@ export const SupportRequestModal = (props) => {
               <input
                 id='txt_subject'
                 placeholder='Enter a subject'
-                rows='5'
                 className='form-control col-lg-12 vote-input'
                 onChange={subjectChangeHandler}
                 required={true}
+                data-cy={'supportFormSubject'}
               />
               <textarea
                 id='txt_description'
@@ -325,6 +329,7 @@ export const SupportRequestModal = (props) => {
                 className='form-control col-lg-12 vote-input'
                 onChange={descriptionChangeHandler}
                 required={true}
+                data-cy={'supportFormDescription'}
               />
             </div>
 
@@ -341,8 +346,10 @@ export const SupportRequestModal = (props) => {
                     alignItems: 'center',
                     border: modalState.attachment.length === 0 ? '1px dashed' : 'none',
                   }}>
-                    <div {...getRootProps()}>
-                      <input {...getInputProps()} />
+                    <div {...getRootProps()}
+                      data-cy={'supportFormAttachmentContainer'}>
+                      <input {...getInputProps()}
+                        data-cy={'supportFormAttachment'}/>
                       <p>
                         {modalState.attachment.length === 0 ? 'Drag or Click to attach a files' :
                           modalState.attachment.length === 1 ? modalState.attachment[0].name :
@@ -385,6 +392,7 @@ export const SupportRequestModal = (props) => {
                   value={modalState.email}
                   onChange={emailChangeHandler}
                   required={true}
+                  data-cy={'supportFormEmail'}
                 />
               </div>
             )}
@@ -396,6 +404,7 @@ export const SupportRequestModal = (props) => {
             className='btn common-background'
             onClick={OKHandler}
             disabled={disableOkBtn}
+            data-cy={'supportFormSubmit'}
           >
             Submit
           </button>
@@ -403,6 +412,7 @@ export const SupportRequestModal = (props) => {
             id='btn_cancel'
             className='btn dismiss-background'
             onClick={closeHandler}
+            data-cy={'supportFormCancel'}
           >
             Cancel
           </button>

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -42,10 +42,6 @@ export const getOntologyUrl = async() => {
   return await Config.getOntologyApiUrl();
 };
 
-export const sleep = (ms) => {
-  return new Promise(resolve => setTimeout(resolve, ms));
-};
-
 export const fetchOk = async (...args) => {
   //TODO: Remove spinnerService calls
   spinnerService.showAll();

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -74,11 +74,6 @@ export const fetchAny = async (...args) => {
   return res;
 };
 
-export const getFileNameFromHttpResponse = (response) => {
-  const respHeaders = response.headers;
-  return respHeaders.get('Content-Disposition').split(';')[1].trim().split('=')[1];
-};
-
 export const reportError = async (url, status) => {
   const msg = 'Error fetching response: '
     .concat(JSON.stringify(url))

--- a/src/libs/ajax/Support.js
+++ b/src/libs/ajax/Support.js
@@ -1,11 +1,10 @@
-import {Config} from '../config';
 import {getApiUrl} from '../ajax';
 import axios from 'axios';
 
 export const Support = {
 
   createTicket: (name, type, email, subject, description, attachmentToken, url) => {
-    return  {
+    return {
       name: name,
       type: type.toUpperCase(),
       email: email,
@@ -18,12 +17,20 @@ export const Support = {
 
   createSupportRequest: async (ticket) => {
     const url = `${await getApiUrl()}/support/request`;
-    return  await axios.post(url, Config.jsonBody(ticket));
+    return await axios.post(url, ticket, {headers: {'Content-Type': 'application/json'}}).catch(
+      function (error) {
+        return Promise.reject(error.response);
+      }
+    );
   },
 
   uploadAttachment: async (file) => {
     const url = `${await getApiUrl()}/support/upload`;
-    return  await axios.post(url, Config.attachmentBody(file));
+    return await axios.post(url, file, {headers: {'Content-Type': 'application/binary'}}).catch(
+      function (error) {
+        return Promise.reject(error.response);
+      }
+    );
   },
 
 };

--- a/src/libs/ajax/Support.js
+++ b/src/libs/ajax/Support.js
@@ -1,40 +1,29 @@
-import * as fp from 'lodash/fp';
-import { Config } from '../config';
-import { fetchAny } from '../ajax';
-
+import {Config} from '../config';
+import {getApiUrl} from '../ajax';
+import axios from 'axios';
 
 export const Support = {
+
   createTicket: (name, type, email, subject, description, attachmentToken, url) => {
-    const ticket = {};
-
-    ticket.request = {
-      requester: { name: name, email: email },
+    return  {
+      name: name,
+      type: type.toUpperCase(),
+      email: email,
       subject: subject,
-      // BEWARE changing the following ids or values! If you change them then you must thoroughly test.
-      custom_fields: [
-        { id: 360012744452, value: type },
-        { id: 360007369412, value: description },
-        { id: 360012744292, value: name },
-        { id: 360012782111, value: email },
-        { id: 360018545031, value: email }
-      ],
-      comment: {
-        body: description + '\n\n------------------\nSubmitted from: ' + url,
-        uploads: attachmentToken
-      },
-      ticket_form_id: 360000669472
+      description: description,
+      url: url,
+      uploads: attachmentToken
     };
-
-    return ticket;
-
   },
+
   createSupportRequest: async (ticket) => {
-    const res = await fetchAny('https://broadinstitute.zendesk.com/api/v2/requests.json', fp.mergeAll([Config.jsonBody(ticket), { method: 'POST' }]));
-    return await res;
+    const url = `${await getApiUrl()}/support/request`;
+    return  await axios.post(url, Config.jsonBody(ticket));
   },
 
   uploadAttachment: async (file) => {
-    const res = await fetchAny('https://broadinstitute.zendesk.com/api/v2/uploads?filename=Attachment', fp.mergeAll([Config.attachmentBody(file), { method: 'POST' }]));
-    return (await res.json()).upload;
+    const url = `${await getApiUrl()}/support/upload`;
+    return  await axios.post(url, Config.attachmentBody(file));
   },
+
 };

--- a/src/libs/config.js
+++ b/src/libs/config.js
@@ -17,8 +17,6 @@ export const Config = {
 
   getNihUrl: async () => (await getConfig()).nihUrl,
 
-  getGoogleClientId: async () => (await getConfig()).clientId,
-
   getGAId: async () => (await getConfig()).gaId,
 
   getErrorApiKey: async () => (await getConfig()).errorApiKey,
@@ -63,11 +61,6 @@ export const Config = {
   jsonBody: body => ({
     body: JSON.stringify(body),
     headers: {'Content-Type': 'application/json'},
-  }),
-
-  attachmentBody: body => ({
-    body: body,
-    headers: {'Content-Type': 'application/binary'}
   }),
 
 };

--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useState } from 'react';
-import { Support } from '../../libs/ajax/Support';
-import { Notifications } from '../../libs/utils';
-import { isNil } from 'lodash';
-import { FormField, FormFieldTypes } from '../../components/forms/forms';
+import {useState} from 'react';
+import {Support} from '../../libs/ajax/Support';
+import {Notifications} from '../../libs/utils';
+import {isNil} from 'lodash';
+import {FormField, FormFieldTypes} from '../../components/forms/forms';
 
 export default function SupportRequestsPage(props) {
 
@@ -47,8 +47,8 @@ export default function SupportRequestsPage(props) {
     await props.history.push('/profile');
   };
 
-  const handleSupportRequestsChange = ({ key, value }) => {
-    let newSupportRequests = Object.assign({}, supportRequests, { [key]: value });
+  const handleSupportRequestsChange = ({key, value}) => {
+    let newSupportRequests = Object.assign({}, supportRequests, {[key]: value});
     setSupportRequests(newSupportRequests);
     const hasAnyRequests = possibleSupportRequests.some(request => newSupportRequests[request.key]);
     setHasSupportRequests(hasAnyRequests);
@@ -91,7 +91,9 @@ export default function SupportRequestsPage(props) {
       };
 
       const ticket = Support.createTicket(
-        profile.profileName, ticketInfo.type, profile.email,
+        profile.profileName,
+        ticketInfo.type,
+        profile.email,
         ticketInfo.subject,
         ticketInfo.description,
         ticketInfo.attachmentToken,
@@ -101,7 +103,7 @@ export default function SupportRequestsPage(props) {
       const response = await Support.createSupportRequest(ticket);
       if (response.status === 201) {
         Notifications.showSuccess(
-          { text: 'Sent Requests Successfully', layout: 'topRight', timeout: 1500 }
+          {text: 'Sent Requests Successfully', layout: 'topRight', timeout: 1500}
         );
       } else {
         Notifications.showError({
@@ -111,7 +113,7 @@ export default function SupportRequestsPage(props) {
       }
     };
 
-  return <div style={{ padding: '25px 270px 0px 270px' }}>
+  return <div style={{padding: '25px 270px 0px 270px'}}>
     <p
       style={{
         color: '#01549F',
@@ -130,7 +132,7 @@ export default function SupportRequestsPage(props) {
       }}>
       <h2
         id='lbl_supportRequests'
-        style={{ ...headerStyle, marginTop: 0 }}>
+        style={{...headerStyle, marginTop: 0}}>
         Which of the following are you looking to do?*
       </h2>
       {possibleSupportRequests.map((supportRequest) => {
@@ -141,9 +143,9 @@ export default function SupportRequestsPage(props) {
           type={FormFieldTypes.CHECKBOX}
           key={supportRequest.key}
           id={supportRequest.key}
-          onChange={handleSupportRequestsChange} />;
+          onChange={handleSupportRequestsChange}/>;
       })}
-      <div style={{ margin: '15px 0 10px' }}>
+      <div style={{margin: '15px 0 10px'}}>
         Is there anything else you would like to request?
       </div>
       <FormField
@@ -152,13 +154,13 @@ export default function SupportRequestsPage(props) {
         placeholder='Enter your request'
         maxLength='512'
         rows='3'
-        onChange={handleSupportRequestsChange} />
+        onChange={handleSupportRequestsChange}/>
     </div>
     <button
       id='btn_save'
       onClick={goToPrevPage}
       className='f-left btn-primary btn-back'
-      style={{ marginTop: '50px' }}>
+      style={{marginTop: '50px'}}>
       Back
     </button>
     <button

--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -5,7 +5,7 @@ import {Notifications} from '../../libs/utils';
 import {isNil} from 'lodash';
 import {FormField, FormFieldTypes} from '../../components/forms/forms';
 
-export default function SupportRequestsPage(props) {
+export default function RequestForm(props) {
 
   const profile = props.location.state?.data || undefined;
   const headerStyle = {
@@ -113,7 +113,10 @@ export default function SupportRequestsPage(props) {
       }
     };
 
-  return <div style={{padding: '25px 270px 0px 270px'}}>
+  return <div
+    style={{padding: '25px 270px 0px 270px'}}
+    data-cy={'supportRequestForm'}
+  >
     <p
       style={{
         color: '#01549F',
@@ -160,7 +163,8 @@ export default function SupportRequestsPage(props) {
       id='btn_save'
       onClick={goToPrevPage}
       className='f-left btn-primary btn-back'
-      style={{marginTop: '50px'}}>
+      style={{marginTop: '50px'}}
+      data-cy={'backButton'}>
       Back
     </button>
     <button
@@ -170,7 +174,8 @@ export default function SupportRequestsPage(props) {
       style={{
         marginTop: '50px',
       }}
-      disabled={!hasSupportRequests}>
+      disabled={!hasSupportRequests}
+      data-cy={'submitButton'}>
       Submit
     </button>
   </div>;


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-1144

## Summary
* Updates the support calls to go through Consent instead of directly to Zendesk
* Adds unit tests for the two components (`RequestForm` and `SupportRequestModal`) that make use of support request functionality.
* Rename the `SupportRequestsPage` component to the file name, `RequestForm`, for consistency
* There are a lot of linting changes, I suggest hiding whitespace changes when reviewing.

Currently blocked on https://github.com/DataBiosphere/consent/pull/2455

###  Testing
To test locally, this needs to be run against a local running consent with the following config setting:
```
services:
  activateSupportNotifications: true
``` 
Visit the Contact Us form on any page, and the Request a New Role from the user profile page. These are the two places where we invoke the new support urls.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
