### PR TITLE
[DT-2136] Sorting error follow-up: add test coverage.

### DIFF
--- a/cypress/component/utils/utils.spec.js
+++ b/cypress/component/utils/utils.spec.js
@@ -490,4 +490,13 @@ describe('processElectionStatus utils - tests', () => {
     expect(rowData[1][2].data).to.equal('2023-01-02')
     expect(rowData[2][2].data).to.equal('2023-01-03')
   })
+
+  it('sortVisibleTables shouldn\'t error when no data is passed', () => {
+    Cypress.on('window:before:load', (win) => {
+      cy.stub(win.console, 'error').callsFake((message) => {
+        throw new Error(`Console Error: ${message}`)
+      })
+    })
+    sortVisibleTable({ list: undefined, sort: { colIndex: 1, dir: -1 } })
+  })
 })


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2136](https://broadworkbench.atlassian.net/browse/DT-2136)

### Summary

Adds coverage for the specific issue we were having that was resolved by the PR here: [https://github.com/DataBiosphere/duos-ui/pull/3026](https://github.com/DataBiosphere/duos-ui/pull/3026)


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
