### PR TITLE
[DT-1826] Add 12-month expiration text to DAR CoC

### DIFF
--- a/src/pages/dar_application/DataUseAgreements.jsx
+++ b/src/pages/dar_application/DataUseAgreements.jsx
@@ -41,7 +41,12 @@ export default function DataUseAgreements(props) {
       </div>
 
       <div>
-        By submitting this DAR you agree to all terms in the agreement(s) below, and you attest you are a permanent employee of your institution at a level equivalent to, at a minimum, a tenure-track professor or senior researcher. This does <span style={{fontWeight: 600}}>not</span> include lab technicians or trainees, e.g., post-docs or graduate students.</div>
+        By submitting this DAR you agree to all terms in the agreement(s) below, and you attest you are a permanent
+          employee of your institution at a level equivalent to, at a minimum, a tenure-track professor or senior
+          researcher. This does <span style={{fontWeight: 600}}>not</span> include lab technicians or trainees, e.g.,
+          post-docs or graduate students. All DARs submitted and approved in DUOS are valid for 12 months. Researchers
+          may submit a Progress Report to extend their access if necessary.
+      </div>
 
       <div className='flex flex-row' style={{ justifyContent: 'left', marginTop: '3rem' }}>
         <div>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1826

### Summary

Adds additional text to the DAR code of conduct regarding the 12-month expiration.

Before
<img width="928" alt="Screenshot 2025-06-16 at 10 24 56 AM" src="https://github.com/user-attachments/assets/d1dddfbf-83fc-4081-b93c-52d12896bc7f" />

After
<img width="930" alt="Screenshot 2025-06-16 at 10 11 43 AM" src="https://github.com/user-attachments/assets/bdc6499d-d4af-41eb-b1ed-7567a178b26f" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
