### PR TITLE
[DT-1954] Use Object instead of React State variable.

### DIFF
--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -259,14 +259,14 @@ const DataAccessRequestApplication = (props) => {
         dar.data.elections = dar.elections;
         dar.data.datasetIds = dar.datasetIds;
       })
-
       // TS thinks that collection.dars is an object, but it is a map
       const darMap = new Map(Object.entries(dars));
       setReverseOrderedDARs(
           [...darMap.values()].sort((a, b) => b.id - a.id)
       );
       // form data = the "root" DAR's data
-      formData = await DAR.getPartialDarRequest(reverseOrderedDARs[reverseOrderedDARs.length - 1].referenceId);
+      const darId = Object.values(dars).sort((a,b) => a.id - b.id)[0].referenceId
+      formData = await DAR.getPartialDarRequest(darId);
 
       // This is a collection, so we need to get the datasets and datasetIds from the collection
       formData.datasetIds = map(ds => get('datasetId')(ds))(datasets);


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1954](https://broadworkbench.atlassian.net/browse/DT-1954)

### Summary

The first implementation of this fix relied on a react state-hook managed value.  This value is being mutated in this same function and can create a loop with unset and then set values causing issues.   This alternate approach relies on the set of DARs already in the value and sorts them ascending so that the first entry is the oldest DAR in the collection and then uses that to load the correct DAR.

Before:
Intermittent endless spinner when loading the "Full DAR" view in reviews.
<img width="706" height="776" alt="image" src="https://github.com/user-attachments/assets/06a01862-f6cc-4801-b228-07411d45ce4c" />


After:

Properly loaded DAR, consistently.
<img width="1017" height="704" alt="image" src="https://github.com/user-attachments/assets/7c152e63-5c98-4529-8a1a-e71225c72f6e" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
