### PR TITLE
DT-1600: Add Update button for non-prod DARs

### DIFF
--- a/cypress/component/DarCollectionTable/actions.spec.jsx
+++ b/cypress/component/DarCollectionTable/actions.spec.jsx
@@ -1,10 +1,10 @@
-/* eslint-disable no-undef */
 import { React } from 'react';
 import { mount } from 'cypress/react';
-import Actions from '../../../src/components/dar_collection_table/Actions';
+import Actions from 'src/components/dar_collection_table/Actions';
 import {cloneDeep} from 'lodash/fp';
-import { Navigation } from '../../../src/libs/utils';
-import { Storage } from '../../../src/libs/storage';
+import { Navigation } from 'src/libs/utils';
+import { Storage } from 'src/libs/storage';
+import EnvironmentUtils from 'src/utils/EnvironmentUtils.js';
 
 let propCopy;
 const collectionId = 1;
@@ -68,8 +68,7 @@ beforeEach(() => {
 describe('Actions - Container', () => {
   it('renders the actions container div', () => {
     mount(<Actions {...propCopy}/>);
-    const container = cy.get('.chair-actions');
-    container.should('exist');
+    cy.get('.chair-actions').should('exist');
   });
 });
 
@@ -77,14 +76,13 @@ describe('Actions - Open Button', () => {
   it('should render the open button if there is a an Open Action', () => {
     propCopy.actions = ['Open'];
     mount(<Actions {...propCopy} />);
-    const openButton = cy.get(`#chair-open-${collectionId}`);
-    openButton.should('exist');
+    cy.get(`#chair-open-${collectionId}`).should('exist');
   });
 
   it('should not render Open Button if there is no valid election for opening/re-opening', () => {
     propCopy.actions = [];
     mount(<Actions {...propCopy} />);
-    const openButton = cy.get(`#chair-open-${collectionId}`);
+    cy.get(`#chair-open-${collectionId}`);
     openButton.should('not.exist');
   });
 });
@@ -93,15 +91,13 @@ describe('Actions - Close Button', () => {
   it('should render if there is a valid election for canceling (all open elections)', () => {
     propCopy.actions = ['Cancel', 'Vote'];
     mount(<Actions {...propCopy} />);
-    const closeButton = cy.get(`#chair-cancel-${collectionId}`);
-    closeButton.should('exist');
+    cy.get(`#chair-cancel-${collectionId}`).should('exist');
   });
 
   it('should not render if there is no valid election for canceling (no open elections)', () => {
     propCopy.actions = [];
     mount(<Actions {...propCopy} />);
-    const closeButton = cy.get(`#chair-cancel-${collectionId}`);
-    closeButton.should('not.exist');
+    cy.get(`#chair-cancel-${collectionId}`).should('not.exist');
   });
 });
 
@@ -109,14 +105,12 @@ describe('Actions - Vote Button', () => {
   it('should not render if relevant elections are not votable', () => {
     propCopy.actions = [];
     mount(<Actions {...propCopy} />);
-    const voteButton = cy.get(`#chair-vote-${collectionId}`);
-    voteButton.should('not.exist');
+    cy.get(`#chair-vote-${collectionId}`).should('not.exist');
   });
   it('should render if all relevant elections are votable', () => {
     propCopy.actions = ['Vote'];
     mount(<Actions {...propCopy} />);
-    const voteButton = cy.get(`#chair-vote-${collectionId}`);
-    voteButton.should('exist');
+    cy.get(`#chair-vote-${collectionId}`).should('exist');
   });
 });
 
@@ -124,14 +118,12 @@ describe('Actions - Update Button', () => {
   it('should not render if relevant elections are not votable', () => {
     propCopy.actions = [];
     mount(<Actions {...propCopy} />);
-    const voteButton = cy.get(`#chair-update-${collectionId}`);
-    voteButton.should('not.exist');
+    cy.get(`#chair-update-${collectionId}`).should('not.exist');
   });
   it('should render if all relevant elections are votable', () => {
     propCopy.actions = ['Update'];
     mount(<Actions {...propCopy} />);
-    const voteButton = cy.get(`#chair-update-${collectionId}`);
-    voteButton.should('exist');
+    cy.get(`#chair-update-${collectionId}`).should('exist');
   });
 });
 
@@ -207,6 +199,22 @@ describe('Researcher Actions - Draft', () => {
     cy.get(`#researcher-cancel-${refId1}`).should('exist');
     cy.get(`#researcher-delete-${refId1}`).should('exist');
     cy.get(`#researcher-revise-${refId1}`).should('exist');
+  });
+});
+
+describe('Researcher Actions - Update Button', () => {
+  it('renders the update button if the collection is updatable', () => {
+    cy.stub(Storage, 'getEnv').returns(EnvironmentUtils.envGroups.NON_PROD[0]);
+    propCopy.consoleType = 'researcher';
+    propCopy.actions = ['Resume', 'Create_Progress_Report'];
+    mount(<Actions {...propCopy} />);
+    cy.get(`#researcher-create-progress-report-${collectionId}`).should('exist');
+  });
+  it('does not render if the election is not updatable', () => {
+    propCopy.consoleType = 'researcher';
+    propCopy.actions = ['Review'];
+    mount(<Actions {...propCopy} />);
+    cy.get(`#researcher-create-progress-report-${collectionId}`).should('not.exist');
   });
 });
 

--- a/cypress/component/DarCollectionTable/actions.spec.jsx
+++ b/cypress/component/DarCollectionTable/actions.spec.jsx
@@ -82,8 +82,7 @@ describe('Actions - Open Button', () => {
   it('should not render Open Button if there is no valid election for opening/re-opening', () => {
     propCopy.actions = [];
     mount(<Actions {...propCopy} />);
-    cy.get(`#chair-open-${collectionId}`);
-    openButton.should('not.exist');
+    cy.get(`#chair-open-${collectionId}`).should('not.exist');
   });
 });
 

--- a/cypress/component/DarCollectionTable/actions.spec.jsx
+++ b/cypress/component/DarCollectionTable/actions.spec.jsx
@@ -209,7 +209,7 @@ describe('Researcher Actions - Update Button', () => {
     mount(<Actions {...propCopy} />);
     cy.get(`#researcher-create-progress-report-${collectionId}`).should('exist');
   });
-  it('does not render if the election is not updatable', () => {
+  it('does not render if the collection is not updatable', () => {
     propCopy.consoleType = 'researcher';
     propCopy.actions = ['Review'];
     mount(<Actions {...propCopy} />);

--- a/src/components/dar_collection_table/Actions.jsx
+++ b/src/components/dar_collection_table/Actions.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import TableIconButton from '../TableIconButton';
-import { Styles, Theme } from '../../libs/theme';
-import { Block, Delete } from '@mui/icons-material';
+import {Styles, Theme} from '../../libs/theme';
+import {Block, Delete} from '@mui/icons-material';
 import SimpleButton from '../SimpleButton';
-import { useHistory } from 'react-router-dom';
-import { Notifications } from '../../libs/utils';
-import { includes, toLower } from 'lodash/fp';
+import {useHistory} from 'react-router-dom';
+import {Notifications} from '../../libs/utils';
+import {includes, toLower} from 'lodash/fp';
+import {checkEnv, envGroups} from 'src/utils/EnvironmentUtils';
 
 const duosBlue = '#0948B7';
 const cancelGray = '#333F52';
@@ -15,8 +16,8 @@ const baseCancelButtonStyle = Object.assign(
   {},
   Styles.TABLE.TABLE_ICON_BUTTON,
   {color: cancelGray},
-  { alignItems: 'center' },
-  { marginRight: '5px' }
+  {alignItems: 'center'},
+  {marginRight: '5px'}
 );
 
 const hoverPrimaryButtonStyle = {
@@ -28,7 +29,7 @@ const hoverPrimaryButtonStyle = {
 const redirectToDARApplication = (darCollectionId, history) => {
   try {
     history.push(`/dar_application_review/${darCollectionId}`);
-  } catch (error) {
+  } catch (_error) {
     Notifications.showError({
       text: 'Error: Cannot view target Data Access Request'
     });
@@ -40,8 +41,13 @@ const resumeDARApplication = (referenceId, history) => {
   history.push(`/dar_application/${referenceId}`);
 };
 
+// redirect function from DAR Collection to create a Progress Report Application
+const createProgressReport = (collectionId, history) => {
+  history.push(`/progress_report_application/${collectionId}`);
+};
+
 export default function Actions(props) {
-  const { showConfirmationModal, collection, goToVote, consoleType, actions = [], status } = props;
+  const {showConfirmationModal, collection, goToVote, consoleType, actions = [], status} = props;
   const collectionId = collection.darCollectionId;
   const uniqueId = (collectionId ? collectionId : collection.referenceIds[0]);
 
@@ -172,6 +178,27 @@ export default function Actions(props) {
     onClick: () => showConfirmationModal(collection, 'revise'),
   };
 
+  const createProgressReportButtonAttributes = {
+    keyProp: `${consoleType}-create-progress-report-${uniqueId}`,
+    onClick: () => {
+      createProgressReport(collection.darCollectionId, history)
+    },
+    label: 'Update',
+    baseColor: 'white',
+    fontColor: Theme.palette.secondary,
+    hoverStyle: {
+      backgroundColor: Theme.palette.secondary,
+      color: 'white'
+    },
+    additionalStyle: {
+      padding: '3%',
+      fontSize: '1.45rem',
+      fontWeight: 600,
+      border: `1px solid ${Theme.palette.secondary}`,
+      marginRight: 5
+    },
+  }
+
   return (
     <div
       className={`${consoleType}-actions`}
@@ -192,6 +219,8 @@ export default function Actions(props) {
       {actions.includes('Review') && <SimpleButton {...reviewButtonAttributes} />}
       {actions.includes('Delete') && <TableIconButton {...deleteButtonAttributes} />}
       {actions.includes('Cancel') && <TableIconButton {...cancelButtonAttributes} />}
+      {checkEnv(envGroups.NON_PROD) && actions.includes('Create_Progress_Report') &&
+        <SimpleButton {...createProgressReportButtonAttributes} />}
     </div>
   );
 }

--- a/src/components/dar_collection_table/Actions.jsx
+++ b/src/components/dar_collection_table/Actions.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import TableIconButton from '../TableIconButton';
-import {Styles, Theme} from '../../libs/theme';
+import TableIconButton from 'src/components/TableIconButton';
+import {Styles, Theme} from 'src/libs/theme';
 import {Block, Delete} from '@mui/icons-material';
-import SimpleButton from '../SimpleButton';
+import SimpleButton from 'src/components/SimpleButton';
 import {useHistory} from 'react-router-dom';
-import {Notifications} from '../../libs/utils';
+import {Notifications} from 'src/libs/utils';
 import {includes, toLower} from 'lodash/fp';
 import {checkEnv, envGroups} from 'src/utils/EnvironmentUtils';
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1600

### Summary
Adds an update button for DAR Collection Summaries that have an action for `Create_Progress_Report`. This feature is only available for non-prod environments. We'll need a code change to remove the environment check to fully release this to production.

Clicking on the `UPDATE` button:
![Screenshot 2025-05-19 at 2 43 21 PM](https://github.com/user-attachments/assets/d2b75c44-1350-4e0e-a8c3-a7feed5dec52)

Redirects the user to the progress report application page:
![Screenshot 2025-05-19 at 2 43 54 PM](https://github.com/user-attachments/assets/9a73ab9c-b43a-4e63-a77f-bf89725305cc)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
