### PR TITLE
[DT-1885] Disable submit while submitting, route user to profile page on success.

### DIFF
--- a/src/pages/user_profile/RequestForm.jsx
+++ b/src/pages/user_profile/RequestForm.jsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import {useState} from 'react';
+import React, {useState} from 'react';
 import {Support} from '../../libs/ajax/Support';
 import {Notifications} from '../../libs/utils';
 import {isNil} from 'lodash';
@@ -40,6 +39,7 @@ export default function RequestForm(props) {
   };
 
   const [hasSupportRequests, setHasSupportRequests] = useState(hasSupportRequestsCond);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [supportRequests, setSupportRequests] = useState(supportRequestsCond);
 
   const goToPrevPage = async (event) => {
@@ -99,18 +99,21 @@ export default function RequestForm(props) {
         ticketInfo.attachmentToken,
         'User Profile Page'
       );
-
-      const response = await Support.createSupportRequest(ticket);
-      if (response.status === 201) {
-        Notifications.showSuccess(
-          {text: 'Sent Requests Successfully', layout: 'topRight', timeout: 1500}
-        );
-      } else {
-        Notifications.showError({
-          text: `ERROR ${response.status} : Unable To Send Requests`,
-          layout: 'topRight',
-        });
-      }
+      try {
+        setIsSubmitting(true);
+        await Support.createSupportRequest(ticket);
+          Notifications.showSuccess(
+              {text: 'Sent Requests Successfully', layout: 'topRight', timeout: 1500}
+          );
+        setIsSubmitting(false);
+        await props.history.push('/profile');
+      } catch (error){
+          Notifications.showError({
+            text: `ERROR ${error.status} : Unable To Send Requests`,
+            layout: 'topRight',
+          });
+          setIsSubmitting(false);
+        }
     };
 
   return <div
@@ -174,7 +177,7 @@ export default function RequestForm(props) {
       style={{
         marginTop: '50px',
       }}
-      disabled={!hasSupportRequests}
+      disabled={!hasSupportRequests || isSubmitting}
       data-cy={'submitButton'}>
       Submit
     </button>


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1885](https://broadworkbench.atlassian.net/browse/DT-1885)

### Summary

BEFORE:


https://github.com/user-attachments/assets/714e3152-38bb-4b78-8591-8a10f175d5e0



AFTER:

https://github.com/user-attachments/assets/66e78fe2-d17b-4ee4-abbe-f412dec44cc7



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
