### PR TITLE
DT-400: Remove Unnecessary Dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,6 @@
         "@babel/eslint-plugin": "7.25.9",
         "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/preset-react": "7.26.3",
-        "@types/dompurify": "3.2.0",
-        "@types/history": "5.0.0",
         "@types/lodash": "4.17.15",
         "@types/react": "18.3.12",
         "@types/react-modal": "3.16.3",
@@ -4427,16 +4425,6 @@
         "@types/ms": "*"
       }
     },
-    "node_modules/@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "deprecated": "This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "dompurify": "*"
-      }
-    },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
@@ -4501,16 +4489,6 @@
       "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
       "dependencies": {
         "@types/unist": "*"
-      }
-    },
-    "node_modules/@types/history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-hy8b7Y1J8OGe6LbAjj3xniQrj3v6lsivCcrmf4TzSgPzLkhIeKgc5IZnT7ReIqmEuodjfO8EYAuoFvIrHi/+jQ==",
-      "deprecated": "This is a stub types definition. history provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "history": "*"
       }
     },
     "node_modules/@types/html-minifier-terser": {
@@ -26265,15 +26243,6 @@
         "@types/ms": "*"
       }
     },
-    "@types/dompurify": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.2.0.tgz",
-      "integrity": "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==",
-      "dev": true,
-      "requires": {
-        "dompurify": "*"
-      }
-    },
     "@types/eslint": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
@@ -26338,15 +26307,6 @@
       "integrity": "sha512-hs/iBJx2aydugBQx5ETV3ZgeSS0oIreQrFJ4bjBl0XvM4wAmDjFEALY7p0rTSLt2eL+ibjRAAs9dTPiCLtmbqQ==",
       "requires": {
         "@types/unist": "*"
-      }
-    },
-    "@types/history": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-5.0.0.tgz",
-      "integrity": "sha512-hy8b7Y1J8OGe6LbAjj3xniQrj3v6lsivCcrmf4TzSgPzLkhIeKgc5IZnT7ReIqmEuodjfO8EYAuoFvIrHi/+jQ==",
-      "dev": true,
-      "requires": {
-        "history": "*"
       }
     },
     "@types/html-minifier-terser": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,6 @@
     "@babel/eslint-plugin": "7.25.9",
     "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/preset-react": "7.26.3",
-    "@types/dompurify": "3.2.0",
-    "@types/history": "5.0.0",
     "@types/lodash": "4.17.15",
     "@types/react": "18.3.12",
     "@types/react-modal": "3.16.3",


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-400

### Summary
This PR removes two unnecessary dependencies that are no longer necessary as per their build warnings:
```
npm warn deprecated @types/dompurify@3.2.0: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
npm warn deprecated @types/history@5.0.0: This is a stub types definition. history provides its own type definitions, so you do not need this installed.
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
