### PR TITLE
[DT-295] Disable HTTPS when running Cypress tests

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   server: {
     host: 'local.dsde-dev.broadinstitute.org',
     port: 3000,
-    https: process.env.CI ? undefined : {
+    https: (process.env.CI || process.env.CYPRESS) ? undefined : {
       key: 'server.key',
       cert: 'server.crt',
     },


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-295

### Summary

Small bugfix which disables HTTPS so Cypress tests can run locally, otherwise the tests do not execute.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
