### PR TITLE
[DT-106] Create DMI component for UI

### DIFF
--- a/cypress/component/ProgressReports/data_management_incident.spec.tsx
+++ b/cypress/component/ProgressReports/data_management_incident.spec.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import DataManagementIncident from '../../../src/pages/progress_reports/DataManagementIncident';
 
+const props = {
+  state: 'step3',
+};
+
 describe('Data Management Incident - Component Tests', () => {
   beforeEach(() => {
-    mount(<DataManagementIncident />);
+    mount(<DataManagementIncident {...props}/>);
   });
 
   it('renders the component correctly', () => {

--- a/cypress/component/ProgressReports/data_management_incident.spec.tsx
+++ b/cypress/component/ProgressReports/data_management_incident.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import DataManagementIncident from '../../../src/pages/progress_reports/DataManagementIncident';
+
+describe('Data Management Incident - Component Tests', () => {
+  beforeEach(() => {
+    mount(<DataManagementIncident />);
+  });
+
+  it('renders the component correctly', () => {
+    cy.get('[data-cy=data-management-incident]').should('exist');
+    cy.contains('Step 3: Data Management Incident').should('be.visible');
+    cy.contains('3.1 Data Management Incident').should('be.visible');
+    cy.contains('Have there been any incidents related to mismanagement or misuse of data?').should('be.visible');
+  });
+
+  it('initially does not show incident details form', () => {
+    cy.contains('Please select any of the following that describe the nature of this Data Management Incident').should('not.exist');
+    cy.get('#dmiCombination').should('not.exist');
+    cy.get('#dmiDescription').should('not.exist');
+  });
+
+  it('shows incident details form when "Yes" is selected', () => {
+    cy.get('#dmiYesNo_yes').click();
+    
+    cy.contains('Please select any of the following that describe the nature of this Data Management Incident').should('be.visible');
+    cy.get('#dmiCombination').should('exist');
+    cy.get('#dmiIdentification').should('exist');
+    cy.get('#dmiSharing').should('exist');
+    cy.get('#dmiSecurity').should('exist');
+    cy.get('#dmiAcknowledgement').should('exist');
+    cy.get('#dmiPublication').should('exist');
+    cy.get('#dmiFalsification').should('exist');
+    cy.get('#dmiOther').should('exist');
+    cy.get('#dmiDescription').should('exist');
+  });
+
+  it('hides incident details form when "No" is selected', () => {
+    // First select Yes to show the form
+    cy.get('#dmiYesNo_yes').click();
+    cy.get('#dmiCombination').should('exist');
+    
+    // Then select No to hide the form
+    cy.get('#dmiYesNo_no').click();
+    cy.get('#dmiCombination').should('not.exist');
+    cy.get('#dmiDescription').should('not.exist');
+  });
+
+  it('allows checking multiple incident types', () => {
+    cy.get('#dmiYesNo_yes').click();
+    
+    cy.get('#dmiCombination').click();
+    cy.get('#dmiIdentification').click();
+    cy.get('#dmiSharing').click();
+    
+    // Verify checkboxes are selected
+    cy.get('#dmiCombination').should('be.checked');
+    cy.get('#dmiIdentification').should('be.checked');
+    cy.get('#dmiSharing').should('be.checked');
+  });
+
+  it('allows entering incident description text', () => {
+    cy.get('#dmiYesNo_yes').click();
+    
+    const testDescription = 'This is a test description of a data management incident.';
+    cy.get('#dmiDescription').type(testDescription);
+    cy.get('#dmiDescription').should('have.value', testDescription);
+  });
+
+  it('enforces character limit on incident description', () => {
+    cy.get('#dmiYesNo_yes').click();
+    
+    // Generate a string longer than the 2200 character limit
+    const longText = 'A'.repeat(2300);
+    const expectedText = longText.substring(0, 2200);
+    
+    cy.get('#dmiDescription').type(longText, { delay: 0 });
+    cy.get('#dmiDescription').should('have.value', expectedText);
+  });
+
+  it('allows toggling checkboxes on and off', () => {
+    cy.get('#dmiYesNo_yes').click();
+    
+    cy.get('#dmiCombination').click();
+    cy.get('#dmiCombination').should('be.checked');
+    
+    cy.get('#dmiCombination').click();
+    cy.get('#dmiCombination').should('not.be.checked');
+  });
+});

--- a/src/pages/progress_reports/DataManagementIncident.tsx
+++ b/src/pages/progress_reports/DataManagementIncident.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { FormField, FormFieldTypes } from '../../components/forms/forms';
+
+const titleStyle = { fontSize: '24px', fontWeight: 500, color: '#333333' };
+
+interface FormStateInterface {
+    dmiYesNo?: boolean;
+    dmiCombination?: boolean;
+    dmiIdentification?: boolean;
+    dmiSharing?: boolean;
+    dmiSecurity?: boolean;
+    dmiAcknowledgement?: boolean;
+    dmiPublication?: boolean;
+    dmiFalsification?: boolean;
+    dmiOther?: boolean;
+    dmiDescription?: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+}
+
+interface DataManagementIncidentProps {
+    readonly state: string;
+}
+
+interface FormFieldChange {
+    key: string;
+    value: boolean | string;
+}
+
+export default function DataManagementIncident(_props: DataManagementIncidentProps): React.JSX.Element {
+    const [formState, setFormState] = useState<FormStateInterface>({});
+
+    return (
+        <div data-cy='data-management-incident'>
+            <div className='progress-report-step-card'>
+                <h2>Step 3: Data Management Incident</h2>
+
+                <div className='progress-report-row'>
+                    <div>
+                        <FormField
+                            id='dmiYesNo'
+                            type={FormFieldTypes.YESNORADIOGROUP}
+                            title='3.1 Data Management Incident'
+                            titleStyle={titleStyle}
+                            description='Have there been any incidents related to mismanagement or misuse of data?'
+                            orientation='horizontal'
+                            onChange={({ key, value }: FormFieldChange) => {
+                                setFormState({ ...formState, [key]: value });
+                            }}
+                        />
+                    </div>
+                    {formState.dmiYesNo === true &&
+                        <>
+                            <div style={{ marginTop: '20px' }}>
+                                <div>Please select any of the following that describe the nature of this Data Management Incident:</div>
+                                <FormField
+                                    id='dmiCombination'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Inappropriate combination or analysis of the requested datasets with unapproved datasets'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiIdentification'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Intentional or accidental identification of participants or generation of data which makes them easily identifiable'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiSharing'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Distribution of the data to an individual or institution beyond those specified in the approved Data Access Request (DAR)'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiSecurity'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Failure to adhere to NIH Security Best Practices for Controlled-Access Data'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiAcknowledgement'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Failure to acknowledge the investigator(s) who generated the data, the funding source, accession numbers of the dataset'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiPublication'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Analysis and/or publication of a study using the data for the research purpose other than the approved research use'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiFalsification'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Fabrication or falsification of data and/or results'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                                <FormField
+                                    id='dmiOther'
+                                    type={FormFieldTypes.CHECKBOX}
+                                    toggleText='Other: such as inadvertent data release or breach of security'
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                            </div>
+                            <div style={{ marginTop: '20px' }}>
+                                <FormField
+                                    id='dmiDescription'
+                                    type={FormFieldTypes.TEXTAREA}
+                                    titleStyle={titleStyle}
+                                    description='Please describe the incidents related to mismanagement or misuse of data below.'
+                                    placeholder='Please limit your Data Management Incident to 2200 characters.'
+                                    rows={6}
+                                    maxLength={2200}
+                                    onChange={({ key, value }: FormFieldChange) => {
+                                        setFormState({ ...formState, [key]: value });
+                                    }}
+                                />
+                            </div>
+                        </>
+                    }
+                </div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-106

### Summary

Creates the DMI component for the UI, and adds a number of unit tests
![Screenshot 2025-05-02 at 13-20-50 Broad Data Use Oversight System](https://github.com/user-attachments/assets/fba9d727-af4b-4e40-9ce5-3738a9892ed0)
![Screenshot 2025-05-02 at 13-20-56 Broad Data Use Oversight System](https://github.com/user-attachments/assets/dc01e778-754b-4cf7-8537-750b0ef57382)



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
