### PR TITLE
[DT-2277] AI/LLM warning banner

### DIFF
--- a/cypress/component/AILLMWarningBanner/ai_llm_warning_banner.spec.tsx
+++ b/cypress/component/AILLMWarningBanner/ai_llm_warning_banner.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import AILLMWarningBanner from 'src/components/AILLMWarningBanner'
+
+describe('AILLMWarningBanner Component', () => {
+  it('should not render when aiLlmUse is false', () => {
+    mount(<AILLMWarningBanner darInfo={{ aiLlmUse: false }} />)
+    cy.get('[data-cy="ai-llm-warning-banner"]').should('not.exist')
+  })
+
+  it('should not render when aiLlmUse is undefined in darInfo', () => {
+    mount(<AILLMWarningBanner darInfo={{}} />)
+    cy.get('[data-cy="ai-llm-warning-banner"]').should('not.exist')
+  })
+
+  it('should not render when darInfo is undefined', () => {
+    mount(<AILLMWarningBanner />)
+    cy.get('[data-cy="ai-llm-warning-banner"]').should('not.exist')
+  })
+
+  it('should render warning banner when aiLlmUse is true', () => {
+    mount(<AILLMWarningBanner darInfo={{ aiLlmUse: true }} />)
+
+    cy.get('[data-cy="ai-llm-warning-banner"]').should('exist')
+    cy.contains('This Data Access Request involves Artificial Intelligence (AI) or Large Language Model (LLM) research').should('be.visible')
+    cy.contains('Please carefully review this request for compliance and ethical considerations before granting approval').should('be.visible')
+  })
+
+  it('should have proper styling for warning banner', () => {
+    mount(<AILLMWarningBanner darInfo={{ aiLlmUse: true }} />)
+
+    cy.get('[data-cy="ai-llm-warning-banner"]')
+      .should('have.css', 'background-color', 'rgb(255, 243, 205)')
+      .should('have.css', 'border', '2px solid rgb(255, 107, 53)')
+      .should('have.css', 'border-radius', '8px')
+  })
+
+  it('should display warning icon', () => {
+    mount(<AILLMWarningBanner darInfo={{ aiLlmUse: true }} />)
+
+    cy.get('[data-cy="ai-llm-warning-banner"]').within(() => {
+      cy.get('svg').should('exist')
+    })
+  })
+})

--- a/src/components/AILLMWarningBanner.tsx
+++ b/src/components/AILLMWarningBanner.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import WarningIcon from '@mui/icons-material/Warning'
+import { DataAccessRequestData } from 'src/types/model'
+
+const styles = {
+  warningBanner: {
+    backgroundColor: '#FFF3CD',
+    border: '2px solid #FF6B35',
+    borderRadius: '8px',
+    padding: '1rem',
+    margin: '1rem 0',
+    display: 'flex' as const,
+    alignItems: 'center' as const,
+    gap: '1rem',
+    fontFamily: 'Montserrat',
+  },
+  warningIcon: {
+    color: '#FF6B35',
+    fontSize: '2.5rem',
+  },
+  warningContent: {
+    display: 'flex' as const,
+    flexDirection: 'column' as const,
+    gap: '0.5rem',
+  },
+  warningMessage: {
+    fontSize: '1.4rem',
+    color: '#333F52',
+    margin: 0,
+  },
+}
+
+interface AILLMWarningBannerProps {
+  darInfo?: Partial<DataAccessRequestData>
+}
+
+export const AILLMWarningBanner = ({ darInfo }: AILLMWarningBannerProps) => {
+  const hasAILLMUse = darInfo?.aiLlmUse === true
+
+  return (
+    hasAILLMUse && (
+      <div style={styles.warningBanner} data-cy="ai-llm-warning-banner">
+        <WarningIcon style={styles.warningIcon} />
+        <div style={styles.warningContent}>
+          <p style={styles.warningMessage}>
+            This Data Access Request involves Artificial Intelligence (AI) or Large Language Model (LLM) research.
+            Please carefully review this request for compliance and ethical considerations before granting approval.
+          </p>
+        </div>
+      </div>
+    )
+  )
+}
+
+export default AILLMWarningBanner

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -12,6 +12,7 @@ import MultiDatasetVotingTab from './MultiDatasetVotingTab'
 import { Collections } from '../../libs/ajax/Collections'
 import DataAccessRequestApplication from '../dar_application/DataAccessRequestApplication'
 import VotingHistory from './VotingHistory'
+import AILLMWarningBanner from 'src/components/AILLMWarningBanner'
 import {
   APPROVED_VOTETYPES,
   ElectionStatus,
@@ -272,6 +273,7 @@ export default function DarCollectionReview(props) {
           isLoading={isLoading}
           readOnly={readOnly || adminPage}
         />
+        <AILLMWarningBanner darInfo={darInfo} />
         {canVote === false && (
           <Notification
             customStyle={{ paddingLeft: 0 }}

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
@@ -1,6 +1,7 @@
 import { filter, find, flow, get, isNil, map } from 'lodash/fp'
 import React, { useEffect, useState } from 'react'
 import { Alert } from '../../components/Alert'
+import AILLMWarningBanner from 'src/components/AILLMWarningBanner'
 import MultiDatasetVoteSlab from '../../components/collection_voting_slab/MultiDatasetVoteSlab'
 import ResearchProposalVoteSlab from '../../components/collection_voting_slab/ResearchProposalVoteSlab'
 import { User } from '../../libs/ajax/User'
@@ -82,6 +83,7 @@ export default function MultiDatasetVotingTab(props) {
 
   return (
     <div style={styles.baseStyle}>
+      <AILLMWarningBanner darInfo={darInfo} />
       <div style={styles.title}>Research Use Statement</div>
       {dataAccessApprovalDisabled() && !readOnly && (
         <Alert


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2277

### Summary

Adds an AI/LLM warning banner if the AI/LLM ethical check question has been selected.

Above the fold for all tabs:

<img width="1645" height="368" alt="Screenshot 2025-09-30 at 5 10 12 PM" src="https://github.com/user-attachments/assets/5e60b6a3-8653-47d1-8235-f2d165b7ddd3" />

In member vote section:

<img width="1684" height="490" alt="Screenshot 2025-09-30 at 5 10 33 PM" src="https://github.com/user-attachments/assets/a5c71860-a15e-4c9e-8538-9aee5aa95496" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
