### PR TITLE
[DT-1254][risk=no] Upgrade cypress to v 14.0.3 and fix mount import per migration guide.

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
@@ -1,6 +1,6 @@
-/* eslint-disable no-undef */
+ 
 import { React } from 'react';
-import { mount } from 'cypress/react18';
+import { mount } from 'cypress/react';
 import DarCollectionReview from '../../../src/pages/dar_collection_review/DarCollectionReview';
 import { Collections } from '../../../src/libs/ajax/Collections';
 import { Match } from '../../../src/libs/ajax/Match';

--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
@@ -1,4 +1,4 @@
- 
+/* eslint-disable no-undef */
 import { React } from 'react';
 import { mount } from 'cypress/react';
 import DarCollectionReview from '../../../src/pages/dar_collection_review/DarCollectionReview';

--- a/cypress/component/DataSearch/dataset_search_filters.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_filters.spec.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable no-undef */
+ 
 
 import { makeDatasetTerm, makeStudyTerm } from '../test-utils';
-import { mount } from 'cypress/react18';
+import { mount } from 'cypress/react';
 import React from 'react';
 import { defaultFilters } from '../../../src/components/data_search/DatasetFilterConstants';
 import DatasetFilterList from '../../../src/components/data_search/DatasetFilterList';

--- a/cypress/component/DataSearch/dataset_search_filters.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_filters.spec.jsx
@@ -1,4 +1,4 @@
- 
+/* eslint-disable no-undef */
 
 import { makeDatasetTerm, makeStudyTerm } from '../test-utils';
 import { mount } from 'cypress/react';

--- a/cypress/component/Forms/draftFileUpload.spec.tsx
+++ b/cypress/component/Forms/draftFileUpload.spec.tsx
@@ -1,4 +1,5 @@
- 
+/* eslint-disable no-undef */
+
 import {mount} from 'cypress/react';
 import React from 'react';
 import {DraftFileUpload} from '../../../src/components/forms/DraftFileUpload';

--- a/cypress/component/Forms/draftFileUpload.spec.tsx
+++ b/cypress/component/Forms/draftFileUpload.spec.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable no-undef */
-import {mount} from 'cypress/react18';
+ 
+import {mount} from 'cypress/react';
 import React from 'react';
 import {DraftFileUpload} from '../../../src/components/forms/DraftFileUpload';
 import {BrowserRouter} from 'react-router-dom';
@@ -39,7 +39,7 @@ describe('Draft File Upload - Tests', () => {
     cy.get('button').contains('Upload a file');
   });
   it('should render a draft file upload control with a required indicator', () => {
-    let customProps = {...baseProps};
+    const customProps = {...baseProps};
     customProps.required = true;
     mount( <DraftFileUpload {...customProps}/>);
     cy.get('#lbl_testFileUpload').contains('File Upload Test*');
@@ -47,7 +47,7 @@ describe('Draft File Upload - Tests', () => {
   });
 
   it('should trigger onAddFile when file is added.', () => {
-    let customProps = {...baseProps};
+    const customProps = {...baseProps};
     customProps.onAddFile = cy.spy().as('onAddFileSpy');
     mount(<DraftFileUpload {...customProps}/>);
     cy.get('input[type="file"]').as('fileUpload');
@@ -59,7 +59,7 @@ describe('Draft File Upload - Tests', () => {
   });
 
   it('should display file name when defaultValue is FSO.', () => {
-    let customProps = {...baseProps};
+    const customProps = {...baseProps};
     customProps.defaultValue = baseFso;
     mount(<BrowserRouter><DraftFileUpload {...customProps}/></BrowserRouter>);
     cy.get('button').should('be.disabled');
@@ -68,7 +68,7 @@ describe('Draft File Upload - Tests', () => {
   });
 
   it('should trigger onDelete when file is removed.', () => {
-    let customProps = {...baseProps};
+    const customProps = {...baseProps};
     customProps.defaultValue = baseFso;
     customProps.onDeleteFile = cy.spy().as('onDeleteFileSpy');
     mount(<BrowserRouter><DraftFileUpload {...customProps}/></BrowserRouter>);

--- a/cypress/component/Forms/forms.spec.jsx
+++ b/cypress/component/Forms/forms.spec.jsx
@@ -1,6 +1,6 @@
-/* eslint-disable no-undef */
+ 
 import React from 'react';
-import {mount} from 'cypress/react18';
+import {mount} from 'cypress/react';
 import {FormField, FormFieldTypes, FormTable, FormValidators} from '../../../src/components/forms/forms';
 import dayjs from 'dayjs';
 

--- a/cypress/component/Forms/forms.spec.jsx
+++ b/cypress/component/Forms/forms.spec.jsx
@@ -1,4 +1,5 @@
- 
+/* eslint-disable no-undef */
+
 import React from 'react';
 import {mount} from 'cypress/react';
 import {FormField, FormFieldTypes, FormTable, FormValidators} from '../../../src/components/forms/forms';

--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -1,4 +1,4 @@
- 
+/* eslint-disable no-undef */
 
 import React from 'react';
 import {mount} from 'cypress/react';

--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable no-undef */
+ 
 
 import React from 'react';
-import {mount} from 'cypress/react18';
+import {mount} from 'cypress/react';
 import SignInButton from '../../../src/components/SignInButton';
 import {User} from '../../../src/libs/ajax/User';
 import {Auth} from '../../../src/libs/auth/auth';
@@ -108,7 +108,7 @@ describe('Sign In: Component Loads', function () {
     cy.stub(Metrics, 'identify');
     cy.stub(Metrics, 'syncProfile');
     cy.stub(Metrics, 'captureEvent');
-    let history = [];
+    const history = [];
     mount(<SignInButton history={history}/>);
     cy.get('button').click();
     cy.wait('@getMe').then(() => {
@@ -127,7 +127,7 @@ describe('Sign In: Component Loads', function () {
     cy.stub(Metrics, 'identify');
     cy.stub(Metrics, 'syncProfile');
     cy.stub(Metrics, 'captureEvent');
-    let history = [];
+    const history = [];
     mount(<SignInButton history={history}/>);
     cy.get('button').click();
     cy.wait('@registerUser').then(() => {

--- a/cypress/component/Support/RequestForm.spec.jsx
+++ b/cypress/component/Support/RequestForm.spec.jsx
@@ -1,4 +1,4 @@
- 
+/* eslint-disable no-undef */
 
 import React from 'react';
 import {mount} from 'cypress/react';

--- a/cypress/component/Support/RequestForm.spec.jsx
+++ b/cypress/component/Support/RequestForm.spec.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable no-undef */
+ 
 
 import React from 'react';
-import {mount} from 'cypress/react18';
+import {mount} from 'cypress/react';
 import RequestForm from '../../../src/pages/user_profile/RequestForm';
 
 describe('SupportRequestsPage Tests', () => {

--- a/cypress/component/Support/SupportRequestModal.spec.jsx
+++ b/cypress/component/Support/SupportRequestModal.spec.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable no-undef */
+ 
 
 import React from 'react';
-import {mount} from 'cypress/react18';
+import {mount} from 'cypress/react';
 import {SupportRequestModal} from '../../../src/components/modals/SupportRequestModal';
 import {Storage} from '../../../src/libs/storage';
 

--- a/cypress/component/Support/SupportRequestModal.spec.jsx
+++ b/cypress/component/Support/SupportRequestModal.spec.jsx
@@ -1,4 +1,4 @@
- 
+/* eslint-disable no-undef */
 
 import React from 'react';
 import {mount} from 'cypress/react';

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@types/node": "^22.13.4",
         "@vitejs/plugin-react": "4.3.4",
         "buffer": "6.0.3",
-        "cypress": "13.17.0",
+        "cypress": "^14.0.3",
         "eslint": "9.20.1",
         "eslint-plugin-cypress": "4.1.0",
         "eslint-plugin-react": "7.37.4",
@@ -408,10 +408,11 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
-      "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.7.tgz",
+      "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -426,7 +427,7 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.13.0",
+        "qs": "6.13.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
@@ -436,23 +437,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/@cypress/request/node_modules/tough-cookie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
-      "dev": true,
-      "dependencies": {
-        "tldts": "^6.1.32"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/@cypress/request/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2679,6 +2669,7 @@
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
@@ -2688,6 +2679,7 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
@@ -2760,6 +2752,7 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -2768,7 +2761,8 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.7.9",
@@ -2839,6 +2833,7 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
@@ -3071,7 +3066,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
@@ -3220,6 +3216,13 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -3265,13 +3268,14 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.3.tgz",
+      "integrity": "sha512-yIdvobANw3kS+KF/t5vwjjPNufBA8ux7iQHaWxPTkUw2yCKI72m9mKM24eOwE84Wk4ALPsSvEcGbDrwgmhr4RA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.6",
+        "@cypress/request": "^3.0.7",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -3319,7 +3323,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -3466,6 +3470,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -3682,6 +3687,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4460,7 +4466,8 @@
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4704,6 +4711,7 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
@@ -4947,6 +4955,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
@@ -5259,6 +5268,7 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
       "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^2.0.2",
@@ -5804,7 +5814,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
@@ -5891,7 +5902,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -6026,7 +6038,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
@@ -6065,7 +6078,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -6082,7 +6096,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -6117,6 +6132,7 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -7446,7 +7462,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -7595,10 +7612,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -8185,7 +8203,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -8572,6 +8591,7 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -8886,22 +8906,24 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/tldts": {
-      "version": "6.1.60",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.60.tgz",
-      "integrity": "sha512-TYVHm7G9NCnhgqOsFalbX6MG1Po5F4efF+tLfoeiOGQq48Oqgwcgz8upY2R1BHWa4aDrj28RYx0dkYJ63qCFMg==",
+      "version": "6.1.77",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.77.tgz",
+      "integrity": "sha512-lBpoWgy+kYmuXWQ83+R7LlJCnsd9YW8DGpZSHhrMl4b8Ly/1vzOie3OdtmUJDkKxcgRGOehDu5btKkty+JEe+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.60"
+        "tldts-core": "^6.1.77"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.60",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.60.tgz",
-      "integrity": "sha512-XHjoxak8SFQnHnmYHb3PcnW5TZ+9ErLZemZei3azuIRhQLw4IExsVbL3VZJdHcLeNaXq6NqawgpDPpjBOg4B5g==",
-      "dev": true
+      "version": "6.1.77",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.77.tgz",
+      "integrity": "sha512-bCaqm24FPk8OgBkM0u/SrEWJgHnhBWYqeBo6yUmcZJDCHt/IfyWBb+14CXdGi4RInMv4v7eUAin15W0DoA+Ytg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -8923,6 +8945,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.1.tgz",
+      "integrity": "sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -9008,6 +9043,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -9019,7 +9055,8 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9363,17 +9400,12 @@
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
-    },
-    "node_modules/verror/node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
     },
     "node_modules/vfile": {
       "version": "6.0.1",
@@ -10033,9 +10065,9 @@
       "optional": true
     },
     "@cypress/request": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
-      "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.7.tgz",
+      "integrity": "sha512-LzxlLEMbBOPYB85uXrDqvD4MgcenjRBLIns3zyhx7vTPj/0u2eQhzXvPiGcaJrV38Q9dbkExWp6cOHPJ+EtFYg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -10051,22 +10083,13 @@
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.13.0",
+        "qs": "6.13.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
       "dependencies": {
-        "tough-cookie": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-          "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
-          "dev": true,
-          "requires": {
-            "tldts": "^6.1.32"
-          }
-        },
         "uuid": {
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -11743,6 +11766,12 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -11779,12 +11808,12 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "cypress": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.17.0.tgz",
-      "integrity": "sha512-5xWkaPurwkIljojFidhw8lFScyxhtiFHl/i/3zov+1Z5CmY4t9tjIdvSXfu82Y3w7wt0uR9KkucbhkVvJZLQSA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.3.tgz",
+      "integrity": "sha512-yIdvobANw3kS+KF/t5vwjjPNufBA8ux7iQHaWxPTkUw2yCKI72m9mKM24eOwE84Wk4ALPsSvEcGbDrwgmhr4RA==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^3.0.6",
+        "@cypress/request": "^3.0.7",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -14730,9 +14759,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.6"
@@ -15684,18 +15713,18 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "tldts": {
-      "version": "6.1.60",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.60.tgz",
-      "integrity": "sha512-TYVHm7G9NCnhgqOsFalbX6MG1Po5F4efF+tLfoeiOGQq48Oqgwcgz8upY2R1BHWa4aDrj28RYx0dkYJ63qCFMg==",
+      "version": "6.1.77",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.77.tgz",
+      "integrity": "sha512-lBpoWgy+kYmuXWQ83+R7LlJCnsd9YW8DGpZSHhrMl4b8Ly/1vzOie3OdtmUJDkKxcgRGOehDu5btKkty+JEe+g==",
       "dev": true,
       "requires": {
-        "tldts-core": "^6.1.60"
+        "tldts-core": "^6.1.77"
       }
     },
     "tldts-core": {
-      "version": "6.1.60",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.60.tgz",
-      "integrity": "sha512-XHjoxak8SFQnHnmYHb3PcnW5TZ+9ErLZemZei3azuIRhQLw4IExsVbL3VZJdHcLeNaXq6NqawgpDPpjBOg4B5g==",
+      "version": "6.1.77",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.77.tgz",
+      "integrity": "sha512-bCaqm24FPk8OgBkM0u/SrEWJgHnhBWYqeBo6yUmcZJDCHt/IfyWBb+14CXdGi4RInMv4v7eUAin15W0DoA+Ytg==",
       "dev": true
     },
     "tmp": {
@@ -15711,6 +15740,15 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tough-cookie": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.1.tgz",
+      "integrity": "sha512-Ek7HndSVkp10hmHP9V4qZO1u+pn1RU5sI0Fw+jCU3lyvuMZcgqsNgc6CmJJZyByK4Vm/qotGRJlfgAX8q+4JiA==",
+      "dev": true,
+      "requires": {
+        "tldts": "^6.1.32"
       }
     },
     "tr46": {
@@ -15988,14 +16026,6 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
-      },
-      "dependencies": {
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-          "dev": true
-        }
       }
     },
     "vfile": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,9 +42,10 @@
       "devDependencies": {
         "@eslint/js": "9.20.0",
         "@types/node": "^22.13.4",
+        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "4.3.4",
         "buffer": "6.0.3",
-        "cypress": "^14.0.3",
+        "cypress": "14.0.3",
         "eslint": "9.20.1",
         "eslint-plugin-cypress": "4.1.0",
         "eslint-plugin-react": "7.37.4",
@@ -2043,6 +2044,13 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2090,6 +2098,29 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -10989,6 +11020,12 @@
         "@types/unist": "*"
       }
     },
+    "@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -11034,6 +11071,27 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "requires": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "@types/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/node": "^22.13.4",
     "@vitejs/plugin-react": "4.3.4",
     "buffer": "6.0.3",
-    "cypress": "13.17.0",
+    "cypress": "^14.0.3",
     "eslint": "9.20.1",
     "eslint-plugin-cypress": "4.1.0",
     "eslint-plugin-react": "7.37.4",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
   "devDependencies": {
     "@eslint/js": "9.20.0",
     "@types/node": "^22.13.4",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "4.3.4",
     "buffer": "6.0.3",
-    "cypress": "^14.0.3",
+    "cypress": "14.0.3",
     "eslint": "9.20.1",
     "eslint-plugin-cypress": "4.1.0",
     "eslint-plugin-react": "7.37.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@eslint/js": "9.20.0",
     "@types/node": "^22.13.4",
-    "@types/react-router-dom": "^5.3.3",
+    "@types/react-router-dom": "5.3.3",
     "@vitejs/plugin-react": "4.3.4",
     "buffer": "6.0.3",
     "cypress": "14.0.3",


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1254](https://broadworkbench.atlassian.net/browse/DT-1254)

### Summary
A handful of Cypress tests were failing locally after the conversion to vite.  This PR updates the cypress version and adapts the mount import in accordance with the cypress 14 [migration guide](https://docs.cypress.io/app/references/migration-guide#React-18-CT-no-longer-supported).

### Screenshots
![image](https://github.com/user-attachments/assets/cd4bea02-7bd3-4816-a56c-64f7b57bebc5)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
