### PR TITLE
[DT-2099] Update to allow RADAR_APPROVE vote types

### DIFF
--- a/cypress/component/utils/dar_utils.spec.ts
+++ b/cypress/component/utils/dar_utils.spec.ts
@@ -5,6 +5,8 @@ import {
   getDataManagementIncidents,
   getPresentationList,
   getPublicationList,
+  FINAL,
+  RADAR_APPROVE,
 } from 'src/utils/DarUtils'
 import { Collaborator, Election, Vote } from 'src/types/model'
 import { FormState } from 'src/pages/progress_reports/ProgressReportFormState'
@@ -24,7 +26,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 101,
           votes: {
-            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote,
+            1: { voteId: 1, type: FINAL, vote: true, userId: 10, electionId: 1 } as Vote,
           } as object,
         } as Election,
         {
@@ -32,7 +34,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 102,
           votes: {
-            2: { voteId: 2, type: 'FINAL', userId: 11, electionId: 2 } as Vote,
+            2: { voteId: 2, type: RADAR_APPROVE, userId: 11, electionId: 2 } as Vote,
           } as object,
         } as Election,
         {
@@ -40,7 +42,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 103,
           votes: {
-            3: { voteId: 3, type: 'FINAL', vote: false, userId: 12, electionId: 3 } as Vote,
+            3: { voteId: 3, type: FINAL, vote: false, userId: 12, electionId: 3 } as Vote,
           } as object,
         } as Election,
       ]
@@ -56,7 +58,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 101,
           votes: {
-            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote,
+            1: { voteId: 1, type: FINAL, vote: true, userId: 10, electionId: 1 } as Vote,
           } as object,
         } as Election,
         {
@@ -64,7 +66,7 @@ describe('DarUtils', () => {
           electionType: 'RP',
           datasetId: 102,
           votes: {
-            2: { voteId: 2, type: 'FINAL', vote: true, userId: 11, electionId: 2 } as Vote,
+            2: { voteId: 2, type: FINAL, vote: true, userId: 11, electionId: 2 } as Vote,
           } as object,
         } as Election,
       ]
@@ -80,7 +82,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 101,
           votes: {
-            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote,
+            1: { voteId: 1, type: RADAR_APPROVE, vote: true, userId: 10, electionId: 1 } as Vote,
             2: { voteId: 2, type: 'Chairperson', vote: false, userId: 11, electionId: 1 } as Vote,
           } as object,
         } as Election,
@@ -90,7 +92,7 @@ describe('DarUtils', () => {
           datasetId: 102,
           votes: {
             3: { voteId: 3, type: 'DAC', vote: true, userId: 12, electionId: 2 } as Vote,
-            4: { voteId: 4, type: 'FINAL', vote: false, userId: 13, electionId: 2 } as Vote,
+            4: { voteId: 4, type: FINAL, vote: false, userId: 13, electionId: 2 } as Vote,
           } as object,
         } as Election,
       ]
@@ -122,7 +124,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 103,
           votes: {
-            3: { voteId: 3, type: 'FINAL', vote: true, userId: 12, electionId: 3 } as Vote,
+            3: { voteId: 3, type: FINAL, vote: true, userId: 12, electionId: 3 } as Vote,
           } as object,
         } as Election,
       ]
@@ -144,7 +146,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 102,
           votes: {
-            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 2 } as Vote,
+            1: { voteId: 1, type: FINAL, vote: true, userId: 10, electionId: 2 } as Vote,
           } as object,
         } as Election,
       ]
@@ -160,7 +162,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 101,
           votes: {
-            1: { voteId: 1, type: 'FINAL', vote: true, userId: 10, electionId: 1 } as Vote,
+            1: { voteId: 1, type: FINAL, vote: true, userId: 10, electionId: 1 } as Vote,
           } as object,
         } as Election,
         {
@@ -168,7 +170,7 @@ describe('DarUtils', () => {
           electionType: 'DataAccess',
           datasetId: 101,
           votes: {
-            2: { voteId: 2, type: 'FINAL', vote: true, userId: 11, electionId: 2 } as Vote,
+            2: { voteId: 2, type: RADAR_APPROVE, vote: true, userId: 11, electionId: 2 } as Vote,
           } as object,
         } as Election,
       ]

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -8,12 +8,16 @@ import {
 } from 'src/types/model'
 import { CLOSEOUT_KEYS, DMI_INCIDENT_KEYS, FormState } from 'src/pages/progress_reports/ProgressReportFormState'
 
+export const FINAL = 'FINAL'
+export const RADAR_APPROVE = 'RADAR_APPROVE'
+const APPROVED_VOTETYPES = [FINAL, RADAR_APPROVE]
+
 export function getApprovedElectionDatasetIds(elections: Array<Election>): Array<number> {
   const approvedDatasetIds = []
   for (const election of elections) {
     if (election.electionType === 'DataAccess') {
       const votes = Object.values(election.votes)
-      const anyApprovedFinalVotes = votes.some(vote => vote.type === 'FINAL' && vote.vote)
+      const anyApprovedFinalVotes = votes.some(vote => (APPROVED_VOTETYPES.includes(vote.type)) && vote.vote)
       if (anyApprovedFinalVotes) {
         approvedDatasetIds.push(election.datasetId)
       }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2099](https://broadworkbench.atlassian.net/browse/DT-2099)

### Summary

DUOS UI has logic to calculate the approved datasets for a DAR that needs to be updated to account for RADAR.

BEFORE:

<img width="1302" height="595" alt="2099-before" src="https://github.com/user-attachments/assets/55c89be3-01f1-41db-ba9f-4a2c560ec596" />

AFTER:

<img width="1301" height="1020" alt="2099-after" src="https://github.com/user-attachments/assets/1f454a3c-7ac1-4f32-9843-61d9be11ba52" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
