### PR TITLE
[DT-1758] Show approved datasets only

### DIFF
--- a/cypress/component/utils/dar_utils.spec.ts
+++ b/cypress/component/utils/dar_utils.spec.ts
@@ -1,0 +1,172 @@
+import { getApprovedElectionDatasetIds } from 'src/utils/DarUtils';
+import { Election, Vote } from 'src/types/model';
+
+describe('DarUtils', () => {
+  describe('getApprovedElectionDatasetIds', () => {
+    it('should return an empty array when given an empty array of elections', () => {
+      const elections: Election[] = [];
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('should return only dataset IDs from DataAccess elections with approved votes', () => {
+      const elections: Election[] = [
+        {
+          electionId: 1,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {
+            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 2,
+          electionType: 'DataAccess',
+          datasetId: 102,
+          votes: {
+            2: { voteId: 2, type: 'FINAL', userId: 11, electionId: 2 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 3,
+          electionType: 'DataAccess',
+          datasetId: 103,
+          votes: {
+            3: { voteId: 3, type: 'FINAL', vote: false, userId: 12, electionId: 3 } as Vote
+          } as object,
+        } as Election
+      ];
+
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([101]);
+    });
+
+    it('should ignore non-DataAccess elections', () => {
+      const elections: Election[] = [
+        {
+          electionId: 1,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {
+            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 2,
+          electionType: 'RP',
+          datasetId: 102,
+          votes: {
+            2: { voteId: 2, type: 'FINAL', vote: true, userId: 11, electionId: 2 } as Vote
+          } as object,
+        } as Election
+      ];
+
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([101]);
+    });
+
+    it('should handle multiple votes per election', () => {
+      const elections: Election[] = [
+        {
+          electionId: 1,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {
+            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote,
+            2: { voteId: 2, type: 'Chairperson', vote: false, userId: 11, electionId: 1 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 2,
+          electionType: 'DataAccess',
+          datasetId: 102,
+          votes: {
+            3: { voteId: 3, type: 'DAC', vote: true, userId: 12, electionId: 2 } as Vote,
+            4: { voteId: 4, type: 'FINAL', vote: false, userId: 13, electionId: 2 } as Vote
+          } as object,
+        } as Election
+      ];
+
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([101]);
+    });
+
+    it('should only consider FINAL vote types', () => {
+      const elections: Election[] = [
+        {
+          electionId: 1,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {
+            1: { voteId: 1, type: 'DAC', vote: true, userId: 10, electionId: 1 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 2,
+          electionType: 'DataAccess',
+          datasetId: 102,
+          votes: {
+            2: { voteId: 2, type: 'Chairperson', vote: true, userId: 11, electionId: 2 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 3,
+          electionType: 'DataAccess',
+          datasetId: 103,
+          votes: {
+            3: { voteId: 3, type: 'FINAL', vote: true, userId: 12, electionId: 3 } as Vote
+          } as object,
+        } as Election
+      ];
+
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([103]);
+    });
+
+    it('should handle elections with no votes', () => {
+      const elections: Election[] = [
+        {
+          electionId: 1,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {} as object,
+        } as Election,
+        {
+          electionId: 2,
+          electionType: 'DataAccess',
+          datasetId: 102,
+          votes: {
+            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 2 } as Vote
+          } as object,
+        } as Election
+      ];
+
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([102]);
+    });
+
+    it('should return unique dataset IDs even if duplicated in multiple elections', () => {
+      const elections: Election[] = [
+        {
+          electionId: 1,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {
+            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote
+          } as object,
+        } as Election,
+        {
+          electionId: 2,
+          electionType: 'DataAccess',
+          datasetId: 101,
+          votes: {
+            2: { voteId: 2, type: 'FINAL', vote: true, userId: 11, electionId: 2 } as Vote
+          } as object,
+        } as Election
+      ];
+
+      const result = getApprovedElectionDatasetIds(elections);
+      expect(result).to.deep.equal([101, 101]);
+    });
+  });
+});

--- a/src/pages/dar_application/DataUseAcknowlegements.tsx
+++ b/src/pages/dar_application/DataUseAcknowlegements.tsx
@@ -3,6 +3,7 @@ import {FormField, FormFieldTitle, FormFieldTypes} from 'src/components/forms/fo
 import React from 'react';
 import {Dataset} from 'src/types/model';
 import {DarErrors, ValidationError} from 'src/pages/dar_application/FormValidationState';
+import { ValidFormState } from 'src/pages/progress_reports/ProgressReportFormState';
 
 type DataUseAcknowledgementsProps = {
     title: string;
@@ -11,7 +12,7 @@ type DataUseAcknowledgementsProps = {
     formData: object,
     readOnlyMode: boolean,
     includeInstructions?: boolean,
-    onChange: (obj: object) => void,
+    onChange: ({ key, value }: ValidFormState) => void,
     onValidationChange?: (validation: {key: string, validation: ValidationError}) => void,
     validation?: DarErrors
 }

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -55,9 +55,13 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
     };
 
     const [formState, setFormState] = useState<FormState>(initialState);
+    const [formValidation, setFormValidation] = useState<FormValidationState>({darErrors:{}});
     const [nihValid, setNihValid] = useState<boolean>(true);
     const [dataUseTranslations, setDataUseTranslations] = useState<string[]>([]);
     const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>(datasets);
+
+    const eRACommonsDestination = 'progress_report_application/' + dar.collectionId;
+
     const getValidation = (newState) => {
         if (!readOnlyMode) {
             return validatePRFormData(
@@ -69,8 +73,6 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
         }
         return {darErrors: {}}
     }
-    const [formValidation, setFormValidation] = useState<FormValidationState>({darErrors:{}});
-    const eRACommonsDestination = 'progress_report_application/' + dar.collectionId;
 
     const onFormChange = (newState: Partial<FormState>) => {
         const setState = {...formState, ...newState};

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -38,6 +38,10 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
         ...(dar?.presentations && {
             presentationsYesNo: (dar.presentations.length > 0)
         }),
+        // additional state for datasets section populated by useEffect
+        datasets: [],
+        datasetIds: [],
+        selectedDatasets: [],
         // additional state for dmi section
         ...(dar?.dmi?.incidents && {
             dmiYesNo: (dar.dmi.incidents.length > 0),
@@ -58,7 +62,6 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
     const [formValidation, setFormValidation] = useState<FormValidationState>({darErrors:{}});
     const [nihValid, setNihValid] = useState<boolean>(true);
     const [dataUseTranslations, setDataUseTranslations] = useState<string[]>([]);
-    const [selectedDatasets, setSelectedDatasets] = useState<Dataset[]>(datasets);
 
     const eRACommonsDestination = 'progress_report_application/' + dar.collectionId;
 
@@ -67,7 +70,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
             return validatePRFormData(
                 nihValid,
                 newState,
-                selectedDatasets,
+                formState.selectedDatasets,
                 dataUseTranslations
             );
         }
@@ -83,22 +86,19 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
         setFormValidation(getValidation(setState))
     };
 
+    const onSelectedDatasetChange = (newDatasets: Dataset[]) => {
+        const newDatasetIds = newDatasets.map((ds) => ds.datasetId);
+        translateDataUseRestrictionsFromDataUseArray(newDatasets.map((ds) => ds.dataUse)).then((translations) => {
+            setDataUseTranslations(translations);
+        });
+        onFormChange({ selectedDatasets: newDatasets, datasetIds: newDatasetIds });
+    }
+
     // required because the datasets state changes during component mount
     useEffect(() => {
-        onFormChange({ datasetIds: datasets.map((ds) => ds.datasetId) });
-        setSelectedDatasets(datasets);
-        translateDataUseRestrictionsFromDataUseArray(datasets.map((ds) => ds.dataUse)).then((translations) => {
-            setDataUseTranslations(translations);
-        });
+        onFormChange({ datasets: datasets });
+        onSelectedDatasetChange(datasets);
     }, [datasets]);
-
-    useEffect(() => {
-        const selectedIds = selectedDatasets.map((ds => ds.datasetId));
-        translateDataUseRestrictionsFromDataUseArray(selectedDatasets.map((ds) => ds.dataUse)).then((translations) => {
-            setDataUseTranslations(translations);
-        });
-        onFormChange({ datasetIds: selectedIds });
-    }, [selectedDatasets]);
 
     return (
         <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
@@ -121,15 +121,15 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
                     <p style={{marginBottom: '1rem'}}>Currently selected datasets:</p>
                     <SelectableDatasets
                         disabled={readOnlyMode}
-                        datasets={datasets}
-                        setSelectedDatasets={setSelectedDatasets}
+                        datasets={formState.datasets}
+                        setSelectedDatasets={onSelectedDatasetChange}
                     />
                 </div>
             </div>
             <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <DataUseAcknowledgements
                     title={'2.1 Data Use Acknowledgements'}
-                    datasets={selectedDatasets}
+                    datasets={formState.selectedDatasets}
                     dataUseTranslations={dataUseTranslations}
                     formData={formState}
                     readOnlyMode={readOnlyMode}

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -15,6 +15,7 @@ import {DataUseAcknowledgements} from 'src/pages/dar_application/DataUseAcknowle
 import {translateDataUseRestrictionsFromDataUseArray} from 'src/libs/dataUseTranslation';
 import {validatePRFormData, validationFailed} from 'src/utils/darFormUtils';
 import {FormValidationState} from 'src/pages/dar_application/FormValidationState';
+import { getApprovedElectionDatasetIds } from 'src/utils/DarUtils';
 
 type ProgressReportApplicationProps = {
   readonly dar: DataAccessRequest; // corresponds either to the parent DAR for a new application or an existing readonly progress report
@@ -96,7 +97,8 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
 
     // required because the datasets state changes during component mount
     useEffect(() => {
-        const approvedDatasets = datasets.filter((ds) => ds.dacApproval);
+        const approvedDatasetIds = getApprovedElectionDatasetIds(Object.values(dar.elections));
+        const approvedDatasets = datasets.filter((ds) => ds.dacApproval && approvedDatasetIds.includes(ds.datasetId));
         onFormChange({ datasets: approvedDatasets });
         onSelectedDatasetChange(approvedDatasets);
     }, [datasets]);

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -133,8 +133,8 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
                     dataUseTranslations={dataUseTranslations}
                     formData={formState}
                     readOnlyMode={readOnlyMode}
-                    onChange={(dua) => {
-                        onFormChange({[dua.key]: dua.value})
+                    onChange={({key, value}) => {
+                        onFormChange({[key]: value})
                     }}
                     validation={formValidation.darErrors}
                 />

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -96,8 +96,9 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
 
     // required because the datasets state changes during component mount
     useEffect(() => {
-        onFormChange({ datasets: datasets });
-        onSelectedDatasetChange(datasets);
+        const approvedDatasets = datasets.filter((ds) => ds.dacApproval);
+        onFormChange({ datasets: approvedDatasets });
+        onSelectedDatasetChange(approvedDatasets);
     }, [datasets]);
 
     return (

--- a/src/pages/progress_reports/ProgressReportFormState.tsx
+++ b/src/pages/progress_reports/ProgressReportFormState.tsx
@@ -1,4 +1,4 @@
-import {CloseOutSupplement, Collaborator} from "src/types/model";
+import {CloseOutSupplement, Collaborator, Dataset} from "src/types/model";
 import {PublicationOrPresentation} from "src/components/publications_list/PublicationOrPresentation";
 
 export type ValidFormState = {
@@ -32,6 +32,8 @@ export interface FormState {
     dmiDescription: string;
     closeoutYesNo: boolean;
     closeoutSupplement: CloseOutSupplement;
+    datasets: Dataset[];
+    selectedDatasets: Dataset[];
 }
 
 export enum FormStateKey {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -318,7 +318,7 @@ export interface DataAccessRequest {
   draft: boolean;
   collectionId: number;
   darCode: string;
-  elections: Array<Election>;
+  elections: Record<number, Election>;
   projectTitle: string;
   datasetIds: number[];
   rus: string;

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -1,0 +1,18 @@
+import { Election } from "src/types/model";
+
+export function getApprovedElectionDatasetIds(elections: Array<Election>) : Array<number> {
+
+    console.log('elections', elections);
+
+    const approvedDatasetIds = [];
+    for (const election of elections) {
+        if (election.electionType === 'DataAccess') {
+            const votes = Object.values(election.votes);
+            const anyApprovedVotes = votes.some(vote => vote.type === 'FINAL' && vote.vote);
+            if (anyApprovedVotes) {
+                approvedDatasetIds.push(election.datasetId);
+            }
+        }
+    }
+    return approvedDatasetIds;
+}

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -1,15 +1,12 @@
 import { Election } from "src/types/model";
 
 export function getApprovedElectionDatasetIds(elections: Array<Election>) : Array<number> {
-
-    console.log('elections', elections);
-
     const approvedDatasetIds = [];
     for (const election of elections) {
         if (election.electionType === 'DataAccess') {
             const votes = Object.values(election.votes);
-            const anyApprovedVotes = votes.some(vote => vote.type === 'FINAL' && vote.vote);
-            if (anyApprovedVotes) {
+            const anyApprovedFinalVotes = votes.some(vote => vote.type === 'FINAL' && vote.vote);
+            if (anyApprovedFinalVotes) {
                 approvedDatasetIds.push(election.datasetId);
             }
         }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1758

### Summary

Only show approved datasets from parent DAR. Also includes some additional refactors to avoid using `useEffect`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
