### PR TITLE
[DT-1611]Library card errors are being swallowed

### DIFF
--- a/src/components/library_card_table/LibraryCardTable.jsx
+++ b/src/components/library_card_table/LibraryCardTable.jsx
@@ -120,8 +120,8 @@ const deleteOnClick = (currentCard, libraryCards, setLibraryCards, setShowConfir
     libraryCardsCopy.splice(targetIndex, 1);
     setLibraryCards(libraryCardsCopy);
     setShowConfirmation(false);
-  } catch(_error) {
-    Notifications.showError('Error: Failed to delete library card');
+  } catch(error) {
+    Notifications.showError({text: error.response.data.message ?? 'Error: Failed to delete library card'});
   }
 };
 
@@ -307,9 +307,9 @@ export default function LibraryCardTable(props) {
           updatedCard.userName || updatedCard.userEmail
         }'s library card successfully updated`,
       });
-    } catch (_error) {
+    } catch (error) {
       setShowModal(false);
-      Notifications.showError({ text: 'Error: Failed to update library card' });
+      Notifications.showError({ text:  error.response.data.message ?? 'Error: Failed to update library card' });
     }
   };
 
@@ -317,18 +317,18 @@ export default function LibraryCardTable(props) {
   const addLibraryCard = async (card) => {
     try {
       //check if card combination already exits, show error if it does
-      const alreadyExists = findIndex(
+      const alreadyExists  = findIndex(
         (element) =>
           (isEqual(element.institutionId)(card.institutionId) &&
             element.userId === card.userId) ||
-          isEqual(element.userEmail)(card.userEmail)
+          isEqual(element.userEmail)(card.userEmail), libraryCards
       );
-      const newCard = await LibraryCard.createLibraryCard(card);
       if (alreadyExists > -1) {
         Notifications.showError({ text: 'Library Card already exists' });
         //otherwise execute library card update with payload, get the updated card, and
         //add(with sort afterwards) library card to libraryCards (reference list)
       } else {
+        const newCard = await LibraryCard.createLibraryCard(card);
         const institution = find(
           (institution) => institution.id === newCard.institutionId
         )(institutions);
@@ -343,10 +343,10 @@ export default function LibraryCardTable(props) {
         setLibraryCards(updatedList);
         setShowModal(false);
       }
-    } catch (_error) {
+    } catch (error) {
       setShowModal(false);
       Notifications.showError({
-        text: 'Error: Failed to create new library card',
+        text: error.response.data.message ?? 'Error: Failed to create new library card',
       });
     }
   };

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -351,8 +351,8 @@ export default function SigningOfficialTable(props) {
       setShowConfirmation(false);
       setShowModal(false);
       Notifications.showSuccess({text: `Issued new library card to ${messageName}`});
-    } catch(_error) {
-      Notifications.showError({text: `Error issuing library card to ${messageName}`});
+    } catch(error) {
+      Notifications.showError({text: error.response.data.message ?? 'Error issuing library card' });
     }
   };
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1611

### Summary
Display the error message from consent if it is present.

TODO: 
The ticket shows this issue for the SO page, and that is what this PR addresses. The issue exists on the Admin page as well, so I could update those calls too.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
