### PR TITLE
DT-1866: Update DAR models used in Progress Reports and Dataset Statistics pages

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
@@ -223,7 +223,6 @@ const dar = {
       'referenceId': 'dars-id-123',
       'collectionId': 777,
       'data': {
-        'referenceId': 'dars-id-123',
         'institution': 'Ace Industries',
         'projectTitle': 'Collection of sleep apnea samples',
         'researcher': 'Bob Jones',

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import { mount } from 'cypress/react';
 import { ProgressReportApplication } from 'src/pages/dar_application/ProgressReportApplication';
-import { DataAccessRequest, Dataset, DuosUser, FileStorageObject } from 'src/types/model';
+import {CombinedDataAccessRequest, Dataset, DuosUser, FileStorageObject} from 'src/types/model';
 import { History, Location, Action } from 'history';
 import { Storage } from 'src/libs/storage';
 
@@ -153,7 +153,7 @@ describe('ProgressReportApplication - Component Tests', () => {
     }
   ];
 
-  const baseDar: Partial<DataAccessRequest> = {
+  const baseDar: Partial<CombinedDataAccessRequest> = {
     userId: 1,
     projectTitle: 'Test Project',
     draft: false,
@@ -161,15 +161,14 @@ describe('ProgressReportApplication - Component Tests', () => {
     referenceId: 'DAR-123',
     collectionId: 1,
     elections: {},
-    darCode: 'DAR-123',
-    createDate: '2023-10-01T00:00:00Z',
-    sortDate: '2023-10-01T00:00:00Z',
-    submissionDate: '2023-10-01T00:00:00Z',
-    updateDate: '2023-10-01T00:00:00Z'
+    createDate: 1748736000,
+    sortDate: 1748736000,
+    submissionDate: 1748736000,
+    updateDate: 1748736000
   };
 
-  const mountComponent = (dar: Partial<DataAccessRequest> = {}, readOnly = true) => {
-    const fullDar = { ...baseDar, ...dar } as DataAccessRequest;
+  const mountComponent = (dar: Partial<CombinedDataAccessRequest> = {}, readOnly = true) => {
+    const fullDar = { ...baseDar, ...dar } as CombinedDataAccessRequest;
 
     const props = {
       dar: fullDar,
@@ -177,7 +176,8 @@ describe('ProgressReportApplication - Component Tests', () => {
       readOnlyMode: readOnly,
       history: mockHistory,
       location,
-      researcher
+      researcher,
+      countriesOfOperation: []
     };
 
     return mount(<ProgressReportApplication {...props} /> as ReactNode);

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -572,7 +572,7 @@ describe('ProgressReportApplication - Component Tests', () => {
     };
 
     // Mount component with datasets and elections
-    const fullDar = { ...baseDar, ...darWithElections } as unknown as DataAccessRequest;
+    const fullDar = { ...baseDar, ...darWithElections } as unknown as CombinedDataAccessRequest;
     const props = {
       dar: fullDar,
       datasets: testDatasets,
@@ -673,7 +673,7 @@ describe('ProgressReportApplication - Component Tests', () => {
       }
     };
 
-    const fullDar = { ...baseDar, ...darWithDeniedElections } as unknown as DataAccessRequest;
+    const fullDar = { ...baseDar, ...darWithDeniedElections } as unknown as CombinedDataAccessRequest;
     const props = {
       dar: fullDar,
       datasets: testDatasets,
@@ -800,7 +800,7 @@ describe('ProgressReportApplication - Component Tests', () => {
       }
     };
 
-    const fullDar = { ...baseDar, ...darWithFilteringTest } as unknown as DataAccessRequest;
+    const fullDar = { ...baseDar, ...darWithFilteringTest } as unknown as CombinedDataAccessRequest;
     const props = {
       dar: fullDar,
       datasets: testDatasets,
@@ -907,7 +907,7 @@ describe('ProgressReportApplication - Component Tests', () => {
       }
     };
 
-    const fullDar = { ...baseDar, ...darWithSelectiveDatasetIds } as unknown as DataAccessRequest;
+    const fullDar = { ...baseDar, ...darWithSelectiveDatasetIds } as unknown as CombinedDataAccessRequest;
 
     const props = {
       dar: fullDar,

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -1,16 +1,15 @@
-import React from 'react';
-import {useCallback, useState, useEffect} from 'react';
-import {DatasetMetrics} from '../libs/ajax/DatasetMetrics';
-import {DataSet} from '../libs/ajax/DataSet';
-import {DAR} from '../libs/ajax/DAR';
-import {Notifications} from '../libs/utils';
-import {Styles, Theme} from '../libs/theme';
+import React, {useCallback, useEffect, useState} from 'react';
+import {DatasetMetrics} from 'src/libs/ajax/DatasetMetrics';
+import {DataSet} from 'src/libs/ajax/DataSet';
+import {DAR} from 'src/libs/ajax/DAR';
+import {formatDate, Notifications} from 'src/libs/utils';
+import {Styles, Theme} from 'src/libs/theme';
 import {find} from 'lodash/fp';
 import {ReadMore} from '../components/ReadMore';
-import {formatDate} from '../libs/utils';
 import {Button} from '@mui/material';
 import {History} from 'history';
-import {DataAccessRequest, Dataset, DatasetStats, DatasetProperty, StudyProperty} from '../types/model';
+import {Dataset, DatasetProperty, DatasetStatisticsDar, DatasetStats, StudyProperty} from 'src/types/model';
+import {extractError} from 'src/utils/ErrorUtils';
 
 const LINE = <div style={{borderTop: '1px solid #BABEC1', height: 0}}/>;
 
@@ -22,8 +21,8 @@ enum AccessManagement {
 
 
 interface DatasetStatisticsProps {
-  history: History,
-  match: {
+  readonly history: History,
+  readonly match: {
     params: {
       datasetIdentifier: string;
     }
@@ -33,7 +32,7 @@ interface DatasetStatisticsProps {
 export default function DatasetStatistics(props: DatasetStatisticsProps) {
   const {history, match: {params: {datasetIdentifier}}} = props;
   const [dataset, setDataset] = useState<Dataset>();
-  const [dars, setDars] = useState<Array<DataAccessRequest>>();
+  const [dars, setDars] = useState<Array<DatasetStatisticsDar>>();
   const [isLoading, setIsLoading] = useState(true);
 
   const showError = (message: string) => {
@@ -58,8 +57,8 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
       } else {
         showError('Unable to create a Draft Data Access Request');
       }
-    } catch (_error) {
-      showError('Unable to create a Draft Data Access Request');
+    } catch (error) {
+      showError('Unable to create a Draft Data Access Request: ' + extractError(error));
     }
   };
 
@@ -71,8 +70,8 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
         setDataset(dataset);
         setDars(metrics.dars);
         setIsLoading(false);
-      } catch (_error) {
-        showError('Unable to retrieve dataset statistics from server');
+      } catch (error) {
+        showError('Unable to retrieve dataset statistics from server: ' + extractError(error));
         setIsLoading(false);
       }
     }
@@ -144,7 +143,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
               <div style={{...Styles.MINOR_HEADER, paddingLeft: '10px'}}>Dataset Description:</div>
               {LINE}
               <div style={{fontSize: Theme.font.size.small, padding: '1rem'}}>
-                {extract('Dataset Description') || dataset?.study?.description || 'N/A'}
+                {extract('Dataset Description') ?? dataset?.study?.description ?? 'N/A'}
               </div>
             </div>
             <div>
@@ -169,7 +168,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
             </div>
           </div>
           <div style={Styles.SUB_HEADER}>Data Access Requests - Research Statements</div>
-          {dars?.map((dar: DataAccessRequest) => (
+          {dars?.map((dar: DatasetStatisticsDar) => (
             <div style={Styles.READ_MORE as React.CSSProperties} id={`${dar.darCode}`} key={`${dar.darCode}`}>
               <ReadMore
                 // @ts-expect-error next-line props for non ts component

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -15,7 +15,7 @@ import {DAR} from 'src/libs/ajax/DAR';
 import {Collections} from 'src/libs/ajax/Collections';
 import {NotificationService} from 'src/libs/notificationService';
 import {Storage} from 'src/libs/storage';
-import {assign, cloneDeep, get, head, isEmpty, isNil, isString, keys, map} from 'lodash/fp';
+import {get, map} from 'lodash/fp';
 import 'src/pages/dar_application/DataAccessRequestApplication.css';
 
 import DucAddendum from 'src/pages/dar_application/DucAddendum';
@@ -30,7 +30,7 @@ import {ConditionalAccordion} from 'src/components/forms/ConditionalAccordion.js
 import {ProgressReportApplication} from 'src/pages/dar_application/ProgressReportApplication';
 import {ScrollableTabs} from 'src/pages/dar_application/ScrollableTabs';
 import {validateDARFormData, validationFailed} from 'src/utils/darFormUtils.js';
-import {isArray, set} from 'lodash';
+import {assign, cloneDeep, head, isArray, isEmpty, isNil, isString, keys, merge, set} from 'lodash';
 import {Countries} from 'src/libs/ajax/Countries.js';
 
 // Constants
@@ -575,7 +575,7 @@ const DataAccessRequestApplication = (props) => {
                     <ProgressReportApplication
                       readOnlyMode={false}
                       datasets={datasets}
-                      dar={reverseOrderedDARs[0]}
+                      dar={merge(reverseOrderedDARs[0]?.data, reverseOrderedDARs[0])}
                       history={history}
                       location={location}
                       researcher={researcher}
@@ -599,7 +599,7 @@ const DataAccessRequestApplication = (props) => {
                               <ProgressReportApplication
                                 readOnlyMode={true}
                                 datasets={datasets}
-                                dar={dar?.data}
+                                dar={merge(dar?.data, dar)}
                                 location={undefined}
                                 researcher={researcher}
                               />

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -52,8 +52,8 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
           ? {
             // In read-only mode, check "No" when undefined
             intellectualPropertyYesNo: !!dar.intellectualPropertySummary,
-            publicationsYesNo: (dar.publications?.length > 0),
-            presentationsYesNo: (dar.presentations?.length > 0),
+            publicationsYesNo: ((dar.publications?.length ?? 0) > 0),
+            presentationsYesNo: ((dar.presentations?.length ?? 0) > 0),
           }
           : {
             // When not in read-only mode, don't check anything when undefined
@@ -80,14 +80,16 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
             dmiDescription: dar.dmi.description,
             // populate DMI incident multiselect based on whether the option appears in list of incidents
             ...DMI_INCIDENT_KEYS.reduce((acc, key) => {
-                acc[key] = dar.dmi.incidents.includes(key);
+                if (dar.dmi?.incidents.includes(key)) {
+                  acc[key] = dar.dmi?.incidents.includes(key);
+                }
                 return acc;
             }, {} as Record<string, boolean>)
         }),
 
         // Set undefined to "No" only in read-only mode
         ...(readOnlyMode && {
-          dmiYesNo: (dar.dmi?.incidents?.length > 0),
+          dmiYesNo: ((dar.dmi?.incidents?.length ?? 0) > 0),
         }),
 
         // additional state for closeout section
@@ -96,14 +98,16 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
             closeoutSigningOfficial: { userId: dar.closeoutSupplement.signingOfficialId } as SimplifiedDuosUser,
             closeoutOtherText: dar.closeoutSupplement.otherText,
             ...CLOSEOUT_KEYS.reduce((acc, key) => {
-                acc[key] = dar.closeoutSupplement.reasons.includes(key);
+                if (dar.closeoutSupplement?.reasons.includes(key)) {
+                  acc[key] = dar.closeoutSupplement?.reasons.includes(key);
+                }
                 return acc;
             },{} as Record<string, boolean>)
         }),
 
         // Set undefined to "No" only in read-only mode
         ...(readOnlyMode && {
-          closeoutYesNo: (dar.closeoutSupplement?.reasons.length > 0),
+          closeoutYesNo: ((dar.closeoutSupplement?.reasons.length ?? 0) > 0),
         }),
     } as FormState;
 

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -33,7 +33,6 @@ type ProgressReportApplicationProps = {
 export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, location, researcher, countriesOfOperation }: ProgressReportApplicationProps) => {
     const initialState = {
         ...dar,
-        ...dar.data,
         dmiCombination:false,
         dmiIdentification: false,
         dmiSharing: false,

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,5 +1,5 @@
 import React, {useState, useEffect} from 'react';
-import {DataAccessRequest, Dataset, DuosUser, SimplifiedDuosUser} from 'src/types/model';
+import {CombinedDataAccessRequest, Dataset, DuosUser, SimplifiedDuosUser} from 'src/types/model';
 import {History, Location} from 'history';
 import {CLOSEOUT_KEYS, DMI_INCIDENT_KEYS, FormState} from 'src/pages/progress_reports/ProgressReportFormState';
 import SummarySection from 'src/pages/progress_reports/SummarySection';
@@ -21,7 +21,7 @@ import { User } from 'src/libs/ajax/User';
 import { AxiosError } from 'axios';
 
 type ProgressReportApplicationProps = {
-  readonly dar: DataAccessRequest; // corresponds either to the parent DAR for a new application or an existing readonly progress report
+  readonly dar: CombinedDataAccessRequest; // corresponds either to the parent DAR for a new application or an existing readonly progress report
   readonly datasets: Dataset[];
   readonly readOnlyMode: boolean;
   readonly history: History;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -348,6 +348,8 @@ export interface DatasetStatisticsDar {
  * in DataAccessRequest.data field. This model simplifies usages in ProgressReport forms.
  */
 export interface CombinedDataAccessRequest extends DataAccessRequest {
+  projectTitle: string;
+  checkNihDataOnly: boolean;
   rus: string;
   nonTechRus: string;
   diseases: boolean;
@@ -371,6 +373,16 @@ export interface CombinedDataAccessRequest extends DataAccessRequest {
   notHealth: boolean;
   hmb: boolean;
   poa: boolean;
+  status: string;
+  darCode: string;
+  validRestriction: boolean;
+  progressReportSummary: string;
+  intellectualPropertySummary: string;
+  publications?: Array<PublicationOrPresentation>;
+  presentations?: Array<PublicationOrPresentation>;
+  dmi?: DataManagementIncident;
+  researchPlans?: string;
+  closeoutSupplement?: Closeout;
   anvilUse: boolean;
   cloudUse: boolean;
   localUse: boolean;
@@ -381,27 +393,25 @@ export interface CombinedDataAccessRequest extends DataAccessRequest {
   irb: boolean;
   irbDocumentLocation: string;
   irbProtocolExpiration: string;
+  itDirector: string;
+  itDirectorEmail: string;
+  signingOfficial: string;
+  signingOfficialEmail: string;
+  publication: boolean;
+  collaboration: boolean;
+  collaborationLetterLocation?: string;
+  collaborationLetterName?: string;
+  forensicActivities?: boolean;
+  sharingDistribution?: boolean;
+  labCollaborators?: Array<Collaborator>;
+  internalCollaborators?: Array<Collaborator>;
+  externalCollaborators?: Array<Collaborator>;
   dsAcknowledgement: boolean;
   gsoAcknowledgement: boolean;
   pubAcknowledgement: boolean;
-  itDirector: string;
-  signingOfficial: string;
-  publication: boolean;
-  collaboration: boolean;
-  collaborationLetterLocation: string;
-  forensicActivities: boolean;
-  sharingDistribution: boolean;
-  externalCollaborators: Array<Collaborator>;
-  internalCollaborators: Array<Collaborator>;
-  labCollaborators: Array<Collaborator>;
-  projectTitle: string;
-  progressReportSummary: string;
-  intellectualPropertySummary: string;
-  publications: Array<PublicationOrPresentation>;
-  presentations: Array<PublicationOrPresentation>;
-  dmi: DataManagementIncident;
-  researchPlans: string;
-  closeoutSupplement: Closeout;
+  piName: string;
+  piEmail: string;
+  piCountryOfOperation: string;
 }
 
 export interface DataAccessRequest {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -335,19 +335,11 @@ export interface DatasetStats {
   elections: Array<Election>;
 }
 
-export interface DataAccessRequest {
-  referenceId: string;
-  userId: number;
-  createDate: string;
-  sortDate: string;
-  submissionDate: string;
-  updateDate: string;
-  draft: boolean;
-  collectionId: number;
-  darCode: string;
-  elections: Record<number, Election>;
-  projectTitle: string;
-  datasetIds: number[];
+/**
+ * This interface combines the DataAccessRequest with all fields from the DataAccessRequestData object stored
+ * in DataAccessRequest.data field. This model simplifies usages in ProgressReport forms.
+ */
+export interface CombinedDataAccessRequest extends DataAccessRequest {
   rus: string;
   nonTechRus: string;
   diseases: boolean;
@@ -394,6 +386,7 @@ export interface DataAccessRequest {
   externalCollaborators: Array<Collaborator>;
   internalCollaborators: Array<Collaborator>;
   labCollaborators: Array<Collaborator>;
+  projectTitle: string;
   progressReportSummary: string;
   intellectualPropertySummary: string;
   publications: Array<PublicationOrPresentation>;
@@ -401,8 +394,26 @@ export interface DataAccessRequest {
   dmi: DataManagementIncident;
   researchPlans: string;
   closeoutSupplement: Closeout;
-  data: object;
+}
+
+export interface DataAccessRequest {
+  id: number;
+  referenceId: string;
+  collectionId: number;
   parentId?: number;
+  data: object;
+  draft: boolean;
+  progressReport: boolean;
+  expired: boolean;
+  expiresAt: number;
+  userId: number;
+  createDate: number;
+  sortDate: number;
+  submissionDate: number;
+  updateDate: number;
+  datasetIds: number[];
+  elections: Record<number, Election>;
+  eraCommonsId: string;
   closeoutSigningOfficialApprovedDate: number;
   closeoutSigningOfficialApprovedUserId: number;
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -331,8 +331,16 @@ export interface Acknowledgement {
 
 export interface DatasetStats {
   dataset: Dataset;
-  dars: Array<DataAccessRequest>;
+  dars: Array<DatasetStatisticsDar>;
   elections: Array<Election>;
+}
+
+export interface DatasetStatisticsDar {
+  updateDate: number;
+  projectTitle: string;
+  darCode: string;
+  nonTechRus: string;
+  referenceId: string;
 }
 
 /**


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1866

### Summary
This PR updates the underlying DAR models to be more explicit about what it is comprised of. Previously, the Progress Report Application component was populated with either a [DataAccessRequest](https://github.com/DataBiosphere/consent/blob/412d337fcd019cbcebf94cc4f15907747ba53b09/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequest.java#L29) or a [DataAccessRequestData](https://github.com/DataBiosphere/consent/blob/412d337fcd019cbcebf94cc4f15907747ba53b09/src/main/java/org/broadinstitute/consent/http/models/DataAccessRequestData.java#L16) object depending on what context it was used in. Inside the component, both items were spread-assigned into the same `dar` object. 

In this approach, we now merge the two objects into a combined DAR model before passing it down to `ProgressReportApplication`.  This allows us to move the `DataAccessRequestData` fields out of the DAR model and into a new, combined model, which should be easier to grok for future developers.

As a side effect of this, the `DatasetStatistics` component became out of date so this PR updates that component as well.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
