### PR TITLE
[DT-1812] Make PI/Submitter the same value 

### DIFF
--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -2,13 +2,13 @@ import {React} from 'react';
 import {mount} from 'cypress/react';
 import DataAccessRequestApplication from '../../../src/pages/dar_application/DataAccessRequestApplication.jsx';
 import { MemoryRouter } from 'react-router-dom';
-import { DAR } from '../../../src/libs/ajax/DAR.js';
-import { DataSet } from '../../../src/libs/ajax/DataSet.js';
-import { Metrics } from '../../../src/libs/ajax/Metrics';
-import { Navigation } from '../../../src/libs/utils.js';
-import { NotificationService } from '../../../src/libs/notificationService.js';
-import { Storage } from '../../../src/libs/storage.js';
-import { User } from '../../../src/libs/ajax/User';
+import { DAR } from 'src/libs/ajax/DAR.js';
+import { DataSet } from 'src/libs/ajax/DataSet.js';
+import { Metrics } from 'src/libs/ajax/Metrics.js';
+import { Navigation } from 'src/libs/utils.js';
+import { NotificationService } from 'src/libs/notificationService.js';
+import { Storage } from 'src/libs/storage.js';
+import { User } from 'src/libs/ajax/User.js';
 
 const props = {
   match: {
@@ -113,7 +113,6 @@ describe('Data Access Request - Validation', () => {
     });
 
     it('Submits given valid DAR', () => {
-      cy.get('#piName').type('Some PI');
       cy.get('#signingOfficial').type('SO 2{enter}');
       cy.get('#itDirector').type('Some IT Director');
       cy.get('#anvilUse_yes').click();
@@ -148,7 +147,6 @@ describe('Data Access Request - Validation', () => {
     });
 
     it('Required fields should not be errored when you open page', () => {
-      cy.get('#piName').should('not.have.class', 'errored');
       cy.get('#signingOfficial').should('not.have.class', 'errored');
       cy.get('#itDirector').should('not.have.class', 'errored');
       cy.get('#anvilUse').should('not.have.class', 'errored');
@@ -177,7 +175,6 @@ describe('Data Access Request - Validation', () => {
     it('Required fields get errors on submit', () => {
       cy.get('#btn_attest').click();
 
-      cy.get('#piName').should('have.class', 'errored');
       cy.get('#signingOfficial').should('have.class', 'errored');
       cy.get('#itDirector').should('have.class', 'errored');
       cy.get('#anvilUse').should('have.class', 'errored');

--- a/cypress/component/DataAccessRequest/researcher_info.spec.jsx
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.jsx
@@ -1,7 +1,7 @@
 import {React} from 'react';
 import {mount} from 'cypress/react';
 import ResearcherInfo from '../../../src/pages/dar_application/ResearcherInfo';
-import { User } from '../../../src/libs/ajax/User';
+import { User } from 'src/libs/ajax/User.js';
 
 import {BrowserRouter} from 'react-router-dom';
 
@@ -18,7 +18,7 @@ const props = {
   setLabCollaboratorsCompleted: () => {},
   setInternalCollaboratorsCompleted: () => {},
   setExternalCollaboratorsCompleted: () => {},
-  researcher: {},
+  researcher: {displayName: 'Researcher Name', email: 'name@email.com'},
   showValidationMessages: false,
   nextPage: () => {},
   validation: {},
@@ -30,6 +30,8 @@ const props = {
     internalCollaborators: [],
     externalCollaborators: [],
     labCollaborators: [],
+    piName: 'PI Name',
+    piEmail: 'pi@email.com'
   }
 };
 
@@ -200,5 +202,20 @@ describe('Researcher Info', () => {
       .find('.collaborator-list-component')
       .find('.row')
       .find('.form-group').should('not.exist');
+  });
+
+  it('renders researcher and pi as disabled with pi fields populated with the researcher data when not in read only mode', () => {
+    mount(<WrappedResearcherInfo {...props}/>);
+    cy.get('#researcherName').should('have.value', props.researcher.displayName);
+    cy.get('#piName').should('have.value', props.researcher.displayName);
+    cy.get('#piEmail').should('have.value', props.researcher.email);
+  });
+
+  it('renders researcher and pi as disabled with pi fields populated with saved pi info in read only mode', () => {
+    const mergedProps = {...props, ...{readOnlyMode: true}};
+    mount(<WrappedResearcherInfo {...mergedProps}/>);
+    cy.get('#researcherName').should('have.value', props.researcher.displayName);
+    cy.get('#piName').should('have.value', props.formData.piName);
+    cy.get('#piEmail').should('have.value', props.formData.piEmail);
   });
 });

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -273,12 +273,14 @@ const DataAccessRequestApplication = (props) => {
     }
 
     formData.researcher = isNil(researcher) ? '' : researcher.displayName;
+    formData.piName = props.existingDarsReadOnlyMode ? formData.piName : formData.researcher;
+    formData.piEmail = props.existingDarsReadOnlyMode ? formData.piEmail : (isNil(researcher) ? '' : researcher.email);
     formData.institution = isNil(researcher) || isNil(researcher.institution) ? '' : researcher.institution.name;
     formData.userId = researcher.userId;
 
     batchFormFieldChange(formData);
     setIsLoading(false);
-  }, [props.match.params, researcher]);
+  }, [props.match.params, props.existingDarsReadOnlyMode, researcher]);
 
   useEffect(() => {
     if (props.existingDarsReadOnlyMode) {

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -115,7 +115,7 @@ const DataAccessRequestApplication = (props) => {
     collaborationLetterName: '',
   });
 
-  const {history, location} = props;
+  const {history, location, existingDarsReadOnlyMode} = props;
 
   const [formValidation, setFormValidation] = useState({ researcherInfoErrors: {}, darErrors: {}, rusErrors: {} });
 
@@ -208,12 +208,12 @@ const DataAccessRequestApplication = (props) => {
     fetchAllDatasets(formData.datasetIds).then((datasets) => {
       setDatasets(datasets);
     });
-    if (!props.existingDarsReadOnlyMode) {
+    if (!existingDarsReadOnlyMode) {
       const tabName = DAAUtils.isEnabled() ? 'Data Access Agreements (DAA)' : 'Data Use Agreement';
       const updatedTabs= [...ApplicationTabs, { name: tabName, id: DATA_ACCESS_AGREEMENTS_TAB_ID }];
       setApplicationTabs(updatedTabs);
     }
-  }, [formData.datasetIds, props.existingDarsReadOnlyMode]);
+  }, [formData.datasetIds, existingDarsReadOnlyMode]);
 
   useEffect(() => {
     translateDataUseRestrictionsFromDataUseArray(datasets.map((ds) => ds.dataUse)).then((translations) => {
@@ -227,7 +227,7 @@ const DataAccessRequestApplication = (props) => {
     const fetchData = async () => {
       try {
         const { collectionId } = props.match.params;
-        if (props.existingDarsReadOnlyMode) {
+        if (existingDarsReadOnlyMode) {
           const collection = await Collections.getCollectionById(collectionId);
           setResearcher(collection.createUser);
         } else {
@@ -242,7 +242,7 @@ const DataAccessRequestApplication = (props) => {
       }
     };
     fetchData();
-  }, [props.match.params, props.existingDarsReadOnlyMode]);
+  }, [props.match.params, existingDarsReadOnlyMode]);
 
   const init = useCallback(async () => {
     const { dataRequestId, collectionId } = props.match.params;
@@ -277,17 +277,17 @@ const DataAccessRequestApplication = (props) => {
     }
 
     formData.researcher = isNil(researcher) ? '' : researcher.displayName;
-    formData.piName = props.existingDarsReadOnlyMode ? formData.piName : formData.researcher;
-    formData.piEmail = props.existingDarsReadOnlyMode ? formData.piEmail : (isNil(researcher) ? '' : researcher.email);
+    formData.piName = existingDarsReadOnlyMode ? formData.piName : formData.researcher;
+    formData.piEmail = existingDarsReadOnlyMode ? formData.piEmail : (isNil(researcher) ? '' : researcher.email);
     formData.institution = isNil(researcher) || isNil(researcher.institution) ? '' : researcher.institution.name;
     formData.userId = researcher.userId;
 
     batchFormFieldChange(formData);
     setIsLoading(false);
-  }, [props.match.params, props.existingDarsReadOnlyMode, researcher]);
+  }, [props.match.params, existingDarsReadOnlyMode, researcher]);
 
   useEffect(() => {
-    if (props.existingDarsReadOnlyMode) {
+    if (existingDarsReadOnlyMode) {
       let appTabs = []
       if(props.isProgressReportApplication){
         // if we are creating a new progress report, we need to add another tab for the application
@@ -301,7 +301,7 @@ const DataAccessRequestApplication = (props) => {
             return {name: itemLabel, id: `${DAR_UPDATE_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false};
           })]);
     }
-  }, [formData?.darCode, props.isProgressReportApplication, props.existingDarsReadOnlyMode, reverseOrderedDARs]);
+  }, [formData?.darCode, props.isProgressReportApplication, existingDarsReadOnlyMode, reverseOrderedDARs]);
 
   useEffect(() => {
     init();
@@ -521,7 +521,7 @@ const DataAccessRequestApplication = (props) => {
 
   return (
     <div>
-      <div className={props.existingDarsReadOnlyMode ? 'application-information-page' : 'container'} style={{ padding: props.existingDarsReadOnlyMode ? '2% 3%' : '0 0 2%', backgroundColor: props.existingDarsReadOnlyMode ? 'white' : '' }}>
+      <div className={existingDarsReadOnlyMode ? 'application-information-page' : 'container'} style={{ padding: existingDarsReadOnlyMode ? '2% 3%' : '0 0 2%', backgroundColor: existingDarsReadOnlyMode ? 'white' : '' }}>
         <div className='col-lg-12 col-md-12 col-sm-12 col-xs-12'>
           <div className='row no-margin'>
             <Notification notificationData={notificationData} />
@@ -529,12 +529,12 @@ const DataAccessRequestApplication = (props) => {
               className={(formData.darCode !== null ?
                 'col-lg-12 col-md-12 col-sm-9 ' : 'col-lg-12 col-md-12 col-sm-12 ')}>
               <PageHeading
-                title={props.existingDarsReadOnlyMode ? formData.darCode : 'Data Access Request Application'}
-                description={props.existingDarsReadOnlyMode ? formData.projectTitle : 'Please complete the fields below to request access to data.'}
+                title={existingDarsReadOnlyMode ? formData.darCode : 'Data Access Request Application'}
+                description={existingDarsReadOnlyMode ? formData.projectTitle : 'Please complete the fields below to request access to data.'}
               />
             </div>
             {formData.darCode !== null &&
-              !props.existingDarsReadOnlyMode &&
+              !existingDarsReadOnlyMode &&
               <div className='col-lg-2 col-md-3 col-sm-3 col-xs-12 no-padding'>
                 <a id='btn_back' onClick={back} className='btn-primary btn-back'>
                   <i className='glyphicon glyphicon-chevron-left' />
@@ -584,7 +584,7 @@ const DataAccessRequestApplication = (props) => {
                   </ConditionalAccordion>
                 </div>
             )}
-            {props.existingDarsReadOnlyMode && reverseOrderedDARs.length > 1  && (
+            {existingDarsReadOnlyMode && reverseOrderedDARs.length > 1  && (
                 <div className='dar-summary'>
                   <h3>Previous Updates</h3>
                   {reverseOrderedDARs.map((dar, index) => {
@@ -611,17 +611,17 @@ const DataAccessRequestApplication = (props) => {
                 </div>
             )}
 
-            <div id={`${DAR_UPDATE_TAB_ID_PREFIX}-0`} className={props.existingDarsReadOnlyMode ? 'dar-summary' : 'dar-steps'}>
-              {props.existingDarsReadOnlyMode && (<h3>{formData.darCode} Summary</h3>)}
-              <div id={RESEARCHER_INFO_TAB_ID} className={props.existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
+            <div id={`${DAR_UPDATE_TAB_ID_PREFIX}-0`} className={existingDarsReadOnlyMode ? 'dar-summary' : 'dar-steps'}>
+              {existingDarsReadOnlyMode && (<h3>{formData.darCode} Summary</h3>)}
+              <div id={RESEARCHER_INFO_TAB_ID} className={existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <ConditionalAccordion
-                    condition={props.existingDarsReadOnlyMode}
+                    condition={existingDarsReadOnlyMode}
                     title="Step 1: Researcher Information"
                     defaultExpanded={reverseOrderedDARs.length === 1}>
                 <ResearcherInfo
                   completed={!isNil(get('institutionId', researcher))}
-                  readOnlyMode={props.existingDarsReadOnlyMode || isAttested}
-                  includeInstructions={!props.existingDarsReadOnlyMode}
+                  readOnlyMode={existingDarsReadOnlyMode || isAttested}
+                  includeInstructions={!existingDarsReadOnlyMode}
                   darCode={formData.darCode}
                   formData={formData}
                   validation={formValidation.researcherInfoErrors}
@@ -642,14 +642,14 @@ const DataAccessRequestApplication = (props) => {
                   </ConditionalAccordion>
               </div>
 
-              <div id={DATA_ACCESS_REQUEST_TAB_ID} className={props.existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
+              <div id={DATA_ACCESS_REQUEST_TAB_ID} className={existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <ConditionalAccordion
-                    condition={props.existingDarsReadOnlyMode}
+                    condition={existingDarsReadOnlyMode}
                     title="Step 2: Data Access Request">
                   <DataAccessRequest
                       formData={formData}
-                      readOnlyMode={props.existingDarsReadOnlyMode || isAttested}
-                      includeInstructions={!props.existingDarsReadOnlyMode}
+                      readOnlyMode={existingDarsReadOnlyMode || isAttested}
+                      includeInstructions={!existingDarsReadOnlyMode}
                       datasets={datasets}
                       validation={formValidation.darErrors}
                       formValidationChange={(val) => formValidationChange('darErrors', val)}
@@ -667,13 +667,13 @@ const DataAccessRequestApplication = (props) => {
                 </ConditionalAccordion>
               </div>
 
-              <div id={RESEARCH_PURPOSE_STATEMENT_TAB_ID} className={props.existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
+              <div id={RESEARCH_PURPOSE_STATEMENT_TAB_ID} className={existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <ConditionalAccordion
-                    condition={props.existingDarsReadOnlyMode}
+                    condition={existingDarsReadOnlyMode}
                     title="Step 3: Research Purpose Statement">
                   <ResearchPurposeStatement
                       darCode={formData.darCode}
-                      readOnlyMode={props.existingDarsReadOnlyMode || isAttested}
+                      readOnlyMode={existingDarsReadOnlyMode || isAttested}
                       validation={formValidation.rusErrors}
                       formValidationChange={(val) => formValidationChange('rusErrors', val)}
                       formFieldChange={formFieldChange}
@@ -682,7 +682,7 @@ const DataAccessRequestApplication = (props) => {
                 </ConditionalAccordion>
               </div>
 
-              {!props.existingDarsReadOnlyMode ?
+              {!existingDarsReadOnlyMode ?
                   <div id={DATA_ACCESS_AGREEMENTS_TAB_ID} className='step-container'>
                   {DAAUtils.isEnabled() ?
                     <DataAccessAgreements
@@ -718,7 +718,7 @@ const DataAccessRequestApplication = (props) => {
           </div>
         </form>
       </div>
-      {!props.existingDarsReadOnlyMode ? <UsgOmbText /> : null}
+      {!existingDarsReadOnlyMode ? <UsgOmbText /> : null}
     </div>
   );
 };

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -87,7 +87,6 @@ export default function ResearcherInfo(props) {
         <div className='dar-application-row'>
           <FormField
             id='researcherName'
-            placeholder='Enter Firstname Lastname'
             title='1.1 Researcher'
             titleStyle={readOnlyMode ? {...titleStyle, ...noTopMarginStyle} : titleStyle}
             validators={[FormValidators.REQUIRED]}
@@ -138,7 +137,7 @@ export default function ResearcherInfo(props) {
 
         <div className='dar-application-row'>
           <h3>1.3 Principal Investigator</h3>
-          <div>I certify that the principal investigator listed below is aware of this study</div>
+          <div>I certify that I am the principal investigator. </div>
           <div className="formTable-row formTable-cols-full">
             <label className="control-label" id="principal-investigator-name">Principal Investigator Name*</label>
             <label className="control-label" id="principal-investigator-email">Principal Investigator Email*</label>
@@ -146,25 +145,18 @@ export default function ResearcherInfo(props) {
           <div className="formTable-row formTable-data-row">
             <FormField
               id='piName'
-              disabled={readOnlyMode}
+              disabled={true}
               placeholder='Principal Investigator Name'
               validators={[FormValidators.REQUIRED]}
               ariaLevel={ariaLevel + 1}
-              validation={validation.piName}
-              onValidationChange={onValidationChange}
-              onChange={({key, value}) => formFieldChange({key, value})}
-              defaultValue={formData.piName}
+              defaultValue={readOnlyMode ? formData.piName : researcher.displayName}
             />
             <FormField
               id='piEmail'
-              disabled={readOnlyMode}
-              placeholder='Principal Investigator Email'
+              disabled={true}
               validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
               ariaLevel={ariaLevel + 1}
-              validation={validation.piEmail}
-              onValidationChange={onValidationChange}
-              onChange={({key, value}) => formFieldChange({key, value})}
-              defaultValue={formData.piEmail}
+              defaultValue={readOnlyMode ? formData.piEmail : researcher.email}
             />
           </div>
         </div>

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -110,10 +110,6 @@ const calcResearcherInfoErrors = (formData, labCollaboratorsCompleted, internalC
     errors.nihEraId = requiredError;
   }
 
-  if (isStringEmpty(formData.piName)) {
-    errors.piName = requiredError;
-  }
-
   if (isStringEmpty(formData.signingOfficial)) {
     errors.signingOfficial = requiredError;
   }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1812

### Summary
When the page is in edit mode, change the pi name and email field to be read only and populate it with the researcher's information. Remove validation from these fields as they cannot be edited by users. 
In read only mode, the form will show whatever was submitted as the pi name and email even if it was different from the researcher. 
Adds unit tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
