### PR TITLE
[DT-1918] Add note on NIH DACs in SO console

### DIFF
--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -402,9 +402,14 @@ export default function SigningOfficialTable(props) {
               </a>
             </div>
             <div style={Object.assign({}, Styles.MEDIUM_DESCRIPTION, {
-              fontSize: '16px',
+              fontSize: '16px', marginTop: '1rem'
             })}>
               Issuing Library Card privileges is done in accordance with the <a target="_blank" rel="noreferrer" href={BroadLibraryCardAgreementLink}>Broad Library Card Agreement</a>, <a target="_blank" rel="noreferrer" href={NihLibraryCardAgreementLink}>NIH Library Card Agreement</a>, and <NIHDataUseCertificationAgreement/> and attests that researchers are a permanent employee of your institution at a level equivalent to, at a minimum, a tenure-track professor or senior researcher. This does <span style={{ fontWeight: 600 }}>not</span> include lab technicians or trainees, e.g., post-docs or graduate students. You also attest this Researcher will have oversight responsibility for others named on their DARs who will be granted access to the data.
+            </div>
+            <div style={Object.assign({}, Styles.MEDIUM_DESCRIPTION, {
+              fontSize: '16px', marginTop: '1rem'
+            })}>
+              Note: NIH DACs are not currently using DUOS to review Data Access Requests (DARs).
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1918

### Summary

Temporarily add note on SO console about NIH DAC datasets.

<img width="1676" alt="Screenshot 2025-06-30 at 1 48 19 PM" src="https://github.com/user-attachments/assets/4cdb8d76-5a7d-4826-bfc6-0d22c584cc76" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
