### PR TITLE
[DT-2093] Speed up DarCollectionReview page

### DIFF
--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import ResearcherInfo from 'src/pages/dar_application/ResearcherInfo'
 import { DataAccessAgreements } from 'src/pages/dar_application/DataAccessAgreements'
 import { DataUseAgreements } from 'src/pages/dar_application/DataUseAgreements'
@@ -200,12 +200,34 @@ const DataAccessRequestApplication = (props) => {
     setUploadedIrbDocument(document)
   }
 
-  const getCollection = async (collectionId, collection) => {
-    if (collection) {
-      return Promise.resolve(collection)
+  // Custom hook to manage async fetch with caching
+  const useCacheAsyncFetch = (initialCache = {}) => {
+    const cacheRef = useRef(initialCache)
+    const fetchingRef = useRef({})
+
+    return async (id, fetchFn) => {
+      if (cacheRef.current[id]) {
+        return cacheRef.current[id]
+      }
+      if (fetchingRef.current[id]) {
+        return fetchingRef.current[id]
+      }
+      fetchingRef.current[id] = fetchFn(id)
+      const result = await fetchingRef.current[id]
+      cacheRef.current[id] = result
+      fetchingRef.current[id] = null
+      return result
     }
-    return await Collections.getCollectionById(collectionId)
   }
+
+  // Initialize cache with collection if available
+  const initialCache = {
+    [collection?.darCollectionId]: collection,
+  }
+  const fetchAsyncData = useCacheAsyncFetch(initialCache)
+
+  const getDarCollection = collectionId => fetchAsyncData(collectionId, Collections.getCollectionById)
+  const getPartialDarRequest = darId => fetchAsyncData(darId, DAR.getPartialDarRequest)
 
   const [reverseOrderedDARs, setReverseOrderedDARs] = useState([])
   const [datasets, setDatasets] = useState([])
@@ -234,7 +256,7 @@ const DataAccessRequestApplication = (props) => {
       try {
         const { collectionId } = match.params
         if (existingDarsReadOnlyMode) {
-          const { createUser } = await getCollection(collectionId, collection)
+          const { createUser } = await getDarCollection(collectionId)
           setResearcher(createUser)
         }
         else {
@@ -250,7 +272,8 @@ const DataAccessRequestApplication = (props) => {
       }
     }
     fetchData()
-  }, [match.params, existingDarsReadOnlyMode, collection])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [match.params, existingDarsReadOnlyMode])
 
   const init = useCallback(async () => {
     const { dataRequestId, collectionId } = match.params
@@ -259,20 +282,21 @@ const DataAccessRequestApplication = (props) => {
     if (!isNil(collectionId)) {
       // Review existing DAR application - retrieves all datasets in the collection
       // Besides the datasets, DARs split off from the collection should have the same formData
-      const { dars, datasets } = await getCollection(collectionId, collection)
+      const { dars, datasets } = await getDarCollection(collectionId)
 
       // Add elections to DAR data passed into form, to enable showing approved datasets
-      Object.values(dars).map((dar) => {
+      const darEntries = dars ? Object.values(dars) : []
+      darEntries.forEach((dar) => {
         dar.data.elections = dar.elections
         dar.data.datasetIds = dar.datasetIds
       })
       // TS thinks that collection.dars is an object, but it is a map
-      const darMap = new Map(Object.entries(dars))
+      const darMap = new Map(Object.entries(dars || {}))
       const newReverseOrderedDARs = [...darMap.values()].sort((a, b) => b.id - a.id)
       setReverseOrderedDARs(newReverseOrderedDARs)
       // form data = the "root" DAR's data
-      const darId = Object.values(dars).sort((a, b) => a.id - b.id)[0].referenceId
-      formData = await DAR.getPartialDarRequest(darId)
+      const darId = darEntries.length > 0 ? darEntries.sort((a, b) => a.id - b.id)[0].referenceId : undefined
+      formData = darId ? await getPartialDarRequest(darId) : {}
 
       // This is a collection, so we need to get the datasets and datasetIds from the collection
       formData.datasetIds = map(ds => get('datasetId')(ds))(datasets)
@@ -280,7 +304,7 @@ const DataAccessRequestApplication = (props) => {
     else if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
       // Same endpoint works for any dataRequestId, not just partials.
-      formData = await DAR.getPartialDarRequest(dataRequestId)
+      formData = await getPartialDarRequest(dataRequestId)
     }
     else {
       // Lastly, try to get the form data from local storage and clear out whatever was there previously
@@ -296,7 +320,8 @@ const DataAccessRequestApplication = (props) => {
 
     batchFormFieldChange(formData)
     setIsLoading(false)
-  }, [match.params, collection, researcher, existingDarsReadOnlyMode])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [match.params, researcher, existingDarsReadOnlyMode])
 
   useEffect(() => {
     if (existingDarsReadOnlyMode) {

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -12,6 +12,7 @@ import { PageHeading } from 'src/components/PageHeading'
 import { User } from 'src/libs/ajax/User'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { DAR } from 'src/libs/ajax/DAR'
+import { Collections } from 'src/libs/ajax/Collections'
 import { NotificationService } from 'src/libs/notificationService'
 import { Storage } from 'src/libs/storage'
 import { get, map } from 'lodash/fp'
@@ -199,6 +200,13 @@ const DataAccessRequestApplication = (props) => {
     setUploadedIrbDocument(document)
   }
 
+  const getCollection = async (collectionId, collection) => {
+    if (collection) {
+      return Promise.resolve(collection)
+    }
+    return await Collections.getCollectionById(collectionId)
+  }
+
   const [reverseOrderedDARs, setReverseOrderedDARs] = useState([])
   const [datasets, setDatasets] = useState([])
   const [selectedDatasets, setSelectedDatasets] = useState([])
@@ -224,8 +232,10 @@ const DataAccessRequestApplication = (props) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
+        const { collectionId } = match.params
         if (existingDarsReadOnlyMode) {
-          setResearcher(collection.createUser)
+          const { createUser } = await getCollection(collectionId, collection)
+          setResearcher(createUser)
         }
         else {
           const response = await User.getMe()
@@ -240,33 +250,34 @@ const DataAccessRequestApplication = (props) => {
       }
     }
     fetchData()
-  }, [match.params, existingDarsReadOnlyMode, collection.createUser])
+  }, [match.params, existingDarsReadOnlyMode, collection])
 
   const init = useCallback(async () => {
-    const { dataRequestId } = match.params
+    const { dataRequestId, collectionId } = match.params
     let formData = {}
 
-    // Review existing DAR application - retrieves all datasets in the collection
-    // Besides the datasets, DARs split off from the collection should have the same formData
-    const { dars, datasets } = collection
+    if (!isNil(collectionId)) {
+      // Review existing DAR application - retrieves all datasets in the collection
+      // Besides the datasets, DARs split off from the collection should have the same formData
+      const { dars, datasets } = await getCollection(collectionId, collection)
 
-    // Add elections to DAR data passed into form, to enable showing approved datasets
-    Object.values(dars).map((dar) => {
-      dar.data.elections = dar.elections
-      dar.data.datasetIds = dar.datasetIds
-    })
-    // TS thinks that collection.dars is an object, but it is a map
-    const darMap = new Map(Object.entries(dars))
-    const newReverseOrderedDARs = [...darMap.values()].sort((a, b) => b.id - a.id)
-    setReverseOrderedDARs(newReverseOrderedDARs)
-    // form data = the "root" DAR's data
-    const darId = Object.values(dars).sort((a, b) => a.id - b.id)[0].referenceId
-    formData = await DAR.getPartialDarRequest(darId)
+      // Add elections to DAR data passed into form, to enable showing approved datasets
+      Object.values(dars).map((dar) => {
+        dar.data.elections = dar.elections
+        dar.data.datasetIds = dar.datasetIds
+      })
+      // TS thinks that collection.dars is an object, but it is a map
+      const darMap = new Map(Object.entries(dars))
+      const newReverseOrderedDARs = [...darMap.values()].sort((a, b) => b.id - a.id)
+      setReverseOrderedDARs(newReverseOrderedDARs)
+      // form data = the "root" DAR's data
+      const darId = Object.values(dars).sort((a, b) => a.id - b.id)[0].referenceId
+      formData = await DAR.getPartialDarRequest(darId)
 
-    // This is a collection, so we need to get the datasets and datasetIds from the collection
-    formData.datasetIds = map(ds => get('datasetId')(ds))(datasets)
-
-    if (!isNil(dataRequestId)) {
+      // This is a collection, so we need to get the datasets and datasetIds from the collection
+      formData.datasetIds = map(ds => get('datasetId')(ds))(datasets)
+    }
+    else if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
       // Same endpoint works for any dataRequestId, not just partials.
       formData = await DAR.getPartialDarRequest(dataRequestId)
@@ -792,4 +803,5 @@ DataAccessRequestApplication.propTypes = {
   draftDar: PropTypes.bool.isRequired,
   isProgressReportApplication: PropTypes.bool.isRequired,
   existingDarsReadOnlyMode: PropTypes.bool,
+  collection: PropTypes.object,
 }

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -12,7 +12,6 @@ import { PageHeading } from 'src/components/PageHeading'
 import { User } from 'src/libs/ajax/User'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { DAR } from 'src/libs/ajax/DAR'
-import { Collections } from 'src/libs/ajax/Collections'
 import { NotificationService } from 'src/libs/notificationService'
 import { Storage } from 'src/libs/storage'
 import { get, map } from 'lodash/fp'
@@ -115,14 +114,14 @@ const DataAccessRequestApplication = (props) => {
     collaborationLetterName: '',
   })
 
-  const { history, location, existingDarsReadOnlyMode, draftDar, match, isProgressReportApplication } = props
+  const { history, location, existingDarsReadOnlyMode, draftDar, match, isProgressReportApplication, collection } = props
 
   const [formValidation, setFormValidation] = useState({ researcherInfoErrors: {}, darErrors: {}, rusErrors: {} })
 
   const [nihValid, setNihValid] = useState(true)
   const [showNihValidationError, setShowNihValidationError] = useState(false)
 
-  const [disableOkBtn, setDisableOkButton] = useState(false)
+  const [disableOkBtn, setDisableOkBtn] = useState(false)
 
   const [labCollaboratorsCompleted, setLabCollaboratorsCompleted] = useState(true)
   const [internalCollaboratorsCompleted, setInternalCollaboratorsCompleted] = useState(true)
@@ -225,9 +224,7 @@ const DataAccessRequestApplication = (props) => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const { collectionId } = match.params
         if (existingDarsReadOnlyMode) {
-          const collection = await Collections.getCollectionById(collectionId)
           setResearcher(collection.createUser)
         }
         else {
@@ -243,35 +240,33 @@ const DataAccessRequestApplication = (props) => {
       }
     }
     fetchData()
-  }, [match.params, existingDarsReadOnlyMode])
+  }, [match.params, existingDarsReadOnlyMode, collection.createUser])
 
   const init = useCallback(async () => {
-    const { dataRequestId, collectionId } = match.params
+    const { dataRequestId } = match.params
     let formData = {}
 
-    if (!isNil(collectionId)) {
-      // Review existing DAR application - retrieves all datasets in the collection
-      // Besides the datasets, DARs split off from the collection should have the same formData
-      const collection = await Collections.getCollectionById(collectionId)
-      const { dars, datasets } = collection
+    // Review existing DAR application - retrieves all datasets in the collection
+    // Besides the datasets, DARs split off from the collection should have the same formData
+    const { dars, datasets } = collection
 
-      // Add elections to DAR data passed into form, to enable showing approved datasets
-      Object.values(dars).map((dar) => {
-        dar.data.elections = dar.elections
-        dar.data.datasetIds = dar.datasetIds
-      })
-      // TS thinks that collection.dars is an object, but it is a map
-      const darMap = new Map(Object.entries(dars))
-      const newReverseOrderedDARs = [...darMap.values()].sort((a, b) => b.id - a.id)
-      setReverseOrderedDARs(newReverseOrderedDARs)
-      // form data = the "root" DAR's data
-      const darId = Object.values(dars).sort((a, b) => a.id - b.id)[0].referenceId
-      formData = await DAR.getPartialDarRequest(darId)
+    // Add elections to DAR data passed into form, to enable showing approved datasets
+    Object.values(dars).map((dar) => {
+      dar.data.elections = dar.elections
+      dar.data.datasetIds = dar.datasetIds
+    })
+    // TS thinks that collection.dars is an object, but it is a map
+    const darMap = new Map(Object.entries(dars))
+    const newReverseOrderedDARs = [...darMap.values()].sort((a, b) => b.id - a.id)
+    setReverseOrderedDARs(newReverseOrderedDARs)
+    // form data = the "root" DAR's data
+    const darId = Object.values(dars).sort((a, b) => a.id - b.id)[0].referenceId
+    formData = await DAR.getPartialDarRequest(darId)
 
-      // This is a collection, so we need to get the datasets and datasetIds from the collection
-      formData.datasetIds = map(ds => get('datasetId')(ds))(datasets)
-    }
-    else if (!isNil(dataRequestId)) {
+    // This is a collection, so we need to get the datasets and datasetIds from the collection
+    formData.datasetIds = map(ds => get('datasetId')(ds))(datasets)
+
+    if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
       // Same endpoint works for any dataRequestId, not just partials.
       formData = await DAR.getPartialDarRequest(dataRequestId)
@@ -290,7 +285,7 @@ const DataAccessRequestApplication = (props) => {
 
     batchFormFieldChange(formData)
     setIsLoading(false)
-  }, [match.params, existingDarsReadOnlyMode, researcher])
+  }, [match.params, collection, researcher, existingDarsReadOnlyMode])
 
   useEffect(() => {
     if (existingDarsReadOnlyMode) {
@@ -367,7 +362,7 @@ const DataAccessRequestApplication = (props) => {
   const removeAddendumTab = () => {
     const hasAddendumTab = applicationTabs.filter(tab => tab.id === ADDENDUM_TAB_ID).length > 0
     if (hasAddendumTab) {
-      const tabs = applicationTabs.filter(tab => tab.id != ADDENDUM_TAB_ID)
+      const tabs = applicationTabs.filter(tab => tab.id !== ADDENDUM_TAB_ID)
       setApplicationTabs(tabs)
     }
   }
@@ -462,26 +457,26 @@ const DataAccessRequestApplication = (props) => {
   }
 
   const onSaveConfirmation = selectedOk => () => {
-    setDisableOkButton(true)
+    setDisableOkBtn(true)
     if (selectedOk === true) {
       saveDarDraft()
-      setDisableOkButton(false)
+      setDisableOkBtn(false)
     }
     else {
       setShowDialogSave(false)
-      setDisableOkButton(false)
+      setDisableOkBtn(false)
     }
   }
 
   const onSubmitConfirmation = selectedOk => () => {
-    setDisableOkButton(true)
+    setDisableOkBtn(true)
     if (selectedOk === true) {
       submitDARFormData()
-      setDisableOkButton(false)
+      setDisableOkBtn(false)
     }
     else {
       setShowDialogSubmit(false)
-      setDisableOkButton(false)
+      setDisableOkBtn(false)
     }
   }
 
@@ -509,11 +504,11 @@ const DataAccessRequestApplication = (props) => {
       }
       batchFormFieldChange(darPartialResponse)
       setShowDialogSave(false)
-      setDisableOkButton(false)
+      setDisableOkBtn(false)
     }
     catch (error) {
       setShowDialogSave(false)
-      setDisableOkButton(false)
+      setDisableOkBtn(false)
       if (error.response.data.code && error.response.data.message) {
         Notifications.showError({ text: <ReactMarkdown>{error.response.data.message}</ReactMarkdown>,
           severity: 'error',

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -1,14 +1,12 @@
-import React from 'react'
-import { useCallback, useEffect, useState } from 'react'
-import { Notifications } from '../../libs/utils'
+import React, { useCallback, useEffect, useState } from 'react'
 import { User } from '../../libs/ajax/User'
 import TabControl from '../../components/TabControl'
 import ReviewHeader from './ReviewHeader'
 import ApplicationInformation from './ApplicationInformation'
-import { find, isEmpty, flatMap, flow, filter, map, get, toLower, uniq, compact } from 'lodash/fp'
+import { isEmpty, flatMap, flow, filter, map, get, toLower, uniq, compact } from 'lodash/fp'
 import { updateFinalVote } from '../../utils/DarCollectionUtils'
 import { binCollectionToBuckets } from '../../utils/BucketUtils'
-import { Navigation } from '../../libs/utils'
+import { Notifications, Navigation } from '../../libs/utils'
 import { Storage } from '../../libs/storage'
 import MultiDatasetVotingTab from './MultiDatasetVotingTab'
 import { Collections } from '../../libs/ajax/Collections'
@@ -93,7 +91,7 @@ const getApprovedDatasetsFromLatestDar = (darCollection, dacIds) => {
 
   // most recent closed election
   const elections = Object.values(mostRecentDar.elections || {})
-  const closedDataAccessElections = elections.filter(e => e.electionType == 'DataAccess' && e.status === 'Closed')
+  const closedDataAccessElections = elections.filter(e => e.electionType === 'DataAccess' && e.status === 'Closed')
   if (closedDataAccessElections.length === 0) return []
   const latestElection = closedDataAccessElections.reduce((latest, current) =>
     new Date(current.createDate) > new Date(latest.createDate) ? current : latest,
@@ -151,13 +149,26 @@ export default function DarCollectionReview(props) {
       else {
         collection = await Collections.getCollectionById(collectionId)
       }
-      const darInfo = find(d => !isEmpty(d.data))(collection.dars).data
-      const referenceIdForDocuments = find(d => !isEmpty(d.referenceId))(collection.dars).referenceId
-      const researcherProfile = await User.getById(collection.createUserId)
+
+      // Find darInfo and referenceIdForDocuments in one pass
+      let darInfo, referenceIdForDocuments
+      for (const d of Object.values(collection.dars)) {
+        if (!darInfo && !isEmpty(d.data)) darInfo = d.data
+        if (!referenceIdForDocuments && !isEmpty(d.referenceId)) referenceIdForDocuments = d.referenceId
+        if (darInfo && referenceIdForDocuments) break
+      }
+
       // If this is NOT an admin view, we need to filter buckets by the user's DACs
       const dacIds = adminPage ? [] : uniq(compact(map(r => r.dacId)(user.roles)))
-      const processedBuckets = await binCollectionToBuckets(collection, dacIds)
+
+      // Parallelize async calls
+      const [researcherProfile, processedBuckets] = await Promise.all([
+        User.getById(collection.createUserId),
+        binCollectionToBuckets(collection, dacIds),
+      ])
+
       const approvedDatasetNames = getApprovedDatasetsFromLatestDar(collection || { dars: [] }, dacIds)
+
       setDataUseBuckets(processedBuckets)
       setCollection(collection)
       setDarInfo(darInfo)
@@ -173,7 +184,7 @@ export default function DarCollectionReview(props) {
       Notifications.showError({
         text: 'Error initializing Data Access Request collection page. You have been redirected to your console',
       })
-      Navigation.console(user, props.history)
+      await Navigation.console(user, props.history)
     }
   }, [adminPage, props.history, collectionId])
 
@@ -265,6 +276,7 @@ export default function DarCollectionReview(props) {
             draftDar={false}
             isProgressReportApplication={false}
             researcherProfile={researcherProfile}
+            collection={collection}
             {...props}
           />
         )}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2093

### Summary

This PR improves performance by making API calls in parallel and reusing collection data instead of re-fetching on tab switches. It also cleans up useEffect usage to avoid unnecessary queries. These changes make the DarCollectionReview page faster and smoother.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
