### PR TITLE
DT-1564-parentId is a number; API requires use of referenceId.

### DIFF
--- a/cypress/component/ProgressReports/SubmitProgressReport.spec.tsx
+++ b/cypress/component/ProgressReports/SubmitProgressReport.spec.tsx
@@ -17,7 +17,7 @@ describe('SubmitProgressReport tests', () => {
     mount(
         <SubmitProgressReport
             progressReport={{}}
-            parentId="1"
+            parentReferenceId="1"
             onSuccess={() => {
             }}
             onCancel={() => {
@@ -36,7 +36,7 @@ describe('SubmitProgressReport tests', () => {
     mount(
         <SubmitProgressReport
             progressReport={{}}
-            parentId="1"
+            parentReferenceId="1"
             onSuccess={() => {
             }}
             onCancel={() => {
@@ -63,7 +63,7 @@ describe('SubmitProgressReport tests', () => {
     mount(
         <SubmitProgressReport
             progressReport={{}}
-            parentId="1"
+            parentReferenceId="1"
             onSuccess={functionSpy.successHandler}
             onCancel={() => {
             }}
@@ -84,7 +84,7 @@ describe('SubmitProgressReport tests', () => {
     mount(
         <SubmitProgressReport
             progressReport={{}}
-            parentId="1"
+            parentReferenceId="1"
             onSuccess={() => {
             }}
             onCancel={functionSpy.cancelHandler}
@@ -104,7 +104,7 @@ describe('SubmitProgressReport tests', () => {
     mount(
         <SubmitProgressReport
             progressReport={{}}
-            parentId="1"
+            parentReferenceId="1"
             onSuccess={() => {
             }}
             onCancel={() => {

--- a/src/libs/ajax/ProgressReport.ts
+++ b/src/libs/ajax/ProgressReport.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 import {Config} from '../config';
 
 export const ProgressReport = {
-  submitProgressReport: async (progressReport: object, parentId: string) => {
-    const url = `${await Config.getApiUrl()}/api/dar/v2/progress_report/` + parentId;
+  submitProgressReport: async (progressReport: object, parentReferenceId: string) => {
+    const url = `${await Config.getApiUrl()}/api/dar/v2/progress_report/` + parentReferenceId;
     return await axios.post(
         url,
         progressReport,

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -22,7 +22,7 @@ export const ProgressReportApplication = ({dar, readOnlyMode=true}: ProgressRepo
                 {dar?.parentId && <div>
                   <SubmitProgressReport
                       progressReport={dar}
-                      parentId={dar.parentId}
+                      parentReferenceId={dar.referenceId}
                       onSuccess={() => {
                       }}
                       onCancel={() => {

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -7,17 +7,17 @@ import {ConsentError} from '../../types/responseTypes';
 
 interface SubmitProgressReportProps {
   readonly progressReport: object;
-  readonly parentId: string;
+  readonly parentReferenceId: string;
   readonly onSuccess: (result: unknown) => void;
   readonly onCancel: (result: unknown) => void;
 }
 
 export default function SubmitProgressReport(props: SubmitProgressReportProps) {
-  const {progressReport, parentId, onSuccess, onCancel} = props;
+  const {progressReport, parentReferenceId, onSuccess, onCancel} = props;
 
   const submit = async () => {
     try {
-      const submittedPR = await ProgressReport.submitProgressReport(progressReport, parentId);
+      const submittedPR = await ProgressReport.submitProgressReport(progressReport, parentReferenceId);
       onSuccess(submittedPR);
     } catch (error: unknown) {
       handleError('Error: Unable to submit progress report: ', error);

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -378,7 +378,7 @@ export interface DataAccessRequest {
   dataManagementIncident: DataManagementIncident;
   researchPlans: string;
   closeOutSupplement: 'PROJECT_COMPLETED' | 'REQUESTOR_MOVED_INSTITUTION' | 'PROJECT_TRANSFERRED' | 'PROJECT_SUPERSEDED';
-  parentId?: string;
+  parentId?: number;
 }
 
 export interface DataManagementIncident {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1564](https://broadworkbench.atlassian.net/browse/DT-1564)

### Summary

Prior to DT-1564, parentId was returned as string encoded number.  DT-1564 corrected this behavior in the backend because the value stored was an integer.

When making this change, I noticed that the SubmitProgressReport component was attempting to use the v2/progress_report/{parentReferenceId} API with the string encoded parentId value.  This pull request fixes this to use the referenceId value.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
