### PR TITLE
[DT-2078] Show Signing Officials or guidance in DUOS Library Card section

### DIFF
--- a/cypress/component/UserProfile/researcher_status.spec.tsx
+++ b/cypress/component/UserProfile/researcher_status.spec.tsx
@@ -59,11 +59,12 @@ describe('ResearcherStatus', () => {
   beforeEach(() => {
     cy.initApplicationConfig()
     cy.stub(DAA, 'getDaaById').resolves(daa)
-    cy.stub(User, 'getSOsForCurrentUser').resolves([signingOfficialUser])
+    cy.stub(User, 'getMe').resolves(user)
     cy.viewport(800, 600)
   })
 
   it('Renders the Researcher Status With Library Card Info', () => {
+    cy.stub(User, 'getSOsForCurrentUser').resolves([signingOfficialUser])
     const pageProps = { location: {} } as ResearcherStatusProps['pageProps']
     const userWithCard = {
       ...user, ...{
@@ -78,7 +79,6 @@ describe('ResearcherStatus', () => {
         },
       },
     }
-    cy.stub(User, 'getMe').resolves(userWithCard)
 
     mount(<ResearcherStatus user={userWithCard} pageProps={pageProps} />)
     cy.contains('Researcher Status')
@@ -89,10 +89,52 @@ describe('ResearcherStatus', () => {
   })
 
   it('Renders the Researcher Status Without Library Card Info', () => {
+    cy.stub(User, 'getSOsForCurrentUser').resolves([signingOfficialUser])
     const pageProps = { location: {} } as ResearcherStatusProps['pageProps']
-    cy.stub(User, 'getMe').resolves(user)
 
     mount(<ResearcherStatus user={user} pageProps={pageProps} />)
     cy.contains('No Library Card Found')
+  })
+
+  it('shows message when no signing officials are found', () => {
+    cy.stub(User, 'getSOsForCurrentUser').resolves([])
+    const pageProps = { location: {} } as ResearcherStatusProps['pageProps']
+    const userWithCard = {
+      ...user, ...{
+        libraryCard: {
+          id: 1,
+          userId: 1,
+          userName: 'Test User',
+          userEmail: 'test.user@test.com',
+          createDate: new Date(),
+          createUserId: 3,
+          daaIds: [1],
+        },
+      },
+    }
+    mount(<ResearcherStatus user={userWithCard} pageProps={pageProps} />)
+    cy.contains('No Signing Official found for your institution')
+    cy.contains('help article')
+  })
+
+  it('shows the Institutional Signing Officials list', () => {
+    cy.stub(User, 'getSOsForCurrentUser').resolves([signingOfficialUser])
+    const pageProps = { location: {} } as ResearcherStatusProps['pageProps']
+    const userWithCard = {
+      ...user, ...{
+        libraryCard: {
+          id: 1,
+          userId: 1,
+          userName: 'Test User',
+          userEmail: 'test.user@test.com',
+          createDate: new Date(),
+          createUserId: 3,
+          daaIds: [1],
+        },
+      },
+    }
+    mount(<ResearcherStatus user={userWithCard} pageProps={pageProps} />)
+    cy.contains('Signing Official(s):')
+    cy.contains('Signing Official - so@test.com')
   })
 })

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -93,6 +93,7 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
       list: processVoteHistoryRowData(voteHistory),
       sort,
     }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, voteHistory])
 
   return (

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -170,6 +170,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
       list: processElectionRowData(electionsWithMemberVotes),
       sort,
     }))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, expandedElections, electionsWithMemberVotes])
 
   return (

--- a/src/pages/user_profile/ResearcherStatus.tsx
+++ b/src/pages/user_profile/ResearcherStatus.tsx
@@ -28,11 +28,14 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
   }, [])
   const accountLabel = nihAccountLabel()
   const accountLink = nihAccountInstructions()
+  const [signingOfficialUsers, setSigningOfficialUsers] = useState<SimplifiedDuosUser[]>([])
 
   useEffect(() => {
     const init = async () => {
       try {
         if (!isNil(user)) {
+          const signingOfficialUsers = await User.getSOsForCurrentUser()
+          setSigningOfficialUsers(signingOfficialUsers)
           if (isNil(user.libraryCard)) {
             setHasCard(false)
           }
@@ -40,7 +43,6 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
             setHasCard(true)
             const card = user.libraryCard
             const daaIds = card.daaIds ?? []
-            const signingOfficialUsers = await User.getSOsForCurrentUser()
             setIssuedOn(new Date(card.createDate).toISOString().slice(0, 10))
             const createUser = signingOfficialUsers.find((so: SimplifiedDuosUser) => so.userId === card.createUserId)
             if (createUser) {
@@ -108,13 +110,13 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
         Account
       </p>
       <p>
-        A&nbsp;
+        A{' '}
         <a href={accountLink}>
-          {accountLabel}
-          &nbsp;Account
+          {accountLabel} Account
         </a>
-&nbsp;is required to submit a Data Access Requeset (DAR).
+        {' '}is required to submit a Data Access Request (DAR).
       </p>
+
       {ERACommons({
         destination: 'profile',
         onNihStatusUpdate: nihStatusUpdate,
@@ -123,6 +125,22 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
       })}
       <div style={{ marginTop: '20px' }} />
       <p style={subheadStyle}>Library Card issued to you</p>
+      {signingOfficialUsers.length === 0
+        ? (
+            <p>
+              No Signing Official found for your institution. Please refer to <a href="https://duos.blog/2025/08/06/how-to-get-a-library-card-from-your-signing-official/" target="_blank" rel="noreferrer">this help article</a> for instructions on how to get a Library Card.
+            </p>
+          )
+        : (
+            <>
+              <p>Signing Official(s):</p>
+              <ul>
+                {signingOfficialUsers.map(so => (
+                  <li key={so.userId}>{so.displayName} - {so.email}</li>
+                ))}
+              </ul>
+            </>
+          )}
       <p>
         A Library Card is a Signing Official’s pre-authorization of a researcher to submit Data Access Requests (DARs)
         in DUOS. A valid Library Card is required to initiate a DAR.


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2078

### Summary

- If an institution has Signing Officials, show their names and emails above the Library Card content.
- If no signing officials exist, send a message with a link to a help article.

This ensures users always know who their Signing Officials are or how to get a Library Card.

**With Officials**
<img width="1324" height="342" alt="With Officials" src="https://github.com/user-attachments/assets/02b7c5a6-9219-4b42-9379-bb478f0e5f76" />

**No Officials**
<img width="1249" height="245" alt="No Officials" src="https://github.com/user-attachments/assets/30df4d5f-ba3b-4048-842b-9edd1458238e" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
