### PR TITLE
DT-1695: Use the singular LC object on user

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
@@ -200,21 +200,19 @@ const dar = {
       'createUser': null,
       'updateUser': null
     },
-    'libraryCards': [
-      {
-        'id': 182,
-        'userId': 7,
-        'institutionId': 90210,
-        'eraCommonsId': null,
-        'userName': 'Bob Jones',
-        'userEmail': 'Bob.Jones@prodigy.com',
-        'createDate': 1667817915000,
-        'createUserId': 5555,
-        'updateDate': null,
-        'updateUserId': null,
-        'institution': null
-      }
-    ]
+    'libraryCard': {
+      'id': 182,
+      'userId': 7,
+      'institutionId': 90210,
+      'eraCommonsId': null,
+      'userName': 'Bob Jones',
+      'userEmail': 'Bob.Jones@prodigy.com',
+      'createDate': 1667817915000,
+      'createUserId': 5555,
+      'updateDate': null,
+      'updateUserId': null,
+      'institution': null
+    }
   },
   'createUserId': 7,
   'updateDate': null,

--- a/cypress/component/DarCollectionTable/darCollection.json
+++ b/cypress/component/DarCollectionTable/darCollection.json
@@ -162,19 +162,17 @@
       "createDate": 1617716382481,
       "updateDate": 1620133344596
     },
-    "libraryCards": [
-      {
-        "id": 92,
-        "userId": 3351,
-        "institutionId": 150,
-        "eraCommonsId": "GREGORYRUSHTON",
-        "userName": "Gregory Rushton",
-        "userEmail": "grushton@test.com",
-        "createDate": 1694797680476,
-        "createUserId": 3351,
-        "daaIds": []
-      }
-    ]
+    "libraryCard": {
+      "id": 92,
+      "userId": 3351,
+      "institutionId": 150,
+      "eraCommonsId": "GREGORYRUSHTON",
+      "userName": "Gregory Rushton",
+      "userEmail": "grushton@test.com",
+      "createDate": 1694797680476,
+      "createUserId": 3351,
+      "daaIds": []
+    }
   },
   "createUserId": 3351,
   "dars": {

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -43,7 +43,6 @@ const userNoLibraryCard = {
   displayName: 'Jane Doe',
   email: 'janedoe@gmail.com',
   eraCommonsId: 'asdg',
-  libraryCard: {},
   properties: [
     {
       propertyId: 10350,

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -89,6 +89,7 @@ describe('Data Access Request - Validation', () => {
 
   describe('With Library Cards', () => {
     beforeEach(() => {
+      cy.initApplicationConfig();
       cy.stub(Metrics, 'captureEvent').returns(Promise.resolve());
       cy.stub(User, 'getSOsForCurrentUser').returns(userSigningOfficials);
       cy.stub(DataSet, 'autocompleteDatasets').returns(Promise.resolve(datasets));
@@ -96,7 +97,10 @@ describe('Data Access Request - Validation', () => {
       cy.stub(Storage, 'getCurrentUser').returns(user);
       cy.stub(User, 'getMe').returns(user);
       cy.stub(Navigation, 'console').returns({});
-      cy.stub(DAR, 'postDar').returns({});
+      cy.intercept('POST', '/api/dar/**', {
+        statusCode: 200,
+        body: {}
+      }).as('postDar');
       cy.stub(DAR, 'updateDarDraft').returns({ referenceId: 'asdf' });
       cy.stub(DAR, 'uploadDARDocument').returns({ referenceId: 'asdf' });
       cy.stub(DAR, 'postDarDraft').returns({ referenceId: 'asdf' });
@@ -137,10 +141,10 @@ describe('Data Access Request - Validation', () => {
 
       cy.get('#btn_attest').click();
       cy.get('#btn_openSubmitModal').click();
-      cy.get('#btn_submit').click().then(() => {
-        expect(DAR.postDar).to.have.been.calledOnce;
+      cy.get('#btn_submit').click();
+      cy.wait('@postDar').then((interception) => {
+        expect(interception.response.statusCode).to.equal(200);
       });
-
     });
 
     it('Required fields should not be errored when you open page', () => {

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import {React} from 'react';
 import {mount} from 'cypress/react';
 import DataAccessRequestApplication from '../../../src/pages/dar_application/DataAccessRequestApplication.jsx';

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -22,7 +22,7 @@ const user = {
   displayName: 'Jane Doe',
   email: 'janedoe@gmail.com',
   eraCommonsId: 'asdg',
-  libraryCards: [{}],
+  libraryCard: {},
   properties: [
     {
       propertyId: 10350,
@@ -44,7 +44,7 @@ const userNoLibraryCard = {
   displayName: 'Jane Doe',
   email: 'janedoe@gmail.com',
   eraCommonsId: 'asdg',
-  libraryCards: [],
+  libraryCard: {},
   properties: [
     {
       propertyId: 10350,

--- a/cypress/component/DataAccessRequest/researcher_info.spec.jsx
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.jsx
@@ -34,21 +34,19 @@ const props = {
   }
 };
 
-const researcherWithLibraryCards = {
-  libraryCards: [
-    {
-      'id': 1,
-      'userId': 1,
-      'institutionId': 150,
-      'eraCommonsId': 'user',
-      'userName': 'User',
-      'userEmail': 'email',
-      'institution': {
-        'id': 150,
-        'name': 'The Broad Institute of MIT and Harvard',
-      }
+const researcherWithLibraryCard = {
+  libraryCard: {
+    'id': 1,
+    'userId': 1,
+    'institutionId': 150,
+    'eraCommonsId': 'user',
+    'userName': 'User',
+    'userEmail': 'email',
+    'institution': {
+      'id': 150,
+      'name': 'The Broad Institute of MIT and Harvard',
     }
-  ]
+  }
 };
 
 const addNewCollaborator = (collaboratorType) => {
@@ -93,14 +91,14 @@ describe('Researcher Info', () => {
   });
 
   it('renders the profile submitted alert', () => {
-    const mergedProps = {...props, ...{completed: true, researcher: researcherWithLibraryCards}};
+    const mergedProps = {...props, ...{completed: true, researcher: researcherWithLibraryCard}};
     mount(<WrappedResearcherInfo {...mergedProps}/>);
     cy.get('[data-cy=researcher-info-profile-submitted]').should('be.visible');
     cy.get('[data-cy=researcher-info-profile-unsubmitted]').should('not.exist');
   });
 
   it('renders the profile unsubmitted alert', () => {
-    const mergedProps = {...props, ...{completed: false, researcher: researcherWithLibraryCards}};
+    const mergedProps = {...props, ...{completed: false, researcher: researcherWithLibraryCard}};
     mount(<WrappedResearcherInfo {...mergedProps}/>);
     cy.get('[data-cy=researcher-info-profile-unsubmitted]').should('be.visible');
     cy.get('[data-cy=researcher-info-profile-submitted]').should('be.visible');

--- a/cypress/component/DataAccessRequest/researcher_info.spec.jsx
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import {React} from 'react';
 import {mount} from 'cypress/react';
 import ResearcherInfo from '../../../src/pages/dar_application/ResearcherInfo';

--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -35,7 +35,7 @@ describe('Library Card Form Modal Tests', () => {
 
   it('Existing users should be visible in the user selection list', () => {
     const userOptions = [
-      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCards: []},
+      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: null},
     ]
     const mergedProps = {...props, ...{users: userOptions}};
     mount(<LibraryCardFormModal {...mergedProps} />);
@@ -50,7 +50,7 @@ describe('Library Card Form Modal Tests', () => {
 
   it('Non-existing users should NOT be visible in the user selection list', () => {
     const userOptions = [
-      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCards: []},
+      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: null},
     ]
     const mergedProps = {...props, ...{users: userOptions}};
     mount(<LibraryCardFormModal {...mergedProps} />);

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.jsx
@@ -101,7 +101,7 @@ const collection = {
     {datasetId: 400}
   ],
   createUser: {
-    libraryCards: [{id: 1}]
+    libraryCard: {id: 1}
   }
 };
 
@@ -110,7 +110,7 @@ const collectionMissingLibraryCard = {
     {datasetId: 300}
   ],
   createUser: {
-    libraryCards: []
+    libraryCard: null
   }
 };
 

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_voting_tab.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 import React from 'react';
 import { mount } from 'cypress/react';
 import {Storage} from '../../../src/libs/storage';

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -27,7 +27,7 @@ interface UserData {
   userId: number;
   displayName: string;
   email: string;
-  libraryCards?: LibraryCard[];
+  libraryCard?: LibraryCard;
 }
 
 export interface LibraryCardTableProps {

--- a/src/components/manage_users_table/ManageUsersTable.jsx
+++ b/src/components/manage_users_table/ManageUsersTable.jsx
@@ -106,13 +106,13 @@ const processUserRowData = ({ users, columns = columns }) => {
         roles,
         userId,
         displayName,
-        libraryCards,
+        libraryCard,
         institution,
         email
       } = user;
       return columns.map((col) => {
         return columnHeaderConfig[col].cellDataFn({
-          user, roles, userId, displayName, email, institution, libraryCards
+          user, roles, userId, displayName, email, institution, libraryCard
         });
       });
     });

--- a/src/components/manage_users_table/ManageUsersTableCellData.jsx
+++ b/src/components/manage_users_table/ManageUsersTableCellData.jsx
@@ -50,8 +50,8 @@ export function emailCellData({userId, email, label = 'email'}) {
   };
 }
 
-export function permissionsCellData({userId, roles, libraryCards, label = 'permissions'}) {
-  const hasLibraryCard = !isNil(libraryCards) && !isEmpty(libraryCards);
+export function permissionsCellData({userId, roles, libraryCard, label = 'permissions'}) {
+  const hasLibraryCard = !isNil(libraryCard);
   const roleNames = map(roles, 'name').filter((roleName) => roleName !== 'Researcher');
   const perms = (hasLibraryCard ? roleNames.concat('LibraryCard') : roleNames);
 

--- a/src/components/manage_users_table/ManageUsersTableCellData.jsx
+++ b/src/components/manage_users_table/ManageUsersTableCellData.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {isNil, isEmpty, map, sortedUniq} from 'lodash';
+import {isNil, map, sortedUniq} from 'lodash';
 import {styles} from './ManageUsersTable';
 import {Link} from 'react-router-dom';
 import ReactTooltip from 'react-tooltip';

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -14,7 +14,7 @@ interface UserOption {
   userId: number;
   displayName: string;
   email: string;
-  libraryCards?: LibraryCard[];
+  libraryCard?: LibraryCard;
 }
 
 interface FormFieldRowProps {
@@ -43,7 +43,7 @@ interface FilterOptions {
 const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
   const { card, dropdownOptions, updateUser, setCard } = props;
 
-  const cardlessOptions = dropdownOptions.filter((option) => isEmpty(option.libraryCards));
+  const cardlessOptions = dropdownOptions.filter((option) => isNil(option.libraryCard));
   const [filteredDropdown, setFilteredDropdown] = useState<UserOption[]>(cardlessOptions);
 
   //filter function for users dropdown

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -66,7 +66,7 @@ export const User = {
 
   update: async (user: UpdateDuosUserRequestV2, userId: number)/*: Promise<UpdateDuosUserResponse>*/ => {
     const url = `${await getApiUrl()}/api/user/${userId}`;
-    // We should not be updating the user's create date, associated institution, or library cards
+    // We should not be updating the user's create date, associated institution, or library card
     // This below code does not seem to work at all and
     // does not seem appropriate for this request anyway.
     // The UpdateDuosUserRequestV2 is not the same shape as a DuosUser
@@ -75,7 +75,7 @@ export const User = {
       cloneDeep,
       unset('updatedUser.createDate'),
       unset('updatedUser.institution'),
-      unset('updatedUser.libraryCards')
+      unset('updatedUser.libraryCard')
     )(user);
     try {
       const res = await fetchOk(

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,4 +1,4 @@
-import {forEach as lodashForEach, isArray} from 'lodash';
+import {forEach as lodashForEach} from 'lodash';
 import {DAR} from './ajax/DAR';
 import {Theme} from './theme';
 import {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -330,7 +330,7 @@ export const getSearchFilterFunctions = () => {
 
       return filter(user => {
         const {
-          displayName, email, roles, institution, libraryCards
+          displayName, email, roles, institution, libraryCard
         } = user;
 
         const matchable = [displayName, email];
@@ -341,8 +341,8 @@ export const getSearchFilterFunctions = () => {
           matchable.push(institution.name);
         }
 
-        if (!isNil(libraryCards) && isArray(libraryCards)) {
-          const hasLibraryCard = !isNil(libraryCards) && !isEmpty(libraryCards);
+        if (!isNil(libraryCard)) {
+          const hasLibraryCard = !isNil(libraryCard);
 
           if (hasLibraryCard) {
             matchable.push('LibraryCard');

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -367,7 +367,7 @@ const DataAccessRequestApplication = (props) => {
 
     setFormValidation(validation);
 
-    const hasLibraryCard = !isEmpty(researcher.libraryCards);
+    const hasLibraryCard = !isNil(researcher.libraryCard);
 
     const isInvalidForm = validationFailed(validation) || !nihValid || !hasLibraryCard;
     setShowNihValidationError(!nihValid);

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -3,7 +3,7 @@ import {Alert} from '../../components/Alert';
 import {Link} from 'react-router-dom';
 import ERACommons from '../../components/ERACommons';
 import CollaboratorList from './collaborator/CollaboratorList';
-import {isEmpty, isNil, get} from 'lodash/fp';
+import {isEmpty, isNil} from 'lodash/fp';
 import {FormField, FormValidators, FormFieldTypes} from '../../components/forms/forms';
 import './dar_application.css';
 import {nihAccountLabel, nihAccountInstructions} from '../../utils/ERACommonsUtils.js';
@@ -58,7 +58,7 @@ export default function ResearcherInfo(props) {
   const [libraryCardReqSatisfied, setLibraryCardReqSatisfied] = useState(false);
 
   useEffect(() => {
-    setLibraryCardReqSatisfied(!isEmpty(get('libraryCards')(researcher)));
+    setLibraryCardReqSatisfied(!isNil(researcher.libraryCard));
   }, [researcher]);
 
   return (

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {useEffect, useState} from 'react';
 import MultiDatasetVoteSlab from '../../components/collection_voting_slab/MultiDatasetVoteSlab';
 import ResearchProposalVoteSlab from '../../components/collection_voting_slab/ResearchProposalVoteSlab';
-import {find, get, filter, flow, map, isNil, isEmpty} from 'lodash/fp';
+import {find, get, filter, flow, map, isNil} from 'lodash/fp';
 import { User } from '../../libs/ajax/User';
 import {Alert} from '../../components/Alert';
 

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
@@ -77,11 +77,11 @@ export default function MultiDatasetVotingTab(props) {
   };
 
   const dataAccessApprovalDisabled = () => {
-    const researcherLibraryCards = flow(
+    const researcherLibraryCard = flow(
       get('createUser'),
-      get('libraryCards')
+      get('libraryCard')
     )(collection);
-    const researcherMissingLibraryCards = isNil(researcherLibraryCards) || isEmpty(researcherLibraryCards);
+    const researcherMissingLibraryCards = isNil(researcherLibraryCard);
     return isChair && researcherMissingLibraryCards;
   };
 

--- a/src/pages/signing_official_console/DAACell.jsx
+++ b/src/pages/signing_official_console/DAACell.jsx
@@ -4,10 +4,9 @@ import { DAA } from '../../libs/ajax/DAA';
 import { Notifications } from '../../libs/utils';
 
 export default function DAACell(props) {
-  const {rowDac, researcher, institutionId, daas, refreshResearchers, setResearchers} = props;
+  const {rowDac, researcher, daas, refreshResearchers, setResearchers} = props;
   const id = researcher?.userId || researcher?.email;
-  const libraryCards = researcher?.libraryCards;
-  const card = libraryCards?.find(card => card.institutionId === institutionId);
+  const card = researcher?.libraryCard;
   const daaIds = researcher && card?.daaIds;
   const filteredDaas = daaIds && daas?.filter(daa => daaIds.includes(daa.daaId));
   const hasDacId = filteredDaas && filteredDaas.some(daa => daa.dacs?.some(dac => dac.dacId === rowDac.dacId));
@@ -17,7 +16,7 @@ export default function DAACell(props) {
       await DAA.createDaaLcLink(daaId, researcher.userId);
       Notifications.showSuccess({text: `Approved access to ${dacName} to user: ${researcher.displayName}`});
       refreshResearchers(setResearchers);
-    } catch(error) {
+    } catch(_error) {
       Notifications.showError({text: `Error approving access to ${dacName} to user: ${researcher.displayName}`});
     }
   };
@@ -27,7 +26,7 @@ export default function DAACell(props) {
       await DAA.deleteDaaLcLink(daaId, researcher.userId);
       Notifications.showSuccess({text: `Removed approval of access to ${dacName} to user: ${researcher.displayName}`});
       refreshResearchers(setResearchers);
-    } catch(error) {
+    } catch(_error) {
       Notifications.showError({text: `Error removing approval of access to ${dacName} to user: ${researcher.displayName}`});
     }
   };

--- a/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Styles } from '../../libs/theme';
-import { isEmpty } from 'lodash/fp';
+import {isNaN} from 'lodash/fp';
 import SimpleTable from '../../components/SimpleTable';
 import PaginationBar from '../../components/PaginationBar';
 import SearchBar from '../../components/SearchBar';
@@ -162,8 +162,7 @@ export default function ManageResearcherDAAsTable(props) {
 
   const processResearcherRowData = (researchers = []) => {
     return researchers.map(researcher => {
-      const { displayName, libraryCards } = researcher;
-      const libraryCard = !isEmpty(libraryCards) ? libraryCards[0] : {};
+      const { displayName, libraryCard } = researcher;
       const email = researcher.email || libraryCard.userEmail;
       const id = researcher.userId || email;
       return [

--- a/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAsTable.jsx
@@ -113,7 +113,7 @@ export default function ManageResearcherDAAsTable(props) {
     const init = async() => {
       try{
         setResearchers(props.researchers);
-      } catch(error) {
+      } catch(_error) {
         Notifications.showError({text: 'Failed to initialize researcher table'});
       }
     };

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -3,7 +3,6 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Info } from '@mui/icons-material';
 import { Styles, Theme } from 'src/libs/theme';
 import { cloneDeep, find, findIndex, join, map, sortedUniq, sortBy, isNil, flow } from 'lodash/fp';
-import {head} from 'lodash';
 import SimpleTable from 'src/components/SimpleTable';
 import SimpleButton from 'src/components/SimpleButton';
 import PaginationBar from 'src/components/PaginationBar';

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -1,28 +1,28 @@
 import React from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Info } from '@mui/icons-material';
-import { Styles, Theme } from '../../libs/theme';
-import { cloneDeep, find, findIndex, join, map, sortedUniq, sortBy, isEmpty, isNil, flow, filter } from 'lodash/fp';
+import { Styles, Theme } from 'src/libs/theme';
+import { cloneDeep, find, findIndex, join, map, sortedUniq, sortBy, isNil, flow } from 'lodash/fp';
 import {head} from 'lodash';
-import SimpleTable from '../../components/SimpleTable';
-import SimpleButton from '../../components/SimpleButton';
-import PaginationBar from '../../components/PaginationBar';
-import SearchBar from '../../components/SearchBar';
+import SimpleTable from 'src/components/SimpleTable';
+import SimpleButton from 'src/components/SimpleButton';
+import PaginationBar from 'src/components/PaginationBar';
+import SearchBar from 'src/components/SearchBar';
 import {
   Notifications,
   recalculateVisibleTable,
   getSearchFilterFunctions,
   searchOnFilteredList
-} from '../../libs/utils';
-import LibraryCardFormModal from '../../components/modals/LibraryCardFormModal';
-import ConfirmationModal from '../../components/modals/ConfirmationModal';
-import { LibraryCard } from '../../libs/ajax/LibraryCard';
-import {LibraryCardAgreementTermsDownload} from '../../components/LibraryCardAgreementTermsDownload';
-import BroadLibraryCardAgreementLink from '../../assets/Library_Card_Agreement_2023_ApplicationVersion.pdf';
-import NihLibraryCardAgreementLink from '../../assets/NIHLibraryCardAgreement08012024.pdf';
+} from 'src/libs/utils';
+import LibraryCardFormModal from 'src/components/modals/LibraryCardFormModal';
+import ConfirmationModal from 'src/components/modals/ConfirmationModal';
+import { LibraryCard } from 'src/libs/ajax/LibraryCard';
+import {LibraryCardAgreementTermsDownload} from 'src/components/LibraryCardAgreementTermsDownload';
+import BroadLibraryCardAgreementLink from 'src/assets/Library_Card_Agreement_2023_ApplicationVersion.pdf';
+import NihLibraryCardAgreementLink from 'src/assets/NIHLibraryCardAgreement08012024.pdf';
 import {
   NIHDataUseCertificationAgreement
-} from '../../components/external_docs/NIHDataUseCertificationAgreement';
+} from 'src/components/external_docs/NIHDataUseCertificationAgreement';
 
 //Styles specific to this table
 const styles = {
@@ -122,7 +122,7 @@ const LibraryCardCell = ({
   showConfirmationModal,
 }) => {
   const id = researcher.userId || researcher.email;
-  const card = head(researcher.libraryCards);
+  const card = researcher.libraryCard;
   const button = !isNil(card)
     ? DeactivateLibraryCardButton({
       card,
@@ -190,13 +190,11 @@ const displayNameCell = (displayName, id) => {
 };
 
 
-const onlyResearchersWithoutCardFilter = (institutionId) => (researcher) => {
-  const cards = researcher.libraryCards;
-  if (isEmpty(cards)) {
+const onlyResearchersWithoutCardFilter = (researcher) => {
+  const card = researcher.libraryCard;
+  if (isNil(card)) {
     return true;
   }
-
-  return isNil(find((card) => card.institutionId === institutionId)(researcher.libraryCards));
 };
 
 export default function SigningOfficialTable(props) {
@@ -287,8 +285,7 @@ export default function SigningOfficialTable(props) {
 
   const processResearcherRowData = (researchers = []) => {
     return researchers.map(researcher => {
-      const {displayName, /*count = 0,*/ roles, libraryCards} = researcher;
-      const libraryCard = !isEmpty(libraryCards) ? libraryCards[0] : {};
+      const {displayName, /*count = 0,*/ roles, libraryCard} = researcher;
       const email = researcher.email || libraryCard.userEmail;
       const id = researcher.userId || email;
       return [
@@ -330,7 +327,7 @@ export default function SigningOfficialTable(props) {
         const attributes = {
           email: userEmail,
           displayName: userName,
-          libraryCards: [newLibraryCard],
+          libraryCard: newLibraryCard,
           roles: [],
         };
         if(!isNil(targetUnregisteredResearcher)) {
@@ -339,7 +336,7 @@ export default function SigningOfficialTable(props) {
         listCopy.unshift(attributes);
         messageName = userEmail;
       } else {
-        listCopy[targetIndex].libraryCards = [newLibraryCard];
+        listCopy[targetIndex].libraryCard = newLibraryCard;
         messageName = userName;
       }
       setResearchers(listCopy);
@@ -358,14 +355,13 @@ export default function SigningOfficialTable(props) {
     try {
       await LibraryCard.deleteLibraryCard(id);
       const targetIndex = findIndex((researcher) => {
-        const libraryCards = researcher.libraryCards || [];
-        const card = libraryCards[0];
+        const card = researcher.libraryCard;
         return !isNil(card) && id === card.id;
       })(researchers);
       if(isNil(userId) || researchers[targetIndex].institutionId !== signingOfficial.institutionId) {
         listCopy.splice(targetIndex, 1);
       } else {
-        listCopy[targetIndex].libraryCards = [];
+        listCopy[targetIndex].libraryCard = undefined;
       }
       setResearchers(listCopy);
       setShowConfirmation(false);
@@ -434,7 +430,7 @@ export default function SigningOfficialTable(props) {
         createOnClick={(card) => issueLibraryCard(card, researchers)}
         closeModal={() => setShowModal(false)}
         card={selectedCard}
-        users={filter(onlyResearchersWithoutCardFilter(signingOfficial.institutionId))(researchers)}
+        users={onlyResearchersWithoutCardFilter(researchers)}
         modalType="add" />
       <ConfirmationModal
         showConfirmation={showConfirmation}

--- a/src/pages/user_profile/ResearcherStatus.jsx
+++ b/src/pages/user_profile/ResearcherStatus.jsx
@@ -27,12 +27,12 @@ export default function ResearcherStatus(props) {
   useEffect(() => {
     const init = async () => {
       try {
-        if (!isNil(user) && !isNil(user.libraryCards)) {
-          if (user.libraryCards.length === 0) {
+        if (!isNil(user)) {
+          if (isNil(user.libraryCard)) {
             setHasCard(false);
-          }
-          else {
-            const card = user.libraryCards[0];
+          } else {
+            setHasCard(true);
+            const card = user.libraryCard;
             const daaIds = card.daaIds;
             const signingOfficialUsers = await User.getSOsForCurrentUser();
             setIssuedOn(card.createDate);

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -48,7 +48,7 @@ export interface DuosUser {
   isMember: boolean;
   isResearcher: boolean;
   isSigningOfficial: boolean;
-  libraryCards?: LibraryCard[];
+  libraryCard?: LibraryCard;
   properties?: UserProperty[];
   roles: UserRole[];
   userId: number;

--- a/src/types/responseTypes.ts
+++ b/src/types/responseTypes.ts
@@ -5,8 +5,8 @@ export interface DuosUserResponse {
   displayName: string;
   email: string;
   emailPreference: boolean;
-  libraryCards: LibraryCard[];
-  properties: UserProperty[];
+  libraryCard?: LibraryCard;
+  properties?: UserProperty[];
   roles: UserRole[];
   userId: number;
   userStatusInfo: UserStatusInfo;

--- a/src/utils/ERACommonsUtils.js
+++ b/src/utils/ERACommonsUtils.js
@@ -2,7 +2,8 @@ import {Buffer} from 'buffer';
 import EnvironmentUtils, {envGroups} from '../utils/EnvironmentUtils.js';
 
 export const rasEnabled = () => {
-  return EnvironmentUtils.checkEnv(envGroups.DEV);
+  // return EnvironmentUtils.checkEnv(envGroups.DEV);
+  return false; // RAS is not enabled in production
 }
 
 export const nihAccountLabel = () => {

--- a/src/utils/ERACommonsUtils.js
+++ b/src/utils/ERACommonsUtils.js
@@ -2,8 +2,7 @@ import {Buffer} from 'buffer';
 import EnvironmentUtils, {envGroups} from '../utils/EnvironmentUtils.js';
 
 export const rasEnabled = () => {
-  // return EnvironmentUtils.checkEnv(envGroups.DEV);
-  return false; // RAS is not enabled in production
+  return EnvironmentUtils.checkEnv(envGroups.DEV);
 }
 
 export const nihAccountLabel = () => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1695

### Summary
* Update all usages of `user.libraryCards` to `user.libraryCard`
* Fixes a bug introduced in https://github.com/DataBiosphere/consent/pull/2536 where the DAC voting page was unable to determine if the DAR create user had a library card or not.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
