### PR TITLE
[DT-104] Add collaborator component

### DIFF
--- a/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
@@ -2,20 +2,16 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorAddEdit from '../../../src/components/collaborator_list/CollaboratorAddEdit';
 
-// Define the Collaborator interface to match the component's expectations
-interface Collaborator {
-  name: string;
-  title: string;
-  institution: string;
-  email: string;
-}
+import { Collaborator } from '../../../src/components/collaborator_list/Collaborator';
 
 describe('CollaboratorAddEdit - Component Tests', () => {
   const mockCollaborator: Collaborator = {
     name: 'John Doe',
     title: 'Researcher',
     institution: 'Research Institute',
-    email: 'john.doe@example.com'
+    email: 'john.doe@example.com',
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    eraCommonsId: 'jdoe123'
   };
 
   const mockCollaborators: Collaborator[] = [mockCollaborator];
@@ -72,8 +68,10 @@ describe('CollaboratorAddEdit - Component Tests', () => {
       onCollaboratorChange={onCollaboratorChange}
     />);
 
-    cy.get('#name').clear().type('Jane Doe');
-    cy.get('#title').clear().type('Senior Researcher');
+    cy.get('#name').clear();
+    cy.get('#name').type('Jane Doe');
+    cy.get('#title').clear();
+    cy.get('#title').type('Senior Researcher');
 
     cy.contains('Save').click();
 
@@ -105,25 +103,36 @@ describe('CollaboratorAddEdit - Component Tests', () => {
     mount(<CollaboratorAddEdit {...defaultProps} />);
 
     const name = 'Test Name';
-    cy.get('#name').type(name).should('have.value', name);
+    cy.get('#name').type(name);
+    cy.get('#name').should('have.value', name);
 
     const title = 'Test Title';
-    cy.get('#title').type(title).should('have.value', title);
+    cy.get('#title').type(title);
+    cy.get('#title').should('have.value', title);
 
     const institution = 'Test Institution';
-    cy.get('#institution').type(institution).should('have.value', institution);
+    cy.get('#institution').type(institution);
+    cy.get('#institution').should('have.value', institution);
 
     const email = 'test@example.com';
-    cy.get('#email').type(email).should('have.value', email);
+    cy.get('#email').type(email);
+    cy.get('#email').should('have.value', email);
   });
 
   it('shows validation error for empty required fields', () => {
     mount(<CollaboratorAddEdit {...defaultProps} />);
 
-    cy.get('#name').focus().blur();
-    cy.get('#title').focus().blur();
-    cy.get('#institution').focus().blur();
-    cy.get('#email').focus().blur();
+    cy.get('#name').focus();
+    cy.get('#name').blur();
+    
+    cy.get('#title').focus();
+    cy.get('#title').blur();
+    
+    cy.get('#institution').focus();
+    cy.get('#institution').blur();
+    
+    cy.get('#email').focus();
+    cy.get('#email').blur();
 
     cy.get('#name').parent().find('.error-message').should('be.visible');
     cy.get('#title').parent().find('.error-message').should('be.visible');
@@ -134,7 +143,8 @@ describe('CollaboratorAddEdit - Component Tests', () => {
   it('shows validation error for invalid email format', () => {
     mount(<CollaboratorAddEdit {...defaultProps} />);
 
-    cy.get('#email').type('invalid').blur();
+    cy.get('#email').type('invalid');
+    cy.get('#email').blur();
 
     cy.get('#email').parent().find('.error-message').should('be.visible');
   });

--- a/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import CollaboratorAddEdit from '../../../src/components/collaborator_list/CollaboratorAddEdit';
+
+// Define the Collaborator interface to match the component's expectations
+interface Collaborator {
+  name: string;
+  title: string;
+  institution: string;
+  email: string;
+}
+
+describe('CollaboratorAddEdit - Component Tests', () => {
+  const mockCollaborator: Collaborator = {
+    name: 'John Doe',
+    title: 'Researcher',
+    institution: 'Research Institute',
+    email: 'john.doe@example.com'
+  };
+
+  const mockCollaborators: Collaborator[] = [mockCollaborator];
+
+  const defaultProps = {
+    id: -1,
+    collaboratorText: 'Collaborator',
+    collaborators: mockCollaborators,
+    closeAction: () => { },
+    onCollaboratorChange: () => { }
+  };
+
+  it('renders the component correctly for adding a new collaborator', () => {
+    mount(<CollaboratorAddEdit {...defaultProps} />);
+
+    cy.contains('New Collaborator Information').should('be.visible');
+    cy.contains('Collaborator Name').should('be.visible');
+    cy.contains('Collaborator Title').should('be.visible');
+    cy.contains('Collaborator Institution').should('be.visible');
+    cy.contains('Collaborator Email').should('be.visible');
+    cy.contains('Add').should('be.visible');
+    cy.contains('Cancel').should('be.visible');
+  });
+
+  it('renders the component correctly for editing an existing collaborator', () => {
+    mount(<CollaboratorAddEdit
+      {...defaultProps}
+      id={0}
+      collaborator={mockCollaborator}
+    />);
+
+    cy.contains(`Edit ${mockCollaborator.name} Information`).should('be.visible');
+    cy.get('#name').should('have.value', mockCollaborator.name);
+    cy.get('#title').should('have.value', mockCollaborator.title);
+    cy.get('#institution').should('have.value', mockCollaborator.institution);
+    cy.get('#email').should('have.value', mockCollaborator.email);
+    cy.contains('Save').should('be.visible');
+  });
+
+  it('calls closeAction when Cancel button is clicked', () => {
+    const closeAction = cy.stub().as('closeAction');
+    mount(<CollaboratorAddEdit {...defaultProps} closeAction={closeAction} />);
+
+    cy.contains('Cancel').click();
+    cy.get('@closeAction').should('have.been.calledOnce');
+  });
+
+  it('calls onCollaboratorChange when Save button is clicked for existing collaborator', () => {
+    const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+    mount(<CollaboratorAddEdit
+      {...defaultProps}
+      id={0}
+      collaborator={mockCollaborator}
+      onCollaboratorChange={onCollaboratorChange}
+    />);
+
+    cy.get('#name').clear().type('Jane Doe');
+    cy.get('#title').clear().type('Senior Researcher');
+
+    cy.contains('Save').click();
+
+    cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+  });
+
+  it('calls both onCollaboratorChange and closeAction when Add button is clicked', () => {
+    const closeAction = cy.stub().as('closeAction');
+    const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+
+    mount(<CollaboratorAddEdit
+      {...defaultProps}
+      closeAction={closeAction}
+      onCollaboratorChange={onCollaboratorChange}
+    />);
+
+    cy.get('#name').type('Test Name');
+    cy.get('#title').type('Test Title');
+    cy.get('#institution').type('Test Institution');
+    cy.get('#email').type('test@example.com');
+
+    cy.contains('Add').click();
+
+    cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+    cy.get('@closeAction').should('have.been.calledOnce');
+  });
+
+  it('updates form fields when typing', () => {
+    mount(<CollaboratorAddEdit {...defaultProps} />);
+
+    const name = 'Test Name';
+    cy.get('#name').type(name).should('have.value', name);
+
+    const title = 'Test Title';
+    cy.get('#title').type(title).should('have.value', title);
+
+    const institution = 'Test Institution';
+    cy.get('#institution').type(institution).should('have.value', institution);
+
+    const email = 'test@example.com';
+    cy.get('#email').type(email).should('have.value', email);
+  });
+
+  it('shows validation error for empty required fields', () => {
+    mount(<CollaboratorAddEdit {...defaultProps} />);
+
+    cy.get('#name').focus().blur();
+    cy.get('#title').focus().blur();
+    cy.get('#institution').focus().blur();
+    cy.get('#email').focus().blur();
+
+    cy.get('#name').parent().find('.error-message').should('be.visible');
+    cy.get('#title').parent().find('.error-message').should('be.visible');
+    cy.get('#institution').parent().find('.error-message').should('be.visible');
+    cy.get('#email').parent().find('.error-message').should('be.visible');
+  });
+
+  it('shows validation error for invalid email format', () => {
+    mount(<CollaboratorAddEdit {...defaultProps} />);
+
+    cy.get('#email').type('invalid').blur();
+
+    cy.get('#email').parent().find('.error-message').should('be.visible');
+  });
+});

--- a/cypress/component/CollaboratorList/collaborator_delete.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_delete.spec.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import CollaboratorDelete from '../../../src/components/collaborator_list/CollaboratorDelete';
+
+describe('CollaboratorDelete - Component Tests', () => {
+    const defaultProps = {
+        collaboratorName: 'John Doe',
+        showDelete: true,
+        confirmAction: () => { },
+        closeAction: () => { }
+    };
+
+    it('renders the component correctly when showDelete is true', () => {
+        mount(<CollaboratorDelete {...defaultProps} />);
+
+        cy.get('.delete-modal').should('exist');
+        cy.get('.delete-modal-header').should('contain', 'Delete Collaborator');
+        cy.get('.delete-modal-title').contains('Are you sure you want to delete').should('be.visible');
+        cy.get('.delete-modal-title strong').should('contain', 'John Doe');
+        cy.get('.delete-modal-message').contains('This action is permanent').should('be.visible');
+    });
+
+    it('does not render when showDelete is false', () => {
+        mount(<CollaboratorDelete {...defaultProps} showDelete={false} />);
+
+        cy.get('.delete-modal').should('not.exist');
+    });
+
+    it('calls confirmAction when Delete button is clicked', () => {
+        const confirmAction = cy.stub().as('confirmAction');
+        mount(<CollaboratorDelete {...defaultProps} confirmAction={confirmAction} />);
+
+        cy.get('.delete-modal-primary-button').contains('Delete').click();
+        cy.get('@confirmAction').should('have.been.calledOnce');
+    });
+
+    it('calls closeAction when Cancel button is clicked', () => {
+        const closeAction = cy.stub().as('closeAction');
+        mount(<CollaboratorDelete {...defaultProps} closeAction={closeAction} />);
+
+        cy.get('.delete-modal-secondary-button').contains('Cancel').click();
+        cy.get('@closeAction').should('have.been.calledOnce');
+    });
+
+    it('calls closeAction when modal overlay is clicked', () => {
+        const closeAction = cy.stub().as('closeAction');
+        mount(<CollaboratorDelete {...defaultProps} closeAction={closeAction} />);
+
+        cy.get('.ReactModal__Overlay').click({ force: true });
+
+        cy.get('@closeAction').should('have.been.calledOnce');
+    });
+
+    it('calls closeAction when ESC key is pressed', () => {
+        const closeAction = cy.stub().as('closeAction');
+        mount(<CollaboratorDelete {...defaultProps} closeAction={closeAction} />);
+
+        // Press ESC key to close modal
+        cy.get('body').type('{esc}');
+
+        cy.get('@closeAction').should('have.been.calledOnce');
+    });
+
+    it('displays different collaborator names correctly', () => {
+        const testName = 'Jane Smith';
+        mount(<CollaboratorDelete {...defaultProps} collaboratorName={testName} />);
+
+        cy.get('.delete-modal-title strong').should('contain', testName);
+    });
+
+    it('has the correct styling on buttons', () => {
+        mount(<CollaboratorDelete {...defaultProps} />);
+
+        // Primary Delete button should be styled as contained
+        cy.get('.delete-modal-primary-button')
+            .should('contain', 'Delete')
+            .and('have.css', 'background-color')
+            .and('not.equal', 'rgba(0, 0, 0, 0)');
+
+        // Secondary Cancel button should be styled as outlined
+        cy.get('.delete-modal-secondary-button')
+            .should('contain', 'Cancel')
+            .and('have.css', 'background-color', 'rgb(255, 255, 255)');
+    });
+
+    it('displays permanent action warning message', () => {
+        mount(<CollaboratorDelete {...defaultProps} />);
+
+        cy.get('.delete-modal-message')
+            .should('contain', 'This action is permanent and cannot be undone');
+    });
+});

--- a/cypress/component/CollaboratorList/collaborator_list.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_list.spec.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorList from '../../../src/components/collaborator_list/CollaboratorList';
 
-// Define the Collaborator interface to match the component's expectations
-interface Collaborator {
-    name: string;
-    title: string;
-    institution: string;
-    email: string;
-}
+import { Collaborator } from '../../../src/components/collaborator_list/Collaborator';
 
 describe('CollaboratorList - Component Tests', () => {
     const mockCollaborators: Collaborator[] = [
@@ -16,13 +10,17 @@ describe('CollaboratorList - Component Tests', () => {
             name: 'John Doe',
             title: 'Researcher',
             institution: 'Research Institute',
-            email: 'john.doe@example.com'
+            email: 'john.doe@example.com',
+            uuid: '123e4567-e89b-12d3-a456-426614174001',
+            eraCommonsId: 'jdoe123'
         },
         {
             name: 'Jane Smith',
             title: 'Professor',
             institution: 'University',
-            email: 'jane.smith@example.com'
+            email: 'jane.smith@example.com',
+            uuid: '123e4567-e89b-12d3-a456-426614174002',
+            eraCommonsId: 'jsmith456'
         }
     ];
 
@@ -102,10 +100,14 @@ describe('CollaboratorList - Component Tests', () => {
 
         cy.contains('Add Collaborator').click();
 
-        cy.get('#name').type('New Person').blur();
-        cy.get('#title').type('New Title').blur();
-        cy.get('#institution').type('New Institution').blur();
-        cy.get('#email').type('new.person@example.com').blur();
+        cy.get('#name').type('New Person');
+        cy.get('#name').blur();
+        cy.get('#title').type('New Title');
+        cy.get('#title').blur();
+        cy.get('#institution').type('New Institution');
+        cy.get('#institution').blur();
+        cy.get('#email').type('new.person@example.com');
+        cy.get('#email').blur();
 
         cy.get('.collaborator-form-add-save-button').click({ force: true });
 
@@ -123,7 +125,8 @@ describe('CollaboratorList - Component Tests', () => {
         cy.get('.glyphicon-pencil').first().parent('a').click({ force: true });
 
         const updatedName = 'Updated Name';
-        cy.get('#name').clear().type(updatedName);
+        cy.get('#name').clear();
+        cy.get('#name').type(updatedName);
 
         cy.contains('Save').click();
 

--- a/cypress/component/CollaboratorList/collaborator_list.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_list.spec.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import CollaboratorList from '../../../src/components/collaborator_list/CollaboratorList';
+
+// Define the Collaborator interface to match the component's expectations
+interface Collaborator {
+    name: string;
+    title: string;
+    institution: string;
+    email: string;
+}
+
+describe('CollaboratorList - Component Tests', () => {
+    const mockCollaborators: Collaborator[] = [
+        {
+            name: 'John Doe',
+            title: 'Researcher',
+            institution: 'Research Institute',
+            email: 'john.doe@example.com'
+        },
+        {
+            name: 'Jane Smith',
+            title: 'Professor',
+            institution: 'University',
+            email: 'jane.smith@example.com'
+        }
+    ];
+
+    const defaultProps = {
+        collaborators: mockCollaborators,
+        collaboratorText: 'Collaborator',
+        columnsToShow: ['name', 'title', 'email'],
+        onCollaboratorChange: () => { },
+        disabled: false
+    };
+
+    it('renders the component with a list of collaborators', () => {
+        mount(<CollaboratorList {...defaultProps} />);
+
+        cy.get('button').contains('Add Collaborator').should('be.visible');
+
+        cy.contains(mockCollaborators[0].name).should('be.visible');
+        cy.contains(mockCollaborators[0].title).should('be.visible');
+        cy.contains(mockCollaborators[0].email).should('be.visible');
+
+        cy.contains(mockCollaborators[1].name).should('be.visible');
+        cy.contains(mockCollaborators[1].title).should('be.visible');
+        cy.contains(mockCollaborators[1].email).should('be.visible');
+
+        cy.get('.collaborator-summary-card').should('have.length', 2);
+    });
+
+    it('opens the add form when Add button is clicked', () => {
+        mount(<CollaboratorList {...defaultProps} />);
+
+        cy.contains('New Collaborator Information').should('not.exist');
+
+        cy.contains('Add Collaborator').click();
+
+        cy.contains('New Collaborator Information').should('be.visible');
+    });
+
+    it('switches to edit mode when edit button is clicked for a collaborator', () => {
+        mount(<CollaboratorList {...defaultProps} />);
+
+        cy.contains(mockCollaborators[0].name).should('be.visible');
+        cy.get('.collaborator-summary-card').first().within(() => {
+            cy.get('.glyphicon-pencil').should('exist');
+        });
+
+        cy.get('.glyphicon-pencil').first().parent('a').click({ force: true });
+
+        cy.contains(`Edit ${mockCollaborators[0].name} Information`).should('be.visible');
+        cy.get('#name').should('have.value', mockCollaborators[0].name);
+        cy.get('#title').should('have.value', mockCollaborators[0].title);
+    });
+
+    it('deletes a collaborator when delete is confirmed', () => {
+        const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+
+        mount(<CollaboratorList
+            {...defaultProps}
+            onCollaboratorChange={onCollaboratorChange}
+        />);
+
+        cy.get('.collaborator-summary-card').should('have.length', 2);
+
+        cy.get('.glyphicon-trash').first().parent('a').click({ force: true });
+
+        cy.get('.delete-modal-primary-button').contains('Delete').click();
+
+        cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+    });
+
+    it('adds a new collaborator when adding through the form', () => {
+        const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+
+        mount(<CollaboratorList
+            {...defaultProps}
+            onCollaboratorChange={onCollaboratorChange}
+        />);
+
+        cy.contains('Add Collaborator').click();
+
+        cy.get('#name').type('New Person').blur();
+        cy.get('#title').type('New Title').blur();
+        cy.get('#institution').type('New Institution').blur();
+        cy.get('#email').type('new.person@example.com').blur();
+
+        cy.get('.collaborator-form-add-save-button').click({ force: true });
+
+        cy.get('@onCollaboratorChange').should('be.called');
+    });
+
+    it('updates a collaborator when editing through the form', () => {
+        const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+
+        mount(<CollaboratorList
+            {...defaultProps}
+            onCollaboratorChange={onCollaboratorChange}
+        />);
+
+        cy.get('.glyphicon-pencil').first().parent('a').click({ force: true });
+
+        const updatedName = 'Updated Name';
+        cy.get('#name').clear().type(updatedName);
+
+        cy.contains('Save').click();
+
+        cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+    });
+
+    it('closes the add form when Cancel is clicked', () => {
+        mount(<CollaboratorList {...defaultProps} />);
+
+        cy.contains('Add Collaborator').click();
+        cy.contains('New Collaborator Information').should('be.visible');
+
+        cy.contains('Cancel').click();
+
+        cy.contains('New Collaborator Information').should('not.exist');
+    });
+
+    it('disables the Add button when disabled prop is true', () => {
+        mount(<CollaboratorList {...defaultProps} disabled={true} />);
+
+        cy.contains('Add Collaborator').should('be.disabled');
+
+        cy.contains('Add Collaborator').click({ force: true });
+
+        cy.contains('New Collaborator Information').should('not.exist');
+    });
+
+    it('passes disabled prop to CollaboratorRow components', () => {
+        mount(<CollaboratorList {...defaultProps} disabled={true} />);
+
+        cy.get('.glyphicon-pencil').parent().should('have.css', 'opacity', '0.5');
+        cy.get('.glyphicon-trash').parent().should('have.css', 'opacity', '0.5');
+    });
+
+    it('renders correctly with empty collaborators list', () => {
+        mount(<CollaboratorList
+            {...defaultProps}
+            collaborators={[]}
+        />);
+
+        cy.contains('Add Collaborator').should('be.visible');
+
+        cy.get('.collaborator-summary-card').should('not.exist');
+    });
+
+    it('renders correctly with custom columnsToShow', () => {
+        mount(<CollaboratorList
+            {...defaultProps}
+            columnsToShow={['name', 'institution']}
+        />);
+
+        cy.contains(mockCollaborators[0].name).should('be.visible');
+        cy.contains(mockCollaborators[0].institution).should('be.visible');
+        cy.contains(mockCollaborators[0].title).should('not.exist');
+        cy.contains(mockCollaborators[0].email).should('not.exist');
+    });
+
+    it('clears edit state after a successful edit', () => {
+        mount(<CollaboratorList {...defaultProps} />);
+
+        cy.get('.glyphicon-pencil').first().parent('a').click({ force: true });
+        cy.contains(`Edit ${mockCollaborators[0].name} Information`).should('be.visible');
+
+        cy.contains('Save').click();
+
+        cy.contains(`Edit ${mockCollaborators[0].name} Information`).should('not.exist');
+        cy.contains(mockCollaborators[0].name).should('be.visible');
+    });
+
+    it('maintains proper edit state when editing multiple collaborators', () => {
+        mount(<CollaboratorList {...defaultProps} />);
+
+        cy.get('.glyphicon-pencil').first().parent('a').click({ force: true });
+        cy.contains(`Edit ${mockCollaborators[0].name} Information`).should('be.visible');
+
+        cy.contains(mockCollaborators[1].name).should('be.visible');
+
+        cy.contains('Cancel').click();
+
+        cy.contains(mockCollaborators[0].name).should('be.visible');
+        cy.contains(mockCollaborators[1].name).should('be.visible');
+
+        cy.get('.glyphicon-pencil').eq(1).parent('a').click({ force: true });
+
+        cy.contains(mockCollaborators[0].name).should('be.visible');
+        cy.contains(`Edit ${mockCollaborators[1].name} Information`).should('be.visible');
+    });
+});

--- a/cypress/component/CollaboratorList/collaborator_row.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_row.spec.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import CollaboratorRow from '../../../src/components/collaborator_list/CollaboratorRow';
+
+interface Collaborator {
+    name: string;
+    title: string;
+    institution: string;
+    email: string;
+}
+
+describe('CollaboratorRow - Component Tests', () => {
+    const mockCollaborator: Collaborator = {
+        name: 'John Doe',
+        title: 'Researcher',
+        institution: 'Research Institute',
+        email: 'john.doe@example.com'
+    };
+
+    const mockCollaborators: Collaborator[] = [mockCollaborator];
+
+    const columnsToShow = ['name', 'title', 'email'];
+
+    const defaultProps = {
+        id: 0,
+        editMode: false,
+        collaborator: mockCollaborator,
+        collaboratorText: 'Collaborator',
+        collaborators: mockCollaborators,
+        columnsToShow: columnsToShow,
+        editAction: () => { },
+        deleteAction: () => { },
+        closeAction: () => { },
+        onCollaboratorChange: () => { },
+        disabled: false
+    };
+
+    it('renders CollaboratorSummary when not in edit mode', () => {
+        mount(<CollaboratorRow {...defaultProps} />);
+
+        cy.contains(mockCollaborator.name).should('be.visible');
+        cy.contains(mockCollaborator.title).should('be.visible');
+        cy.contains(mockCollaborator.email).should('be.visible');
+
+        cy.get('.glyphicon-pencil').should('exist');
+        cy.get('.glyphicon-trash').should('exist');
+
+        cy.contains('New Collaborator Information').should('not.exist');
+        cy.contains('Edit Collaborator Information').should('not.exist');
+    });
+
+    it('renders CollaboratorAddEdit when in edit mode', () => {
+        mount(<CollaboratorRow {...defaultProps} editMode={true} />);
+
+        cy.contains(`Edit ${mockCollaborator.name} Information`).should('be.visible');
+        cy.get('#name').should('have.value', mockCollaborator.name);
+        cy.get('#title').should('have.value', mockCollaborator.title);
+        cy.get('#institution').should('have.value', mockCollaborator.institution);
+        cy.get('#email').should('have.value', mockCollaborator.email);
+
+        cy.contains('Save').should('be.visible');
+        cy.contains('Cancel').should('be.visible');
+
+        cy.get('.glyphicon-pencil').should('not.exist');
+        cy.get('.glyphicon-trash').should('not.exist');
+    });
+
+    it('passes editAction to CollaboratorSummary and triggers it on edit button click', () => {
+        const editAction = cy.stub().as('editAction');
+
+        mount(<CollaboratorRow
+            {...defaultProps}
+            editAction={editAction}
+        />);
+
+        cy.get('.glyphicon-pencil').parent('a').click({ force: true });
+
+        cy.get('@editAction').should('have.been.calledOnce');
+    });
+
+    it('passes deleteAction to CollaboratorSummary and triggers it on delete confirmation', () => {
+        const deleteAction = cy.stub().as('deleteAction');
+
+        mount(<CollaboratorRow
+            {...defaultProps}
+            deleteAction={deleteAction}
+        />);
+
+        cy.get('.glyphicon-trash').parent('a').click({ force: true });
+
+        cy.get('.delete-modal-primary-button').contains('Delete').click();
+
+        cy.get('@deleteAction').should('have.been.calledOnce');
+    });
+
+    it('passes closeAction to CollaboratorAddEdit and triggers it on cancel', () => {
+        const closeAction = cy.stub().as('closeAction');
+
+        mount(<CollaboratorRow
+            {...defaultProps}
+            editMode={true}
+            closeAction={closeAction}
+        />);
+
+        cy.contains('Cancel').click();
+
+        cy.get('@closeAction').should('have.been.calledOnce');
+    });
+
+    it('passes onCollaboratorChange to CollaboratorAddEdit and triggers it on save', () => {
+        const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+
+        mount(<CollaboratorRow
+            {...defaultProps}
+            editMode={true}
+            onCollaboratorChange={onCollaboratorChange}
+        />);
+
+        cy.get('#name').clear().type('Jane Doe');
+
+        cy.contains('Save').click();
+
+        cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+    });
+
+    it('respects the disabled prop for CollaboratorSummary', () => {
+        const editAction = cy.stub().as('editAction');
+        const deleteAction = cy.stub().as('deleteAction');
+
+        mount(<CollaboratorRow
+            {...defaultProps}
+            editAction={editAction}
+            deleteAction={deleteAction}
+            disabled={true}
+        />);
+
+        cy.get('.glyphicon-pencil').parent().should('have.css', 'opacity', '0.5');
+        cy.get('.glyphicon-trash').parent().should('have.css', 'opacity', '0.5');
+
+        cy.get('.glyphicon-pencil').parent('a').click({ force: true });
+        cy.get('.glyphicon-trash').parent('a').click({ force: true });
+
+        cy.get('@editAction').should('not.have.been.called');
+        cy.get('@deleteAction').should('not.have.been.called');
+    });
+
+    it('renders CollaboratorAddEdit with new collaborator in edit mode with no collaborator provided', () => {
+        const newProps = {
+            ...defaultProps,
+            id: -1,
+            collaborator: undefined,
+            editMode: true
+        };
+
+        mount(<CollaboratorRow {...newProps} />);
+
+        cy.contains('New Collaborator Information').should('be.visible');
+
+        cy.get('#name').should('have.value', '');
+        cy.get('#title').should('have.value', '');
+        cy.get('#institution').should('have.value', '');
+        cy.get('#email').should('have.value', '');
+
+        cy.contains('Add').should('be.visible');
+        cy.contains('Cancel').should('be.visible');
+    });
+});

--- a/cypress/component/CollaboratorList/collaborator_row.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_row.spec.tsx
@@ -1,20 +1,16 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorRow from '../../../src/components/collaborator_list/CollaboratorRow';
-
-interface Collaborator {
-    name: string;
-    title: string;
-    institution: string;
-    email: string;
-}
+import { Collaborator } from '../../../src/components/collaborator_list/Collaborator';
 
 describe('CollaboratorRow - Component Tests', () => {
     const mockCollaborator: Collaborator = {
         name: 'John Doe',
         title: 'Researcher',
         institution: 'Research Institute',
-        email: 'john.doe@example.com'
+        email: 'john.doe@example.com',
+        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        eraCommonsId: 'jdoe123'
     };
 
     const mockCollaborators: Collaborator[] = [mockCollaborator];
@@ -116,7 +112,8 @@ describe('CollaboratorRow - Component Tests', () => {
             onCollaboratorChange={onCollaboratorChange}
         />);
 
-        cy.get('#name').clear().type('Jane Doe');
+        cy.get('#name').clear();
+        cy.get('#name').type('Jane Doe');
 
         cy.contains('Save').click();
 
@@ -144,7 +141,7 @@ describe('CollaboratorRow - Component Tests', () => {
         cy.get('@deleteAction').should('not.have.been.called');
     });
 
-    it('renders CollaboratorAddEdit with new collaborator in edit mode with no collaborator provided', () => {
+    it('renders CollaboratorAddEdit with new collaborator in edit mode with id=-1', () => {
         const newProps = {
             ...defaultProps,
             id: -1,

--- a/cypress/component/CollaboratorList/collaborator_summary.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_summary.spec.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import CollaboratorSummary from '../../../src/components/collaborator_list/CollaboratorSummary';
+
+// Define the Collaborator interface to match component expectations
+interface Collaborator {
+  name: string;
+  title: string;
+  institution: string;
+  email: string;
+}
+
+describe('CollaboratorSummary - Component Tests', () => {
+  const mockCollaborator: Collaborator = {
+    name: 'John Doe',
+    title: 'Researcher',
+    institution: 'Research Institute',
+    email: 'john.doe@example.com'
+  };
+
+  const defaultProps = {
+    collaborator: mockCollaborator,
+    columnsToShow: ['name', 'title', 'email'],
+    editAction: () => { },
+    deleteAction: () => { },
+    disabled: false
+  };
+
+  it('renders the component correctly with specified columns', () => {
+    mount(<CollaboratorSummary {...defaultProps} />);
+
+    cy.contains(mockCollaborator.name).should('be.visible');
+    cy.contains(mockCollaborator.title).should('be.visible');
+    cy.contains(mockCollaborator.email).should('be.visible');
+
+    cy.contains(mockCollaborator.institution).should('not.exist');
+
+    cy.get('.collaborator-summary-edit-delete-buttons').should('exist');
+    cy.get('.glyphicon-pencil').should('exist');
+    cy.get('.glyphicon-trash').should('exist');
+  });
+
+  it('renders different columns when columnsToShow changes', () => {
+    const customProps = {
+      ...defaultProps,
+      columnsToShow: ['name', 'institution']
+    };
+
+    mount(<CollaboratorSummary {...customProps} />);
+
+    cy.contains(mockCollaborator.name).should('be.visible');
+    cy.contains(mockCollaborator.institution).should('be.visible');
+
+    cy.contains(mockCollaborator.title).should('not.exist');
+    cy.contains(mockCollaborator.email).should('not.exist');
+  });
+
+  it('calls editAction when edit button is clicked', () => {
+    const editAction = cy.stub().as('editAction');
+
+    mount(<CollaboratorSummary
+      {...defaultProps}
+      editAction={editAction}
+    />);
+
+    cy.get('.glyphicon-pencil').parent('a').click({ force: true });
+    cy.get('@editAction').should('have.been.calledOnce');
+  });
+
+  it('shows delete modal when delete button is clicked', () => {
+    mount(<CollaboratorSummary {...defaultProps} />);
+
+    cy.get('.delete-modal').should('not.exist');
+
+    cy.get('.glyphicon-trash').parent('a').click({ force: true });
+
+    cy.get('.delete-modal').should('be.visible');
+    cy.get('.delete-modal-title').contains(mockCollaborator.name).should('be.visible');
+  });
+
+  it('calls deleteAction when confirming deletion', () => {
+    const deleteAction = cy.stub().as('deleteAction');
+
+    mount(<CollaboratorSummary
+      {...defaultProps}
+      deleteAction={deleteAction}
+    />);
+
+    cy.get('.glyphicon-trash').parent('a').click({ force: true });
+
+    cy.get('.delete-modal-primary-button').contains('Delete').click();
+
+    cy.get('@deleteAction').should('have.been.calledOnce');
+
+    cy.get('.delete-modal').should('not.exist');
+  });
+
+  it('closes delete modal when cancel is clicked', () => {
+    mount(<CollaboratorSummary {...defaultProps} />);
+
+    cy.get('.glyphicon-trash').parent('a').click({ force: true });
+    cy.get('.delete-modal').should('be.visible');
+
+    cy.get('.delete-modal-secondary-button').contains('Cancel').click();
+
+    cy.get('.delete-modal').should('not.exist');
+  });
+
+  it('disables interactions when disabled prop is true', () => {
+    const editAction = cy.stub().as('editAction');
+    const deleteAction = cy.stub().as('deleteAction');
+
+    mount(<CollaboratorSummary
+      {...defaultProps}
+      editAction={editAction}
+      deleteAction={deleteAction}
+      disabled={true}
+    />);
+
+    cy.get('.glyphicon-pencil').parent().should('have.css', 'opacity', '0.5');
+    cy.get('.glyphicon-trash').parent().should('have.css', 'opacity', '0.5');
+
+    cy.get('.glyphicon-pencil').parent('a').click({ force: true });
+    cy.get('.glyphicon-trash').parent('a').click({ force: true });
+
+    cy.get('@editAction').should('not.have.been.called');
+    cy.get('@deleteAction').should('not.have.been.called');
+
+    cy.get('.delete-modal').should('not.exist');
+  });
+
+  it('displays null or undefined column values gracefully', () => {
+    const incompleteCollaborator = {
+      name: 'Jane Doe',
+      title: '',
+      institution: undefined,
+      email: null
+    };
+
+    mount(<CollaboratorSummary
+      {...defaultProps}
+      collaborator={incompleteCollaborator as any}
+    />);
+
+    cy.contains('Jane Doe').should('be.visible');
+
+    cy.get('.collaborator-summary-card > div').should('have.length', 1 + 1); // 1 data div + buttons div
+  });
+});

--- a/cypress/component/CollaboratorList/collaborator_summary.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_summary.spec.tsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorSummary from '../../../src/components/collaborator_list/CollaboratorSummary';
+import { Collaborator } from '../../../src/components/collaborator_list/Collaborator';
 
-// Define the Collaborator interface to match component expectations
-interface Collaborator {
+type PartialCollaborator = {
   name: string;
-  title: string;
-  institution: string;
-  email: string;
+  title?: string | null;
+  institution?: string | null;
+  email?: string | null;
+  uuid?: string;
+  eraCommonsId?: string;
 }
 
 describe('CollaboratorSummary - Component Tests', () => {
@@ -15,7 +17,9 @@ describe('CollaboratorSummary - Component Tests', () => {
     name: 'John Doe',
     title: 'Researcher',
     institution: 'Research Institute',
-    email: 'john.doe@example.com'
+    email: 'john.doe@example.com',
+    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    eraCommonsId: 'jdoe123'
   };
 
   const defaultProps = {
@@ -130,7 +134,7 @@ describe('CollaboratorSummary - Component Tests', () => {
   });
 
   it('displays null or undefined column values gracefully', () => {
-    const incompleteCollaborator = {
+    const incompleteCollaborator: PartialCollaborator = {
       name: 'Jane Doe',
       title: '',
       institution: undefined,
@@ -139,7 +143,7 @@ describe('CollaboratorSummary - Component Tests', () => {
 
     mount(<CollaboratorSummary
       {...defaultProps}
-      collaborator={incompleteCollaborator as any}
+      collaborator={incompleteCollaborator as Collaborator}
     />);
 
     cy.contains('Jane Doe').should('be.visible');

--- a/cypress/component/CollaboratorList/modal_wrapper.spec.tsx
+++ b/cypress/component/CollaboratorList/modal_wrapper.spec.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import ModalWrapper from '../../../src/components/collaborator_list/ModalWrapper';
+
+describe('ModalWrapper - Component Tests', () => {
+  it('renders with default props', () => {
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+      >
+        <div data-cy="modal-content">Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.ReactModal__Content').should('exist');
+    cy.get('[data-cy=modal-content]').should('be.visible');
+    cy.contains('Test Content').should('be.visible');
+  });
+
+  it('does not render when isOpen is false', () => {
+    mount(
+      <ModalWrapper
+        isOpen={false}
+        ariaHideApp={false}
+      >
+        <div data-cy="modal-content">Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.ReactModal__Content').should('not.exist');
+  });
+
+  it('applies custom className', () => {
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+        className="custom-modal-class"
+      >
+        <div>Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.custom-modal-class').should('exist');
+  });
+
+  it('applies overlayClassName', () => {
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+        overlayClassName="custom-overlay-class"
+      >
+        <div>Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.custom-overlay-class').should('exist');
+  });
+
+  it('handles onAfterOpen callback', () => {
+    const onAfterOpen = cy.stub().as('afterOpenCallback');
+
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+        onAfterOpen={onAfterOpen}
+      >
+        <div>Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('@afterOpenCallback').should('have.been.called');
+  });
+
+  it('handles onRequestClose callback when clicking overlay', () => {
+    const onRequestClose = cy.stub().as('requestCloseCallback');
+
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+        onRequestClose={onRequestClose}
+        shouldCloseOnOverlayClick={true}
+      >
+        <div data-cy="modal-content">Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.ReactModal__Overlay').click({ force: true });
+    cy.get('@requestCloseCallback').should('have.been.called');
+  });
+
+  it('supports custom styling', () => {
+    const customStyle = {
+      content: {
+        backgroundColor: 'rgb(255, 0, 0)'
+      }
+    };
+
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+        style={customStyle}
+      >
+        <div>Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.ReactModal__Content').should('have.css', 'background-color', 'rgb(255, 0, 0)');
+  });
+
+  it('renders with custom content label', () => {
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+        contentLabel="Test Modal Label"
+      >
+        <div>Test Content</div>
+      </ModalWrapper>
+    );
+
+    cy.get('.ReactModal__Content').should('have.attr', 'aria-label', 'Test Modal Label');
+  });
+
+  it('allows nested interactive elements to work', () => {
+    const buttonClickStub = cy.stub().as('buttonClickHandler');
+
+    mount(
+      <ModalWrapper
+        isOpen={true}
+        ariaHideApp={false}
+      >
+        <button data-cy="modal-button" onClick={buttonClickStub}>Click Me</button>
+      </ModalWrapper>
+    );
+
+    cy.get('[data-cy=modal-button]').click();
+    cy.get('@buttonClickHandler').should('have.been.called');
+  });
+});

--- a/src/components/collaborator_list/Collaborator.tsx
+++ b/src/components/collaborator_list/Collaborator.tsx
@@ -1,4 +1,4 @@
-interface Collaborator {
+export interface Collaborator {
     uuid: string;
     name: string;
     eraCommonsId: string;

--- a/src/components/collaborator_list/Collaborator.tsx
+++ b/src/components/collaborator_list/Collaborator.tsx
@@ -1,0 +1,8 @@
+interface Collaborator {
+    uuid: string;
+    name: string;
+    eraCommonsId: string;
+    email: string;
+    title: string;
+    institution: string;
+}

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { FormField, FormValidators } from '../forms/forms';
+import { Collaborator } from './Collaborator';
 
 interface FormFieldChange {
     key: string;
@@ -12,7 +13,7 @@ interface CollaboratorAddEditProps {
     readonly collaboratorText: string;
     readonly collaborators: Collaborator[];
     readonly closeAction: () => void;
-    readonly onCollaboratorChange: (input: any) => void;
+    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
 }
 
 export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): React.JSX.Element {
@@ -92,7 +93,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                                 onCollaboratorChange([...collaborators, newCollaborator]);
                                 setNewCollaborator(undefined);
                             } else if (newCollaborator !== undefined) {
-                                let collaboratorsCopy = [...collaborators];
+                                const collaboratorsCopy = [...collaborators];
                                 collaboratorsCopy[id] = newCollaborator;
                                 onCollaboratorChange(collaboratorsCopy);
                                 setNewCollaborator(undefined);

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { FormField, FormValidators } from '../forms/forms';
+
+interface FormFieldChange {
+    key: string;
+    value: string;
+}
+
+interface CollaboratorAddEditProps {
+    readonly id: number;
+    collaborator?: Collaborator;
+    readonly collaboratorText: string;
+    readonly collaborators: Collaborator[];
+    readonly closeAction: () => void;
+    readonly onCollaboratorChange: (input: any) => void;
+}
+
+export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): React.JSX.Element {
+    const { id, collaborator, collaboratorText, collaborators, closeAction, onCollaboratorChange } = props;
+
+    const [newCollaborator, setNewCollaborator] = useState(collaborator);
+
+    return (
+        <div className='form-group row no-margin'>
+            <div className='col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card' key={`collaborator-item-id`}>
+                <div className='row'>
+                    <h2>{collaborator === undefined ? `New ${collaboratorText} Information` : `Edit ${collaborator.name} Information`}</h2>
+                    <FormField
+                        id='name'
+                        title={`${collaboratorText} Name`}
+                        defaultValue={collaborator?.name}
+                        placeholder='Full Name'
+                        validators={[FormValidators.REQUIRED]}
+                        onChange={({ key, value }: FormFieldChange) => {
+                            const setCollaborator = {
+                                ...newCollaborator,
+                                [key]: value
+                            } as Collaborator;
+                            setNewCollaborator(setCollaborator);
+                        }}
+                    />
+                    <FormField
+                        id='title'
+                        title={`${collaboratorText} Title`}
+                        defaultValue={collaborator?.title}
+                        placeholder='Title'
+                        validators={[FormValidators.REQUIRED]}
+                        onChange={({ key, value }: FormFieldChange) => {
+                            const setCollaborator = {
+                                ...newCollaborator,
+                                [key]: value
+                            } as Collaborator;
+                            setNewCollaborator(setCollaborator);
+                        }}
+                    />
+                    <FormField
+                        id='institution'
+                        title={`${collaboratorText} Institution`}
+                        defaultValue={collaborator?.institution}
+                        placeholder='Institution'
+                        validators={[FormValidators.REQUIRED]}
+                        onChange={({ key, value }: FormFieldChange) => {
+                            const setCollaborator = {
+                                ...newCollaborator,
+                                [key]: value
+                            } as Collaborator;
+                            setNewCollaborator(setCollaborator);
+                        }}
+                    />
+                    <FormField
+                        id='email'
+                        title={`${collaboratorText} Email`}
+                        defaultValue={collaborator?.email}
+                        placeholder='Email'
+                        validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+                        onChange={({ key, value }: FormFieldChange) => {
+                            const setCollaborator = {
+                                ...newCollaborator,
+                                [key]: value
+                            } as Collaborator;
+                            setNewCollaborator(setCollaborator);
+                        }}
+                    />
+                </div>
+                <div className='row' style={{ marginTop: 20 }}>
+                    {/* add/save button */}
+                    <div
+                        className='collaborator-form-add-save-button f-left btn'
+                        role='button'
+                        onClick={() => {
+                            if (id < 0) {
+                                onCollaboratorChange([...collaborators, newCollaborator]);
+                                setNewCollaborator(undefined);
+                            } else if (newCollaborator !== undefined) {
+                                let collaboratorsCopy = [...collaborators];
+                                collaboratorsCopy[id] = newCollaborator;
+                                onCollaboratorChange(collaboratorsCopy);
+                                setNewCollaborator(undefined);
+                            }
+                            closeAction();
+                        }}
+                    >
+                        {collaborator === undefined ? 'Add' : 'Save'}
+                    </div>
+                    {/* cancel button */}
+                    <div
+                        className='collaborator-form-cancel-button f-left btn'
+                        role='button'
+                        onClick={closeAction}
+                    >
+                        Cancel
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/collaborator_list/CollaboratorDelete.css
+++ b/src/components/collaborator_list/CollaboratorDelete.css
@@ -1,0 +1,54 @@
+.delete-modal {
+  inset: 30% 42%;
+  padding: 2%;
+  display: flex;
+  justify-content: left;
+  position: absolute;
+  height: 208px;
+  width: 480px;
+  border-radius: 4px;
+  background-color: #FFFFFF;
+  box-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.5);
+}
+
+.delete-modal-header {
+  height: 24px;
+  width: 250px;
+  color: #333F52;
+  font-family: Montserrat;
+  font-size: 20px;
+  font-weight: bold;
+  line-height: 24px;
+  margin-bottom: 4%;
+  align-items: left;
+}
+
+.delete-modal-title {
+  height: 28px;
+  width: 365px;
+  color: #333F52;
+  font-family: Montserrat;
+  font-size: 14px;
+  letter-spacing: 0;
+  line-height: 24px;
+  align-items: left;
+}
+
+.delete-modal-message {
+  height: 48px;
+  width: 365px;
+  color: #333F52;
+  font-family: Montserrat;
+  font-size: 14px;
+  font-style: italic;
+  letter-spacing: 0;
+  line-height: 24px;
+  align-items: left;
+}
+
+.delete-modal-actions {
+  display: flex;
+  justify-content: left;
+  height: 41px;
+  width: 89px;
+}

--- a/src/components/collaborator_list/CollaboratorDelete.tsx
+++ b/src/components/collaborator_list/CollaboratorDelete.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import ModalWrapper from './ModalWrapper';
 import './CollaboratorDelete.css';
 import CloseIconComponent from '../CloseIconComponent';

--- a/src/components/collaborator_list/CollaboratorDelete.tsx
+++ b/src/components/collaborator_list/CollaboratorDelete.tsx
@@ -1,0 +1,71 @@
+import ModalWrapper from './ModalWrapper';
+import './CollaboratorDelete.css';
+import CloseIconComponent from '../CloseIconComponent';
+import { styled } from '@mui/material/styles';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+
+interface CollaboratorDeleteProps {
+    readonly collaboratorName: string;
+    readonly showDelete: boolean;
+    readonly confirmAction: () => void;
+    readonly closeAction: () => void;
+}
+
+export default function CollaboratorDelete(props: CollaboratorDeleteProps): React.JSX.Element {
+    const { collaboratorName, showDelete, confirmAction, closeAction } = props;
+
+    const duosBlue = '#0948B7';
+    const duosBlueHover = 'rgb(9,72,183)';
+
+    const SecondaryButton = styled(Button)(() => ({
+        fontFamily: 'Montserrat, sans-serif',
+        color: duosBlue,
+        backgroundColor: 'white',
+        borderRadius: '4px',
+        fontSize: '1.45rem',
+        borderColor: duosBlue,
+        '&:hover': {
+            borderColor: duosBlueHover,
+            color: duosBlueHover,
+        },
+    }));
+
+    const PrimaryButton = styled(Button)(({ theme }) => ({
+        fontFamily: 'Montserrat, sans-serif',
+        color: theme.palette.getContrastText(duosBlue),
+        backgroundColor: duosBlue,
+        borderRadius: '4px',
+        fontSize: '1.45rem',
+        '&:hover': {
+            backgroundColor: duosBlueHover,
+        },
+    }));
+
+    return (
+        <ModalWrapper
+            isOpen={showDelete}
+            onRequestClose={closeAction}
+            shouldCloseOnEsc={true}
+            shouldCloseOnOverlayClick={true}
+            className={'delete-modal'}
+        >
+            <div>
+                <CloseIconComponent closeFn={closeAction} />
+                <div className={'delete-modal-header'}>Delete Collaborator</div>
+                <div className={'delete-modal-title'}>Are you sure you want to delete <strong>{collaboratorName}</strong>?</div>
+                <div className={'delete-modal-message'}><i>This action is permanent and cannot be undone.</i></div>
+                <div className={'delete-modal-actions'}>
+                    <Stack spacing={2} direction={'row'}>
+                        <PrimaryButton variant={'contained'} className={'delete-modal-primary-button'} onClick={confirmAction}>
+                            Delete
+                        </PrimaryButton>
+                        <SecondaryButton variant={'outlined'} className={'delete-modal-secondary-button'} onClick={closeAction}>
+                            Cancel
+                        </SecondaryButton>
+                    </Stack>
+                </div>
+            </div>
+        </ModalWrapper>
+    );
+}

--- a/src/components/collaborator_list/CollaboratorList.tsx
+++ b/src/components/collaborator_list/CollaboratorList.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import CollaboratorAddEdit from './CollaboratorAddEdit';
+import CollaboratorRow from './CollaboratorRow';
+
+interface CollaboratorListProps {
+    collaborators: Collaborator[];
+    readonly collaboratorText: string;
+    readonly columnsToShow?: string[];
+    readonly onCollaboratorChange: (input: any) => void;
+    readonly disabled?: boolean;
+}
+
+export default function CollaboratorList(props: CollaboratorListProps): React.JSX.Element {
+    const { collaborators, collaboratorText, columnsToShow = [], onCollaboratorChange, disabled = false } = props;
+
+    const [showAddEdit, setShowAddEdit] = useState(false);
+    const [editState, setEditState] = useState(collaborators.map(() => false));
+
+    const toggleEditState = (index: number) => {
+        const editStateCopy = [...editState];
+        editStateCopy[index] = !editStateCopy[index];
+        setEditState(editStateCopy);
+    }
+
+    const handleDeleteCollaborator = (index: number) => {
+        const updatedCollaborators = collaborators.filter((_, i) => i !== index);
+        onCollaboratorChange(updatedCollaborators);
+    }
+
+    return (
+        <div className="collaborator-list-component">
+            <div className="row no-margin">
+                <button
+                    id={`add-${collaboratorText}-btn`}
+                    type="button"
+                    className="button button-white"
+                    style={{
+                        marginTop: 25,
+                        marginBottom: 5,
+                        ...(disabled ? { cursor: 'not-allowed' } : {}),
+                    }}
+                    onClick={() => { !disabled && setShowAddEdit(true); }}
+                    disabled={disabled}
+                >
+                    Add {collaboratorText}
+                </button>
+                {showAddEdit && (
+                    <CollaboratorAddEdit
+                        id={-1}
+                        collaboratorText={collaboratorText}
+                        collaborators={collaborators}
+                        closeAction={() => setShowAddEdit(false)}
+                        onCollaboratorChange={onCollaboratorChange}
+                    />
+                )}
+            </div>
+            <div className="form-group row no-margin">
+                {collaborators.map((collaborator: Collaborator, index: number) => {
+                    return <CollaboratorRow
+                        key={index}
+                        id={index}
+                        editMode={editState[index]}
+                        collaborator={collaborator}
+                        collaboratorText={collaboratorText}
+                        collaborators={collaborators}
+                        columnsToShow={columnsToShow}
+                        editAction={() => toggleEditState(index)}
+                        deleteAction={() => { handleDeleteCollaborator(index); }}
+                        closeAction={() => { toggleEditState(index); setShowAddEdit(false); }}
+                        onCollaboratorChange={onCollaboratorChange}
+                        disabled={disabled}
+                    />
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/collaborator_list/CollaboratorList.tsx
+++ b/src/components/collaborator_list/CollaboratorList.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import CollaboratorAddEdit from './CollaboratorAddEdit';
 import CollaboratorRow from './CollaboratorRow';
+import { Collaborator } from './Collaborator';
 
 interface CollaboratorListProps {
     collaborators: Collaborator[];
     readonly collaboratorText: string;
     readonly columnsToShow?: string[];
-    readonly onCollaboratorChange: (input: any) => void;
+    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
     readonly disabled?: boolean;
 }
 
@@ -39,7 +40,7 @@ export default function CollaboratorList(props: CollaboratorListProps): React.JS
                         marginBottom: 5,
                         ...(disabled ? { cursor: 'not-allowed' } : {}),
                     }}
-                    onClick={() => { !disabled && setShowAddEdit(true); }}
+                    onClick={() => !disabled && setShowAddEdit(true) }
                     disabled={disabled}
                 >
                     Add {collaboratorText}

--- a/src/components/collaborator_list/CollaboratorRow.tsx
+++ b/src/components/collaborator_list/CollaboratorRow.tsx
@@ -1,0 +1,42 @@
+import CollaboratorAddEdit from "./CollaboratorAddEdit";
+import CollaboratorSummary from "./CollaboratorSummary";
+
+interface CollaboratorRowProps {
+    readonly id: number;
+    readonly editMode: boolean;
+    collaborator: Collaborator;
+    readonly collaboratorText: string;
+    readonly collaborators: Collaborator[];
+    readonly columnsToShow: string[];
+    readonly editAction: () => void;
+    readonly deleteAction: () => void;
+    readonly closeAction: () => void;
+    readonly onCollaboratorChange: (input: any) => void;
+    readonly disabled: boolean;
+}
+
+export default function CollaboratorRow(props: CollaboratorRowProps): React.JSX.Element {
+    const { id, editMode, collaborator, collaboratorText, collaborators, columnsToShow, editAction, deleteAction, closeAction, onCollaboratorChange, disabled } = props;
+
+    return (
+        <div>
+            {editMode && (
+                <CollaboratorAddEdit
+                    id={id}
+                    collaborator={collaborator}
+                    collaboratorText={collaboratorText}
+                    collaborators={collaborators}
+                    closeAction={closeAction}
+                    onCollaboratorChange={onCollaboratorChange}
+                />)}
+            {!editMode && (
+                <CollaboratorSummary
+                    collaborator={collaborator}
+                    columnsToShow={columnsToShow}
+                    editAction={editAction}
+                    deleteAction={deleteAction}
+                    disabled={disabled}
+                />)}
+        </div>
+    );
+}

--- a/src/components/collaborator_list/CollaboratorRow.tsx
+++ b/src/components/collaborator_list/CollaboratorRow.tsx
@@ -1,5 +1,7 @@
-import CollaboratorAddEdit from "./CollaboratorAddEdit";
-import CollaboratorSummary from "./CollaboratorSummary";
+import React from 'react';
+import { Collaborator } from './Collaborator';
+import CollaboratorAddEdit from './CollaboratorAddEdit';
+import CollaboratorSummary from './CollaboratorSummary';
 
 interface CollaboratorRowProps {
     readonly id: number;
@@ -11,7 +13,7 @@ interface CollaboratorRowProps {
     readonly editAction: () => void;
     readonly deleteAction: () => void;
     readonly closeAction: () => void;
-    readonly onCollaboratorChange: (input: any) => void;
+    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
     readonly disabled: boolean;
 }
 

--- a/src/components/collaborator_list/CollaboratorSummary.tsx
+++ b/src/components/collaborator_list/CollaboratorSummary.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import CollaboratorDelete from "./CollaboratorDelete";
+import { Collaborator } from "./Collaborator";
 
 interface CollaboratorSummaryProps {
     collaborator: Collaborator;
@@ -52,7 +53,7 @@ export default function CollaboratorSummary(props: CollaboratorSummaryProps): Re
             {/* delete button */}
             <a
                 style={{ marginLeft: 10, ...buttonStyle }}
-                onClick={() => { !disabled && setShowDeleteModal(true);}}
+                onClick={() => !disabled && setShowDeleteModal(true) }
             >
                 <span
                     className='glyphicon glyphicon-trash collaborator-delete-icon'

--- a/src/components/collaborator_list/CollaboratorSummary.tsx
+++ b/src/components/collaborator_list/CollaboratorSummary.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import CollaboratorDelete from "./CollaboratorDelete";
+
+interface CollaboratorSummaryProps {
+    collaborator: Collaborator;
+    readonly columnsToShow: string[];
+    readonly editAction: () => void;
+    readonly deleteAction: () => void;
+    readonly disabled: boolean;
+}
+
+export default function CollaboratorSummary(props: CollaboratorSummaryProps): React.JSX.Element {
+    const { collaborator, columnsToShow, editAction, deleteAction, disabled } = props;
+
+    const [showDeleteModal, setShowDeleteModal] = useState(false);
+
+    const disabledStyle = {
+        cursor: 'not-allowed',
+        opacity: 0.5
+    };
+
+    const buttonStyle = disabled ? disabledStyle : {};
+
+    return (
+        <div className='collaborator-summary-card'>
+            {/* data elements to show in the row summary */}
+            {columnsToShow.map((column, index) => {
+                const columnContent = collaborator[column as keyof Collaborator];
+                return columnContent && (
+                    <div key={'collaborator_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
+                        <span>
+                            {columnContent}
+                        </span>
+                    </div>
+                );
+            })}
+            {/* edit button */}
+            <div className='collaborator-summary-edit-delete-buttons'>
+                <a
+                    style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
+                    onClick={() => !disabled && editAction()}
+                >
+                    <span
+                        className='glyphicon glyphicon-pencil caret-margin collaborator-edit-icon'
+                        aria-hidden='true'
+                        data-tip='Edit dataset'
+                        data-for='tip_edit'
+                    ></span>
+                    <span style={{ marginLeft: '1rem' }}></span>
+                </a>
+            </div>
+            {/* delete button */}
+            <a
+                style={{ marginLeft: 10, ...buttonStyle }}
+                onClick={() => { !disabled && setShowDeleteModal(true);}}
+            >
+                <span
+                    className='glyphicon glyphicon-trash collaborator-delete-icon'
+                    aria-hidden='true'
+                    data-tip='Delete dataset'
+                    data-for='tip_delete'
+                ></span>
+                <span style={{ marginLeft: '1rem' }}></span>
+            </a>
+            {/* delete modal */}
+            <CollaboratorDelete
+                collaboratorName={collaborator.name}
+                showDelete={showDeleteModal}
+                confirmAction={() => { deleteAction(); setShowDeleteModal(false); }}
+                closeAction={() => setShowDeleteModal(false)}
+            />
+        </div>
+    );
+}

--- a/src/components/collaborator_list/ModalWrapper.jsx
+++ b/src/components/collaborator_list/ModalWrapper.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import Modal from 'react-modal';
 
 export default function ModalWrapper(props) {

--- a/src/components/collaborator_list/ModalWrapper.jsx
+++ b/src/components/collaborator_list/ModalWrapper.jsx
@@ -1,0 +1,5 @@
+import Modal from 'react-modal';
+
+export default function ModalWrapper(props) {
+    return <Modal {...props} />;
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-104

### Summary

Adds a collaborator list component which can be used as follows:

```
<CollaboratorList
    collaborators={internalLabStaff}
    collaboratorText='Internal Lab Staff'
    columnsToShow={['name', 'title']}
    onCollaboratorChange={onInternalLabStaffChange}
    disabled={readOnly}
/>
```

<img width="1425" alt="Screenshot 2025-05-14 at 10 05 50 AM" src="https://github.com/user-attachments/assets/8dfed532-c60a-4910-b218-7ee0f8065d82" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
