### PR TITLE
[DT-1915] Better UX for conflicts in voting.

### DIFF
--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -119,7 +119,7 @@ export default function CollectionSubmitVoteBox(props) {
       Notifications.showSuccess({text: 'Successfully updated vote'});
     } catch (error) {
       if (error && error.status === 409) {
-        Notifications.showError({text: error.response.data.message + ' Chair vote not submitted, updating chair votes'});
+        Notifications.showError({text: error.response.data.message + ' Chair vote not submitted, updating chair votes.'});
         reloadFn();
       } else {
         Notifications.showError({text: 'Error: Failed to update vote'});

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -119,7 +119,8 @@ export default function CollectionSubmitVoteBox(props) {
       Notifications.showSuccess({text: 'Successfully updated vote'});
     } catch (error) {
       if (error && error.status === 409) {
-        Notifications.showError({text: error.response.data.message + ' Chair vote not submitted, updating vote display.'});
+        const voteText = isChair ? 'Chair vote' : 'Vote'
+        Notifications.showError({text: `${error.response.data.message} ${voteText} not submitted, updating vote display.`});
         reloadFn();
       } else {
         Notifications.showError({text: 'Error: Failed to update vote'});
@@ -134,7 +135,7 @@ export default function CollectionSubmitVoteBox(props) {
       Notifications.showSuccess({text: 'Successfully updated vote rationale'});
     } catch (error) {
       if (error && error.status === 409) {
-        Notifications.showError({text: error.response.data.message + '  Rationale not submitted, updating vote display.'});
+        Notifications.showError({text: `${error.response.data.message} Rationale not submitted, updating vote display.`});
         reloadFn();
       } else {
         Notifications.showError(

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -119,7 +119,7 @@ export default function CollectionSubmitVoteBox(props) {
       Notifications.showSuccess({text: 'Successfully updated vote'});
     } catch (error) {
       if (error && error.status === 409) {
-        Notifications.showError({text: error.response.data.message + ' Chair vote not submitted, updating chair votes.'});
+        Notifications.showError({text: error.response.data.message + ' Chair vote not submitted, updating vote display.'});
         reloadFn();
       } else {
         Notifications.showError({text: 'Error: Failed to update vote'});

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.jsx
@@ -75,7 +75,7 @@ export default function CollectionSubmitVoteBox(props) {
   const [rationale, setRationale] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [isVotingDisabled, setIsVotingDisabled] = useState(false);
-  const {question, votes, isFinal, isApprovalDisabled, isLoading, adminPage, bucketKey, updateFinalVote} = props;
+  const {question, votes, isFinal, isApprovalDisabled, isLoading, adminPage, bucketKey, updateFinalVote, reloadFn} = props;
 
   useEffect(() => {
     setIsVotingDisabled( props.isDisabled || (isFinal && submitted) || adminPage);
@@ -117,8 +117,13 @@ export default function CollectionSubmitVoteBox(props) {
         setVote(newVote);
       }
       Notifications.showSuccess({text: 'Successfully updated vote'});
-    } catch (_error) {
-      Notifications.showError({text: 'Error: Failed to update vote'});
+    } catch (error) {
+      if (error && error.status === 409) {
+        Notifications.showError({text: error.response.data.message + ' Chair vote not submitted, updating chair votes'});
+        reloadFn();
+      } else {
+        Notifications.showError({text: 'Error: Failed to update vote'});
+      }
     }
   };
 
@@ -127,8 +132,14 @@ export default function CollectionSubmitVoteBox(props) {
       const voteIds = map(v => v.voteId)(votes);
       await Votes.updateRationaleByIds(voteIds, rationale);
       Notifications.showSuccess({text: 'Successfully updated vote rationale'});
-    } catch (_error) {
-      Notifications.showError({text: 'Error: Failed to update vote rationale'});
+    } catch (error) {
+      if (error && error.status === 409) {
+        Notifications.showError({text: error.response.data.message + '  Rationale not submitted, updating vote display.'});
+        reloadFn();
+      } else {
+        Notifications.showError(
+            {text: 'Error: Failed to update vote rationale'});
+      }
     }
   };
 

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.jsx
@@ -69,6 +69,7 @@ export default function MultiDatasetVoteSlab(props) {
     readOnly,
     adminPage,
     updateFinalVote,
+    reloadFn
   } = props;
   const { algorithmResult, key } = bucket;
 
@@ -111,6 +112,7 @@ export default function MultiDatasetVoteSlab(props) {
             adminPage={adminPage}
             bucketKey={key}
             updateFinalVote={updateFinalVote}
+            reloadFn={reloadFn}
           />
         </div>
       </div>

--- a/src/libs/ajax/Votes.js
+++ b/src/libs/ajax/Votes.js
@@ -1,6 +1,5 @@
-import { mergeAll } from 'lodash/fp';
 import { Config } from '../config';
-import { getApiUrl, fetchOk } from '../ajax';
+import { getApiUrl } from '../ajax';
 import axios from 'axios';
 
 

--- a/src/libs/ajax/Votes.js
+++ b/src/libs/ajax/Votes.js
@@ -1,6 +1,7 @@
 import { mergeAll } from 'lodash/fp';
 import { Config } from '../config';
 import { getApiUrl, fetchOk } from '../ajax';
+import axios from 'axios';
 
 
 export const Votes = {
@@ -11,8 +12,8 @@ export const Votes = {
     voteUpdate.voteIds = voteIds;
 
     const url = `${await getApiUrl()}/api/votes`;
-    const res = await fetchOk(url, mergeAll([Config.authOpts(), Config.jsonBody(voteUpdate), { method: 'PUT' }]));
-    return await res.json();
+    const res = await axios.put(url, voteUpdate, Config.authOpts());
+    return res.data;
   },
 
   updateRationaleByIds: async (voteIds, rationale) => {
@@ -21,7 +22,7 @@ export const Votes = {
     rationaleUpdate.voteIds = voteIds;
 
     const url = `${await getApiUrl()}/api/votes/rationale`;
-    const res = await fetchOk(url, mergeAll([Config.authOpts(), Config.jsonBody(rationaleUpdate), { method: 'PUT' }]));
-    return await res.json();
+    const res = await axios.put(url, rationaleUpdate, Config.authOpts());
+    return res.data;
   }
 };

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -219,6 +219,7 @@ export default function DarCollectionReview(props) {
           adminPage={adminPage}
           readOnly={readOnly}
           updateFinalVote={updateFinalVoteFn}
+          reloadFn={init}
         />}
       </div>
     </div>

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
@@ -37,7 +37,7 @@ export default function MultiDatasetVotingTab(props) {
   const [rpBucket, setRpBucket] = useState({});
   const [dataBuckets, setDataBuckets] = useState([]);
   const [dacDatasetIds, setDacDatasetIds] = useState([]);
-  const {darInfo, buckets, collection, isChair, isLoading, readOnly, adminPage, updateFinalVote} = props;
+  const {darInfo, buckets, collection, isChair, isLoading, readOnly, adminPage, updateFinalVote, reloadFn} = props;
   const missingLibraryCardMessage = 'The Researcher must have a Library Card before data access can be granted.\n' +
     (!adminPage ? 'You can still deny this request and/or vote on the Structured Research Purpose.' : '');
 
@@ -72,6 +72,7 @@ export default function MultiDatasetVotingTab(props) {
         adminPage={adminPage}
         updateFinalVote={updateFinalVote}
         isLoading={isLoading}
+        reloadFn={reloadFn}
       />
     ));
   };


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1915](https://broadworkbench.atlassian.net/browse/DT-1915)

### Summary

When two chair people are voting on the data access request or progress report, the experience, it can lead to a poor user experience because when one user votes, the page of the other user isn't updated.

To mitigate this poor experience, when the second user votes - a conflict error will now be thrown by the backend indicating that the election is closed.  This specific error type then causes the UI to refresh the loaded data on the page so that the user can see that the vote was already recorded.

BEFORE:

<img width="326" height="112" alt="image" src="https://github.com/user-attachments/assets/588a88b7-8a17-447e-9796-327a4259c063" />


AFTER:

<img width="830" height="126" alt="image" src="https://github.com/user-attachments/assets/7a6d9a67-b3df-46a5-87b1-1a84929ea972" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
