### PR TITLE
[DT-2003]Progress reports with publication/presentations don't save all info on subsequent progress reports

### DIFF
--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -275,22 +275,22 @@ describe('ProgressReportApplication - Component Tests', () => {
       publications: [
         {
           title: 'Publication 1',
-          pubmed_id: '12345',
+          pubmedId: '12345',
           date: '2023-01-01',
           authors: 'Author 1',
-          bibliographic_citation: 'Citation 1',
-          dataset_citation: 'Dataset Citation 1',
-          did_cite: true,
+          bibliographicCitation: 'Citation 1',
+          datasetCitation: 'Dataset Citation 1',
+          citation: true,
           link: ''
         },
         {
           title: 'Publication 2',
-          pubmed_id: '67890',
+          pubmedId: '67890',
           date: '2023-02-01',
           authors: 'Author 2',
-          bibliographic_citation: 'Citation 2',
-          dataset_citation: 'Dataset Citation 2',
-          did_cite: false,
+          bibliographicCitation: 'Citation 2',
+          datasetCitation: 'Dataset Citation 2',
+          citation: false,
           link: ''
         }
       ]
@@ -313,12 +313,12 @@ describe('ProgressReportApplication - Component Tests', () => {
       publications: [
         {
           title: 'Test Publication',
-          pubmed_id: '11111',
+          pubmedId: '11111',
           date: '2023-03-01',
           authors: 'Test Author',
-          bibliographic_citation: 'Test Citation',
-          dataset_citation: 'Test Dataset Citation',
-          did_cite: true,
+          bibliographicCitation: 'Test Citation',
+          datasetCitation: 'Test Dataset Citation',
+          citation: true,
           link: ''
         }
       ]
@@ -358,20 +358,20 @@ describe('ProgressReportApplication - Component Tests', () => {
           link: 'http://example.com/presentation1',
           date: '2023-01-01',
           authors: 'Author 1',
-          dataset_citation: 'Dataset Citation 1',
-          did_cite: true,
-          bibliographic_citation: 'Bibliographic Citation 1',
-          pubmed_id: ''
+          datasetCitation: 'Dataset Citation 1',
+          citation: true,
+          bibliographicCitation: 'Bibliographic Citation 1',
+          pubmedId: ''
         },
         {
           title: 'Presentation 2',
           link: 'http://example.com/presentation2',
           date: '2023-02-01',
           authors: 'Author 2',
-          dataset_citation: 'Dataset Citation 2',
-          did_cite: false,
-          bibliographic_citation: 'Bibliographic Citation 2',
-          pubmed_id: ''
+          datasetCitation: 'Dataset Citation 2',
+          citation: false,
+          bibliographicCitation: 'Bibliographic Citation 2',
+          pubmedId: ''
         }
       ]
     } as unknown as CombinedDataAccessRequest;

--- a/cypress/component/utils/dar_utils.spec.ts
+++ b/cypress/component/utils/dar_utils.spec.ts
@@ -188,22 +188,22 @@ describe('DarUtils', () => {
         publicationsYesNo: true,
         publications: [{
           title: 'Publication 1',
-          pubmed_id: '12345',
+          pubmedId: '12345',
           date: '2023-01-01',
           authors: ['Author A'],
-          bibliographic_citation: 'Citation 1',
-          dataset_citation: 'Dataset 1',
-          did_cite: true
+          bibliographicCitation: 'Citation 1',
+          datasetCitation: 'Dataset 1',
+          citation: true
         }],
         presentationsYesNo: true,
         presentations: [{
           title: 'Presentation 1',
-          pubmed_id: '67890',
+          pubmedId: '67890',
           date: '2023-02-01',
           authors: ['Author B'],
-          bibliographic_citation: 'Citation 2',
-          dataset_citation: 'Dataset 2',
-          did_cite: true
+          bibliographicCitation: 'Citation 2',
+          datasetCitation: 'Dataset 2',
+          citation: true
         }],
         labCollaborators: [{
           approverStatus: true,

--- a/src/components/presentations_list/PresentationAddEdit.tsx
+++ b/src/components/presentations_list/PresentationAddEdit.tsx
@@ -88,15 +88,16 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
                         validation={validation.link}
                     />
                     <FormField
-                        id='dataset_citation'
+                        id='datasetCitation'
                         title={`Dataset citation used in this presentation`}
                         defaultValue={presentation?.datasetCitation}
                         placeholder='Dataset Citation'
                         onChange={onChange}
                     />
                     <FormField
-                        id='did_cite'
+                        id='citation'
                         type={FormFieldTypes.YESNORADIOGROUP}
+                        defaultValue={presentation?.citation}
                         title='Did you cite the dataset(s) used in this presentation?'
                         orientation='horizontal'
                         onChange={onChange}

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -105,8 +105,9 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
                         onChange={onChange}
                     />
                     <FormField
-                        id='did_cite'
+                        id='citation'
                         type={FormFieldTypes.YESNORADIOGROUP}
+                        defaultValue={publication?.citation}
                         title='Did you cite the dataset(s) used in this publication?'
                         orientation='horizontal'
                         onChange={onChange}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2003

### Summary
This PR fixes the dataset citation for publications and the did you cite yes/no for both publications and presentations.

Note: pubMedId and BibliographicCitation were fixed here: https://github.com/DataBiosphere/duos-ui/pull/2979

This continues the work of that PR.

See fix here:

https://github.com/user-attachments/assets/0ee56ed4-3642-45ba-98c9-5a8fe7fd8983


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
