### PR TITLE
[DT-2037] Accessibility Fix for missing alt attribute for images

### DIFF
--- a/cypress/component/toast_notifications.spec.tsx
+++ b/cypress/component/toast_notifications.spec.tsx
@@ -174,7 +174,7 @@ describe('ToastNotifications', () => {
       })
 
       cy.get('[data-cy="notification-alert"]').should('be.visible')
-      cy.get('[data-cy="notification-alert"]', { timeout: 700 }).should('not.exist')
+      cy.get('[data-cy="notification-alert"]', { timeout: 1000 }).should('not.exist')
     })
   })
 

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -204,7 +204,7 @@ const DuosHeader = (props) => {
   }
 
   const contactUsSource = state.hover ? contactUsHover : contactUsStandard
-  const contactUsIcon = isLogged ? '' : <img src={contactUsSource} style={{ display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline' }} />
+  const contactUsIcon = isLogged ? '' : <img src={contactUsSource} alt="Contact Us Icon" style={{ display: 'inline-block', margin: '0 8px 0 0', verticalAlign: 'baseline' }} />
   const contactUsText = isLogged ? 'Contact Us' : <span style={{ display: 'inline', verticalAlign: 'text-bottom' }}>Contact Us</span>
   const contactUsButton = (
     <button

--- a/src/components/TableHeaderSection.jsx
+++ b/src/components/TableHeaderSection.jsx
@@ -13,6 +13,7 @@ export const TableHeaderSection = (props) => {
             <img
               id="dataset-icon"
               src={icon}
+              alt="Dataset Icon"
               style={{
                 width: icon.width,
                 height: icon.height || 64,

--- a/src/pages/researcher_console/ResearcherConsole.jsx
+++ b/src/pages/researcher_console/ResearcherConsole.jsx
@@ -137,7 +137,7 @@ export default function ResearcherConsole() {
       <div style={{ display: 'flex', justifyContent: 'space-between', margin: '0px -3%' }}>
         <div className="left-header-section" style={Styles.LEFT_HEADER_SECTION}>
           <div style={Styles.ICON_CONTAINER}>
-            <img id="access-icon" src={accessIcon} style={Styles.HEADER_IMG} />
+            <img id="access-icon" src={accessIcon} alt="Access Icon" style={Styles.HEADER_IMG} />
           </div>
           <div style={Styles.HEADER_CONTAINER}>
             <div style={Styles.TITLE}>My Data Access Requests</div>

--- a/src/pages/user_profile/UserProfile.jsx
+++ b/src/pages/user_profile/UserProfile.jsx
@@ -132,6 +132,7 @@ export default function UserProfile(props) {
           >
             <img
               src={ga4ghLogo}
+              alt="GA4GH Logo"
               style={{
                 width: '166px',
                 height: '48px',


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2037

### Summary
[DT-2018](https://broadworkbench.atlassian.net/browse/DT-2018) scanned DUOS-UI pages for accessibility issues and generated HTML reports, identifying a lack of alt attributes for images in some pages. This PR added missing alt attributes to image elements. Pages updated:
- Home
- Researcher Console
- Data Library
- Profile

<table>
<tr><td>Before</td><td>After</td></tr>
<tr>
<td>
<img width="1768" height="1022" alt="Before-Home" src="https://github.com/user-attachments/assets/78be37d0-6432-4925-a2cc-e096373f20b6" />
</td>
<td>
<img width="1768" height="1022" alt="After-Home" src="https://github.com/user-attachments/assets/fa211971-1d2f-4095-9ca8-98e67085ee19" />
</td>
</tr>
<tr>
<td>
<img width="1768" height="1022" alt="Before-ResearcherConsole" src="https://github.com/user-attachments/assets/0b7e9b8f-dd68-4cf4-bb74-9b28d680e41c" />
</td>
<td>
<img width="1768" height="1022" alt="After-ResearcherConsole" src="https://github.com/user-attachments/assets/a93378be-6b12-4c45-b213-8c3ba57d7561" />
</td>
</tr>
<tr>
<td>
<img width="1768" height="1022" alt="Before-DataLibrary" src="https://github.com/user-attachments/assets/1e9997c9-a4fa-4458-8188-3a0e68af5ab0" />
</td>
<td>
<img width="1768" height="1022" alt="After-DataLibrary" src="https://github.com/user-attachments/assets/7c29c3ff-7350-4656-b975-03f59728b7dc" />
</td>
</tr>
<tr>
<td>
<img width="1768" height="1022" alt="Before-Profile" src="https://github.com/user-attachments/assets/ba64598c-249f-410c-8202-1ae83b226ce7" />
</td>
<td>
<img width="1768" height="1022" alt="After-Profile" src="https://github.com/user-attachments/assets/e7d2b94d-3ee3-418b-b906-7e1031e8c92f" />
</td>
</tr>
</table>

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-2018]: https://broadworkbench.atlassian.net/browse/DT-2018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ