### PR TITLE
[DT-1419] Move cron job interval to parent

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: "0 0 1,15 * *"
     open-pull-requests-limit: 10
     target-branch: develop
     commit-message:
@@ -18,13 +19,11 @@ updates:
       action-patch-updates:
         update-types:
           - "patch"
-        schedule:
-          interval: cron
-          cronjob: "0 0 1,15 * *"
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: "0 0 1,15 * *"
     open-pull-requests-limit: 10
     target-branch: develop
     labels:
@@ -42,13 +41,11 @@ updates:
       npm-patch-updates:
         update-types:
           - "patch"
-        schedule:
-          interval: cron
-          cronjob: "0 0 1,15 * *"
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: weekly
+      interval: cron
+      cronjob: "0 0 1,15 * *"
     open-pull-requests-limit: 10
     target-branch: develop
     labels:
@@ -66,6 +63,3 @@ updates:
       docker-patch-updates:
         update-types:
           - "patch"
-        schedule:
-          interval: cron
-          cronjob: "0 0 1,15 * *"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1419

### Summary

For a package ecosystem, it isn't possible to apply the schedule to a subset of updates, for example "patch", so the schedule needs to apply to the entire set of updates.

Alternatively, I can revert all the Dependabot changes.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
