### PR TITLE
[DT-1813] require country of operation for PI and collaborators

### DIFF
--- a/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorAddEdit from 'src/components/collaborator_list/CollaboratorAddEdit';
 import { Collaborator } from 'src/types/model';
+import {Countries} from "src/libs/ajax/Countries";
 
 describe('CollaboratorAddEdit - Component Tests', () => {
   const mockCollaborator: Collaborator = {
@@ -10,6 +11,7 @@ describe('CollaboratorAddEdit - Component Tests', () => {
     email: 'john.doe@example.com',
     uuid: '123e4567-e89b-12d3-a456-426614174000',
     eraCommonsId: 'jdoe123',
+    countryOfOperation: 'United States of America (the)',
     approverStatus: false
   };
 
@@ -17,9 +19,11 @@ describe('CollaboratorAddEdit - Component Tests', () => {
 
   const defaultProps = {
     id: -1,
+    collaborator: {countryOfOperation: Countries.DEFAULT_COUNTRY} as Collaborator,
     collaboratorText: 'Collaborator',
     collaborators: mockCollaborators,
     closeAction: () => { },
+    countriesOfOperation:['France', 'Canada', 'United States of America (the)'],
     onCollaboratorChange: () => { }
   };
 

--- a/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorAddEdit from 'src/components/collaborator_list/CollaboratorAddEdit';
 import { Collaborator } from 'src/types/model';
-import {Countries} from "src/libs/ajax/Countries";
+import {Countries} from 'src/libs/ajax/Countries';
 
 describe('CollaboratorAddEdit - Component Tests', () => {
   const mockCollaborator: Collaborator = {

--- a/cypress/component/CollaboratorList/collaborator_list.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_list.spec.tsx
@@ -11,6 +11,7 @@ describe('CollaboratorList - Component Tests', () => {
             email: 'john.doe@example.com',
             uuid: '123e4567-e89b-12d3-a456-426614174001',
             eraCommonsId: 'jdoe123',
+            countryOfOperation: 'Canada',
             approverStatus: true
         },
         {
@@ -19,6 +20,7 @@ describe('CollaboratorList - Component Tests', () => {
             email: 'jane.smith@example.com',
             uuid: '123e4567-e89b-12d3-a456-426614174002',
             eraCommonsId: 'jsmith456',
+            countryOfOperation: 'United States of America (the)',
             approverStatus: true
         }
     ];
@@ -27,6 +29,7 @@ describe('CollaboratorList - Component Tests', () => {
         collaborators: mockCollaborators,
         collaboratorText: 'Collaborator',
         columnsToShow: ['name', 'title', 'email'],
+        countriesOfOperation:['France', 'Canada', 'United States of America (the)'],
         onCollaboratorChange: () => { },
         disabled: false
     };

--- a/cypress/component/CollaboratorList/collaborator_row.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_row.spec.tsx
@@ -10,6 +10,7 @@ describe('CollaboratorRow - Component Tests', () => {
         email: 'john.doe@example.com',
         uuid: '123e4567-e89b-12d3-a456-426614174000',
         eraCommonsId: 'jdoe123',
+        countryOfOperation: 'United States of America (the)',
         approverStatus: true
     };
 
@@ -24,6 +25,7 @@ describe('CollaboratorRow - Component Tests', () => {
         collaboratorText: 'Collaborator',
         collaborators: mockCollaborators,
         columnsToShow: columnsToShow,
+        countriesOfOperation: ['United States of America (the)', 'Canada', 'France'],
         editAction: () => { },
         deleteAction: () => { },
         closeAction: () => { },
@@ -52,6 +54,8 @@ describe('CollaboratorRow - Component Tests', () => {
         cy.get('#name').should('have.value', mockCollaborator.name);
         cy.get('#title').should('have.value', mockCollaborator.title);
         cy.get('#email').should('have.value', mockCollaborator.email);
+        cy.get('#countryOfOperation').should('contain', mockCollaborator.countryOfOperation);
+        cy.get('#countryOfOperation').should('not.contain', 'France');
 
         cy.contains('Save').should('be.visible');
         cy.contains('Cancel').should('be.visible');

--- a/cypress/component/CollaboratorList/collaborator_row.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_row.spec.tsx
@@ -148,7 +148,7 @@ describe('CollaboratorRow - Component Tests', () => {
         const newProps = {
             ...defaultProps,
             id: -1,
-            collaborator: undefined,
+            collaborator: {countryOfOperation:'United States of America (the)'} as Collaborator,
             editMode: true
         };
 

--- a/cypress/component/CollaboratorList/collaborator_summary.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_summary.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'cypress/react';
-import CollaboratorSummary from '../../../src/components/collaborator_list/CollaboratorSummary';
-import { Collaborator } from '../../../src/components/collaborator_list/Collaborator';
+import CollaboratorSummary from 'src/components/collaborator_list/CollaboratorSummary';
+import {Collaborator} from 'src/types/model';
 
 type PartialCollaborator = {
   name: string;
@@ -16,10 +16,11 @@ describe('CollaboratorSummary - Component Tests', () => {
   const mockCollaborator: Collaborator = {
     name: 'John Doe',
     title: 'Researcher',
-    institution: 'Research Institute',
     email: 'john.doe@example.com',
     uuid: '123e4567-e89b-12d3-a456-426614174000',
-    eraCommonsId: 'jdoe123'
+    eraCommonsId: 'jdoe123',
+    approverStatus: false,
+    countryOfOperation: 'United States of America (the)'
   };
 
   const defaultProps = {
@@ -37,8 +38,6 @@ describe('CollaboratorSummary - Component Tests', () => {
     cy.contains(mockCollaborator.title).should('be.visible');
     cy.contains(mockCollaborator.email).should('be.visible');
 
-    cy.contains(mockCollaborator.institution).should('not.exist');
-
     cy.get('.collaborator-summary-edit-delete-buttons').should('exist');
     cy.get('.glyphicon-pencil').should('exist');
     cy.get('.glyphicon-trash').should('exist');
@@ -47,16 +46,15 @@ describe('CollaboratorSummary - Component Tests', () => {
   it('renders different columns when columnsToShow changes', () => {
     const customProps = {
       ...defaultProps,
-      columnsToShow: ['name', 'institution']
+      columnsToShow: ['name', 'email']
     };
 
     mount(<CollaboratorSummary {...customProps} />);
 
     cy.contains(mockCollaborator.name).should('be.visible');
-    cy.contains(mockCollaborator.institution).should('be.visible');
 
     cy.contains(mockCollaborator.title).should('not.exist');
-    cy.contains(mockCollaborator.email).should('not.exist');
+    cy.contains(mockCollaborator.email).should('be.visible');
   });
 
   it('calls editAction when edit button is clicked', () => {

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -189,7 +189,8 @@ beforeEach(() => {
 
       cy.get('#piName').should('have.class', 'errored');
       cy.get('#piEmail').should('have.class', 'errored');
-      cy.get('#piCountryOfOperation').should('have.class', 'errored');
+      // since we're setting a default value, this should not error on initial validation
+      cy.get('#piCountryOfOperation').should('not.have.class', 'errored');
       cy.get('#signingOfficial').should('have.class', 'errored');
       cy.get('#itDirector').should('have.class', 'errored');
       cy.get('#itDirectorEmail').should('have.class', 'errored');

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -9,6 +9,7 @@ import { Navigation } from '../../../src/libs/utils.js';
 import { NotificationService } from '../../../src/libs/notificationService.js';
 import { Storage } from '../../../src/libs/storage.js';
 import { User } from '../../../src/libs/ajax/User';
+import {Countries} from 'src/libs/ajax/Countries.js';
 
 const props = {
   match: {
@@ -86,6 +87,9 @@ const userSigningOfficials = [
 
 
 describe('Data Access Request - Validation', () => {
+beforeEach(() => {
+  cy.stub(Countries, 'getCountries').returns(Promise.resolve(['United States of America (the)', 'Canada']));
+});
 
   describe('With Library Cards', () => {
     beforeEach(() => {
@@ -114,8 +118,11 @@ describe('Data Access Request - Validation', () => {
 
     it('Submits given valid DAR', () => {
       cy.get('#piName').type('Some PI');
+      cy.get('#piEmail').type('alice@good.org');
+      cy.get('#piCountryOfOperation').type('United{enter}');
       cy.get('#signingOfficial').type('SO 2{enter}');
       cy.get('#itDirector').type('Some IT Director');
+      cy.get('#itDirectorEmail').type('it@good.org');
       cy.get('#anvilUse_yes').click();
 
       cy.get('#datasetIds').type('asdf{enter}');
@@ -149,8 +156,11 @@ describe('Data Access Request - Validation', () => {
 
     it('Required fields should not be errored when you open page', () => {
       cy.get('#piName').should('not.have.class', 'errored');
+      cy.get('#piEmail').should('not.have.class', 'errored');
+      cy.get('#piCountryOfOperation').should('not.have.class', 'errored');
       cy.get('#signingOfficial').should('not.have.class', 'errored');
       cy.get('#itDirector').should('not.have.class', 'errored');
+      cy.get('#itDirectorEmail').should('not.have.class', 'errored');
       cy.get('#anvilUse').should('not.have.class', 'errored');
 
       cy.get('#datasetIds').should('not.have.class', 'errored');
@@ -178,8 +188,11 @@ describe('Data Access Request - Validation', () => {
       cy.get('#btn_attest').click();
 
       cy.get('#piName').should('have.class', 'errored');
+      cy.get('#piEmail').should('have.class', 'errored');
+      cy.get('#piCountryOfOperation').should('have.class', 'errored');
       cy.get('#signingOfficial').should('have.class', 'errored');
       cy.get('#itDirector').should('have.class', 'errored');
+      cy.get('#itDirectorEmail').should('have.class', 'errored');
       cy.get('#anvilUse').should('have.class', 'errored');
 
       cy.get('#datasetIds').should('have.class', 'errored');
@@ -212,6 +225,7 @@ describe('Data Access Request - Validation', () => {
       cy.get('#0_collaboratorTitle').should('not.have.class', 'errored');
       cy.get('#0_collaboratorEmail').should('not.have.class', 'errored');
       cy.get('#0_collaboratorApproval').should('not.have.class', 'errored');
+      cy.get('#0_collaboratorCountryOfOperation').should('not.have.class', 'errored');
 
       cy.get('#collaborator-labCollaborators-add-save').click();
 
@@ -220,6 +234,7 @@ describe('Data Access Request - Validation', () => {
       cy.get('#0_collaboratorEraCommonsId').should('have.class', 'errored');
       cy.get('#0_collaboratorTitle').should('have.class', 'errored');
       cy.get('#0_collaboratorEmail').should('have.class', 'errored');
+      // we set a default value on countryOfOperation, so it does not error.
       cy.get('#0_collaboratorApproval').should('have.class', 'errored');
 
       // fill out fields
@@ -235,6 +250,7 @@ describe('Data Access Request - Validation', () => {
       cy.get('#0_collaboratorTitle').should('not.have.class', 'errored');
       cy.get('#0_collaboratorApproval').should('not.have.class', 'errored');
       cy.get('#0_collaboratorEmail').should('have.class', 'errored');
+      cy.get('#0_collaboratorCountryOfOperation').should('not.have.class', 'errored');
 
       // shouldn't submit since invalid email format
       cy.get('#collaborator-labCollaborators-add-save').click();
@@ -274,8 +290,12 @@ describe('Data Access Request - Validation', () => {
 
     it('Cannot submit without library card', () => {
       cy.get('#piName').type('Some PI');
+      cy.get('#piEmail').type('alice@good.org');
       cy.get('#signingOfficial').type('SO 2{enter}');
       cy.get('#itDirector').type('Some IT Director');
+      cy.get('#itDirectorEmail').type('it@good.org');
+      cy.get('#piEmail').type('alice@good.org');
+      cy.get('#piCountryOfOperation').type('United{enter}');
       cy.get('#anvilUse_yes').click();
 
       cy.get('#datasetIds').type('asdf{enter}');

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -1,15 +1,15 @@
 import {React} from 'react';
 import {mount} from 'cypress/react';
-import DataAccessRequestApplication from '../../../src/pages/dar_application/DataAccessRequestApplication.jsx';
+import DataAccessRequestApplication from 'src/pages/dar_application/DataAccessRequestApplication';
 import { MemoryRouter } from 'react-router-dom';
-import { DAR } from '../../../src/libs/ajax/DAR.js';
-import { DataSet } from '../../../src/libs/ajax/DataSet.js';
-import { Metrics } from '../../../src/libs/ajax/Metrics';
-import { Navigation } from '../../../src/libs/utils.js';
-import { NotificationService } from '../../../src/libs/notificationService.js';
-import { Storage } from '../../../src/libs/storage.js';
-import { User } from '../../../src/libs/ajax/User';
-import {Countries} from 'src/libs/ajax/Countries.js';
+import { DAR } from 'src/libs/ajax/DAR';
+import { DataSet } from 'src/libs/ajax/DataSet';
+import { Metrics } from 'src/libs/ajax/Metrics';
+import { Navigation } from 'src/libs/utils';
+import { NotificationService } from 'src/libs/notificationService';
+import { Storage } from 'src/libs/storage';
+import { User } from 'src/libs/ajax/User';
+import {Countries} from 'src/libs/ajax/Countries';
 
 const props = {
   match: {

--- a/cypress/component/DataAccessRequest/researcher_info.spec.jsx
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.jsx
@@ -1,13 +1,14 @@
 import {React} from 'react';
 import {mount} from 'cypress/react';
 import ResearcherInfo from '../../../src/pages/dar_application/ResearcherInfo';
-import { User } from '../../../src/libs/ajax/User';
+import { User } from 'src/libs/ajax/User.js';
 
 import {BrowserRouter} from 'react-router-dom';
 
 const props = {
   allSigningOfficials: [],
   completed: true,
+  countriesOfOperation:['United States of America (the)', 'France', 'Canada'],
   darCode: undefined,
   eRACommonsDestination: undefined,
   formFieldChange: () => {},

--- a/cypress/component/ProgressReports/collaborator_changes.spec.tsx
+++ b/cypress/component/ProgressReports/collaborator_changes.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges';
 import {Collaborator} from 'src/types/model';
-import {FormState} from "src/pages/progress_reports/ProgressReportFormState";
+import {FormState} from 'src/pages/progress_reports/ProgressReportFormState';
 
 
 describe('Collaborator Changes - Component Tests', () => {

--- a/cypress/component/ProgressReports/collaborator_changes.spec.tsx
+++ b/cypress/component/ProgressReports/collaborator_changes.spec.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { mount } from 'cypress/react';
 import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges';
-import { Collaborator } from 'src/components/collaborator_list/Collaborator';
+import {Collaborator} from 'src/types/model';
+import {FormState} from "src/pages/progress_reports/ProgressReportFormState";
+
 
 describe('Collaborator Changes - Component Tests', () => {
   let onFormChangeSpy: () => void;
-
+  const countriesOfOperation = ['United States of America (the)', 'France'];
   const initialCollaborators: Collaborator[] = [
     {
       name: 'Test User 1',
@@ -13,7 +15,8 @@ describe('Collaborator Changes - Component Tests', () => {
       uuid: '1',
       eraCommonsId: 'user1',
       email: 'user1@example.com',
-      institution: 'Test Institution'
+      countryOfOperation: 'France',
+      approverStatus: false
     },
     {
       name: 'Test User 2',
@@ -21,17 +24,19 @@ describe('Collaborator Changes - Component Tests', () => {
       uuid: '2',
       eraCommonsId: 'user2',
       email: 'user2@example.com',
-      institution: 'Test Institution'
+      approverStatus: false,
+      countryOfOperation: 'United States of America (the)'
     }
   ];
 
   const mountComponent = (customState = {}) => {
-    const formState = { ...customState };
+    const formState = { ...customState } as FormState;
 
     const props = {
       readOnly: false,
       formState,
-      onFormChange: onFormChangeSpy
+      onFormChange: onFormChangeSpy,
+      countriesOfOperation: countriesOfOperation
     };
 
     return mount(<CollaboratorChanges {...props} />);
@@ -82,8 +87,9 @@ describe('Collaborator Changes - Component Tests', () => {
   it('renders in read-only mode correctly', () => {
     const props = {
       readOnly: true,
-      formState: { labCollaborators: initialCollaborators },
-      onFormChange: onFormChangeSpy
+      formState: { labCollaborators: initialCollaborators } as FormState,
+      onFormChange: onFormChangeSpy,
+      countriesOfOperation: countriesOfOperation
     };
 
     mount(<CollaboratorChanges {...props} />);

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -1,10 +1,10 @@
 import React, {useState} from 'react';
-import { FormField, FormValidators } from '../forms/forms';
-import {Collaborator} from "src/types/model";
-import {ValidationError} from "src/pages/dar_application/FormValidationState";
-import {computeCollaboratorErrors, validationFailed} from "src/utils/darFormUtils";
-import {nihAccountLabel} from "src/utils/ERACommonsUtils";
-import ApproverStatus from "src/pages/dar_application/collaborator/ApproverStatus";
+import {FormField, FormFieldTypes, FormValidators} from '../forms/forms';
+import {Collaborator} from 'src/types/model';
+import {ValidationError} from 'src/pages/dar_application/FormValidationState';
+import {computeCollaboratorErrors, validationFailed} from 'src/utils/darFormUtils';
+import {nihAccountLabel} from 'src/utils/ERACommonsUtils';
+import ApproverStatus from 'src/pages/dar_application/collaborator/ApproverStatus';
 
 interface FormFieldChange {
     key: string;
@@ -17,8 +17,9 @@ interface CollaboratorAddEditProps {
     readonly collaboratorText: string;
     readonly collaborators: Collaborator[];
     readonly closeAction: () => void;
-    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
+    readonly onCollaboratorChange: (collaborators: (Collaborator | undefined)[]) => void;
     readonly showApproverStatus?: boolean;
+    readonly countriesOfOperation: string[];
 }
 
 interface Validation {
@@ -27,10 +28,11 @@ interface Validation {
     title?: ValidationError;
     email?: ValidationError;
     approverStatus?: ValidationError;
+    countryOfOperation?: ValidationError;
 }
 
 export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): React.JSX.Element {
-    const { id, collaborator, collaboratorText, collaborators, closeAction, onCollaboratorChange, showApproverStatus = false } = props;
+    const { id, collaborator, collaboratorText, collaborators, closeAction, onCollaboratorChange, showApproverStatus = false, countriesOfOperation } = props;
     const [newCollaborator, setNewCollaborator] = useState(collaborator);
     const [validation, setValidation] = useState<Validation>({});
     const accountLabel = nihAccountLabel();
@@ -84,6 +86,18 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
                         onChange={onChange}
                         validation={validation.email}
+                    />
+                    <FormField
+                        id='countryOfOperation'
+                        title={`${collaboratorText} Country of Operation`}
+                        type={FormFieldTypes.SELECT}
+                        optionsAreString={true}
+                        selectOptions={countriesOfOperation}
+                        defaultValue={collaborator?.countryOfOperation}
+                        placeholder='Country of Operation'
+                        validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+                        onChange={onChange}
+                        validation={validation.countryOfOperation}
                     />
                     {showApproverStatus && (
                     <ApproverStatus

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -50,7 +50,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
         <div className='form-group row no-margin'>
             <div className='col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card' key={`collaborator-item-id`}>
                 <div className='row'>
-                    <h2>{collaborator === undefined ? `New ${collaboratorText} Information` : `Edit ${collaborator.name} Information`}</h2>
+                    <h2>{collaborator?.name === undefined ? `New ${collaboratorText} Information` : `Edit ${collaborator.name} Information`}</h2>
                     <FormField
                         id='name'
                         title={`${collaboratorText} Name`}
@@ -95,7 +95,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         selectOptions={countriesOfOperation}
                         defaultValue={collaborator?.countryOfOperation}
                         placeholder='Country of Operation'
-                        validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+                        validators={[FormValidators.REQUIRED]}
                         onChange={onChange}
                         validation={validation.countryOfOperation}
                     />
@@ -126,7 +126,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         }}
                         disabled={validationFailed(computeCollaboratorErrors({collaborator: newCollaborator, needsApproverStatus: showApproverStatus}))}
                     >
-                        {collaborator === undefined ? 'Add' : 'Save'}
+                        {collaborator?.name === undefined ? 'Add' : 'Save'}
                     </button>
                     {/* cancel button */}
                     <div

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -17,7 +17,7 @@ interface CollaboratorAddEditProps {
     readonly collaboratorText: string;
     readonly collaborators: Collaborator[];
     readonly closeAction: () => void;
-    readonly onCollaboratorChange: (collaborators: (Collaborator | undefined)[]) => void;
+    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
     readonly showApproverStatus?: boolean;
     readonly countriesOfOperation: string[];
 }
@@ -33,7 +33,7 @@ interface Validation {
 
 export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): React.JSX.Element {
     const { id, collaborator, collaboratorText, collaborators, closeAction, onCollaboratorChange, showApproverStatus = false, countriesOfOperation } = props;
-    const [newCollaborator, setNewCollaborator] = useState(collaborator);
+    const [newCollaborator, setNewCollaborator] = useState<Collaborator | undefined>(collaborator);
     const [validation, setValidation] = useState<Validation>({});
     const accountLabel = nihAccountLabel();
 
@@ -114,7 +114,11 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         type='button'
                         onClick={() => {
                             if (id < 0) {
-                                onCollaboratorChange([...collaborators, newCollaborator]);
+                                if (newCollaborator) {
+                                    onCollaboratorChange([...collaborators, newCollaborator]);
+                                } else {
+                                    onCollaboratorChange([...collaborators])
+                                }
                                 setNewCollaborator(undefined);
                             } else if (newCollaborator !== undefined) {
                                 const collaboratorsCopy = [...collaborators];

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -13,7 +13,7 @@ interface FormFieldChange {
 
 interface CollaboratorAddEditProps {
     readonly id: number;
-    collaborator?: Collaborator;
+    collaborator: Collaborator;
     readonly collaboratorText: string;
     readonly collaborators: Collaborator[];
     readonly closeAction: () => void;
@@ -54,7 +54,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                     <FormField
                         id='name'
                         title={`${collaboratorText} Name`}
-                        defaultValue={collaborator?.name}
+                        defaultValue={collaborator.name}
                         placeholder='Full Name'
                         validators={[FormValidators.REQUIRED]}
                         onChange={onChange}
@@ -63,7 +63,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                     <FormField
                         id='eraCommonsId'
                         title={`${collaboratorText} ${accountLabel} Account`}
-                        defaultValue={collaborator?.eraCommonsId}
+                        defaultValue={collaborator.eraCommonsId}
                         placeholder={`${accountLabel} Account`}
                         validators={[FormValidators.REQUIRED]}
                         onChange={onChange}
@@ -72,7 +72,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                     <FormField
                         id='title'
                         title={`${collaboratorText} Title`}
-                        defaultValue={collaborator?.title}
+                        defaultValue={collaborator.title}
                         placeholder='Title'
                         validators={[FormValidators.REQUIRED]}
                         onChange={onChange}
@@ -81,7 +81,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                     <FormField
                         id='email'
                         title={`${collaboratorText} Email`}
-                        defaultValue={collaborator?.email}
+                        defaultValue={collaborator.email}
                         placeholder='Email'
                         validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
                         onChange={onChange}
@@ -93,7 +93,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         type={FormFieldTypes.SELECT}
                         optionsAreString={true}
                         selectOptions={countriesOfOperation}
-                        defaultValue={collaborator?.countryOfOperation}
+                        defaultValue={collaborator.countryOfOperation}
                         placeholder='Country of Operation'
                         validators={[FormValidators.REQUIRED]}
                         onChange={onChange}
@@ -114,11 +114,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         type='button'
                         onClick={() => {
                             if (id < 0) {
-                                if (newCollaborator) {
-                                    onCollaboratorChange([...collaborators, newCollaborator]);
-                                } else {
-                                    onCollaboratorChange([...collaborators])
-                                }
+                                onCollaboratorChange([...collaborators, newCollaborator]);
                                 setNewCollaborator(undefined);
                             } else if (newCollaborator !== undefined) {
                                 const collaboratorsCopy = [...collaborators];

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -5,6 +5,7 @@ import {ValidationError} from 'src/pages/dar_application/FormValidationState';
 import {computeCollaboratorErrors, validationFailed} from 'src/utils/darFormUtils';
 import {nihAccountLabel} from 'src/utils/ERACommonsUtils';
 import ApproverStatus from 'src/pages/dar_application/collaborator/ApproverStatus';
+import { Countries } from 'src/libs/ajax/Countries';
 
 interface FormFieldChange {
     key: string;
@@ -33,7 +34,7 @@ interface Validation {
 
 export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): React.JSX.Element {
     const { id, collaborator, collaboratorText, collaborators, closeAction, onCollaboratorChange, showApproverStatus = false, countriesOfOperation } = props;
-    const [newCollaborator, setNewCollaborator] = useState<Collaborator | undefined>(collaborator);
+    const [newCollaborator, setNewCollaborator] = useState<Collaborator>(collaborator);
     const [validation, setValidation] = useState<Validation>({});
     const accountLabel = nihAccountLabel();
 
@@ -115,12 +116,12 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         onClick={() => {
                             if (id < 0) {
                                 onCollaboratorChange([...collaborators, newCollaborator]);
-                                setNewCollaborator(undefined);
+                                setNewCollaborator({countryOfOperation: Countries.DEFAULT_COUNTRY} as Collaborator);
                             } else if (newCollaborator !== undefined) {
                                 const collaboratorsCopy = [...collaborators];
                                 collaboratorsCopy[id] = newCollaborator;
                                 onCollaboratorChange(collaboratorsCopy);
-                                setNewCollaborator(undefined);
+                                setNewCollaborator({countryOfOperation: Countries.DEFAULT_COUNTRY} as Collaborator);
                             }
                             closeAction();
                         }}

--- a/src/components/collaborator_list/CollaboratorDelete.tsx
+++ b/src/components/collaborator_list/CollaboratorDelete.tsx
@@ -7,7 +7,7 @@ import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 
 interface CollaboratorDeleteProps {
-    readonly collaboratorName: string | undefined;
+    readonly collaboratorName: string;
     readonly showDelete: boolean;
     readonly confirmAction: () => void;
     readonly closeAction: () => void;

--- a/src/components/collaborator_list/CollaboratorDelete.tsx
+++ b/src/components/collaborator_list/CollaboratorDelete.tsx
@@ -7,7 +7,7 @@ import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
 
 interface CollaboratorDeleteProps {
-    readonly collaboratorName: string;
+    readonly collaboratorName: string | undefined;
     readonly showDelete: boolean;
     readonly confirmAction: () => void;
     readonly closeAction: () => void;

--- a/src/components/collaborator_list/CollaboratorList.tsx
+++ b/src/components/collaborator_list/CollaboratorList.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import CollaboratorAddEdit from './CollaboratorAddEdit';
 import CollaboratorRow from './CollaboratorRow';
 import {Collaborator} from 'src/types/model';
+import {Countries} from "src/libs/ajax/Countries";
 
 interface CollaboratorListProps {
     collaborators: Collaborator[];
@@ -52,6 +53,7 @@ export default function CollaboratorList(props: CollaboratorListProps): React.JS
                         id={-1}
                         collaboratorText={collaboratorText}
                         collaborators={collaborators}
+                        collaborator={{countryOfOperation: Countries.DEFAULT_COUNTRY} as Collaborator}
                         closeAction={() => setShowAddEdit(false)}
                         onCollaboratorChange={onCollaboratorChange}
                         showApproverStatus={showApproverStatus}
@@ -69,6 +71,7 @@ export default function CollaboratorList(props: CollaboratorListProps): React.JS
                         collaboratorText={collaboratorText}
                         collaborators={collaborators}
                         columnsToShow={columnsToShow}
+                        countriesOfOperation={countriesOfOperation}
                         editAction={() => toggleEditState(index)}
                         deleteAction={() => { handleDeleteCollaborator(index); }}
                         closeAction={() => { toggleEditState(index); setShowAddEdit(false); }}

--- a/src/components/collaborator_list/CollaboratorList.tsx
+++ b/src/components/collaborator_list/CollaboratorList.tsx
@@ -1,19 +1,20 @@
 import React, { useState } from 'react';
 import CollaboratorAddEdit from './CollaboratorAddEdit';
 import CollaboratorRow from './CollaboratorRow';
-import {Collaborator} from "src/types/model";
+import {Collaborator} from 'src/types/model';
 
 interface CollaboratorListProps {
     collaborators: Collaborator[];
     readonly collaboratorText: string;
     readonly columnsToShow?: string[];
-    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
+    readonly onCollaboratorChange: (collaborators: (Collaborator | undefined)[]) => void;
     readonly disabled?: boolean;
     readonly showApproverStatus?: boolean;
+    readonly countriesOfOperation: string[];
 }
 
 export default function CollaboratorList(props: CollaboratorListProps): React.JSX.Element {
-    const { collaborators, collaboratorText, columnsToShow = [], onCollaboratorChange, disabled = false, showApproverStatus = false } = props;
+    const { collaborators, collaboratorText, columnsToShow = [], onCollaboratorChange, disabled = false, showApproverStatus = false, countriesOfOperation } = props;
 
     const [showAddEdit, setShowAddEdit] = useState(false);
     const [editState, setEditState] = useState(collaborators.map(() => false));
@@ -54,6 +55,7 @@ export default function CollaboratorList(props: CollaboratorListProps): React.JS
                         closeAction={() => setShowAddEdit(false)}
                         onCollaboratorChange={onCollaboratorChange}
                         showApproverStatus={showApproverStatus}
+                        countriesOfOperation={countriesOfOperation}
                     />
                 )}
             </div>

--- a/src/components/collaborator_list/CollaboratorList.tsx
+++ b/src/components/collaborator_list/CollaboratorList.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import CollaboratorAddEdit from './CollaboratorAddEdit';
 import CollaboratorRow from './CollaboratorRow';
 import {Collaborator} from 'src/types/model';
-import {Countries} from "src/libs/ajax/Countries";
+import {Countries} from 'src/libs/ajax/Countries';
 
 interface CollaboratorListProps {
     collaborators: Collaborator[];

--- a/src/components/collaborator_list/CollaboratorList.tsx
+++ b/src/components/collaborator_list/CollaboratorList.tsx
@@ -8,7 +8,7 @@ interface CollaboratorListProps {
     collaborators: Collaborator[];
     readonly collaboratorText: string;
     readonly columnsToShow?: string[];
-    readonly onCollaboratorChange: (collaborators: (Collaborator | undefined)[]) => void;
+    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
     readonly disabled?: boolean;
     readonly showApproverStatus?: boolean;
     readonly countriesOfOperation: string[];

--- a/src/components/collaborator_list/CollaboratorRow.tsx
+++ b/src/components/collaborator_list/CollaboratorRow.tsx
@@ -13,7 +13,7 @@ interface CollaboratorRowProps {
     readonly editAction: () => void;
     readonly deleteAction: () => void;
     readonly closeAction: () => void;
-    readonly onCollaboratorChange: (collaborators: (Collaborator | undefined)[]) => void;
+    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
     readonly countriesOfOperation: string[];
     readonly disabled: boolean;
 }

--- a/src/components/collaborator_list/CollaboratorRow.tsx
+++ b/src/components/collaborator_list/CollaboratorRow.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
 import CollaboratorAddEdit from './CollaboratorAddEdit';
 import CollaboratorSummary from './CollaboratorSummary';
-import {Collaborator} from "src/types/model";
+import {Collaborator} from 'src/types/model';
 
 interface CollaboratorRowProps {
     readonly id: number;
     readonly editMode: boolean;
-    collaborator: Collaborator;
+    collaborator: Collaborator | undefined;
     readonly collaboratorText: string;
     readonly collaborators: Collaborator[];
     readonly columnsToShow: string[];
     readonly editAction: () => void;
     readonly deleteAction: () => void;
     readonly closeAction: () => void;
-    readonly onCollaboratorChange: (collaborators: Collaborator[]) => void;
+    readonly onCollaboratorChange: (collaborators: (Collaborator | undefined)[]) => void;
+    readonly countriesOfOperation: string[];
     readonly disabled: boolean;
 }
 
 export default function CollaboratorRow(props: CollaboratorRowProps): React.JSX.Element {
-    const { id, editMode, collaborator, collaboratorText, collaborators, columnsToShow, editAction, deleteAction, closeAction, onCollaboratorChange, disabled } = props;
+    const { id, editMode, collaborator, collaboratorText, collaborators, columnsToShow, countriesOfOperation, editAction, deleteAction, closeAction, onCollaboratorChange, disabled } = props;
 
     return (
         <div>
@@ -30,6 +31,7 @@ export default function CollaboratorRow(props: CollaboratorRowProps): React.JSX.
                     collaborators={collaborators}
                     closeAction={closeAction}
                     onCollaboratorChange={onCollaboratorChange}
+                    countriesOfOperation={countriesOfOperation}
                 />)}
             {!editMode && (
                 <CollaboratorSummary

--- a/src/components/collaborator_list/CollaboratorRow.tsx
+++ b/src/components/collaborator_list/CollaboratorRow.tsx
@@ -6,7 +6,7 @@ import {Collaborator} from 'src/types/model';
 interface CollaboratorRowProps {
     readonly id: number;
     readonly editMode: boolean;
-    collaborator: Collaborator | undefined;
+    collaborator: Collaborator;
     readonly collaboratorText: string;
     readonly collaborators: Collaborator[];
     readonly columnsToShow: string[];

--- a/src/components/collaborator_list/CollaboratorSummary.tsx
+++ b/src/components/collaborator_list/CollaboratorSummary.tsx
@@ -3,7 +3,7 @@ import CollaboratorDelete from './CollaboratorDelete';
 import {Collaborator} from 'src/types/model';
 
 interface CollaboratorSummaryProps {
-    collaborator: Collaborator | undefined;
+    collaborator: Collaborator;
     readonly columnsToShow: string[];
     readonly editAction: () => void;
     readonly deleteAction: () => void;

--- a/src/components/collaborator_list/CollaboratorSummary.tsx
+++ b/src/components/collaborator_list/CollaboratorSummary.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from "react";
-import CollaboratorDelete from "./CollaboratorDelete";
-import { Collaborator } from "./Collaborator";
+import React, { useState } from 'react';
+import CollaboratorDelete from './CollaboratorDelete';
+import {Collaborator} from 'src/types/model';
 
 interface CollaboratorSummaryProps {
-    collaborator: Collaborator;
+    collaborator: Collaborator | undefined;
     readonly columnsToShow: string[];
     readonly editAction: () => void;
     readonly deleteAction: () => void;
@@ -26,7 +26,7 @@ export default function CollaboratorSummary(props: CollaboratorSummaryProps): Re
         <div className='collaborator-summary-card'>
             {/* data elements to show in the row summary */}
             {columnsToShow.map((column, index) => {
-                const columnContent = collaborator[column as keyof Collaborator];
+                const columnContent = collaborator ? collaborator[column as keyof Collaborator] : [];
                 return columnContent && (
                     <div key={'collaborator_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
                         <span>
@@ -65,7 +65,7 @@ export default function CollaboratorSummary(props: CollaboratorSummaryProps): Re
             </a>
             {/* delete modal */}
             <CollaboratorDelete
-                collaboratorName={collaborator.name}
+                collaboratorName={collaborator?.name}
                 showDelete={showDeleteModal}
                 confirmAction={() => { deleteAction(); setShowDeleteModal(false); }}
                 closeAction={() => setShowDeleteModal(false)}

--- a/src/libs/ajax/Countries.ts
+++ b/src/libs/ajax/Countries.ts
@@ -1,0 +1,12 @@
+import {getApiUrl} from 'src/libs/ajax';
+import {Config} from 'src/libs/config';
+import axios from 'axios';
+
+export const Countries =  {
+    getCountries: async () => {
+        const url = `${await getApiUrl()}/api-docs/ISO-3166-countries.json`
+        const res = await axios.get(url, Config.authOpts());
+        return await res.data;
+    },
+    DEFAULT_COUNTRY: 'United States of America (the)'
+}

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -90,7 +90,7 @@ const DataAccessRequestApplication = (props) => {
     researcher: '',
     piName: '',
     piEmail: '',
-    piCountryOfOperation: '',
+    piCountryOfOperation: Countries.DEFAULT_COUNTRY,
     projectTitle: '',
     profileName: '',
     pubmedId: '',

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -27,13 +27,14 @@ import {DAAUtils} from '../../utils/DAAUtils';
 import {Metrics} from '../../libs/ajax/Metrics';
 import eventList from '../../libs/events';
 import ReactMarkdown from 'react-markdown';
-import {SpinnerComponent} from "../../components/SpinnerComponent.jsx";
-import loadingImage from "../../images/loading-indicator.svg";
-import {ConditionalAccordion} from "../../components/forms/ConditionalAccordion.js";
-import {ProgressReportApplication} from "./ProgressReportApplication";
-import {ScrollableTabs} from "./ScrollableTabs";
-import {validateDARFormData, validationFailed} from "src/utils/darFormUtils.js";
+import {SpinnerComponent} from '../../components/SpinnerComponent.jsx';
+import loadingImage from '../../images/loading-indicator.svg';
+import {ConditionalAccordion} from '../../components/forms/ConditionalAccordion.js';
+import {ProgressReportApplication} from './ProgressReportApplication';
+import {ScrollableTabs} from './ScrollableTabs';
+import {validateDARFormData, validationFailed} from 'src/utils/darFormUtils.js';
 import {isArray, set} from 'lodash';
+import {Countries} from 'src/libs/ajax/Countries.js';
 
 // Constants
 const RESEARCHER_INFO_TAB_ID = 'researcher-info';
@@ -92,6 +93,7 @@ const DataAccessRequestApplication = (props) => {
     researcher: '',
     piName: '',
     piEmail: '',
+    piCountryOfOperation: '',
     projectTitle: '',
     profileName: '',
     pubmedId: '',
@@ -145,6 +147,8 @@ const DataAccessRequestApplication = (props) => {
   const [isAttested, setIsAttested] = useState(false);
 
   const [applicationTabs, setApplicationTabs] = useState([]);
+
+  const [countriesOfOperation, setCountriesOfOperation] = useState([]);
 
   //helper function to coordinate local state changes as well as updates to form data on the parent
   const formFieldChange = useCallback(({ key, value }) => {
@@ -304,6 +308,9 @@ const DataAccessRequestApplication = (props) => {
     init();
     NotificationService.getBannerObjectById('eRACommonsOutage').then((notificationData) => {
       setNotificationData(notificationData);
+    });
+    Countries.getCountries().then((isoCountriesData)=> {
+      setCountriesOfOperation(isoCountriesData);
     });
   }, [init]);
 
@@ -577,6 +584,7 @@ const DataAccessRequestApplication = (props) => {
                       history={history}
                       location={location}
                       researcher={researcher}
+                      countriesOfOperation={countriesOfOperation}
                     />
                   </ConditionalAccordion>
                 </div>
@@ -634,6 +642,7 @@ const DataAccessRequestApplication = (props) => {
                   setLabCollaboratorsCompleted={setLabCollaboratorsCompleted}
                   setInternalCollaboratorsCompleted={setInternalCollaboratorsCompleted}
                   setExternalCollaboratorsCompleted={setExternalCollaboratorsCompleted}
+                  countriesOfOperation={countriesOfOperation}
                 />
                   </ConditionalAccordion>
               </div>

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -31,6 +31,7 @@ import {ProgressReportApplication} from 'src/pages/dar_application/ProgressRepor
 import {ScrollableTabs} from 'src/pages/dar_application/ScrollableTabs';
 import {validateDARFormData, validationFailed} from 'src/utils/darFormUtils.js';
 import {isArray, set} from 'lodash';
+import {Countries} from 'src/libs/ajax/Countries.js';
 
 // Constants
 const RESEARCHER_INFO_TAB_ID = 'researcher-info';

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -8,8 +8,8 @@ import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges'
 import DataManagementIncident from 'src/pages/progress_reports/DataManagementIncident';
 import DarCloseout from 'src/pages/progress_reports/DarCloseout';
 import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressReport';
-import {Navigation} from "src/libs/utils";
-import {Storage} from "src/libs/storage";
+import {Navigation} from 'src/libs/utils';
+import {Storage} from 'src/libs/storage';
 import {DataUseAcknowledgements} from 'src/pages/dar_application/DataUseAcknowlegements';
 import {translateDataUseRestrictionsFromDataUseArray} from 'src/libs/dataUseTranslation';
 import {validatePRFormData, validationFailed} from 'src/utils/darFormUtils';
@@ -23,9 +23,10 @@ type ProgressReportApplicationProps = {
   readonly history: History;
   readonly location?: Location;
   readonly researcher: DuosUser;
+  readonly countriesOfOperation: string[]
 };
 
-export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher }: ProgressReportApplicationProps) => {
+export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher, countriesOfOperation }: ProgressReportApplicationProps) => {
     const initialState = {
         ...dar,
         dmiCombination:false,
@@ -163,7 +164,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
                 />
             </div>
             <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
-                <CollaboratorChanges readOnly={readOnlyMode} formState={formState} onFormChange={onFormChange}/>
+                <CollaboratorChanges readOnly={readOnlyMode} formState={formState} onFormChange={onFormChange} countriesOfOperation={countriesOfOperation}/>
             </div>
             <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <DataManagementIncident

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -29,6 +29,7 @@ type ProgressReportApplicationProps = {
 export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher, countriesOfOperation }: ProgressReportApplicationProps) => {
     const initialState = {
         ...dar,
+        ...dar.data,
         dmiCombination:false,
         dmiIdentification: false,
         dmiSharing: false,

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -173,7 +173,7 @@ export default function ResearcherInfo(props) {
             id='piCountryOfOperation'
             placeholder='Country of Operation'
             disabled={readOnlyMode}
-            defaultValue={(formData.piCountryOfOperation || formData.piCountryOfOperation === '') ? null : formData.piCountryOfOperation}
+            defaultValue={formData.piCountryOfOperation}
             type={FormFieldTypes.SELECT}
             validators={[FormValidators.REQUIRED]}
             validation={validation.piCountryOfOperation}

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -25,6 +25,7 @@ export default function ResearcherInfo(props) {
     readOnlyMode,
     includeInstructions,
     completed,
+    countriesOfOperation,
     darCode,
     eRACommonsDestination,
     formFieldChange,
@@ -167,6 +168,17 @@ export default function ResearcherInfo(props) {
               defaultValue={formData.piEmail}
             />
           </div>
+          <label className="control-label" id="principal-investigator-email">Principal Investigator Country of Operation*</label>
+          <FormField
+            id='piCountryOfOperation'
+            disabled={readOnlyMode}
+            defaultValue={formData.piCountryOfOperation}
+            type={FormFieldTypes.SELECT}
+            validators={[FormValidators.REQUIRED]}
+            selectOptions={countriesOfOperation}
+            optionsAreString={true}
+            onChange={({key, value}) => formFieldChange({key, value})}
+          />
         </div>
 
         <div className='dar-application-row' data-cy='internal-lab-staff'>
@@ -190,6 +202,7 @@ export default function ResearcherInfo(props) {
             onValidationChange={onValidationChange}
             showApproval={true}
             disabled={!isEmpty(darCode) || readOnlyMode}
+            countriesOfOperation={countriesOfOperation}
           />
         </div>
 
@@ -210,6 +223,7 @@ export default function ResearcherInfo(props) {
             collaborators={formData.internalCollaborators}
             collaboratorKey='internalCollaborators'
             collaboratorLabel='Internal Collaborator'
+            countriesOfOperation={countriesOfOperation}
             setCompleted={setInternalCollaboratorsCompleted}
             validation={validation.internalCollaborators}
             onValidationChange={onValidationChange}
@@ -426,6 +440,7 @@ export default function ResearcherInfo(props) {
             collaborators={formData.externalCollaborators}
             collaboratorKey='externalCollaborators'
             collaboratorLabel='External Collaborator'
+            countriesOfOperation={countriesOfOperation}
             setCompleted={setExternalCollaboratorsCompleted}
             showApproval={false}
             disabled={!isEmpty(darCode) || readOnlyMode}

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -168,13 +168,16 @@ export default function ResearcherInfo(props) {
               defaultValue={formData.piEmail}
             />
           </div>
-          <label className="control-label" id="principal-investigator-email">Principal Investigator Country of Operation*</label>
+          <label className="control-label" id="principal-investigator-country-of-operation">Principal Investigator Country of Operation*</label>
           <FormField
             id='piCountryOfOperation'
+            placeholder='Country of Operation'
             disabled={readOnlyMode}
-            defaultValue={formData.piCountryOfOperation}
+            defaultValue={(formData.piCountryOfOperation || formData.piCountryOfOperation === '') ? null : formData.piCountryOfOperation}
             type={FormFieldTypes.SELECT}
             validators={[FormValidators.REQUIRED]}
+            validation={validation.piCountryOfOperation}
+            onValidationChange={onValidationChange}
             selectOptions={countriesOfOperation}
             optionsAreString={true}
             onChange={({key, value}) => formFieldChange({key, value})}

--- a/src/pages/dar_application/collaborator/CollaboratorForm.jsx
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.jsx
@@ -10,6 +10,7 @@ import {computeCollaboratorErrors} from 'src/utils/darFormUtils.js';
 import DeleteCollaboratorModal from './DeleteCollaboratorModal';
 import {nihAccountLabel} from 'src/utils/ERACommonsUtils.js';
 import ApproverStatus from 'src/pages/dar_application/collaborator/ApproverStatus.js';
+import {Countries} from 'src/libs/ajax/Countries.js';
 
 export default function CollaboratorForm(props) {
   const {
@@ -46,6 +47,7 @@ export default function CollaboratorForm(props) {
       setCountryOfOperation(collaborator.countryOfOperation);
     } else {
       setUuid(uuidV4());
+      setCountryOfOperation(Countries.DEFAULT_COUNTRY);
     }
   }, [collaborator]);
 
@@ -120,6 +122,7 @@ export default function CollaboratorForm(props) {
               type={FormFieldTypes.SELECT}
               selectOptions={countriesOfOperation}
               optionsAreString={true}
+              validation={validation.countryOfOperation}
               onValidationChange={onValidationChange}
               onChange={({value})=> setCountryOfOperation(value)}
           />
@@ -161,7 +164,7 @@ export default function CollaboratorForm(props) {
             className='collaborator-form-add-save-button f-left btn'
             role='button'
             onClick={() => {
-              const newCollaborator = {name, eraCommonsId, title, email, approverStatus, uuid};
+              const newCollaborator = {name, eraCommonsId, title, email, approverStatus, countryOfOperation, uuid};
               const errors = computeCollaboratorErrors({
                 collaborator: newCollaborator,
                 needsApproverStatus: props.showApproval

--- a/src/pages/dar_application/collaborator/CollaboratorForm.jsx
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.jsx
@@ -1,4 +1,8 @@
-import {FormField, FormValidators} from 'src/components/forms/forms.jsx';
+import {
+  FormField,
+  FormFieldTypes,
+  FormValidators,
+} from 'src/components/forms/forms.jsx';
 import React, {useEffect, useState} from 'react';
 import {isEmpty, isNil} from 'lodash/fp';
 import {v4 as uuidV4} from 'uuid';
@@ -12,6 +16,7 @@ export default function CollaboratorForm(props) {
     index,
     collaborator,
     collaboratorKey,
+    countriesOfOperation,
     validation,
     onCollaboratorValidationChange
   } = props;
@@ -24,6 +29,7 @@ export default function CollaboratorForm(props) {
   const [uuid, setUuid] = useState('');
   const [showDeleteCollaboratorModal, setShowDeleteCollaboratorModal] = useState(false);
   const accountLabel = nihAccountLabel();
+  const [countryOfOperation, setCountryOfOperation] = useState('');
 
   const onValidationChange = ({key, validation}) => {
     onCollaboratorValidationChange({index, key, validation});
@@ -37,13 +43,14 @@ export default function CollaboratorForm(props) {
       setTitle(collaborator.title);
       setApproverStatus(collaborator.approverStatus);
       setUuid(collaborator.uuid);
+      setCountryOfOperation(collaborator.countryOfOperation);
     } else {
       setUuid(uuidV4());
     }
   }, [collaborator]);
 
   const saveUpdate = () => {
-    props.saveCollaborator({name, eraCommonsId, title, email, approverStatus, uuid});
+    props.saveCollaborator({name, eraCommonsId, title, email, approverStatus, uuid, countryOfOperation});
     props.updateEditState(false);
   };
 
@@ -102,6 +109,19 @@ export default function CollaboratorForm(props) {
             validation={validation.email}
             onValidationChange={onValidationChange}
             onChange={({value}) => setEmail(value)}
+          />
+          <FormField
+              id={`${index}_collaboratorCountryOfOperation`}
+              name='countryOfOperation'
+              title={`${props.collaboratorLabel} Country of Operation`}
+              defaultValue={countryOfOperation === '' ? null : countryOfOperation}
+              placeholder='Country of Operation'
+              validators={[FormValidators.REQUIRED]}
+              type={FormFieldTypes.SELECT}
+              selectOptions={countriesOfOperation}
+              optionsAreString={true}
+              onValidationChange={onValidationChange}
+              onChange={({value})=> setCountryOfOperation(value)}
           />
         </div>
         {props.showApproval && (

--- a/src/pages/dar_application/collaborator/CollaboratorList.jsx
+++ b/src/pages/dar_application/collaborator/CollaboratorList.jsx
@@ -1,12 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import CollaboratorForm from './CollaboratorForm';
 import CollaboratorRow from './CollaboratorRow';
-import { useState, useEffect} from 'react';
 import './collaborator.css';
 import { isNil } from 'lodash';
 
 export default function CollaboratorList(props) {
-  const {formFieldChange, collaboratorLabel, collaboratorKey, showApproval, setCompleted, validation, onValidationChange} = props;
+  const {formFieldChange, collaboratorLabel, collaboratorKey, countriesOfOperation, showApproval, setCompleted, validation, onValidationChange} = props;
 
   const [collaborators, setCollaborators] = useState(props.collaborators || []);
   const [editState, setEditState] = useState([]);
@@ -22,9 +21,9 @@ export default function CollaboratorList(props) {
   };
 
   const deleteCollaborator = (index) => {
-    let deleteCopy = deleteBoolArray.slice();
-    let collaboratorCopy = collaborators.slice();
-    let editCopy = editState.slice();
+    const deleteCopy = deleteBoolArray.slice();
+    const collaboratorCopy = collaborators.slice();
+    const editCopy = editState.slice();
 
     deleteCopy.splice(index, 1);
     collaboratorCopy.splice(index, 1);
@@ -40,7 +39,7 @@ export default function CollaboratorList(props) {
   }, [setCompleted, showNewForm, editState]);
 
   const saveCollaborator = (index, newCollaborator) => {
-    let newCollaborators = collaborators.slice();
+    const newCollaborators = collaborators.slice();
     newCollaborators[index] = newCollaborator;
     setCollaborators(newCollaborators);
     const deleteBoolCopy = [...deleteBoolArray, false];
@@ -48,13 +47,13 @@ export default function CollaboratorList(props) {
   };
 
   const updateEditState = (index, bool) => {
-    let newEditState = [...editState];
+    const newEditState = [...editState];
     newEditState[index] = bool;
     setEditState(newEditState);
   };
 
   const toggleDeleteBool = (index, bool) => {
-    let deleteCopy = [...deleteBoolArray];
+    const deleteCopy = [...deleteBoolArray];
     deleteCopy[index] = bool;
     setDeleteBoolArray(deleteCopy);
   };
@@ -85,6 +84,7 @@ export default function CollaboratorList(props) {
           validation={!isNil(validation) ? validation[index] || {} : {}}
           onCollaboratorValidationChange={onCollaboratorValidationChange}
           deleteMode={deleteBoolArray[index]}
+          countriesOfOperation={countriesOfOperation}
         />
       ))}
     </div>
@@ -120,6 +120,7 @@ export default function CollaboratorList(props) {
             editMode={true}
             validation={!isNil(validation) ? validation[collaborators.length] || {} : {}}
             onCollaboratorValidationChange={onCollaboratorValidationChange}
+            countriesOfOperation={countriesOfOperation}
           />
         )}
       </div>

--- a/src/pages/dar_application/collaborator/CollaboratorList.jsx
+++ b/src/pages/dar_application/collaborator/CollaboratorList.jsx
@@ -103,7 +103,7 @@ export default function CollaboratorList(props) {
             ...(props.disabled ? { cursor: 'not-allowed' } : {}),
           }}
           onClick={() => {
-            !props.disabled && setShowNewForm(true);
+            if (!props.disabled) {setShowNewForm(true);}
           }}
           disabled={props.disabled}
         >

--- a/src/pages/dar_application/collaborator/CollaboratorRow.jsx
+++ b/src/pages/dar_application/collaborator/CollaboratorRow.jsx
@@ -4,6 +4,7 @@ import CollaboratorForm from './CollaboratorForm';
 
 export const CollaboratorRow = (props) => {
   const {
+    countriesOfOperation,
     index,
     validation,
     onCollaboratorValidationChange,
@@ -18,6 +19,7 @@ export const CollaboratorRow = (props) => {
         collaborator={collaborator}
         index={index}
         validation={validation}
+        countriesOfOperation={countriesOfOperation}
         onCollaboratorValidationChange={onCollaboratorValidationChange}
       />}
       {!editMode && <CollaboratorSummary

--- a/src/pages/progress_reports/CollaboratorChanges.tsx
+++ b/src/pages/progress_reports/CollaboratorChanges.tsx
@@ -14,24 +14,24 @@ interface CollaboratorProps {
 export default function CollaboratorChanges(props: CollaboratorProps): React.JSX.Element {
     const { readOnly, formState, onFormChange, countriesOfOperation } = props;
 
-    const [labCollaborators, setLabCollaborators] = useState<Collaborator[]>(formState.labCollaborators || []);
-    const [internalCollaborators, setInternalCollaborators] = useState<Collaborator[]>(formState.internalCollaborators || []);
-    const [externalCollaborators, setExternalCollaborators] = useState<Collaborator[]>(formState.externalCollaborators || []);
+    const [labCollaborators, setLabCollaborators] = useState<(Collaborator | undefined)[]>(formState.labCollaborators || []);
+    const [internalCollaborators, setInternalCollaborators] = useState<(Collaborator | undefined)[]>(formState.internalCollaborators || []);
+    const [externalCollaborators, setExternalCollaborators] = useState<(Collaborator | undefined)[]>(formState.externalCollaborators || []);
 
-    const onCollaboratorChange = (key: string, setState: React.Dispatch<Collaborator[]>, collaborators: Collaborator[]) => {
+    const onCollaboratorChange = (key: string, setState: React.Dispatch<(Collaborator | undefined)[]>, collaborators: (Collaborator | undefined)[]) => {
         onFormChange({ [key]: collaborators } as Partial<FormState>);
         setState(collaborators);
     };
 
-    const onInternalLabStaffChange = (collaborators: Collaborator[]) => {
+    const onInternalLabStaffChange = (collaborators: (Collaborator | undefined)[]) => {
         onCollaboratorChange(FormStateKey.COLLABORATOR_LAB_COLLABORATORS, setLabCollaborators, collaborators);
     }
 
-    const onInternalCollaboratorsChange = (collaborators: Collaborator[]) => {
+    const onInternalCollaboratorsChange = (collaborators: (Collaborator | undefined)[]) => {
         onCollaboratorChange(FormStateKey.COLLABORATOR_INTERNAL_COLLABORATORS, setInternalCollaborators, collaborators);
     }
 
-    const onExternalCollaboratorsChange = (collaborators: Collaborator[]) => {
+    const onExternalCollaboratorsChange = (collaborators: (Collaborator | undefined)[]) => {
         onCollaboratorChange(FormStateKey.COLLABORATOR_EXTERNAL_COLLABORATORS, setExternalCollaborators, collaborators);
     }
 

--- a/src/pages/progress_reports/CollaboratorChanges.tsx
+++ b/src/pages/progress_reports/CollaboratorChanges.tsx
@@ -1,17 +1,18 @@
 import React, { useState } from 'react';
 import {FormState, FormStateKey} from 'src/pages/progress_reports/ProgressReportFormState';
 import CollaboratorList from 'src/components/collaborator_list/CollaboratorList';
-import {Collaborator} from "src/types/model";
-import {FormFieldTitle} from "src/components/forms/forms";
+import {Collaborator} from 'src/types/model';
+import {FormFieldTitle} from 'src/components/forms/forms';
 
 interface CollaboratorProps {
     readonly readOnly: boolean;
     formState: FormState;
     onFormChange: (newState: Partial<FormState>) => void;
+    readonly countriesOfOperation: string[];
 }
 
 export default function CollaboratorChanges(props: CollaboratorProps): React.JSX.Element {
-    const { readOnly, formState, onFormChange } = props;
+    const { readOnly, formState, onFormChange, countriesOfOperation } = props;
 
     const [labCollaborators, setLabCollaborators] = useState<Collaborator[]>(formState.labCollaborators || []);
     const [internalCollaborators, setInternalCollaborators] = useState<Collaborator[]>(formState.internalCollaborators || []);
@@ -52,6 +53,7 @@ export default function CollaboratorChanges(props: CollaboratorProps): React.JSX
                         onCollaboratorChange={onInternalLabStaffChange}
                         disabled={readOnly}
                         showApproverStatus={true}
+                        countriesOfOperation={countriesOfOperation}
                     />
                 </div>
                 <div className='progress-report-row'>
@@ -66,6 +68,7 @@ export default function CollaboratorChanges(props: CollaboratorProps): React.JSX
                         columnsToShow={['name', 'title']}
                         onCollaboratorChange={onInternalCollaboratorsChange}
                         disabled={readOnly}
+                        countriesOfOperation={countriesOfOperation}
                     />
                 </div>
                 <div className='progress-report-row'>
@@ -80,6 +83,7 @@ export default function CollaboratorChanges(props: CollaboratorProps): React.JSX
                         columnsToShow={['name', 'title']}
                         onCollaboratorChange={onExternalCollaboratorsChange}
                         disabled={readOnly}
+                        countriesOfOperation={countriesOfOperation}
                     />
                 </div>
             </div>

--- a/src/pages/progress_reports/CollaboratorChanges.tsx
+++ b/src/pages/progress_reports/CollaboratorChanges.tsx
@@ -14,24 +14,24 @@ interface CollaboratorProps {
 export default function CollaboratorChanges(props: CollaboratorProps): React.JSX.Element {
     const { readOnly, formState, onFormChange, countriesOfOperation } = props;
 
-    const [labCollaborators, setLabCollaborators] = useState<(Collaborator | undefined)[]>(formState.labCollaborators || []);
-    const [internalCollaborators, setInternalCollaborators] = useState<(Collaborator | undefined)[]>(formState.internalCollaborators || []);
-    const [externalCollaborators, setExternalCollaborators] = useState<(Collaborator | undefined)[]>(formState.externalCollaborators || []);
+    const [labCollaborators, setLabCollaborators] = useState<Collaborator[]>(formState.labCollaborators || []);
+    const [internalCollaborators, setInternalCollaborators] = useState<Collaborator[]>(formState.internalCollaborators || []);
+    const [externalCollaborators, setExternalCollaborators] = useState<Collaborator[]>(formState.externalCollaborators || []);
 
-    const onCollaboratorChange = (key: string, setState: React.Dispatch<(Collaborator | undefined)[]>, collaborators: (Collaborator | undefined)[]) => {
+    const onCollaboratorChange = (key: string, setState: React.Dispatch<Collaborator[]>, collaborators: Collaborator[]) => {
         onFormChange({ [key]: collaborators } as Partial<FormState>);
         setState(collaborators);
     };
 
-    const onInternalLabStaffChange = (collaborators: (Collaborator | undefined)[]) => {
+    const onInternalLabStaffChange = (collaborators: Collaborator[]) => {
         onCollaboratorChange(FormStateKey.COLLABORATOR_LAB_COLLABORATORS, setLabCollaborators, collaborators);
     }
 
-    const onInternalCollaboratorsChange = (collaborators: (Collaborator | undefined)[]) => {
+    const onInternalCollaboratorsChange = (collaborators: Collaborator[]) => {
         onCollaboratorChange(FormStateKey.COLLABORATOR_INTERNAL_COLLABORATORS, setInternalCollaborators, collaborators);
     }
 
-    const onExternalCollaboratorsChange = (collaborators: (Collaborator | undefined)[]) => {
+    const onExternalCollaboratorsChange = (collaborators: Collaborator[]) => {
         onCollaboratorChange(FormStateKey.COLLABORATOR_EXTERNAL_COLLABORATORS, setExternalCollaborators, collaborators);
     }
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -435,6 +435,7 @@ export interface Publication {
 
 export interface Collaborator {
   approverStatus: boolean;
+  countryOfOperation: string;
   email: string;
   eraCommonsId: string;
   name: string;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -400,6 +400,7 @@ export interface DataAccessRequest {
   dmi: DataManagementIncident;
   researchPlans: string;
   closeoutSupplement: Closeout;
+  data: object;
   parentId?: number;
 }
 

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -81,6 +81,11 @@ export const computeCollaboratorErrors = ({collaborator, needsApproverStatus=tru
     errors.title = requiredError;
   }
 
+  console.error(collaborator);
+  if (isStringEmpty(collaborator?.countryOfOperation)) {
+    errors.countryOfOperation = requiredError;
+  }
+
   if (isStringEmpty(collaborator?.email)) {
     errors.email = requiredError;
   } else if (!FormValidators.EMAIL.isValid(collaborator.email)) {
@@ -114,12 +119,24 @@ const calcResearcherInfoErrors = (formData, labCollaboratorsCompleted, internalC
     errors.piName = requiredError;
   }
 
+  if (isStringEmpty(formData.piEmail)) {
+    errors.piEmail = requiredError;
+  }
+
+  if (isStringEmpty(formData.piCountryOfOperation)) {
+    errors.piCountryOfOperation = requiredError;
+  }
+
   if (isStringEmpty(formData.signingOfficial)) {
     errors.signingOfficial = requiredError;
   }
 
   if (isStringEmpty(formData.itDirector)) {
     errors.itDirector = requiredError;
+  }
+
+  if (isStringEmpty(formData.itDirectorEmail)) {
+    errors.itDirectorEmail = requiredError;
   }
 
   if (!labCollaboratorsCompleted) {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -81,7 +81,6 @@ export const computeCollaboratorErrors = ({collaborator, needsApproverStatus=tru
     errors.title = requiredError;
   }
 
-  console.error(collaborator);
   if (isStringEmpty(collaborator?.countryOfOperation)) {
     errors.countryOfOperation = requiredError;
   }


### PR DESCRIPTION
### Addresses
[https://broadworkbench.atlassian.net/browse/DT-1813](https://broadworkbench.atlassian.net/browse/DT-1813)

### Summary

Before:
No PI Country of Operation, No validation warning of missing PI or IT email addresses

![image](https://github.com/user-attachments/assets/ec1dd476-7cb9-4de8-ae1c-31a174a99849)


No Collaborator Country of Operation

![image](https://github.com/user-attachments/assets/dd5d1ffd-f8a7-47a4-9768-674f91e2d6a8)


Collaborators not being properly populated in composition or review of progress report

![image](https://github.com/user-attachments/assets/b8d6092d-b14e-4bf8-b208-1fca625f6d3b)


After:
Required Collaborator Country of Operation

![image](https://github.com/user-attachments/assets/07a65683-9351-4a7f-8d3a-435a0c9317a5)


Validation warnings now work for missing PI or IT email address, PI Country of Operation with default set to USA

![image](https://github.com/user-attachments/assets/a5e9ea3f-12af-461b-a768-c27cfa67999b)


Collaborators now displaying

![image](https://github.com/user-attachments/assets/c0b8b790-bb4a-4bfb-aa37-df05b8b775ac)


<screenshots>

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
