### PR TITLE
[DT-1973] IRB approval docs expire after 11 months by default

### DIFF
--- a/cypress/component/utils/dar_form_utils.spec.ts
+++ b/cypress/component/utils/dar_form_utils.spec.ts
@@ -1,0 +1,8 @@
+import {newIrbDocumentExpirationDate} from "src/utils/darFormUtils";
+
+describe('DarFormUtils', () => {
+    it('newIrbDocumentExpirationDate', () => {
+        const result = newIrbDocumentExpirationDate();
+        expect(result).to.match(/^\d{4}-\d{2}-\d{2}$/); // YYYY-MM-DD format
+    });
+});

--- a/cypress/component/utils/dar_form_utils.spec.ts
+++ b/cypress/component/utils/dar_form_utils.spec.ts
@@ -1,8 +1,8 @@
-import {newIrbDocumentExpirationDate} from "src/utils/darFormUtils";
+import { newIrbDocumentExpirationDate } from 'src/utils/darFormUtils'
 
 describe('DarFormUtils', () => {
-    it('newIrbDocumentExpirationDate', () => {
-        const result = newIrbDocumentExpirationDate();
-        expect(result).to.match(/^\d{4}-\d{2}-\d{2}$/); // YYYY-MM-DD format
-    });
-});
+  it('newIrbDocumentExpirationDate', () => {
+    const result = newIrbDocumentExpirationDate()
+    expect(result).to.match(/^\d{4}-\d{2}-\d{2}$/) // YYYY-MM-DD format
+  })
+})

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -37,7 +37,8 @@ export const needsDsAcknowledgement = (dataUseTranslations) => {
 
 export const newIrbDocumentExpirationDate = () => {
   const today = new Date()
-  return `${(today.getFullYear() + 1).toString().padStart(4, '0')}-${today.getMonth().toString().padStart(2, '0')}-${today.getDate().toString().padStart(2, '0')}`
+  // Set the date to one year from today, month is 0 indexed
+  return `${(today.getFullYear() + 1).toString().padStart(4, '0')}-${(today.getMonth()+1).toString().padStart(2, '0')}-${today.getDate().toString().padStart(2, '0')}`
 }
 
 // ********************** DAR FORM VALIDATION ********************** //

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -38,7 +38,7 @@ export const needsDsAcknowledgement = (dataUseTranslations) => {
 export const newIrbDocumentExpirationDate = () => {
   const today = new Date()
   // Set the date to one year from today, month is 0 indexed
-  return `${(today.getFullYear() + 1).toString().padStart(4, '0')}-${(today.getMonth()+1).toString().padStart(2, '0')}-${today.getDate().toString().padStart(2, '0')}`
+  return `${(today.getFullYear() + 1).toString().padStart(4, '0')}-${(today.getMonth() + 1).toString().padStart(2, '0')}-${today.getDate().toString().padStart(2, '0')}`
 }
 
 // ********************** DAR FORM VALIDATION ********************** //


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1973

### Summary
Month is 0-indexed so we need to add one to get the month we are looking for.

This fixes the default expiration date of IRB docs for DARs. The default expiration date of IRB docs for Progress Reports is the expiration date of the IRB doc on the parent DAR. So, that is fixed too. 

Adds a very basic test for the format of this date, but not the value of the date. I was going to test that the year is one greater than the current year, the month is the same, and the date is the same, but I thought that might be a bit flaky if run on day boundaries/midnight. But, if anyone has any better ideas, let me know!

<img width="941" height="180" alt="Screenshot 2025-07-25 at 3 22 11 PM" src="https://github.com/user-attachments/assets/8d186834-a4e8-47b9-bf19-aa5acb273874" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
