### PR TITLE
[DT-2140] Show banner when voting is inactive

### DIFF
--- a/cypress/component/utils/dar_utils.spec.ts
+++ b/cypress/component/utils/dar_utils.spec.ts
@@ -1,13 +1,15 @@
 import {
   convertFormStateToDAR,
+  ElectionStatus, ElectionType,
   getApprovedElectionDatasetIds,
   getCloseoutInfo,
   getDataManagementIncidents,
   getPresentationList,
   getPublicationList,
+  userHasOpenDataAccessElection,
   VOTE_TYPES,
 } from 'src/utils/DarUtils'
-import { Collaborator, Election, Vote } from 'src/types/model'
+import { Collaborator, DarCollection, DataAccessRequest, Election, Vote } from 'src/types/model'
 import { FormState } from 'src/pages/progress_reports/ProgressReportFormState'
 
 describe('DarUtils', () => {
@@ -263,6 +265,97 @@ describe('DarUtils', () => {
       expect(result.irbProtocolExpiration).to.equal(formState.irbProtocolExpiration)
       expect(result.collaborationLetterLocation).to.equal(formState.collaborationLetterLocation)
       expect(result.collaborationLetterName).to.equal(formState.collaborationLetterName)
+    })
+  })
+
+  describe('hasOpenElection', () => {
+    const baseVote = {
+      voteId: 1,
+      userId: 42,
+      electionStatus: ElectionStatus.OPEN,
+    } as Vote
+
+    const openElection = {
+      electionId: 1,
+      status: ElectionStatus.OPEN,
+      electionType: ElectionType.DATA_ACCESS,
+      votes: {
+        1: { ...baseVote },
+      } as object,
+    } as Election
+
+    const closedElection = {
+      electionId: 2,
+      status: ElectionStatus.CLOSED,
+      electionType: ElectionType.DATA_ACCESS,
+      votes: {
+        1: { ...baseVote },
+      } as object,
+    } as Election
+
+    const nonMatchingVote = {
+      electionId: 3,
+      status: ElectionStatus.OPEN,
+      electionType: ElectionType.DATA_ACCESS,
+      votes: {
+        1: { ...baseVote, userId: 99 },
+      } as object,
+    } as Election
+
+    const nonOpenVote = {
+      electionId: 4,
+      status: ElectionStatus.OPEN,
+      electionType: ElectionType.DATA_ACCESS,
+      votes: {
+        1: { ...baseVote, electionStatus: ElectionStatus.CLOSED },
+      } as object,
+    } as Election
+
+    const nonDataAccessElection = {
+      electionId: 5,
+      status: ElectionStatus.OPEN,
+      electionType: 'OtherType',
+      votes: {
+        1: { ...baseVote },
+      } as object,
+    } as Election
+
+    const makeCollection = (elections: Election[]) => ({
+      dars: {
+        1: { elections: { ...elections.reduce((acc, e, i) => ({ ...acc, [i]: e }), {}) } } as object as DataAccessRequest,
+      } as object,
+    } as DarCollection)
+
+    it('returns true if there is an open DataAccess election with a matching open vote for the user', () => {
+      expect(userHasOpenDataAccessElection(makeCollection([openElection]), 42)).to.equal(true)
+    })
+
+    it('returns false if there are no dars', () => {
+      expect(userHasOpenDataAccessElection({ dars: undefined } as object as DarCollection, 42)).to.equal(false)
+    })
+
+    it('returns false if election is closed', () => {
+      expect(userHasOpenDataAccessElection(makeCollection([closedElection]), 42)).to.equal(false)
+    })
+
+    it('returns false if vote userId does not match', () => {
+      expect(userHasOpenDataAccessElection(makeCollection([nonMatchingVote]), 42)).to.equal(false)
+    })
+
+    it('returns false if vote.electionStatus is not OPEN', () => {
+      expect(userHasOpenDataAccessElection(makeCollection([nonOpenVote]), 42)).to.equal(false)
+    })
+
+    it('returns false if electionType is not DataAccess', () => {
+      expect(userHasOpenDataAccessElection(makeCollection([nonDataAccessElection]), 42)).to.equal(false)
+    })
+
+    it('returns true if at least one election matches among many', () => {
+      expect(userHasOpenDataAccessElection(makeCollection([closedElection, nonMatchingVote, openElection]), 42)).to.equal(true)
+    })
+
+    it('returns false if no elections exist', () => {
+      expect(userHasOpenDataAccessElection({ dars: { 1: { elections: {} } as DataAccessRequest } } as object as DarCollection, 42)).to.equal(false)
     })
   })
 })

--- a/src/components/Notification.jsx
+++ b/src/components/Notification.jsx
@@ -8,14 +8,12 @@ import ReportIcon from '@mui/icons-material/Report'
 import style from './Notification.module.css'
 
 export const Notification = (props) => {
-  const { notificationData, index = 1 } = props
+  const { notificationData, index = 1, customStyle } = props
   let notificationDiv = <div key={index} style={{ display: 'none' }} />
 
   if (!isEmpty(notificationData)) {
     const iconStyle = {
-      marginRight: '2rem',
-      marginLeft: '1rem',
-      marginTop: '.5rem',
+      marginRight: '1rem',
       height: 30,
       width: 30,
     }
@@ -42,10 +40,11 @@ export const Notification = (props) => {
     notificationDiv = (
       <div
         key={index}
-        className={'row no-margin alert alert-' + notificationData.level}
+        className={'row alert alert-' + notificationData.level}
+        style={{ margin: 0, padding: '1.5rem', alignItems: 'center', ...customStyle }}
       >
         <div style={{ float: 'left' }}>{icon}</div>
-        <div className={style['underlined']}>{content}</div>
+        <div className={style['underlined']} style={{ margin: '0.5rem auto' }}>{content}</div>
       </div>
     )
   }

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -262,7 +262,7 @@ export default function DarCollectionReview(props) {
 
   return (
     <div className="collection-review-page">
-      <div className="review-page-header" style={{ width: '90%', margin: '0 auto 3% auto' }}>
+      <div className="review-page-header" style={{ width: '90%', margin: '0 auto auto auto' }}>
         <ReviewHeader
           darCode={collection.darCode || '- -'}
           projectTitle={darInfo.projectTitle || '- -'}
@@ -274,13 +274,14 @@ export default function DarCollectionReview(props) {
         />
         {!canVote && (
           <Notification
+            customStyle={{ paddingLeft: 0 }}
             notificationData={{
               message: 'This vote page is read-only. Click vote on the DAR table entry or look at the voting history tab for details.',
             }}
           />
         )}
       </div>
-      <div className="review-page-body" style={{ padding: '1% 0% 0% 5.1%', backgroundColor: tabContainerColor }}>
+      <div className="review-page-body" style={{ marginTop: '1rem', padding: '1% 0% 0% 5.1%', backgroundColor: tabContainerColor }}>
         <TabControl
           labels={Object.values(tabs)}
           selectedTab={selectedTab}

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -12,8 +12,15 @@ import MultiDatasetVotingTab from './MultiDatasetVotingTab'
 import { Collections } from '../../libs/ajax/Collections'
 import DataAccessRequestApplication from '../dar_application/DataAccessRequestApplication'
 import VotingHistory from './VotingHistory'
-import { APPROVED_VOTETYPES, ElectionStatus, ElectionType } from 'src/utils/DarUtils'
+import {
+  APPROVED_VOTETYPES,
+  ElectionStatus,
+  ElectionType,
+  userHasOpenDataAccessElection,
+} from 'src/utils/DarUtils'
 import { extractError } from 'src/utils/ErrorUtils.js'
+import PropTypes from 'prop-types'
+import { Notification } from 'src/components/Notification.jsx'
 
 const tabContainerColor = 'rgb(115,154,164)'
 
@@ -161,9 +168,10 @@ export default function DarCollectionReview(props) {
   const [dataUseBuckets, setDataUseBuckets] = useState([])
   const [dacIds, setDacIds] = useState([])
   const { adminPage = false, readOnly = false } = props
+  const [canVote, setCanVote] = useState(false)
 
   const init = useCallback(async () => {
-    const user = Storage.getCurrentUser()
+    const user = await Storage.getCurrentUser()
     try {
       const collection = await Collections.getCollectionById(collectionId)
       if (adminPage || userIsDacUser(user)) {
@@ -199,8 +207,9 @@ export default function DarCollectionReview(props) {
       setIsLoading(false)
       setSubcomponentLoading(false)
       setReferenceIdForDocuments(referenceIdForDocuments)
+      setCanVote(userHasOpenDataAccessElection(collection, user.userId))
     }
-    catch (_error) {
+    catch {
       Notifications.showError({
         text: 'Error initializing Data Access Request collection page. You have been redirected to your console',
       })
@@ -213,6 +222,17 @@ export default function DarCollectionReview(props) {
   const updateFinalVoteFn = useCallback((key, votePayload, voteIds) => {
     return updateFinalVote({ key, votePayload, voteIds, dataUseBuckets, setDataUseBuckets })
   }, [dataUseBuckets])
+
+  DarCollectionReview.propTypes = {
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        collectionId: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+    history: PropTypes.object.isRequired,
+    adminPage: PropTypes.bool,
+    readOnly: PropTypes.bool,
+  }
 
   useEffect(() => {
     try {
@@ -233,7 +253,7 @@ export default function DarCollectionReview(props) {
         init()
       }
     }
-    catch (_error) {
+    catch {
       Notifications.showError({
         text: 'Failed to initialize collection for chair tab',
       })
@@ -252,6 +272,13 @@ export default function DarCollectionReview(props) {
           isLoading={isLoading}
           readOnly={readOnly || adminPage}
         />
+        {!canVote && (
+          <Notification
+            notificationData={{
+              message: 'This vote page is read-only. Click vote on the DAR table entry or look at the voting history tab for details.',
+            }}
+          />
+        )}
       </div>
       <div className="review-page-body" style={{ padding: '1% 0% 0% 5.1%', backgroundColor: tabContainerColor }}>
         <TabControl

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -168,7 +168,7 @@ export default function DarCollectionReview(props) {
   const [dataUseBuckets, setDataUseBuckets] = useState([])
   const [dacIds, setDacIds] = useState([])
   const { adminPage = false, readOnly = false } = props
-  const [canVote, setCanVote] = useState(false)
+  const [canVote, setCanVote] = useState(undefined)
 
   const init = useCallback(async () => {
     const user = await Storage.getCurrentUser()
@@ -272,7 +272,7 @@ export default function DarCollectionReview(props) {
           isLoading={isLoading}
           readOnly={readOnly || adminPage}
         />
-        {!canVote && (
+        {canVote === false && (
           <Notification
             customStyle={{ paddingLeft: 0 }}
             notificationData={{

--- a/src/pages/dar_collection_review/ReviewHeader.jsx
+++ b/src/pages/dar_collection_review/ReviewHeader.jsx
@@ -62,7 +62,7 @@ export default function ReviewHeader(props) {
   return (
     <>
       {!isLoading && (
-        <div className="header-container" style={{ marginBottom: '3rem' }}>
+        <div className="header-container">
           <div className="primary-header-row" style={appliedPrimaryHeaderStyle}>
             <span style={styles.header}>
               Data Access Request Review

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -1,10 +1,10 @@
 import {
   Closeout,
-  CombinedDataAccessRequest,
+  CombinedDataAccessRequest, DarCollection, DataAccessRequest,
   DataManagementIncident,
   Election,
   Presentation,
-  Publication,
+  Publication, Vote,
 } from 'src/types/model'
 import { CLOSEOUT_KEYS, DMI_INCIDENT_KEYS, FormState } from 'src/pages/progress_reports/ProgressReportFormState'
 
@@ -20,6 +20,7 @@ export const ElectionType = {
   DATA_ACCESS: 'DataAccess',
 }
 export const ElectionStatus = {
+  OPEN: 'Open',
   CLOSED: 'Closed',
 }
 
@@ -126,4 +127,20 @@ export function getCloseoutInfo(formState: FormState): Closeout {
   closeout.signingOfficialId = formState.closeoutSigningOfficial?.userId
 
   return closeout
+}
+
+export function userHasOpenDataAccessElection(collection: DarCollection, userId: number): boolean {
+  if (!collection.dars) return false
+  return Object.values(collection.dars).some((item: DataAccessRequest) =>
+    item?.elections && Object.values(item.elections).some(
+      (election: Election) =>
+        election.status === ElectionStatus.OPEN
+        && election.electionType === ElectionType.DATA_ACCESS
+        && election.votes
+        && Object.values(election.votes).some(
+          (vote: Vote) =>
+            vote.userId === userId && vote.electionStatus === ElectionStatus.OPEN,
+        ),
+    ),
+  )
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2140

### Summary

Adds a gray banner to the voting page when voting is disabled for the logged-in user. The banner indicates:
`This vote page is read-only. Click vote on the DAR table entry or look at the voting history tab for details.`

<img width="1793" height="949" alt="Fixed Positioning" src="https://github.com/user-attachments/assets/aabfa06c-d687-44b0-802d-833156774acd" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
