### PR TITLE
adding Dataset ID to the main level of the Voting History Tab

### DIFF
--- a/cypress/component/VoteHistoryTable/chair_vote_history_table.spec.tsx
+++ b/cypress/component/VoteHistoryTable/chair_vote_history_table.spec.tsx
@@ -12,7 +12,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
       electionId: 201,
       displayName: 'Alice Johnson',
       type: 'Chair',
-      darTitle: 'DAR Title 1',
+      datasetId: 401,
       progressReport: true,
       electionDate: new Date('2023-01-03T10:30:00-05:00').getTime(),
       vote: true,
@@ -26,7 +26,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
       electionId: 202,
       displayName: 'Bob Smith',
       type: 'Chair',
-      darTitle: 'DAR Title 2',
+      datasetId: 402,
       progressReport: false,
       electionDate: new Date('2023-01-01T10:30:00-05:00').getTime(),
       vote: false,
@@ -40,7 +40,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
       electionId: 203,
       displayName: 'Charlie Brown',
       type: 'Chair',
-      darTitle: 'DAR Title 3',
+      datasetId: 403,
       progressReport: true,
       electionDate: new Date('2023-01-02T10:30:00-05:00').getTime(),
       vote: false,
@@ -52,7 +52,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
     mount(<ChairVoteHistoryTable voteHistory={testData} />)
     cy.get('.column-header').should('have.length', 8)
     cy.get(':nth-child(1) > .cell-sort').contains('Request Type')
-    cy.get(':nth-child(2) > .cell-sort').contains('DAR Title')
+    cy.get(':nth-child(2) > .cell-sort').contains('Dataset ID')
     cy.get(':nth-child(3) > .cell-sort').contains('Election Date')
     cy.get(':nth-child(4) > .cell-sort').contains('Vote')
     cy.get(':nth-child(5) > .cell-sort').contains('Name')
@@ -64,7 +64,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
   it('should render rows with correct default sort (by election date descending)', () => {
     mount(<ChairVoteHistoryTable voteHistory={testData} />)
     cy.get('.row-data-0 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-0 > :nth-child(2)').contains('DAR Title 1')
+    cy.get('.row-data-0 > :nth-child(2)').contains('401')
     cy.get('.row-data-0 > :nth-child(3)').contains('2023-01-03')
     cy.get('.row-data-0 > :nth-child(4)').contains('Yes')
     cy.get('.row-data-0 > :nth-child(5)').contains('Alice Johnson')
@@ -73,7 +73,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
     cy.get('.row-data-0 > :nth-child(8)').contains('Approved')
 
     cy.get('.row-data-1 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-1 > :nth-child(2)').contains('DAR Title 3')
+    cy.get('.row-data-1 > :nth-child(2)').contains('403')
     cy.get('.row-data-1 > :nth-child(3)').contains('2023-01-02')
     cy.get('.row-data-1 > :nth-child(4)').contains('No')
     cy.get('.row-data-1 > :nth-child(5)').contains('Charlie Brown')
@@ -82,7 +82,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
     cy.get('.row-data-1 > :nth-child(8)').contains('--')
 
     cy.get('.row-data-2 > :nth-child(1)').contains('Initial DAR')
-    cy.get('.row-data-2 > :nth-child(2)').contains('DAR Title 2')
+    cy.get('.row-data-2 > :nth-child(2)').contains('402')
     cy.get('.row-data-2 > :nth-child(3)').contains('2023-01-01')
     cy.get('.row-data-2 > :nth-child(4)').contains('No')
     cy.get('.row-data-2 > :nth-child(5)').contains('Bob Smith')

--- a/cypress/component/VoteHistoryTable/chair_vote_history_table.spec.tsx
+++ b/cypress/component/VoteHistoryTable/chair_vote_history_table.spec.tsx
@@ -12,7 +12,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
       electionId: 201,
       displayName: 'Alice Johnson',
       type: 'Chair',
-      datasetId: 401,
+      datasetIdentifier: 'DUOS-00401',
       progressReport: true,
       electionDate: new Date('2023-01-03T10:30:00-05:00').getTime(),
       vote: true,
@@ -26,7 +26,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
       electionId: 202,
       displayName: 'Bob Smith',
       type: 'Chair',
-      datasetId: 402,
+      datasetIdentifier: 'DUOS-00402',
       progressReport: false,
       electionDate: new Date('2023-01-01T10:30:00-05:00').getTime(),
       vote: false,
@@ -40,7 +40,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
       electionId: 203,
       displayName: 'Charlie Brown',
       type: 'Chair',
-      datasetId: 403,
+      datasetIdentifier: 'DUOS-00403',
       progressReport: true,
       electionDate: new Date('2023-01-02T10:30:00-05:00').getTime(),
       vote: false,
@@ -64,7 +64,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
   it('should render rows with correct default sort (by election date descending)', () => {
     mount(<ChairVoteHistoryTable voteHistory={testData} />)
     cy.get('.row-data-0 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-0 > :nth-child(2)').contains('401')
+    cy.get('.row-data-0 > :nth-child(2)').contains('DUOS-00401')
     cy.get('.row-data-0 > :nth-child(3)').contains('2023-01-03')
     cy.get('.row-data-0 > :nth-child(4)').contains('Yes')
     cy.get('.row-data-0 > :nth-child(5)').contains('Alice Johnson')
@@ -73,7 +73,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
     cy.get('.row-data-0 > :nth-child(8)').contains('Approved')
 
     cy.get('.row-data-1 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-1 > :nth-child(2)').contains('403')
+    cy.get('.row-data-1 > :nth-child(2)').contains('DUOS-00403')
     cy.get('.row-data-1 > :nth-child(3)').contains('2023-01-02')
     cy.get('.row-data-1 > :nth-child(4)').contains('No')
     cy.get('.row-data-1 > :nth-child(5)').contains('Charlie Brown')
@@ -82,7 +82,7 @@ describe('ChairVoteHistoryTable Component - Tests', () => {
     cy.get('.row-data-1 > :nth-child(8)').contains('--')
 
     cy.get('.row-data-2 > :nth-child(1)').contains('Initial DAR')
-    cy.get('.row-data-2 > :nth-child(2)').contains('402')
+    cy.get('.row-data-2 > :nth-child(2)').contains('DUOS-00402')
     cy.get('.row-data-2 > :nth-child(3)').contains('2023-01-01')
     cy.get('.row-data-2 > :nth-child(4)').contains('No')
     cy.get('.row-data-2 > :nth-child(5)').contains('Bob Smith')

--- a/cypress/component/VoteHistoryTable/election_with_member_votes_table.spec.tsx
+++ b/cypress/component/VoteHistoryTable/election_with_member_votes_table.spec.tsx
@@ -21,7 +21,6 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     version: 2,
     archived: false,
     votes: {},
-    darTitle: 'Study on Environmental Impact',
     progressReport: true,
     memberVotes: [
       {
@@ -70,7 +69,6 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     version: 1,
     archived: false,
     votes: {},
-    darTitle: 'Genomic Data Analysis',
     progressReport: false,
     memberVotes: [
       {
@@ -115,7 +113,6 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     version: 3,
     archived: false,
     votes: {},
-    darTitle: 'Clinical Trial Data Analysis',
     progressReport: true,
     memberVotes: [
       {
@@ -146,7 +143,7 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
 
     cy.get('.column-header').should('have.length', 6)
     cy.get(':nth-child(1) > .cell-sort').contains('Request Type')
-    cy.get(':nth-child(2) > .cell-sort').contains('DAR Title')
+    cy.get(':nth-child(2) > .cell-sort').contains('Dataset ID')
     cy.get(':nth-child(3) > .cell-sort').contains('Election Date')
     cy.get(':nth-child(4) > .cell-sort').contains('Election Status')
     cy.get(':nth-child(5) > .cell-sort').contains('Votes Cast')
@@ -157,21 +154,21 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     mount(<ElectionWithMemberVotesTable electionsWithMemberVotes={electionHistory} />)
 
     cy.get('.row-data-0 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-0 > :nth-child(2)').contains('Clinical Trial Data Analysis')
+    cy.get('.row-data-0 > :nth-child(2)').contains('404')
     cy.get('.row-data-0 > :nth-child(3)').contains('2023-03-10')
     cy.get('.row-data-0 > :nth-child(4)').contains('In Progress')
     cy.get('.row-data-0 > :nth-child(5)').contains('0/2')
     cy.get('.row-data-0 > :nth-child(6)').contains('No votes cast')
 
     cy.get('.row-data-1 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-1 > :nth-child(2)').contains('Study on Environmental Impact')
+    cy.get('.row-data-1 > :nth-child(2)').contains('202')
     cy.get('.row-data-1 > :nth-child(3)').contains('2023-02-01')
     cy.get('.row-data-1 > :nth-child(4)').contains('In Progress')
     cy.get('.row-data-1 > :nth-child(5)').contains('2/2')
     cy.get('.row-data-1 > :nth-child(6)').contains('1 Yes, 1 No')
 
     cy.get('.row-data-2 > :nth-child(1)').contains('Initial DAR')
-    cy.get('.row-data-2 > :nth-child(2)').contains('Genomic Data Analysis')
+    cy.get('.row-data-2 > :nth-child(2)').contains('303')
     cy.get('.row-data-2 > :nth-child(3)').contains('2023-01-15')
     cy.get('.row-data-2 > :nth-child(4)').contains('Closed')
     cy.get('.row-data-2 > :nth-child(5)').contains('1/2')

--- a/cypress/component/VoteHistoryTable/election_with_member_votes_table.spec.tsx
+++ b/cypress/component/VoteHistoryTable/election_with_member_votes_table.spec.tsx
@@ -16,6 +16,7 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     finalRationale: '',
     finalAccessVote: false,
     datasetId: 202,
+    datasetIdentifier: 'DUOS-00202',
     displayId: 'E-002',
     dulName: 'Data Use Agreement',
     version: 2,
@@ -64,6 +65,7 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     finalRationale: 'All criteria met',
     finalAccessVote: true,
     datasetId: 303,
+    datasetIdentifier: 'DUOS-00303',
     displayId: 'E-003',
     dulName: 'Data Use Limitation',
     version: 1,
@@ -108,6 +110,7 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     finalRationale: '',
     finalAccessVote: false,
     datasetId: 404,
+    datasetIdentifier: 'DUOS-00404',
     displayId: 'E-004',
     dulName: 'Data Sharing Agreement',
     version: 3,
@@ -154,21 +157,21 @@ describe('ElectionWithMemberVotesTable Component Tests', () => {
     mount(<ElectionWithMemberVotesTable electionsWithMemberVotes={electionHistory} />)
 
     cy.get('.row-data-0 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-0 > :nth-child(2)').contains('404')
+    cy.get('.row-data-0 > :nth-child(2)').contains('DUOS-00404')
     cy.get('.row-data-0 > :nth-child(3)').contains('2023-03-10')
     cy.get('.row-data-0 > :nth-child(4)').contains('In Progress')
     cy.get('.row-data-0 > :nth-child(5)').contains('0/2')
     cy.get('.row-data-0 > :nth-child(6)').contains('No votes cast')
 
     cy.get('.row-data-1 > :nth-child(1)').contains('Progress Report')
-    cy.get('.row-data-1 > :nth-child(2)').contains('202')
+    cy.get('.row-data-1 > :nth-child(2)').contains('DUOS-00202')
     cy.get('.row-data-1 > :nth-child(3)').contains('2023-02-01')
     cy.get('.row-data-1 > :nth-child(4)').contains('In Progress')
     cy.get('.row-data-1 > :nth-child(5)').contains('2/2')
     cy.get('.row-data-1 > :nth-child(6)').contains('1 Yes, 1 No')
 
     cy.get('.row-data-2 > :nth-child(1)').contains('Initial DAR')
-    cy.get('.row-data-2 > :nth-child(2)').contains('303')
+    cy.get('.row-data-2 > :nth-child(2)').contains('DUOS-00303')
     cy.get('.row-data-2 > :nth-child(3)').contains('2023-01-15')
     cy.get('.row-data-2 > :nth-child(4)').contains('Closed')
     cy.get('.row-data-2 > :nth-child(5)').contains('1/2')

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -52,7 +52,7 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
 
   const columnHeaderFormat = {
     requestType: { label: 'Request Type', cellStyle: { width: '15%' }, sortable: true },
-    darCode: { label: 'DAR Title', cellStyle: { width: '20%' }, sortable: true },
+    datasetId: { label: 'Dataset ID', cellStyle: { width: '20%' }, sortable: true },
     electionDate: { label: 'Election Date', cellStyle: { width: '15%' }, sortable: true },
     vote: { label: 'Vote', cellStyle: { width: '10%' }, sortable: true },
     name: { label: 'Name', cellStyle: { width: '15%' }, sortable: true },
@@ -62,8 +62,8 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
   }
 
   const columnHeaderData = () => {
-    const { requestType, darCode, electionDate, vote, name, voteDate, voteType, rationale } = columnHeaderFormat
-    return [requestType, darCode, electionDate, vote, name, voteDate, voteType, rationale]
+    const { requestType, datasetId, electionDate, vote, name, voteDate, voteType, rationale } = columnHeaderFormat
+    return [requestType, datasetId, electionDate, vote, name, voteDate, voteType, rationale]
   }
 
   const getVoteText = (vote: boolean | null | undefined) => {
@@ -77,7 +77,7 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
 
     const rowData = voteHistory.map((row: VoteHistoryRow, i) => [
       { data: row.progressReport ? 'Progress Report' : 'Initial DAR', cellStyle: { width: '10%' }, label: 'Request Type', id: i },
-      { data: row.darTitle, cellStyle: { width: '20%' }, label: 'DAR Title', id: i },
+      { data: row.datasetId, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
       { data: formatDate(row.electionDate), cellStyle: { width: '10%' }, label: 'Election Date', id: i },
       { data: getVoteText(row.vote), cellStyle: { width: '10%' }, label: 'Vote', id: i },
       { data: row.displayName, cellStyle: { width: '15%' }, label: 'Name', id: i },

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -52,18 +52,18 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
 
   const columnHeaderFormat = {
     requestType: { label: 'Request Type', cellStyle: { width: '15%' }, sortable: true },
-    datasetId: { label: 'Dataset ID', cellStyle: { width: '20%' }, sortable: true },
+    datasetIdentifier: { label: 'Dataset ID', cellStyle: { width: '20%' }, sortable: true },
     electionDate: { label: 'Election Date', cellStyle: { width: '15%' }, sortable: true },
     vote: { label: 'Vote', cellStyle: { width: '10%' }, sortable: true },
     name: { label: 'Name', cellStyle: { width: '15%' }, sortable: true },
     voteDate: { label: 'Vote Date', cellStyle: { width: '10%' }, sortable: true },
-    voteType: { label: 'Vote Type', cellStyle: { width: '10%' }, sortable: true },
-    rationale: { label: 'Rationale', cellStyle: { width: '20%' }, sortable: true },
+    voteType: { label: 'Vote Type', cellStyle: { width: '15%' }, sortable: true },
+    rationale: { label: 'Rationale', cellStyle: { width: '15%' }, sortable: true },
   }
 
   const columnHeaderData = () => {
-    const { requestType, datasetId, electionDate, vote, name, voteDate, voteType, rationale } = columnHeaderFormat
-    return [requestType, datasetId, electionDate, vote, name, voteDate, voteType, rationale]
+    const { requestType, datasetIdentifier, electionDate, vote, name, voteDate, voteType, rationale } = columnHeaderFormat
+    return [requestType, datasetIdentifier, electionDate, vote, name, voteDate, voteType, rationale]
   }
 
   const getVoteText = (vote: boolean | null | undefined) => {
@@ -76,14 +76,14 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
     if (!voteHistory) return []
 
     const rowData = voteHistory.map((row: VoteHistoryRow, i) => [
-      { data: row.progressReport ? 'Progress Report' : 'Initial DAR', cellStyle: { width: '10%' }, label: 'Request Type', id: i },
-      { data: row.datasetId, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
-      { data: formatDate(row.electionDate), cellStyle: { width: '10%' }, label: 'Election Date', id: i },
+      { data: row.progressReport ? 'Progress Report' : 'Initial DAR', cellStyle: { width: '15%' }, label: 'Request Type', id: i },
+      { data: row.datasetIdentifier, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
+      { data: formatDate(row.electionDate), cellStyle: { width: '15%' }, label: 'Election Date', id: i },
       { data: getVoteText(row.vote), cellStyle: { width: '10%' }, label: 'Vote', id: i },
       { data: row.displayName, cellStyle: { width: '15%' }, label: 'Name', id: i },
       { data: formatDate(row.updateDate), cellStyle: { width: '10%' }, label: 'Vote Date', id: i },
-      { data: row.type, cellStyle: { width: '10%' }, label: 'Vote Type', id: i },
-      { data: row.rationale || '--', cellStyle: { width: '20%' }, label: 'Rationale', id: i },
+      { data: row.type, cellStyle: { width: '15%' }, label: 'Vote Type', id: i },
+      { data: row.rationale || '--', cellStyle: { width: '15%' }, label: 'Rationale', id: i },
     ])
     return rowData
   }

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -102,7 +102,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
 
   const columnHeaderFormat = {
     requestType: { label: 'Request Type', cellStyle: { width: '15%' }, sortable: true },
-    datasetId: { label: 'Dataset ID', cellStyle: { width: '20%' }, sortable: true },
+    datasetIdentifier: { label: 'Dataset ID', cellStyle: { width: '20%' }, sortable: true },
     electionDate: { label: 'Election Date', cellStyle: { width: '15%' }, sortable: true },
     electionStatus: { label: 'Election Status', cellStyle: { width: '15%' }, sortable: true },
     votes: { label: 'Votes Cast', cellStyle: { width: '10%' }, sortable: true },
@@ -110,8 +110,8 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
   }
 
   const columnHeaderData = () => {
-    const { requestType, datasetId, electionDate, electionStatus, votes, voteSummary } = columnHeaderFormat
-    return [requestType, datasetId, electionDate, electionStatus, votes, voteSummary]
+    const { requestType, datasetIdentifier, electionDate, electionStatus, votes, voteSummary } = columnHeaderFormat
+    return [requestType, datasetIdentifier, electionDate, electionStatus, votes, voteSummary]
   }
 
   const processElectionRowData = (electionsWithMemberVotes: ElectionWithMemberVotes[]) => {
@@ -137,7 +137,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
         memberVotes: election.memberVotes,
         onClick: () => toggleElectionExpansion(election.electionId),
         },
-        { data: election.datasetId, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
+        { data: election.datasetIdentifier, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
         { data: formatDate(election.createDate), cellStyle: { width: '10%' }, label: 'Election Date', id: i },
         { data: election.status, cellStyle: { width: '10%' }, label: 'Election Status', id: i },
         { data: processVotesCast(election.memberVotes), cellStyle: { width: '10%' }, label: 'Votes', id: i },

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -102,7 +102,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
 
   const columnHeaderFormat = {
     requestType: { label: 'Request Type', cellStyle: { width: '15%' }, sortable: true },
-    darTitle: { label: 'DAR Title', cellStyle: { width: '20%' }, sortable: true },
+    datasetId: { label: 'Dataset ID', cellStyle: { width: '20%' }, sortable: true },
     electionDate: { label: 'Election Date', cellStyle: { width: '15%' }, sortable: true },
     electionStatus: { label: 'Election Status', cellStyle: { width: '15%' }, sortable: true },
     votes: { label: 'Votes Cast', cellStyle: { width: '10%' }, sortable: true },
@@ -110,8 +110,8 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
   }
 
   const columnHeaderData = () => {
-    const { requestType, darTitle, electionDate, electionStatus, votes, voteSummary } = columnHeaderFormat
-    return [requestType, darTitle, electionDate, electionStatus, votes, voteSummary]
+    const { requestType, datasetId, electionDate, electionStatus, votes, voteSummary } = columnHeaderFormat
+    return [requestType, datasetId, electionDate, electionStatus, votes, voteSummary]
   }
 
   const processElectionRowData = (electionsWithMemberVotes: ElectionWithMemberVotes[]) => {
@@ -137,7 +137,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
         memberVotes: election.memberVotes,
         onClick: () => toggleElectionExpansion(election.electionId),
         },
-        { data: election.darTitle, cellStyle: { width: '20%' }, label: 'DAR Title', id: i },
+        { data: election.datasetId, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
         { data: formatDate(election.createDate), cellStyle: { width: '10%' }, label: 'Election Date', id: i },
         { data: election.status, cellStyle: { width: '10%' }, label: 'Election Status', id: i },
         { data: processVotesCast(election.memberVotes), cellStyle: { width: '10%' }, label: 'Votes', id: i },

--- a/src/pages/dar_collection_review/VotingHistory.tsx
+++ b/src/pages/dar_collection_review/VotingHistory.tsx
@@ -78,7 +78,7 @@ const extractChairVotes = (darCollection: DarCollection, filteredDatasetIds: num
           if (isChairVote(vote)) {
             votesByRole.push({
               ...vote,
-              darTitle: dar.data.projectTitle,
+              datasetId: election.datasetId,
               progressReport: dar.progressReport,
               electionDate: election.createDate,
             })
@@ -103,7 +103,7 @@ const extractElectionsWithMemberVotes = (darCollection: DarCollection, filteredD
       .forEach((election: Election) => {
         const electionWithMemberVotes: ElectionWithMemberVotes = {
           ...election,
-          darTitle: dar.data.projectTitle,
+          datasetId: election.datasetId,
           progressReport: dar.progressReport,
           memberVotes: [],
         }

--- a/src/pages/dar_collection_review/VotingHistory.tsx
+++ b/src/pages/dar_collection_review/VotingHistory.tsx
@@ -103,7 +103,6 @@ const extractElectionsWithMemberVotes = (darCollection: DarCollection, filteredD
       .forEach((election: Election) => {
         const electionWithMemberVotes: ElectionWithMemberVotes = {
           ...election,
-          datasetId: election.datasetId,
           progressReport: dar.progressReport,
           memberVotes: [],
         }

--- a/src/pages/dar_collection_review/VotingHistory.tsx
+++ b/src/pages/dar_collection_review/VotingHistory.tsx
@@ -76,9 +76,10 @@ const extractChairVotes = (darCollection: DarCollection, filteredDatasetIds: num
       .forEach((election: Election) => {
         Object.values(election.votes ?? []).forEach((vote: Vote) => {
           if (isChairVote(vote)) {
+            const dataset = darCollection.datasets.find(ds => ds.datasetId === election.datasetId)
             votesByRole.push({
               ...vote,
-              datasetId: election.datasetId,
+              datasetIdentifier: dataset?.datasetIdentifier || `Dataset-${election.datasetId}`,
               progressReport: dar.progressReport,
               electionDate: election.createDate,
             })
@@ -101,8 +102,10 @@ const extractElectionsWithMemberVotes = (darCollection: DarCollection, filteredD
     Object.values(dar.elections ?? [])
       .filter((election: Election) => election.electionType == 'DataAccess' && filteredDatasetIds.includes(election.datasetId))
       .forEach((election: Election) => {
+        const dataset = darCollection.datasets.find(ds => ds.datasetId === election.datasetId)
         const electionWithMemberVotes: ElectionWithMemberVotes = {
           ...election,
+          datasetIdentifier: dataset?.datasetIdentifier || `Dataset-${election.datasetId}`,
           progressReport: dar.progressReport,
           memberVotes: [],
         }
@@ -117,7 +120,6 @@ const extractElectionsWithMemberVotes = (darCollection: DarCollection, filteredD
 
   return dacMemberVotes
 }
-
 const isChairVote = (vote: Vote) => {
   return (vote.type === VOTE_TYPES.FINAL || vote.type === VOTE_TYPES.RADAR_APPROVE) && vote.vote != null
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -660,13 +660,13 @@ export interface AlgorithmResult {
 }
 
 export interface VoteHistoryRow extends Vote {
-  datasetId: number
+  datasetIdentifier: string
   progressReport: boolean
   electionDate: string | number
 }
 
 export interface ElectionWithMemberVotes extends Election {
-  datasetId: number
+  datasetIdentifier: string
   progressReport: boolean
   memberVotes: Vote[]
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -660,13 +660,13 @@ export interface AlgorithmResult {
 }
 
 export interface VoteHistoryRow extends Vote {
-  darTitle: string
+  datasetId: number
   progressReport: boolean
   electionDate: string | number
 }
 
 export interface ElectionWithMemberVotes extends Election {
-  darTitle: string
+  datasetId: number
   progressReport: boolean
   memberVotes: Vote[]
 }


### PR DESCRIPTION

### Addresses
https://broadworkbench.atlassian.net/browse/DT-2247

### Summary
The Dataset ID needed to be added to the Voting History Tab under the Data Access Request Review. Also updated the Cypress tests.

*New Screenshots*
<img width="1377" height="772" alt="Screenshot 2025-09-26 at 3 38 24 PM" src="https://github.com/user-attachments/assets/e0edf4fb-3133-497e-8996-6903b46b7926" />

But you will notice that the `VOTE TYPE` field is overlapping `RATIONALE`, so I also adjusted the column width to correct this overlap. Now it looks like:
<img width="1432" height="755" alt="Screenshot 2025-09-26 at 3 46 49 PM" src="https://github.com/user-attachments/assets/e5e845a3-ecb2-477d-a083-7b5e302574e6" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
