### PR TITLE
[DT-1291] Remove `js-file-download`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-debug.log*
 yarn-error.log*
 
 public/config.json
+/cypress/downloads/
 /cypress/videos/
 /cypress/fixtures/duos-automation*.json
 /cypress/screenshots

--- a/cypress/component/utils/file_download.spec.ts
+++ b/cypress/component/utils/file_download.spec.ts
@@ -1,0 +1,47 @@
+import { fileDownload } from "../../../src/utils/FileDownload";
+
+describe('FileDownload', () => {
+    it('should create and trigger download with correct attributes', () => {
+        const testData = 'test content';
+        const filename = 'test.txt';
+        const mime = 'text/plain';
+
+        cy.window().then((win) => {
+            const createObjectURLSpy = cy.spy(win.URL, 'createObjectURL');
+            const revokeObjectURLSpy = cy.spy(win.URL, 'revokeObjectURL');
+
+            fileDownload(testData, filename, mime);
+
+            // verify blob creation
+            expect(createObjectURLSpy).to.be.calledOnce;
+            const blob = createObjectURLSpy.firstCall.args[0];
+            expect(blob).to.be.instanceOf(Blob);
+            expect(blob.type).to.equal(mime);
+
+            // verify anchor element
+            const anchor = win.document.querySelector('a');
+            expect(anchor).to.have.attr('download', filename);
+            expect(anchor?.style.display).to.equal('none');
+
+            // verify cleanup
+            cy.wait(200).then(() => {
+                expect(revokeObjectURLSpy).to.be.calledOnce;
+                expect(win.document.querySelector('a')).to.be.null;
+            });
+        });
+    });
+
+    it('should use default mime type if none provided', () => {
+        const testData = 'test content';
+        const filename = 'test.txt';
+
+        cy.window().then((win) => {
+            const createObjectURLSpy = cy.spy(win.URL, 'createObjectURL');
+
+            fileDownload(testData, filename, '');
+
+            const blob = createObjectURLSpy.firstCall.args[0];
+            expect(blob.type).to.equal('application/octet-stream');
+        });
+    });
+});

--- a/cypress/component/utils/file_download.spec.ts
+++ b/cypress/component/utils/file_download.spec.ts
@@ -9,6 +9,7 @@ describe('FileDownload', () => {
         cy.window().then((win) => {
             const createObjectURLSpy = cy.spy(win.URL, 'createObjectURL');
             const revokeObjectURLSpy = cy.spy(win.URL, 'revokeObjectURL');
+            const clickSpy = cy.spy(HTMLAnchorElement.prototype, 'click');
 
             fileDownload(testData, filename, mime);
 
@@ -19,16 +20,17 @@ describe('FileDownload', () => {
             cy.wrap(blob.type).should('equal', mime);
 
             // verify anchor element
-            const anchor = win.document.querySelector('a');
-            cy.wrap(anchor).should('not.be.null');
-            cy.wrap(anchor).should('have.attr', 'download', filename);
-            cy.wrap(anchor?.style.display).should('equal', 'none');
+            cy.get('a').should('exist')
+                .and('have.attr', 'download', filename)
+                .and('have.css', 'display', 'none')
+                .then(() => {
+                    cy.wrap(clickSpy).should('be.calledOnce');
+                });
 
             // verify cleanup
-            // eslint-disable-next-line cypress/no-unnecessary-waiting
-            cy.wait(200).then(() => {
+            cy.wrap(clickSpy).then(() => {
                 cy.wrap(revokeObjectURLSpy).should('be.calledOnce');
-                cy.wrap(win.document.querySelector('a')).should('be.null');
+                cy.get('a').should('not.exist');
             });
         });
     });
@@ -40,10 +42,31 @@ describe('FileDownload', () => {
         cy.window().then((win) => {
             const createObjectURLSpy = cy.spy(win.URL, 'createObjectURL');
 
-            fileDownload(testData, filename, '');
+            fileDownload(testData, filename);
 
             const blob = createObjectURLSpy.firstCall.args[0];
             cy.wrap(blob.type).should('be.equal', 'application/octet-stream');
+        });
+    });
+
+    it('should handle different input types', () => {
+        const testCases = [
+            { data: new Uint8Array([1, 2, 3]), type: 'ArrayBufferView' },
+            { data: new Blob(['test']), type: 'Blob' },
+            { data: new ArrayBuffer(8), type: 'ArrayBuffer' }
+        ];
+
+        cy.window().then((win) => {
+            const createObjectURLSpy = cy.spy(win.URL, 'createObjectURL');
+
+            testCases.forEach(({ data, type }, index) => {
+                fileDownload(data, `test.${type}`);
+
+                const blob = createObjectURLSpy.getCall(index).args[0];
+                cy.wrap(blob).should('be.instanceOf', Blob);
+            });
+
+            cy.wrap(createObjectURLSpy).should('have.callCount', testCases.length);
         });
     });
 });

--- a/cypress/component/utils/file_download.spec.ts
+++ b/cypress/component/utils/file_download.spec.ts
@@ -13,20 +13,22 @@ describe('FileDownload', () => {
             fileDownload(testData, filename, mime);
 
             // verify blob creation
-            expect(createObjectURLSpy).to.be.calledOnce;
+            cy.wrap(createObjectURLSpy).should('be.calledOnce');
             const blob = createObjectURLSpy.firstCall.args[0];
-            expect(blob).to.be.instanceOf(Blob);
-            expect(blob.type).to.equal(mime);
+            cy.wrap(blob).should('be.instanceOf', Blob);
+            cy.wrap(blob.type).should('equal', mime);
 
             // verify anchor element
             const anchor = win.document.querySelector('a');
-            expect(anchor).to.have.attr('download', filename);
-            expect(anchor?.style.display).to.equal('none');
+            cy.wrap(anchor).should('not.be.null');
+            cy.wrap(anchor).should('have.attr', 'download', filename);
+            cy.wrap(anchor?.style.display).should('equal', 'none');
 
             // verify cleanup
+            // eslint-disable-next-line cypress/no-unnecessary-waiting
             cy.wait(200).then(() => {
-                expect(revokeObjectURLSpy).to.be.calledOnce;
-                expect(win.document.querySelector('a')).to.be.null;
+                cy.wrap(revokeObjectURLSpy).should('be.calledOnce');
+                cy.wrap(win.document.querySelector('a')).should('be.null');
             });
         });
     });
@@ -41,7 +43,7 @@ describe('FileDownload', () => {
             fileDownload(testData, filename, '');
 
             const blob = createObjectURLSpy.firstCall.args[0];
-            expect(blob.type).to.equal('application/octet-stream');
+            cy.wrap(blob.type).should('be.equal', 'application/octet-stream');
         });
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "axios": "1.7.9",
         "dayjs": "1.11.13",
         "dompurify": "3.2.4",
-        "js-file-download": "0.4.12",
         "lodash": "4.17.21",
         "noty": "3.2.0-beta",
         "oidc-client-ts": "3.1.0",
@@ -5847,11 +5846,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/js-file-download": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
-      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -13331,11 +13325,6 @@
         "has-symbols": "^1.1.0",
         "set-function-name": "^2.0.2"
       }
-    },
-    "js-file-download": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
-      "integrity": "sha512-rML+NkoD08p5Dllpjo0ffy4jRHeY6Zsapvr/W86N7E0yuzAO6qa5X9+xog6zQNlH102J7IXljNY2FtS6Lj3ucg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "axios": "1.7.9",
     "dayjs": "1.11.13",
     "dompurify": "3.2.4",
-    "js-file-download": "0.4.12",
     "lodash": "4.17.21",
     "noty": "3.2.0-beta",
     "oidc-client-ts": "3.1.0",

--- a/src/libs/ajax/DAA.js
+++ b/src/libs/ajax/DAA.js
@@ -70,9 +70,9 @@ export const DAA = {
     if (isFileEmpty(file)) {
       return Promise.resolve({ data: null });
     } else {
-      let authOpts = Config.authOpts();
+      const authOpts = Config.authOpts();
       authOpts.headers['Content-Type'] = 'multipart/form-data';
-      let formData = new FormData();
+      const formData = new FormData();
       formData.append('file', file);
       const url = `${await getApiUrl()}/api/daa/dac/${dacId}`;
       return axios.post(url, formData, authOpts);

--- a/src/libs/ajax/DAA.js
+++ b/src/libs/ajax/DAA.js
@@ -1,4 +1,4 @@
-import fileDownload from 'js-file-download';
+import { fileDownload } from '../../utils/FileDownload';
 import { getApiUrl } from '../ajax';
 import { Config } from '../config';
 import { isFileEmpty } from '../utils';

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -1,4 +1,4 @@
-import fileDownload from 'js-file-download';
+import { fileDownload } from '../../utils/FileDownload';
 import * as fp from 'lodash/fp';
 import { isNil } from 'lodash/fp';
 import { Config } from '../config';

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -93,9 +93,9 @@ export const DAR = {
     if (isFileEmpty(file)) {
       return Promise.resolve({ data: null });
     } else {
-      let authOpts = Config.authOpts();
+      const authOpts = Config.authOpts();
       authOpts.headers['Content-Type'] = 'multipart/form-data';
-      let formData = new FormData();
+      const formData = new FormData();
       formData.append('file', file);
       const url = `${await getApiUrl()}/api/dar/v2/${darId}/${fileType}`;
       return axios.post(url, formData, authOpts);

--- a/src/utils/FileDownload.ts
+++ b/src/utils/FileDownload.ts
@@ -8,10 +8,9 @@ export const fileDownload = (data: string | ArrayBuffer | ArrayBufferView | Blob
     a.href = blobUrl;
 
     document.body.appendChild(a);
-    a.click();
 
-    setTimeout(() => {
+    Promise.resolve(a.click()).then(() => {
         document.body.removeChild(a);
         URL.revokeObjectURL(blobUrl);
-    }, 100);
+    });
 }

--- a/src/utils/FileDownload.ts
+++ b/src/utils/FileDownload.ts
@@ -1,0 +1,17 @@
+export const fileDownload = (data: string | ArrayBuffer | ArrayBufferView | Blob, filename: string, mime?: string) => {
+    const blob = new Blob([data], { type: mime || 'application/octet-stream' });
+    const blobUrl = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.style.display = 'none';
+    a.download = filename;
+    a.href = blobUrl;
+
+    document.body.appendChild(a);
+    a.click();
+
+    setTimeout(() => {
+        document.body.removeChild(a);
+        URL.revokeObjectURL(blobUrl);
+    }, 100);
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1291

### Summary

Replace `js-file-download`: this package has not received updates in 5 years, is very simple, bloats our package dependencies, has workarounds for unsupported browsers, doesn't have tests, and isn't fully in Typescript.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
