### PR TITLE
[DT-1871] Enable Progress Reports on production

### DIFF
--- a/cypress/component/DarCollectionTable/actions.spec.jsx
+++ b/cypress/component/DarCollectionTable/actions.spec.jsx
@@ -226,12 +226,12 @@ describe('Researcher Actions - Review Closeout Button', () => {
     cy.get(`#researcher-review-closeout-${collectionId}`).should('exist')
   })
 
-  it('does not render in production environment even with Review_Progress_Report action', () => {
+  it('does render in production environment even with Review_Progress_Report action', () => {
     cy.stub(Storage, 'getEnv').returns('prod')
     propCopy.consoleType = 'researcher'
     propCopy.actions = ['Review_Progress_Report']
     mount(<Actions {...propCopy} />)
-    cy.get(`#researcher-review-closeout-${collectionId}`).should('not.exist')
+    cy.get(`#researcher-review-closeout-${collectionId}`).should('exist')
   })
 
   it('does not render if Review_Progress_Report action is not present', () => {

--- a/src/components/dar_collection_table/Actions.jsx
+++ b/src/components/dar_collection_table/Actions.jsx
@@ -238,10 +238,8 @@ export default function Actions(props) {
       {actions.includes('Review') && <SimpleButton {...reviewButtonAttributes} />}
       {actions.includes('Delete') && <TableIconButton {...deleteButtonAttributes} />}
       {actions.includes('Cancel') && <TableIconButton {...cancelButtonAttributes} />}
-      {checkEnv(envGroups.NON_PROD) && actions.includes('Create_Progress_Report')
-        && <SimpleButton {...createProgressReportButtonAttributes} />}
-      {checkEnv(envGroups.NON_PROD) && actions.includes('Review_Progress_Report')
-        && <SimpleButton {...reviewCloseoutButtonAttributes} />}
+      {actions.includes('Create_Progress_Report') && <SimpleButton {...createProgressReportButtonAttributes} />}
+      {actions.includes('Review_Progress_Report') && <SimpleButton {...reviewCloseoutButtonAttributes} />}
     </div>
   )
 }

--- a/src/components/dar_collection_table/Actions.jsx
+++ b/src/components/dar_collection_table/Actions.jsx
@@ -6,7 +6,6 @@ import SimpleButton from 'src/components/SimpleButton'
 import { useHistory } from 'react-router-dom'
 import { Notifications } from 'src/libs/utils'
 import { includes, toLower } from 'lodash/fp'
-import { checkEnv, envGroups } from 'src/utils/EnvironmentUtils'
 
 const duosBlue = '#0948B7'
 const cancelGray = '#333F52'


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1871

### Summary
This enables Progress Reports on production, i.e. https://duos.org, by enabling the "UPDATE" and "REVIEW CLOSEOUT" action buttons in the DAR collection table.  Feature flags were added for those in #2875 and #2925.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
