### PR TITLE
[DT-2045] Fix Flaky Toast Notification UI Test

### DIFF
--- a/cypress/component/toast_notifications.spec.tsx
+++ b/cypress/component/toast_notifications.spec.tsx
@@ -157,7 +157,7 @@ describe('ToastNotifications', () => {
     })
   })
 
-  describe('showWarning', () => {
+  describe('showWarning', { retries: 3 }, () => {
     it('should display warning notification', () => {
       ToastNotifications.showWarning({ text: 'Warning message' })
 
@@ -168,13 +168,19 @@ describe('ToastNotifications', () => {
     })
 
     it('should accept custom timeout for warning notifications', () => {
+      // Arrange
+      cy.clock()
+
+      // Act
       ToastNotifications.showWarning({
         text: 'Warning message',
         timeout: 500,
       })
 
+      // Assert
       cy.get('[data-cy="notification-alert"]').should('be.visible')
-      cy.get('[data-cy="notification-alert"]', { timeout: 1000 }).should('not.exist')
+      cy.tick(2000) // Fast-forward time by 2000ms
+      cy.get('[data-cy="notification-alert"]').should('not.exist')
     })
   })
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2045

### Summary

The Cypress toast notification test at [toast_notifications.spec.tsx#L170](https://github.com/DataBiosphere/duos-ui/blob/d2bfdf32c7021f4a3d0c2d9b438592e849a40bb5/cypress/component/toast_notifications.spec.tsx#L170) fails often locally and is intermittently flaky in CI. This update investigates and resolves the cause to make the test run reliably.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
