### PR TITLE
[DT-1870] Remove Add Library Card functionality from admin console

### DIFF
--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {mount} from 'cypress/react';
 import LibraryCardTable, {LibraryCardTableProps} from 'src/components/library_card_table/LibraryCardTable';
 import {LibraryCard as LibraryCardModel} from 'src/types/model';
-import {LibraryCard} from 'src/libs/ajax/LibraryCard';
 
 describe('Library Card Table Tests', () => {
 
@@ -14,69 +13,60 @@ describe('Library Card Table Tests', () => {
       userEmail: 'test.user.1@test.com',
       createUserId: 2,
       createDate: new Date(),
+    },
+    {
+      id: 2,
+      userId: 2,
+      userName: 'Test User 2',
+      userEmail: 'test.user.2@test.com',
+      createUserId: 2,
+      createDate: new Date(),
+    },
+    {
+      id: 3,
+      userId: 3,
+      userName: 'Test User 3',
+      userEmail: 'test.user.3@test.com',
+      createUserId: 2,
+      createDate: new Date(),
     }
-  ]
-
-  const userOptions = [
-    {userId: 1, displayName: 'Test User 1', email: 'user1@test.com', libraryCard: undefined},
-    {userId: 2, displayName: 'Test User 2', email: 'user2@test.com', libraryCard: undefined},
-    {userId: 3, displayName: 'Test User 3', email: 'user3@test.com', libraryCard: undefined}
   ]
 
   beforeEach(() => {
     cy.viewport(1000, 800);
   });
 
-  it('Should render the Library Card Table', () => {
+  it('should render the Library Card Table with a list of users', () => {
     const props: LibraryCardTableProps = {
-      libraryCards: libraryCardList,
-      users: [],
+      libraryCards: libraryCardList
     }
     mount(<LibraryCardTable {...props}/>);
     cy.get('[data-cy=manage-library-card-table]').should('exist');
-    cy.get('[data-cy=add-library-card-button]').should('exist');
-    // For each user in the list, teest that the row is deletable and removed from the table view
+    // For each user in the list, test that the row is visible
     libraryCardList.forEach((card) => {
       cy.get('[data-cy=manage-library-card-table]').should('contain', card.userName);
       cy.get('[data-cy=manage-library-card-table]').should('contain', card.userEmail);
-      cy.get(`[id=show-delete-modal-${card.id}]`).should('exist');
-      cy.get(`[id=show-delete-modal-${card.id}]`).click();
-      cy.get('.confirmation-modal').should('exist');
-      cy.get('.confirmation-modal').find('button[type="button"]').contains('Cancel').click();
-      cy.get(`[id=show-delete-modal-${card.id}]`).click();
-      cy.get('.confirmation-modal').find('button[type="button"]').contains('Confirm').click();
-    });
-    libraryCardList.forEach((card) => {
-      cy.get('.table-data').should('not.contain', card.userName)
     });
   });
 
-  it('Should display an error message if a library card failed to create', () => {
-    cy.stub(LibraryCard, 'createLibraryCard')
-        .callsFake((card) => {
-          return Promise.reject({
-            response: {
-              data: {
-                message: `Failed to issue library card for ${card.userEmail}`
-              }
-            }
-          });
-        });
-
+  it('should allow deleting a library card', () => {
     const props: LibraryCardTableProps = {
-      libraryCards: [],
-      users: userOptions,
-    }
+      libraryCards: libraryCardList
+    };
 
-    mount(<LibraryCardTable {...props}/>);
-    cy.get('[data-cy=add-library-card-button]').click();
-    cy.get('[data-cy=library-card-form-modal]').should('exist');
+    mount(<LibraryCardTable {...props} />);
 
-    cy.get('input[id^=react-select-]').should('exist');
-    cy.get('input[id^=react-select-]').type('Test User');
-    cy.get('[id$=option-1]').click(); // Test User 1
+    cy.get('[data-cy=manage-library-card-table]').should('contain', libraryCardList[0].userName);
+    cy.get(`[id=show-delete-modal-1]`).click();
+    cy.get('.confirmation-modal').find('button[type="button"]').contains('Confirm').click();
 
-    cy.get('[id=Add-button]').click();
-    cy.contains('Failed to issue library card for user1@test.com')
+    // Verify that the card is removed from the table
+    cy.get('[data-cy=manage-library-card-table]').should('not.contain', libraryCardList[0].userName);
+
+    // Verify that the remaining cards are still present
+    libraryCardList.slice(1).forEach((card) => {
+      cy.get('[data-cy=manage-library-card-table]').should('contain', card.userName);
+      cy.get('[data-cy=manage-library-card-table]').should('contain', card.userEmail);
+    });
   });
 });

--- a/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardTable.spec.tsx
@@ -69,4 +69,42 @@ describe('Library Card Table Tests', () => {
       cy.get('[data-cy=manage-library-card-table]').should('contain', card.userEmail);
     });
   });
+
+  it('should allow searching for a library card by email', () => {
+    const props: LibraryCardTableProps = {
+      libraryCards: libraryCardList
+    };
+
+    mount(<LibraryCardTable {...props} />);
+
+    cy.get('[data-cy=search-bar]').type(libraryCardList[0].userEmail);
+
+    // Verify that only the matching card is displayed
+    cy.get('[data-cy=manage-library-card-table]').should('contain', libraryCardList[0].userName);
+
+    //Remaining cards should not be displayed
+    libraryCardList.slice(1).forEach((card) => {
+      cy.get('[data-cy=manage-library-card-table]').should('not.contain', card.userName);
+      cy.get('[data-cy=manage-library-card-table]').should('not.contain', card.userEmail);
+    });
+  });
+
+  it('should allow searching for a library card by user name', () => {
+    const props: LibraryCardTableProps = {
+      libraryCards: libraryCardList
+    };
+
+    mount(<LibraryCardTable {...props} />);
+
+    cy.get('[data-cy=search-bar]').type(libraryCardList[0].userName.toLowerCase());
+
+    // Verify that only the matching card is displayed
+    cy.get('[data-cy=manage-library-card-table]').should('contain', libraryCardList[0].userName);
+
+    //Remaining cards should not be displayed
+    libraryCardList.slice(1).forEach((card) => {
+      cy.get('[data-cy=manage-library-card-table]').should('not.contain', card.userName);
+      cy.get('[data-cy=manage-library-card-table]').should('not.contain', card.userEmail);
+    });
+  });
 });

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -22,13 +22,6 @@ import {AxiosError} from 'axios';
 import {ConsentError} from 'src/types/responseTypes';
 import {LibraryCard} from 'src/types/model';
 
-interface UserData {
-  userId: number;
-  displayName: string;
-  email: string;
-  libraryCard?: LibraryCard;
-}
-
 export interface LibraryCardTableProps {
   libraryCards?: LibraryCard[];
 }

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -14,7 +14,6 @@ import PaginationBar from 'src/components/PaginationBar';
 import SearchBar from 'src/components/SearchBar';
 import SimpleTable from 'src/components/SimpleTable';
 import lockIcon from 'src/images/lock-icon.png';
-import LibraryCardFormModal from 'src/components/modals/LibraryCardFormModal';
 import {LibraryCard as LibraryCardAPI} from 'src/libs/ajax/LibraryCard';
 import ConfirmationModal from 'src/components/modals/ConfirmationModal';
 import {Delete} from '@mui/icons-material';
@@ -22,7 +21,6 @@ import TableIconButton from 'src/components/TableIconButton';
 import {AxiosError} from 'axios';
 import {ConsentError} from 'src/types/responseTypes';
 import {LibraryCard} from 'src/types/model';
-import { processLibraryCards } from 'src/utils/LibraryCardUtils';
 
 interface UserData {
   userId: number;
@@ -33,7 +31,6 @@ interface UserData {
 
 export interface LibraryCardTableProps {
   libraryCards?: LibraryCard[];
-  users?: UserData[];
 }
 
 interface TableCell {
@@ -176,16 +173,6 @@ const DeleteRecordButton: React.FC<DeleteRecordButtonProps> = (props) => {
   );
 };
 
-// onClick function to show target card via modal
-const showModalOnClick = (
-    card: LibraryCard,
-    setShowModal: React.Dispatch<React.SetStateAction<boolean>>,
-    setCurrentCard: React.Dispatch<React.SetStateAction<LibraryCard>>
-): void => {
-  setCurrentCard(cloneDeep(card));
-  setShowModal(true);
-};
-
 const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   const [libraryCards, setLibraryCards] = useState<LibraryCard[]>(props.libraryCards ?? []);
   const [tableSize, setTableSize] = useState<number>(10);
@@ -194,9 +181,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [filteredCards, setFilteredCards] = useState<LibraryCard[]>([]);
   const [visibleCards, setVisibleCards] = useState<LibraryCard[]>([]);
-  const [showModal, setShowModal] = useState<boolean>(false);
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
-  const [users, setUsers] = useState<UserData[]>(props.users ?? []);
   const [currentCard, setCurrentCard] = useState<LibraryCard>({} as LibraryCard);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -245,14 +230,10 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   // Hook that executes on prop load (initialization hook)
   useEffect(() => {
     setLibraryCards(props.libraryCards ?? []);
-    setUsers(props.users ?? []);
-    if (
-        !isNil(props.libraryCards) &&
-        !isNil(props.users)
-    ) {
+    if (!isNil(props.libraryCards)) {
       setIsLoading(false);
     }
-  }, [props.libraryCards, props.users]);
+  }, [props.libraryCards]);
 
   // Formats institution data to be used by SimpleTable component
   const processLCData = (cards: LibraryCard[] = []): TableCell[][] => {
@@ -293,41 +274,6 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
       goToPage={goToPage}
       changeTableSize={changeTableSize}
   />;
-
-  // onClick function, used to create new card on modal based on form data
-  const addLibraryCards = async (newLibraryCards: LibraryCard[]): Promise<void> => {
-    // Check if any cards already exist, show error if any do
-    const duplicateLibraryCards = newLibraryCards.filter((card) => {
-      return libraryCards.some((element: LibraryCard) =>
-          element.userEmail === card.userEmail
-      );
-    });
-
-    if (duplicateLibraryCards.length > 0) {
-      Notifications.showError({
-        text: 'Error updating library cards. The following users already have library cards: ' + duplicateLibraryCards.map(card => card.userEmail).join(', ')
-      });
-    } else {
-      const { successfulCards, failedCards } = await processLibraryCards(newLibraryCards);
-
-      if (successfulCards.length > 0) {
-        const updatedList = [...cloneDeep(libraryCards), ...successfulCards];
-
-        updatedList.sort((a, b) => {
-          return dayjs(b.createDate).valueOf() - dayjs(a.createDate).valueOf();
-        });
-
-        setLibraryCards(updatedList);
-      }
-
-      setShowModal(false);
-
-      if(failedCards.length > 0) {
-        const errorMessages = failedCards.map(failure => `${failure.error}`).join(', ');
-        Notifications.showError({text: `${errorMessages}`});
-      }
-    }
-  };
 
   // Search function for SearchBar component
   const handleSearchChange = useCallback(
@@ -370,37 +316,6 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
                 width: '100%',
                 margin: '0 3% 0 0',
               }}
-              button={
-                <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      alignItems: 'flex-end',
-                      justifyContent: 'center',
-                      width: '300px'
-                    }}
-                >
-                  <button
-                      data-cy={'add-library-card-button'}
-                      type={'button'}
-                      id="btn_addLibraryCard"
-                      className="btn-primary btn-add common-background"
-                      style={{
-                        marginTop: '30%',
-                        display: 'flex',
-                      }}
-                      onClick={() =>
-                          showModalOnClick(
-                              {} as LibraryCard,
-                              setShowModal,
-                              setCurrentCard
-                          )
-                      }
-                  >
-                    <span>Add Library Card</span>
-                  </button>
-                </div>
-              }
           />
         </div>
         <SimpleTable
@@ -410,12 +325,6 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
             styles={styles}
             tableSize={tableSize}
             paginationBar={paginationBar}
-        />
-        <LibraryCardFormModal
-            showModal={showModal}
-            createOnClick={addLibraryCards}
-            closeModal={() => setShowModal(false)}
-            users={users}
         />
         <ConfirmationModal
             showConfirmation={showConfirmation}

--- a/src/pages/AdminManageLC.jsx
+++ b/src/pages/AdminManageLC.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
-import { Institution } from '../libs/ajax/Institution';
-import { LibraryCard } from '../libs/ajax/LibraryCard';
-import { Notifications } from '../libs/utils';
-import LibraryCardTable from '../components/library_card_table/LibraryCardTable';
+import { Institution } from 'src/libs/ajax/Institution';
+import { LibraryCard } from 'src/libs/ajax/LibraryCard';
+import { Notifications } from 'src/libs/utils';
+import LibraryCardTable from 'src/components/library_card_table/LibraryCardTable';
 
 export default function AdminManageLC() {
   const [libraryCards, setLibraryCards] = useState();

--- a/src/pages/AdminManageLC.jsx
+++ b/src/pages/AdminManageLC.jsx
@@ -1,23 +1,20 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
 import { Institution } from '../libs/ajax/Institution';
-import { User } from '../libs/ajax/User';
 import { LibraryCard } from '../libs/ajax/LibraryCard';
-import { Notifications, USER_ROLES } from '../libs/utils';
+import { Notifications } from '../libs/utils';
 import LibraryCardTable from '../components/library_card_table/LibraryCardTable';
 
 export default function AdminManageLC() {
   const [libraryCards, setLibraryCards] = useState();
   const [institutions, setInstitutions] = useState();
-  const [users, setUsers] = useState();
 
   //init hook to get users, institutions, and cards to be passed down as props
   useEffect(() => {
     const initData = async() => {
       const dataPromiseArray = await Promise.all([
         LibraryCard.getAllLibraryCards(),
-        Institution.list(),
-        User.list(USER_ROLES.admin)
+        Institution.list()
       ]);
       const cards = dataPromiseArray[0];
       const institutions = dataPromiseArray[1].map((institution) => {
@@ -27,10 +24,8 @@ export default function AdminManageLC() {
           displayText: institution.name
         };
       });
-      const users = dataPromiseArray[2];
       setLibraryCards(cards);
       setInstitutions(institutions);
-      setUsers(users);
     };
     try{
       initData();
@@ -41,6 +36,6 @@ export default function AdminManageLC() {
 
   //props are expecting array format
   return (
-    <LibraryCardTable users={users} institutions={institutions} libraryCards={libraryCards} />
+    <LibraryCardTable institutions={institutions} libraryCards={libraryCards} />
   );
 }

--- a/src/pages/AdminManageLC.jsx
+++ b/src/pages/AdminManageLC.jsx
@@ -29,7 +29,7 @@ export default function AdminManageLC() {
     };
     try{
       initData();
-    } catch(error) {
+    } catch {
       Notifications.showError({text:'Error: Failed to initialize component'});
     }
   }, []);


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1870

### Summary

Removes the "Add Library Card" button from the Library Cards page in the admin console. Also improves test coverage of the `LibraryCardTable` component

A related backend PR is coming soon, which will prevent this functionality entirely.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
