### PR TITLE
DT-1528: Handle undefined user case

### DIFF
--- a/cypress/component/UserProfile/AffiliationAndRole.spec.tsx
+++ b/cypress/component/UserProfile/AffiliationAndRole.spec.tsx
@@ -44,25 +44,34 @@ describe('Affiliation And Role', () => {
   beforeEach(() => {
     cy.viewport(600, 600);
     cy.initApplicationConfig();
-    cy.stub(Institution, 'getById').returns(institution);
   });
 
   it('Displays institution name when institution is present', () => {
+    cy.stub(Institution, 'getById').returns(institution);
     mount(<AffiliationAndRole user={user} />);
     cy.get('[ data-cy="institutional-affiliation"]').contains(institution.name);
   });
 
   it('Displays contact us text when no institution present', () => {
+    cy.stub(Institution, 'getById').returns(institution);
     const {institutionId, ...userWithoutInstitution} = user;
     mount(<AffiliationAndRole user={userWithoutInstitution} />);
     cy.get('[ data-cy="institutional-affiliation"]').contains('Please use the Contact Us form to request an institutional affiliation');
   });
 
   it('Displays all role names for user', () => {
+    cy.stub(Institution, 'getById').returns(institution);
     mount(<AffiliationAndRole user={user} />);
     user.roles.forEach((role) => {
       cy.get('[ data-cy="user-roles"]').contains(role.name);
     });
+  });
+
+  it('Displays error when error is thrown loading user information', () => {
+    const error = new Error('Error: Unable to retrieve user information');
+    cy.stub(Institution, 'getById').throws(error);
+    mount(<AffiliationAndRole user={user} />);
+    cy.get('[ data-cy="notification-alert"]').contains(error.message);
   });
 
 });

--- a/cypress/component/UserProfile/AffiliationAndRole.spec.tsx
+++ b/cypress/component/UserProfile/AffiliationAndRole.spec.tsx
@@ -74,4 +74,14 @@ describe('Affiliation And Role', () => {
     cy.get('[ data-cy="notification-alert"]').contains(error.message);
   });
 
+  it('Handles non-TS compliant user argument', () => {
+    // cy.stub(Institution, 'getById').returns(institution);
+    [{}, undefined, null].forEach((value) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      mount(<AffiliationAndRole user={value} />);
+      cy.get('[ data-cy="notification-alert"]').should('not.exist');
+    })
+  });
+
 });

--- a/src/libs/ToastNotifications.tsx
+++ b/src/libs/ToastNotifications.tsx
@@ -81,6 +81,7 @@ export const ToastNotifications = {
           {...props}
         >
           <Alert
+            data-cy='notification-alert'
             onClose={handleClose}
             severity={severity}
             variant="filled"

--- a/src/pages/user_profile/AffiliationAndRoles.tsx
+++ b/src/pages/user_profile/AffiliationAndRoles.tsx
@@ -16,7 +16,7 @@ export default function AffiliationAndRole(props: AffiliationAndRoleProps) {
   useEffect(() => {
     const init = async () => {
       try {
-        const allRoles = user.roles.map((role) => role.name).join(', ');
+        const allRoles = user?.roles?.map((role) => role.name).join(', ');
         setRoles(allRoles);
         if (user.institutionId) {
           const institution: Institution = await InstitutionAPI.getById(user.institutionId);

--- a/src/pages/user_profile/AffiliationAndRoles.tsx
+++ b/src/pages/user_profile/AffiliationAndRoles.tsx
@@ -20,7 +20,7 @@ export default function AffiliationAndRole(props: AffiliationAndRoleProps) {
         // not honor that and pass an undefined entity during load.
         const allRoles = user?.roles?.map((role) => role.name).join(', ');
         setRoles(allRoles);
-        if (user.institutionId) {
+        if (user?.institutionId) {
           const institution: Institution = await InstitutionAPI.getById(user.institutionId);
           if (institution) {
             setInstitution(institution);

--- a/src/pages/user_profile/AffiliationAndRoles.tsx
+++ b/src/pages/user_profile/AffiliationAndRoles.tsx
@@ -16,6 +16,8 @@ export default function AffiliationAndRole(props: AffiliationAndRoleProps) {
   useEffect(() => {
     const init = async () => {
       try {
+        // Note that although user is a required prop and roles is a required property, the parent JSX component may
+        // not honor that and pass an undefined entity during load.
         const allRoles = user?.roles?.map((role) => role.name).join(', ');
         setRoles(allRoles);
         if (user.institutionId) {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1528

### Summary
This fixes a bug introduced in https://github.com/DataBiosphere/duos-ui/pull/2821
The user passed in from the parent component can be an empty object instead of a fully populated user. This causes an error message to flash while state is being updated and the component is being re-rendered.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
