### PR TITLE
[DT-2268] Remove `.control-label` Margin Top

### DIFF
--- a/src/pages/data_submission/ds_common.css
+++ b/src/pages/data_submission/ds_common.css
@@ -2,7 +2,7 @@
   font-weight: bold;
   color: #333F52;
   font-size: 16px;
-  margin-top: 2rem;
+  margin-top: 0;
   margin-bottom: 1rem;
 }
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2268

### Summary

**Before**
<img width="1920" height="1032" alt="Before" src="https://github.com/user-attachments/assets/616c7175-01dc-47a1-bc13-fa726900e0a5" />

**After**
<img width="1796" height="954" alt="After" src="https://github.com/user-attachments/assets/d3539f1e-3b72-4ce5-be15-13d6a70f7f77" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
