### PR TITLE
[DT-2162] Error not displayed when cannot set role.

### DIFF
--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, flow, unset, mergeAll } from 'lodash/fp'
 import { Config } from '../config'
 import axios from 'axios'
-import { getApiUrl, fetchOk, fetchAny } from '../ajax'
+import { getApiUrl, fetchOk } from '../ajax'
 import { CreateDuosUserResponse, DuosUserResponse, UpdateDuosUserResponse } from 'src/types/responseTypes'
 import { CreateDuosUserRequest, UpdateDuosUserRequestV1, UpdateDuosUserRequestV2 } from 'src/types/requestTypes'
 import {

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -130,20 +130,14 @@ export const User = {
 
   addRoleToUser: async (userId: number, roleId: number): Promise<DuosUserResponse> => {
     const url = `${await getApiUrl()}/api/user/${userId}/${roleId}`
-    const res = await fetchAny(
-      url,
-      mergeAll([Config.authOpts(), { method: 'PUT' }]),
-    )
-    return res.json()
+    const res = await axios.put(url, null, Config.authOpts())
+    return res.data
   },
 
   deleteRoleFromUser: async (userId: number, roleId: number): Promise<DuosUserResponse> => {
     const url = `${await getApiUrl()}/api/user/${userId}/${roleId}`
-    const res = await fetchAny(
-      url,
-      mergeAll([Config.authOpts(), { method: 'DELETE' }]),
-    )
-    return res.json()
+    const res = await axios.delete(url, Config.authOpts())
+    return res.data
   },
 
   getUserRelevantDatasets: async (): Promise<Dataset[]> => {

--- a/src/pages/AdminEditUser.jsx
+++ b/src/pages/AdminEditUser.jsx
@@ -8,6 +8,7 @@ import { ResearcherReview } from '../components/ResearcherReview'
 import editUserIcon from '../images/icon_edit_user.png'
 import { PageHeading } from '../components/PageHeading'
 import { SearchSelect } from '../components/SearchSelect'
+import { extractError } from 'src/utils/ErrorUtils.js'
 
 const adminRole = { roleId: 4, name: USER_ROLES.admin }
 const researcherRole = { roleId: 5, name: USER_ROLES.researcher }
@@ -91,8 +92,9 @@ export const AdminEditUser = (props) => {
       await updateRolesIfDifferent(userId, state.updatedRoles)
       props.history.push('/admin_manage_users')
     }
-    catch (_error) {
-      Notifications.showError({ text: 'Error: Failed to update user' })
+    catch (error) {
+      const errorText = extractError(error)
+      Notifications.showError({ text: errorText ? errorText : 'Error: Failed to update user' })
     }
   }
 
@@ -102,20 +104,20 @@ export const AdminEditUser = (props) => {
     // Always make sure researcher is a role we already have or need to add.
     const updatedRoleIds = union([researcherRole.roleId])(map('roleId')(updatedRoles))
 
-    lodashMap(updatedRoleIds, (roleId) => {
+    await Promise.all(lodashMap(updatedRoleIds, async (roleId) => {
       if (!contains(roleId)(currentRoleIds)) {
-        User.addRoleToUser(userId, roleId)
+        await User.addRoleToUser(userId, roleId)
       }
-    })
+    }))
 
-    lodashMap(currentRoleIds, (roleId) => {
+    await Promise.all(lodashMap(currentRoleIds, async (roleId) => {
       if (!contains(roleId)(updatedRoleIds)) {
         // Safety check ... never delete the researcher role!!!
         if (roleId !== researcherRole.roleId) {
-          User.deleteRoleFromUser(userId, roleId)
+          await User.deleteRoleFromUser(userId, roleId)
         }
       }
-    })
+    }))
   }
 
   const emailPreferenceChanged = (e) => {

--- a/src/pages/AdminEditUser.jsx
+++ b/src/pages/AdminEditUser.jsx
@@ -94,7 +94,7 @@ export const AdminEditUser = (props) => {
     }
     catch (error) {
       const errorText = extractError(error)
-      Notifications.showError({ text: errorText ? errorText : 'Error: Failed to update user' })
+      Notifications.showError({ text: errorText || 'Error: Failed to update user' })
     }
   }
 


### PR DESCRIPTION
### Addresses

[DT-4010](https://broadworkbench.atlassian.net/browse/DT-4010).

Security risk: no.

### Summary

`MatchAlgorithm.version` was package-private and non-final with a public `setVersion`. Enum constants are JVM-wide singletons, so one call anywhere would change the version stamped on every subsequent match row for the life of the process. The field is now private and final and the setter is gone; nothing called it.

The three-argument `matchFailure` and four-argument `matchSuccess` defaulted to `V4` with no caller in main or test — `MatchService` passes `V5` explicitly at both sites. A future caller would have stamped `v4` on a row produced by V5 logic. Both are deleted and the explicit-algorithm overloads cover every use.

`V1` through `V3` stay declared: production still holds `v1` and `v2` rows and duos-ui matches on those literals. No API contract change, so `api-docs.yaml` is untouched.

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4010]: https://broadworkbench.atlassian.net/browse/DT-4010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ