### PR TITLE
[DT-104] Add collaborators, DMI, and DAR Closeout to Progress Report page

### DIFF
--- a/cypress/component/ProgressReports/collaborator_changes.spec.tsx
+++ b/cypress/component/ProgressReports/collaborator_changes.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges';
+import { Collaborator } from 'src/components/collaborator_list/Collaborator';
+
+describe('Collaborator Changes - Component Tests', () => {
+  let onFormChangeSpy: () => void;
+  
+  const initialCollaborators: Collaborator[] = [
+    { 
+      name: 'Test User 1', 
+      title: 'Researcher',
+      uuid: '1',
+      eraCommonsId: 'user1',
+      email: 'user1@example.com',
+      institution: 'Test Institution'
+    },
+    { 
+      name: 'Test User 2', 
+      title: 'Assistant',
+      uuid: '2',
+      eraCommonsId: 'user2',
+      email: 'user2@example.com',
+      institution: 'Test Institution'
+    }
+  ];
+  
+  const mountComponent = (customState = {}) => {
+    const formState = { ...customState };
+    
+    const props = {
+      readOnly: false,
+      formState,
+      onFormChange: onFormChangeSpy
+    };
+    
+    return mount(<CollaboratorChanges {...props} />);
+  };
+  
+  beforeEach(() => {
+    onFormChangeSpy = cy.stub().as('formChangeStub');
+    mountComponent();
+  });
+
+  it('renders the component correctly', () => {
+    cy.get('[data-cy=dar-closeout]').should('exist');
+    cy.contains('Step 2: Add or Remove Collaborators').should('be.visible');
+    cy.contains('2.1 Internal Lab Staff').should('be.visible');
+    cy.contains('2.2 Internal Collaborators').should('be.visible');
+    cy.contains('2.3 External Collaborators').should('be.visible');
+  });
+
+  it('renders all three collaborator sections', () => {
+    cy.contains('Internal Lab Staff').should('exist');
+    cy.contains('Internal Collaborators').should('exist');
+    cy.contains('External Collaborators').should('exist');
+  });
+
+  it('displays preloaded internal lab staff', () => {
+    mountComponent({ internalLabStaff: initialCollaborators });
+    
+    cy.contains('Test User 1').should('be.visible');
+    cy.contains('Test User 2').should('be.visible');
+    cy.contains('Researcher').should('be.visible');
+    cy.contains('Assistant').should('be.visible');
+  });
+
+  it('displays preloaded internal collaborators', () => {
+    mountComponent({ internalCollaborators: initialCollaborators });
+    
+    cy.contains('Test User 1').should('be.visible');
+    cy.contains('Test User 2').should('be.visible');
+  });
+
+  it('displays preloaded external collaborators', () => {
+    mountComponent({ externalCollaborators: initialCollaborators });
+    
+    cy.contains('Test User 1').should('be.visible');
+    cy.contains('Test User 2').should('be.visible');
+  });
+
+  it('renders in read-only mode correctly', () => {
+    const props = {
+      readOnly: true,
+      formState: { internalLabStaff: initialCollaborators },
+      onFormChange: onFormChangeSpy
+    };
+    
+    mount(<CollaboratorChanges {...props} />);
+
+    cy.contains('Test User 1').should('be.visible');
+    cy.contains('Test User 2').should('be.visible');
+  });
+
+  it('handles empty collaborator lists', () => {
+    mountComponent({
+      internalLabStaff: [],
+      internalCollaborators: [],
+      externalCollaborators: []
+    });
+    
+    cy.contains('Internal Lab Staff').should('exist');
+    cy.contains('Internal Collaborators').should('exist');
+    cy.contains('External Collaborators').should('exist');
+  });
+
+  it('displays correct description text for each collaborator type', () => {
+    mountComponent();
+    
+    cy.contains('Please add Internal Lab Staff here').should('be.visible');
+    cy.contains('Please add Internal Collaborators here').should('be.visible');
+    cy.contains('Please list External collaborators here').should('be.visible');
+
+    cy.contains('Internal Lab Staff are defined as users of data from this Data Access Request').should('be.visible');
+    cy.contains('Internal Collaborators are defined as individuals who are not under the direct supervision of the PI').should('be.visible');
+    cy.contains('External Collaboratos are not employees of the Requesting PI').should('be.visible');
+  });
+});

--- a/cypress/component/ProgressReports/dar_closeout.spec.tsx
+++ b/cypress/component/ProgressReports/dar_closeout.spec.tsx
@@ -1,14 +1,25 @@
 import React from 'react';
 import { mount } from 'cypress/react';
-import DarCloseout from '../../../src/pages/progress_reports/DarCloseout';
-
-const props = {
-  state: 'step4',
-};
+import DarCloseout from 'src/pages/progress_reports/DarCloseout';
 
 describe('DAR Closeout - Component Tests', () => {
+  let onFormChangeSpy: () => void;
+  
+  const mountComponent = (customState = {}) => {
+    const formState = { ...customState };
+    
+    const props = {
+      readOnly: false,
+      formState,
+      onFormChange: onFormChangeSpy
+    };
+    
+    return mount(<DarCloseout {...props} />);
+  };
+  
   beforeEach(() => {
-    mount(<DarCloseout {...props}/>);
+    onFormChangeSpy = cy.stub().as('formChangeStub');
+    mountComponent();
   });
 
   it('renders the component correctly', () => {
@@ -30,18 +41,16 @@ describe('DAR Closeout - Component Tests', () => {
     cy.get('#closeoutOtherContext').should('not.exist');
   });
 
-  it('shows "Other" reason text area when "Other" checkbox is selected', () => {
-    cy.get('#closeoutOther').click();
+  it('shows "Other" reason text area when state is true', () => {
+    mountComponent({ closeoutOther: true });
     cy.get('#closeoutOtherContext').should('exist');
   });
 
-  it('hides "Other" reason text area when "Other" checkbox is unselected', () => {
-    // First select the checkbox to show the text area
-    cy.get('#closeoutOther').click();
+  it('hides "Other" reason text area when state is false', () => {
+    mountComponent({ closeoutOther: true });
     cy.get('#closeoutOtherContext').should('exist');
-    
-    // Then unselect to hide the text area
-    cy.get('#closeoutOther').click();
+
+    mountComponent({ closeoutOther: false });
     cy.get('#closeoutOtherContext').should('not.exist');
   });
 
@@ -57,7 +66,7 @@ describe('DAR Closeout - Component Tests', () => {
   });
 
   it('allows entering other closeout reason text', () => {
-    cy.get('#closeoutOther').click();
+    mountComponent({ closeoutOther: true });
     
     const testDescription = 'This is a test description for the other closeout reason.';
     cy.get('#closeoutOtherContext').type(testDescription);
@@ -65,7 +74,7 @@ describe('DAR Closeout - Component Tests', () => {
   });
 
   it('enforces character limit on other closeout reason', () => {
-    cy.get('#closeoutOther').click();
+    mountComponent({ closeoutOther: true });
     
     // Generate a string longer than the 2200 character limit
     const longText = 'A'.repeat(2300);

--- a/cypress/component/ProgressReports/data_management_incident.spec.tsx
+++ b/cypress/component/ProgressReports/data_management_incident.spec.tsx
@@ -1,14 +1,25 @@
 import React from 'react';
 import { mount } from 'cypress/react';
-import DataManagementIncident from '../../../src/pages/progress_reports/DataManagementIncident';
-
-const props = {
-  state: 'step3',
-};
+import DataManagementIncident from 'src/pages/progress_reports/DataManagementIncident';
 
 describe('Data Management Incident - Component Tests', () => {
+  let onFormChangeSpy: () => void;
+  
+  const mountComponent = (customState = {}) => {
+    const formState = { ...customState };
+    
+    const props = {
+      readOnly: false,
+      formState,
+      onFormChange: onFormChangeSpy
+    };
+    
+    return mount(<DataManagementIncident {...props} />);
+  };
+  
   beforeEach(() => {
-    mount(<DataManagementIncident {...props}/>);
+    onFormChangeSpy = cy.stub().as('formChangeStub');
+    mountComponent();
   });
 
   it('renders the component correctly', () => {
@@ -25,7 +36,7 @@ describe('Data Management Incident - Component Tests', () => {
   });
 
   it('shows incident details form when "Yes" is selected', () => {
-    cy.get('#dmiYesNo_yes').click();
+    mountComponent({ dmiYesNo: true });
     
     cy.contains('Please select any of the following that describe the nature of this Data Management Incident').should('be.visible');
     cy.get('#dmiCombination').should('exist');
@@ -40,18 +51,18 @@ describe('Data Management Incident - Component Tests', () => {
   });
 
   it('hides incident details form when "No" is selected', () => {
-    // First select Yes to show the form
-    cy.get('#dmiYesNo_yes').click();
+    // First mount with Yes to show the form
+    mountComponent({ dmiYesNo: true });
     cy.get('#dmiCombination').should('exist');
     
-    // Then select No to hide the form
-    cy.get('#dmiYesNo_no').click();
+    // Then mount with No to hide the form
+    mountComponent({ dmiYesNo: false });
     cy.get('#dmiCombination').should('not.exist');
     cy.get('#dmiDescription').should('not.exist');
   });
 
   it('allows checking multiple incident types', () => {
-    cy.get('#dmiYesNo_yes').click();
+    mountComponent({ dmiYesNo: true });
     
     cy.get('#dmiCombination').click();
     cy.get('#dmiIdentification').click();
@@ -64,7 +75,7 @@ describe('Data Management Incident - Component Tests', () => {
   });
 
   it('allows entering incident description text', () => {
-    cy.get('#dmiYesNo_yes').click();
+    mountComponent({ dmiYesNo: true });
     
     const testDescription = 'This is a test description of a data management incident.';
     cy.get('#dmiDescription').type(testDescription);
@@ -72,7 +83,7 @@ describe('Data Management Incident - Component Tests', () => {
   });
 
   it('enforces character limit on incident description', () => {
-    cy.get('#dmiYesNo_yes').click();
+    mountComponent({ dmiYesNo: true });
     
     // Generate a string longer than the 2200 character limit
     const longText = 'A'.repeat(2300);
@@ -83,7 +94,7 @@ describe('Data Management Incident - Component Tests', () => {
   });
 
   it('allows toggling checkboxes on and off', () => {
-    cy.get('#dmiYesNo_yes').click();
+    mountComponent({ dmiYesNo: true });
     
     cy.get('#dmiCombination').click();
     cy.get('#dmiCombination').should('be.checked');

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,7 +1,11 @@
-import React, {useState, useEffect} from 'react';
-import {DataAccessRequest, Dataset} from 'src/types/model';
-import SubmitProgressReport from '../progress_reports/SubmitProgressReport';
-import SelectableDatasets from '../../pages/dar_application/SelectableDatasets';
+import React, { useEffect, useState } from 'react';
+import { DataAccessRequest, Dataset } from 'src/types/model';
+import SelectableDatasets from 'src/pages/dar_application/SelectableDatasets';
+import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressReport';
+import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges';
+import DataManagementIncident from 'src/pages/progress_reports/DataManagementIncident';
+import DarCloseout from 'src/pages/progress_reports/DarCloseout';
+import { FormState } from 'src/pages/progress_reports/ProgressReportFormState';
 
 type ProgressReportApplicationProps = {
     dar?: DataAccessRequest, // Dar will be empty if this is an application
@@ -10,55 +14,65 @@ type ProgressReportApplicationProps = {
     readOnlyMode?: boolean
 };
 
-interface FormStateInterface {
-    datasetIds: number[];
-}
+export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMode = true }: ProgressReportApplicationProps) => {
+    const [formState, setFormState] = useState<FormState>({});
 
-export const ProgressReportApplication = ({dar, parentDar, datasets, readOnlyMode=true}: ProgressReportApplicationProps) => {
-    const [_formState, setFormState] = useState<FormStateInterface>({datasetIds: []});
+    const onFormChange = (newState: Partial<FormState>) => {
+        setFormState(prevState => ({
+            ...prevState,
+            ...newState
+        }));
+    };
 
+    /* required because the datasets state changes during component mount */
     useEffect(() => {
-        setFormState({datasetIds: datasets.map((ds) => ds.datasetId)});
+        onFormChange({ datasetIds: datasets.map((ds) => ds.datasetId) });
     }, [datasets]);
 
     return (
         <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
             {!readOnlyMode && <h3>Submit a progress report</h3>}
-                {/*TODO we'll want each of these to be components that accept a 'readOnly' flag*/}
-                <div>
-                    <h4>Progress Report Summary</h4>
-                    {dar?.progressReportSummary ?? "PLACEHOLDER Progress Report Summary"}
-                </div>
-                <div>
-                    <h4>Intellectual Property Summary</h4>
-                    {dar?.intellectualPropertySummary ?? "PLACEHOLDER Intellectual Property Summary"}
-                </div>
-                <div data-cy='remove-datasets'>
-                    <div className='progress-report-step-card'>
-                        <h2>Step 3: Dataset(s) in this DAR</h2>
-                        <p style={{ marginBottom: '1rem' }}>Currently selected datasets:</p>
-                        <SelectableDatasets
-                            disabled={readOnlyMode}
-                            datasets={datasets}
-                            setSelectedDatasets={(selectedDatasets) => {
-                                setFormState((prevState) => ({
-                                    ...prevState,
-                                    datasetIds: selectedDatasets.map((ds) => ds.datasetId)
-                                }));
-                            }}
-                        />
-                    </div>
-                </div>
-                {!readOnlyMode && parentDar && <div>
-                  <SubmitProgressReport
-                      progressReport={dar}
-                      parentReferenceId={parentDar.referenceId}
-                      onSuccess={() => {
-                      }}
-                      onCancel={() => {
-                      }}
-                  />
-                </div>}
+            {/*TODO we'll want each of these to be components that accept a 'readOnly' flag*/}
+            <div>
+                <h4>Progress Report Summary</h4>
+                {dar?.progressReportSummary ?? "PLACEHOLDER Progress Report Summary"}
             </div>
+            <div>
+                <h4>Intellectual Property Summary</h4>
+                {dar?.intellectualPropertySummary ?? "PLACEHOLDER Intellectual Property Summary"}
+            </div>
+            <div data-cy='remove-datasets'>
+                <div className='progress-report-step-card'>
+                    <h2>Step 3: Dataset(s) in this DAR</h2>
+                    <p style={{ marginBottom: '1rem' }}>Currently selected datasets:</p>
+                    <SelectableDatasets
+                        disabled={readOnlyMode}
+                        datasets={datasets}
+                        setSelectedDatasets={(selectedDatasets: Dataset[]) => {
+                            onFormChange({ datasetIds: selectedDatasets.map((ds) => ds.datasetId) });
+                        }}
+                    />
+                </div>
+            </div>
+            <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
+                <CollaboratorChanges readOnly={readOnlyMode} formState={formState} onFormChange={onFormChange} />
+            </div>
+            <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
+                <DataManagementIncident readOnly={readOnlyMode} formState={formState} onFormChange={onFormChange} />
+            </div>
+            <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
+                <DarCloseout readOnly={readOnlyMode} formState={formState} onFormChange={onFormChange} />
+            </div>
+            {!readOnlyMode && parentDar && <div>
+                <SubmitProgressReport
+                    progressReport={dar}
+                    parentReferenceId={parentDar.referenceId}
+                    onSuccess={() => {
+                    }}
+                    onCancel={() => {
+                    }}
+                />
+            </div>}
+        </div >
     )
 };

--- a/src/pages/progress_reports/CollaboratorChanges.tsx
+++ b/src/pages/progress_reports/CollaboratorChanges.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { FormState } from 'src/pages/progress_reports/ProgressReportFormState';
+import { Collaborator } from 'src/components/collaborator_list/Collaborator';
+import CollaboratorList from 'src/components/collaborator_list/CollaboratorList';
+
+interface CollaboratorProps {
+    readonly readOnly: boolean;
+    formState: FormState;
+    onFormChange: (newState: Partial<FormState>) => void;
+}
+
+export default function CollaboratorChanges(props: CollaboratorProps): React.JSX.Element {
+    const { readOnly, formState, onFormChange } = props;
+
+    const [internalLabStaff, setInternalLabStaff] = useState(formState.internalLabStaff || []);
+    const [internalCollaborators, setInternalCollaborators] = useState(formState.internalCollaborators || []);
+    const [externalCollaborators, setExternalCollaborators] = useState(formState.externalCollaborators || []);
+
+    const onCollaboratorChange = (key: string, setState: React.Dispatch<Collaborator[]>, collaborators: Collaborator[]) => {
+        onFormChange({ [key]: collaborators });
+        setState(collaborators);
+    };
+
+    const onInternalLabStaffChange = (collaborators: Collaborator[]) => {
+        onCollaboratorChange('internalLabStaff', setInternalLabStaff, collaborators);
+    }
+
+    const onInternalCollaboratorsChange = (collaborators: Collaborator[]) => {
+        onCollaboratorChange('internalCollaborators', setInternalCollaborators, collaborators);
+    }
+
+    const onExternalCollaboratorsChange = (collaborators: Collaborator[]) => {
+        onCollaboratorChange('externalCollaborators', setExternalCollaborators, collaborators);
+    }
+
+    return (
+        <div data-cy='dar-closeout'>
+            <div className='progress-report-step-card'>
+                <h2>Step 2: Add or Remove Collaborators</h2>
+
+                <div className='progress-report-row'>
+                    <div>
+                        <h3>2.1 Internal Lab Staff</h3>
+                        <p>
+                            Please add Internal Lab Staff here. Internal Lab Staff are defined as users of data from this Data Access Request, including any data that are downloaded or utilized in the cloud. Please do not list External Collaborators or Internal Collaborators at a PI or equivalent level here.
+                        </p>
+                    </div>
+                    <CollaboratorList
+                        collaborators={internalLabStaff}
+                        collaboratorText='Internal Lab Staff'
+                        columnsToShow={['name', 'title']}
+                        onCollaboratorChange={onInternalLabStaffChange}
+                        disabled={readOnly}
+                    />
+                </div>
+                <div className='progress-report-row'>
+                    <div>
+                        <h3>2.2 Internal Collaborators</h3>
+                        <p>
+                            Please add Internal Collaborators here. Internal Collaborators are defined as individuals who are not under the direct supervision of the PI (e.g., not a member of the PI&apos;s laboratory) who assists with the PI&apos;s research project involving controlled-access data subject to the NIH GDS Policy. Internal collaborators are employees of the Requesting PI&apos;s institution and work at the same location/campus as the PI. Internal Collaborators must be at the PI or equivalent level and are required to have a Library Card in order to access data through this request. Internal Collaborators will have Data Downloader/Approver status so that they may add their own relevant Internal Lab Staff. Internal Collaborators will not be required to submit an independent DAR to collaborate on this project.
+                        </p>
+                    </div>
+                    <CollaboratorList
+                        collaborators={internalCollaborators}
+                        collaboratorText='Internal Collaborators'
+                        columnsToShow={['name', 'title']}
+                        onCollaboratorChange={onInternalCollaboratorsChange}
+                        disabled={readOnly}
+                    />
+                </div>
+                <div className='progress-report-row'>
+                    <div>
+                        <h3>2.3 External Collaborators</h3>
+                        <p>
+                            Please list External collaborators here. External Collaboratos are not employees of the Requesting PI&apos;s institution and/or do not work at the same location as the PI, and consequently must be independently approved to access controlled-access data subject to the GDS Policy. External Collaborators must be at the PI or equivalent level and are not required to have a Library Card in order to access data, although it is encouraged. Note: External Collaborators must submit an independent DAR approved by their signing Official to collaborate on this project. External Collaborators will be able to add their Lab Staff, as needed, via their independent DAR. Approval of this DAR does not indicate approval of the External Collaborators listed.
+                        </p>
+                    </div>
+                    <CollaboratorList
+                        collaborators={externalCollaborators}
+                        collaboratorText='External Collaborators'
+                        columnsToShow={['name', 'title']}
+                        onCollaboratorChange={onExternalCollaboratorsChange}
+                        disabled={readOnly}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/pages/progress_reports/DarCloseout.tsx
+++ b/src/pages/progress_reports/DarCloseout.tsx
@@ -1,22 +1,15 @@
-import React, { useState } from 'react';
-import { FormField, FormFieldTypes } from '../../components/forms/forms';
-
-interface FormStateInterface {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
-}
+import React from 'react';
+import { FormField, FormFieldTypes } from 'src/components/forms/forms';
+import { FormFieldChange, FormState } from 'src/pages/progress_reports/ProgressReportFormState';
 
 interface DarCloseoutProps {
-    readonly state: string;
+    readonly readOnly: boolean;
+    formState: FormState;
+    onFormChange: (newState: Partial<FormState>) => void;
 }
 
-interface FormFieldChange {
-    key: string;
-    value: boolean | string;
-}
-
-export default function DarCloseout(_props: DarCloseoutProps): React.JSX.Element {
-    const [formState, setFormState] = useState<FormStateInterface>({});
+export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element {
+    const { readOnly, formState, onFormChange } = props;
 
     return (
         <div data-cy='dar-closeout'>
@@ -39,40 +32,45 @@ export default function DarCloseout(_props: DarCloseoutProps): React.JSX.Element
                             type={FormFieldTypes.CHECKBOX}
                             toggleText='The Requestor has completed the project'
                             onChange={({ key, value }: FormFieldChange) => {
-                                setFormState({ ...formState, [key]: value });
+                                onFormChange({ [key]: value });
                             }}
+                            disabled={readOnly}
                         />
                         <FormField
                             id='closeoutMoved'
                             type={FormFieldTypes.CHECKBOX}
                             toggleText='The Requestor has moved institutions (if the project will continue in a new institution or by a new PI, they must go through Project Transfer)'
                             onChange={({ key, value }: FormFieldChange) => {
-                                setFormState({ ...formState, [key]: value });
+                                onFormChange({ [key]: value });
                             }}
+                            disabled={readOnly}
                         />
                         <FormField
                             id='closeoutTransferred'
                             type={FormFieldTypes.CHECKBOX}
                             toggleText='The project is being transferred to a new Requestor at the same institution'
                             onChange={({ key, value }: FormFieldChange) => {
-                                setFormState({ ...formState, [key]: value });
+                                onFormChange({ [key]: value });
                             }}
+                            disabled={readOnly}
                         />
                         <FormField
                             id='closeoutSuperceded'
                             type={FormFieldTypes.CHECKBOX}
                             toggleText='The project is being superceded by a new project'
                             onChange={({ key, value }: FormFieldChange) => {
-                                setFormState({ ...formState, [key]: value });
+                                onFormChange({ [key]: value });
                             }}
+                            disabled={readOnly}
                         />
                         <FormField
                             id='closeoutOther'
                             type={FormFieldTypes.CHECKBOX}
                             toggleText='Other'
                             onChange={({ key, value }: FormFieldChange) => {
-                                setFormState({ ...formState, [key]: value });
+                                onFormChange({ [key]: value });
                             }}
+                            disabled={readOnly}
                         />
                         {formState.closeoutOther === true &&
                             <div style={{ marginTop: '20px' }}>
@@ -83,8 +81,9 @@ export default function DarCloseout(_props: DarCloseoutProps): React.JSX.Element
                                     rows={6}
                                     maxLength={2200}
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                             </div>
                         }

--- a/src/pages/progress_reports/DataManagementIncident.tsx
+++ b/src/pages/progress_reports/DataManagementIncident.tsx
@@ -1,34 +1,17 @@
-import React, { useState } from 'react';
-import { FormField, FormFieldTypes } from '../../components/forms/forms';
+import React from 'react';
+import { FormField, FormFieldTypes } from 'src/components/forms/forms';
+import { FormFieldChange, FormState } from 'src/pages/progress_reports/ProgressReportFormState';
 
 const titleStyle = { fontSize: '24px', fontWeight: 500, color: '#333333' };
 
-interface FormStateInterface {
-    dmiYesNo?: boolean;
-    dmiCombination?: boolean;
-    dmiIdentification?: boolean;
-    dmiSharing?: boolean;
-    dmiSecurity?: boolean;
-    dmiAcknowledgement?: boolean;
-    dmiPublication?: boolean;
-    dmiFalsification?: boolean;
-    dmiOther?: boolean;
-    dmiDescription?: string;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key: string]: any;
-}
-
 interface DataManagementIncidentProps {
-    readonly state: string;
+    readonly readOnly: boolean;
+    formState: FormState;
+    onFormChange: (newState: Partial<FormState>) => void;
 }
 
-interface FormFieldChange {
-    key: string;
-    value: boolean | string;
-}
-
-export default function DataManagementIncident(_props: DataManagementIncidentProps): React.JSX.Element {
-    const [formState, setFormState] = useState<FormStateInterface>({});
+export default function DataManagementIncident(props: DataManagementIncidentProps): React.JSX.Element {
+    const { readOnly, formState, onFormChange } = props;
 
     return (
         <div data-cy='data-management-incident'>
@@ -45,8 +28,21 @@ export default function DataManagementIncident(_props: DataManagementIncidentPro
                             description='Have there been any incidents related to mismanagement or misuse of data?'
                             orientation='horizontal'
                             onChange={({ key, value }: FormFieldChange) => {
-                                setFormState({ ...formState, [key]: value });
+                                if (value === false) {
+                                    onFormChange({
+                                        dmiCombination: false,
+                                        dmiIdentification: false,
+                                        dmiSharing: false,
+                                        dmiSecurity: false,
+                                        dmiAcknowledgement: false,
+                                        dmiPublication: false,
+                                        dmiFalsification: false,
+                                        dmiOther: false
+                                    });
+                                }
+                                onFormChange({ [key]: value });
                             }}
+                            disabled={readOnly}
                         />
                     </div>
                     {formState.dmiYesNo === true &&
@@ -58,64 +54,72 @@ export default function DataManagementIncident(_props: DataManagementIncidentPro
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Inappropriate combination or analysis of the requested datasets with unapproved datasets'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiIdentification'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Intentional or accidental identification of participants or generation of data which makes them easily identifiable'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiSharing'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Distribution of the data to an individual or institution beyond those specified in the approved Data Access Request (DAR)'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiSecurity'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Failure to adhere to NIH Security Best Practices for Controlled-Access Data'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiAcknowledgement'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Failure to acknowledge the investigator(s) who generated the data, the funding source, accession numbers of the dataset'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiPublication'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Analysis and/or publication of a study using the data for the research purpose other than the approved research use'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiFalsification'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Fabrication or falsification of data and/or results'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                                 <FormField
                                     id='dmiOther'
                                     type={FormFieldTypes.CHECKBOX}
                                     toggleText='Other: such as inadvertent data release or breach of security'
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                             </div>
                             <div style={{ marginTop: '20px' }}>
@@ -128,8 +132,9 @@ export default function DataManagementIncident(_props: DataManagementIncidentPro
                                     rows={6}
                                     maxLength={2200}
                                     onChange={({ key, value }: FormFieldChange) => {
-                                        setFormState({ ...formState, [key]: value });
+                                        onFormChange({ [key]: value });
                                     }}
+                                    disabled={readOnly}
                                 />
                             </div>
                         </>

--- a/src/pages/progress_reports/ProgressReportFormState.tsx
+++ b/src/pages/progress_reports/ProgressReportFormState.tsx
@@ -1,0 +1,9 @@
+export interface FormState {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: any;
+}
+
+export interface FormFieldChange {
+    key: string;
+    value: boolean | string;
+}


### PR DESCRIPTION
Requires #2866 to go in first. I recommend reviewing and excluding whitespace changes.

### Addresses

https://broadworkbench.atlassian.net/browse/DT-104

### Summary

Add collaborators, DMI, and Dar Closeout to Progress Report page. Refactors the form state so it only exists on the parent form.

![Screenshot 2025-05-15 at 12-08-01 Broad Data Use Oversight System](https://github.com/user-attachments/assets/87f098cb-f989-4754-8765-4d639e65e615)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
