### PR TITLE
[DT-1999] Compute logged in state from OIDC response

### DIFF
--- a/cypress/component/Auth/auth.spec.ts
+++ b/cypress/component/Auth/auth.spec.ts
@@ -38,11 +38,9 @@ describe('Auth Success', function () {
   });
 
   it('Sign Out Clears the session when called', function () {
-    Storage.setUserIsLogged(true);
     Storage.setAnonymousId(uuid());
     Storage.setData('key', 'val');
     Storage.setEnv('test');
-    cy.wrap(Storage.userIsLogged()).should('be.true');
     cy.wrap(Storage.getAnonymousId()).should('not.be.empty');
     cy.wrap(Storage.getData('key')).should('not.be.empty');
     cy.wrap(Storage.getEnv()).should('not.be.empty');

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -51,7 +51,6 @@ export const SignInButton = (props: SignInButtonProps) => {
     const {tosAccepted} = userStatus;
     if (!isEmpty(userStatus) && !tosAccepted) {
       // User has authenticated, but has not accepted ToS
-      Storage.setUserIsLogged(false);
       if (isNil(redirectPath)) {
         history.push(`/tos_acceptance`);
       } else {

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -46,19 +46,19 @@ declare global {
   interface Window {
     Appcues?: {
       /** Identifies the current user with an ID and an optional set of properties. */
-      identify: (userId: string, properties?: never) => void;
+      identify: (userId: string, properties?: unknown) => void;
       /** Notifies the SDK that the state of the application has changed. */
       page: () => void;
       /** Forces specific Appcues content to appear for the current user by passing in the ID. */
       show: (contentId: string) => void;
       /** Fire the callback function when the given event is triggered by the SDK */
-      on: ((eventName: Exclude<string, 'all'>, callbackFn: (event: never) => void | Promise<void>) => void) &
-          ((eventName: 'all', callbackFn: (eventName: string, event: never) => void | Promise<void>) => void);
+      on: ((eventName: Exclude<string, 'all'>, callbackFn: (event: unknown) => void | Promise<void>) => void) &
+          ((eventName: 'all', callbackFn: (eventName: string, event: unknown) => void | Promise<void>) => void);
       /** Clears all known information about the current user in this session */
       reset: () => void;
       /** Tracks a custom event (by name) taken by the current user. */
       track: (eventName: MetricsEventName) => void;
     };
-    forceSignIn: never;
+    forceSignIn: unknown;
   }
 }

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -16,7 +16,6 @@ export const Auth = {
     const um: UserManager = OidcBroker.getUserManager();
     // UserManager events.
     // For details of each event, see https://authts.github.io/oidc-client-ts/classes/UserManagerEvents.html
-    // eslint-disable-next-line no-unused-vars
     um.events.addUserLoaded((_: OidcUser) => {
       //TODO: DUOS-3072 Add metrics for user loaded
     });
@@ -47,19 +46,19 @@ declare global {
   interface Window {
     Appcues?: {
       /** Identifies the current user with an ID and an optional set of properties. */
-      identify: (userId: string, properties?: any) => void;
+      identify: (userId: string, properties?: never) => void;
       /** Notifies the SDK that the state of the application has changed. */
       page: () => void;
       /** Forces specific Appcues content to appear for the current user by passing in the ID. */
       show: (contentId: string) => void;
       /** Fire the callback function when the given event is triggered by the SDK */
-      on: ((eventName: Exclude<string, 'all'>, callbackFn: (event: any) => void | Promise<void>) => void) &
-          ((eventName: 'all', callbackFn: (eventName: string, event: any) => void | Promise<void>) => void);
+      on: ((eventName: Exclude<string, 'all'>, callbackFn: (event: never) => void | Promise<void>) => void) &
+          ((eventName: 'all', callbackFn: (eventName: string, event: never) => void | Promise<void>) => void);
       /** Clears all known information about the current user in this session */
       reset: () => void;
       /** Tracks a custom event (by name) taken by the current user. */
       track: (eventName: MetricsEventName) => void;
     };
-    forceSignIn: any;
+    forceSignIn: never;
   }
 }

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -34,12 +34,10 @@ export const Auth = {
       throw new Error(Auth.signInError());
     }
     Storage.setOidcUser(user);
-    Storage.setUserIsLogged(true);
     return user;
   },
   signOut: async () => {
     Storage.clearStorage();
-    Storage.setUserIsLogged(false);
     await OidcBroker.signOut();
   },
 };

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -67,10 +67,6 @@ export const Storage = {
     return oidcUser && oidcUser.expires_at > Math.floor(Date.now() / 1000);
   },
 
-  setUserIsLogged: value => {
-    localStorage.setItem(UserIsLogged, value);
-  },
-
   setData: (key, value) => {
     localStorage.setItem(key, JSON.stringify(value));
   },

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -4,7 +4,6 @@ import { v4 as uuid } from 'uuid';
 // Storage Variables
 const CurrentUser = 'CurrentUser'; // System user
 const OidcUser = 'OidcUser'; // B2C Tenant user info, including token
-const UserIsLogged = 'isLogged'; // User log status flag
 const UserSettings = 'UserSettings'; // Different user settings for saving statuses in the app
 const anonymousId = 'anonymousId';
 const ENV = 'env';

--- a/src/libs/storage.js
+++ b/src/libs/storage.js
@@ -63,7 +63,8 @@ export const Storage = {
   },
 
   userIsLogged: () => {
-    return localStorage.getItem(UserIsLogged) === 'true';
+    const oidcUser = localStorage.getItem(OidcUser) ? JSON.parse(localStorage.getItem(OidcUser)) : null;
+    return oidcUser && oidcUser.expires_at > Math.floor(Date.now() / 1000);
   },
 
   setUserIsLogged: value => {

--- a/src/pages/BackgroundSignIn.jsx
+++ b/src/pages/BackgroundSignIn.jsx
@@ -30,17 +30,12 @@ export default function BackgroundSignIn(props) {
         onSignIn();
     };
 
-    const setIsLogged = () => {
-      Storage.setUserIsLogged(true);
-    };
-
     const performLogin = () => {
       setLoading(true);
       Storage.setOidcUser({ id_token: accessToken });
       getUser().then(
         user => {
           user = Object.assign(user, setUserRoleStatuses(user, Storage));
-          setIsLogged();
           setLoading(false);
           redirect(user);
         },
@@ -57,7 +52,6 @@ export default function BackgroundSignIn(props) {
               getUser().then(
                 user => {
                   user = Object.assign(user, setUserRoleStatuses(user, Storage));
-                  setIsLogged();
                   redirect(user);
                   setLoading(false);
                 },

--- a/src/pages/TermsOfServiceAcceptance.jsx
+++ b/src/pages/TermsOfServiceAcceptance.jsx
@@ -20,7 +20,6 @@ export default function TermsOfServiceAcceptance(props) {
 
   const acceptToS = useCallback(async () => {
     await TosService.acceptTos();
-    await Storage.setUserIsLogged(true);
 
     // if there is a redirectTo, we should go to that. otherwise, just go to the appropriate
     // data library.

--- a/src/pages/TermsOfServiceAcceptance.jsx
+++ b/src/pages/TermsOfServiceAcceptance.jsx
@@ -1,8 +1,6 @@
-import React from 'react';
-import {useCallback, useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Auth} from 'src/libs/auth/auth';
 import {TosService} from 'src/libs/tosService';
-import {Storage} from 'src/libs/storage';
 import SimpleButton from 'src/components/SimpleButton';
 import {Theme} from 'src/libs/theme';
 


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-1999](https://broadworkbench.atlassian.net/browse/DT-1999)

### Summary

Examine the OidcUser `expires_at` to figure out when a user is logged out.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
