### PR TITLE
DT-1777: Allow SOs to navigate to DARs visible in their console page

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -82,7 +82,7 @@ const Routes = (props) => (
     <AuthenticatedRoute path='/chair_console' component={ChairConsole} props={props} rolesAllowed={[USER_ROLES.chairperson]}/>
     <AuthenticatedRoute path='/member_console' component={MemberConsole} props={props} rolesAllowed={[USER_ROLES.member]}/>
     <AuthenticatedRoute path='/dar_vote_review/:collectionId' component={DarCollectionReview} props={Object.assign({readOnly: true}, props)}
-      rolesAllowed={[USER_ROLES.chairperson, USER_ROLES.member]}/>
+      rolesAllowed={[USER_ROLES.chairperson, USER_ROLES.member, USER_ROLES.signingOfficial]}/>
     <AuthenticatedRoute path='/dar_application_review/:collectionId' component={DataAccessRequestApplication} props={Object.assign({}, props, {existingDarsReadOnlyMode: true})}
       rolesAllowed={[USER_ROLES.researcher]} />
     <AuthenticatedRoute path='/progress_report_application/:collectionId' component={DataAccessRequestApplication} props={Object.assign({}, props, {existingDarsReadOnlyMode: true, isProgressReportApplication: true})}


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-1777

### Summary
See https://github.com/DataBiosphere/consent/pull/2543 for the back end work.
The SO has a link on their console page to this route, but it isn't allowed in the route. 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
