### PR TITLE
[DT-1609] [DT-1851] Add support for bulk-issuing library cards

### DIFF
--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {mount} from 'cypress/react';
 import LibraryCardFormModal, {LibraryCardFormModalProps} from 'src/components/modals/LibraryCardFormModal';
-import {LibraryCard} from 'src/types/model';
 
 describe('Library Card Form Modal Tests', () => {
 
@@ -13,8 +12,7 @@ describe('Library Card Form Modal Tests', () => {
       showModal: true,
       createOnClick: cy.stub().as('createOnClick'),
       closeModal: cy.stub().as('closeModal'),
-      users: [],
-      card: {} as LibraryCard
+      users: []
     };
   });
 

--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -20,7 +20,7 @@ describe('Library Card Form Modal Tests', () => {
     mount(<LibraryCardFormModal {...props} />);
     cy.get('[data-cy=library-card-form-modal]').should('exist');
     cy.get('[data-cy=library-card-form-modal]').should('contain', 'Add Library Cards');
-    cy.contains('button', 'Bulk Issue / Add Users')
+    cy.get('[id=Add-button]').click();
     cy.get('[id=Cancel-button]').should('exist');
     ['Broad Library Card Agreement',
       'NIH Library Card Agreement',
@@ -42,7 +42,7 @@ describe('Library Card Form Modal Tests', () => {
     cy.get('[data-cy=library-card-form-modal]').should('contain', userOptions[0].email);
     // select the second option since the first is always the 'New User...' option
     cy.get('[id$=option-1]').click();
-    cy.contains('button', 'Bulk Issue / Add Users').click()
+    cy.get('[id=Add-button]').click();
     cy.get('@createOnClick').should('have.been.called');
   });
 
@@ -70,7 +70,7 @@ describe('Library Card Form Modal Tests', () => {
     cy.get('[id$=option-3]').click();
 
     // click add and confirm the call was made with all selected users
-    cy.contains('button', 'Bulk Issue / Add Users').click()
+    cy.get('[id=Add-button]').click();
     cy.get('@createOnClick').should('have.been.calledWith', [
       {userId: 1, userEmail: 'user1@test.com', userName: 'Test User 1'},
         {userId: 2, userEmail: 'user2@test.com', userName: 'Test User 2'},

--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from 'cypress/react';
-import LibraryCardFormModal, {LibraryCardFormModalProps} from 'src/components/modals/LibraryCardFormModal';
+import LibraryCardFormModal, {LibraryCardFormModalProps, UserOption} from 'src/components/modals/LibraryCardFormModal';
 import {LibraryCard} from 'src/types/model';
 
 describe('Library Card Form Modal Tests', () => {
@@ -34,8 +34,8 @@ describe('Library Card Form Modal Tests', () => {
   });
 
   it('Existing users should be visible in the user selection list', () => {
-    const userOptions = [
-      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: null},
+    const userOptions: UserOption[] = [
+      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: undefined},
     ]
     const mergedProps = {...props, ...{users: userOptions}};
     mount(<LibraryCardFormModal {...mergedProps} />);
@@ -48,9 +48,41 @@ describe('Library Card Form Modal Tests', () => {
     cy.get('@createOnClick').should('have.been.called');
   });
 
+  it('Multiple users should be selectable in the user selection list', () => {
+    const userOptions: UserOption[] = [
+      {userId: 1, displayName: 'Test User 1', email: 'user1@test.com', libraryCard: undefined},
+        {userId: 2, displayName: 'Test User 2', email: 'user2@test.com', libraryCard: undefined},
+        {userId: 3, displayName: 'Test User 3', email: 'user3@test.com', libraryCard: undefined}
+    ]
+
+    const mergedProps = {...props, ...{users: userOptions}};
+    mount(<LibraryCardFormModal {...mergedProps} />);
+    cy.get('input').should('exist');
+
+    // select the first option
+    cy.get('input').type('Test User');
+    cy.get('[id$=option-1]').click();
+
+    // select the second option
+    cy.get('input').type('Test User');
+    cy.get('[id$=option-2]').click();
+
+    // select the third option
+    cy.get('input').type('Test User');
+    cy.get('[id$=option-3]').click();
+
+    // click add and confirm the call was made with all selected users
+    cy.get('[id=Add-button]').click();
+    cy.get('@createOnClick').should('have.been.calledWith', [
+      {userId: 1, userEmail: 'user1@test.com', userName: 'Test User 1'},
+        {userId: 2, userEmail: 'user2@test.com', userName: 'Test User 2'},
+        {userId: 3, userEmail: 'user3@test.com', userName: 'Test User 3'}
+    ]);
+  });
+
   it('Non-existing users should NOT be visible in the user selection list', () => {
-    const userOptions = [
-      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: null},
+    const userOptions: UserOption[] = [
+      {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: undefined},
     ]
     const mergedProps = {...props, ...{users: userOptions}};
     mount(<LibraryCardFormModal {...mergedProps} />);

--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {mount} from 'cypress/react';
-import LibraryCardFormModal, {LibraryCardFormModalProps, UserOption} from 'src/components/modals/LibraryCardFormModal';
+import LibraryCardFormModal, {LibraryCardFormModalProps} from 'src/components/modals/LibraryCardFormModal';
 import {LibraryCard} from 'src/types/model';
 
 describe('Library Card Form Modal Tests', () => {
@@ -34,7 +34,7 @@ describe('Library Card Form Modal Tests', () => {
   });
 
   it('Existing users should be visible in the user selection list', () => {
-    const userOptions: UserOption[] = [
+    const userOptions = [
       {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: undefined},
     ]
     const mergedProps = {...props, ...{users: userOptions}};
@@ -49,7 +49,7 @@ describe('Library Card Form Modal Tests', () => {
   });
 
   it('Multiple users should be selectable in the user selection list', () => {
-    const userOptions: UserOption[] = [
+    const userOptions = [
       {userId: 1, displayName: 'Test User 1', email: 'user1@test.com', libraryCard: undefined},
         {userId: 2, displayName: 'Test User 2', email: 'user2@test.com', libraryCard: undefined},
         {userId: 3, displayName: 'Test User 3', email: 'user3@test.com', libraryCard: undefined}
@@ -81,7 +81,7 @@ describe('Library Card Form Modal Tests', () => {
   });
 
   it('Non-existing users should NOT be visible in the user selection list', () => {
-    const userOptions: UserOption[] = [
+    const userOptions = [
       {userId: 1, displayName: 'Test User 1', email: 'user@test.com', libraryCard: undefined},
     ]
     const mergedProps = {...props, ...{users: userOptions}};

--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -21,8 +21,8 @@ describe('Library Card Form Modal Tests', () => {
   it('Should render the Library Card Form Modal', () => {
     mount(<LibraryCardFormModal {...props} />);
     cy.get('[data-cy=library-card-form-modal]').should('exist');
-    cy.get('[data-cy=library-card-form-modal]').should('contain', 'Add Library Card');
-    cy.get('[id=Add-button]').should('exist');
+    cy.get('[data-cy=library-card-form-modal]').should('contain', 'Add Library Cards');
+    cy.contains('button', 'Bulk Issue / Add Users')
     cy.get('[id=Cancel-button]').should('exist');
     ['Broad Library Card Agreement',
       'NIH Library Card Agreement',
@@ -44,7 +44,7 @@ describe('Library Card Form Modal Tests', () => {
     cy.get('[data-cy=library-card-form-modal]').should('contain', userOptions[0].email);
     // select the second option since the first is always the 'New User...' option
     cy.get('[id$=option-1]').click();
-    cy.get('[id=Add-button]').click();
+    cy.contains('button', 'Bulk Issue / Add Users').click()
     cy.get('@createOnClick').should('have.been.called');
   });
 
@@ -72,7 +72,7 @@ describe('Library Card Form Modal Tests', () => {
     cy.get('[id$=option-3]').click();
 
     // click add and confirm the call was made with all selected users
-    cy.get('[id=Add-button]').click();
+    cy.contains('button', 'Bulk Issue / Add Users').click()
     cy.get('@createOnClick').should('have.been.calledWith', [
       {userId: 1, userEmail: 'user1@test.com', userName: 'Test User 1'},
         {userId: 2, userEmail: 'user2@test.com', userName: 'Test User 2'},

--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -76,7 +76,7 @@ describe('Library Card Table Tests', () => {
     cy.get('input[id^=react-select-]').type('Test User');
     cy.get('[id$=option-1]').click(); // Test User 1
 
-    cy.get('[id=Add-button]').click();
+    cy.contains('button', 'Bulk Issue / Add Users').click()
     cy.contains('Failed to issue library card for user1@test.com')
   });
 });

--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -76,7 +76,7 @@ describe('Library Card Table Tests', () => {
     cy.get('input[id^=react-select-]').type('Test User');
     cy.get('[id$=option-1]').click(); // Test User 1
 
-    cy.contains('button', 'Bulk Issue / Add Users').click()
+    cy.get('[id=Add-button]').click();
     cy.contains('Failed to issue library card for user1@test.com')
   });
 });

--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {mount} from 'cypress/react';
 import LibraryCardTable, {LibraryCardTableProps} from 'src/components/library_card_table/LibraryCardTable';
 import {LibraryCard as LibraryCardModel} from 'src/types/model';
+import {UserOption} from "src/components/modals/LibraryCardFormModal";
 
 describe('Library Card Table Tests', () => {
 
@@ -14,6 +15,12 @@ describe('Library Card Table Tests', () => {
       createUserId: 2,
       createDate: new Date(),
     }
+  ]
+
+  const userOptions: UserOption[] = [
+    {userId: 1, displayName: 'Test User 1', email: 'user1@test.com', libraryCard: undefined},
+    {userId: 2, displayName: 'Test User 2', email: 'user2@test.com', libraryCard: undefined},
+    {userId: 3, displayName: 'Test User 3', email: 'user3@test.com', libraryCard: undefined}
   ]
 
   beforeEach(() => {
@@ -42,6 +49,29 @@ describe('Library Card Table Tests', () => {
     libraryCardList.forEach((card) => {
       cy.get('.table-data').should('not.contain', card.userName)
     });
+  });
+
+  it('Should display an error message if a library card failed to create', () => {
+    cy.intercept('POST', '/api/libraryCards', {
+        statusCode: 500,
+        body: {
+            message: 'Failed to issue library card for user1@test.com'
+        }
+    }).as('createLibraryCard')
+    const props: LibraryCardTableProps = {
+      libraryCards: [],
+      users: userOptions,
+    }
+    mount(<LibraryCardTable {...props}/>);
+    cy.get('[data-cy=add-library-card-button]').click();
+    cy.get('[data-cy=library-card-form-modal]').should('exist');
+
+    cy.get('input[id^=react-select-]').should('exist');
+    cy.get('input[id^=react-select-]').type('Test User');
+    cy.get('[id$=option-1]').click(); // Test User 1
+
+    cy.get('[id=Add-button]').click();
+    cy.contains('Unknown error')
   });
 
 });

--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mount} from 'cypress/react';
 import LibraryCardTable, {LibraryCardTableProps} from 'src/components/library_card_table/LibraryCardTable';
 import {LibraryCard as LibraryCardModel} from 'src/types/model';
-import {UserOption} from 'src/components/modals/LibraryCardFormModal';
 import {LibraryCard} from 'src/libs/ajax/LibraryCard';
 
 describe('Library Card Table Tests', () => {
@@ -18,7 +17,7 @@ describe('Library Card Table Tests', () => {
     }
   ]
 
-  const userOptions: UserOption[] = [
+  const userOptions = [
     {userId: 1, displayName: 'Test User 1', email: 'user1@test.com', libraryCard: undefined},
     {userId: 2, displayName: 'Test User 2', email: 'user2@test.com', libraryCard: undefined},
     {userId: 3, displayName: 'Test User 3', email: 'user3@test.com', libraryCard: undefined}

--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import {mount} from 'cypress/react';
 import LibraryCardTable, {LibraryCardTableProps} from 'src/components/library_card_table/LibraryCardTable';
 import {LibraryCard as LibraryCardModel} from 'src/types/model';
-import {UserOption} from "src/components/modals/LibraryCardFormModal";
+import {UserOption} from 'src/components/modals/LibraryCardFormModal';
+import {LibraryCard} from 'src/libs/ajax/LibraryCard';
 
 describe('Library Card Table Tests', () => {
 
@@ -52,16 +53,22 @@ describe('Library Card Table Tests', () => {
   });
 
   it('Should display an error message if a library card failed to create', () => {
-    cy.intercept('POST', '/api/libraryCards', {
-        statusCode: 500,
-        body: {
-            message: 'Failed to issue library card for user1@test.com'
-        }
-    }).as('createLibraryCard')
+    cy.stub(LibraryCard, 'createLibraryCard')
+        .callsFake((card) => {
+          return Promise.reject({
+            response: {
+              data: {
+                message: `Failed to issue library card for ${card.userEmail}`
+              }
+            }
+          });
+        });
+
     const props: LibraryCardTableProps = {
       libraryCards: [],
       users: userOptions,
     }
+
     mount(<LibraryCardTable {...props}/>);
     cy.get('[data-cy=add-library-card-button]').click();
     cy.get('[data-cy=library-card-form-modal]').should('exist');
@@ -71,7 +78,6 @@ describe('Library Card Table Tests', () => {
     cy.get('[id$=option-1]').click(); // Test User 1
 
     cy.get('[id=Add-button]').click();
-    cy.contains('Unknown error')
+    cy.contains('Failed to issue library card for user1@test.com')
   });
-
 });

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -73,7 +73,7 @@ describe('SigningOfficialTable', () => {
     cy.get('[id$=option-1]').click();
 
     // Submit the form
-    cy.contains('button', 'Bulk Issue / Add Users').click();
+    cy.get('[id=Add-button]').click();
 
     // Verify error notification is shown
     cy.contains('Error issuing library card').should('be.visible');
@@ -107,7 +107,7 @@ describe('SigningOfficialTable', () => {
     cy.get('[id$=option-1]').click();
 
     // Submit the form
-    cy.contains('button', 'Bulk Issue / Add Users').click();
+    cy.get('[id=Add-button]').click();
 
     // Verify success notification is shown
     cy.contains('Issued 1 library card').should('be.visible');
@@ -152,7 +152,7 @@ describe('SigningOfficialTable', () => {
     cy.get('[id$=option-2]').click();
 
     // Submit the form
-    cy.contains('button', 'Bulk Issue / Add Users').click();
+    cy.get('[id=Add-button]').click();
 
     // Verify warning notification is shown
     cy.contains(`Issued 1 library card, but encountered errors issuing library cards to ${mockResearcher2.email}`).should('be.visible');

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -50,7 +50,7 @@ describe('SigningOfficialTable', () => {
     cy.get('[data-cy=library-card-form-modal]').should('contain', 'Add Library Cards');
   });
 
-  it('should display an error message issuing a library card fails', () => {
+  it('should display an error message when issuing a library card fails', () => {
     // Stub to make all requests fail
     cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
       .callsFake((card) => {
@@ -118,7 +118,7 @@ describe('SigningOfficialTable', () => {
     });
   });
 
-  it('should display a warning when some cards succeed and some fail', () => {
+  it('should display a warning when there are both failures and successes bulk-issuing library cards', () => {
     // Stub to make some requests succeed and some fail
     cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
       .callsFake((card) => {

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -47,7 +47,7 @@ describe('SigningOfficialTable', () => {
   it('should render the modal when Add Users button is clicked', () => {
     mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial} />);
 
-    cy.contains('Bulk Issue / Add Users').should('exist').click();
+    cy.contains('Add Library Card').should('exist').click();
     cy.get('[data-cy=library-card-form-modal]').should('be.visible');
     cy.get('[data-cy=library-card-form-modal]').should('contain', 'Add Library Cards');
   });
@@ -66,14 +66,14 @@ describe('SigningOfficialTable', () => {
       });
 
     mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial} />);
-    cy.contains('Bulk Issue / Add Users').click();
+    cy.contains('Add Library Card').click();
 
     // Select user
     cy.get('input[id^=react-select-]').type(mockResearcher1.displayName);
     cy.get('[id$=option-1]').click();
 
     // Submit the form
-    cy.get('[id=Add-button]').click();
+    cy.contains('button', 'Bulk Issue / Add Users').click();
 
     // Verify error notification is shown
     cy.contains('Error issuing library card').should('be.visible');
@@ -100,14 +100,14 @@ describe('SigningOfficialTable', () => {
 
     mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial}/>);
 
-    cy.contains('Bulk Issue / Add Users').click();
+    cy.contains('Add Library Card').click();
 
     // Select user
     cy.get('input[id^=react-select-]').type(mockResearcher1.displayName);
     cy.get('[id$=option-1]').click();
 
     // Submit the form
-    cy.get('[id=Add-button]').click();
+    cy.contains('button', 'Bulk Issue / Add Users').click();
 
     // Verify success notification is shown
     cy.contains('Issued 1 library card').should('be.visible');
@@ -143,7 +143,7 @@ describe('SigningOfficialTable', () => {
       });
 
     mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial} />);
-    cy.contains('Bulk Issue / Add Users').click();
+    cy.contains('Add Library Card').click();
 
     // Select users
     cy.get('input[id^=react-select-]').type(mockResearcher1.displayName);
@@ -152,7 +152,7 @@ describe('SigningOfficialTable', () => {
     cy.get('[id$=option-2]').click();
 
     // Submit the form
-    cy.get('[id=Add-button]').click();
+    cy.contains('button', 'Bulk Issue / Add Users').click();
 
     // Verify warning notification is shown
     cy.contains(`Issued 1 library card, but encountered errors issuing library cards to ${mockResearcher2.email}`).should('be.visible');

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -100,7 +100,7 @@ describe('SigningOfficialTable', () => {
 
     cy.contains('Bulk Issue / Add Users').click();
 
-    // Select users
+    // Select user
     cy.get('input[id^=react-select-]').type('Existing Researcher 1');
     cy.get('[id$=option-1]').click();
 

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -9,41 +9,43 @@ describe('SigningOfficialTable', () => {
     displayName: 'Test Signing Official',
   };
 
-  const mockResearchers = [
-    {
-      userId: 1,
-      email: 'existing.researcher1@test.com',
-      displayName: 'Existing Researcher 1',
-      roles: [{name: 'Researcher'}],
-      libraryCard: null
-    },
-    {
-      userId: 2,
-      email: 'existing.researcher2@test.com',
-      displayName: 'Existing Researcher 2',
-      roles: [{name: 'Researcher'}],
-      libraryCard: null
-    },
-    {
+  const mockResearcher1 = {
+    userId: 1,
+    email: 'existing.researcher1@test.com',
+    displayName: 'Existing Researcher 1',
+    roles: [{name: 'Researcher'}],
+    libraryCard: undefined
+  }
+
+  const mockResearcher2 = {
+    userId: 2,
+    email: 'existing.researcher2@test.com',
+    displayName: 'Existing Researcher 2',
+    roles: [{name: 'Researcher'}],
+    libraryCard: undefined
+  }
+
+  const mockResearcher3 = {
+    userId: 3,
+    email: 'researcher.with.card@test.com',
+    displayName: 'Researcher With Card',
+    roles: [{name: 'Researcher'}],
+    libraryCard: {
+      id: 'existing-card-1',
       userId: 3,
-      email: 'researcher.with.card@test.com',
-      displayName: 'Researcher With Card',
-      roles: [{name: 'Researcher'}],
-      libraryCard: {
-        id: 'existing-card-1',
-        userId: 3,
-        userEmail: 'researcher.with.card@test.com',
-        userName: 'Researcher With Card'
-      }
+      userEmail: 'researcher.with.card@test.com',
+      userName: 'Researcher With Card'
     }
-  ];
+  }
+
+  const mockResearcherList = [mockResearcher1, mockResearcher2, mockResearcher3];
 
   beforeEach(() => {
     cy.viewport(1600, 1000);
   });
 
-  it('should render the modal when Add Library Card button is clicked', () => {
-    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial} />);
+  it('should render the modal when Add Users button is clicked', () => {
+    mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial} />);
 
     cy.contains('Bulk Issue / Add Users').should('exist').click();
     cy.get('[data-cy=library-card-form-modal]').should('be.visible');
@@ -63,12 +65,11 @@ describe('SigningOfficialTable', () => {
         });
       });
 
-    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial} />);
-
+    mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial} />);
     cy.contains('Bulk Issue / Add Users').click();
 
-    // Select users
-    cy.get('input[id^=react-select-]').type('Existing Researcher 1');
+    // Select user
+    cy.get('input[id^=react-select-]').type(mockResearcher1.displayName);
     cy.get('[id$=option-1]').click();
 
     // Submit the form
@@ -77,31 +78,32 @@ describe('SigningOfficialTable', () => {
     // Verify error notification is shown
     cy.contains('Error issuing library card').should('be.visible');
 
-    // Verify the table did not change
-    cy.contains('div[role="row"]', 'Existing Researcher 1').within(() => {
-      cy.get('button[id="issue-card-existing.researcher1@test.com"]')
+    // Verify the table still shows the issue button for the failed user
+    cy.contains('div[role="row"]', mockResearcher1.displayName).within(() => {
+      cy.get(`button[id="issue-card-${mockResearcher1.email}"]`)
           .should('contain', 'Issue');
     });
   });
 
   it('should display a success message when issuing a library card succeeds', () => {
     // Stub to make the request succeed
+    const newCardId= 'new-card-id';
     cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
         .callsFake((card) => {
           return Promise.resolve({
-            id: 'new-card-id',
+            id: newCardId,
             userId: card.userId,
             userEmail: card.userEmail,
-            userName: card.userName || 'New User',
+            userName: card.userName,
           });
         });
 
-    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial}/>);
+    mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial}/>);
 
     cy.contains('Bulk Issue / Add Users').click();
 
     // Select user
-    cy.get('input[id^=react-select-]').type('Existing Researcher 1');
+    cy.get('input[id^=react-select-]').type(mockResearcher1.displayName);
     cy.get('[id$=option-1]').click();
 
     // Submit the form
@@ -110,9 +112,9 @@ describe('SigningOfficialTable', () => {
     // Verify success notification is shown
     cy.contains('Issued 1 library card').should('be.visible');
 
-    // Verify the table updated with the new library card
-    cy.contains('div[role="row"]', 'Existing Researcher 1').within(() => {
-      cy.get('button[id="deactivate-card-new-card-id"]')
+    // Verify the table was updated with the new library card
+    cy.contains('div[role="row"]', mockResearcher1.displayName).within(() => {
+      cy.get(`button[id="deactivate-card-${newCardId}"]`)
           .should('contain', 'Deactivate');
 
     });
@@ -120,14 +122,15 @@ describe('SigningOfficialTable', () => {
 
   it('should display a warning when there are both failures and successes bulk-issuing library cards', () => {
     // Stub to make some requests succeed and some fail
+    const newCardId= 'new-card-id';
     cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
       .callsFake((card) => {
-        if (card.userEmail === 'existing.researcher1@test.com') {
+        if (card.userEmail === mockResearcher1.email) {
           return Promise.resolve({
-            id: 'new-card-id',
+            id: newCardId,
             userId: card.userId,
             userEmail: card.userEmail,
-            userName: card.userName || 'New User',
+            userName: card.userName,
           });
         }
         return Promise.reject({
@@ -137,25 +140,32 @@ describe('SigningOfficialTable', () => {
             }
           }
         });
-        });
-    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial} />);
+      });
+
+    mount(<SigningOfficialTable researchers={mockResearcherList} signingOfficial={mockSigningOfficial} />);
     cy.contains('Bulk Issue / Add Users').click();
+
     // Select users
-    cy.get('input[id^=react-select-]').type('Existing Researcher 1');
+    cy.get('input[id^=react-select-]').type(mockResearcher1.displayName);
     cy.get('[id$=option-1]').click();
-    cy.get('input[id^=react-select-]').type('Existing Researcher 2');
+    cy.get('input[id^=react-select-]').type(mockResearcher2.displayName);
     cy.get('[id$=option-2]').click();
+
     // Submit the form
     cy.get('[id=Add-button]').click();
+
     // Verify warning notification is shown
-    cy.contains('Issued 1 library card, but encountered errors issuing library cards to existing.researcher2@test.com').should('be.visible');
-    // Verify the table updated with the new library card
-    cy.contains('div[role="row"]', 'Existing Researcher 1').within(() => {
-      cy.get('button[id="deactivate-card-new-card-id"]')
+    cy.contains(`Issued 1 library card, but encountered errors issuing library cards to ${mockResearcher2.email}`).should('be.visible');
+
+    // Verify the table was updated with the new library card
+    cy.contains('div[role="row"]', mockResearcher1.displayName).within(() => {
+      cy.get(`button[id="deactivate-card-${newCardId}"]`)
           .should('contain', 'Deactivate');
     });
-    cy.contains('div[role="row"]', 'Existing Researcher 2').within(() => {
-      cy.get('button[id="issue-card-existing.researcher2@test.com"]')
+
+    // Verify the table still shows the issue button for the failed user
+    cy.contains('div[role="row"]', mockResearcher2.displayName).within(() => {
+      cy.get(`button[id="issue-card-${mockResearcher2.email}"]`)
             .should('contain', 'Issue');
     });
   });

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import {mount} from 'cypress/react';
+import SigningOfficialTable from 'src/pages/signing_official_console/SigningOfficialTable';
+import * as LibraryCardApi from 'src/libs/ajax/LibraryCard';
+
+describe('SigningOfficialTable', () => {
+  const mockSigningOfficial = {
+    institutionId: 1,
+    displayName: 'Test Signing Official',
+  };
+
+  const mockResearchers = [
+    {
+      userId: 1,
+      email: 'existing.researcher1@test.com',
+      displayName: 'Existing Researcher 1',
+      roles: [{name: 'Researcher'}],
+      libraryCard: null
+    },
+    {
+      userId: 2,
+      email: 'existing.researcher2@test.com',
+      displayName: 'Existing Researcher 2',
+      roles: [{name: 'Researcher'}],
+      libraryCard: null
+    },
+    {
+      userId: 3,
+      email: 'researcher.with.card@test.com',
+      displayName: 'Researcher With Card',
+      roles: [{name: 'Researcher'}],
+      libraryCard: {
+        id: 'existing-card-1',
+        userId: 3,
+        userEmail: 'researcher.with.card@test.com',
+        userName: 'Researcher With Card'
+      }
+    }
+  ];
+
+  beforeEach(() => {
+    cy.viewport(1600, 1000);
+  });
+
+  it('should render the modal when Add Library Card button is clicked', () => {
+    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial} />);
+
+    cy.contains('Bulk Issue / Add Users').should('exist').click();
+    cy.get('[data-cy=library-card-form-modal]').should('be.visible');
+    cy.get('[data-cy=library-card-form-modal]').should('contain', 'Add Library Cards');
+  });
+
+  it('should display an error message issuing a library card fails', () => {
+    // Stub to make all requests fail
+    cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
+      .callsFake((card) => {
+        return Promise.reject({
+          response: {
+            data: {
+              message: `Failed to issue library card for ${card.userEmail}`
+            }
+          }
+        });
+      });
+
+    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial} />);
+
+    cy.contains('Bulk Issue / Add Users').click();
+
+    // Select users
+    cy.get('input[id^=react-select-]').type('Existing Researcher 1');
+    cy.get('[id$=option-1]').click();
+
+    // Submit the form
+    cy.get('[id=Add-button]').click();
+
+    // Verify error notification is shown
+    cy.contains('Error issuing library card').should('be.visible');
+
+    // Verify the table did not change
+    cy.contains('div[role="row"]', 'Existing Researcher 1').within(() => {
+      cy.get('button[id="issue-card-existing.researcher1@test.com"]')
+          .should('contain', 'Issue');
+    });
+  });
+
+  it('should display a success message when issuing a library card succeeds', () => {
+    // Stub to make the request succeed
+    cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
+        .callsFake((card) => {
+          return Promise.resolve({
+            id: 'new-card-id',
+            userId: card.userId,
+            userEmail: card.userEmail,
+            userName: card.userName || 'New User',
+          });
+        });
+
+    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial}/>);
+
+    cy.contains('Bulk Issue / Add Users').click();
+
+    // Select users
+    cy.get('input[id^=react-select-]').type('Existing Researcher 1');
+    cy.get('[id$=option-1]').click();
+
+    // Submit the form
+    cy.get('[id=Add-button]').click();
+
+    // Verify success notification is shown
+    cy.contains('Issued 1 library card').should('be.visible');
+
+    // Verify the table updated with the new library card
+    cy.contains('div[role="row"]', 'Existing Researcher 1').within(() => {
+      cy.get('button[id="deactivate-card-new-card-id"]')
+          .should('contain', 'Deactivate');
+
+    });
+  });
+
+  it('should display a warning when some cards succeed and some fail', () => {
+    // Stub to make some requests succeed and some fail
+    cy.stub(LibraryCardApi.LibraryCard, 'createLibraryCard')
+      .callsFake((card) => {
+        if (card.userEmail === 'existing.researcher1@test.com') {
+          return Promise.resolve({
+            id: 'new-card-id',
+            userId: card.userId,
+            userEmail: card.userEmail,
+            userName: card.userName || 'New User',
+          });
+        }
+        return Promise.reject({
+          response: {
+            data: {
+              message: `Failed to issue library card for ${card.userEmail}`
+            }
+          }
+        });
+        });
+    mount(<SigningOfficialTable researchers={mockResearchers} signingOfficial={mockSigningOfficial} />);
+    cy.contains('Bulk Issue / Add Users').click();
+    // Select users
+    cy.get('input[id^=react-select-]').type('Existing Researcher 1');
+    cy.get('[id$=option-1]').click();
+    cy.get('input[id^=react-select-]').type('Existing Researcher 2');
+    cy.get('[id$=option-2]').click();
+    // Submit the form
+    cy.get('[id=Add-button]').click();
+    // Verify warning notification is shown
+    cy.contains('Issued 1 library card, but encountered errors issuing library cards to existing.researcher2@test.com').should('be.visible');
+    // Verify the table updated with the new library card
+    cy.contains('div[role="row"]', 'Existing Researcher 1').within(() => {
+      cy.get('button[id="deactivate-card-new-card-id"]')
+          .should('contain', 'Deactivate');
+    });
+    cy.contains('div[role="row"]', 'Existing Researcher 2').within(() => {
+      cy.get('button[id="issue-card-existing.researcher2@test.com"]')
+            .should('contain', 'Issue');
+    });
+  });
+});

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -22,7 +22,6 @@ import TableIconButton from 'src/components/TableIconButton';
 import {AxiosError} from 'axios';
 import {ConsentError} from 'src/types/responseTypes';
 import {LibraryCard} from 'src/types/model';
-import {extractError} from 'src/utils/ErrorUtils';
 import { processLibraryCards } from 'src/utils/LibraryCardUtils';
 
 interface UserData {

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -22,7 +22,7 @@ import TableIconButton from 'src/components/TableIconButton';
 import {AxiosError} from 'axios';
 import {ConsentError} from 'src/types/responseTypes';
 import {LibraryCard} from 'src/types/model';
-import {extractError} from "src/utils/ErrorUtils";
+import {extractError} from 'src/utils/ErrorUtils';
 
 interface UserData {
   userId: number;
@@ -306,7 +306,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
     if (hasDuplicateCard) {
       Notifications.showError({text: 'One or more of the library cards already exist.'});
     } else {
-      // Execute library card update with payload, get the updated card, and
+      // Execute library card updates with payload, get the updated card, and
       // add (with sort afterwards) library card to libraryCards (reference list)
       const successfulCards = [];
       const failedCards = [];
@@ -324,16 +324,16 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
       const updatedList = cloneDeep(libraryCards);
       libraryCards.push(...successfulCards);
 
-      updatedList.sort((a: LibraryCard, b: LibraryCard) => {
-        const dateA = new Date(a.createDate ?? '');
-        const dateB = new Date(b.createDate ?? '');
-        return dateB.getTime() - dateA.getTime();
+      updatedList.sort((a, b) => {
+        return dayjs(b.createDate).valueOf() - dayjs(a.createDate).valueOf();
       });
+
       setLibraryCards(updatedList);
       setShowModal(false);
+
       if(failedCards.length > 0) {
-        const errorMessages = failedCards.map(failure => `${failure.card.userEmail}: ${failure.error}`).join('\n');
-        Notifications.showError({text: `Failed to create the following library cards:\n${errorMessages}`});
+        const errorMessages = failedCards.map(failure => `${failure.error}`).join(', ');
+        Notifications.showError({text: `${errorMessages}`});
       }
     }
   };
@@ -386,7 +386,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
                       flexDirection: 'row',
                       alignItems: 'flex-end',
                       justifyContent: 'center',
-                      width: '300px'
+                      width: '380px'
                     }}
                 >
                   <button
@@ -406,7 +406,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
                           )
                       }
                   >
-                    <span>Add Library Card</span>
+                    <span>Bulk Issue / Add Users</span>
                   </button>
                 </div>
               }

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -297,14 +297,17 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   // onClick function, used to create new card on modal based on form data
   const addLibraryCards = async (newLibraryCards: LibraryCard[]): Promise<void> => {
     // Check if any cards already exist, show error if any do
-    const hasDuplicateCard = newLibraryCards.some((card) => {
-      return findIndex(
-          (element: LibraryCard) => isEqual(element.userEmail)(card.userEmail),
-          libraryCards
-      ) > -1;
+    const duplicateLibraryCards = newLibraryCards.filter((card) => {
+        return findIndex(
+            (element: LibraryCard) => isEqual(element.userEmail)(card.userEmail),
+            libraryCards
+        ) > -1;
     });
-    if (hasDuplicateCard) {
-      Notifications.showError({text: 'One or more of the library cards already exist.'});
+
+    if (duplicateLibraryCards.length > 0) {
+      Notifications.showError({
+        text: 'Error updating library cards. The following users already have library cards: ' + duplicateLibraryCards.map(card => card.userEmail).join(', ')
+      });
     } else {
       // Execute library card updates with payload, get the updated card, and
       // add (with sort afterwards) library card to libraryCards (reference list)

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -311,7 +311,8 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
       const successfulCards = [];
       const failedCards = [];
 
-      // Process each card individually
+      // Process each card individually. Eventually, if there's a bulk API endpoint, this can be optimized.
+      // But for now, the volume of cards being added is small enough that this should be okay
       for (const card of newLibraryCards) {
         try {
           const newCard = await LibraryCardAPI.createLibraryCard(card);
@@ -321,8 +322,8 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
           failedCards.push({ card, error: errorMessage });
         }
       }
-      const updatedList = cloneDeep(libraryCards);
-      libraryCards.push(...successfulCards);
+
+      const updatedList = [...cloneDeep(libraryCards), ...successfulCards];
 
       updatedList.sort((a, b) => {
         return dayjs(b.createDate).valueOf() - dayjs(a.createDate).valueOf();

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -410,7 +410,8 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
         />
         <LibraryCardFormModal
             showModal={showModal}
-            createOnClick={addLibraryCard}
+            // TODO: LibraryCardTable doesn't support bulk creation
+            createOnClick={(card) => addLibraryCard(card[0])}
             closeModal={() => setShowModal(false)}
             users={users}
             card={currentCard}

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -416,7 +416,6 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
             createOnClick={addLibraryCards}
             closeModal={() => setShowModal(false)}
             users={users}
-            card={currentCard}
         />
         <ConfirmationModal
             showConfirmation={showConfirmation}

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -22,6 +22,7 @@ import TableIconButton from 'src/components/TableIconButton';
 import {AxiosError} from 'axios';
 import {ConsentError} from 'src/types/responseTypes';
 import {LibraryCard} from 'src/types/model';
+import {extractError} from "src/utils/ErrorUtils";
 
 interface UserData {
   userId: number;
@@ -316,13 +317,8 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
           const newCard = await LibraryCardAPI.createLibraryCard(card);
           successfulCards.push(newCard);
         } catch (error: unknown) {
-          const axiosError = error as AxiosError;
-          const consentError = axiosError?.response?.data as ConsentError;
-          const serverError = consentError.message ?? 'Error: Failed to create new library card';
-          failedCards.push({
-            card,
-            error: serverError || 'Unknown error'
-          });
+          const errorMessage = extractError(error);
+          failedCards.push({ card, error: errorMessage });
         }
       }
       const updatedList = cloneDeep(libraryCards);

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -311,11 +311,12 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
     } else {
       // Execute library card updates with payload, get the updated card, and
       // add (with sort afterwards) library card to libraryCards (reference list)
+
+      // Process each card individually and aggregate the results at the end.
+      // Eventually, if there's a bulk API endpoint, this can be optimized. But for
+      // now, the volume of cards being added is small enough that this should be okay
       const successfulCards = [];
       const failedCards = [];
-
-      // Process each card individually. Eventually, if there's a bulk API endpoint, this can be optimized.
-      // But for now, the volume of cards being added is small enough that this should be okay
       for (const card of newLibraryCards) {
         try {
           const newCard = await LibraryCardAPI.createLibraryCard(card);
@@ -390,7 +391,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
                       flexDirection: 'row',
                       alignItems: 'flex-end',
                       justifyContent: 'center',
-                      width: '380px'
+                      width: '300px'
                     }}
                 >
                   <button
@@ -410,7 +411,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
                           )
                       }
                   >
-                    <span>Bulk Issue / Add Users</span>
+                    <span>Add Library Card</span>
                   </button>
                 </div>
               }

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -8,7 +8,7 @@ import {
   Notifications,
   searchOnFilteredList
 } from 'src/libs/utils';
-import {cloneDeep, findIndex, isEmpty, isEqual, isNaN, isNil} from 'lodash/fp';
+import {cloneDeep, findIndex, isEmpty, isNaN, isNil} from 'lodash/fp';
 import {Styles} from 'src/libs/theme';
 import PaginationBar from 'src/components/PaginationBar';
 import SearchBar from 'src/components/SearchBar';
@@ -298,10 +298,9 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   const addLibraryCards = async (newLibraryCards: LibraryCard[]): Promise<void> => {
     // Check if any cards already exist, show error if any do
     const duplicateLibraryCards = newLibraryCards.filter((card) => {
-        return findIndex(
-            (element: LibraryCard) => isEqual(element.userEmail)(card.userEmail),
-            libraryCards
-        ) > -1;
+      return libraryCards.some((element: LibraryCard) =>
+          element.userEmail === card.userEmail
+      );
     });
 
     if (duplicateLibraryCards.length > 0) {
@@ -427,7 +426,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
         />
         <LibraryCardFormModal
             showModal={showModal}
-            createOnClick={(cards) => addLibraryCards(cards)}
+            createOnClick={addLibraryCards}
             closeModal={() => setShowModal(false)}
             users={users}
             card={currentCard}

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -23,6 +23,7 @@ import {AxiosError} from 'axios';
 import {ConsentError} from 'src/types/responseTypes';
 import {LibraryCard} from 'src/types/model';
 import {extractError} from 'src/utils/ErrorUtils';
+import { processLibraryCards } from 'src/utils/LibraryCardUtils';
 
 interface UserData {
   userId: number;
@@ -308,31 +309,18 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
         text: 'Error updating library cards. The following users already have library cards: ' + duplicateLibraryCards.map(card => card.userEmail).join(', ')
       });
     } else {
-      // Execute library card updates with payload, get the updated card, and
-      // add (with sort afterwards) library card to libraryCards (reference list)
+      const { successfulCards, failedCards } = await processLibraryCards(newLibraryCards);
 
-      // Process each card individually and aggregate the results at the end.
-      // Eventually, if there's a bulk API endpoint, this can be optimized. But for
-      // now, the volume of cards being added is small enough that this should be okay
-      const successfulCards = [];
-      const failedCards = [];
-      for (const card of newLibraryCards) {
-        try {
-          const newCard = await LibraryCardAPI.createLibraryCard(card);
-          successfulCards.push(newCard);
-        } catch (error: unknown) {
-          const errorMessage = extractError(error);
-          failedCards.push({ card, error: errorMessage });
-        }
+      if (successfulCards.length > 0) {
+        const updatedList = [...cloneDeep(libraryCards), ...successfulCards];
+
+        updatedList.sort((a, b) => {
+          return dayjs(b.createDate).valueOf() - dayjs(a.createDate).valueOf();
+        });
+
+        setLibraryCards(updatedList);
       }
 
-      const updatedList = [...cloneDeep(libraryCards), ...successfulCards];
-
-      updatedList.sort((a, b) => {
-        return dayjs(b.createDate).valueOf() - dayjs(a.createDate).valueOf();
-      });
-
-      setLibraryCards(updatedList);
       setShowModal(false);
 
       if(failedCards.length > 0) {

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -294,35 +294,51 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   />;
 
   // onClick function, used to create new card on modal based on form data
-  const addLibraryCard = async (card: LibraryCard): Promise<void> => {
-    try {
-      // Check if card already exists, show error if it does
-      const alreadyExists = findIndex(
+  const addLibraryCards = async (newLibraryCards: LibraryCard[]): Promise<void> => {
+    // Check if any cards already exist, show error if any do
+    const hasDuplicateCard = newLibraryCards.some((card) => {
+      return findIndex(
           (element: LibraryCard) => isEqual(element.userEmail)(card.userEmail),
           libraryCards
-      );
-      if (alreadyExists > -1) {
-        Notifications.showError({text: 'Library Card already exists'});
-      } else {
-        // Execute library card update with payload, get the updated card, and
-        // add (with sort afterwards) library card to libraryCards (reference list)
-        const newCard = await LibraryCardAPI.createLibraryCard(card);
-        const updatedList = cloneDeep(libraryCards);
-        updatedList.push(newCard);
-        updatedList.sort((a: LibraryCard, b: LibraryCard) => {
-          const dateA = new Date(a.createDate ?? '');
-          const dateB = new Date(b.createDate ?? '');
-          return dateB.getTime() - dateA.getTime();
-        });
-        setLibraryCards(updatedList);
-        setShowModal(false);
+      ) > -1;
+    });
+    if (hasDuplicateCard) {
+      Notifications.showError({text: 'One or more of the library cards already exist.'});
+    } else {
+      // Execute library card update with payload, get the updated card, and
+      // add (with sort afterwards) library card to libraryCards (reference list)
+      const successfulCards = [];
+      const failedCards = [];
+
+      // Process each card individually
+      for (const card of newLibraryCards) {
+        try {
+          const newCard = await LibraryCardAPI.createLibraryCard(card);
+          successfulCards.push(newCard);
+        } catch (error: unknown) {
+          const axiosError = error as AxiosError;
+          const consentError = axiosError?.response?.data as ConsentError;
+          const serverError = consentError.message ?? 'Error: Failed to create new library card';
+          failedCards.push({
+            card,
+            error: serverError || 'Unknown error'
+          });
+        }
       }
-    } catch (error: unknown) {
-      const axiosError = error as AxiosError;
-      const consentError = axiosError?.response?.data as ConsentError;
-      const serverError = consentError.message ?? 'Error: Failed to create new library card';
+      const updatedList = cloneDeep(libraryCards);
+      libraryCards.push(...successfulCards);
+
+      updatedList.sort((a: LibraryCard, b: LibraryCard) => {
+        const dateA = new Date(a.createDate ?? '');
+        const dateB = new Date(b.createDate ?? '');
+        return dateB.getTime() - dateA.getTime();
+      });
+      setLibraryCards(updatedList);
       setShowModal(false);
-      Notifications.showError({text: serverError});
+      if(failedCards.length > 0) {
+        const errorMessages = failedCards.map(failure => `${failure.card.userEmail}: ${failure.error}`).join('\n');
+        Notifications.showError({text: `Failed to create the following library cards:\n${errorMessages}`});
+      }
     }
   };
 
@@ -410,8 +426,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
         />
         <LibraryCardFormModal
             showModal={showModal}
-            // TODO: LibraryCardTable doesn't support bulk creation
-            createOnClick={(card) => addLibraryCard(card[0])}
+            createOnClick={(cards) => addLibraryCards(cards)}
             closeModal={() => setShowModal(false)}
             users={users}
             card={currentCard}

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -6,7 +6,7 @@ import ModalWrapper from "src/components/collaborator_list/ModalWrapper";
 import Creatable from 'react-select/creatable';
 import SimpleButton from 'src/components/SimpleButton';
 import {LibraryCardAgreementTermsDownload} from 'src/components/LibraryCardAgreementTermsDownload';
-import {SingleValue} from 'react-select';
+import {MultiValue} from 'react-select';
 import {LibraryCard} from 'src/types/model';
 
 // This represents the fields describing users in a selection dropdown menu
@@ -18,15 +18,14 @@ interface UserOption {
 }
 
 interface FormFieldRowProps {
-  card: LibraryCard;
+  selectedUsers: UserOption[];
   dropdownOptions: UserOption[];
-  updateUser: (value: SingleValue<UserOption>) => void;
-  setCard: React.Dispatch<React.SetStateAction<LibraryCard>>;
+  updateUsers: (values: MultiValue<UserOption>) => void;
 }
 
 export interface LibraryCardFormModalProps {
   showModal: boolean;
-  createOnClick: (card: LibraryCard) => void;
+  createOnClick: (cards: LibraryCard[]) => void;
   closeModal: () => void;
   users: UserOption[];
   card: LibraryCard;
@@ -41,13 +40,13 @@ interface FilterOptions {
 }
 
 const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
-  const { card, dropdownOptions, updateUser, setCard } = props;
+  const { selectedUsers, dropdownOptions, updateUsers } = props;
 
   const cardlessOptions = dropdownOptions.filter((option) => isNil(option.libraryCard));
   const [filteredDropdown, setFilteredDropdown] = useState<UserOption[]>(cardlessOptions);
 
   //filter function for users dropdown
-  const userListFilter = ({ searchTerm, input, card, setCard, action }: FilterOptions) => {
+  const userListFilter = ({ searchTerm, input, action }: { searchTerm?: string, input?: string, action: string }) => {
     const term = searchTerm ?? input ?? '';
     let filteredCopy: UserOption[];
 
@@ -62,9 +61,6 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
       });
     }
     setFilteredDropdown(filteredCopy);
-    if (action !== 'input-blur' && action !== 'menu-close') {
-      setCard({...card, ...{email: term}});
-    }
   };
 
   return (
@@ -74,15 +70,17 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
           <Creatable
               key="select-user"
               isClearable={true}
-              onChange={updateUser}
+              isMulti={true}
+              onChange={updateUsers}
+              value={selectedUsers}
               createOptionPosition="first"
               onInputChange={(input: string, { action }: { action: string }) =>
-                  userListFilter({ input, card, setCard, action })}
+                  userListFilter({ input, action })}
               getNewOptionData={(input: string) => {
                 return { email: input } as UserOption;
               }}
-              options={dropdownOptions}
-              placeholder="Select or type a new user email"
+              options={cardlessOptions}
+              placeholder="Select or type new user emails"
               isOptionSelected={() => false} //Workaround to prevent odd react-select behavior where all dropdown options are highlighted
               /* eslint-disable-next-line no-constant-binary-expression */
               getOptionLabel={(option: UserOption) => `${option.displayName || 'New User'} (${option.email || 'No email provided'})` || option.email || ''}
@@ -94,30 +92,41 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
 
 const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
   const { showModal, createOnClick, closeModal, users } = props;
-  const [card, setCard] = useState<LibraryCard>(props.card);
+  const [selectedUsers, setSelectedUsers] = useState<UserOption[]>([]);
 
-  //initialization hook, sets card as state variables
-  useEffect(() => {
-    setCard(props.card);
-  }, [props.card]);
+  // Create a library card for each selected user
+  const createLibraryCards = () => {
+    if (selectedUsers.length === 0) return;
 
-  const updateUser = (value: SingleValue<UserOption> | string) => {
-    let userEmail, userId, userName;
-    if (isObject(value)) {
-      const userOption = value;
-      userId = userOption.userId;
-      userEmail = userOption.email;
-      userName = userOption.displayName;
-    } else {
-      userEmail = value;
-    }
-    const updatedCard = {...card, userEmail, userId, userName};
-    setCard(updatedCard as LibraryCard);
+    // Map selected users to library cards
+    const cards = selectedUsers.map(user => {
+      return {
+        userId: user.userId,
+        userEmail: user.email,
+        userName: user.displayName,
+      } as LibraryCard;
+    });
+
+    createOnClick(cards);
+    setSelectedUsers([]);
   };
 
-  //boolean function, used to determine if submit button should be disabled
-  const isConfirmDisabled = (card: LibraryCard): boolean => {
-    return isNil(card.userEmail);
+  // Handle multi-selection changes
+  const updateUsers = (newValues: MultiValue<UserOption>) => {
+    setSelectedUsers(newValues as UserOption[]);
+  };
+
+  // Check if we have any selected users
+  const isConfirmDisabled = (): boolean => {
+    return selectedUsers.length === 0;
+  };
+
+  // Update text to reflect multiple users
+  const getActionText = (): string => {
+    const userCount = selectedUsers.length;
+    if (userCount === 0) return "By clicking 'ADD' you agree to the terms of the agreements above.";
+    if (userCount === 1) return "By clicking 'ADD' you agree to the terms of the agreements above for this user.";
+    return `By clicking 'ADD' you agree to the terms of the agreements above for all ${userCount} users.`;
   };
 
   return (
@@ -135,20 +144,19 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
         <div data-cy={'library-card-form-modal'} style={Styles.MODAL.CONTENT}>
           <CloseIconComponent closeFn={closeModal}/>
           <div style={Styles.MODAL.TITLE_HEADER}>
-            Add Library Card
+            Add Library Cards
           </div>
           <div style={{borderBottom: '1px solid #1FB50'}}/>
           {/* LCA Terms Download */}
           <LibraryCardAgreementTermsDownload/>
           {/* users dropdown */}
           <FormFieldRow
-              card={card}
-              updateUser={updateUser}
-              setCard={setCard}
+              selectedUsers={selectedUsers}
+              updateUsers={updateUsers}
               dropdownOptions={users}
           />
           <div style={{display: 'inline-block'}}>
-            By clicking {'\'ADD\''} you agree to the terms of the agreements above for this user.
+            {getActionText()}
           </div>
           <div
               style={{
@@ -158,10 +166,10 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
           >
             <SimpleButton
                 data-cy={'library-card-form-modal-add-button'}
-                onClick={() => createOnClick(card)}
+                onClick={createLibraryCards}
                 additionalStyle={{margin: '0%', width: '80px', height: '15px', padding: '20px'}}
                 baseColor={Theme.palette.secondary}
-                disabled={isConfirmDisabled(card)}
+                disabled={isConfirmDisabled()}
                 label={'Add'}
             />
             <SimpleButton

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -145,8 +145,8 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
               updateUsers={updateUsers}
               dropdownOptions={users}
           />
-          <div style={{display: 'inline-block'}}>
-            By clicking {'\'ADD\''} you agree to the terms of the agreements above for all users.
+          <div style={{display: 'inline-block', marginBottom: '1rem',}}>
+            By clicking {'\'BULK ISSUE / ADD USERS\''} you agree to the terms of the agreements above for all users.
           </div>
           <div
               style={{
@@ -157,10 +157,10 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
             <SimpleButton
                 data-cy={'library-card-form-modal-add-button'}
                 onClick={createLibraryCards}
-                additionalStyle={{margin: '0%', width: '80px', height: '15px', padding: '20px'}}
+                additionalStyle={{margin: '0%', width: '280px', height: '15px', padding: '20px'}}
                 baseColor={Theme.palette.secondary}
                 disabled={isConfirmDisabled()}
-                label={'Add'}
+                label={'Bulk Issue / Add Users'}
             />
             <SimpleButton
                 data-cy={'library-card-form-modal-close-button'}

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -10,7 +10,7 @@ import {MultiValue} from 'react-select';
 import {LibraryCard} from 'src/types/model';
 
 // This represents the fields describing users in a selection dropdown menu
-export interface UserOption {
+interface UserOption {
   userId: number;
   displayName: string;
   email: string;

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -34,8 +34,6 @@ export interface LibraryCardFormModalProps {
 interface FilterOptions {
   searchTerm?: string;
   input?: string;
-  card: LibraryCard;
-  setCard: React.Dispatch<React.SetStateAction<LibraryCard>>;
   action: string;
 }
 
@@ -121,14 +119,6 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
     return selectedUsers.length === 0;
   };
 
-  // Update text to reflect multiple users
-  const getActionText = (): string => {
-    const userCount = selectedUsers.length;
-    if (userCount === 0) return "By clicking 'ADD' you agree to the terms of the agreements above.";
-    if (userCount === 1) return "By clicking 'ADD' you agree to the terms of the agreements above for this user.";
-    return `By clicking 'ADD' you agree to the terms of the agreements above for all ${userCount} users.`;
-  };
-
   return (
       <ModalWrapper
           isOpen={showModal}
@@ -156,7 +146,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
               dropdownOptions={users}
           />
           <div style={{display: 'inline-block'}}>
-            {getActionText()}
+            By clicking {'\'ADD\''} you agree to the terms of the agreements above for all users.
           </div>
           <div
               style={{

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect, useState} from 'react';
-import {cloneDeep, includes, isEmpty, isNil, isObject} from 'lodash/fp';
+import React, {useState} from 'react';
+import {cloneDeep, includes, isEmpty, isNil} from 'lodash/fp';
 import {Styles, Theme} from 'src/libs/theme';
 import CloseIconComponent from 'src/components/CloseIconComponent';
-import ModalWrapper from "src/components/collaborator_list/ModalWrapper";
+import ModalWrapper from 'src/components/collaborator_list/ModalWrapper';
 import Creatable from 'react-select/creatable';
 import SimpleButton from 'src/components/SimpleButton';
 import {LibraryCardAgreementTermsDownload} from 'src/components/LibraryCardAgreementTermsDownload';
@@ -46,7 +46,7 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
   const [filteredDropdown, setFilteredDropdown] = useState<UserOption[]>(cardlessOptions);
 
   //filter function for users dropdown
-  const userListFilter = ({ searchTerm, input, action }: { searchTerm?: string, input?: string, action: string }) => {
+  const userListFilter = ({ searchTerm, input }: FilterOptions) => {
     const term = searchTerm ?? input ?? '';
     let filteredCopy: UserOption[];
 

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -10,7 +10,7 @@ import {MultiValue} from 'react-select';
 import {LibraryCard} from 'src/types/model';
 
 // This represents the fields describing users in a selection dropdown menu
-interface UserOption {
+export interface UserOption {
   userId: number;
   displayName: string;
   email: string;

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -26,10 +26,9 @@ interface FormFieldRowProps {
 
 export interface LibraryCardFormModalProps {
   showModal: boolean;
-  createOnClick: (cards: LibraryCard[]) => void;
+  createOnClick: (cards: LibraryCard[]) => Promise<void>;
   closeModal: () => void;
   users: UserOption[];
-  card: LibraryCard;
 }
 
 interface FilterOptions {

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -8,6 +8,7 @@ import SimpleButton from 'src/components/SimpleButton';
 import {LibraryCardAgreementTermsDownload} from 'src/components/LibraryCardAgreementTermsDownload';
 import {MultiValue} from 'react-select';
 import {LibraryCard} from 'src/types/model';
+import {Spinner} from 'src/components/Spinner';
 
 // This represents the fields describing users in a selection dropdown menu
 interface UserOption {
@@ -91,22 +92,29 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
 const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
   const { showModal, createOnClick, closeModal, users } = props;
   const [selectedUsers, setSelectedUsers] = useState<UserOption[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   // Create a library card for each selected user
-  const createLibraryCards = () => {
+  const createLibraryCards = async () => {
     if (selectedUsers.length === 0) return;
 
-    // Map selected users to library cards
-    const cards = selectedUsers.map(user => {
-      return {
-        userId: user.userId,
-        userEmail: user.email,
-        userName: user.displayName,
-      } as LibraryCard;
-    });
+    try {
+      setIsLoading(true);
 
-    createOnClick(cards);
-    setSelectedUsers([]);
+      // Map selected users to library cards
+      const cards = selectedUsers.map(user => {
+        return {
+          userId: user.userId,
+          userEmail: user.email,
+          userName: user.displayName,
+        } as LibraryCard;
+      });
+
+      await createOnClick(cards);
+      setSelectedUsers([]);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   // Handle multi-selection changes
@@ -116,7 +124,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
 
   // Check if we have any selected users
   const isConfirmDisabled = (): boolean => {
-    return selectedUsers.length === 0;
+    return selectedUsers.length === 0 || isLoading;
   };
 
   return (
@@ -154,6 +162,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
                 justifyContent: 'flex-end',
               }}
           >
+            {isLoading && <Spinner />}
             <SimpleButton
                 data-cy={'library-card-form-modal-add-button'}
                 onClick={createLibraryCards}

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -153,7 +153,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
               dropdownOptions={users}
           />
           <div style={{display: 'inline-block', marginBottom: '1rem',}}>
-            By clicking {'\'BULK ISSUE / ADD USERS\''} you agree to the terms of the agreements above for all users.
+            By clicking {'\'ADD\''} you agree to the terms of the agreements above for all users.
           </div>
           <div
               style={{
@@ -165,10 +165,10 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
             <SimpleButton
                 data-cy={'library-card-form-modal-add-button'}
                 onClick={createLibraryCards}
-                additionalStyle={{margin: '0%', width: '280px', height: '15px', padding: '20px'}}
+                additionalStyle={{margin: '0%', width: '80px', height: '15px', padding: '20px'}}
                 baseColor={Theme.palette.secondary}
                 disabled={isConfirmDisabled()}
-                label={'Bulk Issue / Add Users'}
+                label={'Add'}
             />
             <SimpleButton
                 data-cy={'library-card-form-modal-close-button'}

--- a/src/libs/ajax/LibraryCard.js
+++ b/src/libs/ajax/LibraryCard.js
@@ -10,9 +10,30 @@ export const LibraryCard = {
     return res.data;
   },
   createLibraryCard: async (card) => {
-    const url = `${await getApiUrl()}/api/libraryCards`;
-    const res = await axios.post(url, card, Config.authOpts());
-    return res.data;
+    // const url = `${await getApiUrl()}/api/libraryCards`;
+    // const res = await axios.post(url, card, Config.authOpts());
+    // return res.data;
+    console.log('using mock createLibraryCard!');
+
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        // 50% chance of returning an error
+        if (Math.random() < 0.5) {
+          resolve({
+            id: 'stubbed-id',
+            ...card
+          });
+        } else {
+          reject({
+            response: {
+              data: {
+                message: `Failed to issue library card for ${card.userEmail || card.email}`
+              }
+            }
+          });
+        }
+      }, 1000);
+    });
   },
   deleteLibraryCard: async (id) => {
     const url = `${await getApiUrl()}/api/libraryCards/${id}`;

--- a/src/libs/ajax/LibraryCard.js
+++ b/src/libs/ajax/LibraryCard.js
@@ -10,30 +10,30 @@ export const LibraryCard = {
     return res.data;
   },
   createLibraryCard: async (card) => {
-    // const url = `${await getApiUrl()}/api/libraryCards`;
-    // const res = await axios.post(url, card, Config.authOpts());
-    // return res.data;
-    console.warn('WARNING: you are using a mock createLibraryCard implementation');
+    const url = `${await getApiUrl()}/api/libraryCards`;
+    const res = await axios.post(url, card, Config.authOpts());
+    return res.data;
+    // console.warn('WARNING: you are using a mock createLibraryCard implementation');
 
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        // 50% chance of returning an error
-        if (Math.random() < 0.5) {
-          resolve({
-            id: 'stubbed-id',
-            ...card
-          });
-        } else {
-          reject({
-            response: {
-              data: {
-                message: `Failed to issue library card for ${card.userEmail || card.email}`
-              }
-            }
-          });
-        }
-      }, 1000);
-    });
+    // return new Promise((resolve, reject) => {
+    //   setTimeout(() => {
+    //     // 50% chance of returning an error
+    //     if (Math.random() < 0) {
+    //       resolve({
+    //         id: 'stubbed-id',
+    //         ...card
+    //       });
+    //     } else {
+    //       reject({
+    //         response: {
+    //           data: {
+    //             message: `Failed to issue library card for ${card.userEmail || card.email}`
+    //           }
+    //         }
+    //       });
+    //     }
+    //   }, 1000);
+    // });
   },
   deleteLibraryCard: async (id) => {
     const url = `${await getApiUrl()}/api/libraryCards/${id}`;

--- a/src/libs/ajax/LibraryCard.js
+++ b/src/libs/ajax/LibraryCard.js
@@ -13,27 +13,6 @@ export const LibraryCard = {
     const url = `${await getApiUrl()}/api/libraryCards`;
     const res = await axios.post(url, card, Config.authOpts());
     return res.data;
-    // console.warn('WARNING: you are using a mock createLibraryCard implementation');
-
-    // return new Promise((resolve, reject) => {
-    //   setTimeout(() => {
-    //     // 50% chance of returning an error
-    //     if (Math.random() < 0) {
-    //       resolve({
-    //         id: 'stubbed-id',
-    //         ...card
-    //       });
-    //     } else {
-    //       reject({
-    //         response: {
-    //           data: {
-    //             message: `Failed to issue library card for ${card.userEmail || card.email}`
-    //           }
-    //         }
-    //       });
-    //     }
-    //   }, 1000);
-    // });
   },
   deleteLibraryCard: async (id) => {
     const url = `${await getApiUrl()}/api/libraryCards/${id}`;

--- a/src/libs/ajax/LibraryCard.js
+++ b/src/libs/ajax/LibraryCard.js
@@ -13,7 +13,7 @@ export const LibraryCard = {
     // const url = `${await getApiUrl()}/api/libraryCards`;
     // const res = await axios.post(url, card, Config.authOpts());
     // return res.data;
-    console.log('using mock createLibraryCard!');
+    console.warn('WARNING: you are using a mock createLibraryCard implementation');
 
     return new Promise((resolve, reject) => {
       setTimeout(() => {

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Info } from '@mui/icons-material';
 import { Styles, Theme } from 'src/libs/theme';
-import { cloneDeep, find, findIndex, join, map, sortedUniq, sortBy, isNil, flow } from 'lodash/fp';
+import { cloneDeep, findIndex, join, map, sortedUniq, sortBy, isNil, flow } from 'lodash/fp';
 import SimpleTable from 'src/components/SimpleTable';
 import SimpleButton from 'src/components/SimpleButton';
 import PaginationBar from 'src/components/PaginationBar';

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -23,6 +23,7 @@ import {
   NIHDataUseCertificationAgreement
 } from 'src/components/external_docs/NIHDataUseCertificationAgreement';
 import {extractError} from 'src/utils/ErrorUtils.js';
+import { processLibraryCards } from 'src/utils/LibraryCardUtils';
 
 //Styles specific to this table
 const styles = {
@@ -315,19 +316,7 @@ export default function SigningOfficialTable(props) {
   };
 
   const issueLibraryCards = async (cards, researchers) => {
-    const successfulCards = [];
-    const failedCards = [];
-
-    // Process each card individually
-    for (const card of cards) {
-      try {
-        const newCard = await LibraryCard.createLibraryCard(card);
-        successfulCards.push(newCard);
-      } catch (error) {
-        const errorMessage = extractError(error);
-        failedCards.push({ card, error: errorMessage });
-      }
-    }
+    const { successfulCards, failedCards } = await processLibraryCards(cards);
 
     // Update researchers list with successful cards
     if (successfulCards.length > 0) {

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -313,41 +313,7 @@ export default function SigningOfficialTable(props) {
     setShowModal(true);
   };
 
-  const issueLibraryCard = async (selectedCard, researchers) => {
-    let messageName;
-    try {
-      const listCopy = cloneDeep(researchers);
-      const newLibraryCard = await LibraryCard.createLibraryCard(selectedCard);
-      const {userEmail, userName, userId} = newLibraryCard;
-      const targetIndex = findIndex((researcher) => userId === researcher.userId)(listCopy);
-      //library cards array should only have one card MAX (officials should not be able to see cards from other institutions)
-      if(targetIndex === -1) { //if card is not found, push new user to top of list
-        const targetUnregisteredResearcher = find((researcher) => userId === researcher.userId)(props.unregisteredResearchers);
-        const attributes = {
-          email: userEmail,
-          displayName: userName,
-          libraryCard: newLibraryCard,
-          roles: [],
-        };
-        if(!isNil(targetUnregisteredResearcher)) {
-          attributes.roles = targetUnregisteredResearcher.roles;
-        }
-        listCopy.unshift(attributes);
-        messageName = userEmail;
-      } else {
-        listCopy[targetIndex].libraryCard = newLibraryCard;
-        messageName = userName;
-      }
-      setResearchers(listCopy);
-      setShowConfirmation(false);
-      setShowModal(false);
-      Notifications.showSuccess({text: `Issued new library card to ${messageName}`});
-    } catch(error) {
-      Notifications.showError({text: error.response.data.message ?? 'Error issuing library card' });
-    }
-  };
-
-  const bulkIssueLibraryCards = async (cards) => {
+  const bulkIssueLibraryCards = async (cards, researchers) => {
     const successfulCards = [];
     const failedCards = [];
 
@@ -384,12 +350,12 @@ export default function SigningOfficialTable(props) {
       setResearchers(listCopy);
     }
 
-    // Close modal regardless of success/failure
+    setShowConfirmation(false);
     setShowModal(false);
 
     const successNotificationText = `Issued ${successfulCards.length} library card${successfulCards.length > 1 ? 's' : ''}`;
     const errorNotificationText = `Error issuing library card${failedCards.length > 1 ? 's' : ''}.`;
-    const warningNotificationText = `${successNotificationText}, but encountered errors issuing library cards for: ${failedCards.map(fc => fc.card.userEmail || fc.card.email).join(', ')}`;
+    const warningNotificationText = `${successNotificationText}, but encountered errors issuing library cards to ${failedCards.map(fc => fc.card.userEmail || fc.card.email).join(', ')}`;
 
     if(successfulCards.length > 0 && failedCards.length > 0) {
       Notifications.showWarning({ text: warningNotificationText });
@@ -479,7 +445,7 @@ export default function SigningOfficialTable(props) {
       />
       <LibraryCardFormModal
         showModal={showModal}
-        createOnClick={(cards) => bulkIssueLibraryCards(cards)}
+        createOnClick={(cards) => bulkIssueLibraryCards(cards, researchers)}
         closeModal={() => setShowModal(false)}
         card={selectedCard}
         users={researchers.filter(onlyResearchersWithoutCardFilter)}
@@ -500,7 +466,7 @@ export default function SigningOfficialTable(props) {
         onConfirm={() =>
           confirmType === confirmModalType.delete
             ? deactivateLibraryCard(selectedCard, researchers)
-            : issueLibraryCard(selectedCard, researchers)}
+            : bulkIssueLibraryCards([selectedCard], researchers)}
       />
     </>
   );

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -425,10 +425,10 @@ export default function SigningOfficialTable(props) {
           <SimpleButton
             onClick={() => showModalOnClick()}
             baseColor={Theme.palette.secondary}
-            label="Add Library Card"
+            label="Bulk Issue / Add Users"
             additionalStyle={{
               width: '22rem',
-              height: '4rem',
+              height: '5rem',
               padding: '4% 10%',
               fontWeight: '600' }}
           />

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -347,6 +347,59 @@ export default function SigningOfficialTable(props) {
     }
   };
 
+  const bulkIssueLibraryCards = async (cards) => {
+    const successfulCards = [];
+    const failedCards = [];
+
+    // Process each card individually
+    for (const card of cards) {
+      try {
+        const newCard = await LibraryCard.createLibraryCard(card);
+        successfulCards.push(newCard);
+      } catch (error) {
+        failedCards.push({
+          card,
+          error: error.response?.data?.message || 'Unknown error'
+        });
+      }
+    }
+
+    // Update researchers list with successful cards
+    if (successfulCards.length > 0) {
+      const listCopy = cloneDeep(researchers);
+      successfulCards.forEach((newCard) => {
+        const {userEmail, userName, userId} = newCard;
+        const targetIndex = findIndex((researcher) => userId === researcher.userId)(listCopy);
+        if(targetIndex === -1) { //if card is not found, push new user to top of list
+          listCopy.unshift({
+            email: userEmail,
+            displayName: userName,
+            libraryCard: newCard,
+            roles: [],
+          });
+        } else {
+          listCopy[targetIndex].libraryCard = newCard;
+        }
+      });
+      setResearchers(listCopy);
+    }
+
+    // Close modal regardless of success/failure
+    setShowModal(false);
+
+    const successNotificationText = `Issued ${successfulCards.length} library card${successfulCards.length > 1 ? 's' : ''}`;
+    const errorNotificationText = `Error issuing library card${failedCards.length > 1 ? 's' : ''}.`;
+    const warningNotificationText = `${successNotificationText}, but encountered errors issuing library cards for: ${failedCards.map(fc => fc.card.userEmail || fc.card.email).join(', ')}`;
+
+    if(successfulCards.length > 0 && failedCards.length > 0) {
+      Notifications.showWarning({ text: warningNotificationText });
+    } else if (successfulCards.length > 0) {
+      Notifications.showSuccess({ text: successNotificationText });
+    } else if (failedCards.length > 0) {
+      Notifications.showError({ text: errorNotificationText });
+    }
+  };
+
   const deactivateLibraryCard = async (selectedCard, researchers) => {
     const {id, userName, userEmail, userId} = selectedCard;
     const listCopy = cloneDeep(researchers);
@@ -426,10 +479,10 @@ export default function SigningOfficialTable(props) {
       />
       <LibraryCardFormModal
         showModal={showModal}
-        createOnClick={(card) => issueLibraryCard(card, researchers)}
+        createOnClick={(cards) => bulkIssueLibraryCards(cards)}
         closeModal={() => setShowModal(false)}
         card={selectedCard}
-        users={onlyResearchersWithoutCardFilter(researchers)}
+        users={researchers.filter(onlyResearchersWithoutCardFilter)}
         modalType="add" />
       <ConfirmationModal
         showConfirmation={showConfirmation}

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -434,7 +434,6 @@ export default function SigningOfficialTable(props) {
         showModal={showModal}
         createOnClick={(cards) => issueLibraryCards(cards, researchers)}
         closeModal={() => setShowModal(false)}
-        card={selectedCard}
         users={researchers.filter(onlyResearchersWithoutCardFilter)}
         modalType="add" />
       <ConfirmationModal

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -22,7 +22,6 @@ import NihLibraryCardAgreementLink from 'src/assets/NIHLibraryCardAgreement08012
 import {
   NIHDataUseCertificationAgreement
 } from 'src/components/external_docs/NIHDataUseCertificationAgreement';
-import {extractError} from 'src/utils/ErrorUtils.js';
 import { processLibraryCards } from 'src/utils/LibraryCardUtils';
 
 //Styles specific to this table

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -314,7 +314,7 @@ export default function SigningOfficialTable(props) {
     setShowModal(true);
   };
 
-  const bulkIssueLibraryCards = async (cards, researchers) => {
+  const issueLibraryCards = async (cards, researchers) => {
     const successfulCards = [];
     const failedCards = [];
 
@@ -425,10 +425,10 @@ export default function SigningOfficialTable(props) {
           <SimpleButton
             onClick={() => showModalOnClick()}
             baseColor={Theme.palette.secondary}
-            label="Bulk Issue / Add Users"
+            label="Add Library Card"
             additionalStyle={{
               width: '22rem',
-              height: '5rem',
+              height: '4rem',
               padding: '4% 10%',
               fontWeight: '600' }}
           />
@@ -444,7 +444,7 @@ export default function SigningOfficialTable(props) {
       />
       <LibraryCardFormModal
         showModal={showModal}
-        createOnClick={(cards) => bulkIssueLibraryCards(cards, researchers)}
+        createOnClick={(cards) => issueLibraryCards(cards, researchers)}
         closeModal={() => setShowModal(false)}
         card={selectedCard}
         users={researchers.filter(onlyResearchersWithoutCardFilter)}
@@ -465,7 +465,7 @@ export default function SigningOfficialTable(props) {
         onConfirm={() =>
           confirmType === confirmModalType.delete
             ? deactivateLibraryCard(selectedCard, researchers)
-            : bulkIssueLibraryCards([selectedCard], researchers)}
+            : issueLibraryCards([selectedCard], researchers)}
       />
     </>
   );

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -22,6 +22,7 @@ import NihLibraryCardAgreementLink from 'src/assets/NIHLibraryCardAgreement08012
 import {
   NIHDataUseCertificationAgreement
 } from 'src/components/external_docs/NIHDataUseCertificationAgreement';
+import {extractError} from 'src/utils/ErrorUtils.js';
 
 //Styles specific to this table
 const styles = {
@@ -323,10 +324,8 @@ export default function SigningOfficialTable(props) {
         const newCard = await LibraryCard.createLibraryCard(card);
         successfulCards.push(newCard);
       } catch (error) {
-        failedCards.push({
-          card,
-          error: error.response?.data?.message || 'Unknown error'
-        });
+        const errorMessage = extractError(error);
+        failedCards.push({ card, error: errorMessage });
       }
     }
 

--- a/src/utils/LibraryCardUtils.ts
+++ b/src/utils/LibraryCardUtils.ts
@@ -1,0 +1,33 @@
+import { LibraryCard } from 'src/libs/ajax/LibraryCard';
+import { LibraryCard as LibraryCardType } from 'src/types/model';
+import { extractError } from './ErrorUtils';
+
+interface ProcessCardResult {
+  successfulCards: LibraryCardType[];
+  failedCards: { card: LibraryCardType; error: string }[];
+}
+
+/**
+ * Process issuing multiple library cards through the single-issue API
+ *
+ * @param cards - Array of library card objects to be processed
+ * @returns ProcessCardResult containing arrays of successful and failed cards, with error messages for failures
+ */
+export const processLibraryCards = async (cards: LibraryCardType[]): Promise<ProcessCardResult> => {
+  const successfulCards: LibraryCardType[] = [];
+  const failedCards: { card: LibraryCardType; error: string }[] = [];
+
+  // Process each card individually
+  // Future enhancements rely on a bulk API, but for now we handle them one by one
+  for (const card of cards) {
+    try {
+      const newCard = await LibraryCard.createLibraryCard(card);
+      successfulCards.push(newCard);
+    } catch (error) {
+      const errorMessage = extractError(error);
+      failedCards.push({ card, error: errorMessage });
+    }
+  }
+
+  return { successfulCards, failedCards };
+};


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1609
https://broadworkbench.atlassian.net/browse/DT-1851

### Summary

Adds frontend support for issuing library cards in bulk, accessible through the SO Console and the Admin Console. Since the number of library cards being issued in one go is expected to be small, this was only implemented on the frontend. But a future optimization could be to implement a bulk version of the existing createLibraryCard endpoint.

The two videos are pretty much the same because they use the same modal, but here's both of them in action:

SO Console:

https://github.com/user-attachments/assets/7ef9c794-9e40-44ff-83fe-badb27c57cc5

Admin Console:

https://github.com/user-attachments/assets/da35d218-717d-46d2-bf22-e71db1d03a59



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
