### PR TITLE
DT-1912: Navigate to page regardless of history

### DIFF
--- a/cypress/component/TermsOfService/tos_acceptance.spec.jsx
+++ b/cypress/component/TermsOfService/tos_acceptance.spec.jsx
@@ -30,7 +30,7 @@ describe('Terms of Service Acceptance Page', function () {
     cy.stub(ToS, 'getDUOSText').returns(text);
     cy.stub(ToS, 'acceptToS').as('acceptToS');
     cy.stub(Storage, 'getCurrentUser').returns({});
-    cy.stub(Navigation, 'back').returns(true);
+    cy.stub(Navigation, 'console').returns(true);
     cy.stub(Auth, 'signOut').as('signOut');
 
     mount(<TermsOfServiceAcceptance

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -60,13 +60,13 @@ export const SignInButton = (props: SignInButtonProps) => {
     } else {
       // User is authenticated, registered and has accepted ToS: redirect to destination.
       if (isNil(redirectPath)) {
-        await Navigation.back(Storage.getCurrentUser(), history);
+        await Navigation.console(Storage.getCurrentUser(), history);
       } else {
         history.push(redirectPath);
       }
     }
   };
-   
+
   const onSuccess = async (_: OidcUser) => {
     const redirectTo = getRedirectTo();
     const shouldRedirect = shouldRedirectTo(redirectTo);

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -154,26 +154,11 @@ export const setUserRoleStatuses = (user, Storage) => {
 };
 
 export const Navigation = {
-  back: async (user, history) => {
-    const queryParams = new URLSearchParams(window.location.search);
-    const firstConsole = headerTabsConfig.find(config => config.isRendered(user));
-    const page =
-      queryParams.get('redirectTo') ? queryParams.get('redirectTo')
-        : firstConsole ? firstConsole.link
-          : '/';
-    if (history) {
-      history.push(page);
-    } else {
-      window.location = page;
-    }
-  },
   console: async (user, history) => {
     const queryParams = new URLSearchParams(window.location.search);
+    const redirectTo = queryParams?.get('redirectTo');
     const firstConsole = headerTabsConfig.find(config => config.isRendered(user));
-    const page =
-      queryParams.get('redirectTo') ? queryParams.get('redirectTo')
-        : firstConsole ? firstConsole.link
-          : '/';
+    const page = redirectTo || (firstConsole ? firstConsole.link : '/');
     if (history) {
       history.push(page);
     } else {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -161,7 +161,11 @@ export const Navigation = {
       queryParams.get('redirectTo') ? queryParams.get('redirectTo')
         : firstConsole ? firstConsole.link
           : '/';
-    history.push(page);
+    if (history) {
+      history.push(page);
+    } else {
+      window.location = page;
+    }
   },
   console: async (user, history) => {
     const queryParams = new URLSearchParams(window.location.search);
@@ -170,7 +174,11 @@ export const Navigation = {
       queryParams.get('redirectTo') ? queryParams.get('redirectTo')
         : firstConsole ? firstConsole.link
           : '/';
-    history.push(page);
+    if (history) {
+      history.push(page);
+    } else {
+      window.location = page;
+    }
   }
 };
 

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -154,6 +154,16 @@ export const setUserRoleStatuses = (user, Storage) => {
 };
 
 export const Navigation = {
+  /**
+   * This function is used to redirect the user to one of the following locations in order of priority:
+   * - The redirectTo query parameter in the URL if it exists
+   * - The first console tab that is rendered for the user if it exists
+   * - The root path ("/") if no redirectTo or console tab is available
+   *
+   * @param user The user object to determine which console tabs are available
+   * @param history The history object to use for navigation (optional)
+   * @returns {Promise<void>}
+   */
   console: async (user, history) => {
     const queryParams = new URLSearchParams(window.location.search);
     const redirectTo = queryParams?.get('redirectTo');

--- a/src/pages/BackgroundSignIn.jsx
+++ b/src/pages/BackgroundSignIn.jsx
@@ -25,7 +25,7 @@ export default function BackgroundSignIn(props) {
     };
 
     const redirect = (user) => {
-      Navigation.back(user, history);
+      Navigation.console(user, history);
       if (onSignIn)
         onSignIn();
     };


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1912

### Summary
There are cases where there is no `history` to push onto when calling the `Navigation` functions. In that case, navigate directly to the calculated page instead of relying on `history.push`. Additionally, the `back` and `console` functions were exactly the same so I've consolidated them both into `console`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
