### PR TITLE
[DT-1818] Show selected datasets in read-only progress reports

### DIFF
--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -177,7 +177,8 @@ describe('ProgressReportApplication - Component Tests', () => {
       readOnlyMode: readOnly,
       history: mockHistory,
       location,
-      researcher
+      researcher,
+      countriesOfOperation: []
     };
 
     return mount(<ProgressReportApplication {...props} /> as ReactNode);
@@ -579,7 +580,8 @@ describe('ProgressReportApplication - Component Tests', () => {
       readOnlyMode: false,
       history: mockHistory,
       location,
-      researcher
+      researcher,
+      countriesOfOperation: []
     };
 
     mount(<ProgressReportApplication {...props} /> as ReactNode);
@@ -679,7 +681,8 @@ describe('ProgressReportApplication - Component Tests', () => {
       readOnlyMode: false,
       history: mockHistory,
       location,
-      researcher
+      researcher,
+      countriesOfOperation: []
     };
 
     mount(<ProgressReportApplication {...props} /> as ReactNode);
@@ -805,7 +808,8 @@ describe('ProgressReportApplication - Component Tests', () => {
       readOnlyMode: false,
       history: mockHistory,
       location,
-      researcher
+      researcher,
+      countriesOfOperation: []
     };
 
     mount(<ProgressReportApplication {...props} /> as ReactNode);

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -450,4 +450,374 @@ describe('ProgressReportApplication - Component Tests', () => {
     cy.get('#intellectualPropertySummary').should('be.visible');
     cy.get('#intellectualPropertySummary').should('contain.value', 'Test intellectual property description with important details');
   });
+
+  it('shows only approved datasets in create-mode progress report', () => {
+    // Create multiple datasets with different approval states
+    const testDatasets: Dataset[] = [
+      {
+        ...mockDatasets[0],
+        datasetId: 1,
+        name: 'Approved Dataset 1',
+        datasetName: 'Approved Dataset 1',
+        datasetIdentifier: 'DUOS-000001',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 2,
+        name: 'Approved Dataset 2',
+        datasetName: 'Approved Dataset 2',
+        datasetIdentifier: 'DUOS-000002',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 3,
+        name: 'Not DAC Approved Dataset',
+        datasetName: 'Not DAC Approved Dataset',
+        datasetIdentifier: 'DUOS-000003',
+        dacApproval: false,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 4,
+        name: 'DAC Approved but Not Election Approved Dataset',
+        datasetName: 'DAC Approved but Not Election Approved Dataset',
+        datasetIdentifier: 'DUOS-000004',
+        dacApproval: true,
+      }
+    ];
+
+    // Create elections where only datasets 1 and 2 are approved
+    const darWithElections = {
+      datasetIds: [1, 2, 3, 4], // All datasets are requested in the DAR
+      elections: {
+        1001: {
+          electionId: 1001,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 1,
+          votes: {
+            10001: {
+              voteId: 10001,
+              vote: true, // Approved
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 1001,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        1002: {
+          electionId: 1002,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 2,
+          votes: {
+            10002: {
+              voteId: 10002,
+              vote: true, // Approved
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 1002,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        1003: {
+          electionId: 1003,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 3,
+          votes: {
+            10003: {
+              voteId: 10003,
+              vote: false, // Denied
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 1003,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        1004: {
+          electionId: 1004,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 4,
+          votes: {
+            10004: {
+              voteId: 10004,
+              vote: false, // Denied
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 1004,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        }
+      }
+    };
+
+    // Mount component with datasets and elections
+    const fullDar = { ...baseDar, ...darWithElections } as unknown as DataAccessRequest;
+    const props = {
+      dar: fullDar,
+      datasets: testDatasets,
+      readOnlyMode: false,
+      history: mockHistory,
+      location,
+      researcher
+    };
+
+    mount(<ProgressReportApplication {...props} /> as ReactNode);
+
+    // Verify that only approved datasets are shown
+    // The component should only show datasets that are:
+    // 1. In dar.datasetIds
+    // 2. Have dacApproval = true
+    // 3. Have approved elections (finalAccessVote = true)
+
+    // Should show dataset 1 and 2 (both DAC approved AND election approved)
+    cy.get('[data-cy="remove-datasets"]').within(() => {
+      cy.contains('Approved Dataset 1').should('exist');
+      cy.contains('Approved Dataset 2').should('exist');
+
+      // Should NOT show dataset 3 (not DAC approved)
+      cy.contains('Not DAC Approved Dataset').should('not.exist');
+
+      // Should NOT show dataset 4 (DAC approved but election denied)
+      cy.contains('DAC Approved but Not Election Approved Dataset').should('not.exist');
+    });
+
+    // Verify the count of displayed datasets using the actual CSS class
+    cy.get('[data-cy="remove-datasets"] .collaborator-summary-card').should('have.length', 2);
+  });
+
+  it('in create-mode, shows no datasets when none are approved through elections', () => {
+    // Create datasets where all have DAC approval but none have election approval
+    const testDatasets: Dataset[] = [
+      {
+        ...mockDatasets[0],
+        datasetId: 1,
+        name: 'DAC Approved Dataset 1',
+        datasetName: 'DAC Approved Dataset 1',
+        datasetIdentifier: 'DUOS-000001',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 2,
+        name: 'DAC Approved Dataset 2',
+        datasetName: 'DAC Approved Dataset 2',
+        datasetIdentifier: 'DUOS-000002',
+        dacApproval: true,
+      }
+    ];
+
+    // Create elections where all datasets are denied
+    const darWithDeniedElections = {
+      datasetIds: [1, 2],
+      elections: {
+        2001: {
+          electionId: 2001,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 1,
+          votes: {
+            20001: {
+              voteId: 20001,
+              vote: false, // Denied
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 2001,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        2002: {
+          electionId: 2002,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 2,
+          votes: {
+            20002: {
+              voteId: 20002,
+              vote: false, // Denied
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 2002,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        }
+      }
+    };
+
+    const fullDar = { ...baseDar, ...darWithDeniedElections } as unknown as DataAccessRequest;
+    const props = {
+      dar: fullDar,
+      datasets: testDatasets,
+      readOnlyMode: false,
+      history: mockHistory,
+      location,
+      researcher
+    };
+
+    mount(<ProgressReportApplication {...props} /> as ReactNode);
+
+    // Should show no datasets since none are approved through elections
+    cy.get('[data-cy="remove-datasets"]').within(() => {
+      cy.contains('DAC Approved Dataset 1').should('not.exist');
+      cy.contains('DAC Approved Dataset 2').should('not.exist');
+    });
+
+    // The dataset list should be empty or show a message about no datasets
+    cy.get('[data-cy="remove-datasets"] .collaborator-summary-card').should('have.length', 0);
+  });
+
+  it('in create-mode, only shows datasets that pass all approval criteria', () => {
+    // This test ensures the filtering logic works correctly by testing the exact criteria:
+    // 1. Dataset must be in dar.datasetIds
+    // 2. Dataset must have dacApproval = true
+    // 3. Dataset must have an approved election (type=FINAL, vote=true)
+
+    const testDatasets: Dataset[] = [
+      {
+        ...mockDatasets[0],
+        datasetId: 1,
+        name: 'All Criteria Met',
+        datasetName: 'All Criteria Met',
+        datasetIdentifier: 'DUOS-000001',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 2,
+        name: 'Not in DAR datasetIds',
+        datasetName: 'Not in DAR datasetIds',
+        datasetIdentifier: 'DUOS-000002',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 3,
+        name: 'No DAC Approval',
+        datasetName: 'No DAC Approval',
+        datasetIdentifier: 'DUOS-000003',
+        dacApproval: false,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 4,
+        name: 'No Election Approval',
+        datasetName: 'No Election Approval',
+        datasetIdentifier: 'DUOS-000004',
+        dacApproval: true,
+      }
+    ];
+
+    const darWithFilteringTest = {
+      datasetIds: [1, 3, 4], // Note: dataset 2 is NOT included in DAR
+      elections: {
+        3001: {
+          electionId: 3001,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 1,
+          votes: {
+            30001: {
+              voteId: 30001,
+              vote: true, // Approved
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 3001,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        3003: {
+          electionId: 3003,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 3,
+          votes: {
+            30003: {
+              voteId: 30003,
+              vote: true, // Approved
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 3003,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        3004: {
+          electionId: 3004,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 4,
+          votes: {
+            30004: {
+              voteId: 30004,
+              vote: false, // Denied
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 3004,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        }
+      }
+    };
+
+    const fullDar = { ...baseDar, ...darWithFilteringTest } as unknown as DataAccessRequest;
+    const props = {
+      dar: fullDar,
+      datasets: testDatasets,
+      readOnlyMode: false,
+      history: mockHistory,
+      location,
+      researcher
+    };
+
+    mount(<ProgressReportApplication {...props} /> as ReactNode);
+
+    // Only dataset 1 should be shown (meets all criteria)
+    cy.get('[data-cy="remove-datasets"]').within(() => {
+      cy.contains('All Criteria Met').should('exist');
+      cy.contains('Not in DAR datasetIds').should('not.exist');
+      cy.contains('No DAC Approval').should('not.exist');
+      cy.contains('No Election Approval').should('not.exist');
+    });
+
+    cy.get('[data-cy="remove-datasets"] .collaborator-summary-card').should('have.length', 1);
+  });
 });

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -820,4 +820,124 @@ describe('ProgressReportApplication - Component Tests', () => {
 
     cy.get('[data-cy="remove-datasets"] .collaborator-summary-card').should('have.length', 1);
   });
+
+  it('shows only datasets with IDs included in DAR.datasetIds as available datasets (read-only mode)', () => {
+    // Create multiple datasets where some are DAC approved but only some are in the DAR datasetIds
+    const testDatasets: Dataset[] = [
+      {
+        ...mockDatasets[0],
+        datasetId: 1,
+        name: 'Dataset In DAR 1',
+        datasetName: 'Dataset In DAR 1',
+        datasetIdentifier: 'DUOS-000001',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 2,
+        name: 'Dataset In DAR 2',
+        datasetName: 'Dataset In DAR 2',
+        datasetIdentifier: 'DUOS-000002',
+        dacApproval: true,
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 3,
+        name: 'Dataset NOT In DAR',
+        datasetName: 'Dataset NOT In DAR',
+        datasetIdentifier: 'DUOS-000003',
+        dacApproval: true, // DAC approved but NOT in DAR datasetIds
+      },
+      {
+        ...mockDatasets[0],
+        datasetId: 4,
+        name: 'Another Dataset NOT In DAR',
+        datasetName: 'Another Dataset NOT In DAR',
+        datasetIdentifier: 'DUOS-000004',
+        dacApproval: true, // DAC approved but NOT in DAR datasetIds
+      }
+    ];
+
+    // Create elections where all datasets are approved (to isolate the datasetIds filtering)
+    const darWithSelectiveDatasetIds = {
+      datasetIds: [1, 2], // Only datasets 1 and 2 are in the DAR request
+      elections: {
+        1001: {
+          electionId: 1001,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 1,
+          votes: {
+            10001: {
+              voteId: 10001,
+              vote: true, // Approved
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 1001,
+              type: 'FINAL',
+              displayName: 'Test Voter 1'
+            }
+          }
+        },
+        1002: {
+          electionId: 1002,
+          electionType: 'DataAccess',
+          status: 'Closed',
+          createDate: 1700000000000,
+          referenceId: 'DAR-123',
+          datasetId: 2,
+          votes: {
+            10002: {
+              voteId: 10002,
+              vote: true, // Approved
+              userId: 1,
+              createDate: 1700000000000,
+              electionId: 1002,
+              type: 'FINAL',
+              displayName: 'Test Voter 2'
+            }
+          }
+        },
+        // Note: No elections for datasets 3 and 4 since they're not in the DAR
+      }
+    };
+
+    const fullDar = { ...baseDar, ...darWithSelectiveDatasetIds } as unknown as DataAccessRequest;
+
+    const props = {
+      dar: fullDar,
+      datasets: testDatasets,
+      readOnlyMode: true, // Testing in read-only mode
+      history: mockHistory,
+      location,
+      researcher,
+      countriesOfOperation: []
+    };
+
+    mount(<ProgressReportApplication {...props} /> as ReactNode);
+
+    cy.get('[data-cy="remove-datasets"]').should('exist');
+
+    // Should show only datasets 1 and 2 (which are in dar.datasetIds)
+    cy.get('[data-cy="remove-datasets"]').within(() => {
+      cy.contains('Dataset In DAR 1').should('exist');
+      cy.contains('Dataset In DAR 2').should('exist');
+
+      // Should NOT show datasets 3 and 4 (not in dar.datasetIds, even though they have DAC approval)
+      cy.contains('Dataset NOT In DAR').should('not.exist');
+      cy.contains('Another Dataset NOT In DAR').should('not.exist');
+    });
+
+    // Verify exactly 2 datasets are displayed (only those in dar.datasetIds)
+    cy.get('[data-cy="remove-datasets"] .collaborator-summary-card').should('have.length', 2);
+
+    // In read-only mode, verify that the datasets are displayed but not editable
+    cy.get('[data-cy="remove-datasets"] .collaborator-summary-card').each(($card) => {
+      // Should not have remove buttons or other interactive elements in read-only mode
+      cy.wrap($card).find('button').should('not.exist');
+      cy.wrap($card).find('input[type="checkbox"]').should('not.exist');
+    });
+  });
 });

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -52,6 +52,7 @@ const fetchAllDatasets = async (dsIds) => {
   if (isEmpty(filteredDatasetIds)) {
     return [];
   }
+
   // filter just for safety
   return DataSet.getDatasetsByIds(filteredDatasetIds);
 };
@@ -257,6 +258,7 @@ const DataAccessRequestApplication = (props) => {
       // Add elections to DAR data passed into form, to enable showing approved datasets
       Object.values(dars).map((dar) => {
         dar.data.elections = dar.elections;
+        dar.data.datasetIds = dar.datasetIds;
       })
 
       // TS thinks that collection.dars is an object, but it is a map

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -249,6 +249,12 @@ const DataAccessRequestApplication = (props) => {
       // Besides the datasets, DARs split off from the collection should have the same formData
       const collection = await Collections.getCollectionById(collectionId);
       const { dars, datasets } = collection;
+
+      // Add elections to DAR data passed into form, to enable showing approved datasets
+      Object.values(dars).map((dar) => {
+        dar.data.elections = dar.elections;
+      })
+
       // TS thinks that collection.dars is an object, but it is a map
       const darMap = new Map(Object.entries(dars));
       setReverseOrderedDARs(
@@ -259,6 +265,7 @@ const DataAccessRequestApplication = (props) => {
       //  in theory, we should be able to replace this call with the info returned from the collection
       // form data = the first DAR's data
       formData = await DAR.getPartialDarRequest(darReferenceId);
+
       // This is a collection, so we need to get the datasets and datasetIds from the collection
       formData.datasetIds = map(ds => get('datasetId')(ds))(datasets);
     }

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -31,7 +31,6 @@ type ProgressReportApplicationProps = {
 };
 
 export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher, countriesOfOperation }: ProgressReportApplicationProps) => {
-  console.log('ProgressReportApplication', { dar, datasets, readOnlyMode, history, location, researcher });
     const initialState = {
         ...dar,
         ...dar.data,
@@ -70,10 +69,12 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
             })
           }
         ),
+
         // additional state for datasets section populated by useEffect
         datasets: [],
         datasetIds: [],
         selectedDatasets: [],
+
         // additional state for dmi section
         ...(dar?.dmi?.incidents && {
             dmiYesNo: (dar.dmi.incidents.length > 0),
@@ -173,36 +174,27 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
     }
 
     function getDatasetsInApprovedElections(datasets: Dataset[], approvedElectionDatasetIds: number[]) {
-      console.log('in getDatasetsInApprovedElections, approvedElectionDatasetIds', approvedElectionDatasetIds);
-      console.log('in getDatasetsInApprovedElections, datasets', JSON.stringify(datasets));
-
       const datasetsInApprovedElections = datasets.filter(dataset => {
         return approvedElectionDatasetIds.includes(dataset.datasetId)
       });
-      console.log('datasetsInApprovedElections', datasetsInApprovedElections);
       return datasetsInApprovedElections
     }
 
     // required because the datasets state changes during component mount
     useEffect(() => {
       let approvedDatasets;
-      console.log('dar.elections', dar.elections);
       if (readOnlyMode) {
-        // Only approved datasets are submittable for a DAR, so
-        // simply
         approvedDatasets = datasets.filter(
           dataset => dar.datasetIds.includes(dataset.datasetId)
         )
       } else {
         const approvedDatasetIds = dar.elections ? getApprovedElectionDatasetIds(Object.values(dar.elections)) : [];
-        console.log('approvedDatasetIds', approvedDatasetIds)
         approvedDatasets = getDatasetsInApprovedElections(datasets, approvedDatasetIds)
           .filter((ds) => ds.dacApproval);
       }
-      console.log('approvedDatasets', approvedDatasets);
+
       onFormChange({ datasets: approvedDatasets });
       onSelectedDatasetChange(approvedDatasets);
-
     }, [datasets]);
 
     return (

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -30,6 +30,7 @@ type ProgressReportApplicationProps = {
 };
 
 export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher }: ProgressReportApplicationProps) => {
+  console.log('ProgressReportApplication', { dar, datasets, readOnlyMode, history, location, researcher });
     const initialState = {
         ...dar,
         dmiCombination:false,
@@ -169,17 +170,37 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
         }
     }
 
-    function filterForProgressReport(datasets: Dataset[], datasetIds: number[]) {
-        return datasets.filter(dataset => {return datasetIds.includes(dataset.datasetId)});
+    function getDatasetsInApprovedElections(datasets: Dataset[], approvedElectionDatasetIds: number[]) {
+      console.log('in getDatasetsInApprovedElections, approvedElectionDatasetIds', approvedElectionDatasetIds);
+      console.log('in getDatasetsInApprovedElections, datasets', JSON.stringify(datasets));
+
+      const datasetsInApprovedElections = datasets.filter(dataset => {
+        return approvedElectionDatasetIds.includes(dataset.datasetId)
+      });
+      console.log('datasetsInApprovedElections', datasetsInApprovedElections);
+      return datasetsInApprovedElections
     }
 
     // required because the datasets state changes during component mount
     useEffect(() => {
+      let approvedDatasets;
+      console.log('dar.elections', dar.elections);
+      if (readOnlyMode) {
+        // Only approved datasets are submittable for a DAR, so
+        // simply
+        approvedDatasets = datasets.filter(
+          dataset => dar.datasetIds.includes(dataset.datasetId)
+        )
+      } else {
         const approvedDatasetIds = dar.elections ? getApprovedElectionDatasetIds(Object.values(dar.elections)) : [];
-        const approvedDatasets = filterForProgressReport(datasets, dar.datasetIds)
-            .filter((ds) => ds.dacApproval && approvedDatasetIds.includes(ds.datasetId));
-        onFormChange({ datasets: approvedDatasets });
-        onSelectedDatasetChange(approvedDatasets);
+        console.log('approvedDatasetIds', approvedDatasetIds)
+        approvedDatasets = getDatasetsInApprovedElections(datasets, approvedDatasetIds)
+          .filter((ds) => ds.dacApproval);
+      }
+      console.log('approvedDatasets', approvedDatasets);
+      onFormChange({ datasets: approvedDatasets });
+      onSelectedDatasetChange(approvedDatasets);
+
     }, [datasets]);
 
     return (

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -30,7 +30,7 @@ type ProgressReportApplicationProps = {
   readonly countriesOfOperation: string[]
 };
 
-export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher }: ProgressReportApplicationProps) => {
+export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher, countriesOfOperation }: ProgressReportApplicationProps) => {
   console.log('ProgressReportApplication', { dar, datasets, readOnlyMode, history, location, researcher });
     const initialState = {
         ...dar,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1818

### Summary
Previously selected datasets were not shown in read-only progress reports.  Now they are.

This retains the new approval logic from #2894 for create-mode progress reports.

Here's how it looks, before and after.

https://github.com/user-attachments/assets/421d4cdf-b772-4384-942f-2b746dd5b442


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
