### PR TITLE
[DT-1994] Ease fixing DARs with server-side validation errors

### DIFF
--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -154,6 +154,64 @@ beforeEach(() => {
       });
     });
 
+    it('Sets isAttested to false when postDar returns 400 error', () => {
+      // Mock postDar to reject with 400 error
+      cy.stub(DAR, 'postDar').rejects({
+        response: {
+          status: 400,
+          data: {
+            code: 'VALIDATION_ERROR',
+            message: 'Bad request error message'
+          }
+        }
+      });
+
+      cy.get('#piCountryOfOperation').type('United{enter}');
+      cy.get('#signingOfficial').type('SO 2{enter}');
+      cy.get('#itDirector').type('Some IT Director');
+      cy.get('#itDirectorEmail').type('it@good.org');
+      cy.get('#anvilUse_yes').click();
+
+      cy.get('#datasetIds').type('asdf{enter}');
+
+      cy.get('#projectTitle').type('Title');
+      cy.get('#rus').type('asdf');
+      cy.get('#nonTechRus').type('asdf asdf');
+
+      cy.get('#diseases_no').click();
+      cy.get('#hmb_yes').click();
+
+      cy.get('#controls_no').click();
+      cy.get('#population_no').click();
+      cy.get('#oneGender_no').click();
+      cy.get('#forProfit_no').click();
+      cy.get('#pediatric_no').click();
+      cy.get('#vulnerablePopulation_no').click();
+      cy.get('#illegalBehavior_no').click();
+      cy.get('#sexualDiseases_no').click();
+      cy.get('#psychiatricTraits_no').click();
+      cy.get('#notHealth_no').click();
+      cy.get('#stigmatizedDiseases_no').click();
+
+      // First attest to enable submit button
+      cy.get('#btn_attest').click();
+      cy.get('#btn_openSubmitModal').should('exist');
+
+      // Now the form should be attested and addendum tab should be visible
+      cy.get('#addendum').should('exist');
+
+      // Try to submit and expect 400 error to reset attestation
+      cy.get('#btn_openSubmitModal').click();
+      cy.get('#btn_submit').click();
+
+      // After 400 error, the form should no longer be attested
+      // The addendum tab should be hidden again
+      cy.get('#addendum').should('not.exist');
+
+      // Should be able to attest again
+      cy.get('#btn_attest').should('exist').and('not.be.disabled');
+    });
+
     it('Required fields should not be errored when you open page', () => {
       cy.get('#piCountryOfOperation').should('not.have.class', 'errored');
       cy.get('#signingOfficial').should('not.have.class', 'errored');
@@ -183,7 +241,7 @@ beforeEach(() => {
     });
 
     it('Required fields get errors on submit', () => {
-      cy.get('#btn_attest').click();
+      cy.get('#btn_attest').click({ force: true });
 
       // since we're setting a default value, this should not error on initial validation
       cy.get('#piCountryOfOperation').should('not.have.class', 'errored');

--- a/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
+++ b/cypress/component/DataAccessRequest/data_access_request_validation.spec.jsx
@@ -154,7 +154,7 @@ beforeEach(() => {
       });
     });
 
-    it('Sets isAttested to false when postDar returns 400 error', () => {
+    it('Makes DAR editable POST to submit returns 400 error', () => {
       // Mock postDar to reject with 400 error
       cy.stub(DAR, 'postDar').rejects({
         response: {
@@ -173,6 +173,16 @@ beforeEach(() => {
       cy.get('#anvilUse_yes').click();
 
       cy.get('#datasetIds').type('asdf{enter}');
+
+      // Add an Internal Collaborator that lacks a Library Card,
+      // which triggers a 400 error on submit
+      cy.get('#add-internalCollaborators-btn').click();
+      cy.get('#0_collaboratorName').type('No LibraryCard');
+      cy.get('#0_collaboratorEraCommonsId').type('nolibcard123');
+      cy.get('#0_collaboratorTitle').type('Research Assistant');
+      cy.get('#0_collaboratorEmail').type('nolibrarycard@broadinstitute.org');
+      // Skip approval for now and save directly
+      cy.get('#collaborator-internalCollaborators-add-save').click();
 
       cy.get('#projectTitle').type('Title');
       cy.get('#rus').type('asdf');
@@ -200,6 +210,9 @@ beforeEach(() => {
       // Now the form should be attested and addendum tab should be visible
       cy.get('#addendum').should('exist');
 
+      // Verify that collaborator form is read-only when attested
+      cy.get('#0_summary').should('exist'); // Summary should be shown (read-only mode)
+
       // Try to submit and expect 400 error to reset attestation
       cy.get('#btn_openSubmitModal').click();
       cy.get('#btn_submit').click();
@@ -210,6 +223,10 @@ beforeEach(() => {
 
       // Should be able to attest again
       cy.get('#btn_attest').should('exist').and('not.be.disabled');
+
+      // Verify we can attest again (proving the form is editable)
+      cy.get('#btn_attest').click({ force: true });
+      cy.get('#addendum').should('exist');
     });
 
     it('Required fields should not be errored when you open page', () => {

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -426,6 +426,12 @@ const DataAccessRequestApplication = (props) => {
       }, Navigation.console(Storage.getCurrentUser(), history).response);
     } catch (error) {
       setShowDialogSubmit(false);
+
+      // Make DAR editable if we get a 400 status (Bad Request) error
+      if (error.response && error.response.status === 400) {
+        setIsAttested(false);
+      }
+
       if (error.response.data.code && error.response.data.message) {
         Notifications.showError(
             {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1994

### Summary
Previously, after submitting a DAR that had a validation problem not caught by the frontend, it was not clear in the UI how to fix the issue.  Users could A) click Cancel on the line with the Attest button, or B) refresh the page or submit a new DAR.  But these workarounds were quite likely to be overlooked by users.

Now, upon submitting a DAR and receiving a server-side validation error, the UI automatically cancels the DAR attestation.  This makes the invalid DAR instantly editable, making it much easier for users to fix.

### Demo

#### Before
DAR with server-side error is not automatically editable

https://github.com/user-attachments/assets/3ced3f89-baa2-4d2a-837e-b0484d79b379

#### After
DAR with server-side error is automatically editable

https://github.com/user-attachments/assets/2d6e9b3b-2120-4915-ad94-e4ea329fd19e


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
