### PR TITLE
DT-2246: Bug fix for Chair/Member Voting Tabs

### DIFF
--- a/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.tsx
+++ b/cypress/component/MultiDatasetVoteTab/collection_submit_vote_box.spec.tsx
@@ -165,6 +165,9 @@ describe('CollectionSubmitVoteBox - Tests', function () {
         reloadFn={() => {}}
       />,
     )
+    cy.stub(Votes, 'updateVotesByIds')
+    cy.stub(Votes, 'updateRationaleByIds')
+
     cy.get('textarea').should('have.text', 'test')
     cy.get('textarea').type('sample text')
     cy.get('textarea').blur()
@@ -193,6 +196,9 @@ describe('CollectionSubmitVoteBox - Tests', function () {
         reloadFn={() => {}}
       />,
     )
+    cy.stub(Votes, 'updateVotesByIds')
+    cy.stub(Votes, 'updateRationaleByIds')
+
     cy.get('[data-cy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default)
     cy.get('[data-cy=no-collection-vote-button]').should('have.css', 'background-color', votingColors.default)
     cy.get('[data-cy=yes-collection-vote-button]').click()
@@ -216,6 +222,8 @@ describe('CollectionSubmitVoteBox - Tests', function () {
         reloadFn={() => {}}
       />,
     )
+    cy.stub(Votes, 'updateRationaleByIds')
+
     cy.get('textarea').should('have.text', '')
     cy.get('textarea').type('sample text')
     cy.get('textarea').blur()
@@ -240,6 +248,7 @@ describe('CollectionSubmitVoteBox - Tests', function () {
       />,
     )
     cy.stub(Votes, 'updateVotesByIds')
+    cy.stub(Votes, 'updateRationaleByIds')
 
     cy.get('textarea').should('have.text', '')
     cy.get('textarea').type('sample text')
@@ -353,6 +362,7 @@ describe('CollectionSubmitVoteBox - Tests', function () {
         reloadFn={() => {}}
       />,
     )
+    cy.stub(Votes, 'updateRationaleByIds')
     cy.stub(Votes, 'updateVotesByIds')
 
     cy.get('[data-cy=yes-collection-vote-button]').should('have.css', 'background-color', votingColors.default)

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
@@ -192,6 +192,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
   }
 
   const onVoteError = (error: unknown, isChair: boolean) => {
+    setVoteInProgress(false)
     const consentError = extractConsentError(error)
     if (consentError && consentError.code === 409) {
       const voteText = isChair ? 'Chair vote' : 'Vote'

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
@@ -132,6 +132,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
   const [isVotingDisabled, setIsVotingDisabled] = useState<boolean>(false)
   const [isRadar, setIsRadar] = useState<boolean>(false)
   const [isElectionClosed, setIsElectionClosed] = useState<boolean>(false)
+  const [voteInProgress, setVoteInProgress] = useState<boolean>(false)
   const {
     question,
     votes,
@@ -173,6 +174,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
   }, [votes])
 
   const updateVote = async (newVote: boolean, isChair: boolean) => {
+    setVoteInProgress(true)
     const openElectionVotes = votes.filter(v => v.electionStatus?.toLowerCase() === 'open')
     const voteIds = openElectionVotes.map(v => v.voteId)
     await Votes.updateVotesByIds(voteIds, { vote: newVote, rationale })
@@ -186,6 +188,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
     }
     Notifications.showSuccess({ text: 'Successfully updated vote' })
     reloadFn()
+    setVoteInProgress(false)
   }
 
   const onVoteError = (error: unknown, isChair: boolean) => {
@@ -247,7 +250,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
                     <CollectionVoteYesButton
                       onClick={async () => await updateVote(true, !!updateFinalVote)}
                       onError={(error: unknown) => onVoteError(error, !!updateFinalVote)}
-                      disabled={isVotingDisabled || isApprovalDisabled || isLoading || isElectionClosed}
+                      disabled={voteInProgress || isVotingDisabled || isApprovalDisabled || isLoading || isElectionClosed}
                       isSelected={vote === true}
                     />
                   )}
@@ -255,7 +258,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
                     <CollectionVoteNoButton
                       onClick={async () => await updateVote(false, !!updateFinalVote)}
                       onError={(error: unknown) => onVoteError(error, !!updateFinalVote)}
-                      disabled={isLoading || isVotingDisabled || isElectionClosed}
+                      disabled={voteInProgress || isLoading || isVotingDisabled || isElectionClosed}
                       isSelected={vote === false}
                     />
                   )}

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
@@ -183,9 +183,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
     if (isChair && updateFinalVote && bucketKey) {
       updateFinalVote(bucketKey, { vote: newVote, rationale }, voteIds)
     }
-    else {
-      setVote(newVote)
-    }
+    setVote(newVote)
     Notifications.showSuccess({ text: 'Successfully updated vote' })
     reloadFn()
     setVoteInProgress(false)

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -13,6 +13,7 @@ import { Collections } from '../../libs/ajax/Collections'
 import DataAccessRequestApplication from '../dar_application/DataAccessRequestApplication'
 import VotingHistory from './VotingHistory'
 import { APPROVED_VOTETYPES, ElectionStatus, ElectionType } from 'src/utils/DarUtils'
+import { extractError } from 'src/utils/ErrorUtils.js'
 
 const tabContainerColor = 'rgb(115,154,164)'
 
@@ -145,6 +146,7 @@ const userIsDacUser = (user) => {
 export default function DarCollectionReview(props) {
   const collectionId = props.match.params.collectionId
   const [collection, setCollection] = useState({})
+  const [collectionWithHistory, setCollectionWithHistory] = useState({})
   const [darInfo, setDarInfo] = useState({})
   const [referenceIdForDocuments, setReferenceIdForDocuments] = useState()
   const [approvedDatasets, setApprovedDatasets] = useState([])
@@ -163,12 +165,9 @@ export default function DarCollectionReview(props) {
   const init = useCallback(async () => {
     const user = Storage.getCurrentUser()
     try {
-      let collection
+      const collection = await Collections.getCollectionById(collectionId)
       if (adminPage || userIsDacUser(user)) {
-        collection = await Collections.getCollectionByIdWithElectionHistory(collectionId)
-      }
-      else {
-        collection = await Collections.getCollectionById(collectionId)
+        setCollectionWithHistory(await Collections.getCollectionByIdWithElectionHistory(collectionId))
       }
 
       // Find darInfo and referenceIdForDocuments in one pass
@@ -221,8 +220,9 @@ export default function DarCollectionReview(props) {
       setSubcomponentLoading(true)
       init()
     }
-    catch (_error) {
-      Notifications.showError({ text: 'Failed to initialize collection' })
+    catch (error) {
+      const message = extractError(error)
+      Notifications.showError({ text: 'Failed to initialize collection: ' + message })
     }
   }, [init])
 
@@ -326,7 +326,7 @@ export default function DarCollectionReview(props) {
         )}
         {selectedTab === tabs.votingHistory && (
           <VotingHistory
-            darCollection={collection}
+            darCollection={collectionWithHistory}
             dacIds={dacIds}
           />
         )}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2246

### Summary
Currently, we are using the endpoint to get a collection with a full set of election history items to populate similar structures in different tabs. Previously, we populated the vote tabs with the singular dar collection (most recent one), but started using the full collection (with history) when we added the vote history tab. This made a degree of sense since the singular collection is a subset of the full collection with history. However, the bucketing utility doesn't correctly parse out the current set of elections from the full history. It was putting extra votes into the voting tabs that were for previously closed elections which created a number of UI bugs.

This PR:
* Uses the singular dar collection API to populate the voting tabs
* Continues to use the collection with history to populate the vote history tab
* Small update to the vote button functionality to set buttons to disabled while a call to the vote API is taking place. This prevents users from submitting conflicting votes in quick succession which can trigger an error in the chairperson vote tabs.
* Small bug fix to always set the vote state after it has been updated instead of in an else block.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
