### PR TITLE
DT-1953: Update to the non-deprecated API call

### DIFF
--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -145,7 +145,7 @@ export const User = {
 
 
   getUserRelevantDatasets: async (): Promise<Dataset[]> => {
-    const url = `${await getApiUrl()}/api/user/me/dac/datasets`;
+    const url = `${await getApiUrl()}/api/user/me/dac/datasets/v2`;
     const res = await axios.get(url, Config.authOpts());
     return res.data;
   },


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1953

### Summary
This PR updates the UI to use the preferred API. The one it is using now was deprecated with https://github.com/DataBiosphere/consent/pull/1909

Testing locally, the DAC Chair and Member console pages load identically using the newer API.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
