### PR TITLE
[DT-1114] Moves storage from session to local.

### DIFF
--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -277,7 +277,7 @@ describe('ProgressReportApplication - Component Tests', () => {
           link: ''
         }
       ]
-    };
+    } as unknown as CombinedDataAccessRequest;
 
     mountComponent(darWithPublications, true);
 
@@ -305,7 +305,7 @@ describe('ProgressReportApplication - Component Tests', () => {
           link: ''
         }
       ]
-    };
+    } as unknown as CombinedDataAccessRequest;
 
     mountComponent(darWithPublications, true);
 
@@ -357,7 +357,7 @@ describe('ProgressReportApplication - Component Tests', () => {
           pubmed_id: ''
         }
       ]
-    };
+    } as unknown as CombinedDataAccessRequest;
 
     mountComponent(darWithPresentations, true);
 

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -20,7 +20,7 @@ describe('ProgressReportApplication - Component Tests', () => {
     // Mock Storage methods that might be used
     cy.window().then((win) => {
       win.localStorage.clear();
-      win.sessionStorage.clear();
+      win.localStorage.clear();
     });
 
     cy.stub(Storage, 'getCurrentUser').returns(researcher);

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -11,7 +11,7 @@ const ENV = 'env';
 
 export const Storage = {
   clearStorage: () => {
-    sessionStorage.clear();
+    localStorage.clear();
   },
 
   /**
@@ -19,35 +19,35 @@ export const Storage = {
    * @param data
    */
   setCurrentUser: data => {
-    sessionStorage.setItem(CurrentUser, JSON.stringify(data));
+    localStorage.setItem(CurrentUser, JSON.stringify(data));
   },
 
   getCurrentUser: () => {
-    return sessionStorage.getItem(CurrentUser) ? JSON.parse(sessionStorage.getItem(CurrentUser)) : null;
+    return localStorage.getItem(CurrentUser) ? JSON.parse(localStorage.getItem(CurrentUser)) : null;
   },
 
   getCurrentUserSettings: (key) => {
     const id = Storage.getCurrentUser()?.userId || '';
-    const userSettings = JSON.parse(sessionStorage.getItem(UserSettings)) || {};
+    const userSettings = JSON.parse(localStorage.getItem(UserSettings)) || {};
     return get([id, key], userSettings);
   },
 
   getAnonymousId: () => {
-    return sessionStorage.getItem(anonymousId) ? sessionStorage.getItem(anonymousId) : null;
+    return localStorage.getItem(anonymousId) ? localStorage.getItem(anonymousId) : null;
   },
 
   setAnonymousId: (id = uuid()) => {
-    return sessionStorage.setItem(anonymousId, id);
+    return localStorage.setItem(anonymousId, id);
   },
 
   setCurrentUserSettings: (key, value) => {
     const id = Storage.getCurrentUser()?.userId || '';
-    const userSettings = JSON.parse(sessionStorage.getItem(UserSettings)) || {};
+    const userSettings = JSON.parse(localStorage.getItem(UserSettings)) || {};
     if (!userSettings[id]) {
       userSettings[id] = {};
     }
     userSettings[id][key] = value;
-    sessionStorage.setItem(UserSettings, JSON.stringify(userSettings));
+    localStorage.setItem(UserSettings, JSON.stringify(userSettings));
   },
 
   /**
@@ -55,38 +55,38 @@ export const Storage = {
    * @param oidcUser
    */
   setOidcUser: oidcUser => {
-    sessionStorage.setItem(OidcUser, JSON.stringify(oidcUser));
+    localStorage.setItem(OidcUser, JSON.stringify(oidcUser));
   },
 
   getOidcUser: () => {
-    return sessionStorage.getItem(OidcUser) ? JSON.parse(sessionStorage.getItem(OidcUser)) : null;
+    return localStorage.getItem(OidcUser) ? JSON.parse(localStorage.getItem(OidcUser)) : null;
   },
 
   userIsLogged: () => {
-    return sessionStorage.getItem(UserIsLogged) === 'true';
+    return localStorage.getItem(UserIsLogged) === 'true';
   },
 
   setUserIsLogged: value => {
-    sessionStorage.setItem(UserIsLogged, value);
+    localStorage.setItem(UserIsLogged, value);
   },
 
   setData: (key, value) => {
-    sessionStorage.setItem(key, JSON.stringify(value));
+    localStorage.setItem(key, JSON.stringify(value));
   },
 
   getData: key => {
-    return sessionStorage.getItem(key) !== null ? JSON.parse(sessionStorage.getItem(key)) : null;
+    return localStorage.getItem(key) !== null ? JSON.parse(localStorage.getItem(key)) : null;
   },
 
   removeData: key => {
-    sessionStorage.removeItem(key);
+    localStorage.removeItem(key);
   },
 
   setEnv: (value) => {
-    sessionStorage.setItem(ENV, value);
+    localStorage.setItem(ENV, value);
   },
 
   getEnv: () => {
-    return sessionStorage.getItem(ENV);
+    return localStorage.getItem(ENV);
   },
 };


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1114](https://broadworkbench.atlassian.net/browse/DT-1114)

### Summary

DUOS' OIDC broker is already writing to local storage.  This change moves DUOS's use of storage from session storage to local storage.   This allows for DUOS to open in new tabs without requiring users to log in a second time.
When a user logs out in one tab, the user will effectively be logged out of all tabs however other tabs will not automatically return to the login screen until an action is taken in them.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
