### PR TITLE
[DT-2019] Fix Apply for Access button on dataset details page

### DIFF
--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -14,6 +14,7 @@ import {
 import {extractError} from 'src/utils/ErrorUtils';
 import {getDataLocationLink} from 'src/utils/DataLocationUtils';
 import {createDataUseDisplay} from 'src/utils/DataUseUtils';
+import {History} from 'history';
 
 const LINE = <div style={{borderTop: '1px solid #BABEC1', height: 0}}/>;
 
@@ -64,7 +65,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
     try {
       const draftResponse = await DAR.postDarDraft({datasetId: [datasetTerm?.datasetId]});
       if (draftResponse.referenceId) {
-        history.pushState({}, '', `/dar_application/${draftResponse.referenceId}`);
+        history.push(`/dar_application/${draftResponse.referenceId}`);
       } else if (draftResponse.message) {
         showError(draftResponse.message + ' Please contact customer support for help.');
       } else {


### PR DESCRIPTION
### Addresses

[DT-2019](https://broadworkbench.atlassian.net/browse/DT-2019)

### Summary

Currently if you click on the Apply for Access button on the [dataset details page](https://duos-k8s.dsde-dev.broadinstitute.org/dataset/DUOS-000688), you get an error: `TypeError: history.pushState is not a function`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-2019]: https://broadworkbench.atlassian.net/browse/DT-2019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ