### PR TITLE
DT-2108: Fix researcher profile alert styling

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -13,7 +13,7 @@ export interface AlertProps {
 export const Alert = (props: AlertProps) => {
   const { id, type, title, description, onClose } = props
   return (
-    <div id={`${id}_alert`} className={`alert-wrapper ${type}`} style={{ border: '1px solid red', borderRadius: '5px' }}>
+    <div id={`${id}_alert`} className={`alert-wrapper ${type}`} style={{ border: '1px solid', borderRadius: '5px' }}>
       {onClose && (
         <span
           style={{ float: 'right', fontWeight: 'bolder', fontSize: 24, cursor: 'pointer' }}

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -25,10 +25,7 @@ const profileUnsubmitted = (
 )
 const profileSubmitted = (
   <span>
-    Please make sure
-    {profileLink}
-    {' '}
-    is updated as it will be used to pre-populate parts of the Data Access Request
+    Please make sure {profileLink} is updated as it will be used to pre-populate parts of the Data Access Request
   </span>
 )
 const libraryCardLink = (

--- a/src/pages/dar_application/ResearcherInfo.jsx
+++ b/src/pages/dar_application/ResearcherInfo.jsx
@@ -17,10 +17,7 @@ const noTopMarginStyle = { marginTop: 0, paddingTop: 0 }
 const profileLink = <Link to="/profile" style={linkStyle}>Your Profile</Link>
 const profileUnsubmitted = (
   <span>
-    Please submit
-    {profileLink}
-    {' '}
-    to be able to create a Data Access Request
+    Please submit {profileLink} to be able to create a Data Access Request
   </span>
 )
 const profileSubmitted = (


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2108

## Summary
Two small changes to make the profile alert be consistent with default styles.

### 
Old:
<img width="712" height="220" alt="Screenshot 2025-08-12 at 11 18 22 AM" src="https://github.com/user-attachments/assets/24cbea99-cdb8-4ec1-ac12-cad1bed1f1bd" />

This is the current `info` style for this block:
<img width="712" height="212" alt="Screenshot 2025-08-12 at 11 24 07 AM" src="https://github.com/user-attachments/assets/20a41fd8-e1e8-44bb-a1a4-84fb90454517" />

This is what a `danger` style _would_ look like:
<img width="713" height="220" alt="Screenshot 2025-08-12 at 11 25 54 AM" src="https://github.com/user-attachments/assets/ec5c8ac5-4d79-4752-a5f9-9d8d026271ee" />

This is what a `warn` style _would_ look like:
<img width="718" height="223" alt="Screenshot 2025-08-12 at 11 26 08 AM" src="https://github.com/user-attachments/assets/33661c39-5849-4bf9-904a-d52b7522f219" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
