### PR TITLE
[DT-2269] Don't redirect the /api/user/me call if it fails with a 401 

### DIFF
--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -18,7 +18,9 @@ axios.interceptors.response.use(function (response) {
 }, function (error) {
   // Default to a 502 when we can't get a real response object.
   const status = getOr(502)('response.status')(error)
-  if (status === 401) {
+  const url = error.config.url
+  const data = error.config.data
+  if (status === 401 && !(url.endsWith('/api/user/me') && data === undefined)) {
     redirectOnLogout()
   }
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -20,9 +20,8 @@ axios.interceptors.response.use(function (response) {
   const status = getOr(502)('response.status')(error)
   const reportUrl = getOr(null)('response.config.url')(error)
   const method = getOr(null)('response.config.method')(error)
-  console.error(reportUrl, method)
-  debugger
-  if (status === 401 && !(reportUrl?.endsWith('/api/user/me') && (method?.toLowerCase() === 'get'))) {
+  const isMeCheck = reportUrl?.endsWith('/api/user/me') && (method?.toLowerCase() === 'get')
+  if (status === 401 && !isMeCheck) {
     redirectOnLogout()
   }
 

--- a/src/libs/ajax.js
+++ b/src/libs/ajax.js
@@ -18,13 +18,14 @@ axios.interceptors.response.use(function (response) {
 }, function (error) {
   // Default to a 502 when we can't get a real response object.
   const status = getOr(502)('response.status')(error)
-  const url = error.config.url
-  const data = error.config.data
-  if (status === 401 && !(url.endsWith('/api/user/me') && data === undefined)) {
+  const reportUrl = getOr(null)('response.config.url')(error)
+  const method = getOr(null)('response.config.method')(error)
+  console.error(reportUrl, method)
+  debugger
+  if (status === 401 && !(reportUrl?.endsWith('/api/user/me') && (method?.toLowerCase() === 'get'))) {
     redirectOnLogout()
   }
 
-  const reportUrl = getOr(null)('response.config.url')(error)
   if (!isNil(reportUrl) && status >= 500) {
     reportError(reportUrl, status)
   }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2269](https://broadworkbench.atlassian.net/browse/DT-2269)

### Summary

The backend will return a 401 when /api/user/me is called.  The SigninButton.tsx code depends on the logic continuing to flow so we must exclude this call from the traditional 401 handling so that the user account can be created.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
