### PR TITLE
[DT-1996] Max width for toast notifications

### DIFF
--- a/cypress/component/toast_notifications.spec.tsx
+++ b/cypress/component/toast_notifications.spec.tsx
@@ -1,0 +1,229 @@
+
+import { ToastNotifications } from 'src/libs/ToastNotifications';
+
+describe('ToastNotifications', () => {
+  beforeEach(() => {
+    cy.get('body').then(($body) => {
+      $body.find('[role="presentation"]').each((_, el) => {
+        if (el.parentNode) {
+          el.parentNode.removeChild(el);
+        }
+      });
+    });
+  });
+
+  afterEach(() => {
+    cy.get('body').then(($body) => {
+      $body.find('[role="presentation"]').each((_, el) => {
+        if (el.parentNode) {
+          el.parentNode.removeChild(el);
+        }
+      });
+    });
+  });
+
+  describe('showNotification', () => {
+    it('should display a notification with default props', () => {
+      ToastNotifications.showNotification({ text: 'Test notification' });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .and('contain.text', 'Test notification');
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('have.class', 'MuiAlert-filledInfo');
+    });
+
+    it('should display notification with custom severity', () => {
+      ToastNotifications.showNotification({
+        text: 'Warning message',
+        severity: 'warning'
+      });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .and('contain.text', 'Warning message')
+        .and('have.class', 'MuiAlert-filledWarning');
+    });
+
+    it('should display notification with React node as text', () => {
+      const reactText = <span data-testid="react-text">React notification</span>;
+      ToastNotifications.showNotification({ text: reactText });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .find('[data-testid="react-text"]')
+        .should('contain.text', 'React notification');
+    });
+
+    it('should position notification using string layout', () => {
+      ToastNotifications.showNotification({
+        text: 'Top left notification',
+        layout: 'topLeft'
+      });
+
+      cy.get('.MuiSnackbar-root')
+        .should('have.class', 'MuiSnackbar-anchorOriginTopLeft');
+    });
+
+    it('should position notification using SnackbarOrigin layout', () => {
+      ToastNotifications.showNotification({
+        text: 'Custom position notification',
+        layout: { vertical: 'top', horizontal: 'center' }
+      });
+
+      cy.get('.MuiSnackbar-root')
+        .should('have.class', 'MuiSnackbar-anchorOriginTopCenter');
+    });
+
+    it('should auto-hide notification after timeout', () => {
+      ToastNotifications.showNotification({
+        text: 'Quick timeout',
+        timeout: 1000
+      });
+
+      cy.get('[data-cy="notification-alert"]').should('be.visible');
+      cy.wait(1100);
+      cy.get('[data-cy="notification-alert"]').should('not.exist');
+    });
+
+    it('should close notification when close button is clicked', () => {
+      ToastNotifications.showNotification({ text: 'Closeable notification' });
+
+      cy.get('[data-cy="notification-alert"]').should('be.visible');
+      cy.get('[data-cy="notification-alert"] .MuiAlert-action button').click();
+
+      cy.wait(350);
+      cy.get('[data-cy="notification-alert"]').should('not.exist');
+    });
+
+    it('should apply custom styling with sx prop', () => {
+      ToastNotifications.showNotification({
+        text: 'Styled notification',
+        sx: { backgroundColor: 'red' }
+      });
+
+      cy.get('.MuiSnackbar-root')
+        .should('have.css', 'background-color', 'rgb(255, 0, 0)');
+    });
+
+    it('should handle multiple notifications', () => {
+      ToastNotifications.showNotification({ text: 'First notification' });
+      ToastNotifications.showNotification({ text: 'Second notification' });
+
+      cy.get('[data-cy="notification-alert"]').should('have.length', 2);
+      cy.get('[data-cy="notification-alert"]').first().should('contain.text', 'First notification');
+      cy.get('[data-cy="notification-alert"]').last().should('contain.text', 'Second notification');
+    });
+  });
+
+  describe('showError', () => {
+    it('should display error notification', () => {
+      ToastNotifications.showError({ text: 'Error message' });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .and('contain.text', 'Error message')
+        .and('have.class', 'MuiAlert-filledError');
+    });
+
+    it('should override severity prop for error notifications', () => {
+      ToastNotifications.showError({
+        text: 'Error message',
+        severity: 'success' // This should be overridden
+      });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('have.class', 'MuiAlert-filledError')
+        .and('not.have.class', 'MuiAlert-filledSuccess');
+    });
+  });
+
+  describe('showSuccess', () => {
+    it('should display success notification', () => {
+      ToastNotifications.showSuccess({ text: 'Success message' });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .and('contain.text', 'Success message')
+        .and('have.class', 'MuiAlert-filledSuccess');
+    });
+
+    it('should accept custom layout for success notifications', () => {
+      ToastNotifications.showSuccess({
+        text: 'Success message',
+        layout: 'topRight'
+      });
+
+      cy.get('.MuiSnackbar-root')
+        .should('have.class', 'MuiSnackbar-anchorOriginTopRight');
+    });
+  });
+
+  describe('showWarning', () => {
+    it('should display warning notification', () => {
+      ToastNotifications.showWarning({ text: 'Warning message' });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .and('contain.text', 'Warning message')
+        .and('have.class', 'MuiAlert-filledWarning');
+    });
+
+    it('should accept custom timeout for warning notifications', () => {
+      ToastNotifications.showWarning({
+        text: 'Warning message',
+        timeout: 500
+      });
+
+      cy.get('[data-cy="notification-alert"]').should('be.visible');
+      cy.wait(600);
+      cy.get('[data-cy="notification-alert"]').should('not.exist');
+    });
+  });
+
+  describe('showInformation', () => {
+    it('should display info notification', () => {
+      ToastNotifications.showInformation({ text: 'Info message' });
+
+      cy.get('[data-cy="notification-alert"]')
+        .should('be.visible')
+        .and('contain.text', 'Info message')
+        .and('have.class', 'MuiAlert-filledInfo');
+    });
+  });
+
+  describe('Layout positioning', () => {
+    const positions = [
+      { layout: 'topLeft', expectedClass: 'MuiSnackbar-anchorOriginTopLeft' },
+      { layout: 'topRight', expectedClass: 'MuiSnackbar-anchorOriginTopRight' },
+      { layout: 'bottomLeft', expectedClass: 'MuiSnackbar-anchorOriginBottomLeft' },
+      { layout: 'bottomRight', expectedClass: 'MuiSnackbar-anchorOriginBottomRight' }
+    ];
+
+    positions.forEach(({ layout, expectedClass }) => {
+      it(`should position notification at ${layout}`, () => {
+        ToastNotifications.showNotification({
+          text: `${layout} notification`,
+          layout: layout as any
+        });
+
+        cy.get('.MuiSnackbar-root')
+          .should('have.class', expectedClass);
+      });
+    });
+  });
+
+  describe('Cleanup behavior', () => {
+    it('should not close notification on clickaway', () => {
+      ToastNotifications.showNotification({
+        text: 'Clickaway test',
+        timeout: 5000
+      });
+
+      cy.get('[data-cy="notification-alert"]').should('be.visible');
+      cy.get('body').click({ force: true });
+      cy.get('[data-cy="notification-alert"]').should('still.be.visible');
+    });
+  });
+});

--- a/cypress/component/toast_notifications.spec.tsx
+++ b/cypress/component/toast_notifications.spec.tsx
@@ -1,5 +1,5 @@
-
-import { ToastNotifications } from 'src/libs/ToastNotifications';
+import React from 'react';
+import { ToastNotifications, ToastPosition } from 'src/libs/ToastNotifications';
 
 describe('ToastNotifications', () => {
   beforeEach(() => {
@@ -83,8 +83,7 @@ describe('ToastNotifications', () => {
       });
 
       cy.get('[data-cy="notification-alert"]').should('be.visible');
-      cy.wait(1100);
-      cy.get('[data-cy="notification-alert"]').should('not.exist');
+      cy.get('[data-cy="notification-alert"]', {timeout: 1200}).should('not.exist');
     });
 
     it('should close notification when close button is clicked', () => {
@@ -92,9 +91,7 @@ describe('ToastNotifications', () => {
 
       cy.get('[data-cy="notification-alert"]').should('be.visible');
       cy.get('[data-cy="notification-alert"] .MuiAlert-action button').click();
-
-      cy.wait(350);
-      cy.get('[data-cy="notification-alert"]').should('not.exist');
+      cy.get('[data-cy="notification-alert"]', {timeout: 350}).should('not.exist');
     });
 
     it('should apply custom styling with sx prop', () => {
@@ -177,8 +174,7 @@ describe('ToastNotifications', () => {
       });
 
       cy.get('[data-cy="notification-alert"]').should('be.visible');
-      cy.wait(600);
-      cy.get('[data-cy="notification-alert"]').should('not.exist');
+      cy.get('[data-cy="notification-alert"]', {timeout: 700}).should('not.exist');
     });
   });
 
@@ -205,7 +201,7 @@ describe('ToastNotifications', () => {
       it(`should position notification at ${layout}`, () => {
         ToastNotifications.showNotification({
           text: `${layout} notification`,
-          layout: layout as any
+          layout: layout as ToastPosition
         });
 
         cy.get('.MuiSnackbar-root')

--- a/cypress/component/toast_notifications.spec.tsx
+++ b/cypress/component/toast_notifications.spec.tsx
@@ -214,16 +214,33 @@ describe('ToastNotifications', () => {
     });
   });
 
-  describe('Cleanup behavior', () => {
-    it('should not close notification on clickaway', () => {
+  describe('Styling and constraints', () => {
+    it('should respect maximum width constraint', () => {
       ToastNotifications.showNotification({
-        text: 'Clickaway test',
-        timeout: 5000
+        text: 'This is a very long notification message that should be constrained by the maximum width setting to ensure it does not overflow off the page and remains readable within the viewport boundaries'
       });
 
-      cy.get('[data-cy="notification-alert"]').should('be.visible');
-      cy.get('body').click({ force: true });
-      cy.get('[data-cy="notification-alert"]').should('still.be.visible');
+      cy.get('.MuiSnackbar-root')
+        .should('be.visible')
+        .then(($snackbar) => {
+          const snackbarWidth = $snackbar.outerWidth();
+          const viewportWidth = Cypress.config('viewportWidth');
+          expect(snackbarWidth).to.be.lessThan(viewportWidth);
+        });
+    });
+
+    it('should have appropriate width for content', () => {
+      ToastNotifications.showNotification({
+        text: 'Short text'
+      });
+
+      cy.get('.MuiSnackbar-root')
+        .should('be.visible')
+        .then(($snackbar) => {
+          const snackbarWidth = $snackbar.outerWidth();
+          const viewportWidth = Cypress.config('viewportWidth');
+          expect(snackbarWidth).to.be.lessThan(viewportWidth);
+        });
     });
   });
 });

--- a/src/libs/ToastNotifications.tsx
+++ b/src/libs/ToastNotifications.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { AlertColor, Alert, Snackbar, SnackbarOrigin } from '@mui/material';
 
-type ToastPosition = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
+export type ToastPosition = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight';
 
 interface NotificationRequiredProps extends NotificationProps {
   severity: AlertColor;

--- a/src/libs/ToastNotifications.tsx
+++ b/src/libs/ToastNotifications.tsx
@@ -77,7 +77,12 @@ export const ToastNotifications = {
           open={open}
           onClose={handleClose}
           // these transforms are required because the rule `html { font-size: 10px }` exists in bootstrap_replacement.css
-          sx={{ transform: 'scale(1.5)', transformOrigin: `${snackbarLayout.vertical} ${snackbarLayout.horizontal}` }}
+          sx={{
+            transform: 'scale(1.5)',
+            transformOrigin: `${snackbarLayout.vertical} ${snackbarLayout.horizontal}`,
+            maxWidth: '30vw',
+            width: 'fit-content'
+          }}
           {...props}
         >
           <Alert


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1996

### Summary

Adds a max width for toast notifications. Added unit tests including some to make sure none of the notifications go beyond the viewport width.

<img width="820" height="164" alt="Screenshot 2025-07-23 at 10 48 27 AM" src="https://github.com/user-attachments/assets/701e21c9-8882-45f8-91c9-9ad1bebafbb5" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
