### PR TITLE
[DT-2002] Hide `Approve Closeout` button after click

### DIFF
--- a/cypress/component/ProgressReports/closeout_review.spec.tsx
+++ b/cypress/component/ProgressReports/closeout_review.spec.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import {mount} from 'cypress/react';
 import {CloseoutReview} from 'src/pages/progress_reports/CloseoutReview';
-import {Acknowledgement} from 'src/types/model';
+import {Acknowledgement, DataAccessRequest} from 'src/types/model';
 import {User} from 'src/libs/ajax/User';
+import {Storage} from 'src/libs/storage';
+import {DAR} from 'src/libs/ajax/DAR';
 
 describe('CloseoutReview - Component Tests', () => {
-  let onApproveSpy: () => void;
   let onReturnSpy: () => void;
+  const user = {isSigningOfficial: true};
 
   const mountComponent = (props = {}) => {
     const defaultProps = {
-      onApprove: onApproveSpy,
       onReturn: onReturnSpy,
-      referenceId: 'DAR-UUID',
+      dar: {referenceId:'DAR-UUID'} as DataAccessRequest,
       ...props
     };
 
@@ -20,11 +21,12 @@ describe('CloseoutReview - Component Tests', () => {
   };
 
   beforeEach(() => {
-    onApproveSpy = cy.stub().as('approveStub');
     onReturnSpy = cy.stub().as('returnStub');
   });
 
   it('renders the component correctly', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     // Check for the main container
@@ -39,6 +41,8 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays both buttons with correct text', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     cy.get('button').contains('Approve closeout').should('be.visible');
@@ -46,13 +50,19 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('calls onApprove when Approve closeout button is clicked', () => {
-    mountComponent();
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(DAR, 'approveCloseout').returns(true);
+    cy.stub(User, 'getAcknowledgement').returns(false);
 
-    cy.get('button').contains('Approve closeout').click();
-    cy.get('@approveStub').should('have.been.calledOnce');
+    mountComponent();
+    cy.get('button').contains('Approve closeout').click({force: true});
+    cy.get('.MuiAlert-message').contains('Closeout review approved successfully.').should('be.visible');
+
   });
 
   it('calls onReturn when Go to DAR Requests button is clicked', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     cy.get('button').contains('Go to DAR Requests').click();
@@ -60,6 +70,8 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('maintains proper layout with icon, text, and buttons', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     cy.get('.progress-report-step-card').within(() => {
@@ -73,6 +85,8 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays "Please note:" text in bold', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     cy.contains('Please note:')
@@ -80,6 +94,8 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays explanatory text with normal font weight', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     cy.contains('If there are issues with the content in this closeout report, please contact the researcher.')
@@ -87,6 +103,8 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays closeout approve when no acknowledgement exists', () => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
+    cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
     // Approve button should be visible
@@ -102,6 +120,7 @@ describe('CloseoutReview - Component Tests', () => {
       firstAcknowledged: now.getTime(),
       lastAcknowledged: now.getTime(),
     } as Acknowledgement;
+    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(acknowledgement);
     mountComponent();
 

--- a/cypress/component/ProgressReports/closeout_review.spec.tsx
+++ b/cypress/component/ProgressReports/closeout_review.spec.tsx
@@ -21,11 +21,11 @@ describe('CloseoutReview - Component Tests', () => {
   };
 
   beforeEach(() => {
+    cy.stub(Storage, 'getCurrentUser').returns(user);
     onReturnSpy = cy.stub().as('returnStub');
   });
 
   it('renders the component correctly', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -41,7 +41,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays both buttons with correct text', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -50,7 +49,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('calls onApprove when Approve closeout button is clicked', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(DAR, 'approveCloseout').returns(true);
     cy.stub(User, 'getAcknowledgement').returns(false);
 
@@ -61,7 +59,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('calls onReturn when Go to DAR Requests button is clicked', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -70,7 +67,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('maintains proper layout with icon, text, and buttons', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -85,7 +81,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays "Please note:" text in bold', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -94,7 +89,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays explanatory text with normal font weight', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -103,7 +97,6 @@ describe('CloseoutReview - Component Tests', () => {
   });
 
   it('displays closeout approve when no acknowledgement exists', () => {
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(null);
     mountComponent();
 
@@ -120,7 +113,6 @@ describe('CloseoutReview - Component Tests', () => {
       firstAcknowledged: now.getTime(),
       lastAcknowledged: now.getTime(),
     } as Acknowledgement;
-    cy.stub(Storage, 'getCurrentUser').returns(user);
     cy.stub(User, 'getAcknowledgement').returns(acknowledgement);
     mountComponent();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@mui/x-date-pickers": "^7.29.4",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
-        "axios": "1.10.0",
+        "axios": "1.11.0",
         "dayjs": "1.11.13",
         "dompurify": "3.2.6",
         "lodash": "4.17.21",
@@ -3019,13 +3019,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mui/system": "7.2.0",
     "ajv": "8.17.1",
     "ajv-formats": "3.0.1",
-    "axios": "1.10.0",
+    "axios": "1.11.0",
     "dayjs": "1.11.13",
     "dompurify": "3.2.6",
     "lodash": "4.17.21",
@@ -49,8 +49,8 @@
   "devDependencies": {
     "@emotion/styled": "11.14.1",
     "@eslint/js": "9.31.0",
-    "@types/node": "24.0.13",
     "@types/lodash": "4.17.20",
+    "@types/node": "24.0.13",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@types/react-router-dom": "5.3.3",

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -15,16 +15,13 @@ import DarCloseout from 'src/pages/progress_reports/DarCloseout';
 import {CloseoutReview} from 'src/pages/progress_reports/CloseoutReview';
 import SubmitProgressReport from 'src/pages/progress_reports/SubmitProgressReport';
 import IrbDocumentUpload from 'src/pages/progress_reports/IrbDocumentUpload';
-import {Navigation, Notifications} from 'src/libs/utils';
+import {Navigation} from 'src/libs/utils';
 import {Storage} from 'src/libs/storage';
 import {DataUseAcknowledgements} from 'src/pages/dar_application/DataUseAcknowlegements';
 import {translateDataUseRestrictionsFromDataUseArray} from 'src/libs/dataUseTranslation';
 import {validatePRFormData, validationFailed} from 'src/utils/darFormUtils';
 import {FormValidationState} from 'src/pages/dar_application/FormValidationState';
 import { getApprovedElectionDatasetIds } from 'src/utils/DarUtils';
-import { DAR } from 'src/libs/ajax/DAR';
-import { User } from 'src/libs/ajax/User';
-import { AxiosError } from 'axios';
 
 type ProgressReportApplicationProps = {
   readonly dar: CombinedDataAccessRequest; // corresponds either to the parent DAR for a new application or an existing readonly progress report
@@ -175,24 +172,6 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
             (user.isChairPerson && isCloseoutApproved);
     }
 
-    const onApproveReview = async () => {
-        const user = Storage.getCurrentUser();
-        const isCloseoutApproved = dar.closeoutSigningOfficialApprovedDate !== undefined;
-        try {
-            if (user.isSigningOfficial && !isCloseoutApproved) {
-                await DAR.approveCloseout(dar.referenceId);
-            } else {
-                const acknowledgement = 'dar_closeout_chair_ref_' + dar.referenceId;
-                await User.acceptAcknowledgments(acknowledgement);
-            }
-            Notifications.showSuccess({ text: 'Closeout review approved successfully.' });
-        } catch (e) {
-            const err = e as AxiosError<Record<string, string>>;
-            const message = err.response?.data.message;
-            Notifications.showError({ text: 'Error approving closeout review: ' + message });
-        }
-    }
-
     function getDatasetsInApprovedElections(datasets: Dataset[], approvedElectionDatasetIds: number[]) {
       const datasetsInApprovedElections = datasets.filter(dataset => {
         return approvedElectionDatasetIds.includes(dataset.datasetId)
@@ -296,8 +275,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
             </div>
             {isCloseoutReview() && <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
                 <CloseoutReview
-                    referenceId={dar.referenceId}
-                    onApprove={onApproveReview}
+                    dar={dar}
                     onReturn={() => {
                         Navigation.console(Storage.getCurrentUser(), history);
                     }}

--- a/src/pages/progress_reports/CloseoutReview.tsx
+++ b/src/pages/progress_reports/CloseoutReview.tsx
@@ -3,27 +3,50 @@ import InfoIcon from '@mui/icons-material/Info';
 import {User} from 'src/libs/ajax/User';
 import {Notifications} from 'src/libs/utils';
 import {extractConsentError, extractError} from 'src/utils/ErrorUtils';
+import {Storage} from 'src/libs/storage';
+import {DAR} from 'src/libs/ajax/DAR';
+import {AxiosError} from 'axios';
+import {DataAccessRequest} from 'src/types/model';
 
 interface CloseoutReviewProps {
-  onApprove?: () => void;
+  dar: DataAccessRequest;
   onReturn?: () => void;
-  referenceId: string;
 }
 
 export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
-    onApprove,
-    onReturn,
-    referenceId
+    dar, onReturn
 }) => {
 
   const [acknowledged, setAcknowledged] = useState<boolean | undefined>(undefined);
+  const [pendingApproval, setPendingApproval] = useState<boolean> (false);
 
+    const onApprove = async () => {
+        setPendingApproval(true);
+        const user = Storage.getCurrentUser();
+        const isCloseoutApproved = dar.closeoutSigningOfficialApprovedDate !== undefined;
+        try {
+            if (user.isSigningOfficial && !isCloseoutApproved) {
+                await DAR.approveCloseout(dar.referenceId);
+            } else {
+                const acknowledgement = 'dar_closeout_chair_ref_' + dar.referenceId;
+                await User.acceptAcknowledgments(acknowledgement);
+            }
+            setAcknowledged(true);
+            Notifications.showSuccess({ text: 'Closeout review approved successfully.' });
+        } catch (e) {
+            setAcknowledged(false);
+            setPendingApproval(false);
+            const err = e as AxiosError<Record<string, string>>;
+            const message = err.response?.data.message;
+            Notifications.showError({ text: 'Error approving closeout review: ' + message });
+        }
+    }
   // Required to get Chairperson acknowledgments of closeouts
   useEffect(() => {
     // Fetch the acknowledgement for the given referenceId
     const fetchAcknowledgement = async () => {
       try {
-        const key = `dar_closeout_chair_ref_${referenceId}`;
+        const key = `dar_closeout_chair_ref_${dar.referenceId}`;
         const chairAcknowledgement = await User.getAcknowledgement(key);
         if (chairAcknowledgement) {
           setAcknowledged(true);
@@ -38,7 +61,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
       }
     };
     fetchAcknowledgement();
-  }, [referenceId]);
+  }, [dar]);
 
   return (
       <div className="progress-report-step-card" style={{
@@ -80,6 +103,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
               {(!acknowledged) &&
                 (<button
                   data-cy="closeout-review-approve-button"
+                  disabled={pendingApproval}
                   type="button"
                   onClick={onApprove}
                   style={{


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2002](https://broadworkbench.atlassian.net/browse/DT-2002)

### Summary

The `Approve Closeout` button wasn't disappearing after the user clicked it.  Now, after each user clicks it, the button will disappear.  The button also becomes disabled while the request is processing so that it can't be clicked again while a request is in flight.

BEFORE:

https://github.com/user-attachments/assets/ef5e2397-c771-4c2c-8b24-8ba483626922


AFTER:

https://github.com/user-attachments/assets/7d80cd48-4296-4e00-b056-5eb4fc3fc9c6




----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
