### PR TITLE
[DT-1625] Add Data Use Acknowledgement component to Progress Report Form

### DIFF
--- a/cypress/component/DataAccessRequest/data_use_acknowledgements.spec.tsx
+++ b/cypress/component/DataAccessRequest/data_use_acknowledgements.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import { DataUseAcknowledgements } from 'src/pages/dar_application/DataUseAcknowlegements';
+
+describe('DataUseAcknowledgements Component', () => {
+    let defaultProps: any;
+
+    beforeEach(() => {
+        defaultProps = {
+            title: 'Data Use Acknowledgements',
+            datasets: [],
+            dataUseTranslations: [],
+            formData: {},
+            readOnlyMode: false,
+            includeInstructions: true,
+            onChange: cy.stub(),
+            onValidationChange: cy.stub(),
+            validation: {}
+        };
+    });
+
+    it('renders the component with default props', () => {
+        mount(<DataUseAcknowledgements {...defaultProps} />);
+        cy.get('.data-use-acknowledgements').should('exist');
+    });
+
+    it('renders the GSO acknowledgement field when needed', () => {
+        const props = {
+            ...defaultProps,
+            datasets: [{ dataUse: {geneticStudiesOnly: true }}]
+        };
+        mount(<DataUseAcknowledgements {...props} />);
+        cy.get('#gsoAcknowledgement').should('exist');
+    });
+
+    it('renders the PUB acknowledgement field when needed', () => {
+        const props = {
+            ...defaultProps,
+            datasets: [{dataUse: { publicationResults: true }}]
+        };
+        mount(<DataUseAcknowledgements {...props} />);
+        cy.get('#pubAcknowledgement').should('exist');
+    });
+
+    it('renders the DS acknowledgement field when needed', () => {
+        const props = {
+            ...defaultProps,
+            dataUseTranslations: ['DS', 'DS2']
+        };
+        mount(<DataUseAcknowledgements {...props} />);
+        cy.get('#dsAcknowledgement').should('exist');
+    });
+
+    it('does not render fields when conditions are not met', () => {
+        mount(<DataUseAcknowledgements {...defaultProps} />);
+        cy.get('#gsoAcknowledgement').should('not.exist');
+        cy.get('#pubAcknowledgement').should('not.exist');
+        cy.get('#dsAcknowledgement').should('not.exist');
+    });
+
+    it('calls onChange when a checkbox is toggled', () => {
+        const props = {
+            ...defaultProps,
+            datasets: [{ dataUse: {geneticStudiesOnly: true }}]
+        };
+        mount(<DataUseAcknowledgements {...props} />);
+        cy.get('input[type="checkbox"]').check().then(() => {
+            expect(props.onChange).to.have.been.called;
+        });
+    });
+
+    it('disables fields in read-only mode', () => {
+        const props = {
+            ...defaultProps,
+            datasets: [{ dataUse: {geneticStudiesOnly: true }}],
+            readOnlyMode: true
+        };
+        mount(<DataUseAcknowledgements {...props} />);
+        cy.get('input[type="checkbox"]').should('be.disabled');
+    });
+});

--- a/cypress/component/DataAccessRequest/data_use_acknowledgements.spec.tsx
+++ b/cypress/component/DataAccessRequest/data_use_acknowledgements.spec.tsx
@@ -3,7 +3,7 @@ import { mount } from 'cypress/react';
 import { DataUseAcknowledgements } from 'src/pages/dar_application/DataUseAcknowlegements';
 
 describe('DataUseAcknowledgements Component', () => {
-    let defaultProps: any;
+    let defaultProps: object;
 
     beforeEach(() => {
         defaultProps = {

--- a/cypress/component/DataAccessRequest/data_use_acknowledgements.spec.tsx
+++ b/cypress/component/DataAccessRequest/data_use_acknowledgements.spec.tsx
@@ -59,14 +59,15 @@ describe('DataUseAcknowledgements Component', () => {
     });
 
     it('calls onChange when a checkbox is toggled', () => {
+        const onChangeSpy = cy.spy().as('onChangeSpy');
         const props = {
             ...defaultProps,
-            datasets: [{ dataUse: {geneticStudiesOnly: true }}]
+            datasets: [{ dataUse: { geneticStudiesOnly: true } }],
+            onChange: onChangeSpy
         };
         mount(<DataUseAcknowledgements {...props} />);
-        cy.get('input[type="checkbox"]').check().then(() => {
-            expect(props.onChange).to.have.been.called;
-        });
+        cy.get('input[type="checkbox"]').check();
+        cy.get('@onChangeSpy').should('have.been.called');
     });
 
     it('disables fields in read-only mode', () => {

--- a/cypress/component/ProgressReports/SubmitProgressReport.spec.tsx
+++ b/cypress/component/ProgressReports/SubmitProgressReport.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import {mount} from 'cypress/react';
-import SubmitProgressReport from '../../../src/pages/progress_reports/SubmitProgressReport';
-import {StackdriverReporter} from '../../../src/libs/stackdriverReporter';
-import '../../../src/index.css';
-import '../../../src/styles/buttons.css';
+import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressReport';
+import {StackdriverReporter} from 'src/libs/stackdriverReporter';
+import 'src/index.css';
+import 'src/styles/buttons.css';
 
 
 describe('SubmitProgressReport tests', () => {
@@ -21,6 +21,9 @@ describe('SubmitProgressReport tests', () => {
             onSuccess={() => {
             }}
             onCancel={() => {
+            }}
+            validateForm={() => {
+              return {}
             }}
         />
     );
@@ -41,6 +44,9 @@ describe('SubmitProgressReport tests', () => {
             }}
             onCancel={() => {
             }}
+            validateForm={() => {
+              return {}
+            }}
         />
     );
     cy.get('[data-cy=pr-submit-button]').click();
@@ -60,6 +66,13 @@ describe('SubmitProgressReport tests', () => {
       statusCode: 200,
       body: {},
     });
+    const validationSpy = {
+        validateForm: () => {
+            return {}
+        }
+    }
+    cy.spy(validationSpy, 'validateForm').as('validateForm');
+
     mount(
         <SubmitProgressReport
             progressReport={{}}
@@ -67,11 +80,38 @@ describe('SubmitProgressReport tests', () => {
             onSuccess={functionSpy.successHandler}
             onCancel={() => {
             }}
+            validateForm={validationSpy.validateForm}
         />
     );
     cy.get('[data-cy=pr-submit-button]').should('exist');
     cy.get('[data-cy=pr-submit-button]').click();
+    cy.get('@validateForm').should('have.been.calledOnce');
     cy.get('@successHandler').should('have.been.calledOnce');
+  });
+
+  it('On Submit handler should not be called if validation fails', () => {
+      const functionSpy = {
+          successHandler: () => {
+              console.log('successHandler')
+          }
+      }
+      cy.spy(functionSpy, 'successHandler').as('successHandler');
+
+      mount(
+          <SubmitProgressReport
+              progressReport={{}}
+              parentReferenceId="1"
+              onSuccess={functionSpy.successHandler}
+              onCancel={() => {
+              }}
+              validateForm={() => {
+                  return {darErrors: {datasetIds: {valid: false, failed: ['required']}}}
+              }}
+            />
+      );
+      cy.get('[data-cy=pr-submit-button]').should('exist');
+      cy.get('[data-cy=pr-submit-button]').click();
+      cy.get('@successHandler').should('not.have.been.called');
   });
 
   it('On Cancel handler should be called after cancel button clicked', () => {
@@ -88,6 +128,9 @@ describe('SubmitProgressReport tests', () => {
             onSuccess={() => {
             }}
             onCancel={functionSpy.cancelHandler}
+            validateForm={() => {
+              return {}
+            }}
         />
     );
     cy.get('[data-cy=pr-cancel-button]').should('exist');
@@ -108,6 +151,9 @@ describe('SubmitProgressReport tests', () => {
             onSuccess={() => {
             }}
             onCancel={() => {
+            }}
+            validateForm={() => {
+              return {}
             }}
         />
     );

--- a/cypress/component/ProgressReports/SubmitProgressReport.spec.tsx
+++ b/cypress/component/ProgressReports/SubmitProgressReport.spec.tsx
@@ -89,13 +89,15 @@ describe('SubmitProgressReport tests', () => {
     cy.get('@successHandler').should('have.been.calledOnce');
   });
 
-  it('On Submit handler should not be called if validation fails', () => {
+  it('API and On Submit handler should not be called if validation fails', () => {
       const functionSpy = {
           successHandler: () => {
               console.log('successHandler')
           }
       }
       cy.spy(functionSpy, 'successHandler').as('successHandler');
+      const submitSpy = cy.spy().as('submitSpy');
+      cy.intercept('POST', '/api/dar/v2/progress_report/1', () => submitSpy());
 
       mount(
           <SubmitProgressReport
@@ -111,6 +113,7 @@ describe('SubmitProgressReport tests', () => {
       );
       cy.get('[data-cy=pr-submit-button]').should('exist');
       cy.get('[data-cy=pr-submit-button]').click();
+      cy.get('@submitSpy').should('not.always.have.been.called')
       cy.get('@successHandler').should('not.have.been.called');
   });
 

--- a/src/pages/dar_application/DataAccessRequest.jsx
+++ b/src/pages/dar_application/DataAccessRequest.jsx
@@ -3,16 +3,14 @@ import {DataSet} from '../../libs/ajax/DataSet';
 import {DAR} from '../../libs/ajax/DAR';
 import {FormField, FormFieldTitle, FormFieldTypes, FormValidators} from '../../components/forms/forms';
 import {
-  needsDsAcknowledgement,
-  needsPubAcknowledgement,
   needsIrbApprovalDocument,
   needsCollaborationLetter,
-  needsGsoAcknowledgement,
   newIrbDocumentExpirationDate,
 } from '../../utils/darFormUtils';
 import SelectableDatasets from './SelectableDatasets';
 import {DAAUtils} from '../../utils/DAAUtils';
 import {DuosDatePicker} from '../../components/DuosDatePicker.js';
+import {DataUseAcknowledgements} from 'src/pages/dar_application/DataUseAcknowlegements.js';
 
 const titleStyle = { fontSize: '24px', fontWeight: 500, color: '#333333' };
 const noTopMarginStyle = { marginTop: '0', paddingTop: '0' };
@@ -345,56 +343,16 @@ export default function DataAccessRequest(props) {
           onChange={onChange}
         />
 
-        {(needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets)) &&
-            <FormFieldTitle
-              id={'dataUseAcknowledgements'}
-              key={'dataUseAcknowledgements'}
-              title={'2.5 Data Use Acknowledgements'}
-              description={includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : ''}
-            />
-        }
-
-        {needsGsoAcknowledgement(datasets) &&
-            <FormField
-              id={'gsoAcknowledgement'}
-              key={'gsoAcknowledgement'}
-              disabled={readOnlyMode}
-              type={FormFieldTypes.CHECKBOX}
-              toggleText={'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'}
-              defaultValue={formData.gsoAcknowledgement}
-              onChange={onChange}
-              validation={validation.gsoAcknowledgement}
-              onValidationChange={onValidationChange}
-            />
-        }
-
-        {needsPubAcknowledgement(datasets) &&
-            <FormField
-              id={'pubAcknowledgement'}
-              key={'pubAcknowledgement'}
-              disabled={readOnlyMode}
-              type={FormFieldTypes.CHECKBOX}
-              toggleText={'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'}
-              defaultValue={formData.pubAcknowledgement}
-              validation={validation.pubAcknowledgement}
-              onValidationChange={onValidationChange}
-              onChange={onChange}
-            />
-        }
-
-        {needsDsAcknowledgement(dataUseTranslations) &&
-            <FormField
-              id={'dsAcknowledgement'}
-              key={'dsAcknowledgement'}
-              disabled={readOnlyMode}
-              type={FormFieldTypes.CHECKBOX}
-              toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
-              defaultValue={formData.dsAcknowledgement}
-              validation={validation.dsAcknowledgement}
-              onValidationChange={onValidationChange}
-              onChange={onChange}
-            />
-        }
+        <DataUseAcknowledgements
+          title={'2.5 Data Use Acknowledgements'}
+          datasets={datasets}
+          dataUseTranslations={dataUseTranslations}
+          formData={formData}
+          readOnlyMode={readOnlyMode}
+          onChange={onChange}
+          onValidationChange={onValidationChange}
+          validation={validation}
+          />
 
         {needsIrbApprovalDocument(datasets) &&
                     <FormFieldTitle

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -21,10 +21,7 @@ import { Storage } from '../../libs/storage';
 import { assign, cloneDeep, get, head, isEmpty, isNil, isString, keys, map } from 'lodash/fp';
 import './DataAccessRequestApplication.css';
 
-import {
-  getNewFormValidation,
-  validateDARFormData
-} from '../../utils/darFormUtils';
+import {validateDARFormData} from '../../utils/darFormUtils';
 import DucAddendum from './DucAddendum';
 import UsgOmbText from '../../components/UsgOmbText';
 import {DAAUtils} from '../../utils/DAAUtils';
@@ -37,6 +34,7 @@ import {ConditionalAccordion} from "../../components/forms/ConditionalAccordion.
 import {ProgressReportApplication} from "./ProgressReportApplication";
 import {ScrollableTabs} from "./ScrollableTabs";
 import {validationFailed} from "../../utils/darFormUtils.js";
+import {isArray, set} from 'lodash';
 
 // Constants
 const RESEARCHER_INFO_TAB_ID = 'researcher-info';
@@ -163,7 +161,13 @@ const DataAccessRequestApplication = (props) => {
 
   const formValidationChange = useCallback((section, { key, validation }) => {
     setFormValidation((formValidation) => {
-      getNewFormValidation(formValidation, section, key, validation);
+      const newFormValidation = cloneDeep(formValidation);
+      if (isArray(key)) {
+        set(newFormValidation, [section, ...key], validation);
+      } else {
+        set(newFormValidation, [section, key], validation);
+      }
+      return newFormValidation;
     });
   }, []);
 

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -5,7 +5,7 @@ import DataAccessAgreements from './DataAccessAgreements';
 import DataUseAgreements from './DataUseAgreements';
 import DataAccessRequest from './DataAccessRequest';
 import ResearchPurposeStatement from './ResearchPurposeStatement';
-import { translateDataUseRestrictionsFromDataUseArray } from '../../libs/dataUseTranslation';
+import { translateDataUseRestrictionsFromDataUseArray } from 'src/libs/dataUseTranslation';
 import {
   Navigation, Notifications,
 } from '../../libs/utils';
@@ -21,7 +21,6 @@ import { Storage } from '../../libs/storage';
 import { assign, cloneDeep, get, head, isEmpty, isNil, isString, keys, map } from 'lodash/fp';
 import './DataAccessRequestApplication.css';
 
-import {validateDARFormData} from '../../utils/darFormUtils';
 import DucAddendum from './DucAddendum';
 import UsgOmbText from '../../components/UsgOmbText';
 import {DAAUtils} from '../../utils/DAAUtils';
@@ -33,7 +32,7 @@ import loadingImage from "../../images/loading-indicator.svg";
 import {ConditionalAccordion} from "../../components/forms/ConditionalAccordion.js";
 import {ProgressReportApplication} from "./ProgressReportApplication";
 import {ScrollableTabs} from "./ScrollableTabs";
-import {validationFailed} from "../../utils/darFormUtils.js";
+import {validateDARFormData, validationFailed} from "src/utils/darFormUtils.js";
 import {isArray, set} from 'lodash';
 
 // Constants

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -22,9 +22,9 @@ import { assign, cloneDeep, get, head, isEmpty, isNil, isString, keys, map } fro
 import './DataAccessRequestApplication.css';
 
 import {
+  getNewFormValidation,
   validateDARFormData
 } from '../../utils/darFormUtils';
-import { isArray, set } from 'lodash';
 import DucAddendum from './DucAddendum';
 import UsgOmbText from '../../components/UsgOmbText';
 import {DAAUtils} from '../../utils/DAAUtils';
@@ -36,6 +36,7 @@ import loadingImage from "../../images/loading-indicator.svg";
 import {ConditionalAccordion} from "../../components/forms/ConditionalAccordion.js";
 import {ProgressReportApplication} from "./ProgressReportApplication";
 import {ScrollableTabs} from "./ScrollableTabs";
+import {validationFailed} from "../../utils/darFormUtils.js";
 
 // Constants
 const RESEARCHER_INFO_TAB_ID = 'researcher-info';
@@ -58,10 +59,6 @@ const fetchAllDatasets = async (dsIds) => {
   }
   // filter just for safety
   return DataSet.getDatasetsByIds(filteredDatasetIds);
-};
-
-const validationFailed = (validation) => {
-  return Object.keys(validation).some((key) => !isEmpty(validation[key]));
 };
 
 const DataAccessRequestApplication = (props) => {
@@ -166,15 +163,7 @@ const DataAccessRequestApplication = (props) => {
 
   const formValidationChange = useCallback((section, { key, validation }) => {
     setFormValidation((formValidation) => {
-      const newFormValidation = cloneDeep(formValidation);
-
-      if (isArray(key)) {
-        set(newFormValidation, [section, ...key], validation);
-      } else {
-        set(newFormValidation, [section, key], validation);
-      }
-
-      return newFormValidation;
+      getNewFormValidation(formValidation, section, key, validation);
     });
   }, []);
 

--- a/src/pages/dar_application/DataUseAcknowlegements.tsx
+++ b/src/pages/dar_application/DataUseAcknowlegements.tsx
@@ -1,8 +1,8 @@
-import {needsDsAcknowledgement, needsGsoAcknowledgement, needsPubAcknowledgement} from "src/utils/darFormUtils";
-import {FormField, FormFieldTitle, FormFieldTypes} from "src/components/forms/forms";
-import React from "react";
-import {Dataset} from "src/types/model";
-import {DarErrors, ValidationError} from "src/pages/dar_application/FormValidationState";
+import {needsDsAcknowledgement, needsGsoAcknowledgement, needsPubAcknowledgement} from 'src/utils/darFormUtils';
+import {FormField, FormFieldTitle, FormFieldTypes} from 'src/components/forms/forms';
+import React from 'react';
+import {Dataset} from 'src/types/model';
+import {DarErrors, ValidationError} from 'src/pages/dar_application/FormValidationState';
 
 type DataUseAcknowledgementsProps = {
     title: string;

--- a/src/pages/dar_application/DataUseAcknowlegements.tsx
+++ b/src/pages/dar_application/DataUseAcknowlegements.tsx
@@ -2,17 +2,18 @@ import {needsDsAcknowledgement, needsGsoAcknowledgement, needsPubAcknowledgement
 import {FormField, FormFieldTitle, FormFieldTypes} from "src/components/forms/forms";
 import React from "react";
 import {Dataset} from "src/types/model";
+import {DarErrors, ValidationError} from "src/pages/dar_application/FormValidationState";
 
 type DataUseAcknowledgementsProps = {
     title: string;
     datasets: Dataset[],
     dataUseTranslations: string[],
-    formData: any,
+    formData: object,
     readOnlyMode: boolean,
     includeInstructions?: boolean,
-    onChange: (any) => void,
-    onValidationChange: (validation: any) => void,
-    validation: any
+    onChange: (object) => void,
+    onValidationChange: (validation: {key: string, validation: ValidationError}) => void,
+    validation?: DarErrors
 }
 
 export const DataUseAcknowledgements = ({
@@ -48,7 +49,7 @@ return (
               toggleText={'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'}
               defaultValue={formData.gsoAcknowledgement}
               onChange={onChange}
-              validation={validation.gsoAcknowledgement}
+              validation={validation?.gsoAcknowledgement}
               onValidationChange={onValidationChange}
             />
         }
@@ -62,7 +63,7 @@ return (
               type={FormFieldTypes.CHECKBOX}
               toggleText={'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'}
               defaultValue={formData.pubAcknowledgement}
-              validation={validation.pubAcknowledgement}
+              validation={validation?.pubAcknowledgement}
               onValidationChange={onValidationChange}
               onChange={onChange}
             />
@@ -77,7 +78,7 @@ return (
               type={FormFieldTypes.CHECKBOX}
               toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
               defaultValue={formData.dsAcknowledgement}
-              validation={validation.dsAcknowledgement}
+              validation={validation?.dsAcknowledgement}
               onValidationChange={onValidationChange}
               onChange={onChange}
             />

--- a/src/pages/dar_application/DataUseAcknowlegements.tsx
+++ b/src/pages/dar_application/DataUseAcknowlegements.tsx
@@ -1,5 +1,5 @@
 import {needsDsAcknowledgement, needsGsoAcknowledgement, needsPubAcknowledgement} from "src/utils/darFormUtils";
-import {FormField, FormFieldTitle, FormFieldTypes, FormValidators} from "src/components/forms/forms";
+import {FormField, FormFieldTitle, FormFieldTypes} from "src/components/forms/forms";
 import React from "react";
 import {Dataset} from "src/types/model";
 
@@ -77,7 +77,7 @@ return (
               type={FormFieldTypes.CHECKBOX}
               toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
               defaultValue={formData.dsAcknowledgement}
-              validation={validation?.dsAcknowledgement || [FormValidators.REQUIRED]}
+              validation={validation.dsAcknowledgement}
               onValidationChange={onValidationChange}
               onChange={onChange}
             />

--- a/src/pages/dar_application/DataUseAcknowlegements.tsx
+++ b/src/pages/dar_application/DataUseAcknowlegements.tsx
@@ -1,0 +1,87 @@
+import {needsDsAcknowledgement, needsGsoAcknowledgement, needsPubAcknowledgement} from "src/utils/darFormUtils";
+import {FormField, FormFieldTitle, FormFieldTypes, FormValidators} from "src/components/forms/forms";
+import React from "react";
+import {Dataset} from "src/types/model";
+
+type DataUseAcknowledgementsProps = {
+    title: string;
+    datasets: Dataset[],
+    dataUseTranslations: string[],
+    formData: any,
+    readOnlyMode: boolean,
+    includeInstructions?: boolean,
+    onChange: (any) => void,
+    onValidationChange: (validation: any) => void,
+    validation: any
+}
+
+export const DataUseAcknowledgements = ({
+    title,
+    datasets,
+    dataUseTranslations,
+    formData,
+    readOnlyMode,
+    includeInstructions = true,
+    onChange,
+    onValidationChange,
+    validation
+} : DataUseAcknowledgementsProps) => {
+
+return (
+    <div className='data-use-acknowledgements'>
+        {
+          (needsGsoAcknowledgement(datasets) || needsDsAcknowledgement(dataUseTranslations) || needsPubAcknowledgement(datasets)) &&
+          <FormFieldTitle
+              id={'dataUseAcknowledgements'}
+              key={'dataUseAcknowledgements'}
+              title={title}
+              description={includeInstructions ? 'Please confirm listed acknowledgements and/or document requirements below:' : ''}
+          />
+        }
+        {
+            needsGsoAcknowledgement(datasets) &&
+            <FormField
+              id={'gsoAcknowledgement'}
+              key={'gsoAcknowledgement'}
+              disabled={readOnlyMode}
+              type={FormFieldTypes.CHECKBOX}
+              toggleText={'I acknowledge that I have selected a dataset limited to use on genetic studies only (GSO). I attest that I will respect this data use condition.'}
+              defaultValue={formData.gsoAcknowledgement}
+              onChange={onChange}
+              validation={validation.gsoAcknowledgement}
+              onValidationChange={onValidationChange}
+            />
+        }
+
+        {
+            needsPubAcknowledgement(datasets) &&
+            <FormField
+              id={'pubAcknowledgement'}
+              key={'pubAcknowledgement'}
+              disabled={readOnlyMode}
+              type={FormFieldTypes.CHECKBOX}
+              toggleText={'I acknowledge that I have selected a dataset which requires results of studies using the data to be made available to the larger scientific community (PUB). I attest that I will respect this data use condition.'}
+              defaultValue={formData.pubAcknowledgement}
+              validation={validation.pubAcknowledgement}
+              onValidationChange={onValidationChange}
+              onChange={onChange}
+            />
+        }
+
+        {
+            needsDsAcknowledgement(dataUseTranslations) &&
+            <FormField
+              id={'dsAcknowledgement'}
+              key={'dsAcknowledgement'}
+              disabled={readOnlyMode}
+              type={FormFieldTypes.CHECKBOX}
+              toggleText={'I acknowledge that the dataset can only be used in research consistent with the Data Use Limitations (DULs) and cannot be combined with other datasets of other phenotypes. Research uses inconsistent with DUL are considered a violation of the Data Use Certification agreement and any additional terms descried in the addendum'}
+              defaultValue={formData.dsAcknowledgement}
+              validation={validation?.dsAcknowledgement || [FormValidators.REQUIRED]}
+              onValidationChange={onValidationChange}
+              onChange={onChange}
+            />
+        }
+    </div>
+);
+};

--- a/src/pages/dar_application/FormValidationState.tsx
+++ b/src/pages/dar_application/FormValidationState.tsx
@@ -1,0 +1,57 @@
+
+export interface FormValidationState {
+    researcherInfoErrors?: ResearcherErrors,
+    darErrors?: DarErrors,
+    rusErrors?: RusErrors,
+    nihValid?: boolean,
+}
+export interface ResearcherErrors {
+    researcher?: ValidationError,
+    nihEraId?: ValidationError,
+    piName?: ValidationError,
+    signingOfficial?: ValidationError,
+    itDirector?: ValidationError,
+    labCollaboratorsCompleted?: ValidationError,
+    internalCollaborators?: ValidationError,
+    externalCollaborators?: ValidationError,
+    anvilUse?: ValidationError,
+    dataStorageAndAnalysis?: ValidationError,
+    cloudProvider?: ValidationError,
+    cloudProviderType?: ValidationError,
+    cloudProviderDescription?: ValidationError,
+}
+
+export interface DarErrors {
+    datasetIds?: ValidationError,
+    projectTitle?: ValidationError,
+    rus?: ValidationError,
+    diseases?: ValidationError,
+    ontologies?: ValidationError,
+    nonTechRus?: ValidationError,
+    collaborationLetter?: ValidationError,
+    irbDocument?: ValidationError,
+    gsoAcknowledgement?: ValidationError,
+    pubAcknowledgement?: ValidationError,
+    dsAcknowledgement?: ValidationError,
+}
+
+export interface RusErrors {
+    gender?: ValidationError,
+    controls?: ValidationError,
+    population?: ValidationError,
+    forProfit?: ValidationError,
+    oneGender?: ValidationError,
+    pediatric?: ValidationError,
+    vulnerablePopulation?: ValidationError,
+    illegalBehavior?: ValidationError,
+    sexualDiseases?: ValidationError,
+    psychiatricTraits?: ValidationError,
+    notHealth?: ValidationError,
+    stigmatizedDiseases?: ValidationError,
+}
+
+export interface ValidationError {
+    valid?: boolean,
+    failed?: Array<string>,
+}
+

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -10,6 +10,7 @@ import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressRepor
 import {DataUseAcknowledgements} from "src/pages/dar_application/DataUseAcknowlegements";
 import {translateDataUseRestrictionsFromDataUseArray} from "src/libs/dataUseTranslation";
 import {validatePRFormData} from "src/utils/darFormUtils";
+import {FormValidationState} from "src/pages/dar_application/FormValidationState";
 
 type ProgressReportApplicationProps = {
     dar?: DataAccessRequest, // Dar will be empty if this is an application
@@ -22,7 +23,7 @@ export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMo
     const [formState, setFormState] = useState<FormState>({});
     const [dataUseTranslations, setDataUseTranslations] = useState<string[]>([]);
     const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>(datasets);
-    const [formValidation, setFormValidation] = useState<any>(
+    const [formValidation, setFormValidation] = useState<FormValidationState>(
         {darErrors:
                     {gsoAcknowledgement: {}, pubAcknowledgement: {}, dsAcknowledgement: {}}});
     const onFormChange = (newState: Partial<FormState>) => {

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import { DataAccessRequest, Dataset } from 'src/types/model';
 import SelectableDatasets from 'src/pages/dar_application/SelectableDatasets';
 import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressReport';
@@ -6,17 +6,24 @@ import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges'
 import DataManagementIncident from 'src/pages/progress_reports/DataManagementIncident';
 import DarCloseout from 'src/pages/progress_reports/DarCloseout';
 import { FormState } from 'src/pages/progress_reports/ProgressReportFormState';
+import {DataUseAcknowledgements} from "src/pages/dar_application/DataUseAcknowlegements";
+import {translateDataUseRestrictionsFromDataUseArray} from "src/libs/dataUseTranslation";
+import {getNewFormValidation, validatePRFormData} from "src/utils/darFormUtils";
 
 type ProgressReportApplicationProps = {
     dar?: DataAccessRequest, // Dar will be empty if this is an application
     parentDar?: DataAccessRequest, // Dar will be empty if this is view only
     datasets: Dataset[],
-    readOnlyMode?: boolean
+    readOnlyMode: boolean
 };
 
 export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMode = true }: ProgressReportApplicationProps) => {
     const [formState, setFormState] = useState<FormState>({});
-
+    const [dataUseTranslations, setDataUseTranslations] = useState<string[]>([]);
+    const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>(datasets);
+    const [formValidation, setFormValidation] = useState<any>(
+        {darErrors:
+                    {gsoAcknowledgement: {}, pubAcknowledgement: {}, dsAcknowledgement: {}}});
     const onFormChange = (newState: Partial<FormState>) => {
         setFormState(prevState => ({
             ...prevState,
@@ -27,7 +34,35 @@ export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMo
     /* required because the datasets state changes during component mount */
     useEffect(() => {
         onFormChange({ datasetIds: datasets.map((ds) => ds.datasetId) });
+        setSelectedDatasets(datasets);
+        translateDataUseRestrictionsFromDataUseArray(datasets.map((ds) => ds.dataUse)).then((translations) => {
+            setDataUseTranslations(translations);
+        });
     }, [datasets]);
+
+    useEffect(() => {
+        const selectedIds = selectedDatasets.map((ds => ds.datasetId));
+        translateDataUseRestrictionsFromDataUseArray(selectedDatasets.map((ds) => ds.dataUse)).then((translations) => {
+            setDataUseTranslations(translations);
+        });
+        onFormChange({ datasetIds: selectedIds });
+    }, [selectedDatasets]);
+
+    const validateForm = () => {
+        const validation = validatePRFormData(
+            formState,
+            selectedDatasets,
+            dataUseTranslations
+        );
+        setFormValidation(validation);
+        return validation;
+    }
+
+    const formValidationChange = useCallback(({ key, validation }) => {
+        setFormValidation((formValidation) => {
+            getNewFormValidation(formValidation, 'darErrors', key, validation);
+        });
+    }, []);
 
     return (
         <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
@@ -48,11 +83,22 @@ export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMo
                     <SelectableDatasets
                         disabled={readOnlyMode}
                         datasets={datasets}
-                        setSelectedDatasets={(selectedDatasets: Dataset[]) => {
-                            onFormChange({ datasetIds: selectedDatasets.map((ds) => ds.datasetId) });
-                        }}
+                        setSelectedDatasets={setSelectedDatasets}
                     />
                 </div>
+            </div>
+            <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
+                <DataUseAcknowledgements
+                    title={'3.1 Data Use Acknowledgements'}
+                    datasets={selectedDatasets}
+                    dataUseTranslations={dataUseTranslations}
+                    formData={formState}
+                    readOnlyMode={readOnlyMode}
+                    onChange={(dua) => {
+                        onFormChange({[dua.key]: dua.value})}}
+                    onValidationChange={formValidationChange}
+                    validation={formValidation.darErrors}
+                />
             </div>
             <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <CollaboratorChanges readOnly={readOnlyMode} formState={formState} onFormChange={onFormChange} />
@@ -71,6 +117,7 @@ export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMo
                     }}
                     onCancel={() => {
                     }}
+                    validateForm={validateForm}
                 />
             </div>}
         </div >

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,4 +1,3 @@
-import React, { useState, useEffect } from 'react';
 import React, {useCallback, useEffect, useState} from 'react';
 import { DataAccessRequest, Dataset } from 'src/types/model';
 import { FormState } from 'src/pages/progress_reports/ProgressReportFormState';

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -18,13 +18,6 @@ type ProgressReportApplicationProps = {
     readOnlyMode: boolean
 };
 
-export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMode = true }: ProgressReportApplicationProps) => {
-    const [formState, setFormState] = useState<FormState>({});
-    const [dataUseTranslations, setDataUseTranslations] = useState<string[]>([]);
-    const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>(datasets);
-    const [formValidation, setFormValidation] = useState<FormValidationState>(
-        {darErrors:
-                    {gsoAcknowledgement: {}, pubAcknowledgement: {}, dsAcknowledgement: {}}});
 export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true }: ProgressReportApplicationProps) => {
     const initialState = {
         ...dar,
@@ -49,6 +42,11 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true }
     }
 
     const [formState, setFormState] = useState<FormState>(initialState);
+    const [dataUseTranslations, setDataUseTranslations] = useState<string[]>([]);
+    const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>(datasets);
+    const [formValidation, setFormValidation] = useState<FormValidationState>(
+        {darErrors:
+                {gsoAcknowledgement: {}, pubAcknowledgement: {}, dsAcknowledgement: {}}});
 
     const onFormChange = (newState: Partial<FormState>) => {
         setFormState(prevState => ({

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -7,10 +7,10 @@ import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges'
 import DataManagementIncident from 'src/pages/progress_reports/DataManagementIncident';
 import DarCloseout from 'src/pages/progress_reports/DarCloseout';
 import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressReport';
-import {DataUseAcknowledgements} from "src/pages/dar_application/DataUseAcknowlegements";
-import {translateDataUseRestrictionsFromDataUseArray} from "src/libs/dataUseTranslation";
-import {validatePRFormData} from "src/utils/darFormUtils";
-import {FormValidationState} from "src/pages/dar_application/FormValidationState";
+import {DataUseAcknowledgements} from 'src/pages/dar_application/DataUseAcknowlegements';
+import {translateDataUseRestrictionsFromDataUseArray} from 'src/libs/dataUseTranslation';
+import {validatePRFormData} from 'src/utils/darFormUtils';
+import {FormValidationState} from 'src/pages/dar_application/FormValidationState';
 
 type ProgressReportApplicationProps = {
     dar?: DataAccessRequest, // Dar will be empty if this is an application

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -8,7 +8,7 @@ import DarCloseout from 'src/pages/progress_reports/DarCloseout';
 import { FormState } from 'src/pages/progress_reports/ProgressReportFormState';
 import {DataUseAcknowledgements} from "src/pages/dar_application/DataUseAcknowlegements";
 import {translateDataUseRestrictionsFromDataUseArray} from "src/libs/dataUseTranslation";
-import {getNewFormValidation, validatePRFormData} from "src/utils/darFormUtils";
+import {validatePRFormData} from "src/utils/darFormUtils";
 
 type ProgressReportApplicationProps = {
     dar?: DataAccessRequest, // Dar will be empty if this is an application
@@ -60,7 +60,13 @@ export const ProgressReportApplication = ({ dar, parentDar, datasets, readOnlyMo
 
     const formValidationChange = useCallback(({ key, validation }) => {
         setFormValidation((formValidation) => {
-            getNewFormValidation(formValidation, 'darErrors', key, validation);
+            return {
+                ...formValidation,
+                darErrors: {
+                    ...formValidation.darErrors,
+                    [key]: validation
+                }
+            };
         });
     }, []);
 

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -4,6 +4,7 @@ import {ProgressReport} from 'src/libs/ajax/ProgressReport';
 import {Notifications} from 'src/libs/utils';
 import {ConsentError} from 'src/types/responseTypes';
 import {validationFailed} from "src/utils/darFormUtils";
+import {FormValidationState} from "src/pages/dar_application/FormValidationState";
 
 
 interface SubmitProgressReportProps {
@@ -11,7 +12,7 @@ interface SubmitProgressReportProps {
   readonly parentReferenceId: string;
   readonly onSuccess: (result: unknown) => void;
   readonly onCancel: (result: unknown) => void;
-  readonly validateForm: () => any;
+  readonly validateForm: () => FormValidationState;
 }
 
 export default function SubmitProgressReport(props: SubmitProgressReportProps) {

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import {AxiosError} from 'axios';
-import {ProgressReport} from '../../libs/ajax/ProgressReport';
-import {Notifications} from '../../libs/utils';
-import {ConsentError} from '../../types/responseTypes';
+import {ProgressReport} from 'src/libs/ajax/ProgressReport';
+import {Notifications} from 'src/libs/utils';
+import {ConsentError} from 'src/types/responseTypes';
 import {validationFailed} from "src/utils/darFormUtils";
 
 
@@ -17,8 +17,7 @@ interface SubmitProgressReportProps {
 export default function SubmitProgressReport(props: SubmitProgressReportProps) {
   const {progressReport, parentReferenceId, onSuccess, onCancel, validateForm} = props;
 
-  const submit = async (e) => {
-    e.preventDefault();
+  const submit = async () => {
     if (validationFailed(validateForm())) {
       Notifications.showError({text: "Form validation failed. Please check the form for errors."});
     } else {
@@ -31,8 +30,7 @@ export default function SubmitProgressReport(props: SubmitProgressReportProps) {
     }
   }
 
-  const cancel = async (e) => {
-    e.preventDefault();
+  const cancel = async () => {
     try {
       onCancel(progressReport);
     } catch (error: unknown) {

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -3,6 +3,7 @@ import {AxiosError} from 'axios';
 import {ProgressReport} from '../../libs/ajax/ProgressReport';
 import {Notifications} from '../../libs/utils';
 import {ConsentError} from '../../types/responseTypes';
+import {validationFailed} from "src/utils/darFormUtils";
 
 
 interface SubmitProgressReportProps {
@@ -10,21 +11,28 @@ interface SubmitProgressReportProps {
   readonly parentReferenceId: string;
   readonly onSuccess: (result: unknown) => void;
   readonly onCancel: (result: unknown) => void;
+  readonly validateForm: () => any;
 }
 
 export default function SubmitProgressReport(props: SubmitProgressReportProps) {
-  const {progressReport, parentReferenceId, onSuccess, onCancel} = props;
+  const {progressReport, parentReferenceId, onSuccess, onCancel, validateForm} = props;
 
-  const submit = async () => {
-    try {
-      const submittedPR = await ProgressReport.submitProgressReport(progressReport, parentReferenceId);
-      onSuccess(submittedPR);
-    } catch (error: unknown) {
-      handleError('Error: Unable to submit progress report: ', error);
+  const submit = async (e) => {
+    e.preventDefault();
+    if (validationFailed(validateForm())) {
+      Notifications.showError({text: "Form validation failed. Please check the form for errors."});
+    } else {
+      try {
+        const submittedPR = await ProgressReport.submitProgressReport(progressReport, parentReferenceId);
+        onSuccess(submittedPR);
+      } catch (error: unknown) {
+        handleError('Error: Unable to submit progress report: ', error);
+      }
     }
   }
 
-  const cancel = async () => {
+  const cancel = async (e) => {
+    e.preventDefault();
     try {
       onCancel(progressReport);
     } catch (error: unknown) {

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -4,7 +4,7 @@ import {ProgressReport} from 'src/libs/ajax/ProgressReport';
 import {Notifications} from 'src/libs/utils';
 import {ConsentError} from 'src/types/responseTypes';
 import {validationFailed} from "src/utils/darFormUtils";
-import {FormValidationState} from "src/pages/dar_application/FormValidationState";
+import {FormValidationState} from 'src/pages/dar_application/FormValidationState';
 
 
 interface SubmitProgressReportProps {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -2,9 +2,8 @@
 
 // ********************** DUL LOGIC ********************** //
 
-import {isEmpty, isNil, isEqual, isString, isArray, set} from 'lodash';
+import {isEmpty, isNil, isEqual, isString, isArray} from 'lodash';
 import { FormValidators } from '../components/forms/forms';
-import {cloneDeep} from 'lodash/fp';
 
 const datasetsContainDataUseFlag = (datasets, flag) => {
   return datasets?.some((ds) => {
@@ -49,15 +48,6 @@ export const validationFailed = (validation) => {
   return Object.keys(validation).some((key) => !isEmpty(validation[key]));
 };
 
-export const getNewFormValidation = (formValidation, section, key, validation) => {
-  const newFormValidation = cloneDeep(formValidation);
-  if (isArray(key)) {
-    set(newFormValidation, [section, ...key], validation);
-  } else {
-    set(newFormValidation, [section, key], validation);
-  }
-  return newFormValidation;
-}
 const validationError = (failed) => {
   if (isArray(failed)) {
     return { valid: false, failed: failed };

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -195,7 +195,7 @@ const calcDarErrors = (formData, datasets, dataUseTranslations, irbDocument, col
     errors.irbDocument = requiredError;
   }
 
-  calcDUAErrors(formData, datasets, errors);
+  calcDUAErrors(formData, datasets, dataUseTranslations, errors);
 
   return errors;
 };

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -2,8 +2,9 @@
 
 // ********************** DUL LOGIC ********************** //
 
-import { isEmpty, isNil, isEqual, isString, isArray } from 'lodash';
+import {isEmpty, isNil, isEqual, isString, isArray, set} from 'lodash';
 import { FormValidators } from '../components/forms/forms';
+import {cloneDeep} from 'lodash/fp';
 
 const datasetsContainDataUseFlag = (datasets, flag) => {
   return datasets?.some((ds) => {
@@ -44,6 +45,19 @@ export const newIrbDocumentExpirationDate = () => {
 
 // ********************** DAR FORM VALIDATION ********************** //
 
+export const validationFailed = (validation) => {
+  return Object.keys(validation).some((key) => !isEmpty(validation[key]));
+};
+
+export const getNewFormValidation = (formValidation, section, key, validation) => {
+  const newFormValidation = cloneDeep(formValidation);
+  if (isArray(key)) {
+    set(newFormValidation, [section, ...key], validation);
+  } else {
+    set(newFormValidation, [section, key], validation);
+  }
+  return newFormValidation;
+}
 const validationError = (failed) => {
   if (isArray(failed)) {
     return { valid: false, failed: failed };
@@ -191,6 +205,18 @@ const calcDarErrors = (formData, datasets, dataUseTranslations, irbDocument, col
     errors.irbDocument = requiredError;
   }
 
+  calcDUAErrors(formData, datasets, errors);
+
+  return errors;
+};
+
+const calcPRErrors = (formData, datasets, dataUseTranslations) => {
+  const errors = {};
+  calcDUAErrors(formData, datasets, dataUseTranslations, errors);
+  return errors;
+};
+
+const calcDUAErrors = (formData, datasets, dataUseTranslations, errors) => {
   if ((needsGsoAcknowledgement(datasets) && !formData.gsoAcknowledgement)) {
     errors.gsoAcknowledgement = requiredError;
   }
@@ -202,10 +228,7 @@ const calcDarErrors = (formData, datasets, dataUseTranslations, irbDocument, col
   if ((needsDsAcknowledgement(dataUseTranslations) && !formData.dsAcknowledgement)) {
     errors.dsAcknowledgement = requiredError;
   }
-
-
-  return errors;
-};
+}
 
 const requiredRusFields = [
   'controls',
@@ -267,3 +290,13 @@ export const validateDARFormData = ({
     nihValid: isNil(researcher.eraCommonsId),
   };
 };
+
+export const validatePRFormData = (
+    formData,
+    datasets,
+    dataUseTranslations,
+    ) => {
+    return {
+        darErrors: calcPRErrors(formData, datasets, dataUseTranslations)
+    };
+}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1625

### Summary
Refactors data use acknowledgements into their own component and reuses it on the DataAccessRequest page and the ProgressReportApplication page
Adds validation on submit to ensure the data use acknowledgments are checked
Makes selectedDatasets part of state because it is used in multiple places (instead of filtering the datasets each time)
Maintains current functionality on DAR application page

It said the screen recording is too big so here is a link: https://drive.google.com/file/d/1aeDiniYv_incMiL2iRunnRotgg17eT1H/view?usp=sharing 


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
