### PR TITLE
DT-1795: Handle undefined elections case

### DIFF
--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -97,7 +97,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
 
     // required because the datasets state changes during component mount
     useEffect(() => {
-        const approvedDatasetIds = getApprovedElectionDatasetIds(Object.values(dar.elections));
+        const approvedDatasetIds = dar.elections ? getApprovedElectionDatasetIds(Object.values(dar.elections)) : [];
         const approvedDatasets = datasets.filter((ds) => ds.dacApproval && approvedDatasetIds.includes(ds.datasetId));
         onFormChange({ datasets: approvedDatasets });
         onSelectedDatasetChange(approvedDatasets);


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1795

### Summary
When a Progress Report is submitted, there are no elections yet created for it. When a researcher navigates to the "Review" page in this state, the page errors out because there are no elections on the `dar` object. 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
