### PR TITLE
[DT-1772] Add signing official to progress report closeout

### DIFF
--- a/cypress/component/ProgressReports/dar_closeout.spec.tsx
+++ b/cypress/component/ProgressReports/dar_closeout.spec.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import DarCloseout from 'src/pages/progress_reports/DarCloseout';
+import { User } from 'src/libs/ajax/User';
 
 describe('DAR Closeout - Component Tests', () => {
   let onFormChangeSpy: () => void;
+
+  const mockSigningOfficials = [
+    { userId: 1, displayName: 'John Doe', email: 'john.doe@example.com' },
+    { userId: 2, displayName: 'Jane Smith', email: 'jane.smith@example.com' },
+    { userId: 3, displayName: 'Bob Johnson', email: '' }
+  ];
 
   const mountComponent = (customState = {}) => {
     const formState = { ...customState };
@@ -18,6 +25,7 @@ describe('DAR Closeout - Component Tests', () => {
   };
 
   beforeEach(() => {
+    cy.stub(User, 'getSOsForCurrentUser').resolves(mockSigningOfficials);
     onFormChangeSpy = cy.stub().as('formChangeStub');
     mountComponent();
   });
@@ -104,5 +112,25 @@ describe('DAR Closeout - Component Tests', () => {
     cy.get('#closeoutOther').should('be.checked');
     cy.get('#closeoutOtherText').should('be.visible');
     cy.get('#closeoutOtherText').contains('My Other Text');
+  });
+
+  it('displays signing official dropdown when closeout is enabled', () => {
+    mountComponent({ closeoutYesNo: true });
+    cy.get('[data-cy=dar-closeout-details]').should('exist');
+    cy.contains('I certify that the individual listed below is my institutional Signing Official').should('be.visible');
+    cy.get('#closeoutSigningOfficial').should('exist');
+  });
+
+  it('does not display signing official dropdown when closeout is disabled', () => {
+    mountComponent({ closeoutYesNo: false });
+    cy.get('#closeoutSigningOfficial').should('not.exist');
+  });
+
+  it('populates signing official options correctly with email', () => {
+    mountComponent({ closeoutYesNo: true });
+    cy.get('#closeoutSigningOfficial').should('exist');
+    cy.get('#closeoutSigningOfficial').click();
+    cy.contains('John Doe (john.doe@example.com)').should('exist');
+    cy.contains('Jane Smith (jane.smith@example.com)').should('exist');
   });
 });

--- a/src/pages/dar_application/FormValidationState.tsx
+++ b/src/pages/dar_application/FormValidationState.tsx
@@ -55,6 +55,7 @@ export interface DarErrors {
     dmiOther?: ValidationError,
     dmiDescription?: ValidationError,
     closeoutYesNo?: ValidationError,
+    closeoutSigningOfficial?: ValidationError,
     closeoutProjectCompleted?: ValidationError,
     closeoutRequestorMovedInstitution?: ValidationError,
     closeoutProjectTransferred?: ValidationError,

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {DataAccessRequest, Dataset, DuosUser} from 'src/types/model';
+import {DataAccessRequest, Dataset, DuosUser, SimplifiedDuosUser} from 'src/types/model';
 import {History, Location} from 'history';
 import {CLOSEOUT_KEYS, DMI_INCIDENT_KEYS, FormState} from 'src/pages/progress_reports/ProgressReportFormState';
 import SummarySection from 'src/pages/progress_reports/SummarySection';
@@ -70,6 +70,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
         // additional state for closeout section
         ...(dar?.closeoutSupplement && {
             closeoutYesNo: (dar.closeoutSupplement.reasons.length > 0),
+            closeoutSigningOfficial: { userId: dar.closeoutSupplement.signingOfficialId } as SimplifiedDuosUser,
             closeoutOtherText: dar.closeoutSupplement.otherText,
             ...CLOSEOUT_KEYS.reduce((acc, key) => {
                 acc[key] = dar.closeoutSupplement.reasons.includes(key);

--- a/src/pages/progress_reports/DarCloseout.tsx
+++ b/src/pages/progress_reports/DarCloseout.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {FormField, FormFieldTypes, FormValidators} from 'src/components/forms/forms';
 import {ValidFormState, FormState, FormStateKey} from 'src/pages/progress_reports/ProgressReportFormState';
 import {DarErrors, ValidationError} from "src/pages/dar_application/FormValidationState";
 import {FORM_TEXT_AREA_MAX_LENGTH} from "src/components/forms/formConstants";
+import { User } from 'src/libs/ajax/User';
+import { SimplifiedDuosUser } from 'src/types/model';
 
 interface DarCloseoutProps {
     readonly readOnly: boolean;
@@ -14,6 +16,27 @@ interface DarCloseoutProps {
 
 export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element {
     const { readOnly, formState, onFormChange, onValidationChange, validation } = props;
+
+    const [allSigningOfficials, setAllSigningOfficials] = useState<SimplifiedDuosUser[]>([]);
+    const [defaultSigningOfficial, setDefaultSigningOfficial] = useState<SimplifiedDuosUser>();
+
+    const displaySigningOfficial = (so: SimplifiedDuosUser) => {
+        const {displayName, email} = so;
+        const nameString = (email !== undefined && email.length > 0) ? `${displayName} (${email})` : displayName;
+        return {displayText: nameString, ...so};
+    }
+
+    useEffect(() => {
+        const init = async () => {
+            const signingOfficials = await User.getSOsForCurrentUser();
+            setAllSigningOfficials(signingOfficials);
+            const closeoutSigningOfficial = signingOfficials.find(so => so.userId === formState.closeoutSigningOfficial?.userId);
+            if (closeoutSigningOfficial !== undefined) {
+                setDefaultSigningOfficial(closeoutSigningOfficial);
+            }
+        }
+        init();
+    }, []);
 
     return (
         <div data-cy='dar-closeout'>
@@ -47,6 +70,25 @@ export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element 
                     />
                     {formState.closeoutYesNo && (
                         <div data-cy='dar-closeout-details'>
+
+                        <div style={{ marginTop: '10px' }}>
+                            <FormField
+                                id={FormStateKey.CLOSEOUT_SIGNING_OFFICIAL}
+                                type={FormFieldTypes.SELECT}
+                                description='I certify that the individual listed below is my institutional Signing Official'
+                                validators={[FormValidators.REQUIRED]}
+                                disabled={readOnly}
+                                onChange={({ key, value }: ValidFormState) => {
+                                    onFormChange({
+                                        [key]: value,
+                                    } as Partial<FormState>);
+                                }}
+                                defaultValue={defaultSigningOfficial}
+                                selectOptions={(allSigningOfficials?.map((so) => displaySigningOfficial(so)) || [''])}
+                                validation={validation?.closeoutSigningOfficial}
+                            />
+                        </div>
+
                         <p>
                             By completing this page, upon project close-out, the PI and all approved users agree to destroy all copies, versions, and derivations of the dataset(s) retrieved from NIH-designated controlled-access databases, on both local servers and hardware, and if cloud computing was used, delete the data and cloud images from cloud computing provider storage, virtual machines, databases, and random access archives, except as required by publication practices, institutional policies, or law to retain them.
                         </p>

--- a/src/pages/progress_reports/DarCloseout.tsx
+++ b/src/pages/progress_reports/DarCloseout.tsx
@@ -84,7 +84,7 @@ export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element 
                                     } as Partial<FormState>);
                                 }}
                                 defaultValue={defaultSigningOfficial}
-                                selectOptions={(allSigningOfficials?.map((so) => displaySigningOfficial(so)) || [''])}
+                                selectOptions={(allSigningOfficials?.map((so) => displaySigningOfficial(so)) ?? [''])}
                                 validation={validation?.closeoutSigningOfficial}
                             />
                         </div>

--- a/src/pages/progress_reports/ProgressReportFormState.tsx
+++ b/src/pages/progress_reports/ProgressReportFormState.tsx
@@ -1,5 +1,5 @@
-import {Collaborator, Dataset} from "src/types/model";
-import {PublicationOrPresentation} from "src/components/publications_list/PublicationOrPresentation";
+import {Collaborator, Dataset, SimplifiedDuosUser} from 'src/types/model';
+import {PublicationOrPresentation} from 'src/components/publications_list/PublicationOrPresentation';
 
 export type ValidFormState = {
   [K in keyof FormState]: {
@@ -31,6 +31,7 @@ export interface FormState {
     dmiOther: boolean;
     dmiDescription: string;
     closeoutYesNo: boolean;
+    closeoutSigningOfficial: SimplifiedDuosUser;
     closeoutProjectCompleted: boolean;
     closeoutRequestorMovedInstitution: boolean;
     closeoutProjectTransferred: boolean;
@@ -64,6 +65,7 @@ export enum FormStateKey {
     DMI_OTHER = 'dmiOther',
     DMI_DESCRIPTION = 'dmiDescription',
     CLOSEOUT_YES_NO = 'closeoutYesNo',
+    CLOSEOUT_SIGNING_OFFICIAL = 'closeoutSigningOfficial',
     CLOSEOUT_PROJECT_COMPLETED = 'closeoutProjectCompleted',
     CLOSEOUT_REQUESTOR_MOVED_INSTITUTION = 'closeoutRequestorMovedInstitution',
     CLOSEOUT_PROJECT_TRANSFERRED = 'closeoutProjectTransferred',

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -79,6 +79,7 @@ export default function SubmitProgressReport(props: SubmitProgressReportProps) {
       }
     });
     closeout.otherText = formState.closeoutOtherText ?? '';
+    closeout.signingOfficialId = formState.closeoutSigningOfficial?.userId;
 
     return closeout;
   }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -409,6 +409,7 @@ export interface DataManagementIncident {
 export interface Closeout {
   reasons: string[];
   otherText: string;
+  signingOfficialId: number;
 }
 
 export interface Presentation {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -257,13 +257,17 @@ const calcCloseoutErrors= (formData, errors) => {
   if (formData.closeoutOther && isEmpty(formData.closeoutOtherText)) {
     errors.closeoutOtherText = requiredError
   }
-
-  if (formData.closeoutYesNo && !closeoutFields.some((field) => field)) {
-    errors.closeoutProjectCompleted = requiredError;
-    errors.closeoutRequestorMovedInstitution = requiredError;
-    errors.closeoutProjectTransferred = requiredError;
-    errors.closeoutProjectSuperseded = requiredError;
-    errors.closeoutOther = requiredError;
+  if (formData.closeoutYesNo) {
+    if (formData.closeoutSigningOfficial?.userId === undefined) {
+      errors.closeoutSigningOfficial = requiredError;
+    }
+    if (!closeoutFields.some((field) => field)) {
+      errors.closeoutProjectCompleted = requiredError;
+      errors.closeoutRequestorMovedInstitution = requiredError;
+      errors.closeoutProjectTransferred = requiredError;
+      errors.closeoutProjectSuperseded = requiredError;
+      errors.closeoutOther = requiredError;
+    }
   }
 }
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1772

### Summary

Add signing official to progress report closeout:

<img width="529" alt="Screenshot 2025-06-06 at 1 37 22 PM" src="https://github.com/user-attachments/assets/04fc732b-7697-40cb-ac1d-1fa8b27e3335" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
