### PR TITLE
[DT-1965] Fix truncated confirmation modal in short viewport

### DIFF
--- a/cypress/component/modals/ConfirmationModal.spec.tsx
+++ b/cypress/component/modals/ConfirmationModal.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import ConfirmationModal from '../../../src/components/modals/ConfirmationModal'
+
+describe('ConfirmationModal z-index Tests', () => {
+  it('should have a high z-index to appear above navigation', () => {
+    const mockProps = {
+      showConfirmation: true,
+      closeConfirmation: () => {},
+      title: 'Test Modal',
+      message: 'Test message',
+      header: 'Test Header',
+      onConfirm: () => {}
+    }
+
+    mount(<ConfirmationModal {...mockProps} />)
+
+    // Check that modal content has the correct z-index
+    cy.get('.confirmation-modal')
+      .should('exist')
+      .should('have.css', 'z-index', '1080')
+
+    // Check that modal overlay has the correct z-index
+    cy.get('.confirmation-modal-overlay')
+      .should('exist')
+      .should('have.css', 'z-index', '1075')
+  })
+
+  it('should render confirmation modal with proper structure', () => {
+    const mockProps = {
+      showConfirmation: true,
+      closeConfirmation: cy.stub(),
+      title: 'Delete DAR',
+      message: 'Are you sure you want to delete this DAR?',
+      header: 'DAR-123 - Test Project',
+      onConfirm: cy.stub()
+    }
+
+    mount(<ConfirmationModal {...mockProps} />)
+
+    cy.get('.confirmation-modal-header').should('contain', 'DAR-123 - Test Project')
+    cy.get('.confirmation-modal-title').should('contain', 'Delete DAR')
+    cy.get('.confirmation-modal-message').should('contain', 'Are you sure you want to delete this DAR?')
+    cy.get('.confirmation-modal-primary-button').should('contain', 'Confirm')
+    cy.get('.confirmation-modal-secondary-button').should('contain', 'Cancel')
+  })
+})

--- a/cypress/component/modals/ConfirmationModal.spec.tsx
+++ b/cypress/component/modals/ConfirmationModal.spec.tsx
@@ -10,7 +10,7 @@ describe('ConfirmationModal z-index Tests', () => {
       title: 'Test Modal',
       message: 'Test message',
       header: 'Test Header',
-      onConfirm: () => {}
+      onConfirm: () => {},
     }
 
     mount(<ConfirmationModal {...mockProps} />)
@@ -33,7 +33,7 @@ describe('ConfirmationModal z-index Tests', () => {
       title: 'Delete DAR',
       message: 'Are you sure you want to delete this DAR?',
       header: 'DAR-123 - Test Project',
-      onConfirm: cy.stub()
+      onConfirm: cy.stub(),
     }
 
     mount(<ConfirmationModal {...mockProps} />)

--- a/src/components/modals/ConfirmationModal.css
+++ b/src/components/modals/ConfirmationModal.css
@@ -17,7 +17,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(255, 255, 255, 0.75);
     z-index: 1075;
 }
 

--- a/src/components/modals/ConfirmationModal.css
+++ b/src/components/modals/ConfirmationModal.css
@@ -8,6 +8,17 @@
     background-color: white;
     border: 1px solid lightgrey;
     border-radius: 4px;
+    z-index: 1080;
+}
+
+.confirmation-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 1075;
 }
 
 .confirmation-modal-header {

--- a/src/components/modals/ConfirmationModal.jsx
+++ b/src/components/modals/ConfirmationModal.jsx
@@ -51,6 +51,7 @@ const ConfirmationModal = (props) => {
       shouldCloseOnEsc={true}
       shouldCloseOnOverlayClick={true}
       className="confirmation-modal"
+      overlayClassName="confirmation-modal-overlay"
       style={{ content: styleOverride }}
     >
       <div>


### PR DESCRIPTION
# Addresses
https://broadworkbench.atlassian.net/browse/DT-1965

# Summary
Previously, when the viewport had a somewhat lower height, modals that appear and ask the user for confirmation could appear partly cut off.  Now, such modals always fully display.

# Demo
### Before

https://github.com/user-attachments/assets/4368c1ff-f0f9-4cb2-ac17-19a739bea3e2

### After

https://github.com/user-attachments/assets/1e0c8931-e41e-4e20-b322-2d4182d8d03a

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
