### PR TITLE
DT-1318: Show the custodian emails on the statistics page

### DIFF
--- a/cypress/component/Dataset/dataset.json
+++ b/cypress/component/Dataset/dataset.json
@@ -51,7 +51,7 @@
   ],
   "createUser": {
     "userId": 3396,
-    "email": "jlawson@broadinstitute.org",
+    "email": "jlawson@test.com",
     "displayName": "Jonathan Lawson (Admin \u0026 DAC Member)",
     "createDate": 1526056488000,
     "emailPreference": false,
@@ -93,7 +93,8 @@
         "key": "dataCustodianEmail",
         "type": "Json",
         "value": [
-          "geraldg@spurs.bb"
+          "user_1@test.com",
+          "user_2@test.com"
         ]
       },
       {

--- a/cypress/component/Dataset/datasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/datasetStatistics.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef,no-console */
-
 import React from 'react';
 import {mount} from 'cypress/react';
 import DatasetStatistics from '../../../src/pages/DatasetStatistics';
@@ -45,9 +43,12 @@ const location = {
 
 describe('Dataset Statistics Tests', () => {
 
+  beforeEach(() => {
+    cy.viewport(600, 800);
+  });
+
   it('Displays Controlled Access Dataset Apply Button', () => {
     const controlled = Object.assign(dataset, {properties: [controlledProp]});
-    cy.viewport(600, 800);
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(controlled));
     cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(controlled));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
@@ -70,7 +71,6 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays External Access Language With Location', () => {
     const external = Object.assign(dataset, {properties: [externalProp, location]});
-    cy.viewport(600, 800);
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(external));
     cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(external));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
@@ -94,7 +94,6 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays External Access Language Without Location', () => {
     const external = Object.assign(dataset, {properties: [externalProp]});
-    cy.viewport(600, 800);
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(external));
     cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(external));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
@@ -118,7 +117,6 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays Open Access Language With Location', () => {
     const open = Object.assign(dataset, {properties: [openProp, location]});
-    cy.viewport(600, 800);
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(open));
     cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(open));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
@@ -142,7 +140,6 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays Open Access Language Without Location', () => {
     const open = Object.assign(dataset, {properties: [openProp]});
-    cy.viewport(600, 800);
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(open));
     cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(open));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
@@ -182,5 +179,30 @@ describe('Dataset Statistics Tests', () => {
     };
     mount(<DatasetStatistics {...props}/>);
     cy.contains(dataset.datasetIdentifier).should('exist');
+  });
+
+  it('Displays All Data Custodian Emails', () => {
+    cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(dataset));
+    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(dataset));
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
+
+    const props = {
+      match: {
+        params: {
+          datasetIdentifier: dataset.datasetIdentifier
+        }
+      },
+      history: {
+        push() {
+        }
+      }
+    };
+    mount(<DatasetStatistics {...props}/>);
+    cy.contains(dataset.datasetIdentifier).should('exist');
+    cy.contains('Data Custodian').should('exist');
+    const dataCustodians = dataset.study.properties.find((property) => property.key === 'dataCustodianEmail').value;
+    dataCustodians.forEach((dataCustodian) => {
+      cy.contains(dataCustodian).should('exist');
+    });
   });
 });

--- a/cypress/component/Dataset/datasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/datasetStatistics.spec.jsx
@@ -50,7 +50,6 @@ describe('Dataset Statistics Tests', () => {
   it('Displays Controlled Access Dataset Apply Button', () => {
     const controlled = Object.assign(dataset, {properties: [controlledProp]});
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(controlled));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(controlled));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {
@@ -72,7 +71,6 @@ describe('Dataset Statistics Tests', () => {
   it('Displays External Access Language With Location', () => {
     const external = Object.assign(dataset, {properties: [externalProp, location]});
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(external));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(external));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {
@@ -95,7 +93,6 @@ describe('Dataset Statistics Tests', () => {
   it('Displays External Access Language Without Location', () => {
     const external = Object.assign(dataset, {properties: [externalProp]});
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(external));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(external));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {
@@ -118,7 +115,6 @@ describe('Dataset Statistics Tests', () => {
   it('Displays Open Access Language With Location', () => {
     const open = Object.assign(dataset, {properties: [openProp, location]});
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(open));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(open));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {
@@ -141,7 +137,6 @@ describe('Dataset Statistics Tests', () => {
   it('Displays Open Access Language Without Location', () => {
     const open = Object.assign(dataset, {properties: [openProp]});
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(open));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(open));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {
@@ -163,7 +158,6 @@ describe('Dataset Statistics Tests', () => {
 
   it('displays with no additional properties', () => {
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(dataset));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(dataset));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {
@@ -183,7 +177,6 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays All Data Custodian Emails', () => {
     cy.stub(DataSet, 'getDatasetByDatasetIdentifier').returns(Promise.resolve(dataset));
-    cy.stub(DataSet, 'getDataSetsByDatasetId').returns(Promise.resolve(dataset));
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}));
 
     const props = {

--- a/cypress/component/Dataset/datasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/datasetStatistics.spec.jsx
@@ -201,6 +201,8 @@ describe('Dataset Statistics Tests', () => {
     cy.contains(dataset.datasetIdentifier).should('exist');
     cy.contains('Data Custodian').should('exist');
     const dataCustodians = dataset.study.properties.find((property) => property.key === 'dataCustodianEmail').value;
+    expect(dataCustodians).to.be.an('array');
+    expect(dataCustodians.length).to.be.greaterThan(0);
     dataCustodians.forEach((dataCustodian) => {
       cy.contains(dataCustodian).should('exist');
     });

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -32,7 +32,6 @@ interface DatasetStatisticsProps {
 
 export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const {history, match: {params: {datasetIdentifier}}} = props;
-  const [datasetId, setDatasetId] = useState<number>();
   const [dataset, setDataset] = useState<Dataset>();
   const [dars, setDars] = useState<Array<DataAccessRequest>>();
   const [isLoading, setIsLoading] = useState(true);
@@ -51,7 +50,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
 
   const applyForAccess = async () => {
     try {
-      const draftResponse = await DAR.postDarDraft({datasetId: [datasetId]});
+      const draftResponse = await DAR.postDarDraft({datasetId: [dataset?.datasetId]});
       if (draftResponse.referenceId) {
         history.push(`/dar_application/${draftResponse.referenceId}`);
       } else if (draftResponse.message) {
@@ -65,11 +64,19 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
   };
 
   useEffect(() => {
-    DataSet.getDatasetByDatasetIdentifier(datasetIdentifier).then((dataset) => {
-      setData(dataset.datasetId);
-    }).catch(() => {
-      showError('Error: Unable to retrieve dataset from server');
-    });
+    const init = async () => {
+      try {
+        const dataset: Dataset = await DataSet.getDatasetByDatasetIdentifier(datasetIdentifier);
+        const metrics: DatasetStats = await DatasetMetrics.getDatasetStats(dataset.datasetId);
+        setDataset(dataset);
+        setDars(metrics.dars);
+        setIsLoading(false);
+      } catch (_error) {
+        showError('Unable to retrieve dataset statistics from server');
+        setIsLoading(false);
+      }
+    }
+    init();
   }, [datasetIdentifier]);
 
   const extract = useCallback((propertyName: string) => {
@@ -84,21 +91,6 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
     }
     return property?.value;
   }, [dataset]);
-
-  const setData = async (datasetId: number) => {
-    try {
-      setIsLoading(true);
-      const metrics: DatasetStats = await DatasetMetrics.getDatasetStats(datasetId);
-      const dataset = await DataSet.getDataSetsByDatasetId(datasetId);
-      setDatasetId(datasetId);
-      setDataset(dataset);
-      setDars(metrics.dars);
-      setIsLoading(false);
-    } catch (_error) {
-      showError('Error: Unable to retrieve dataset statistics from server')
-      setIsLoading(false);
-    }
-  };
 
   const accessInstructions = () => {
     const accessManagement = extract('Access Management')?.toLowerCase();

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -10,7 +10,7 @@ import {ReadMore} from '../components/ReadMore';
 import {formatDate} from '../libs/utils';
 import {Button} from '@mui/material';
 import {History} from 'history';
-import {Dataset, DatasetProperty} from '../types/model';
+import {Dataset, DatasetProperty, StudyProperty} from '../types/model';
 
 const LINE = <div style={{borderTop: '1px solid #BABEC1', height: 0}}/>;
 
@@ -75,6 +75,14 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const extract = useCallback((propertyName: string) => {
     const property = find({propertyName})(dataset?.properties) as DatasetProperty;
     return property?.propertyValue;
+  }, [dataset]);
+
+  const extractStudyProp = useCallback((key: string) => {
+    const property = find({key})(dataset?.study?.properties) as StudyProperty;
+    if (Array.isArray(property?.value)) {
+      return property.value.join(', ');
+    }
+    return property?.value;
   }, [dataset]);
 
   const setData = async (datasetId: number) => {
@@ -160,10 +168,10 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
                   {extract('Principal Investigator(PI)') || dataset?.study?.piName}
                 </div>
               </div>}
-              {(extract('Data Depositor') || dataset?.createUser?.displayName) && <div style={{display: 'flex'}}>
+              {(extractStudyProp('dataCustodianEmail') || dataset?.createUser?.displayName) && <div style={{display: 'flex'}}>
                 <div style={Styles.SMALL_BOLD}>Data Custodian:</div>
                 <div style={Styles.SMALL_BOLD}>
-                  {extract('Data Depositor') || dataset?.createUser?.displayName}
+                  {extractStudyProp('dataCustodianEmail') || dataset?.createUser?.displayName}
                 </div>
               </div>}
             </div>

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -172,7 +172,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
           {dars?.map((dar: any) => (
             <div style={Styles.READ_MORE as React.CSSProperties} id={`${dar.darCode}`} key={`${dar.darCode}`}>
               <ReadMore
-                // @ts-ignore next-line props for non ts component
+                // @ts-expect-error next-line props for non ts component
                 props={props}
                 readLessText='Show less'
                 readMoreText='Show More'

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -10,7 +10,7 @@ import {ReadMore} from '../components/ReadMore';
 import {formatDate} from '../libs/utils';
 import {Button} from '@mui/material';
 import {History} from 'history';
-import {Dataset, DatasetProperty, StudyProperty} from '../types/model';
+import {DataAccessRequest, Dataset, DatasetProperty, StudyProperty} from '../types/model';
 
 const LINE = <div style={{borderTop: '1px solid #BABEC1', height: 0}}/>;
 
@@ -34,7 +34,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const {history, match: {params: {datasetIdentifier}}} = props;
   const [datasetId, setDatasetId] = useState<number>();
   const [dataset, setDataset] = useState<Dataset>();
-  const [dars, setDars] = useState<any>();
+  const [dars, setDars] = useState<Array<DataAccessRequest>>();
   const [isLoading, setIsLoading] = useState(true);
 
   const showError = (message: string) => {
@@ -177,7 +177,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
             </div>
           </div>
           <div style={Styles.SUB_HEADER}>Data Access Requests - Research Statements</div>
-          {dars?.map((dar: any) => (
+          {dars?.map((dar: DataAccessRequest) => (
             <div style={Styles.READ_MORE as React.CSSProperties} id={`${dar.darCode}`} key={`${dar.darCode}`}>
               <ReadMore
                 // @ts-expect-error next-line props for non ts component

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -10,7 +10,7 @@ import {ReadMore} from '../components/ReadMore';
 import {formatDate} from '../libs/utils';
 import {Button} from '@mui/material';
 import {History} from 'history';
-import {DataAccessRequest, Dataset, DatasetMetric, DatasetProperty, StudyProperty} from '../types/model';
+import {DataAccessRequest, Dataset, DatasetStats, DatasetProperty, StudyProperty} from '../types/model';
 
 const LINE = <div style={{borderTop: '1px solid #BABEC1', height: 0}}/>;
 
@@ -88,7 +88,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const setData = async (datasetId: number) => {
     try {
       setIsLoading(true);
-      const metrics: DatasetMetric = await DatasetMetrics.getDatasetStats(datasetId);
+      const metrics: DatasetStats = await DatasetMetrics.getDatasetStats(datasetId);
       const dataset = await DataSet.getDataSetsByDatasetId(datasetId);
       setDatasetId(datasetId);
       setDataset(dataset);

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -10,7 +10,7 @@ import {ReadMore} from '../components/ReadMore';
 import {formatDate} from '../libs/utils';
 import {Button} from '@mui/material';
 import {History} from 'history';
-import {DataAccessRequest, Dataset, DatasetProperty, StudyProperty} from '../types/model';
+import {DataAccessRequest, Dataset, DatasetMetric, DatasetProperty, StudyProperty} from '../types/model';
 
 const LINE = <div style={{borderTop: '1px solid #BABEC1', height: 0}}/>;
 
@@ -88,7 +88,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const setData = async (datasetId: number) => {
     try {
       setIsLoading(true);
-      const metrics = await DatasetMetrics.getDatasetStats(datasetId);
+      const metrics: DatasetMetric = await DatasetMetrics.getDatasetStats(datasetId);
       const dataset = await DataSet.getDataSetsByDatasetId(datasetId);
       setDatasetId(datasetId);
       setDataset(dataset);

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -37,18 +37,30 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const [dars, setDars] = useState<any>();
   const [isLoading, setIsLoading] = useState(true);
 
+  const showError = (message: string) => {
+    Notifications.showError({
+      severity: 'error',
+      text: `Error: ${message}`,
+      timeout: 3500,
+      layout: {
+        vertical: 'bottom',
+        horizontal: 'right'
+      }
+    });
+  };
+
   const applyForAccess = async () => {
     try {
       const draftResponse = await DAR.postDarDraft({datasetId: [datasetId]});
       if (draftResponse.referenceId) {
         history.push(`/dar_application/${draftResponse.referenceId}`);
       } else if (draftResponse.message) {
-        Notifications.showError({text: draftResponse.message + ' Please contact customer support for help.'});
+        showError(draftResponse.message + ' Please contact customer support for help.');
       } else {
-        Notifications.showError({text: 'Error: Unable to create a Draft Data Access Request'});
+        showError('Unable to create a Draft Data Access Request');
       }
-    } catch (error) {
-      Notifications.showError({text: 'Error: Unable to create a Draft Data Access Request'});
+    } catch (_error) {
+      showError('Unable to create a Draft Data Access Request');
     }
   };
 
@@ -56,7 +68,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
     DataSet.getDatasetByDatasetIdentifier(datasetIdentifier).then((dataset) => {
       setData(dataset.datasetId);
     }).catch(() => {
-      Notifications.showError({text: 'Error: Unable to retrieve dataset from server'});
+      showError('Error: Unable to retrieve dataset from server');
     });
   }, [datasetIdentifier]);
 
@@ -74,8 +86,8 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
       setDataset(dataset);
       setDars(metrics.dars);
       setIsLoading(false);
-    } catch (error) {
-      Notifications.showError({text: 'Error: Unable to retrieve dataset statistics from server'});
+    } catch (_error) {
+      showError('Error: Unable to retrieve dataset statistics from server')
       setIsLoading(false);
     }
   };

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,6 +2,7 @@ import { DuosUserResponse } from './responseTypes';
 import externalAccessIcon from '../images/external_access.svg';
 import openAccessIcon from '../images/open_access.svg';
 import controlledAccessIcon from '../images/controlled_access.svg';
+import {b} from "vite/dist/node/moduleRunnerTransport.d-CXw_Ws6P";
 
 export type UserRoleName =
   | 'Admin'
@@ -118,7 +119,7 @@ export interface Dataset {
 
 export interface DatasetMetric {
   dataset: Dataset;
-  dars: Array<unknown>;
+  dars: Array<DataAccessRequest>;
   elections: Array<unknown>;
 }
 
@@ -187,7 +188,7 @@ export interface DatasetTerm {
 
 export interface AccessManagementSummary {
   name: string;
-  icon: any;
+  icon: unknown;
   description: string;
 }
 
@@ -321,7 +322,7 @@ export interface DataAccessRequest {
   updateDate: string;
   draft: boolean;
   darCode: string;
-  elections: Array<unknown>;
+  elections: Array<Election>;
   projectTitle: string;
   datasetIds: number[];
   rus: string;
@@ -410,4 +411,37 @@ export interface Collaborator {
   name: string;
   title: number;
   uuid: number;
+}
+
+export interface Election {
+  electionId: number;
+  electionType: string;
+  finalVote: boolean;
+  status:	string;
+  createDate: string;
+  lastUpdate: string;
+  finalVoteDate: string;
+  referenceId: string;
+  finalRationale: string;
+  finalAccessVote: boolean;
+  datasetId: number;
+  displayId: string;
+  dulName: string;
+  version: number;
+  archived: boolean;
+  votes: Map<number, Vote>;
+}
+
+export interface Vote {
+  voteId: number;
+  vote: boolean;
+  userId: number;
+  createDate: string;
+  updateDate: string;
+  electionId: number;
+  rationale: string;
+  type: string;
+  isReminderSent: boolean;
+  hasConcerns: boolean;
+  displayName: string;
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -116,6 +116,12 @@ export interface Dataset {
   alternativeDataSharingPlanFile: FileStorageObject;
 }
 
+export interface DatasetMetric {
+  dataset: Dataset;
+  dars: Array<unknown>;
+  elections: Array<unknown>;
+}
+
 interface DacTerm {
   dacId: number;
   dacName: string;
@@ -304,4 +310,71 @@ export interface Acknowledgement {
   ackKey: string;
   firstAcknowledged: number;
   lastAcknowledged: number;
+}
+
+export interface DataAccessRequest {
+  referenceId: string;
+  userId: number;
+  createDate: string;
+  sortDate: string;
+  submissionDate: string;
+  updateDate: string;
+  draft: boolean;
+  darCode: string;
+  elections: Array<unknown>;
+  projectTitle: string;
+  datasetIds: number[];
+  rus: string;
+  nonTechRus: string;
+  diseases: boolean;
+  methods: boolean;
+  controls: boolean;
+  population: boolean;
+  other: boolean;
+  otherText: string;
+  ontologies: string[];
+  forProfit: boolean;
+  oneGender: boolean;
+  gender: string;
+  pediatric: boolean;
+  illegalBehavior: boolean;
+  addiction: boolean;
+  sexualDiseases: boolean;
+  stigmatizedDiseases: boolean;
+  vulnerablePopulation: boolean;
+  populationMigration: boolean;
+  psychiatricTraits: boolean;
+  notHealth: boolean;
+  hmb: boolean;
+  poa: boolean;
+  anvilUse: boolean;
+  cloudUse: boolean;
+  localUse: boolean;
+  cloudProvider: string;
+  cloudProviderType: string;
+  cloudProviderDescription: string;
+  geneticStudiesOnly: boolean;
+  irb: boolean;
+  irbDocumentLocation: string;
+  irbProtocolExpiration: string;
+  dsAcknowledgement: boolean;
+  gsoAcknowledgement: boolean;
+  pubAcknowledgement: boolean;
+  itDirector: string;
+  signingOfficial: string;
+  publication: boolean;
+  collaboration: boolean;
+  collaborationLetterLocation: string;
+  forensicActivities: boolean;
+  sharingDistribution: boolean;
+  externalCollaborators: Array<unknown>;
+  internalCollaborators: Array<unknown>;
+  labCollaborators: Array<unknown>;
+  progressReportSummary: string;
+  intellectualPropertySummary: string;
+  publications: Array<unknown>;
+  presentations: Array<unknown>;
+  dataManagementIncident: unknown;
+  researchPlans: string;
+  clouseOutSupplement: 'PROJECT_COMPLETED' | 'REQUESTOR_MOVED_INSTITUTION' | 'PROJECT_TRANSFERRED' | 'PROJECT_SUPERSEDED';
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -116,12 +116,6 @@ export interface Dataset {
   alternativeDataSharingPlanFile: FileStorageObject;
 }
 
-export interface DatasetMetric {
-  dataset: Dataset;
-  dars: Array<DataAccessRequest>;
-  elections: Array<unknown>;
-}
-
 interface DacTerm {
   dacId: number;
   dacName: string;
@@ -310,6 +304,12 @@ export interface Acknowledgement {
   ackKey: string;
   firstAcknowledged: number;
   lastAcknowledged: number;
+}
+
+export interface DatasetMetric {
+  dataset: Dataset;
+  dars: Array<DataAccessRequest>;
+  elections: Array<Election>;
 }
 
 export interface DataAccessRequest {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -367,14 +367,47 @@ export interface DataAccessRequest {
   collaborationLetterLocation: string;
   forensicActivities: boolean;
   sharingDistribution: boolean;
-  externalCollaborators: Array<unknown>;
-  internalCollaborators: Array<unknown>;
-  labCollaborators: Array<unknown>;
+  externalCollaborators: Array<Collaborator>;
+  internalCollaborators: Array<Collaborator>;
+  labCollaborators: Array<Collaborator>;
   progressReportSummary: string;
   intellectualPropertySummary: string;
-  publications: Array<unknown>;
-  presentations: Array<unknown>;
-  dataManagementIncident: unknown;
+  publications: Array<Publication>;
+  presentations: Array<Presentation>;
+  dataManagementIncident: DataManagementIncident;
   researchPlans: string;
-  clouseOutSupplement: 'PROJECT_COMPLETED' | 'REQUESTOR_MOVED_INSTITUTION' | 'PROJECT_TRANSFERRED' | 'PROJECT_SUPERSEDED';
+  closeOutSupplement: 'PROJECT_COMPLETED' | 'REQUESTOR_MOVED_INSTITUTION' | 'PROJECT_TRANSFERRED' | 'PROJECT_SUPERSEDED';
+}
+
+export interface DataManagementIncident {
+  incidents: string[];
+  description: string;
+}
+
+export interface Presentation {
+  title: string;
+  link: string;
+  date: string;
+  authors: string;
+  datasetCitation: string;
+  citation: string;
+}
+
+export interface Publication {
+  title: string;
+  pubmedId: string;
+  date: string;
+  authors: string;
+  bibliographicCitation: string;
+  datasetCitation: string;
+  citation: string;
+}
+
+export interface Collaborator {
+  approverStatus: boolean;
+  email: string;
+  eraCommonsId: string;
+  name: string;
+  title: number;
+  uuid: number;
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -306,7 +306,7 @@ export interface Acknowledgement {
   lastAcknowledged: number;
 }
 
-export interface DatasetMetric {
+export interface DatasetStats {
   dataset: Dataset;
   dars: Array<DataAccessRequest>;
   elections: Array<Election>;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,7 +2,6 @@ import { DuosUserResponse } from './responseTypes';
 import externalAccessIcon from '../images/external_access.svg';
 import openAccessIcon from '../images/open_access.svg';
 import controlledAccessIcon from '../images/controlled_access.svg';
-import {b} from "vite/dist/node/moduleRunnerTransport.d-CXw_Ws6P";
 
 export type UserRoleName =
   | 'Admin'


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1318

### Summary
* Update the source of the Data Custodian value when we have it populated on the study.
* Update typing and linting warnings
* New test to ensure we're showing the custodian as defined in the study
* Clean up the initialization - we were originally making 2 calls for the dataset, one by identifier and one by id. They both return the same payload, so we didn't need both.

### Screens
**Before:**
![Screenshot 2025-03-06 at 7 36 34 AM](https://github.com/user-attachments/assets/0d11e0d8-bd46-429c-831b-8fd2adc93b26)

**After:**
![Screenshot 2025-03-06 at 7 36 52 AM](https://github.com/user-attachments/assets/9f9e4872-0c45-4bf4-b1af-3a68788f4694)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
