### PR TITLE
[DT-2307] Downgrade Node LTS to 24.7.0 for DevContainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Node.js",
-    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:24",
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:24-trixie",
     "postCreateCommand": "./scripts/setup-devcontainer.sh",
     "remoteUser": "node"
 }

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -13,7 +13,7 @@ Alternatively, you may install DUOS locally.
 1. Install Node LTS, but verify the [version of Node declared in the Dockerfile](https://github.com/DataBiosphere/duos-ui/blob/develop/Dockerfile#L2) and install that when setting up. You can install it with [Volta](https://docs.volta.sh/guide/understanding) or NVM.
 
 ```
-volta install node@24.9.0
+volta install node@24.7.0
 ```
 
 2. Next, install the project dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM node:24.9.0 AS builder
+FROM node:24.7.0-trixie AS builder
 LABEL maintainer="grushton@broadinstitute.org"
 
 # set working directory

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "vite": "7.1.7"
       },
       "engines": {
-        "node": ">=24.9.0"
+        "node": ">=24.7.0 <25"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "not op_mini all"
   ],
   "engines": {
-    "node": ">=24.9.0 <25"
+    "node": ">=24.7.0 <25"
   },
   "type": "module"
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2307

### Summary

Downgrades Node LTS to 24.7.0 to fix the DevContainer build and locks the OS to Debian 13 Trixie.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
