### PR TITLE
[DT-1519] Ensure errors displayed on dar submission.

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -45,7 +45,7 @@ export const applyForAccess = async (selected, history) => {
             timeout: 6000,
             layout: {
               vertical: 'bottom',
-              horizontal: 'center'
+              horizontal: 'right'
             }
           }
       );

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -16,6 +16,7 @@ import DatasetFilterList from './DatasetFilterList';
 import { Notifications } from '../../libs/utils';
 import { Styles } from '../../libs/theme';
 import {DatasetSearchFooter} from './DatasetSearchFooter';
+import ReactMarkdown from 'react-markdown';
 
 const styles = {
   subTab: {
@@ -37,7 +38,18 @@ export const applyForAccess = async (selected, history) => {
     if (draftResponse.referenceId) {
       history.push(`/dar_application/${draftResponse.referenceId}`);
     } else if (draftResponse.message) {
-      Notifications.showError({ text: draftResponse.message + ' Please contact customer support for help.' });
+      Notifications.showError(
+          {
+            text: <ReactMarkdown>{draftResponse.message}</ReactMarkdown>,
+            severity: 'error',
+            timeout: 6000,
+            layout: {
+              vertical: 'bottom',
+              horizontal: 'center'
+            }
+          }
+      );
+     // Notifications.showError({ text: <ReactMarkdown>${draftResponse.message}</ReactMarkdown> + ' Please contact customer support for help.' });
     } else {
       Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
     }

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -36,7 +36,7 @@ export const applyForAccess = async (selected, history) => {
     const draftResponse = await DAR.postDarDraft({ datasetId: selected });
     if (draftResponse.referenceId) {
       history.push(`/dar_application/${draftResponse.referenceId}`);
-    } else if (draftResponse.code && draftResponse.code===422) {
+    } else if (draftResponse.code && draftResponse.code === 422) {
       Notifications.showError(
           {
             text: "Please register in DUOS with your institution's email and obtain approval from your Signing Official in order to submit a data access request.",

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -16,6 +16,7 @@ import DatasetFilterList from './DatasetFilterList';
 import { Notifications } from '../../libs/utils';
 import { Styles } from '../../libs/theme';
 import {DatasetSearchFooter} from './DatasetSearchFooter';
+import ReactMarkdown from 'react-markdown';
 
 const styles = {
   subTab: {
@@ -36,10 +37,10 @@ export const applyForAccess = async (selected, history) => {
     const draftResponse = await DAR.postDarDraft({ datasetId: selected });
     if (draftResponse.referenceId) {
       history.push(`/dar_application/${draftResponse.referenceId}`);
-    } else if (draftResponse.code && draftResponse.code === 422) {
+    } else if (draftResponse.code && draftResponse.message) {
       Notifications.showError(
           {
-            text: "Please register in DUOS with your institution's email and obtain approval from your Signing Official in order to submit a data access request.",
+            text: <ReactMarkdown>{draftResponse.message}</ReactMarkdown>,
             timeout: 6000
             });
     } else {

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -48,7 +48,6 @@ export const applyForAccess = async (selected, history) => {
             }
           }
       );
-     // Notifications.showError({ text: <ReactMarkdown>${draftResponse.message}</ReactMarkdown> + ' Please contact customer support for help.' });
     } else {
       Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
     }

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -40,14 +40,8 @@ export const applyForAccess = async (selected, history) => {
       Notifications.showError(
           {
             text: "Please register in DUOS with your institution's email and obtain approval from your Signing Official in order to submit a data access request.",
-            severity: 'error',
-            timeout: 6000,
-            layout: {
-              vertical: 'bottom',
-              horizontal: 'right'
-            }
-          }
-      );
+            timeout: 6000
+            });
     } else {
       Notifications.showError({ text: 'Error: Unable to create a Draft Data Access Request' });
     }

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -16,7 +16,6 @@ import DatasetFilterList from './DatasetFilterList';
 import { Notifications } from '../../libs/utils';
 import { Styles } from '../../libs/theme';
 import {DatasetSearchFooter} from './DatasetSearchFooter';
-import ReactMarkdown from 'react-markdown';
 
 const styles = {
   subTab: {
@@ -37,10 +36,10 @@ export const applyForAccess = async (selected, history) => {
     const draftResponse = await DAR.postDarDraft({ datasetId: selected });
     if (draftResponse.referenceId) {
       history.push(`/dar_application/${draftResponse.referenceId}`);
-    } else if (draftResponse.message) {
+    } else if (draftResponse.code && draftResponse.code===422) {
       Notifications.showError(
           {
-            text: <ReactMarkdown>{draftResponse.message}</ReactMarkdown>,
+            text: "Please register in DUOS with your institution's email and obtain approval from your Signing Official in order to submit a data access request.",
             severity: 'error',
             timeout: 6000,
             layout: {

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -412,11 +412,11 @@ const DataAccessRequestApplication = (props) => {
       setShowDialogSubmit({
         showDialogSubmit: false
       }, Navigation.console(Storage.getCurrentUser(), props.history).response);
-    } catch (_error) {
+    } catch (error) {
       setShowDialogSubmit(false);
       Notifications.showError(
           {
-            text: <ReactMarkdown>{_error.response.data.message}</ReactMarkdown>,
+            text: <ReactMarkdown>{error.response.data.message}</ReactMarkdown>,
             severity: 'error',
             timeout: 6000,
             layout: {

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -7,8 +7,8 @@ import DataAccessRequest from './DataAccessRequest';
 import ResearchPurposeStatement from './ResearchPurposeStatement';
 import { translateDataUseRestrictionsFromDataUseArray } from '../../libs/dataUseTranslation';
 import {
-  Navigation,
-  Notifications as NotyUtil
+  Navigation, Notifications,
+  Notifications as NotyUtil,
 } from '../../libs/utils';
 import { ConfirmationDialog } from '../../components/ConfirmationDialog_new';
 import { Notification } from '../../components/Notification';
@@ -33,6 +33,7 @@ import UsgOmbText from '../../components/UsgOmbText';
 import {DAAUtils} from '../../utils/DAAUtils';
 import {Metrics} from '../../libs/ajax/Metrics';
 import eventList from '../../libs/events';
+import ReactMarkdown from 'react-markdown';
 const ApplicationTabs = [
   { name: 'Researcher Information' },
   { name: 'Data Access Request' },
@@ -412,10 +413,19 @@ const DataAccessRequestApplication = (props) => {
         showDialogSubmit: false
       }, Navigation.console(Storage.getCurrentUser(), props.history).response);
     } catch (_error) {
+      console.log("error", _error);
       setShowDialogSubmit(false);
-      NotyUtil.showError({
-        text: 'Data Access Request submission failed. Please save and try submitting again.'
-      });
+      Notifications.showError(
+          {
+            text: <ReactMarkdown>{_error.response.data.message}</ReactMarkdown>,
+            severity: 'error',
+            timeout: 6000,
+            layout: {
+              vertical: 'bottom',
+              horizontal: 'center'
+            }
+          }
+      );
     }
   };
 

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -413,11 +413,19 @@ const DataAccessRequestApplication = (props) => {
       }, Navigation.console(Storage.getCurrentUser(), props.history).response);
     } catch (error) {
       setShowDialogSubmit(false);
-      Notifications.showError(
-          {
-            text: <ReactMarkdown>{error.response.data.message}</ReactMarkdown>,
-            timeout: 6000
-          });
+      if (error.response.data.code && error.response.data.message) {
+        Notifications.showError(
+            {
+              text: <ReactMarkdown>{error.response.data.message}</ReactMarkdown>,
+              timeout: 6000
+            });
+      } else {
+        Notifications.showError(
+            {
+              text: 'Error saving Data Access Request. Please try again in a few moments.',
+              timeout: 6000
+            });
+      }
     }
   };
 
@@ -472,8 +480,8 @@ const DataAccessRequestApplication = (props) => {
     } catch (error) {
       setShowDialogSave(false);
       setDisableOkButton(false);
-      if (error.response.data.code && error.response.data.code === 422){
-        Notifications.showError({text:'Please register in DUOS with your institution\'s email and obtain approval from your Signing Official in order to submit a data access request.',
+      if (error.response.data.code && error.response.data.message){
+        Notifications.showError({text: <ReactMarkdown>{error.response.data.message}</ReactMarkdown>,
           severity: 'error',
           timeout: 6000
           });

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -408,12 +408,12 @@ const DataAccessRequestApplication = (props) => {
         darPartialResponse = await saveDARDocuments(uploadedIrbDocument, uploadedCollaborationLetter, referenceId);
       }
       const updatedFormData = assign(formattedFormData, darPartialResponse);
+      //const responseData = await DAR.postDar(updatedFormData);
       await DAR.postDar(updatedFormData);
       setShowDialogSubmit({
         showDialogSubmit: false
       }, Navigation.console(Storage.getCurrentUser(), props.history).response);
     } catch (_error) {
-      console.log("error", _error);
       setShowDialogSubmit(false);
       Notifications.showError(
           {
@@ -422,7 +422,7 @@ const DataAccessRequestApplication = (props) => {
             timeout: 6000,
             layout: {
               vertical: 'bottom',
-              horizontal: 'center'
+              horizontal: 'right'
             }
           }
       );

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -479,7 +479,6 @@ const DataAccessRequestApplication = (props) => {
     } catch (error) {
       setShowDialogSave(false);
       setDisableOkButton(false);
-      console.error(error);
       if (error.response.data.code && error.response.data.code === 422){
         Notifications.showError({text:'Please register in DUOS with your institution\'s email and obtain approval from your Signing Official in order to submit a data access request.',
           severity: 'error',

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -408,7 +408,6 @@ const DataAccessRequestApplication = (props) => {
         darPartialResponse = await saveDARDocuments(uploadedIrbDocument, uploadedCollaborationLetter, referenceId);
       }
       const updatedFormData = assign(formattedFormData, darPartialResponse);
-      //const responseData = await DAR.postDar(updatedFormData);
       await DAR.postDar(updatedFormData);
       setShowDialogSubmit({
         showDialogSubmit: false

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -8,7 +8,6 @@ import ResearchPurposeStatement from './ResearchPurposeStatement';
 import { translateDataUseRestrictionsFromDataUseArray } from '../../libs/dataUseTranslation';
 import {
   Navigation, Notifications,
-  Notifications as NotyUtil,
 } from '../../libs/utils';
 import { ConfirmationDialog } from '../../components/ConfirmationDialog_new';
 import { Notification } from '../../components/Notification';

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -417,14 +417,8 @@ const DataAccessRequestApplication = (props) => {
       Notifications.showError(
           {
             text: <ReactMarkdown>{error.response.data.message}</ReactMarkdown>,
-            severity: 'error',
-            timeout: 6000,
-            layout: {
-              vertical: 'bottom',
-              horizontal: 'right'
-            }
-          }
-      );
+            timeout: 6000
+          });
     }
   };
 
@@ -482,19 +476,12 @@ const DataAccessRequestApplication = (props) => {
       if (error.response.data.code && error.response.data.code === 422){
         Notifications.showError({text:'Please register in DUOS with your institution\'s email and obtain approval from your Signing Official in order to submit a data access request.',
           severity: 'error',
-          timeout: 6000,
-          layout: {
-            vertical: 'bottom',
-            horizontal: 'right'
-          }});
+          timeout: 6000
+          });
       } else {
         Notifications.showError({text:'Error saving Data Access Request. Please try again in a few moments.',
           severity: 'error',
-          timeout: 3500,
-          layout: {
-            vertical: 'bottom',
-            horizontal: 'right'
-          }});
+          });
       }
 
     }

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -252,7 +252,7 @@ const DataAccessRequestApplication = (props) => {
         }
       } catch (_error) {
         setShowDialogSave(false);
-        NotyUtil.showError('Error displaying user information. Please try again in a few moments.');
+        Notifications({text:'Error displaying user information. Please try again in a few moments.', });
       }
     };
     fetchData();
@@ -476,10 +476,28 @@ const DataAccessRequestApplication = (props) => {
       batchFormFieldChange(darPartialResponse);
       setShowDialogSave(false);
       setDisableOkButton(false);
-    } catch (_error) {
+    } catch (error) {
       setShowDialogSave(false);
       setDisableOkButton(false);
-      NotyUtil.showError('Error saving Data Access Request. Please try again in a few moments.');
+      console.error(error);
+      if (error.response.data.code && error.response.data.code === 422){
+        Notifications.showError({text:'Please register in DUOS with your institution\'s email and obtain approval from your Signing Official in order to submit a data access request.',
+          severity: 'error',
+          timeout: 6000,
+          layout: {
+            vertical: 'bottom',
+            horizontal: 'right'
+          }});
+      } else {
+        Notifications.showError({text:'Error saving Data Access Request. Please try again in a few moments.',
+          severity: 'error',
+          timeout: 3500,
+          layout: {
+            vertical: 'bottom',
+            horizontal: 'right'
+          }});
+      }
+
     }
   };
 


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1519](https://broadworkbench.atlassian.net/browse/DT-1519)

### Summary
Renders markdown formatted error messages returned by the server when a DAR can't be created.

After:
In Data Library:
![image](https://github.com/user-attachments/assets/8bf4cdcd-08eb-40df-b298-09d2687315f2)


In DAR submission (requires some level of contortion to get into this state):
![image](https://github.com/user-attachments/assets/adc2a6fa-d167-4b03-987c-045b10c30d6f)

When clicking save on a DAR when the user doesn't have a library card:
![image](https://github.com/user-attachments/assets/e1525b11-ace3-4961-b82e-6995c2816aab)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
