### PR TITLE
[DT-1573 ]Allow admins to assign the service account role.

### DIFF
--- a/cypress/component/SignIn/sign_in_button.spec.jsx
+++ b/cypress/component/SignIn/sign_in_button.spec.jsx
@@ -21,6 +21,7 @@ const duosUser = {
   isMember: false,
   isResearcher: false,
   isSigningOfficial: false,
+  isServiceAccount: false,
   roles: [{
     name: 'Admin'
   }]

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -158,6 +158,7 @@ export const USER_ROLES = {
   alumni: 'Alumni',
   signingOfficial: 'SigningOfficial',
   dataSubmitter: 'DataSubmitter',
+  serviceAccount: 'ServiceAccount',
   all: 'All'
 };
 
@@ -192,6 +193,7 @@ export const setUserRoleStatuses = (user, Storage) => {
   user.isAlumni = currentUserRoles.indexOf(USER_ROLES.alumni) > -1;
   user.isSigningOfficial = currentUserRoles.indexOf(USER_ROLES.signingOfficial) > -1;
   user.isDataSubmitter = currentUserRoles.indexOf(USER_ROLES.dataSubmitter) > -1;
+  user.isServiceAccount = currentUserRoles.indexOf(USER_ROLES.serviceAccount) > -1;
   Storage.setCurrentUser(user);
   return user;
 };

--- a/src/pages/AdminEditUser.jsx
+++ b/src/pages/AdminEditUser.jsx
@@ -12,6 +12,7 @@ import {SearchSelect} from '../components/SearchSelect';
 const adminRole = {'roleId': 4, 'name': USER_ROLES.admin};
 const researcherRole = {'roleId': 5, 'name': USER_ROLES.researcher};
 const signingOfficialRole = {'roleId': 7, 'name': USER_ROLES.signingOfficial};
+const serviceAccount = {'roleId': 10, 'name': USER_ROLES.serviceAccount}
 
 
 export const AdminEditUser = (props) => {
@@ -266,7 +267,6 @@ export const AdminEditUser = (props) => {
                 </div>
               </div>
             </div>
-
             <div className='form-group'>
               <div className='col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4' style={{ paddingLeft: '30px' }}>
                 <div className='checkbox'>
@@ -278,6 +278,20 @@ export const AdminEditUser = (props) => {
                     onChange={(e) => roleStatusChanged(e, adminRole)}
                   />
                   <label id='lbl_admin' className='regular-checkbox rp-choice-questions' htmlFor='chk_admin'>Admin</label>
+                </div>
+              </div>
+            </div>
+            <div className='form-group'>
+              <div className='col-lg-9 col-lg-offset-3 col-md-9 col-md-offset-3 col-sm-9 col-sm-offset-3 col-xs-8 col-xs-offset-4' style={{ paddingLeft: '30px' }}>
+                <div className='checkbox'>
+                  <input
+                      type='checkbox'
+                      id='chk_service_account'
+                      checked={userHasRole(serviceAccount)}
+                      className='checkbox-inline user-checkbox'
+                      onChange={(e) => roleStatusChanged(e, serviceAccount)}
+                  />
+                  <label id='lbl_service_account' className='regular-checkbox rp-choice-questions' htmlFor='chk_service_account'>Service Account</label>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1573](https://broadworkbench.atlassian.net/browse/DT-1573)
### Summary
To enable email notifications, a new service endpoint is being established.  This endpoint can only be invoked by users with the role SERVICE_ACCOUNT.

This UI change adds the ability for an admin to assign the role SERVICE_ACCOUNT.

![image](https://github.com/user-attachments/assets/4c09ed66-e83d-40bc-b341-437ac00c64bd)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
