### PR TITLE
DT-2282: Force the response object to be a DuosUser

### DIFF
--- a/src/components/era_commons/ERACommons.tsx
+++ b/src/components/era_commons/ERACommons.tsx
@@ -139,8 +139,7 @@ export default function ERACommons({
     try {
       await AuthenticateNIH.deleteAccountLinkage()
       const response = await User.getMe()
-      const eraAuthState = extractEraAuthenticationState(response.properties as unknown as DuosUser)
-
+      const eraAuthState = extractEraAuthenticationState(response as DuosUser)
       setIsAuthorized(eraAuthState.isAuthorized)
       setExpirationCount(eraAuthState.expirationCount)
       setEraCommonsId('')


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2282

### Summary
Small type fix to correctly pass a `DuosUser` to the extract auth state function.

This uncovers a larger issue with the User.ts class that is returning `DuosUserResponse` objects which is incorrect, they should be `DuosUser` objects, but that can be tackled separately from this bug.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
