### PR TITLE
DT-1289: Update min participant count calculation in the data library

### DIFF
--- a/cypress/component/DataSearch/dataset_search_filters.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_filters.spec.jsx
@@ -53,8 +53,7 @@ describe('Data Library Filters', () => {
     mount(<DatasetFilterList {...props} />);
     cy.get('#participantCountMax-range-input').should('have.value',
       datasets[0].participantCount);
-    cy.get('#participantCountMin-range-input').should('have.value',
-      datasets[1].participantCount);
+    cy.get('#participantCountMin-range-input').should('have.value', 0);
   });
 
   it('calls the filter handler on range changes', () => {

--- a/cypress/component/DataSearch/dataset_search_filters.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_filters.spec.jsx
@@ -53,7 +53,8 @@ describe('Data Library Filters', () => {
     mount(<DatasetFilterList {...props} />);
     cy.get('#participantCountMax-range-input').should('have.value',
       datasets[0].participantCount);
-    cy.get('#participantCountMin-range-input').should('have.value', 0);
+    cy.get('#participantCountMin-range-input').should('have.value',
+      datasets[1].participantCount);
   });
 
   it('calls the filter handler on range changes', () => {

--- a/src/components/data_search/DatasetFilterConstants.tsx
+++ b/src/components/data_search/DatasetFilterConstants.tsx
@@ -21,9 +21,9 @@ export const defaultFilters = (datasets: DatasetTerm[]): FiltersTypes => {
   };
 };
 
-export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => datasets.reduce(() => {
+export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => {
   return {
     max: datasets.reduce((max, dataset) => Math.max(max, dataset.participantCount ? dataset.participantCount : 0), 0),
     min: 0
   };
-}, {max: 0, min: Infinity});
+}

--- a/src/components/data_search/DatasetFilterConstants.tsx
+++ b/src/components/data_search/DatasetFilterConstants.tsx
@@ -24,5 +24,5 @@ export const defaultFilters = (datasets: DatasetTerm[]): FiltersTypes => {
 export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => datasets.reduce((acc, dataset) => {
   return {
     max: Math.max(acc.max, dataset.participantCount ? dataset.participantCount : 0),
-    min: Math.min(acc.min, dataset.participantCount ? dataset.participantCount : Infinity) };
+    min: 0 };
 }, {max: 0, min: Infinity});

--- a/src/components/data_search/DatasetFilterConstants.tsx
+++ b/src/components/data_search/DatasetFilterConstants.tsx
@@ -21,8 +21,9 @@ export const defaultFilters = (datasets: DatasetTerm[]): FiltersTypes => {
   };
 };
 
-export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => datasets.reduce((acc, dataset) => {
+export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => datasets.reduce(() => {
   return {
-    max: Math.max(acc.max, dataset.participantCount ? dataset.participantCount : 0),
-    min: 0 };
+    max: datasets.reduce((max, dataset) => Math.max(max, dataset.participantCount ? dataset.participantCount : 0), 0),
+    min: 0
+  };
 }, {max: 0, min: Infinity});

--- a/src/components/data_search/DatasetFilterConstants.tsx
+++ b/src/components/data_search/DatasetFilterConstants.tsx
@@ -21,9 +21,8 @@ export const defaultFilters = (datasets: DatasetTerm[]): FiltersTypes => {
   };
 };
 
-export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => {
+export const generateDefaultParticipantCountValues = (datasets: DatasetTerm[]) => datasets.reduce((acc, dataset) => {
   return {
-    max: datasets.reduce((max, dataset) => Math.max(max, dataset.participantCount ? dataset.participantCount : 0), 0),
-    min: 0
-  };
-}
+    max: Math.max(acc.max, dataset.participantCount ?? 0),
+    min: Math.min(acc.min, dataset.participantCount ?? Infinity) };
+}, {max: 0, min: Infinity});


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1289

### Summary
On prod, there are datasets with participant counts of `0`, but the default min value shown in the filter defaults to `1`:

![Screenshot 2025-02-27 at 3 05 03 PM](https://github.com/user-attachments/assets/d3309bdd-9deb-4f3c-8067-2f50e4396d00)

Manually setting that to `0` reveals a number of filtered datasets:

![Screenshot 2025-02-27 at 3 06 10 PM](https://github.com/user-attachments/assets/97ac4e29-1d60-4fb7-b80c-3035d142f94b)

This PR fixes the calculation logic so that it doesn't exclude datasets with a `0` count.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
