### PR TITLE
[DT-1757] Refine local development setup instructions

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -12,8 +12,8 @@ volta install 22.11.0
 npm install
 ```
 
-3. Generate configuration files and populate certificates by running the [render-configs.sh](scripts/render-configs.sh) script. This requires 
-connection to the Broad VPN. By default, this points the DUOS UI to the dev environment. 
+3. Generate configuration files and populate certificates by running the [render-configs.sh](scripts/render-configs.sh) script. This requires
+connection to the Broad VPN. By default, this points the DUOS UI to the dev environment.
 
 ```
 cd scripts
@@ -22,12 +22,12 @@ cd scripts
 
 #### Notes on render-configs:
 * Ensure that HOST is not set in your shell environment, as it will override the value in `.env.local`.
-* **Development against other envs**: If you want to point to other envs, you can populate public/config.json with the values from any 
-environment by looking at the deployed configs in https://duos-k8s.dsde-{%ENV%}.broadinstitute.org/config.json where 
+* **Development against other envs**: If you want to point to other envs, you can populate public/config.json with the values from any
+environment by looking at the deployed configs in https://duos-k8s.dsde-{%ENV%}.broadinstitute.org/config.json where
 {%ENV%} is any of `dev`, `staging`, `alpha`, or `prod`. Remember to set the `env` value appropriately, for example,
-`dev`. Certain features are available only in specific environments. Setting the `env` value to the desired environment 
+`dev`. Certain features are available only in specific environments. Setting the `env` value to the desired environment
 will simulate it for local development.
-* **Refresh certs on rotation**: render-config.sh populates local certificate files. The certificates are rotated every 
+* **Refresh certs on rotation**: render-config.sh populates local certificate files. The certificates are rotated every
 3 months and can be repopulated by re-running the script. Again, you'll need to be on the broad VPN.
 
 ```shell
@@ -41,7 +41,7 @@ cd scripts
 127.0.0.1	local.dsde-dev.broadinstitute.org
 ```
 
-5. Create a `site.conf` file in the project root directory using https://github.com/broadinstitute/terra-helmfile/blob/master/charts/duos/templates/_site.conf.tpl as a model. 
+5. Create a `site.conf` file in the project root directory using https://github.com/broadinstitute/terra-helmfile/blob/master/charts/duos/templates/_site.conf.tpl as a model.
 
 
 
@@ -59,7 +59,7 @@ the `env` value to the desired environment will simulate it for local developmen
 ```yaml
     volumes:
       - ./public/config.json:/usr/share/nginx/html/config.json
-``` 
+```
 
 Build and run:
 
@@ -125,4 +125,4 @@ To run a single test suite:
 ```shell
 npm run cypress:open:component --spec "**/data_access_governance.spec.js"
 ```
- 
+

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -21,7 +21,7 @@ cd scripts
 ```
 
 #### Notes on render-configs:
-* Ensure that HOST is not set in your shell environment, as it will override the value in `.env.local`.
+* Ensure that HOST is not set in your shell environment, as it will override the value in `.env.local`.  You can check like so: `env | grep HOST=`.
 * **Development against other envs**: If you want to point to other envs, you can populate public/config.json with the values from any
 environment by looking at the deployed configs in https://duos-k8s.dsde-{%ENV%}.broadinstitute.org/config.json where
 {%ENV%} is any of `dev`, `staging`, `alpha`, or `prod`. Remember to set the `env` value appropriately, for example,

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -1,9 +1,9 @@
 # Local Development
 
-1. We use [node@22.11.0](https://docs.volta.sh/guide/understanding):
+1. We use node 24.0.2 at time of writing, but check the [version of Node declared in the Dockerfile](https://github.com/DataBiosphere/duos-ui/blob/develop/Dockerfile#L2) and install that when setting up.  You can install it with [Volta](https://docs.volta.sh/guide/understanding) or NVM.
 
 ```
-volta install 22.11.0
+volta install 24.0.2
 ```
 
 2. Install deps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@databiosphere/bard-client": "0.1.0",
         "@mui/icons-material": "5.17.1",
         "@mui/material": "5.17.1",
+        "@mui/system": "^5.17.1",
         "@mui/utils": "5.17.1",
         "@mui/x-date-pickers": "^7.29.4",
         "ajv": "8.17.1",
@@ -490,7 +491,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
       "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
@@ -549,7 +550,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -1422,14 +1423,14 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/@mui/private-theming": {
+    "node_modules/@mui/private-theming": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.17.1.tgz",
       "integrity": "sha512-XMxU0NTYcKqdsG8LRmSoxERPXwMbp16sIXPcLVgLGII/bVNagX0xaheWAwFv8+zDK7tI3ajllkuD3GZZE++ICQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/utils": "5.17.1",
+        "@mui/utils": "^5.17.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1449,7 +1450,7 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/@mui/styled-engine": {
+    "node_modules/@mui/styled-engine": {
       "version": "5.16.14",
       "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.14.tgz",
       "integrity": "sha512-UAiMPZABZ7p8mUW4akDV6O7N3+4DatStpXMZwPlt+H/dA0lt67qawN021MNND+4QTpjaiMYxbhKZeQcyWCbuKw==",
@@ -1481,7 +1482,7 @@
         }
       }
     },
-    "node_modules/@mui/material/node_modules/@mui/system": {
+    "node_modules/@mui/system": {
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.17.1.tgz",
       "integrity": "sha512-aJrmGfQpyF0U4D4xYwA6ueVtQcEMebET43CUmKMP7e7iFh3sMIF3sBR0l8Urb4pqx1CBjHAaWgB0ojpND4Q3Jg==",
@@ -1491,7 +1492,7 @@
         "@mui/private-theming": "^5.17.1",
         "@mui/styled-engine": "^5.16.14",
         "@mui/types": "~7.2.15",
-        "@mui/utils": "5.17.1",
+        "@mui/utils": "^5.17.1",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1516,172 +1517,6 @@
         "@emotion/styled": {
           "optional": true
         },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/private-theming": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-6.4.6.tgz",
-      "integrity": "sha512-T5FxdPzCELuOrhpA2g4Pi6241HAxRwZudzAuL9vBvniuB5YU82HCmrARw32AuCiyTfWzbrYGGpZ4zyeqqp9RvQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/utils": "^6.4.6",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/private-theming/node_modules/@mui/utils": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.6.tgz",
-      "integrity": "sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.21",
-        "@types/prop-types": "^15.7.14",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/styled-engine": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-6.4.6.tgz",
-      "integrity": "sha512-vSWYc9ZLX46be5gP+FCzWVn5rvDr4cXC5JBZwSIkYk9xbC7GeV+0kCvB8Q6XLFQJy+a62bbqtmdwS4Ghi9NBlQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@emotion/cache": "^11.13.5",
-        "@emotion/serialize": "^1.3.3",
-        "@emotion/sheet": "^1.4.0",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.4.1",
-        "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system": {
-      "version": "6.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-6.4.7.tgz",
-      "integrity": "sha512-7wwc4++Ak6tGIooEVA9AY7FhH2p9fvBMORT4vNLMAysH3Yus/9B9RYMbrn3ANgsOyvT3Z7nE+SP8/+3FimQmcg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/private-theming": "^6.4.6",
-        "@mui/styled-engine": "^6.4.6",
-        "@mui/types": "^7.2.21",
-        "@mui/utils": "^6.4.6",
-        "clsx": "^2.1.1",
-        "csstype": "^3.1.3",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/system/node_modules/@mui/utils": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.6.tgz",
-      "integrity": "sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.21",
-        "@types/prop-types": "^15.7.14",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1",
-        "react-is": "^19.0.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }
@@ -2278,6 +2113,7 @@
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -10076,21 +9912,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@mui/material": "5.17.1",
     "@mui/utils": "5.17.1",
     "@mui/x-date-pickers": "^7.29.4",
+    "@mui/system": "^5.17.1",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
     "axios": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@mui/material": "5.17.1",
     "@mui/utils": "5.17.1",
     "@mui/x-date-pickers": "^7.29.4",
-    "@mui/system": "^5.17.1",
+    "@mui/system": "5.17.1",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
     "axios": "1.9.0",


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1757

### Summary
This fixes some minor rough edges I encountered while setting up my development environment.

For context, one roadbump I hit seems due to a breaking change in upstream JS dependencies.  This repo has a `@mui/x-date-pickers` package, which, upstream, has [declared `@mui/system` in peerDependencies](https://github.com/mui/mui-x/blob/e9c13ba43f7200a22f06e8b1d7063f31594d09b1/packages/x-date-pickers/package.json) for a while.  That means dependents like this repo need to explicitly declare `@mui/system` as a dependency in their `package.json`.  

We hadn't done that in our `package.json`, so my local `npm start` failed with messages like:

```
✘ [ERROR] Could not resolve "@mui/system/RtlProvider"
```

Adding `@mui/system` as a dependency fixed that.  

This also refines a few instructions in `DEVNOTES.md`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
