### PR TITLE
DT-1949: Update the GED data library query

### DIFF
--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -1,9 +1,8 @@
-import React from 'react';
-import { useEffect, useState } from 'react';
-import { Box, CircularProgress } from '@mui/material';
-import { toLower } from 'lodash';
-import { Notifications } from 'src/libs/utils';
-import { DataSet } from 'src/libs/ajax/DataSet';
+import React, {useEffect, useState} from 'react';
+import {Box, CircularProgress} from '@mui/material';
+import {toLower} from 'lodash';
+import {Notifications} from 'src/libs/utils';
+import {DataSet} from 'src/libs/ajax/DataSet';
 import DatasetSearchTable from 'src/components/data_search/DatasetSearchTable';
 import broadIcon from 'src/logo.svg';
 import duosIcon from 'src/images/duos-network-logo.svg';
@@ -24,8 +23,8 @@ import gp2Icon from 'src/images/gp2-logo.svg';
 import asapIcon from 'src/images/asap-logo.svg';
 import gedIcon from 'src/images/ged-logo.png';
 import homeIcon from 'src/images/icon_dataset_.png';
-import { Storage } from 'src/libs/storage';
-import { Metrics } from 'src/libs/ajax/Metrics';
+import {Storage} from 'src/libs/storage';
+import {Metrics} from 'src/libs/ajax/Metrics';
 import eventList from 'src/libs/events';
 
 const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery) => {
@@ -305,7 +304,7 @@ export const DatasetSearch = (props) => {
     'ged': {
       query: {
         'match_phrase': {
-          'study.description': 'GED'
+          'study.description': 'Eating Disorder Sequencing Program'
         }
       },
       icon: gedIcon,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1949

### Summary
Update the data library query to get back the GED datasets/studies. This query on prod returns valid results:
```
{
  "query": {
        "match_phrase": {
          "study.description": "Eating Disorder Sequencing Program"
        }
  }
}
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
