### PR TITLE
[DT-295] Cypress configuration cleanup

### DIFF
--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 declare namespace Cypress {
     interface Chainable {
         /**
@@ -7,5 +5,10 @@ declare namespace Cypress {
          * @example cy.auth('admin')
          */
         auth(roleName: string): Chainable<Element>
+        /**
+         * Custom command to initialize application configuration
+         * @example cy.initApplicationConfig()
+         */
+        initApplicationConfig(): Chainable<void>
     }
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,17 +1,10 @@
 {
+  "extends": "../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "es5",
-      "dom"
-    ],
     "types": [
       "cypress",
       "node"
     ],
-    "jsx": "react",
-    "esModuleInterop": true,
-    "resolveJsonModule": true
   },
   "include": [
     "**/*.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       },
       "devDependencies": {
         "@eslint/js": "9.20.0",
+        "@types/node": "^22.13.4",
         "@vitejs/plugin-react": "4.3.4",
         "buffer": "6.0.3",
         "cypress": "13.17.0",
@@ -2073,12 +2074,11 @@
       "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -9183,8 +9183,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/unified": {
       "version": "11.0.3",
@@ -10987,11 +10986,10 @@
       "integrity": "sha512-xPSg0jm4mqgEkNhowKgZFBNtwoEwF6gJ4Dhww+GFpm3IgtNseHQZ5IqdNwnquZEoANxyDAKDRAdVo4Z72VvD/g=="
     },
     "@types/node": {
-      "version": "22.13.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.1.tgz",
-      "integrity": "sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==",
+      "version": "22.13.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.4.tgz",
+      "integrity": "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "undici-types": "~6.20.0"
       }
@@ -15875,8 +15873,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unified": {
       "version": "11.0.3",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.20.0",
+    "@types/node": "^22.13.4",
     "@vitejs/plugin-react": "4.3.4",
     "buffer": "6.0.3",
     "cypress": "13.17.0",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-295

### Summary

Follow up to https://github.com/DataBiosphere/duos-ui/pull/2782 , configures Cypress to the latest standards.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
