### PR TITLE
DT-2075: Update Library Card language on the profile page

### DIFF
--- a/cypress/component/UserProfile/LibraryCard.spec.tsx
+++ b/cypress/component/UserProfile/LibraryCard.spec.tsx
@@ -1,0 +1,21 @@
+import { mount } from 'cypress/react'
+import React from 'react'
+import LibraryCard from 'src/pages/user_profile/LibraryCard'
+
+describe('LibraryCard', () => {
+  beforeEach(() => {
+    cy.viewport(600, 600)
+    cy.initApplicationConfig()
+  })
+
+  it('renders issuedOn and issuedBy props', () => {
+    const issuedOn = '2024-06-01'
+    const issuedBy = 'John Doe'
+
+    mount(<LibraryCard issuedOn={issuedOn} issuedBy={issuedBy} />)
+
+    cy.contains(`Issued on: ${issuedOn}`).should('exist')
+    cy.contains(`Issued by: ${issuedBy}`).should('exist')
+    cy.contains('Yes').should('exist')
+  })
+})

--- a/cypress/component/UserProfile/researcher_status.spec.tsx
+++ b/cypress/component/UserProfile/researcher_status.spec.tsx
@@ -83,7 +83,7 @@ describe('ResearcherStatus', () => {
     mount(<ResearcherStatus user={userWithCard} pageProps={pageProps} />)
     cy.contains('Researcher Status')
     cy.contains('eRA Commons Account')
-    cy.contains('Library Cards issued to you')
+    cy.contains('Library Card issued to you')
     cy.contains('Issued on: ' + userWithCard.libraryCard?.createDate.toISOString().slice(0, 10))
     cy.contains('Issued by: ' + signingOfficialUser.displayName)
   })

--- a/src/pages/user_profile/LibraryCard.tsx
+++ b/src/pages/user_profile/LibraryCard.tsx
@@ -2,7 +2,12 @@ import React from 'react'
 
 // NOTE: This component will be deprecated upon promotion of dynamic DAAs. It will be replaced by DAAs.jsx.
 
-export default function LibraryCard(props) {
+interface LibraryCardProps {
+  readonly issuedOn: string
+  readonly issuedBy: string
+}
+
+export default function LibraryCard(props: LibraryCardProps) {
   const {
     issuedOn,
     issuedBy,
@@ -34,14 +39,10 @@ export default function LibraryCard(props) {
       </div>
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <p style={{ margin: '0px 0px 0px 10px' }}>
-          Issued on:
-          {' '}
-          {issuedOn}
+          Issued on: {issuedOn}
         </p>
         <p style={{ margin: '0px 0px 0px 10px' }}>
-          Issued by:
-          {' '}
-          {issuedBy}
+          Issued by: {issuedBy}
         </p>
       </div>
     </div>

--- a/src/pages/user_profile/ResearcherStatus.tsx
+++ b/src/pages/user_profile/ResearcherStatus.tsx
@@ -77,7 +77,6 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
           <LibraryCard
             issuedOn={issuedOn}
             issuedBy={issuedBy}
-            daas={daaObjects}
           />
         )
   }
@@ -112,7 +111,7 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
         A&nbsp;
         <a href={accountLink}>
           {accountLabel}
-&nbsp;Account
+          &nbsp;Account
         </a>
 &nbsp;is required to submit a Data Access Requeset (DAR).
       </p>
@@ -123,7 +122,11 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
         header: false,
       })}
       <div style={{ marginTop: '20px' }} />
-      <p style={subheadStyle}>Library Cards issued to you</p>
+      <p style={subheadStyle}>Library Card issued to you</p>
+      <p>
+        A Library Card is a Signing Official’s pre-authorization of a researcher to submit Data Access Requests (DARs)
+        in DUOS. A valid Library Card is required to initiate a DAR.
+      </p>
       <div style={{ marginTop: '15px' }} />
       {hasCard
         ? cardComponent()


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2075

## Summary
This PR adds some explanatory text about Library Cards on the User Profile page

### When a user has a Library Card
<img width="791" height="373" alt="Screenshot 2025-09-12 at 2 35 22 PM" src="https://github.com/user-attachments/assets/6f6d6745-d8a8-4935-aff0-dc8c64d2bdc1" />

### When a user does **NOT** have a Library Card
<img width="790" height="439" alt="Screenshot 2025-09-12 at 2 36 19 PM" src="https://github.com/user-attachments/assets/09575607-bb80-4b38-aed0-9396e816fa59" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
