### PR TITLE
DT-1131: Add Consent status check to sign in

### DIFF
--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -51,19 +51,18 @@ const notAcceptedUserStatus = Object.assign({}, userStatus, {'tosAccepted': fals
 describe('Sign In: Component Loads', function () {
 
   beforeEach(() => {
+    cy.viewport(600, 300);
     cy.initApplicationConfig();
     cy.stub(ServiceStatus, 'getConsentStatus').resolves(consentStatus);
   });
 
   it('Sign In Button Loads', function () {
-    cy.viewport(600, 300);
     mount(<SignInButton history={undefined}/>);
     cy.contains(signInText).should('exist');
     cy.get('button').should('exist').and('not.be.disabled');
   });
 
   it('Sign In: On Success', function () {
-    cy.viewport(600, 300);
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: duosUser}).as('getMe');
     cy.stub(StackdriverReporter, 'report');
@@ -85,7 +84,6 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: No Roles Error Reporter Is Called', function () {
     const bareUser = {email: 'test@user.com'};
-    cy.viewport(600, 300);
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: bareUser}).as('getMe');
     cy.stub(StackdriverReporter, 'report');
@@ -101,7 +99,6 @@ describe('Sign In: Component Loads', function () {
   });
 
   it('Sign In: Redirects to ToS if not accepted', function () {
-    cy.viewport(600, 300);
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: duosUser}).as('getMe');
     cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus);
@@ -118,7 +115,6 @@ describe('Sign In: Component Loads', function () {
   });
 
   it('Sign In: Registers user if not found and redirects to ToS', function () {
-    cy.viewport(600, 300);
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     // Simulate user not found
     cy.stub(User, 'getMe').throws();
@@ -137,9 +133,15 @@ describe('Sign In: Component Loads', function () {
   });
 
   it('Sign In: Button is disabled when SAM is unhealthy', function () {
-    cy.viewport(600, 300);
     cy.stub(ServiceStatus, 'isSamHealthy').resolves(false);
     mount(<SignInButton history={[]}/>);
     cy.get('button').should('exist').and('be.disabled');
   });
+
+  it('Sign In: Button is disabled when Consent is unhealthy', function () {
+    cy.stub(ServiceStatus, 'isConsentHealthy').resolves(false);
+    mount(<SignInButton history={[]}/>);
+    cy.get('button').should('exist').and('be.disabled');
+  });
+
 });

--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -65,20 +65,20 @@ describe('Sign In: Component Loads', function () {
   it('Sign In: On Success', function () {
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: duosUser}).as('getMe');
-    cy.stub(StackdriverReporter, 'report');
-    cy.stub(Metrics, 'identify');
-    cy.stub(Metrics, 'syncProfile');
-    cy.stub(Metrics, 'captureEvent');
+    cy.stub(StackdriverReporter, 'report').as('report');
+    cy.stub(Metrics, 'identify').as('identify');
+    cy.stub(Metrics, 'syncProfile').as('syncProfile');
+    cy.stub(Metrics, 'captureEvent').as('captureEvent');
     cy.stub(ToS, 'getStatus').returns(userStatus);
     mount(<SignInButton history={[]}/>);
     cy.get('button').click();
     cy.wait('@getMe').then(() => {
       expect(Storage.getCurrentUser()).to.deep.equal(duosUser);
-      expect(Storage.getAnonymousId()).to.not.be.null;
-      expect(StackdriverReporter.report).to.not.be.called;
-      expect(Metrics.identify).to.be.called;
-      expect(Metrics.syncProfile).to.be.called;
-      expect(Metrics.captureEvent).to.be.called;
+      assert.isNotNull(Storage.getAnonymousId(), 'Anonymous ID should not be null');
+      cy.get('@report').should('not.be.called');
+      cy.get('@identify').should('be.called');
+      cy.get('@syncProfile').should('be.called');
+      cy.get('@captureEvent').should('be.called');
     });
   });
 
@@ -86,15 +86,12 @@ describe('Sign In: Component Loads', function () {
     const bareUser = {email: 'test@user.com'};
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: bareUser}).as('getMe');
-    cy.stub(StackdriverReporter, 'report');
-    cy.stub(Metrics, 'identify');
-    cy.stub(Metrics, 'syncProfile');
-    cy.stub(Metrics, 'captureEvent');
+    cy.stub(StackdriverReporter, 'report').as('report');
     cy.stub(ToS, 'getStatus').returns(userStatus);
     mount(<SignInButton history={[]}/>);
     cy.get('button').click();
     cy.wait('@getMe').then(() => {
-      expect(StackdriverReporter.report).to.be.called;
+      cy.get('@report').should('be.called');
     });
   });
 
@@ -102,15 +99,12 @@ describe('Sign In: Component Loads', function () {
     cy.stub(Auth, 'signIn').resolves(mockOidcUser);
     cy.intercept({method: 'GET', url: '**/api/user/me'}, {statusCode: 200, body: duosUser}).as('getMe');
     cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus);
-    cy.stub(Metrics, 'identify');
-    cy.stub(Metrics, 'syncProfile');
-    cy.stub(Metrics, 'captureEvent');
     const history = [];
     mount(<SignInButton history={history}/>);
     cy.get('button').click();
     cy.wait('@getMe').then(() => {
-      expect(history).to.not.be.empty;
-      expect(history[0].includes('tos_acceptance')).to.be.true;
+      assert.isNotEmpty(history, 'History should not be empty');
+      assert.isTrue(history[0].includes('tos_acceptance'), 'History should contain tos_acceptance');
     });
   });
 
@@ -120,15 +114,12 @@ describe('Sign In: Component Loads', function () {
     cy.stub(User, 'getMe').throws();
     cy.intercept({method: 'POST', url: '**/api/user'}, {statusCode: 200, body: duosUser}).as('registerUser');
     cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus);
-    cy.stub(Metrics, 'identify');
-    cy.stub(Metrics, 'syncProfile');
-    cy.stub(Metrics, 'captureEvent');
     const history = [];
     mount(<SignInButton history={history}/>);
     cy.get('button').click();
     cy.wait('@registerUser').then(() => {
-      expect(history).to.not.be.empty;
-      expect(history[0].includes('tos_acceptance')).to.be.true;
+      assert.isNotEmpty(history, 'History should not be empty');
+      assert.isTrue(history[0].includes('tos_acceptance'), 'History should contain tos_acceptance');
     });
   });
 

--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-undef */
-
 import React from 'react';
 import {mount} from 'cypress/react';
 import SignInButton from '../../../src/components/SignInButton';

--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -35,6 +35,8 @@ const userStatus = {
 };
 
 const consentStatus = {
+  ok: true,
+  degraded: false,
   systems: {
     sam: {
       details: {

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -40,6 +40,7 @@ export const SignInButton = (props: SignInButtonProps) => {
   const [errorDisplay, setErrorDisplay] = useState<ErrorDisplay>({});
   const {history} = props;
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isConsentDown, setIsConsentDown] = useState<boolean>(false);
   const [isSamDown, setIsSamDown] = useState<boolean>(false);
 
   // Utility function called in the normal success case and in the undocumented 409 case
@@ -83,7 +84,7 @@ export const SignInButton = (props: SignInButtonProps) => {
       } else {
         await handleRegistration(redirectTo, shouldRedirect);
       }
-    } catch (err) {
+    } catch (_error) {
       await handleRegistration(redirectTo, shouldRedirect);
     }
   };
@@ -152,11 +153,12 @@ export const SignInButton = (props: SignInButtonProps) => {
   const handleConflictError = async (redirectTo: string, shouldRedirect: boolean) => {
     try {
       await checkToSAndRedirect(shouldRedirect ? redirectTo : null);
-    } catch (error) {
+    } catch (_error) {
       await Auth.signOut();
     }
   };
 
+  // eslint-disable-next-line
   const onFailure = (response: any) => {
     Storage.clearStorage();
     // Known error case from oidc-client-ts PopupWindow: "new Error("Popup closed by user")"
@@ -180,6 +182,7 @@ export const SignInButton = (props: SignInButtonProps) => {
 
   useEffect(() => {
     const init = async () => {
+      setIsConsentDown(!(await ServiceStatus.isConsentHealthy()));
       setIsSamDown(!(await ServiceStatus.isSamHealthy()));
     };
     init();
@@ -206,14 +209,14 @@ export const SignInButton = (props: SignInButtonProps) => {
               Auth.signIn().then(onSuccess, onFailure);
               setIsLoading(false);
             }}
-            disabled={isLoading || isSamDown}
+            disabled={isLoading || isConsentDown || isSamDown}
           >
             {isLoading ? loadingElement() : 'Sign In'}
           </button>
         </div>
         <ReactTooltip
           place={'top'}
-          disable={!isSamDown}
+          disable={!isConsentDown && !isSamDown}
           effect={'solid'}
           id={'sam-disabled-sign-in-tooltip'}
           className='interactiveTooltip'

--- a/src/libs/ajax/ServiceStatus.ts
+++ b/src/libs/ajax/ServiceStatus.ts
@@ -39,7 +39,7 @@ interface SamSystemStatus {
     ok: boolean;
 }
 
-interface SamDetails {
+export interface SamDetails {
     ok: boolean;
     systems: {
         GoogleGroups: SamSystemStatus;
@@ -80,6 +80,11 @@ export const ServiceStatus = {
         const url = `${await getOntologyUrl()}/status`;
         const result = await axios.get(url);
         return result.data;
+    },
+
+    isConsentHealthy: async (): Promise<boolean> => {
+        const status = await ServiceStatus.getConsentStatus();
+        return status.ok || false;
     },
 
     isSamHealthy: async (): Promise<boolean> => {

--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -1,33 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { getOr, isNil, map, uniq } from 'lodash/fp';
 import { TaskAltOutlined, ErrorOutline } from '@mui/icons-material';
 import { ServiceStatus } from '../libs/ajax/ServiceStatus';
+import { ConsentStatus, OntologyStatus, SamDetails } from '../libs/ajax/ServiceStatus';
 
 const Status = () => {
-  const [consentStatus, setConsentStatus] = useState({});
-  const [ontologyStatus, setOntologyStatus] = useState({});
-  const [samStatus, setSamStatus] = useState({});
-
-  const isConsentHealthy = (elements) => {
-    return getOr(false)('ok')(elements);
-  };
-
-  const isOntologyHealthy = (elements) => {
-    const ok = getOr(undefined)('ok')(elements);
-    if (!isNil(ok)) {
-      return ok;
-    } else {
-      const bools = uniq(map('healthy')(elements));
-      return bools.length === 1 && bools[0];
-    }
-  };
+  const [consentStatus, setConsentStatus] = useState<ConsentStatus | undefined>(undefined);
+  const [ontologyStatus, setOntologyStatus] = useState<OntologyStatus | undefined>(undefined);
+  const [samStatus, setSamStatus] = useState<SamDetails | undefined>(undefined);
 
   useEffect(() => {
     const fetchStatus = async () => {
       const consentData = await ServiceStatus.getConsentStatus();
       setConsentStatus(consentData);
-      setSamStatus(consentData.systems.sam.details);
-
+      setSamStatus(consentData?.systems?.sam?.details);
       const ontologyData = await ServiceStatus.getOntologyStatus();
       setOntologyStatus(ontologyData);
     };
@@ -37,9 +22,9 @@ const Status = () => {
   const healthyState = <TaskAltOutlined sx={{ marginLeft: '2rem', verticalAlign: 'middle', fontSize: '24px', color: 'green' }} />;
   const unhealthyState = <ErrorOutline sx={{ marginLeft: '2rem', verticalAlign: 'middle', fontSize: '24px', color: 'red' }} />;
 
-  const consentHealthy = isConsentHealthy(consentStatus) ? healthyState : unhealthyState;
-  const ontologyHealthy = isOntologyHealthy(ontologyStatus) ? healthyState : unhealthyState;
-  const samHealthy = isConsentHealthy(samStatus) ? healthyState : unhealthyState;
+  const consentHealthy = consentStatus?.ok ? healthyState : unhealthyState;
+  const ontologyHealthy = ontologyStatus?.ok ? healthyState : unhealthyState;
+  const samHealthy = samStatus?.ok ? healthyState : unhealthyState;
 
   return (
     <div style={{ margin: '2rem' }}>


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1131

### Summary
This PR does several things:
- Convert Status to typescript to take advantage of status models
- Update spec class to address lint warnings
- Add check on consent for the sign in button

#### Screen when consent is not healthy
![Screenshot 2025-03-18 at 9 28 03 AM](https://github.com/user-attachments/assets/7e684417-b149-4208-809f-20d71ae369cd)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
