### PR TITLE
DT-1432: Add redirects for DUOS-Sxxx and handle DUOS-Dxxx identifiers

### DIFF
--- a/cypress/component/Dataset/datasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/datasetStatistics.spec.jsx
@@ -10,6 +10,44 @@ describe('Dataset Statistics Tests', () => {
     cy.viewport(600, 800)
   })
 
+  it('Renders the correct dataset from a DUOS-xxx identifier path paramter', () => {
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+
+    const props = {
+      match: {
+        params: {
+          datasetIdentifier: datasetTerm.datasetIdentifier,
+        },
+      },
+      history: {
+        push() {
+        },
+      },
+    }
+    mount(<DatasetStatistics {...props} />)
+    cy.contains(datasetTerm.datasetIdentifier).should('exist')
+  })
+
+  it('Renders the correct dataset from a DUOS-Dxxx identifier path parameter', () => {
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+
+    const props = {
+      match: {
+        params: {
+          datasetIdentifier: 'DUOS-D' + datasetTerm.datasetId,
+        },
+      },
+      history: {
+        push() {
+        },
+      },
+    }
+    mount(<DatasetStatistics {...props} />)
+    cy.contains(datasetTerm.datasetIdentifier).should('exist')
+  })
+
   it('Displays Controlled Access Dataset Apply Button', () => {
     const controlled = { ...datasetTerm, accessManagement: 'controlled' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([controlled]))

--- a/cypress/component/StudyDetails/StudyDetails.spec.tsx
+++ b/cypress/component/StudyDetails/StudyDetails.spec.tsx
@@ -59,6 +59,7 @@ describe('Study details test', () => {
   })
 
   it('shows the appropriate data for fields', () => {
+    cy.contains('DUOS-S' + datasets[0].study.studyId).should('exist')
     cy.contains(datasets[0].study.studyName).should('exist')
     cy.contains(datasets[0].study.description).should('exist')
     cy.contains((datasets[0].participantCount + datasets[1].participantCount).toString()).should('exist')

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -133,6 +133,7 @@ const Routes = props => (
     <AuthenticatedRoute path="/datalibrary" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/studies/:studyId" component={StudyDetails} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/dataset/:datasetIdentifier" component={DatasetStatistics} props={props} rolesAllowed={[USER_ROLES.all]} />
+    <Redirect from="/DUOS-S:studyId" to="/studies/:studyId" props={props} rolesAllowed={[USER_ROLES.all]} />
     <Redirect from="/DUOS-:duosId" to="/dataset/DUOS-:duosId" props={props} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/dac_datasets" component={DACDatasets} props={props} rolesAllowed={[USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/tos_acceptance" component={TermsOfServiceAcceptance} props={props} rolesAllowed={[USER_ROLES.all]} />

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -133,11 +133,11 @@ const Routes = props => (
     <AuthenticatedRoute path="/datalibrary" component={DatasetSearch} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/studies/:studyId" component={StudyDetails} props={props} rolesAllowed={[USER_ROLES.admin, USER_ROLES.all]} />
     <AuthenticatedRoute path="/dataset/:datasetIdentifier" component={DatasetStatistics} props={props} rolesAllowed={[USER_ROLES.all]} />
-    <Redirect from="/DUOS-S:studyId" to="/studies/:studyId" props={props} rolesAllowed={[USER_ROLES.all]} />
-    <Redirect from="/DUOS-:duosId" to="/dataset/DUOS-:duosId" props={props} rolesAllowed={[USER_ROLES.all]} />
     <AuthenticatedRoute path="/dac_datasets" component={DACDatasets} props={props} rolesAllowed={[USER_ROLES.chairperson]} />
     <AuthenticatedRoute path="/tos_acceptance" component={TermsOfServiceAcceptance} props={props} rolesAllowed={[USER_ROLES.all]} />
     {checkEnv(envGroups.NON_PROD) && <AuthenticatedRoute path="/translate" component={Translator} props={props} rolesAllowed={[USER_ROLES.researcher]} />}
+    <Redirect from="/DUOS-S:studyId" to="/studies/:studyId" props={props} rolesAllowed={[USER_ROLES.all]} />
+    <Redirect from="/DUOS-:duosId" to="/dataset/DUOS-:duosId" props={props} rolesAllowed={[USER_ROLES.all]} />
     <Route path="*" component={NotFound} />
   </Switch>
 )

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -1,19 +1,16 @@
 import React, { useEffect, useState } from 'react'
-import { DataSet } from '../../libs/ajax/DataSet'
-import { DatasetTerm, StudyTerm } from '../../types/model'
-import backArrowIcon from '../../images/back_arrow.svg'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { DatasetTerm, StudyTerm } from 'src/types/model'
+import backArrowIcon from 'src/images/back_arrow.svg'
 import { Link } from 'react-router-dom'
-import {
-  makeDatasetTableHeader,
-  makeDatasetTableRows,
-} from '../data_search/DatasetSearchTableConstants'
-import SimpleTable from '../SimpleTable'
-import { Styles } from '../../libs/theme'
-import { TerraDataRepo } from '../../libs/ajax/TerraDataRepo'
-import { chain, intersection, isEmpty, Dictionary } from 'lodash'
-import { EnumerateSnapshotModel, SnapshotSummaryModel } from '../../types/tdrModel'
-import { DatasetSearchFooter } from '../data_search/DatasetSearchFooter'
-import { applyForAccess } from '../../utils/accessUtils'
+import { makeDatasetTableHeader, makeDatasetTableRows } from 'src/components/data_search/DatasetSearchTableConstants'
+import SimpleTable from 'src/components/SimpleTable'
+import { Styles } from 'src/libs/theme'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { chain, Dictionary, intersection, isEmpty } from 'lodash'
+import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
+import { DatasetSearchFooter } from 'src/components/data_search/DatasetSearchFooter'
+import { applyForAccess } from 'src/utils/accessUtils'
 import { History } from 'history'
 
 const styles = {
@@ -37,8 +34,8 @@ const styles = {
     height: '4rem',
     marginTop: 5,
   },
-  columnStyle: Object.assign({}, Styles.TABLE.HEADER_ROW, {
-    justifyContent: 'space-between',
+  columnStyle: {
+    ...Styles.TABLE.HEADER_ROW, justifyContent: 'space-between',
     fontFamily: 'Montserrat',
     fontSize: '1.2rem',
     fontWeight: 'bold',
@@ -47,7 +44,7 @@ const styles = {
     border: 'none',
     textTransform: 'uppercase',
     lineHeight: '16px',
-  }),
+  },
   containerOverride: {},
 }
 
@@ -149,6 +146,11 @@ export const StudyDetails = (props: StudyDetailsProps) => {
           <div style={{ padding: '0 16px', display: 'flex', flexDirection: 'column', width: '100%' }}>
             <div style={{ fontSize: 20, fontWeight: 600 }}>
               Back to library
+            </div>
+            <div style={{ fontSize: 20, fontWeight: 600, paddingTop: 20 }}>
+              <Link to={`/DUOS-S${study?.studyId}`}>
+                DUOS-S{study?.studyId}
+              </Link>
             </div>
             <div style={{ fontSize: 20, fontWeight: 600, paddingTop: 20 }}>
               {study?.studyName}

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -82,6 +82,20 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
     }
   }
 
+  const getMatchPhrase = (datasetIdentifier: string) => {
+    if (datasetIdentifier.startsWith('DUOS-D')) {
+      const id = parseInt(datasetIdentifier.replace('DUOS-D', ''))
+      return {
+        datasetId: id,
+      }
+    }
+    else {
+      return {
+        datasetIdentifier: datasetIdentifier,
+      }
+    }
+  }
+
   useEffect(() => {
     const init = async () => {
       try {
@@ -94,9 +108,7 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
                 },
               },
               {
-                match_phrase: {
-                  datasetIdentifier: datasetIdentifier,
-                },
+                match_phrase: getMatchPhrase(datasetIdentifier),
               },
             ],
           },
@@ -192,7 +204,11 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
             {(datasetTerm.accessManagement === AccessManagement.CONTROLLED || datasetTerm.accessManagement === AccessManagement.EXTERNAL)
               && (
                 <LabeledField label="Data Use">
-                  {createDataUseDisplay({ dataset: datasetTerm, divStyle: { display: 'inline-block' }, tooltipPlace: 'right' })}
+                  {createDataUseDisplay({
+                    dataset: datasetTerm,
+                    divStyle: { display: 'inline-block' },
+                    tooltipPlace: 'right',
+                  })}
                 </LabeledField>
               )}
             <LabeledField label="Data Location">
@@ -223,14 +239,21 @@ export default function DatasetStatistics(props: DatasetStatisticsProps) {
               </div>
             )}
           {dars?.map((dar: DatasetStatisticsDar) => (
-            <div style={Styles.READ_MORE as React.CSSProperties} id={`${dar.darCode}`} key={`${dar.darCode}`}>
+            <div
+              style={Styles.READ_MORE as React.CSSProperties}
+              id={`${dar.darCode}`}
+              key={`${dar.darCode}`}
+            >
               <ReadMore
                 readLessText="Show less"
                 readMoreText="Show More"
                 readStyle={{ fontWeight: 500, margin: '20px', height: 0 }}
                 content={[
                   <div key="dar" style={{ display: 'flex' }}>
-                    <div style={{ ...Styles.MEDIUM, width: '12%', margin: '15px' }}>{dar.darCode}</div>
+                    <div
+                      style={{ ...Styles.MEDIUM, width: '12%', margin: '15px' }}
+                    >{dar.darCode}
+                    </div>
                     <div style={{ ...Styles.MEDIUM, margin: '15px' }}>{dar.projectTitle}</div>
                   </div>,
                   LINE,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-1432

### Summary
This PR adds redirect support for durable identifiers for studies and datasets in the following format:

DUOS-Sxxx where xxx represents the database ID. 
DUOS-Dxxx where xxx represents the database ID. 

* Users can now navigate to duos.org/DUOS-Sxxx and get directly to the study details page
* Study identifier is now displayed on the study details page as a new section with a self link so users can copy it.
* Users can now navigate to duos.org/DUOS-Dxxx and get directly to the dataset details page

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
