### PR TITLE
[DT-2001] Display missing DAC info on DAR addendum

### DIFF
--- a/cypress/component/DucAddendum/DucAddendum.spec.tsx
+++ b/cypress/component/DucAddendum/DucAddendum.spec.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { mount } from 'cypress/react';
-import DucAddendum from 'src/pages/dar_application/DucAddendum';
-import { DAC } from 'src/libs/ajax/DAC';
+import React from 'react'
+import { mount } from 'cypress/react'
+import DucAddendum from 'src/pages/dar_application/DucAddendum'
+import { DAC } from 'src/libs/ajax/DAC'
 
 describe('DucAddendum', () => {
   const mockDatasets = [
@@ -9,80 +9,82 @@ describe('DucAddendum', () => {
       datasetId: 1,
       datasetIdentifier: 'DUOS-1001',
       datasetName: 'Test Dataset 1',
-      dacId: 1
+      dacId: 1,
     },
     {
       datasetId: 2,
       datasetIdentifier: 'DUOS-1002',
       datasetName: 'Test Dataset 2',
-      dacId: 2
-    }
-  ];
+      dacId: 2,
+    },
+  ]
 
   const mockDacs = [
     {
       dacId: 1,
-      name: 'DAC 0001'
+      name: 'DAC 0001',
     },
     {
       dacId: 2,
-      name: 'DAC 0002'
-    }
-  ];
+      name: 'DAC 0002',
+    },
+  ]
 
   beforeEach(() => {
-    cy.viewport(1200, 800);
-  });
+    cy.viewport(1200, 800)
+  })
 
   it('should render addendum table with selected datasets', () => {
-    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs));
+    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs))
     cy.stub(DAC, 'get').callsFake((dacId) => {
-      return Promise.resolve(mockDacs.find(dac => dac.dacId === dacId));
-    });
+      return Promise.resolve(mockDacs.find(dac => dac.dacId === dacId))
+    })
 
     const props = {
       datasets: mockDatasets,
       isLoading: false,
       save: cy.stub(),
-      doSubmit: cy.stub()
-    };
+      doSubmit: cy.stub(),
+    }
 
-    mount(<DucAddendum {...props} />);
+    mount(<DucAddendum {...props} />)
 
     // Check the informational header
-    cy.contains('Addendum').should('be.visible');
-    cy.contains('Please review the datasets you requested').should('be.visible');
+    cy.contains('Addendum').should('be.visible')
+    cy.contains('Please review the datasets you requested').should('be.visible')
 
     // Verify column headers
-    cy.contains('Dataset ID').should('be.visible');
-    cy.contains('Dataset Name').should('be.visible');
-    cy.contains('DAC').should('be.visible');
-    cy.contains('Acknowledgment').should('be.visible');
+    cy.contains('Dataset ID').should('be.visible')
+    cy.contains('Dataset Name').should('be.visible')
+    cy.contains('DAC').should('be.visible')
+    cy.contains('Acknowledgment').should('be.visible')
 
     // Verify dataset row content
     cy.contains('DUOS-1001')
-        .next().should('have.text', 'Test Dataset 1')
-        .next().should('have.text', 'DAC 0001');
+      .next().should('have.text', 'Test Dataset 1')
+      .next().should('have.text', 'DAC 0001')
 
     cy.contains('DUOS-1002')
-        .next().should('have.text', 'Test Dataset 2')
-        .next().should('have.text', 'DAC 0002');
-  });
+      .next().should('have.text', 'Test Dataset 2')
+      .next().should('have.text', 'DAC 0002')
+  })
 
   it('should display `Unknown DAC` when relevant DAC cannot be loaded', () => {
-    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs));
-    cy.stub(DAC, 'get').callsFake(() => { return Promise.reject(new Error('DAC not found')); });
+    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs))
+    cy.stub(DAC, 'get').callsFake(() => {
+      return Promise.reject(new Error('DAC not found'))
+    })
 
     const props = {
       datasets: [mockDatasets.at(0)],
       isLoading: false,
       save: cy.stub(),
-      doSubmit: cy.stub()
-    };
+      doSubmit: cy.stub(),
+    }
 
-    mount(<DucAddendum {...props} />);
+    mount(<DucAddendum {...props} />)
 
-    cy.contains('Unknown DAC').should('be.visible');
-    cy.contains('Error loading DAC information for datasets').should('be.visible');
-  });
-});
+    cy.contains('Unknown DAC').should('be.visible')
+    cy.contains('Error loading DAC information for datasets').should('be.visible')
+  })
+})

--- a/cypress/component/DucAddendum/DucAddendum.spec.tsx
+++ b/cypress/component/DucAddendum/DucAddendum.spec.tsx
@@ -3,7 +3,7 @@ import { mount } from 'cypress/react';
 import DucAddendum from 'src/pages/dar_application/DucAddendum';
 import { DAC } from 'src/libs/ajax/DAC';
 
-describe('DucAddendum Component Tests', () => {
+describe('DucAddendum', () => {
   const mockDatasets = [
     {
       datasetId: 1,

--- a/cypress/component/DucAddendum/DucAddendum.spec.tsx
+++ b/cypress/component/DucAddendum/DucAddendum.spec.tsx
@@ -71,7 +71,7 @@ describe('DucAddendum', () => {
 
   it('should display `Unknown DAC` when relevant DAC cannot be loaded', () => {
     cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs));
-    cy.stub(DAC, 'get').callsFake(() => { return Promise.reject('DAC not found'); });
+    cy.stub(DAC, 'get').callsFake(() => { return Promise.reject(new Error('DAC not found')); });
 
     const props = {
       datasets: [mockDatasets.at(0)],

--- a/cypress/component/DucAddendum/DucAddendum.spec.tsx
+++ b/cypress/component/DucAddendum/DucAddendum.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { mount } from 'cypress/react'
 import DucAddendum from 'src/pages/dar_application/DucAddendum'
-import { DAC } from 'src/libs/ajax/DAC'
+import { makeDatasetTerm } from '../test-utils'
+import { DataSet } from 'src/libs/ajax/DataSet'
 
 describe('DucAddendum', () => {
   const mockDatasets = [
@@ -19,15 +20,21 @@ describe('DucAddendum', () => {
     },
   ]
 
-  const mockDacs = [
-    {
-      dacId: 1,
-      name: 'DAC 0001',
-    },
-    {
-      dacId: 2,
-      name: 'DAC 0002',
-    },
+  const mockDatasetTerms = [
+    makeDatasetTerm({
+      dac: {
+        dacId: 1,
+        dacName: 'DAC 0001',
+        dacEmail: 'foo@bar.com',
+      },
+    }),
+    makeDatasetTerm({
+      dac: {
+        dacId: 2,
+        dacName: 'DAC 0002',
+        dacEmail: 'bar@foo.com',
+      },
+    }),
   ]
 
   beforeEach(() => {
@@ -35,10 +42,7 @@ describe('DucAddendum', () => {
   })
 
   it('should render addendum table with selected datasets', () => {
-    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs))
-    cy.stub(DAC, 'get').callsFake((dacId) => {
-      return Promise.resolve(mockDacs.find(dac => dac.dacId === dacId))
-    })
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve(mockDatasetTerms))
 
     const props = {
       datasets: mockDatasets,
@@ -69,10 +73,9 @@ describe('DucAddendum', () => {
       .next().should('have.text', 'DAC 0002')
   })
 
-  it('should display `Unknown DAC` when relevant DAC cannot be loaded', () => {
-    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs))
-    cy.stub(DAC, 'get').callsFake(() => {
-      return Promise.reject(new Error('DAC not found'))
+  it('should display a warning when relevant DAC cannot be loaded', () => {
+    cy.stub(DataSet, 'searchDatasetIndex').callsFake(() => {
+      return Promise.reject(new Error('DAC information could not be found'))
     })
 
     const props = {
@@ -84,7 +87,28 @@ describe('DucAddendum', () => {
 
     mount(<DucAddendum {...props} />)
 
-    cy.contains('Unknown DAC').should('be.visible')
+    cy.contains('N/A').should('be.visible')
     cy.contains('Error loading DAC information for datasets').should('be.visible')
+  })
+
+  it('should display `N/A` when the DAC information is missing entirely', () => {
+    const datasetTermsMissingDAC = makeDatasetTerm({
+      dac: undefined,
+    })
+
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTermsMissingDAC]))
+
+    const props = {
+      datasets: [mockDatasets.at(0)],
+      isLoading: false,
+      save: cy.stub(),
+      doSubmit: cy.stub(),
+    }
+
+    mount(<DucAddendum {...props} />)
+
+    cy.contains('DUOS-1001')
+      .next().should('have.text', 'Test Dataset 1')
+      .next().should('have.text', 'N/A')
   })
 })

--- a/cypress/component/DucAddendum/DucAddendum.spec.tsx
+++ b/cypress/component/DucAddendum/DucAddendum.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { mount } from 'cypress/react';
+import DucAddendum from 'src/pages/dar_application/DucAddendum';
+import { DAC } from 'src/libs/ajax/DAC';
+
+describe('DucAddendum Component Tests', () => {
+  const mockDatasets = [
+    {
+      datasetId: 1,
+      datasetIdentifier: 'DUOS-1001',
+      datasetName: 'Test Dataset 1',
+      dacId: 1
+    },
+    {
+      datasetId: 2,
+      datasetIdentifier: 'DUOS-1002',
+      datasetName: 'Test Dataset 2',
+      dacId: 2
+    }
+  ];
+
+  const mockDacs = [
+    {
+      dacId: 1,
+      name: 'DAC 0001'
+    },
+    {
+      dacId: 2,
+      name: 'DAC 0002'
+    }
+  ];
+
+  beforeEach(() => {
+    cy.viewport(1200, 800);
+  });
+
+  it('should render addendum table with selected datasets', () => {
+    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs));
+    cy.stub(DAC, 'get').callsFake((dacId) => {
+      return Promise.resolve(mockDacs.find(dac => dac.dacId === dacId));
+    });
+
+    const props = {
+      datasets: mockDatasets,
+      isLoading: false,
+      save: cy.stub(),
+      doSubmit: cy.stub()
+    };
+
+    mount(<DucAddendum {...props} />);
+
+    // Check the informational header
+    cy.contains('Addendum').should('be.visible');
+    cy.contains('Please review the datasets you requested').should('be.visible');
+
+    // Verify column headers
+    cy.contains('Dataset ID').should('be.visible');
+    cy.contains('Dataset Name').should('be.visible');
+    cy.contains('DAC').should('be.visible');
+    cy.contains('Acknowledgment').should('be.visible');
+
+    // Verify dataset row content
+    cy.contains('DUOS-1001')
+        .next().should('have.text', 'Test Dataset 1')
+        .next().should('have.text', 'DAC 0001');
+
+    cy.contains('DUOS-1002')
+        .next().should('have.text', 'Test Dataset 2')
+        .next().should('have.text', 'DAC 0002');
+  });
+
+  it('should display `Unknown DAC` when relevant DAC cannot be loaded', () => {
+    cy.stub(DAC, 'list').returns(Promise.resolve(mockDacs));
+    cy.stub(DAC, 'get').callsFake(() => { return Promise.reject('DAC not found'); });
+
+    const props = {
+      datasets: [mockDatasets.at(0)],
+      isLoading: false,
+      save: cy.stub(),
+      doSubmit: cy.stub()
+    };
+
+    mount(<DucAddendum {...props} />);
+
+    cy.contains('Unknown DAC').should('be.visible');
+    cy.contains('Error loading DAC information for datasets').should('be.visible');
+  });
+});

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -715,7 +715,7 @@ const DataAccessRequestApplication = (props) => {
                   }
                 </div> : <div />}
 
-              {!isAttested &&
+              {isAttested &&
                 <div id={ADDENDUM_TAB_ID} className='step-container'>
                   <DucAddendum
                     doSubmit={doSubmit}

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -715,7 +715,7 @@ const DataAccessRequestApplication = (props) => {
                   }
                 </div> : <div />}
 
-              {isAttested &&
+              {!isAttested &&
                 <div id={ADDENDUM_TAB_ID} className='step-container'>
                   <DucAddendum
                     doSubmit={doSubmit}

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -127,6 +127,11 @@ export default function DucAddendum(props) {
   }, [datasets])
 
   const buildDucAddendumTable = useCallback(async () => {
+    const getDacName = (dacId) => {
+      const dac = dacs.find(dac => dac.dacId === dacId)
+      return dac?.name || 'Unknown DAC'
+    }
+
     const tableChunks = buckets.map((bucket) => {
       const dataUseCodes = bucket.label
       const dataUseSummary = bucket.dataUses.map(dataUse => dataUse.description).join('. ')
@@ -157,7 +162,7 @@ export default function DucAddendum(props) {
             style: columnStyles,
           },
           {
-            data: dacs.find(dac => dac.dacId === dataset.dacId)?.name || 'Unknown DAC',
+            data: getDacName(dataset.dacId),
             id: dataset.datasetId,
             style: columnStyles,
           },

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -6,6 +6,7 @@ import { binCollectionToBuckets } from '../../utils/BucketUtils';
 import { useCallback } from 'react';
 import { isEmpty, flatten } from 'lodash/fp';
 import {DAC} from 'src/libs/ajax/DAC.js';
+import {Notifications} from 'src/libs/utils.js';
 
 const commonStyles = {
   baseStyle: {
@@ -86,10 +87,9 @@ const columnHeaderData = (columns) => {
 
 export default function DucAddendum(props) {
   const { datasets, isLoading, save, doSubmit } = props;
-  console.log(datasets);
   const dacIds = useMemo(() => datasets.map(dataset => dataset.dacId), [datasets]);
-  const [dacs, setDacs] = useState([]);
 
+  const [dacs, setDacs] = useState([]);
   const [buckets, setBuckets] = useState([]);
   const [ducAddendumTable, setDucAddendumTable] = useState([]);
 
@@ -110,23 +110,19 @@ export default function DucAddendum(props) {
   }, [getBuckets]);
 
   useEffect(() => {
-    if (isEmpty(dacIds)) {
-      setDacs([]);
-      return;
-    }
-    const uniqueDacIds = [...new Set(dacIds)];
-    const dacPromises = uniqueDacIds.map(dacId => DAC.get(dacId));
+    const loadDacs = async () => {
+      const uniqueDacIds = [...new Set(dacIds)];
+      const dacPromises = uniqueDacIds.map(dacId => DAC.get(dacId));
 
-    Promise.all(dacPromises)
-      .then(dacsData => {
+      try {
+        const dacsData = await Promise.all(dacPromises);
         setDacs(dacsData);
-      })
-      .catch(error => {
-        Notification.error({
-            message: 'Error fetching DACs',
-            description: `There was an error fetching information about the DACs related to the selected dataset(s): ${error.message}`,
-        })
-      });
+      } catch (error) {
+        Notifications.showWarning({text: `Error loading DAC information for datasets: ${error.message}`});
+      }
+    }
+
+    loadDacs();
   }, [dacIds]);
 
   const buildDucAddendumTable = useCallback(async () => {

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { useState, useEffect, Fragment } from 'react';
+import React, {useState, useEffect, Fragment, useMemo} from 'react';
 import { Styles } from '../../libs/theme';
 import SimpleTable from '../../components/SimpleTable';
 import './dar_application.css';
 import { binCollectionToBuckets } from '../../utils/BucketUtils';
 import { useCallback } from 'react';
 import { isEmpty, flatten } from 'lodash/fp';
+import {DAC} from 'src/libs/ajax/DAC.js';
 
 const commonStyles = {
   baseStyle: {
@@ -86,6 +86,9 @@ const columnHeaderData = (columns) => {
 
 export default function DucAddendum(props) {
   const { datasets, isLoading, save, doSubmit } = props;
+  console.log(datasets);
+  const dacIds = useMemo(() => datasets.map(dataset => dataset.dacId), [datasets]);
+  const [dacs, setDacs] = useState([]);
 
   const [buckets, setBuckets] = useState([]);
   const [ducAddendumTable, setDucAddendumTable] = useState([]);
@@ -105,6 +108,26 @@ export default function DucAddendum(props) {
   useEffect(() => {
     getBuckets();
   }, [getBuckets]);
+
+  useEffect(() => {
+    if (isEmpty(dacIds)) {
+      setDacs([]);
+      return;
+    }
+    const uniqueDacIds = [...new Set(dacIds)];
+    const dacPromises = uniqueDacIds.map(dacId => DAC.get(dacId));
+
+    Promise.all(dacPromises)
+      .then(dacsData => {
+        setDacs(dacsData);
+      })
+      .catch(error => {
+        Notification.error({
+            message: 'Error fetching DACs',
+            description: `There was an error fetching information about the DACs related to the selected dataset(s): ${error.message}`,
+        })
+      });
+  }, [dacIds]);
 
   const buildDucAddendumTable = useCallback(async () => {
     const tableChunks = buckets.map(bucket => {

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -161,7 +161,7 @@ export default function DucAddendum(props) {
             style: columnStyles
           },
           {
-            data: '',
+            data: dacs.find(dac => dac.dacId === dataset.dacId)?.name || 'Unknown DAC',
             id: dataset.datasetId,
             style: columnStyles
           },
@@ -207,7 +207,7 @@ export default function DucAddendum(props) {
 
     const fullTable = flatten(tableChunks);
     setDucAddendumTable(fullTable);
-  }, [buckets, isLoading]);
+  }, [buckets, isLoading, dacs]);
 
   useEffect(() => {
     buildDucAddendumTable();

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -6,8 +6,8 @@ import './dar_application.css'
 import { binCollectionToBuckets } from 'src/utils/BucketUtils'
 import { useCallback } from 'react'
 import { isEmpty, flatten } from 'lodash/fp'
-import { DAC } from 'src/libs/ajax/DAC.js'
 import { Notifications } from 'src/libs/utils.js'
+import { DataSet } from 'src/libs/ajax/DataSet.js'
 
 const commonStyles = {
   baseStyle: {
@@ -110,26 +110,47 @@ export default function DucAddendum(props) {
   }, [getBuckets])
 
   useEffect(() => {
-    const loadDacs = async () => {
-      const dacIds = [...new Set(datasets.map(dataset => dataset.dacId))]
-      const dacPromises = dacIds.map(dacId => DAC.get(dacId))
+    const loadDatasetTerms = async () => {
+      const datasetQuery = DataSet.searchDatasetIndex({
+        query: {
+          bool: {
+            must: [
+              {
+                match: {
+                  _type: 'dataset',
+                },
+              },
+              {
+                terms: {
+                  _id: datasets.map(dataset => dataset.datasetId),
+                },
+              },
+            ],
+          },
+        },
+      })
 
       try {
-        const dacsData = await Promise.all(dacPromises)
-        setDacs(dacsData)
+        const datasetTerms = await datasetQuery
+
+        const dacs = datasetTerms.map((datasetTerm) => {
+          return datasetTerm.dac
+        })
+
+        setDacs(dacs)
       }
       catch (error) {
         Notifications.showWarning({ text: `Error loading DAC information for datasets: ${error.message}` })
       }
     }
 
-    loadDacs()
+    loadDatasetTerms()
   }, [datasets])
 
   const buildDucAddendumTable = useCallback(async () => {
     const getDacName = (dacId) => {
-      const dac = dacs.find(dac => dac.dacId === dacId)
-      return dac?.name || 'Unknown DAC'
+      const dac = dacs.find(dac => dac?.dacId === dacId)
+      return dac?.dacName || 'N/A'
     }
 
     const tableChunks = buckets.map((bucket) => {

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -1,8 +1,8 @@
-import React, {useState, useEffect, Fragment, useMemo} from 'react';
-import { Styles } from '../../libs/theme';
-import SimpleTable from '../../components/SimpleTable';
+import React, {useState, useEffect, Fragment} from 'react';
+import { Styles } from 'src/libs/theme';
+import SimpleTable from 'src/components/SimpleTable';
 import './dar_application.css';
-import { binCollectionToBuckets } from '../../utils/BucketUtils';
+import { binCollectionToBuckets } from 'src/utils/BucketUtils';
 import { useCallback } from 'react';
 import { isEmpty, flatten } from 'lodash/fp';
 import {DAC} from 'src/libs/ajax/DAC.js';

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -87,7 +87,6 @@ const columnHeaderData = (columns) => {
 
 export default function DucAddendum(props) {
   const { datasets, isLoading, save, doSubmit } = props;
-  const dacIds = useMemo(() => datasets.map(dataset => dataset.dacId), [datasets]);
 
   const [dacs, setDacs] = useState([]);
   const [buckets, setBuckets] = useState([]);
@@ -111,8 +110,8 @@ export default function DucAddendum(props) {
 
   useEffect(() => {
     const loadDacs = async () => {
-      const uniqueDacIds = [...new Set(dacIds)];
-      const dacPromises = uniqueDacIds.map(dacId => DAC.get(dacId));
+      const dacIds = [...new Set(datasets.map(dataset => dataset.dacId))];
+      const dacPromises = dacIds.map(dacId => DAC.get(dacId));
 
       try {
         const dacsData = await Promise.all(dacPromises);
@@ -123,7 +122,7 @@ export default function DucAddendum(props) {
     }
 
     loadDacs();
-  }, [dacIds]);
+  }, [datasets]);
 
   const buildDucAddendumTable = useCallback(async () => {
     const tableChunks = buckets.map(bucket => {

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -1,4 +1,3 @@
-
 import React from 'react'
 import { useState, useEffect, Fragment } from 'react'
 import { Styles } from 'src/libs/theme'
@@ -112,19 +111,20 @@ export default function DucAddendum(props) {
 
   useEffect(() => {
     const loadDacs = async () => {
-      const dacIds = [...new Set(datasets.map(dataset => dataset.dacId))];
-      const dacPromises = dacIds.map(dacId => DAC.get(dacId));
+      const dacIds = [...new Set(datasets.map(dataset => dataset.dacId))]
+      const dacPromises = dacIds.map(dacId => DAC.get(dacId))
 
       try {
-        const dacsData = await Promise.all(dacPromises);
-        setDacs(dacsData);
-      } catch (error) {
-        Notifications.showWarning({text: `Error loading DAC information for datasets: ${error.message}`});
+        const dacsData = await Promise.all(dacPromises)
+        setDacs(dacsData)
+      }
+      catch (error) {
+        Notifications.showWarning({ text: `Error loading DAC information for datasets: ${error.message}` })
       }
     }
 
-    loadDacs();
-  }, [datasets]);
+    loadDacs()
+  }, [datasets])
 
   const buildDucAddendumTable = useCallback(async () => {
     const tableChunks = buckets.map((bucket) => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2001

### Summary

Previously, the DAC name was not displayed in the DAR addendum. Now, that information is retrieved and displayed to the user.

Before:
<img width="958" height="805" alt="Screenshot 2025-07-24 at 1 54 31 PM" src="https://github.com/user-attachments/assets/4b11ecff-c4ad-4a53-9db7-b0999979cc4f" />

After:
<img width="985" height="825" alt="Screenshot 2025-07-24 at 1 53 39 PM" src="https://github.com/user-attachments/assets/86e071e1-7a17-4c2d-92b4-09348255aa0f" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
