### PR TITLE
[DT-1329] Enable RAS in production

### DIFF
--- a/cypress/component/ERACommons/era_commons_utils.spec.ts
+++ b/cypress/component/ERACommons/era_commons_utils.spec.ts
@@ -1,12 +1,8 @@
 import * as ERACommonsUtils from 'src/components/era_commons/ERACommonsUtils'
-import EnvironmentUtils from 'src/utils/EnvironmentUtils'
 import { DuosUser } from 'src/types/model'
 
 describe('ERACommonsUtils Tests', () => {
-  describe('Test environment-enabled cases', () => {
-    beforeEach(() => {
-      cy.stub(EnvironmentUtils, 'checkEnv').returns(true)
-    })
+  describe('Verify RAS is enabled', () => {
     it('rasEnabled', () => {
       const result = ERACommonsUtils.rasEnabled()
       expect(result).to.eq(true)
@@ -18,24 +14,6 @@ describe('ERACommonsUtils Tests', () => {
     it('nihAccountInstructions', () => {
       const result = ERACommonsUtils.nihAccountInstructions()
       expect(result).to.eq('https://datascience.nih.gov/researcher-auth-service-initiative')
-    })
-  })
-
-  describe('Test environment-disabled cases', () => {
-    beforeEach(() => {
-      cy.stub(EnvironmentUtils, 'checkEnv').returns(false)
-    })
-    it('rasEnabled', () => {
-      const result = ERACommonsUtils.rasEnabled()
-      expect(result).to.eq(false)
-    })
-    it('nihAccountLabel', () => {
-      const result = ERACommonsUtils.nihAccountLabel()
-      expect(result).to.eq('eRA Commons')
-    })
-    it('nihAccountInstructions', () => {
-      const result = ERACommonsUtils.nihAccountInstructions()
-      expect(result).to.eq('https://www.era.nih.gov/register-accounts/understanding-era-commons-accounts.htm')
     })
   })
 

--- a/cypress/component/UserProfile/researcher_status.spec.tsx
+++ b/cypress/component/UserProfile/researcher_status.spec.tsx
@@ -82,7 +82,7 @@ describe('ResearcherStatus', () => {
 
     mount(<ResearcherStatus user={userWithCard} pageProps={pageProps} />)
     cy.contains('Researcher Status')
-    cy.contains('eRA Commons Account')
+    cy.contains('RAS Account')
     cy.contains('Library Card issued to you')
     cy.contains('Issued on: ' + userWithCard.libraryCard?.createDate.toISOString().slice(0, 10))
     cy.contains('Issued by: ' + signingOfficialUser.displayName)

--- a/cypress/component/app.spec.jsx
+++ b/cypress/component/app.spec.jsx
@@ -4,11 +4,10 @@ import App from 'src/App'
 import ReactGA from 'react-ga4'
 import StackdriverReporter from 'src/libs/stackdriverReporter'
 import { Config } from 'src/libs/config'
-import { MemoryRouter, Route } from 'react-router-dom'
+import { MemoryRouter, Route, Router } from 'react-router-dom'
 import { AuthenticateNIH } from 'src/libs/ajax/AuthenticateNIH'
 import { Storage } from 'src/libs/storage'
 import { createMemoryHistory } from 'history'
-import { Router } from 'react-router'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 
 const user = {

--- a/src/components/era_commons/ERACommons.tsx
+++ b/src/components/era_commons/ERACommons.tsx
@@ -129,7 +129,9 @@ export default function ERACommons({
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     catch (error: never) {
-      displayError('Error from Authentication Provider: ' + error?.response?.data?.message + ': ' + currentUser.email)
+      const userEmail = currentUser?.email || 'unknown user'
+      const errorMessage = 'Error from Authentication Provider: ' + error?.response?.data?.message + ': ' + userEmail
+      displayError(errorMessage)
     }
   }
 

--- a/src/components/era_commons/ERACommonsUtils.ts
+++ b/src/components/era_commons/ERACommonsUtils.ts
@@ -1,8 +1,7 @@
-import EnvironmentUtils, { envGroups } from 'src/utils/EnvironmentUtils'
 import { DuosUser } from 'src/types/model'
 
 export const rasEnabled = (): boolean => {
-  return EnvironmentUtils.checkEnv(envGroups.NON_PROD)
+  return true
 }
 
 export const nihAccountLabel = () => {


### PR DESCRIPTION
> [!WARNING]
> DO NOT MERGE UNTIL 2025-09-29. Requires https://github.com/DataBiosphere/consent/pull/2647 to be merged first.

### Addresses

https://broadworkbench.atlassian.net/browse/DT-1329

### Summary

Enables RAS in production. The cleanup for this code is explicitly called out in DT-2116.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
