### PR TITLE
[DT-1844] Lower Node version to Node LTS (currently 22.16.0)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,8 +8,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - run: echo "NODE_VERSION=$(cat Dockerfile | awk 'NR==2 {gsub(":","@",$2); print $2}' | awk '{split($0, array, "@"); print array[2]}')" >> $GITHUB_ENV
-      - run: echo $NODE_VERSION
+      - run: echo "NODE_VERSION=$(sed -n 's/FROM node:\([0-9.]*\).*/\1/p' Dockerfile)" >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -8,8 +8,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - run: echo "NODE_VERSION=$(cat Dockerfile | awk 'NR==2 {gsub(":","@",$2); print $2}' | awk '{split($0, array, "@"); print array[2]}')" >> $GITHUB_ENV
-      - run: echo $NODE_VERSION
+      - run: echo "NODE_VERSION=$(sed -n 's/FROM node:\([0-9.]*\).*/\1/p' Dockerfile)" >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,8 +9,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - run: echo "NODE_VERSION=$(cat Dockerfile | awk 'NR==2 {gsub(":","@",$2); print $2}' | awk '{split($0, array, "@"); print array[2]}')" >> $GITHUB_ENV
-      - run: echo $NODE_VERSION
+      - run: echo "NODE_VERSION=$(sed -n 's/FROM node:\([0-9.]*\).*/\1/p' Dockerfile)" >> $GITHUB_ENV
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -1,9 +1,9 @@
 # Local Development
 
-1. We use node 24.0.2 at time of writing, but check the [version of Node declared in the Dockerfile](https://github.com/DataBiosphere/duos-ui/blob/develop/Dockerfile#L2) and install that when setting up.  You can install it with [Volta](https://docs.volta.sh/guide/understanding) or NVM.
+1. We use node LTS at time of writing, but check the [version of Node declared in the Dockerfile](https://github.com/DataBiosphere/duos-ui/blob/develop/Dockerfile#L2) and install that when setting up.  You can install it with [Volta](https://docs.volta.sh/guide/understanding) or NVM.
 
 ```
-volta install 24.0.2
+volta install node@22.16.0
 ```
 
 2. Install deps:
@@ -125,4 +125,3 @@ To run a single test suite:
 ```shell
 npm run cypress:open:component --spec "**/data_access_governance.spec.js"
 ```
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM node:24.2.0 AS builder
+FROM node:22.16.0 AS builder
 LABEL maintainer="grushton@broadinstitute.org"
 
 # set working directory

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "not op_mini all"
   ],
   "engines": {
-    "node": ">=22.11.0"
+    "node": ">=22.16.0 <23"
   },
   "type": "module"
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1844

### Summary

Lower Node version to Node LTS (currently 22.16.0) for stability.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
