### PR TITLE
[DT-1779] Add closeout review buttons

### DIFF
--- a/cypress/component/DarCollectionTable/actions.spec.jsx
+++ b/cypress/component/DarCollectionTable/actions.spec.jsx
@@ -217,3 +217,36 @@ describe('Researcher Actions - Update Button', () => {
   });
 });
 
+describe('Researcher Actions - Review Closeout Button', () => {
+  it('renders the review closeout button if the collection has Review_Progress_Report action in non-prod environment', () => {
+    cy.stub(Storage, 'getEnv').returns(EnvironmentUtils.envGroups.NON_PROD[0]);
+    propCopy.consoleType = 'researcher';
+    propCopy.actions = ['Review_Progress_Report'];
+    mount(<Actions {...propCopy} />);
+    cy.get(`#researcher-review-closeout-${collectionId}`).should('exist');
+  });
+
+  it('does not render in production environment even with Review_Progress_Report action', () => {
+    cy.stub(Storage, 'getEnv').returns('prod');
+    propCopy.consoleType = 'researcher';
+    propCopy.actions = ['Review_Progress_Report'];
+    mount(<Actions {...propCopy} />);
+    cy.get(`#researcher-review-closeout-${collectionId}`).should('not.exist');
+  });
+
+  it('does not render if Review_Progress_Report action is not present', () => {
+    cy.stub(Storage, 'getEnv').returns(EnvironmentUtils.envGroups.NON_PROD[0]);
+    propCopy.consoleType = 'researcher';
+    propCopy.actions = ['Review'];
+    mount(<Actions {...propCopy} />);
+    cy.get(`#researcher-review-closeout-${collectionId}`).should('not.exist');
+  });
+
+  it('renders with correct label "Review Closeout"', () => {
+    cy.stub(Storage, 'getEnv').returns(EnvironmentUtils.envGroups.NON_PROD[0]);
+    propCopy.consoleType = 'researcher';
+    propCopy.actions = ['Review_Progress_Report'];
+    mount(<Actions {...propCopy} />);
+    cy.get(`#researcher-review-closeout-${collectionId}`).should('contain.text', 'Review Closeout');
+  });
+});

--- a/src/components/dar_collection_table/Actions.jsx
+++ b/src/components/dar_collection_table/Actions.jsx
@@ -137,6 +137,25 @@ export default function Actions(props) {
     },
   };
 
+  const reviewCloseoutButtonAttributes = {
+    keyProp: `${consoleType}-review-closeout-${uniqueId}`,
+    label: 'Review Closeout',
+    onClick: () => redirectToDARApplication(collectionId, history),
+    baseColor: 'white',
+    fontColor: Theme.palette.secondary,
+    hoverStyle: {
+      backgroundColor: Theme.palette.secondary,
+      color: 'white'
+    },
+    additionalStyle: {
+      padding: '3%',
+      fontSize: '1.45rem',
+      fontWeight: 600,
+      border: `1px solid ${Theme.palette.secondary}`,
+      marginRight: 5
+    },
+  };
+
   const deleteButtonAttributes = {
     keyProp: `${consoleType}-delete-${uniqueId}`,
     label: 'Delete',
@@ -221,6 +240,8 @@ export default function Actions(props) {
       {actions.includes('Cancel') && <TableIconButton {...cancelButtonAttributes} />}
       {checkEnv(envGroups.NON_PROD) && actions.includes('Create_Progress_Report') &&
         <SimpleButton {...createProgressReportButtonAttributes} />}
+      {checkEnv(envGroups.NON_PROD) && actions.includes('Review_Progress_Report') &&
+        <SimpleButton {...reviewCloseoutButtonAttributes} />}
     </div>
   );
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1779

### Summary

Add closeout review buttons and unit tests.

<img width="1740" alt="Screenshot 2025-06-23 at 2 16 53 PM" src="https://github.com/user-attachments/assets/5783353d-4d0c-4714-8860-15e424d393f7" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
