### PR TITLE
DT-1697: Enable voting on progress reports

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.jsx
@@ -6,14 +6,14 @@ import { Votes } from '../../../src/libs/ajax/Votes';
 import {votingColors} from '../../../src/pages/dar_collection_review/MultiDatasetVotingTab';
 
 const votesMatch = [
-  {vote: true, voteId: 1, rationale: 'test'},
-  {vote: true, voteId: 2, rationale: 'test'},
-  {vote: true, voteId: 3, rationale: 'test'}
+  {vote: true, voteId: 1, rationale: 'test', electionStatus: 'Open'},
+  {vote: true, voteId: 2, rationale: 'test', electionStatus: 'Open'},
+  {vote: true, voteId: 3, rationale: 'test', electionStatus: 'Open'}
 ];
 
 const votesMixed = [
-  {vote: true, voteId: 1, rationale: 'test1'},
-  {vote: false, voteId: 2, rationale: 'test2'},
+  {vote: true, voteId: 1, rationale: 'test1', electionStatus: 'Open'},
+  {vote: false, voteId: 2, rationale: 'test2', electionStatus: 'Open'},
 ];
 
 

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
@@ -16,15 +16,15 @@ const closedElection = {datasetId: 30, electionId: 103, status: 'Closed', electi
 const votesForOpenElection1 = {
   dataAccess: {
     finalVotes: [
-      {userId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1, electionStatus: 'Open'},
     ],
     chairpersonVotes: [
-      {userId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: true, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1, electionStatus: 'Open'},
     ],
     memberVotes: [
-      {userId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1},
-      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
-      {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
+      {userId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1, electionStatus: 'Open'},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1, electionStatus: 'Open'},
+      {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1, electionStatus: 'Open'}
     ]
   }
 };
@@ -32,15 +32,15 @@ const votesForOpenElection1 = {
 const votesForOpenElection2 = {
   dataAccess: {
     finalVotes: [
-      {userId: 200, displayName: 'Sarah',  vote: true, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: true, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1, electionStatus: 'Open'},
     ],
     chairpersonVotes: [
-      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1, electionStatus: 'Open'},
     ],
     memberVotes: [
-      {userId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2},
-      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
-      {userId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6}
+      {userId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2, electionStatus: 'Open'},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1, electionStatus: 'Open'},
+      {userId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6, electionStatus: 'Open'}
     ]
   }
 };
@@ -48,14 +48,14 @@ const votesForOpenElection2 = {
 const votesForClosedElection = {
   dataAccess: {
     finalVotes: [
-      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7, electionStatus: 'Closed'},
     ],
     chairpersonVotes: [
-      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7, electionStatus: 'Closed'},
     ],
     memberVotes: [
-      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7},
-      {userId: 300, displayName: 'Matt', vote: true, rationale: 'test3', electionId: 103, voteId: 8}
+      {userId: 200, displayName: 'Sarah', vote: false, electionId: 103, voteId: 7, electionStatus: 'Closed'},
+      {userId: 300, displayName: 'Matt', vote: true, rationale: 'test3', electionId: 103, voteId: 8, electionStatus: 'Closed'}
     ]
   }
 };
@@ -70,7 +70,8 @@ describe('MultiDatasetVoteSlab - Tests', function() {
             {code: 'GRU', description: 'Use is permitted for any research purpose', type: ControlledAccessType.permissions},
             {code: 'HMB', description: 'Use is permitted for a health, medical, or biomedical research purpose', type: ControlledAccessType.permissions},
             {code: 'NCU', description: 'The dataset will be used in a study related to a commercial purpose.', type: ControlledAccessType.modifiers}
-          ]
+          ],
+          elections: []
         }}
         dacDatasetIds={[10, 20]}
         isChair={true}

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
@@ -199,7 +199,7 @@ describe('MultiDatasetVoteSlab - Tests', function() {
     cy.get('textarea').should('be.disabled');
   });
 
-  it('Renders NOT SELECTED vote result text if some elections are closed and current votes do not match', function() {
+  it('Renders vote button if any election is open', function() {
     mount(
       <MultiDatasetVoteSlab
         title={'GROUP 1'}
@@ -211,34 +211,15 @@ describe('MultiDatasetVoteSlab - Tests', function() {
         isChair={false}
       />
     );
-    cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
+    cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    cy.get('[data-cy=vote-subsection-heading]').should('have.text', 'NOT SELECTED');
-    cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
-    cy.get('[datacy=no-collection-vote-button]').should('not.exist');
-    cy.get('textarea').should('be.disabled');
-  });
-
-  it('Renders vote result text if some elections are closed and current votes do match', function() {
-    mount(
-      <MultiDatasetVoteSlab
-        title={'GROUP 1'}
-        bucket={{
-          elections: [openElection1, closedElection],
-          votes: [votesForOpenElection1, votesForClosedElection]
-        }}
-        dacDatasetIds={[10, 30]}
-        isChair={false}
-      />
-    );
-    cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
-    cy.stub(Votes, 'updateVotesByIds');
-
-    cy.get('[data-cy=vote-subsection-heading]').should('have.text', 'YES');
-    cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
-    cy.get('[datacy=no-collection-vote-button]').should('not.exist');
-    cy.get('textarea').should('be.disabled');
+    cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
+    cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.no);
+    cy.get('[datacy=yes-collection-vote-button]').click();
+    cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.yes);
+    cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
+    cy.get('textarea').should('not.be.disabled');
   });
 
   it('Replaces vote buttons with vote result text when readOnly is true', function() {

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
@@ -313,11 +313,11 @@ describe('MultiDatasetVoteSlab - Tests', function() {
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
-    const component = cy.get('.table-data');
-    component.should('exist');
-    component.should('contain', 'test1');
-    component.should('contain', 'test2');
-    component.should('not.contain', 'test3');
+    cy.get('.table-data')
+        .should('exist')
+        .should('contain', 'test1')
+        .should('contain', 'test2')
+        .should('not.contain', 'test3');
   });
 
   it('Renders collapsed row of vote summary table when the same user has same vote for multiple elections', function() {

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.jsx
@@ -29,15 +29,15 @@ const collapseSlabLinkText = 'Hide Research Use Statement (Narrative)';
 const votesForElection1 = {
   rp: {
     finalVotes: [
-      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1, electionStatus: 'Open'},
     ],
     chairpersonVotes: [
-      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1, electionStatus: 'Open'},
     ],
     memberVotes: [
-      {userId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1},
-      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1},
-      {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1}
+      {userId: 100, displayName: 'Joe', rationale: 'test1', electionId: 101, voteId: 1, createDate: 1, electionStatus: 'Open'},
+      {userId: 200, displayName: 'Sarah', vote: false, rationale: 'test1', electionId: 101, voteId: 2, createDate: 1, electionStatus: 'Open'},
+      {userId: 300, displayName: 'Matt', vote: true, electionId: 101, voteId: 3, createDate: 1, electionStatus: 'Open'}
     ]
   }
 };
@@ -45,15 +45,15 @@ const votesForElection1 = {
 const votesForElection2 = {
   rp: {
     finalVotes: [
-      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1, electionStatus: 'Open'},
     ],
     chairpersonVotes: [
-      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1, electionStatus: 'Open'},
     ],
     memberVotes: [
-      {userId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2},
-      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1},
-      {userId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6}
+      {userId: 100, displayName: 'Joe', rationale: 'test2', electionId: 102, voteId: 4, createDate: 2, electionStatus: 'Open'},
+      {userId: 200, displayName: 'Sarah',  vote: false, rationale: 'test1', electionId: 102, voteId: 5, createDate: 1, electionStatus: 'Open'},
+      {userId: 300, displayName: 'Matt', vote: false, electionId: 102, voteId: 6, electionStatus: 'Open'}
     ]
   }
 };

--- a/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/research_proposal_vote_slab.spec.jsx
@@ -130,8 +130,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         bucket={{key: 'test'}}
       />
     );
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
     cy.contains(collapseSlabLinkText);
   });
 
@@ -142,8 +141,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         bucket={{ key: 'test' }}
       />
     );
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
     cy.contains(primaryUseCode);
     cy.contains(secondaryUseCode);
   });
@@ -155,8 +153,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         bucket={{key: 'test'}}
       />
     );
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
     cy.get('[data-cy=research-purpose]').should('exist');
     cy.contains('test');
   });
@@ -179,8 +176,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
       />
     );
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
     cy.get('[datacy=alert-box]').should('exist');
   });
 
@@ -191,8 +187,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
         bucket={{ key: 'test' }}
       />
     );
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
     cy.get('[datacy=alert-box]').should('not.exist');
   });
 
@@ -258,8 +253,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.no);
@@ -281,8 +275,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.no);
@@ -304,8 +297,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
     cy.stub(Votes, 'updateVotesByIds');
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
@@ -327,8 +319,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[datacy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
     cy.get('[datacy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default);
@@ -350,8 +341,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
     cy.stub(Votes, 'updateVotesByIds');
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[data-cy=vote-subsection-heading]').should('have.text', 'NOT SELECTED');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
@@ -372,8 +362,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
     cy.stub(Votes, 'updateVotesByIds');
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[data-cy=vote-subsection-heading]').should('have.text', 'NO');
     cy.get('[datacy=yes-collection-vote-button]').should('not.exist');
@@ -392,8 +381,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[data-cy=chair-vote-info]').should('not.exist');
   });
@@ -409,8 +397,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[data-cy=chair-vote-info]').should('not.exist');
   });
@@ -426,8 +413,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 300});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('[data-cy=chair-vote-info]').should('exist');
   });
@@ -443,16 +429,15 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
-    const component = cy.get('.table-data');
-    component.should('exist');
-    component.should('contain', 'test1');
-    component.should('contain', 'test2');
-    component.should('not.contain', 'test3');
+    cy.get('.table-data')
+    .should('exist')
+    .should('contain', 'test1')
+    .should('contain', 'test2')
+    .should('not.contain', 'test3');
   });
 
   it('Renders collapsed row of vote summary table when the same user has same vote for multiple elections', function() {
@@ -466,8 +451,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
@@ -486,8 +470,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
@@ -506,8 +489,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 200});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
@@ -526,8 +508,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
@@ -547,8 +528,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();
@@ -568,8 +548,7 @@ describe('ResearchProposalVoteSlab - Tests', function() {
     );
     cy.stub(Storage, 'getCurrentUser').returns({userId: 100});
 
-    const link = cy.contains(expandSlabLinkText);
-    link.click();
+    cy.contains(expandSlabLinkText).click();
 
     cy.get('.table-data').should('not.exist');
     cy.get('#show-member-vote-dropdown').click();

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -4,7 +4,6 @@ import CollectionVoteYesButton from './CollectionVoteYesButton';
 import CollectionVoteNoButton from './CollectionVoteNoButton';
 import {Notifications} from '../../libs/utils';
 import { Votes } from '../../libs/ajax/Votes';
-import {toLower} from "lodash";
 
 const styles = {
   baseStyle: {
@@ -107,8 +106,8 @@ export default function CollectionSubmitVoteBox(props) {
 
   const updateVote = async (newVote, isChair) => {
     try {
-      const openElectionVotes = votes.filter(v => toLower(v.electionStatus) === 'open');
-      const voteIds = map(v => v.voteId)(openElectionVotes);
+      const openElectionVotes = votes.filter(v => v.electionStatus.toLowerCase() === 'open');
+      const voteIds = openElectionVotes.map(v => v.voteId);
       await Votes.updateVotesByIds(voteIds, {vote: newVote, rationale});
       setSubmitted(true);
       //call updateFinalVote for chairs in order to update source collection's votes and trigger sub-component re-render

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -112,9 +112,13 @@ export default function CollectionSubmitVoteBox(props) {
       await Votes.updateVotesByIds(voteIds, {vote: newVote, rationale});
       setSubmitted(true);
       //call updateFinalVote for chairs in order to update source collection's votes and trigger sub-component re-render
-      isChair ? updateFinalVote(bucketKey, {vote: newVote, rationale}, voteIds) : setVote(newVote);
+      if (isChair) {
+        updateFinalVote(bucketKey, {vote: newVote, rationale}, voteIds);
+      } else {
+        setVote(newVote);
+      }
       Notifications.showSuccess({text: 'Successfully updated vote'});
-    } catch (error) {
+    } catch (_error) {
       Notifications.showError({text: 'Error: Failed to update vote'});
     }
   };
@@ -124,7 +128,7 @@ export default function CollectionSubmitVoteBox(props) {
       const voteIds = map(v => v.voteId)(votes);
       await Votes.updateRationaleByIds(voteIds, rationale);
       Notifications.showSuccess({text: 'Successfully updated vote rationale'});
-    } catch (error) {
+    } catch (_error) {
       Notifications.showError({text: 'Error: Failed to update vote rationale'});
     }
   };

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -4,6 +4,7 @@ import CollectionVoteYesButton from './CollectionVoteYesButton';
 import CollectionVoteNoButton from './CollectionVoteNoButton';
 import {Notifications} from '../../libs/utils';
 import { Votes } from '../../libs/ajax/Votes';
+import {toLower} from "lodash";
 
 const styles = {
   baseStyle: {
@@ -106,7 +107,8 @@ export default function CollectionSubmitVoteBox(props) {
 
   const updateVote = async (newVote, isChair) => {
     try {
-      const voteIds = map(v => v.voteId)(votes);
+      const openElectionVotes = votes.filter(v => toLower(v.electionStatus) === 'open');
+      const voteIds = map(v => v.voteId)(openElectionVotes);
       await Votes.updateVotesByIds(voteIds, {vote: newVote, rationale});
       setSubmitted(true);
       //call updateFinalVote for chairs in order to update source collection's votes and trigger sub-component re-render

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
@@ -8,7 +8,6 @@ import {
   isEmpty,
   get,
   includes,
-  every,
   toLower,
 } from 'lodash/fp';
 import { Storage } from '../../libs/storage';

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import CollectionSubmitVoteBox from '../collection_vote_box/CollectionSubmitVoteBox';
 import {
-  filter,
-  flow,
-  map,
   isNil,
   isEmpty,
-  get,
-  includes,
-  toLower,
+  get
 } from 'lodash/fp';
 import { Storage } from '../../libs/storage';
 import { useEffect, useState } from 'react';
@@ -93,12 +88,10 @@ export default function MultiDatasetVoteSlab(props) {
   };
 
   const VoteInfoSubsection = () => {
-    const electionIds = map((vote) => vote.electionId)(currentUserVotes);
-    const allOpenElections = flow(
-      get('elections'),
-      filter((election) => includes(election.electionId)(electionIds)),
-      filter((election) => toLower(election.status) === 'open')
-    )(bucket);
+    const electionIds = currentUserVotes.map((vote) => vote.electionId);
+    const allOpenElections = bucket.elections
+        .filter((election) => electionIds.includes(election.electionId))
+        .filter((election) => election.status.toLowerCase() === 'open');
 
     return (
       <div style={styles.voteInfo}>

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
@@ -98,7 +98,7 @@ export default function MultiDatasetVoteSlab(props) {
     const allOpenElections = flow(
       get('elections'),
       filter((election) => includes(election.electionId)(electionIds)),
-      every((election) => toLower(election.status) === 'open')
+      filter((election) => toLower(election.status) === 'open')
     )(bucket);
 
     return (

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -18,8 +18,16 @@ export const processVotesForBucket = (darElections = []) => {
     agreementVotes: []
   };
   darElections.forEach((election) => {
-    const {electionType, votes = []} = election;
-    let dateSortedVotes = sortBy((vote) => vote.updateDate)(votes);
+    const {electionType, votes, status = []} = election;
+    // add field to each vote object to indicate election status
+    const updatedVotes = Object.values(votes).map(vote => ({
+      ...vote,
+      electionStatus: status
+    }));
+    updatedVotes.forEach(vote => {
+      votes[vote.voteId] = vote;
+    });
+    const dateSortedVotes = sortBy((vote) => vote.updateDate)(updatedVotes);
     let targetFinal, targetChair, targetMember, targetFinalType;
 
     if(electionType === 'RP') {

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -1,4 +1,4 @@
-import {flow, isEmpty, map, filter, find, forEach, flatMap, toLower, sortBy, isNil, includes, concat, findIndex, cloneDeep, groupBy, flatten} from 'lodash/fp';
+import {flow, isEmpty, map, filter, find, forEach, flatMap, toLower, isNil, includes, concat, findIndex, cloneDeep, groupBy, flatten} from 'lodash/fp';
 import { formatDate, Notifications } from '../libs/utils';
 import { Collections } from '../libs/ajax/Collections';
 
@@ -27,7 +27,7 @@ export const processVotesForBucket = (darElections = []) => {
     updatedVotes.forEach(vote => {
       votes[vote.voteId] = vote;
     });
-    const dateSortedVotes = sortBy((vote) => vote.updateDate)(updatedVotes);
+    const dateSortedVotes = updatedVotes.sort((vote) => vote.updateDate);
     let targetFinal, targetChair, targetMember, targetFinalType;
 
     if(electionType === 'RP') {

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -4,7 +4,7 @@ import { Collections } from '../libs/ajax/Collections';
 
 export const rpVoteKey = 'RUS Vote';
 
-//Helper function for processDataUseBuckets, essentilly organizes votes in a dar's elections by type
+//Helper function for processDataUseBuckets, essentially organizes votes in a dar's elections by type
 export const processVotesForBucket = (darElections = []) => {
   const rp =  {
     chairpersonVotes: [],
@@ -111,7 +111,7 @@ const filterVoteArraysForUsersDac = (voteArrays = [], user) => {
 //Note that filtering by DAC does not occur for users viewing through admin review page
 export const extractUserDataAccessVotesFromBucket = (bucket, user, isChair = false, adminPage = false) => {
   const votes = !isNil(bucket) ? bucket.votes : [];
-  let output = flow(
+  const output = flow(
     map(voteData => voteData.dataAccess),
     filter((dataAccessData) => !isEmpty(dataAccessData)),
     flatMap(filteredData => adminPage || isChair ?
@@ -241,7 +241,7 @@ export const cancelCollectionFn =
         });
         updateCollections(summary);
         Notifications.showSuccess({ text: `Successfully canceled ${darCode}` });
-      } catch (error) {
+      } catch (_error) {
         Notifications.showError({ text: `Error canceling ${darCode}` });
       }
     };
@@ -257,7 +257,7 @@ export const openCollectionFn =
         });
         updateCollections(summary);
         Notifications.showSuccess({ text: `Successfully opened ${darCode}` });
-      } catch (error) {
+      } catch (_error) {
         Notifications.showError({ text: `Error opening ${darCode}` });
       }
     };

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -27,7 +27,7 @@ export const processVotesForBucket = (darElections = []) => {
     updatedVotes.forEach(vote => {
       votes[vote.voteId] = vote;
     });
-    const dateSortedVotes = updatedVotes.sort((vote) => vote.updateDate);
+    const dateSortedVotes = updatedVotes.toSorted((vote) => vote.updateDate);
     let targetFinal, targetChair, targetMember, targetFinalType;
 
     if(electionType === 'RP') {


### PR DESCRIPTION
### Addresses

This PR aims to address an issue where Progress reports could not be voted on because the UI thought the election was closed. 
<img width="499" alt="image" src="https://github.com/user-attachments/assets/5852ea09-0b64-405c-a3c8-e12d9cc87eb1" />
We previously required that all elections in the DAR collection were open. However, it is neccessary for the original DAR to have elections closed in order to open a progress report. 

In other words, within a DAR collection that has a DAR and a progress report, we would have at least two elections:
**Dar Collection**
1. Original DAR - Approved with a closed election
2. Progress report - Open election

### Summary
These changes do two things:
1. Only require there to be one open election on a dataset/Data use in order for a user to submit a vote in the UI
2. Only submit votes for the open elections
