### PR TITLE
[DT-1907] Read only NHGRI datasets

### DIFF
--- a/src/libs/ajax/DataSet.js
+++ b/src/libs/ajax/DataSet.js
@@ -1,8 +1,7 @@
-import { mergeAll } from 'lodash/fp';
-import { Config } from '../config';
 import axios from 'axios';
-import { getApiUrl, fetchOk } from '../ajax';
-
+import { mergeAll } from 'lodash/fp';
+import { Config } from 'src/libs/config';
+import { getApiUrl, fetchOk } from 'src/libs/ajax';
 
 export const DataSet = {
   getDatasetNames: async () => {

--- a/src/libs/ajax/DataSet.js
+++ b/src/libs/ajax/DataSet.js
@@ -3,6 +3,17 @@ import { mergeAll } from 'lodash/fp';
 import { Config } from 'src/libs/config';
 import { getApiUrl, fetchOk } from 'src/libs/ajax';
 
+// FIXME: temporary read-only mode for NHGRI datasets
+const setNhgriExternalAccess = (datasets) => {
+  return datasets.map(d => {
+    // nhgri dac id in prod is 2, verified in db
+    if (d.dacId === 2 && d.accessManagement === 'controlled') {
+      d.accessManagement = 'external';
+    }
+    return d;
+  })
+};
+
 export const DataSet = {
   getDatasetNames: async () => {
     const url = `${await getApiUrl()}/api/dataset/datasetNames`;
@@ -37,7 +48,7 @@ export const DataSet = {
   searchDatasetIndex: async (query) => {
     const url = `${await getApiUrl()}/api/dataset/search/index`;
     const res = await axios.post(url, query, Config.authOpts());
-    return res.data;
+    return setNhgriExternalAccess(res.data);
   },
 
   getDataSetsByDatasetId: async (datasetId) => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1907

### Summary

When prepared to do so, **only** revert the following commit: 2b43979324ecb54abe3ef4dd5dee30f874853691

Full information below:

## Story

**As an** NHGRI DAC chair, **I want** to temporarily prevent users from requesting datasets to my DAC, **so that** DUOS remains compliant with security requirements.

## Requirements

1. Temporarily disallowing DARs from being created on NHGRI (AnVIL) datasets in the UI
2. Datasets should not disappear from the UI, they should not be selectable instead
3. The approach should be easy to undo

## What

Due to administrative processes on the NHGRI side and to remain compliant with new requirements around controlled access datasets, we need to prevent researchers from making Data Access Requests (DARs) against NHGRI datasets.

## When

To continue being compliant, the solution needs to be implemented by Monday June 30th, 2025.

## How

To keep the implementation extremely simple, all datasets in the NHGRI DAC are switched in the UI from “controlled” access to “external” access. This will effectively prevent researchers from making requests against those datasets.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
