### PR TITLE
[DT-2113] Prevent duplicate submissions on Progress Report form

### DIFF
--- a/cypress/component/AsyncSpinnerButton.spec.tsx
+++ b/cypress/component/AsyncSpinnerButton.spec.tsx
@@ -1,15 +1,15 @@
 import { mount } from 'cypress/react'
 import React from 'react'
-import { AsyncActionButton } from 'src/components/AsyncActionButton'
+import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton'
 
-describe('AsyncActionButton', () => {
+describe('AsyncSpinnerButton', () => {
   it('renders the button with default styling', () => {
     const mockOnClick = cy.stub().resolves()
 
     mount(
-      <AsyncActionButton onClick={mockOnClick}>
+      <AsyncSpinnerButton onClick={mockOnClick}>
         Test Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-test-button"]')
@@ -24,13 +24,13 @@ describe('AsyncActionButton', () => {
     const customStyle = { backgroundColor: 'red', color: 'white' }
 
     mount(
-      <AsyncActionButton
+      <AsyncSpinnerButton
         onClick={mockOnClick}
         style={customStyle}
         className="custom-button-class"
       >
         Styled Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-styled-button"]')
@@ -43,13 +43,13 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().resolves()
 
     mount(
-      <AsyncActionButton
+      <AsyncSpinnerButton
         onClick={mockOnClick}
         data-cy="custom-test-id"
         aria-label="Custom accessible label"
       >
         Custom Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="custom-test-id"]')
@@ -65,9 +65,9 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().returns(asyncAction)
 
     mount(
-      <AsyncActionButton onClick={mockOnClick}>
+      <AsyncSpinnerButton onClick={mockOnClick}>
         Loading Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-loading-button"]').click()
@@ -93,9 +93,9 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().resolves()
 
     mount(
-      <AsyncActionButton onClick={mockOnClick}>
+      <AsyncSpinnerButton onClick={mockOnClick}>
         Success Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-success-button"]')
@@ -118,9 +118,9 @@ describe('AsyncActionButton', () => {
     })
 
     mount(
-      <AsyncActionButton onClick={mockOnClick}>
+      <AsyncSpinnerButton onClick={mockOnClick}>
         Error Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     // First click should fail
@@ -149,9 +149,9 @@ describe('AsyncActionButton', () => {
     cy.wrap(mockOnClick).as('mockOnClick')
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} disabled={true}>
+      <AsyncSpinnerButton onClick={mockOnClick} disabled={true}>
         Disabled Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-disabled-button"]')
@@ -170,9 +170,9 @@ describe('AsyncActionButton', () => {
     cy.wrap(mockOnClick).as('mockOnClick')
 
     mount(
-      <AsyncActionButton onClick={mockOnClick}>
+      <AsyncSpinnerButton onClick={mockOnClick}>
         Multi Click Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     // First click starts the action
@@ -196,13 +196,13 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().resolves()
 
     mount(
-      <AsyncActionButton
+      <AsyncSpinnerButton
         onClick={mockOnClick}
         id="accessible-button"
         aria-label="Accessible action button"
       >
         Accessible Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('#accessible-button')
@@ -218,9 +218,9 @@ describe('AsyncActionButton', () => {
     cy.wrap(mockOnError).as('mockOnError')
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} onError={mockOnError}>
+      <AsyncSpinnerButton onClick={mockOnClick} onError={mockOnError}>
         Error Callback Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-error-callback-button"]').click()
@@ -234,9 +234,9 @@ describe('AsyncActionButton', () => {
     cy.wrap(mockOnError).as('mockOnError')
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} onError={mockOnError}>
+      <AsyncSpinnerButton onClick={mockOnClick} onError={mockOnError}>
         Success Callback Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-success-callback-button"]').click()
@@ -248,9 +248,9 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().resolves()
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} hideOnSuccess={true}>
+      <AsyncSpinnerButton onClick={mockOnClick} hideOnSuccess={true}>
         Hide True Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-hide-true-button"]')
@@ -265,9 +265,9 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().resolves()
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} hideOnSuccess={false}>
+      <AsyncSpinnerButton onClick={mockOnClick} hideOnSuccess={false}>
         Stay Visible Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-stay-visible-button"]')
@@ -286,9 +286,9 @@ describe('AsyncActionButton', () => {
     cy.wrap(mockOnClick).as('mockOnClick')
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} hideOnSuccess={false}>
+      <AsyncSpinnerButton onClick={mockOnClick} hideOnSuccess={false}>
         Multi Use Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-multi-use-button"]').click()
@@ -309,9 +309,9 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().returns(asyncAction)
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} hideOnSuccess={false}>
+      <AsyncSpinnerButton onClick={mockOnClick} hideOnSuccess={false}>
         Loading Stay Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-loading-stay-button"]').click()
@@ -335,9 +335,9 @@ describe('AsyncActionButton', () => {
     const mockOnClick = cy.stub().rejects(error)
 
     mount(
-      <AsyncActionButton onClick={mockOnClick} hideOnSuccess={true}>
+      <AsyncSpinnerButton onClick={mockOnClick} hideOnSuccess={true}>
         Error With Hide Button
-      </AsyncActionButton>,
+      </AsyncSpinnerButton>,
     )
 
     cy.get('[data-cy="async-action-button-error-with-hide-button"]').click()

--- a/src/components/AsyncSpinnerButton.tsx
+++ b/src/components/AsyncSpinnerButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react'
 import { Spinner } from 'src/components/Spinner'
 
-export interface AsyncActionButtonProps {
+export interface AsyncSpinnerButtonProps {
   /** The text to display on the button */
   'children': React.ReactNode
   /** Function to execute when button is clicked - should return a Promise */
@@ -28,7 +28,7 @@ export interface AsyncActionButtonProps {
   'hideOnSuccess'?: boolean
 }
 
-export const AsyncActionButton: React.FC<AsyncActionButtonProps> = ({
+export const AsyncSpinnerButton: React.FC<AsyncSpinnerButtonProps> = ({
   children,
   onClick,
   style,
@@ -127,4 +127,4 @@ export const AsyncActionButton: React.FC<AsyncActionButtonProps> = ({
   )
 }
 
-export default AsyncActionButton
+export default AsyncSpinnerButton

--- a/src/components/ConfirmationDialog_new.jsx
+++ b/src/components/ConfirmationDialog_new.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Modal from 'react-modal'
 import { Alert } from 'src/components/Alert'
 import CloseIconComponent from 'src/components/CloseIconComponent'
-import { AsyncActionButton } from 'src/components/AsyncActionButton'
+import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton.js'
 import './ConfirmationDialog_new.css'
 
 const customStyles = {
@@ -63,14 +63,14 @@ export const ConfirmationDialog = (props) => {
         >
           No
         </a>
-        <AsyncActionButton
+        <AsyncSpinnerButton
           id="btn_submit"
           className="button button-blue"
           onClick={props.action.handler(true)}
           disabled={disableOkBtn}
         >
           {props.action.label}
-        </AsyncActionButton>
+        </AsyncSpinnerButton>
       </div>
     </Modal>
   )

--- a/src/components/collection_vote_box/CollectionVoteButton.tsx
+++ b/src/components/collection_vote_box/CollectionVoteButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { votingColors } from 'src/libs/VotingColors'
-import { AsyncActionButton } from 'src/components/AsyncActionButton'
+import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton'
 
 const styles = {
   baseStyle: {
@@ -77,7 +77,7 @@ export default function CollectionVoteButton({
   }, [disabled, onClick])
 
   return (
-    <AsyncActionButton
+    <AsyncSpinnerButton
       data-cy={datacy}
       style={{ ...styles.baseStyle, ...additionalStyle }}
       onClick={handleAsyncClick}
@@ -88,6 +88,6 @@ export default function CollectionVoteButton({
       hideOnSuccess={false}
     >
       {label}
-    </AsyncActionButton>
+    </AsyncSpinnerButton>
   )
 }

--- a/src/components/modals/ConfirmationModal.jsx
+++ b/src/components/modals/ConfirmationModal.jsx
@@ -5,7 +5,7 @@ import './ConfirmationModal.css'
 import { styled } from '@mui/material/styles'
 import Stack from '@mui/material/Stack'
 import Button from '@mui/material/Button'
-import { AsyncActionButton } from '../AsyncActionButton'
+import { AsyncSpinnerButton } from '../AsyncSpinnerButton.js'
 
 const ConfirmationModal = (props) => {
   const { showConfirmation, closeConfirmation, title, message, header, onConfirm, styleOverride = {} } = props
@@ -36,7 +36,7 @@ const ConfirmationModal = (props) => {
   const actionButtons = (
     <Stack spacing={2} direction="row">
       <SecondaryButton variant="outlined" className="confirmation-modal-secondary-button" onClick={closeFn}>Cancel</SecondaryButton>
-      <AsyncActionButton
+      <AsyncSpinnerButton
         onClick={onConfirm}
         className="confirmation-modal-primary-button"
         style={{
@@ -52,7 +52,7 @@ const ConfirmationModal = (props) => {
         onMouseLeave={e => setHoverState(e, duosBlue)}
       >
         Confirm
-      </AsyncActionButton>
+      </AsyncSpinnerButton>
     </Stack>
   )
 

--- a/src/pages/data_submission/DataSubmissionForm.jsx
+++ b/src/pages/data_submission/DataSubmissionForm.jsx
@@ -15,7 +15,7 @@ import NIHAdministrativeInformation from 'src/pages/data_submission/NIHAdministr
 import NIHDataManagement from 'src/pages/data_submission/NIHDataManagement'
 import NihAnvilUse from 'src/pages/data_submission/NihAnvilUse'
 import { uniqueValidator } from 'src/components/forms/formValidation'
-import { AsyncActionButton } from 'src/components/AsyncActionButton'
+import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton.js'
 
 export const DataSubmissionForm = (props) => {
   const {
@@ -209,14 +209,14 @@ export const DataSubmissionForm = (props) => {
             <DataAccessGovernance onChange={onChange} onFileChange={onFileChange} validation={formValidation} onValidationChange={onValidationChange} setAllConsentGroupsSaved={setAllConsentGroupsSaved} studyEditMode={studyEditMode} datasetNames={datasetNames} />
 
             <div className="flex flex-row" style={{ justifyContent: 'flex-end', marginBottom: '2rem' }}>
-              <AsyncActionButton
+              <AsyncSpinnerButton
                 onClick={submit}
                 onError={onError}
                 className="button button-white"
                 data-cy="data-submission-submit-button"
               >
                 Submit
-              </AsyncActionButton>
+              </AsyncSpinnerButton>
             </div>
           </form>
         </div>

--- a/src/pages/progress_reports/CloseoutReview.tsx
+++ b/src/pages/progress_reports/CloseoutReview.tsx
@@ -7,7 +7,7 @@ import { Storage } from 'src/libs/storage'
 import { DAR } from 'src/libs/ajax/DAR'
 import { AxiosError } from 'axios'
 import { DataAccessRequest } from 'src/types/model'
-import { AsyncActionButton } from 'src/components/AsyncActionButton'
+import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton'
 
 interface CloseoutReviewProps {
   dar: DataAccessRequest
@@ -111,7 +111,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
             {/* Hide the Approve button if there is no closeout acknowledgement */}
             {(!acknowledged)
               && (
-                <AsyncActionButton
+                <AsyncSpinnerButton
                   onClick={onApprove}
                   onError={onError}
                   data-cy="closeout-review-approve-button"
@@ -127,7 +127,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
                   }}
                 >
                   Approve closeout
-                </AsyncActionButton>
+                </AsyncSpinnerButton>
               )}
             <button
               type="button"

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -7,6 +7,7 @@ import { Theme } from 'src/libs/theme'
 import { convertFormStateToDAR } from 'src/utils/DarUtils'
 import { extractError } from 'src/utils/ErrorUtils'
 import { DAR } from 'src/libs/ajax/DAR'
+import AsyncActionButton from 'src/components/AsyncActionButton'
 
 interface SubmitProgressReportProps {
   readonly formState: FormState
@@ -89,17 +90,17 @@ export default function SubmitProgressReport(props: SubmitProgressReportProps) {
   return (
     <div className="flex flex-row" style={{ justifyContent: 'flex-start' }}>
       <span>
-        <button
-          type="button"
+        <AsyncActionButton
+          id="btn_submit"
           className="button button-blue"
           style={{ marginRight: '2rem', cursor: 'pointer', ...(disabled ? disabledStyle : {}) }}
           data-cy="pr-submit-button"
           disabled={disabled}
-          title="Complete required form fields to enable submission."
+          aria-label="Complete required form fields to enable submission."
           onClick={submit}
         >
           Submit
-        </button>
+        </AsyncActionButton>
       </span>
       <button
         type="button"

--- a/src/pages/progress_reports/SubmitProgressReport.tsx
+++ b/src/pages/progress_reports/SubmitProgressReport.tsx
@@ -7,7 +7,7 @@ import { Theme } from 'src/libs/theme'
 import { convertFormStateToDAR } from 'src/utils/DarUtils'
 import { extractError } from 'src/utils/ErrorUtils'
 import { DAR } from 'src/libs/ajax/DAR'
-import AsyncActionButton from 'src/components/AsyncActionButton'
+import AsyncSpinnerButton from 'src/components/AsyncSpinnerButton'
 
 interface SubmitProgressReportProps {
   readonly formState: FormState
@@ -90,7 +90,7 @@ export default function SubmitProgressReport(props: SubmitProgressReportProps) {
   return (
     <div className="flex flex-row" style={{ justifyContent: 'flex-start' }}>
       <span>
-        <AsyncActionButton
+        <AsyncSpinnerButton
           id="btn_submit"
           className="button button-blue"
           style={{ marginRight: '2rem', cursor: 'pointer', ...(disabled ? disabledStyle : {}) }}
@@ -100,7 +100,7 @@ export default function SubmitProgressReport(props: SubmitProgressReportProps) {
           onClick={submit}
         >
           Submit
-        </AsyncActionButton>
+        </AsyncSpinnerButton>
       </span>
       <button
         type="button"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2113

### Summary

Fixes an issue where users could click Submit twice on the Progress Report form, causing an error. The button is now replaced with a spinner after the first click to block duplicates. If the request fails, the button returns so the user can try again.

https://github.com/user-attachments/assets/9a2e7d3c-ffa8-4763-be60-a40204616d7b

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
