### PR TITLE
[DT-2080] Enable RADAR in all environments.

### DIFF
--- a/cypress/component/manage_dac_table/manageDacTableCellData.spec.tsx
+++ b/cypress/component/manage_dac_table/manageDacTableCellData.spec.tsx
@@ -68,8 +68,8 @@ describe('ManageDacTableCellData Actions Tests', () => {
       cy.get('img.radar-icon').should('have.attr', 'alt', 'Edit rule automation')
     })
 
-    it('should hide RADAR action in staging environment', () => {
-      // Mock the environment to return 'staging'
+    it('should show RADAR action in staging environment', () => {
+      // Mock the environment to return 'local'
       cy.stub(Storage, 'getEnv').returns('staging')
 
       const mockProps = {
@@ -86,14 +86,12 @@ describe('ManageDacTableCellData Actions Tests', () => {
         </WrappedActionCell>,
       )
 
-      // Should not show RADAR icon in staging environment
-      cy.get('img.radar-icon').should('not.exist')
-
-      // Should still show edit icon
-      cy.get('img#edit-pencil-icon').should('exist')
+      // Should show RADAR icon in local environment
+      cy.get('img.radar-icon').should('exist')
+      cy.get('img.radar-icon').should('have.attr', 'alt', 'Edit rule automation')
     })
 
-    it('should hide RADAR action in production environment', () => {
+    it('should show RADAR action in prod environment', () => {
       // Mock the environment to return 'prod'
       cy.stub(Storage, 'getEnv').returns('prod')
 
@@ -111,14 +109,12 @@ describe('ManageDacTableCellData Actions Tests', () => {
         </WrappedActionCell>,
       )
 
-      // Should not show RADAR icon in production environment
-      cy.get('img.radar-icon').should('not.exist')
-
-      // Should still show edit icon
-      cy.get('img#edit-pencil-icon').should('exist')
+      // Should show RADAR icon in local environment
+      cy.get('img.radar-icon').should('exist')
+      cy.get('img.radar-icon').should('have.attr', 'alt', 'Edit rule automation')
     })
 
-    it('should hide RADAR action when environment is undefined', () => {
+    it('should show RADAR action when environment is undefined', () => {
       // Mock the environment to return undefined
       cy.stub(Storage, 'getEnv').returns(undefined)
 
@@ -136,8 +132,8 @@ describe('ManageDacTableCellData Actions Tests', () => {
         </WrappedActionCell>,
       )
 
-      // Should not show RADAR icon when environment is undefined
-      cy.get('img.radar-icon').should('not.exist')
+      // Should show RADAR icon when environment is undefined
+      cy.get('img.radar-icon').should('exist')
 
       // Should still show edit icon
       cy.get('img#edit-pencil-icon').should('exist')
@@ -145,10 +141,7 @@ describe('ManageDacTableCellData Actions Tests', () => {
   })
 
   describe('RADAR Link Navigation', () => {
-    it('should have correct link path in dev environment', () => {
-      // Mock the environment to return 'dev'
-      cy.stub(Storage, 'getEnv').returns('dev')
-
+    it('should have correct link path', () => {
       const mockProps = {
         dac: mockDac,
         deleteDac: cy.stub(),
@@ -169,61 +162,28 @@ describe('ManageDacTableCellData Actions Tests', () => {
     })
   })
 
-  describe('Actions Layout', () => {
-    it('should maintain proper action layout when RADAR is hidden', () => {
-      // Mock the environment to return 'prod'
-      cy.stub(Storage, 'getEnv').returns('prod')
+  it('should show all actions', () => {
+    const mockProps = {
+      dac: mockDac,
+      deleteDac: cy.stub(),
+      userRole: 'Admin',
+    }
 
-      const mockProps = {
-        dac: mockDac,
-        deleteDac: cy.stub(),
-        userRole: 'Admin',
-      }
+    const cellData = actionsCellData(mockProps)
 
-      const cellData = actionsCellData(mockProps)
+    mount(
+      <WrappedActionCell>
+        {cellData.data}
+      </WrappedActionCell>,
+    )
 
-      mount(
-        <WrappedActionCell>
-          {cellData.data}
-        </WrappedActionCell>,
-      )
+    // Should have RADAR icon
+    cy.get('img.radar-icon').should('exist')
 
-      // Should still have the main actions container
-      cy.get('div').should('exist')
+    // Should have edit icon
+    cy.get('img#edit-pencil-icon').should('exist')
 
-      // Should have edit icon
-      cy.get('img#edit-pencil-icon').should('exist')
-
-      // Should not have RADAR icon
-      cy.get('img.radar-icon').should('not.exist')
-    })
-
-    it('should show all actions when RADAR is visible in dev', () => {
-      // Mock the environment to return 'dev'
-      cy.stub(Storage, 'getEnv').returns('dev')
-
-      const mockProps = {
-        dac: mockDac,
-        deleteDac: cy.stub(),
-        userRole: 'Admin',
-      }
-
-      const cellData = actionsCellData(mockProps)
-
-      mount(
-        <WrappedActionCell>
-          {cellData.data}
-        </WrappedActionCell>,
-      )
-
-      // Should have RADAR icon
-      cy.get('img.radar-icon').should('exist')
-
-      // Should have edit icon
-      cy.get('img#edit-pencil-icon').should('exist')
-
-      // Both should be within the flex container
-      cy.get('div[style*="display: flex"]').should('exist')
-    })
+    // Both should be within the flex container
+    cy.get('div[style*="display: flex"]').should('exist')
   })
 })

--- a/cypress/component/manage_dac_table/manageDacTableCellData.spec.tsx
+++ b/cypress/component/manage_dac_table/manageDacTableCellData.spec.tsx
@@ -69,7 +69,7 @@ describe('ManageDacTableCellData Actions Tests', () => {
     })
 
     it('should show RADAR action in staging environment', () => {
-      // Mock the environment to return 'local'
+      // Mock the environment to return 'staging'
       cy.stub(Storage, 'getEnv').returns('staging')
 
       const mockProps = {

--- a/src/components/manage_dac_table/ManageDacTableCellData.jsx
+++ b/src/components/manage_dac_table/ManageDacTableCellData.jsx
@@ -8,7 +8,6 @@ import { Link } from 'react-router-dom'
 import editPencilIcon from 'src/images/edit_pencil.svg'
 import radarIcon from 'src/images/google-svg/radar.svg'
 import { DAAUtils } from 'src/utils/DAAUtils'
-import { isDevEnv } from 'src/utils/EnvironmentUtils'
 
 export function nameCellData({ name = '- -', dac, viewMembers, dacId, label = 'dac-name' }) {
   return {

--- a/src/components/manage_dac_table/ManageDacTableCellData.jsx
+++ b/src/components/manage_dac_table/ManageDacTableCellData.jsx
@@ -63,19 +63,17 @@ export function actionsCellData({ dac, deleteDac, userRole }) {
 
   const actions = (
     <>
-      {isDevEnv() && (
-        <div style={{ paddingTop: '5px', paddingRight: '4px' }}>
-          <Link
-            to={{
-              pathname: `/manage_radar/${dac.dacId}`,
-              state: { userRole: userRole },
-            }}
-            data-tip={`Edit rule automation for DARs in ${dac.name}`}
-          >
-            <img className="radar-icon" src={radarIcon} alt="Edit rule automation" />
-          </Link>
-        </div>
-      )}
+      <div style={{ paddingTop: '5px', paddingRight: '4px' }}>
+        <Link
+          to={{
+            pathname: `/manage_radar/${dac.dacId}`,
+            state: { userRole: userRole },
+          }}
+          data-tip={`Edit rule automation for DARs in ${dac.name}`}
+        >
+          <img className="radar-icon" src={radarIcon} alt="Edit rule automation" />
+        </Link>
+      </div>
       <div style={{ paddingTop: '5px' }}>
         <Link
           to={{


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2080](https://broadworkbench.atlassian.net/browse/DT-2080)

### Summary

Removes the dev only restriction on RADAR.

### DO NOT MERGE UNTIL [https://broadworkbench.atlassian.net/browse/DT-2071](https://broadworkbench.atlassian.net/browse/DT-2071) is closed

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
