### PR TITLE
[DT-1917] Remove OMB control statement

### DIFF
--- a/src/components/SigningOfficialDaaAgreementWrapper.jsx
+++ b/src/components/SigningOfficialDaaAgreementWrapper.jsx
@@ -1,16 +1,15 @@
+import React, { useEffect, useState } from 'react';
+import { isNil, isNull } from 'lodash';
 import { Notifications } from 'src/libs/utils';
 import BroadLibraryCardAgreementLink from 'src/assets/Library_Card_Agreement_2023_ApplicationVersion.pdf';
 import NihLibraryCardAgreementLink from 'src/assets/NIHLibraryCardAgreement06252025.pdf';
 import DataSubmitterAgreementLink from 'src/assets/Data_Registrant_Agreement_7.2.24.22.pdf';
 import Acknowledgments, {acceptAcknowledgments, hasSOAcceptedDAAs} from 'src/libs/acknowledgements';
-import React, { useEffect, useState } from 'react';
 import { spinnerService } from 'src/libs/spinner-service';
-import { isNil, isNull } from 'lodash';
 import { Styles } from 'src/libs/theme';
-import UsgOmbText from './UsgOmbText';
 import {
   NIHDataUseCertificationAgreement
-} from '../components/external_docs/NIHDataUseCertificationAgreement';
+} from 'src/components/external_docs/NIHDataUseCertificationAgreement';
 
 export const SigningOfficialDaaAgreementWrapper = (props) => {
   const {
@@ -111,12 +110,12 @@ export const SigningOfficialDaaAgreementWrapper = (props) => {
 // Broad and NIH agreements before proceeding to the given
 // component.
 export const ensureSoHasDaaAcknowledgement = (Component, isLibraryCardIssueTable = false, isDataSubmitterTab = false) => {
+  const _ignored = isLibraryCardIssueTable;
   const WrappedComponent = (props) => (
     <>
       <SigningOfficialDaaAgreementWrapper isDataSubmitterTab={isDataSubmitterTab}>
         <Component {...props} />
       </SigningOfficialDaaAgreementWrapper>
-      {isLibraryCardIssueTable && <UsgOmbText />}
     </>
   );
   return WrappedComponent;

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -19,7 +19,6 @@ import {get, map} from 'lodash/fp';
 import 'src/pages/dar_application/DataAccessRequestApplication.css';
 
 import DucAddendum from 'src/pages/dar_application/DucAddendum';
-import UsgOmbText from 'src/components/UsgOmbText';
 import {DAAUtils} from 'src/utils/DAAUtils';
 import {Metrics} from 'src/libs/ajax/Metrics';
 import eventList from 'src/libs/events';
@@ -727,7 +726,6 @@ const DataAccessRequestApplication = (props) => {
           </div>
         </form>
       </div>
-      {!existingDarsReadOnlyMode ? <UsgOmbText /> : null}
     </div>
   );
 };

--- a/src/pages/data_submission/DataSubmissionForm.jsx
+++ b/src/pages/data_submission/DataSubmissionForm.jsx
@@ -2,20 +2,19 @@ import React from 'react';
 import {useCallback, useEffect, useState} from 'react';
 import {validateForm} from './RegistrationValidation';
 import {cloneDeep, isNil} from 'lodash/fp';
-import { Institution } from '../../libs/ajax/Institution';
-import { Study } from '../../libs/ajax/Study';
-import { DataSet } from '../../libs/ajax/DataSet';
-import {Notifications} from '../../libs/utils';
-import lockIcon from '../../images/lock-icon.png';
-import {Styles} from '../../libs/theme';
-import DataAccessGovernance from './DataAccessGovernance';
-import DataSubmissionStudyInformation from './ds_study_information';
-import NIHAdministrativeInformation from './NIHAdministrativeInformation';
-import NIHDataManagement from './NIHDataManagement';
-import NihAnvilUse from './NihAnvilUse';
-import {uniqueValidator} from '../../components/forms/formValidation';
 import {set} from 'lodash';
-import UsgOmbText from '../../components/UsgOmbText';
+import { Institution } from 'src/libs/ajax/Institution';
+import { Study } from 'src/libs/ajax/Study';
+import { DataSet } from 'src/libs/ajax/DataSet';
+import {Notifications} from 'src/libs/utils';
+import lockIcon from 'src/images/lock-icon.png';
+import {Styles} from 'src/libs/theme';
+import DataAccessGovernance from 'src/pages/data_submission/DataAccessGovernance';
+import DataSubmissionStudyInformation from 'src/pages/data_submission/ds_study_information';
+import NIHAdministrativeInformation from 'src/pages/data_submission/NIHAdministrativeInformation';
+import NIHDataManagement from 'src/pages/data_submission/NIHDataManagement';
+import NihAnvilUse from 'src/pages/data_submission/NihAnvilUse';
+import {uniqueValidator} from 'src/components/forms/formValidation';
 
 export const DataSubmissionForm = (props) => {
   const {
@@ -59,7 +58,7 @@ export const DataSubmissionForm = (props) => {
         await getAllInstitutions();
         await getAllStudyNames();
         await getAllDatasetNames();
-      } catch (error) {
+      } catch (_error) {
         setFailedInit(true);
         Notifications.showError({
           text: 'Error: Unable to initialize data from server',
@@ -118,7 +117,8 @@ export const DataSubmissionForm = (props) => {
     formatForRegistration(registration);
 
     // check against json schema validator to see if there are uncaught validation issues
-    let [valid, validation] = validateForm(registrationSchema, registration);
+    const [valid0, validation] = validateForm(registrationSchema, registration);
+    let valid = valid0;
 
     // check secondary validation for non-schema validation issues
     if (!uniqueValidator.isValid(registration.studyName, studyNames)) {
@@ -214,7 +214,6 @@ export const DataSubmissionForm = (props) => {
         </div>
       </form>
     </div>}
-    <UsgOmbText />
   </div>;
 };
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1917

### Summary

Temporarily remove the OMB control statement from DUOS.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
