### PR TITLE
[DT-1954] Load the correct DAR as the base DAR.

### DIFF
--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -265,11 +265,8 @@ const DataAccessRequestApplication = (props) => {
       setReverseOrderedDARs(
           [...darMap.values()].sort((a, b) => b.id - a.id)
       );
-      const darReferenceId = head(keys(dars));
-      // TODO - future improvement
-      //  in theory, we should be able to replace this call with the info returned from the collection
-      // form data = the first DAR's data
-      formData = await DAR.getPartialDarRequest(darReferenceId);
+      // form data = the "root" DAR's data
+      formData = await DAR.getPartialDarRequest(reverseOrderedDARs[reverseOrderedDARs.length - 1].referenceId);
 
       // This is a collection, so we need to get the datasets and datasetIds from the collection
       formData.datasetIds = map(ds => get('datasetId')(ds))(datasets);

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -28,7 +28,7 @@ import {ConditionalAccordion} from 'src/components/forms/ConditionalAccordion.js
 import {ProgressReportApplication} from 'src/pages/dar_application/ProgressReportApplication';
 import {ScrollableTabs} from 'src/pages/dar_application/ScrollableTabs';
 import {validateDARFormData, validationFailed} from 'src/utils/darFormUtils.js';
-import {assign, cloneDeep, head, isArray, isEmpty, isNil, isString, keys, merge, set} from 'lodash';
+import {assign, cloneDeep, isArray, isEmpty, isNil, isString, merge, set} from 'lodash';
 import {Countries} from 'src/libs/ajax/Countries.js';
 import PropTypes from 'prop-types';
 

--- a/src/pages/dar_application/DataUseAcknowlegements.tsx
+++ b/src/pages/dar_application/DataUseAcknowlegements.tsx
@@ -3,7 +3,7 @@ import {FormField, FormFieldTitle, FormFieldTypes} from 'src/components/forms/fo
 import React from 'react';
 import {Dataset} from 'src/types/model';
 import {DarErrors, ValidationError} from 'src/pages/dar_application/FormValidationState';
-import { FormState, ValidFormState } from 'src/pages/progress_reports/ProgressReportFormState';
+import {FormState, ValidFormState} from 'src/pages/progress_reports/ProgressReportFormState';
 
 type DataUseAcknowledgementsProps = {
     title: string;

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -4,8 +4,7 @@ import {History, Location} from 'history';
 import {
     CLOSEOUT_KEYS,
     DMI_INCIDENT_KEYS,
-    FormState,
-    ValidFormState
+    FormState
 } from 'src/pages/progress_reports/ProgressReportFormState';
 import SummarySection from 'src/pages/progress_reports/SummarySection';
 import SelectableDatasets from 'src/pages/dar_application/SelectableDatasets';
@@ -205,8 +204,6 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
       onSelectedDatasetChange(approvedDatasets);
     }, [datasets]);
 
-    // @ts-ignore
-    // @ts-ignore
     return (
         <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
             <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,7 +1,12 @@
 import React, {useState, useEffect} from 'react';
 import {CombinedDataAccessRequest, Dataset, DuosUser, SimplifiedDuosUser} from 'src/types/model';
 import {History, Location} from 'history';
-import {CLOSEOUT_KEYS, DMI_INCIDENT_KEYS, FormState} from 'src/pages/progress_reports/ProgressReportFormState';
+import {
+    CLOSEOUT_KEYS,
+    DMI_INCIDENT_KEYS,
+    FormState,
+    ValidFormState
+} from 'src/pages/progress_reports/ProgressReportFormState';
 import SummarySection from 'src/pages/progress_reports/SummarySection';
 import SelectableDatasets from 'src/pages/dar_application/SelectableDatasets';
 import CollaboratorChanges from 'src/pages/progress_reports/CollaboratorChanges';
@@ -200,6 +205,8 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
       onSelectedDatasetChange(approvedDatasets);
     }, [datasets]);
 
+    // @ts-ignore
+    // @ts-ignore
     return (
         <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
             <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>

--- a/src/pages/progress_reports/ProgressReportFormState.tsx
+++ b/src/pages/progress_reports/ProgressReportFormState.tsx
@@ -1,12 +1,11 @@
-import { PublicationOrPresentation } from 'src/components/publications_list/PublicationOrPresentation';
-import {Collaborator, Dataset, SimplifiedDuosUser} from 'src/types/model';
+import {Collaborator, Dataset, Presentation, Publication, SimplifiedDuosUser} from 'src/types/model';
+
+type FormStateKeys = keyof FormState;
 
 export type ValidFormState = {
-  [K in keyof FormState]: {
-    key: K;
-    value: FormState[K];
-  }
-}[keyof FormState];
+    key: FormStateKeys,
+    value: FormState[keyof FormState]
+}
 
 export interface FormState {
     progressReportSummary: string;
@@ -14,9 +13,9 @@ export interface FormState {
     intellectualPropertySummary: string;
     datasetIds: number[];
     publicationsYesNo: boolean;
-    publications: PublicationOrPresentation[];
+    publications: Publication[];
     presentationsYesNo: boolean;
-    presentations: PublicationOrPresentation[];
+    presentations: Presentation[];
     dsAcknowledgement: boolean;
     gsoAcknowledgement: boolean;
     pubAcknowledgement: boolean;


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1954](https://broadworkbench.atlassian.net/browse/DT-1954)

### Summary

DataAccessRequestApplication was not deterministically loading the "root" DAR's data as the original DAR.  This bug manifests because the order in the collection isn't guaranteed.  We're now loading the DAR from the earliest DAR in the collection (e.g. the root DAR).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
