### PR TITLE
DT-1995: Fix Cloud Use Statement text alignment

### DIFF
--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -300,13 +300,12 @@ export default function ResearcherInfo(props) {
               type={FormFieldTypes.RADIOGROUP}
               title='1.8 Cloud Use Statement'
               titleStyle={titleStyle}
-              description={[
-                <span key='anvil-use-description'>
-                  Will you perform all of your data storage and analysis for this project on the
-                  <a rel='noopener noreferrer' href='https://anvil.terra.bio/' target='_blank'> AnVIL</a>
-                  ?
+              description={
+                <span key='anvil-use-description' style={{display: 'flex', flexDirection: 'row', alignItems: 'baseline'}}>
+                  Will you perform all of your data storage and analysis for this project on the&nbsp;
+                  <a rel='noopener noreferrer' href='https://anvil.terra.bio/' target='_blank'> AnVIL</a>?
                 </span>
-              ]}
+              }
               options={[
                 {name: 'yes', text: 'Yes'},
                 {name: 'no', text: 'No'}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1995

### Summary
Fixes a minor alignment issue in one of the DAR Form questions.

Before:
<img width="659" height="183" alt="Screenshot 2025-07-17 at 5 05 23 PM" src="https://github.com/user-attachments/assets/76b9abc6-d708-4622-9520-46af40629d0e" />

After:
<img width="647" height="143" alt="Screenshot 2025-07-17 at 5 05 54 PM" src="https://github.com/user-attachments/assets/12bf67c3-986e-46ab-a4d7-e8fff5fa94c9" />



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
