### PR TITLE
DT-101: Set the type so buttons don't auto-submit

### DIFF
--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -41,12 +41,13 @@ export default function SubmitProgressReport(props: SubmitProgressReportProps) {
 
   return (
       <div className='flex flex-row' style={{justifyContent: 'flex-start'}}>
-        <button className='button button-blue'
+        <button type={'button'}
+                className='button button-blue'
                 style={{marginRight: '2rem', cursor: 'pointer'}}
                 data-cy='pr-submit-button'
                 onClick={submit}>Submit
         </button>
-        <button
+        <button type={'button'}
             className='button button-white'
             style={{cursor: 'pointer'}}
             data-cy='pr-cancel-button'


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-101

### Summary
Set the button type to `button` so they don't auto-submit

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
