### PR TITLE
[DT-1869] Set displayText so that SO renders in read-only view.

### DIFF
--- a/src/pages/progress_reports/DarCloseout.tsx
+++ b/src/pages/progress_reports/DarCloseout.tsx
@@ -33,7 +33,7 @@ export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element 
       setAllSigningOfficials(signingOfficials);
       const closeoutSigningOfficial = signingOfficials.find(so => so.userId === formState.closeoutSigningOfficial?.userId);
       if (closeoutSigningOfficial !== undefined) {
-        setDefaultSigningOfficial(closeoutSigningOfficial);
+        setDefaultSigningOfficial(displaySigningOfficial(closeoutSigningOfficial));
       }
     }
     init();


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1869](https://broadworkbench.atlassian.net/browse/DT-1869)

### Summary

`displayText` needed to be calculated for read-only mode.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
