### PR TITLE
[DT-1825] Re-enable RAS.

### DIFF
--- a/cypress/component/ERACommons/era_commons.spec.jsx
+++ b/cypress/component/ERACommons/era_commons.spec.jsx
@@ -172,8 +172,7 @@ describe('ERA Commons Component', function () {
     cy.stub(AuthenticateNIH, 'getECMProviderAuthUrl').throws(new Error('error'));
     cy.get('[data-cy=era-commons-authenticate-link]').should('exist');
     cy.get('[data-cy=era-commons-authenticate-link]').click();
-    // WHEN DT-1800 is reverted, enable this test.
-    //cy.get('[data-cy=era-commons-error-span]').should('be.visible');
+    cy.get('[data-cy=era-commons-error-span]').should('be.visible');
   });
 
 });

--- a/src/utils/ERACommonsUtils.js
+++ b/src/utils/ERACommonsUtils.js
@@ -1,11 +1,8 @@
 import {Buffer} from 'buffer';
-//import EnvironmentUtils, {envGroups} from '../utils/EnvironmentUtils.js';
+import EnvironmentUtils, {envGroups} from 'src/utils/EnvironmentUtils.js';
 
 export const rasEnabled = () => {
-  // when re-enabling this, don't forget to turn back on the test in era_commons_spec.jsx.
-  // search DT-1800 to find it.
-  //return EnvironmentUtils.checkEnv(envGroups.DEV);
-  return false;
+  return EnvironmentUtils.checkEnv(envGroups.DEV);
 }
 
 export const nihAccountLabel = () => {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1825](https://broadworkbench.atlassian.net/browse/DT-1825)

### Summary

Re-enables RAS for DEV.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
