### PR TITLE
DT-2092: Rename researcher tab and header for Signing Officials

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -16,7 +16,7 @@ import PrivacyPolicy from 'src/pages/PrivacyPolicy'
 import ResearcherConsole from 'src/pages/researcher_console/ResearcherConsole'
 import UserProfile from 'src/pages/user_profile/UserProfile'
 import RequestForm from 'src/pages/user_profile/RequestForm'
-import SigningOfficialResearchers from 'src/pages/signing_official_console/SigningOfficialResearchers'
+import SigningOfficialLibraryCards from 'src/pages/signing_official_console/SigningOfficialLibraryCards'
 import ManageResearcherDAAs from 'src/pages/signing_official_console/ManageResearcherDAAs'
 import SigningOfficialDarRequests from 'src/pages/signing_official_console/SigningOfficialDarRequests'
 import SigningOfficialDataSubmitters from 'src/pages/signing_official_console/SigningOfficialDataSubmitters'
@@ -119,7 +119,7 @@ const Routes = props => (
       rolesAllowed={[USER_ROLES.researcher]}
     />
     <AuthenticatedRoute path="/dar_application" component={DataAccessRequestApplication} props={Object.assign({}, props, { draftDar: true, isProgressReportApplication: false })} rolesAllowed={[USER_ROLES.researcher]} />
-    <AuthenticatedRoute path="/signing_official_console/researchers" component={ensureSoHasDaaAcknowledgement(SigningOfficialResearchers, true)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />
+    <AuthenticatedRoute path="/signing_official_console/library_cards" component={ensureSoHasDaaAcknowledgement(SigningOfficialLibraryCards, true)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />
     {DAAUtils.isEnabled() && <AuthenticatedRoute path="/signing_official_console/researchers_daa_associations" component={ensureSoHasDaaAcknowledgement(ManageResearcherDAAs, true)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />}
     <AuthenticatedRoute path="/signing_official_console/dar_requests" component={ensureSoHasDaaAcknowledgement(SigningOfficialDarRequests)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />
     {DAAUtils.isEnabled() && <AuthenticatedRoute path="/signing_official_console/data_submitters" component={ensureSoHasDaaAcknowledgement(SigningOfficialDataSubmitters, false, true)} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.signingOfficial]} />}

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -48,9 +48,9 @@ export const headerTabsConfig = [
   },
   {
     label: 'SO Console',
-    link: '/signing_official_console/researchers',
+    link: '/signing_official_console/library_cards',
     children: [
-      { label: 'Library Cards', link: '/signing_official_console/researchers' },
+      { label: 'Library Cards', link: '/signing_official_console/library_cards' },
       { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },
       { label: 'Data Submitters', link: '/signing_official_console/data_submitters', isRendered: () => DAAUtils.isEnabled() },
       { label: 'My Datasets', link: '/datalibrary/myinstitution' },

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -50,7 +50,7 @@ export const headerTabsConfig = [
     label: 'SO Console',
     link: '/signing_official_console/researchers',
     children: [
-      { label: 'Researchers', link: '/signing_official_console/researchers' },
+      { label: 'Library Cards', link: '/signing_official_console/researchers' },
       { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },
       { label: 'Data Submitters', link: '/signing_official_console/data_submitters', isRendered: () => DAAUtils.isEnabled() },
       { label: 'My Datasets', link: '/datalibrary/myinstitution' },

--- a/src/pages/signing_official_console/SigningOfficialLibraryCards.jsx
+++ b/src/pages/signing_official_console/SigningOfficialLibraryCards.jsx
@@ -1,12 +1,10 @@
-import React from 'react'
-import { useState, useEffect } from 'react'
-import { Notifications } from '../../libs/utils'
-import { Styles } from '../../libs/theme'
+import React, { useEffect, useState } from 'react'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
+import { Styles } from 'src/libs/theme'
 import SigningOfficialTable from './SigningOfficialTable'
-import { User } from '../../libs/ajax/User'
-import { USER_ROLES } from '../../libs/utils'
+import { User } from 'src/libs/ajax/User'
 
-export default function SigningOfficialResearchers() {
+export default function SigningOfficialLibraryCards() {
   const [signingOfficial, setSigningOfficial] = useState({})
   const [researchers, setResearchers] = useState([])
 

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -386,7 +386,7 @@ export default function SigningOfficialTable(props) {
               fontWeight: 600,
               fontSize: '2.8rem' }}
             >
-              My Institution&apos;s Researchers
+              My Institution&apos;s Library Cards
             </div>
             <div style={Object.assign({}, Styles.MEDIUM_DESCRIPTION, {
               fontSize: '16px',


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2092

## Summary
Update the default landing tab and heading text for Signing Officials. Also update link and component name to match new tab/header name.

### New Screen
<img width="1086" height="842" alt="Screenshot 2025-09-15 at 3 35 25 PM" src="https://github.com/user-attachments/assets/4408090c-c7ad-4bc5-8df9-ebbe01cd389d" />


### Old Screen
<img width="1086" height="842" alt="Screenshot 2025-09-15 at 3 36 05 PM" src="https://github.com/user-attachments/assets/d09fb3f2-c22a-410d-9c2f-459c603a4ef7" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
