### PR TITLE
[DT-2033] Update render-accounts.sh to use GSM

### DIFF
--- a/scripts/render-accounts.sh
+++ b/scripts/render-accounts.sh
@@ -1,38 +1,24 @@
 #!/usr/bin/env bash
-set -e
+#
+# Pulls service account credentials for Cypress tests. Requires gcloud and jq.
+#
+# USAGE: ./scripts/render-accounts.sh
+#
 
-## Run from root
-##    ./scripts/render-accounts.sh [optional vault token]
-## Pulls service account files for Cypress tests
-## Log into vault first:
-##    vault login -method=github token=$(cat ~/.github-token)
-## Requires jq:
-##    brew install jq
+set -eu
+set -o pipefail
 
-# Defaults
-VAULT_TOKEN=$(cat ~/.vault-token)
-VAULT_TOKEN=${1:-$VAULT_TOKEN}
-
-docker pull broadinstitute/dsde-toolbox:dev
-
-# render role service account credential files
-
-listOfRoles="admin
+LIST_OF_ROLES="admin
 chair
 member
 researcher
 signing-official"
 
-secretPath="/secret/dsde/firecloud/dev/consent/automation"
-outputPath="cypress/fixtures"
+PROJECT="broad-dsde-qa"
+OUTPUT_DIR="cypress/fixtures"
 
-for role in $listOfRoles; do
-  echo "Writing $role file from $secretPath/duos-automation-$role.json"
-  docker run -it --rm \
-    -v "$HOME":/root \
-    broadinstitute/dsde-toolbox:dev vault read \
-    --format=json \
-    "$secretPath"/duos-automation-"$role".json |
-    jq .data \
-    >"$outputPath"/duos-automation-"$role".json
+for ROLE in $LIST_OF_ROLES; do
+  FILE="$OUTPUT_DIR/duos-automation-$ROLE.json"
+  echo "Writing $ROLE secret to $FILE"
+  gcloud secrets versions access latest --project="$PROJECT" --secret="duos-automation-${ROLE}-sa" | jq . > "$FILE"
 done


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2033

### Summary

Partially addresses having test users by updating `render-accounts.sh` to use GSM.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
