### PR TITLE
[DT-1808]Hide Controlled Access Grants Area on Profile

### DIFF
--- a/src/pages/user_profile/UserProfile.jsx
+++ b/src/pages/user_profile/UserProfile.jsx
@@ -6,13 +6,12 @@ import { Notification } from 'src/components/Notification';
 import { User } from 'src/libs/ajax/User';
 import { Storage } from 'src/libs/storage';
 import { NotificationService } from 'src/libs/notificationService';
-import { Notifications } from 'src/libs/utils';
+import { Notifications, setUserRoleStatuses } from 'src/libs/utils';
 import AffiliationAndRoles from './AffiliationAndRoles';
 import ResearcherStatus from './ResearcherStatus';
 import AcceptedAcknowledgements from './AcceptedAcknowledgements';
 import ga4ghLogo from 'src/images/ga4gh-logo.png';
 import userProfileIcon from 'src/images/user-profile.png';
-import {setUserRoleStatuses} from 'src/libs/utils';
 
 export default function UserProfile(props) {
 

--- a/src/pages/user_profile/UserProfile.jsx
+++ b/src/pages/user_profile/UserProfile.jsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
-import { FormField, FormFieldTypes } from '../../components/forms/forms';
-import { PageHeading } from '../../components/PageHeading';
-import { Notification } from '../../components/Notification';
-import { User } from '../../libs/ajax/User';
-import { Storage } from '../../libs/storage';
-import { NotificationService } from '../../libs/notificationService';
-import { Notifications } from '../../libs/utils';
+import { FormField, FormFieldTypes } from 'src/components/forms/forms';
+import { PageHeading } from 'src/components/PageHeading';
+import { Notification } from 'src/components/Notification';
+import { User } from 'src/libs/ajax/User';
+import { Storage } from 'src/libs/storage';
+import { NotificationService } from 'src/libs/notificationService';
+import { Notifications } from 'src/libs/utils';
 import AffiliationAndRoles from './AffiliationAndRoles';
 import ResearcherStatus from './ResearcherStatus';
 import AcceptedAcknowledgements from './AcceptedAcknowledgements';
-import ControlledAccessGrants from './ControlledAccessGrants';
-import ga4ghLogo from '../../images/ga4gh-logo.png';
-import userProfileIcon from '../../images/user-profile.png';
-import {setUserRoleStatuses} from '../../libs/utils';
+import ga4ghLogo from 'src/images/ga4gh-logo.png';
+import userProfileIcon from 'src/images/user-profile.png';
+import {setUserRoleStatuses} from 'src/libs/utils';
 
 export default function UserProfile(props) {
 
@@ -203,9 +202,7 @@ export default function UserProfile(props) {
         defaultValue={profile.emailPreference}
         onChange={(field) => updateEmailPreference(field.value)}
       />
-    <div style={{ 'marginTop': '60px' }} />
-    <ControlledAccessGrants />
-    <div style={{ 'marginTop': '60px' }} />
+    <div style={{ 'marginTop': '45px' }} />
     <AffiliationAndRoles
       user={user}
     />
@@ -225,7 +222,7 @@ export default function UserProfile(props) {
       pageProps={props}
       profile={profile}
     />
-    <div style={{ marginTop: '115px' }} />
+    <div style={{ marginTop: '60px' }} />
     <AcceptedAcknowledgements />
   </div>;
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1880

### Summary
Remove the datasets table from the profile page
Does not delete the now unused component ControlledAccessGrants or the getApprovedDatasets endpoint (/api/user/me/researcher/datasets) because they will both be used once this is added to its own tab in the researcher console in DT-1886.

Also updates spacing so the titles are more evenly spaced
Also updates imports to reference src

Video of updated page: https://drive.google.com/file/d/18Nvk5ITrMp7JQXwnXePzn5G73sh4UrpH/view?usp=sharing

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
