### PR TITLE
DT-1291: Remove `react-material-icon-svg`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "react-ga4": "2.1.0",
         "react-google-charts": "5.2.1",
         "react-markdown": "10.0.0",
-        "react-material-icon-svg": "3.20.0",
         "react-modal": "3.16.3",
         "react-paginating": "1.4.0",
         "react-router-dom": "5.3.0",
@@ -7551,11 +7550,6 @@
         "react": ">=18"
       }
     },
-    "node_modules/react-material-icon-svg": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/react-material-icon-svg/-/react-material-icon-svg-3.20.0.tgz",
-      "integrity": "sha512-MIrn+7FO4r0oH0cdVVYURRmKPk853HKsdwEaEkYFgCoNS422Zt5Z4B/BRY3DBB9cf+gyVudLxGNO24AD41a7fw=="
-    },
     "node_modules/react-modal": {
       "version": "3.16.3",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
@@ -14450,11 +14444,6 @@
         "unist-util-visit": "^5.0.0",
         "vfile": "^6.0.0"
       }
-    },
-    "react-material-icon-svg": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/react-material-icon-svg/-/react-material-icon-svg-3.20.0.tgz",
-      "integrity": "sha512-MIrn+7FO4r0oH0cdVVYURRmKPk853HKsdwEaEkYFgCoNS422Zt5Z4B/BRY3DBB9cf+gyVudLxGNO24AD41a7fw=="
     },
     "react-modal": {
       "version": "3.16.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "react-ga4": "2.1.0",
     "react-google-charts": "5.2.1",
     "react-markdown": "10.0.0",
-    "react-material-icon-svg": "3.20.0",
     "react-modal": "3.16.3",
     "react-paginating": "1.4.0",
     "react-router-dom": "5.3.0",

--- a/src/components/LibraryCardAgreementTermsDownload.jsx
+++ b/src/components/LibraryCardAgreementTermsDownload.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LibraryCardAgreementLink from '../assets/Library_Card_Agreement_2023_ApplicationVersion.pdf';
-import DownloadIcon from 'react-material-icon-svg/dist/Download';
+import { Download } from '@mui/icons-material';
 
 export const LibraryCardAgreementTermsDownload = () => (
   <div>
@@ -12,7 +12,7 @@ export const LibraryCardAgreementTermsDownload = () => (
       rel="noreferrer"
       style={{marginLeft: '.5rem'}}
     >
-      <DownloadIcon fill={'black'} style={{verticalAlign: 'middle', height: '24px'}}/>
+      <Download sx={{ verticalAlign: 'middle', fontSize: '24px' }}/>
     </a>
   </div>
 );

--- a/src/pages/Status.jsx
+++ b/src/pages/Status.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { getOr, isNil, map, uniq } from 'lodash/fp';
-import CheckboxMarkedCircleOutline from 'react-material-icon-svg/dist/CheckboxMarkedCircleOutline';
-import DiameterVariant from 'react-material-icon-svg/dist/DiameterVariant';
+import { TaskAltOutlined, ErrorOutline } from '@mui/icons-material';
 import { ServiceStatus } from '../libs/ajax/ServiceStatus';
 
 const Status = () => {
@@ -35,8 +34,8 @@ const Status = () => {
     fetchStatus();
   }, []);
 
-  const healthyState = <CheckboxMarkedCircleOutline fill={'green'} style={{ marginLeft: '2rem', verticalAlign: 'middle', height: '24px' }} />;
-  const unhealthyState = <DiameterVariant fill={'red'} style={{ marginLeft: '2rem', verticalAlign: 'middle', height: '24px' }} />;
+  const healthyState = <TaskAltOutlined sx={{ marginLeft: '2rem', verticalAlign: 'middle', fontSize: '24px', color: 'green' }} />;
+  const unhealthyState = <ErrorOutline sx={{ marginLeft: '2rem', verticalAlign: 'middle', fontSize: '24px', color: 'red' }} />;
 
   const consentHealthy = isConsentHealthy(consentStatus) ? healthyState : unhealthyState;
   const ontologyHealthy = isOntologyHealthy(ontologyStatus) ? healthyState : unhealthyState;


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1291

### Summary

We only use this package on two pages, but we already include `@mui/icons-material` which includes these icons.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
