### PR TITLE
DT-2240: Replace select menu for LC Add User modal

### DIFF
--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -9,7 +9,7 @@ describe('Library Card Form Modal Tests', () => {
     cy.viewport(1000, 800)
     props = {
       showModal: true,
-      createOnClick: cy.stub().as('createOnClick'),
+      addButton: cy.stub().as('addButton'),
       closeModal: cy.stub().as('closeModal'),
       users: [],
     }
@@ -39,10 +39,10 @@ describe('Library Card Form Modal Tests', () => {
     cy.get('input').should('exist')
     cy.get('input').type(userOptions[0].displayName)
     cy.get('[data-cy=library-card-form-modal]').should('contain', userOptions[0].email)
-    // select the second option since the first is always the 'New User...' option
-    cy.get('[id$=option-1]').click()
+    // select the first option
+    cy.get('input').type('{enter}')
     cy.get('[id=Add-button]').click()
-    cy.get('@createOnClick').should('have.been.called')
+    cy.get('@addButton').should('have.been.called')
   })
 
   it('Multiple users should be selectable in the user selection list', () => {
@@ -58,19 +58,19 @@ describe('Library Card Form Modal Tests', () => {
 
     // select the first option
     cy.get('input').type('Test User')
-    cy.get('[id$=option-1]').click()
+    cy.get('input').type('{enter}')
 
     // select the second option
     cy.get('input').type('Test User')
-    cy.get('[id$=option-2]').click()
+    cy.get('input').type('{enter}')
 
     // select the third option
     cy.get('input').type('Test User')
-    cy.get('[id$=option-3]').click()
+    cy.get('input').type('{enter}')
 
     // click add and confirm the call was made with all selected users
     cy.get('[id=Add-button]').click()
-    cy.get('@createOnClick').should('have.been.calledWith', [
+    cy.get('@addButton').should('have.been.calledWith', [
       { userId: 1, userEmail: 'user1@test.com', userName: 'Test User 1' },
       { userId: 2, userEmail: 'user2@test.com', userName: 'Test User 2' },
       { userId: 3, userEmail: 'user3@test.com', userName: 'Test User 3' },

--- a/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
+++ b/cypress/component/LibraryCard/LibraryCardFormModal.spec.tsx
@@ -9,7 +9,7 @@ describe('Library Card Form Modal Tests', () => {
     cy.viewport(1000, 800)
     props = {
       showModal: true,
-      addButton: cy.stub().as('addButton'),
+      createOnClick: cy.stub().as('createOnClick'),
       closeModal: cy.stub().as('closeModal'),
       users: [],
     }
@@ -42,7 +42,7 @@ describe('Library Card Form Modal Tests', () => {
     // select the first option
     cy.get('input').type('{enter}')
     cy.get('[id=Add-button]').click()
-    cy.get('@addButton').should('have.been.called')
+    cy.get('@createOnClick').should('have.been.called')
   })
 
   it('Multiple users should be selectable in the user selection list', () => {
@@ -70,7 +70,7 @@ describe('Library Card Form Modal Tests', () => {
 
     // click add and confirm the call was made with all selected users
     cy.get('[id=Add-button]').click()
-    cy.get('@addButton').should('have.been.calledWith', [
+    cy.get('@createOnClick').should('have.been.calledWith', [
       { userId: 1, userEmail: 'user1@test.com', userName: 'Test User 1' },
       { userId: 2, userEmail: 'user2@test.com', userName: 'Test User 2' },
       { userId: 3, userEmail: 'user3@test.com', userName: 'Test User 3' },

--- a/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
+++ b/cypress/component/SigningOfficialTable/SigningOfficialTable.spec.jsx
@@ -70,7 +70,7 @@ describe('SigningOfficialTable', () => {
 
     // Select user
     cy.get('input[id^=react-select-]').type(mockResearcher1.displayName)
-    cy.get('[id$=option-1]').click()
+    cy.get('input[id^=react-select-]').type('{enter}')
 
     // Submit the form
     cy.get('[id=Add-button]').click()
@@ -104,7 +104,7 @@ describe('SigningOfficialTable', () => {
 
     // Select user
     cy.get('input[id^=react-select-]').type(mockResearcher1.displayName)
-    cy.get('[id$=option-1]').click()
+    cy.get('input[id^=react-select-]').type('{enter}')
 
     // Submit the form
     cy.get('[id=Add-button]').click()
@@ -146,9 +146,9 @@ describe('SigningOfficialTable', () => {
 
     // Select users
     cy.get('input[id^=react-select-]').type(mockResearcher1.displayName)
-    cy.get('[id$=option-1]').click()
+    cy.get('input[id^=react-select-]').type('{enter}')
     cy.get('input[id^=react-select-]').type(mockResearcher2.displayName)
-    cy.get('[id$=option-2]').click()
+    cy.get('input[id^=react-select-]').type('{enter}')
 
     // Submit the form
     cy.get('[id=Add-button]').click()

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -26,7 +26,7 @@ interface FormFieldRowProps {
 
 export interface LibraryCardFormModalProps {
   showModal: boolean
-  createOnClick: (cards: LibraryCard[]) => Promise<void>
+  addButton: (cards: LibraryCard[]) => Promise<void>
   closeModal: () => void
   users: UserOption[]
 }
@@ -76,7 +76,7 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
 }
 
 const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
-  const { showModal, createOnClick, closeModal, users } = props
+  const { showModal, addButton, closeModal, users } = props
   const [selectedUsers, setSelectedUsers] = useState<UserOption[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
@@ -96,7 +96,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
         } as LibraryCard
       })
 
-      await createOnClick(cards)
+      await addButton(cards)
       setSelectedUsers([])
     }
     finally {

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -26,7 +26,7 @@ interface FormFieldRowProps {
 
 export interface LibraryCardFormModalProps {
   showModal: boolean
-  addButton: (cards: LibraryCard[]) => Promise<void>
+  createOnClick: (cards: LibraryCard[]) => Promise<void>
   closeModal: () => void
   users: UserOption[]
 }
@@ -76,7 +76,7 @@ const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
 }
 
 const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
-  const { showModal, addButton, closeModal, users } = props
+  const { showModal, createOnClick, closeModal, users } = props
   const [selectedUsers, setSelectedUsers] = useState<UserOption[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
@@ -96,7 +96,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
         } as LibraryCard
       })
 
-      await addButton(cards)
+      await createOnClick(cards)
       setSelectedUsers([])
     }
     finally {

--- a/src/components/modals/LibraryCardFormModal.tsx
+++ b/src/components/modals/LibraryCardFormModal.tsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react'
-import { cloneDeep, includes, isEmpty, isNil } from 'lodash/fp'
+import { isNil } from 'lodash'
 import { Styles, Theme } from 'src/libs/theme'
 import CloseIconComponent from 'src/components/CloseIconComponent'
 import ModalWrapper from 'src/components/collaborator_list/ModalWrapper'
-import Creatable from 'react-select/creatable'
+import AsyncSelect from 'react-select/async'
 import SimpleButton from 'src/components/SimpleButton'
 import { LibraryCardAgreementTermsDownload } from 'src/components/LibraryCardAgreementTermsDownload'
 import { MultiValue } from 'react-select'
@@ -31,58 +31,44 @@ export interface LibraryCardFormModalProps {
   users: UserOption[]
 }
 
-interface FilterOptions {
-  searchTerm?: string
-  input?: string
-  action: string
-}
-
 const FormFieldRow: React.FC<FormFieldRowProps> = (props) => {
   const { selectedUsers, dropdownOptions, updateUsers } = props
 
-  const cardlessOptions = dropdownOptions.filter(option => isNil(option.libraryCard))
-  const [filteredDropdown, setFilteredDropdown] = useState<UserOption[]>(cardlessOptions)
+  // Represents users that do not already have library cards
+  const cardlessUserOptions = dropdownOptions.filter(option => isNil(option.libraryCard))
 
-  // filter function for users dropdown
-  const userListFilter = ({ searchTerm, input }: FilterOptions) => {
-    const term = searchTerm ?? input ?? ''
-    let filteredCopy: UserOption[]
+  // Filter function for auto-completing user dropdown
+  const filterUserOptions = (term: string) => {
+    return cardlessUserOptions.filter((user) => {
+      const filterTarget = (user.displayName + ' ' + user.email).toLowerCase()
+      return filterTarget.includes(term.toLowerCase())
+    })
+  }
 
-    if (isEmpty(term)) {
-      filteredCopy = dropdownOptions
-    }
-    else {
-      const copiedDropdown = cloneDeep(filteredDropdown)
-      filteredCopy = copiedDropdown.filter((user) => {
-        const userNameFilter = !isEmpty(user.displayName) ? includes(term)(user.displayName) : false
-        const emailFilter = !isEmpty(user.email) ? includes(term)(user.email) : false
-        return userNameFilter ?? emailFilter
-      })
-    }
-    setFilteredDropdown(filteredCopy)
+  const loadOptions = (inputValue: string, callback: (options: UserOption[]) => void) => {
+    setTimeout(() => {
+      callback(filterUserOptions(inputValue))
+    }, 0)
   }
 
   return (
     <div style={{ display: 'flex' }}>
       <div style={{ marginBottom: '2%', width: '100%' }}>
         <p><strong>Users</strong></p>
-        <Creatable
+        <AsyncSelect
+          classNamePrefix="select"
+          className="select-autocomplete"
           key="select-user"
           isClearable={true}
           isMulti={true}
           onChange={updateUsers}
           value={selectedUsers}
-          createOptionPosition="first"
-          onInputChange={(input: string, { action }: { action: string }) =>
-            userListFilter({ input, action })}
-          getNewOptionData={(input: string) => {
-            return { email: input } as UserOption
-          }}
-          options={cardlessOptions}
-          placeholder="Select or type new user emails"
+          defaultOptions={cardlessUserOptions}
+          loadOptions={loadOptions}
+          placeholder="Select a DUOS User..."
           isOptionSelected={() => false} // Workaround to prevent odd react-select behavior where all dropdown options are highlighted
           /* eslint-disable-next-line no-constant-binary-expression */
-          getOptionLabel={(option: UserOption) => `${option.displayName || 'New User'} (${option.email || 'No email provided'})` || option.email || ''}
+          getOptionLabel={(option: UserOption) => `${option.displayName} (${option.email})` || option.email || ''}
         />
       </div>
     </div>
@@ -155,11 +141,7 @@ const LibraryCardFormModal = (props: LibraryCardFormModalProps) => {
           dropdownOptions={users}
         />
         <div style={{ display: 'inline-block', marginBottom: '1rem' }}>
-          By clicking
-          {' '}
-          {'\'ADD\''}
-          {' '}
-          you agree to the terms of the agreements above for all users.
+          By clicking &#39;ADD&#39; you agree to the terms of the agreements above for all users.
         </div>
         <div
           style={{


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2240

## Summary

- Update the select component so that it doesn't allow for creating new entities.
- Updated the styling to match what we're doing in the edit DAC page.
- Minor refactoring to simplify the complicated TS form field construction.

### New screen

<img width="869" height="669" alt="Screenshot 2025-09-17 at 4 58 00 PM" src="https://github.com/user-attachments/assets/7cd199b9-4001-48b2-a505-5881e751fb0a" />

 <img width="877" height="669" alt="Screenshot 2025-09-17 at 4 56 09 PM" src="https://github.com/user-attachments/assets/d402b613-d812-4c66-bf51-1fd74defe78c" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
