### PR TITLE
[DT-1930] Store approverStatus as true/false as per API in consent.

### DIFF
--- a/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
+++ b/cypress/component/CollaboratorList/collaborator_add_edit.spec.tsx
@@ -1,148 +1,221 @@
 import React from 'react';
-import { mount } from 'cypress/react';
+import {mount} from 'cypress/react';
 import CollaboratorAddEdit from 'src/components/collaborator_list/CollaboratorAddEdit';
-import { Collaborator } from 'src/types/model';
+import {Collaborator} from 'src/types/model';
 import {Countries} from 'src/libs/ajax/Countries';
 
 describe('CollaboratorAddEdit - Component Tests', () => {
-  const mockCollaborator: Collaborator = {
-    name: 'John Doe',
-    title: 'Researcher',
-    email: 'john.doe@example.com',
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
-    eraCommonsId: 'jdoe123',
-    countryOfOperation: 'United States of America (the)',
-    approverStatus: false
-  };
+    const mockCollaborator: Collaborator = {
+        name: 'John Doe',
+        title: 'Researcher',
+        email: 'john.doe@example.com',
+        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        eraCommonsId: 'jdoe123',
+        countryOfOperation: 'United States of America (the)',
+        approverStatus: false
+    };
 
-  const mockCollaborators: Collaborator[] = [mockCollaborator];
+    const mockCollaborators: Collaborator[] = [mockCollaborator];
 
-  const defaultProps = {
-    id: -1,
-    collaborator: {countryOfOperation: Countries.DEFAULT_COUNTRY} as Collaborator,
-    collaboratorText: 'Collaborator',
-    collaborators: mockCollaborators,
-    closeAction: () => { },
-    countriesOfOperation:['France', 'Canada', 'United States of America (the)'],
-    onCollaboratorChange: () => { }
-  };
+    const defaultProps = {
+        id: -1,
+        collaborator: {countryOfOperation: Countries.DEFAULT_COUNTRY} as Collaborator,
+        collaboratorText: 'Collaborator',
+        collaborators: mockCollaborators,
+        closeAction: () => {
+        },
+        countriesOfOperation: ['France', 'Canada', 'United States of America (the)'],
+        onCollaboratorChange: () => {
+        },
+        deleteAction: () => {
+        }
+    };
 
-  it('renders the component correctly for adding a new collaborator', () => {
-    mount(<CollaboratorAddEdit {...defaultProps} />);
+    const approverProps = {
+        ...defaultProps,
+        showApproverStatus: true
+    };
 
-    cy.contains('New Collaborator Information').should('be.visible');
-    cy.contains('Collaborator Name').should('be.visible');
-    cy.contains('Collaborator Title').should('be.visible');
-    cy.contains('Collaborator Email').should('be.visible');
-    cy.contains('Add').should('be.visible');
-    cy.contains('Cancel').should('be.visible');
-  });
+    it('renders the component correctly for adding a new collaborator', () => {
+        mount(<CollaboratorAddEdit {...defaultProps} />);
 
-  it('renders the component correctly for editing an existing collaborator', () => {
-    mount(<CollaboratorAddEdit
-      {...defaultProps}
-      id={0}
-      collaborator={mockCollaborator}
-    />);
+        cy.contains('New Collaborator Information').should('be.visible');
+        cy.contains('Collaborator Name').should('be.visible');
+        cy.contains('Collaborator Title').should('be.visible');
+        cy.contains('Collaborator Email').should('be.visible');
+        cy.contains('Add').should('be.visible');
+        cy.contains('Cancel').should('be.visible');
+    });
 
-    cy.contains(`Edit ${mockCollaborator.name} Information`).should('be.visible');
-    cy.get('#name').should('have.value', mockCollaborator.name);
-    cy.get('#title').should('have.value', mockCollaborator.title);
-    cy.get('#email').should('have.value', mockCollaborator.email);
-    cy.contains('Save').should('be.visible');
-  });
+    it('renders the component correctly for editing an existing collaborator', () => {
+        mount(<CollaboratorAddEdit
+            {...defaultProps}
+            id={0}
+            collaborator={mockCollaborator}
+        />);
 
-  it('calls closeAction when Cancel button is clicked', () => {
-    const closeAction = cy.stub().as('closeAction');
-    mount(<CollaboratorAddEdit {...defaultProps} closeAction={closeAction} />);
+        cy.contains(`Edit ${mockCollaborator.name} Information`).should('be.visible');
+        cy.get('#name').should('have.value', mockCollaborator.name);
+        cy.get('#title').should('have.value', mockCollaborator.title);
+        cy.get('#email').should('have.value', mockCollaborator.email);
+        cy.contains('Save').should('be.visible');
+    });
 
-    cy.contains('Cancel').click();
-    cy.get('@closeAction').should('have.been.calledOnce');
-  });
+    it('calls closeAction when Cancel button is clicked', () => {
+        const closeAction = cy.stub().as('closeAction');
+        mount(<CollaboratorAddEdit {...defaultProps} closeAction={closeAction}/>);
 
-  it('calls onCollaboratorChange when Save button is clicked for existing collaborator', () => {
-    const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
-    mount(<CollaboratorAddEdit
-      {...defaultProps}
-      id={0}
-      collaborator={mockCollaborator}
-      onCollaboratorChange={onCollaboratorChange}
-    />);
+        cy.contains('Cancel').click();
+        cy.get('@closeAction').should('have.been.calledOnce');
+    });
 
-    cy.get('#name').clear();
-    cy.get('#name').type('Jane Doe');
-    cy.get('#eraCommonsId').clear();
-    cy.get('#eraCommonsId').type('janedoe456');
-    cy.get('#title').clear();
-    cy.get('#title').type('Senior Researcher');
-    cy.get('#email').clear();
-    cy.get('#email').type('janedoe@example.com')
+    it('calls onCollaboratorChange when Save button is clicked for existing collaborator', () => {
+        const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+        mount(<CollaboratorAddEdit
+            {...defaultProps}
+            id={0}
+            collaborator={mockCollaborator}
+            onCollaboratorChange={onCollaboratorChange}
+        />);
 
-    cy.contains('Save').click();
+        cy.get('#name').clear();
+        cy.get('#name').type('Jane Doe');
+        cy.get('#eraCommonsId').clear();
+        cy.get('#eraCommonsId').type('janedoe456');
+        cy.get('#title').clear();
+        cy.get('#title').type('Senior Researcher');
+        cy.get('#email').clear();
+        cy.get('#email').type('janedoe@example.com')
 
-    cy.get('@onCollaboratorChange').should('have.been.calledOnce');
-  });
+        cy.contains('Save').click();
 
-  it('calls both onCollaboratorChange and closeAction when Add button is clicked', () => {
-    const closeAction = cy.stub().as('closeAction');
-    const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
+        cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+    });
 
-    mount(<CollaboratorAddEdit
-      {...defaultProps}
-      closeAction={closeAction}
-      onCollaboratorChange={onCollaboratorChange}
-    />);
+    it('calls both onCollaboratorChange and closeAction when Add button is clicked', () => {
+        const closeAction = cy.stub().as('closeAction');
+        const onCollaboratorChange = cy.stub().as('onCollaboratorChange');
 
-    cy.get('#name').type('Test Name');
-    cy.get('#eraCommonsId').type('example123');
-    cy.get('#title').type('Test Title');
-    cy.get('#email').type('test@example.com');
+        mount(<CollaboratorAddEdit
+            {...defaultProps}
+            closeAction={closeAction}
+            onCollaboratorChange={onCollaboratorChange}
+        />);
 
-    cy.contains('Add').click();
+        cy.get('#name').type('Test Name');
+        cy.get('#eraCommonsId').type('example123');
+        cy.get('#title').type('Test Title');
+        cy.get('#email').type('test@example.com');
 
-    cy.get('@onCollaboratorChange').should('have.been.calledOnce');
-    cy.get('@closeAction').should('have.been.calledOnce');
-  });
+        cy.contains('Add').click();
 
-  it('updates form fields when typing', () => {
-    mount(<CollaboratorAddEdit {...defaultProps} />);
+        cy.get('@onCollaboratorChange').should('have.been.calledOnce');
+        cy.get('@closeAction').should('have.been.calledOnce');
+    });
 
-    const name = 'Test Name';
-    cy.get('#name').type(name);
-    cy.get('#name').should('have.value', name);
+    it('updates form fields when typing', () => {
+        mount(<CollaboratorAddEdit {...defaultProps} />);
 
-    const title = 'Test Title';
-    cy.get('#title').type(title);
-    cy.get('#title').should('have.value', title);
+        const name = 'Test Name';
+        cy.get('#name').type(name);
+        cy.get('#name').should('have.value', name);
 
-    const email = 'test@example.com';
-    cy.get('#email').type(email);
-    cy.get('#email').should('have.value', email);
-  });
+        const title = 'Test Title';
+        cy.get('#title').type(title);
+        cy.get('#title').should('have.value', title);
 
-  it('shows validation error for empty required fields', () => {
-    mount(<CollaboratorAddEdit {...defaultProps} />);
+        const email = 'test@example.com';
+        cy.get('#email').type(email);
+        cy.get('#email').should('have.value', email);
+    });
 
-    cy.get('#name').focus();
-    cy.get('#name').blur();
+    it('shows validation error for empty required fields', () => {
+        mount(<CollaboratorAddEdit {...defaultProps} />);
 
-    cy.get('#title').focus();
-    cy.get('#title').blur();
+        cy.get('#name').focus();
+        cy.get('#name').blur();
 
-    cy.get('#email').focus();
-    cy.get('#email').blur();
+        cy.get('#title').focus();
+        cy.get('#title').blur();
 
-    cy.get('#name').parent().find('.error-message').should('be.visible');
-    cy.get('#title').parent().find('.error-message').should('be.visible');
-    cy.get('#email').parent().find('.error-message').should('be.visible');
-  });
+        cy.get('#email').focus();
+        cy.get('#email').blur();
 
-  it('shows validation error for invalid email format', () => {
-    mount(<CollaboratorAddEdit {...defaultProps} />);
+        cy.get('#name').parent().find('.error-message').should('be.visible');
+        cy.get('#title').parent().find('.error-message').should('be.visible');
+        cy.get('#email').parent().find('.error-message').should('be.visible');
+    });
 
-    cy.get('#email').type('invalid');
-    cy.get('#email').blur();
+    it('shows validation error for invalid email format', () => {
+        mount(<CollaboratorAddEdit {...defaultProps} />);
 
-    cy.get('#email').parent().find('.error-message').should('be.visible');
-  });
+        cy.get('#email').type('invalid');
+        cy.get('#email').blur();
+
+        cy.get('#email').parent().find('.error-message').should('be.visible');
+    });
+
+    it('shows the approver status radio button, emits true for yes', () => {
+
+        approverProps.onCollaboratorChange = cy.spy().as('onChangeSpy');
+        mount(<CollaboratorAddEdit {...approverProps} />)
+
+        cy.get('#-1_collaboratorApproval').should('be.visible');
+
+        cy.get('#name').type('Test Name');
+        cy.get('#eraCommonsId').type('example123');
+        cy.get('#title').type('Test Title');
+        cy.get('#email').type('test@example.com');
+        cy.get('#-1_collaboratorApproval_true').click();
+        cy.contains('Add').click();
+
+        cy.get('@onChangeSpy').should('be.calledWith', [{
+            'name': 'John Doe',
+            'title': 'Researcher',
+            'email': 'john.doe@example.com',
+            'uuid': '123e4567-e89b-12d3-a456-426614174000',
+            'eraCommonsId': 'jdoe123',
+            'countryOfOperation': 'United States of America (the)',
+            'approverStatus': false
+        }, {
+            'countryOfOperation': 'United States of America (the)',
+            'name': 'Test Name',
+            'eraCommonsId': 'example123',
+            'title': 'Test Title',
+            'email': 'test@example.com',
+            'approverStatus': 'true'
+        }]);
+    });
+
+    it('shows the approver status radio button, emits false for no', () => {
+
+        approverProps.onCollaboratorChange = cy.spy().as('onChangeSpy');
+        mount(<CollaboratorAddEdit {...approverProps} />)
+
+        cy.get('#-1_collaboratorApproval').should('be.visible');
+
+        cy.get('#name').type('Test Name');
+        cy.get('#eraCommonsId').type('example123');
+        cy.get('#title').type('Test Title');
+        cy.get('#email').type('test@example.com');
+        cy.get('#-1_collaboratorApproval_false').click();
+        cy.contains('Add').click();
+
+        cy.get('@onChangeSpy').should('be.calledWith', [{
+            'name': 'John Doe',
+            'title': 'Researcher',
+            'email': 'john.doe@example.com',
+            'uuid': '123e4567-e89b-12d3-a456-426614174000',
+            'eraCommonsId': 'jdoe123',
+            'countryOfOperation': 'United States of America (the)',
+            'approverStatus': false
+        }, {
+            'countryOfOperation': 'United States of America (the)',
+            'name': 'Test Name',
+            'eraCommonsId': 'example123',
+            'title': 'Test Title',
+            'email': 'test@example.com',
+            'approverStatus': 'false'
+        }]);
+    })
 });

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -238,7 +238,7 @@ beforeEach(() => {
       cy.get('#0_collaboratorEraCommonsId').type('asdgasdg');
       cy.get('#0_collaboratorTitle').type('asdgasdgasdgas');
       cy.get('#0_collaboratorEmail').type('asdgasdgasdgasdga'); // not a valid email
-      cy.get('#0_collaboratorApproval_no').click();
+      cy.get('#0_collaboratorApproval_false').click();
 
       // should remove errors, except for email
       cy.get('#0_collaboratorName').should('not.have.class', 'errored');

--- a/cypress/component/DataAccessRequest/researcher_info.spec.jsx
+++ b/cypress/component/DataAccessRequest/researcher_info.spec.jsx
@@ -145,7 +145,7 @@ describe('Researcher Info', () => {
   it('saves new collaborators properly', () => {
     mount(<WrappedResearcherInfo {...props}/>);
     addNewCollaborator('internal-lab-staff');
-    cy.get('#0_collaboratorApproval_yes').check();
+    cy.get('#0_collaboratorApproval_true').check();
     // save collaborator and switch to summary view
     cy.get('.collaborator-form-add-save-button').click();
     cy.get('#0_summary').should('exist');
@@ -158,7 +158,7 @@ describe('Researcher Info', () => {
   it('deletes saved collaborators properly', () => {
     mount(<WrappedResearcherInfo {...props}/>);
     addNewCollaborator('internal-lab-staff');
-    cy.get('#0_collaboratorApproval_yes').check();
+    cy.get('#0_collaboratorApproval_true').check();
     // save collaborator and switch to summary view
     cy.get('.collaborator-form-add-save-button').click();
     cy.get('#0_deleteMember').click();
@@ -169,7 +169,7 @@ describe('Researcher Info', () => {
   it('cancels adding new collaborators properly', () => {
     mount(<WrappedResearcherInfo {...props}/>);
     addNewCollaborator('internal-lab-staff');
-    cy.get('#0_collaboratorApproval_yes').check();
+    cy.get('#0_collaboratorApproval_true').check();
     // save collaborator and switch to summary view
     cy.get('.collaborator-form-cancel-button').click();
     cy.get('#0_summary').should('not.exist');
@@ -178,7 +178,7 @@ describe('Researcher Info', () => {
   it('updates collaborator properly', () => {
     mount(<WrappedResearcherInfo {...props}/>);
     addNewCollaborator('internal-lab-staff');
-    cy.get('#0_collaboratorApproval_yes').check();
+    cy.get('#0_collaboratorApproval_true').check();
     // save collaborator and switch to summary view
     cy.get('.collaborator-form-add-save-button').click();
     // edit and switch to form view

--- a/src/components/collaborator_list/CollaboratorAddEdit.tsx
+++ b/src/components/collaborator_list/CollaboratorAddEdit.tsx
@@ -146,7 +146,7 @@ export default function CollaboratorAddEdit(props: CollaboratorAddEditProps): Re
                         approverStatus={newCollaborator?.approverStatus}
                         readOnly={readOnly}
                         validation={validation.approverStatus}
-                        onChange={(!readOnly ? ({ key: _key, value }: { key: string; value: boolean | 'yes' | 'no' | undefined }) => {
+                        onChange={(!readOnly ? ({ key: _key, value }: { key: string; value: boolean | 'true' | 'false' | undefined }) => {
                             onChange({ key: 'approverStatus', value: String(value || '') });
                         } : null)}/>
                     )}

--- a/src/pages/dar_application/collaborator/ApproverStatus.tsx
+++ b/src/pages/dar_application/collaborator/ApproverStatus.tsx
@@ -2,7 +2,7 @@ import {FormField, FormFieldTypes, FormValidators} from 'src/components/forms/fo
 import React from 'react';
 import {ValidationError} from 'src/pages/dar_application/FormValidationState';
 
-type ApproverStatusType = boolean | 'yes' | 'no' | undefined;
+type ApproverStatusType = boolean | 'true' | 'false' |  undefined;
 
 interface ApproverStatusProps {
     readonly index: number;
@@ -14,14 +14,30 @@ interface ApproverStatusProps {
 }
 export default function ApproverStatus(props: ApproverStatusProps): React.JSX.Element {
     const {index, approverStatus, validation, onValidationChange, onChange} = props;
-    const calculateDefaultValue = () => {
-        if (approverStatus === true || approverStatus === 'yes') {
-            return 'yes';
-        }
-        if (approverStatus === false || approverStatus === 'no') {
-            return 'no';
-        }
+
+    const isYes = (approverStatus: ApproverStatusType) => {
+        return (approverStatus === true ||  approverStatus === 'true')
+    }
+
+    const isNo = (approverStatus: ApproverStatusType) => {
+        return (approverStatus === false || approverStatus === 'false')
+    }
+
+    const getApproverStatusValue = (approverStatus: ApproverStatusType) => {
+        if (isYes(approverStatus)) return 'true';
+        if (isNo(approverStatus)) return 'false';
         return undefined;
+    }
+
+    const calculateDefaultValue = () => {
+        return getApproverStatusValue(approverStatus)
+    }
+
+    const localOnChange = ({key, value}: {key: string, value: ApproverStatusType}) => {
+        const approverStatusType = getApproverStatusValue(value);
+        if (onChange) {
+            onChange({key: key, value: approverStatusType});
+        }
     }
 
     return (
@@ -35,8 +51,8 @@ export default function ApproverStatus(props: ApproverStatusProps): React.JSX.El
                 the PI designates to download data and/or share the requested data with other Internal Lab Staff
                 (ie., staff members and trainees under the direct supervision of the PI).`}
                 options={[
-                    {name: 'yes', text: 'Yes'},
-                    {name: 'no', text: 'No'}
+                    {name: 'true', text: 'Yes'},
+                    {name: 'false', text: 'No'}
                 ]}
                 disabled={props.readOnly}
                 validators={[FormValidators.REQUIRED]}
@@ -44,7 +60,7 @@ export default function ApproverStatus(props: ApproverStatusProps): React.JSX.El
                 defaultValue={calculateDefaultValue}
                 validation={validation}
                 onValidationChange={onValidationChange}
-                onChange={onChange}
+                onChange={localOnChange}
             />
             <p className='control-label rp-choice-questions' style={{fontSize: 14, marginTop: 5, marginBottom: 5}}>
                 Please note: the terms of the Library Card Agreement are applicable to the Library Card Holder as well


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1930](https://broadworkbench.atlassian.net/browse/DT-1930)

### Summary

Before this change:
UI was setting the value to yes/no, but consent requires a boolean true/false.

https://github.com/user-attachments/assets/7b1287e4-4c98-48fb-993b-b558fea9d807

After:
UI now sends true/false and true persists.

https://github.com/user-attachments/assets/b40237b0-c879-42e3-93c5-a53a1e375947


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
