### PR TITLE
[DT-2310] Ensure DevContainer build version matches Dockerfile

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -13,7 +13,7 @@ Alternatively, you may install DUOS locally.
 1. Install Node LTS, but verify the [version of Node declared in the Dockerfile](https://github.com/DataBiosphere/duos-ui/blob/develop/Dockerfile#L2) and install that when setting up. You can install it with [Volta](https://docs.volta.sh/guide/understanding) or NVM.
 
 ```
-volta install node@24.7.0
+volta install node@24.9.0
 ```
 
 2. Next, install the project dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # builder image
-FROM node:24.7.0-trixie AS builder
+FROM node:24.9.0-trixie AS builder
 LABEL maintainer="grushton@broadinstitute.org"
 
 # set working directory

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -70,7 +70,7 @@ gcloud auth application-default login
 gcloud auth configure-docker
 
 # install the appropriate version of nodejs and its dependencies
-NODE_VERSION=$(curl -L https://raw.githubusercontent.com/DataBiosphere/duos-ui/develop/Dockerfile | awk 'NR==2 {gsub(":","@",$2); print $2}')
+NODE_VERSION=$(curl -L https://raw.githubusercontent.com/DataBiosphere/duos-ui/develop/Dockerfile | awk 'NR==2 {gsub(/node:|-.*/,"", $2); print "node@" $2}')
 volta setup && volta install ${NODE_VERSION}
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "vite": "7.1.7"
       },
       "engines": {
-        "node": ">=24.7.0 <25"
+        "node": ">=24.9.0 <25"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "not op_mini all"
   ],
   "engines": {
-    "node": ">=24.7.0 <25"
+    "node": ">=24.9.0 <25"
   },
   "type": "module"
 }

--- a/scripts/setup-devcontainer.sh
+++ b/scripts/setup-devcontainer.sh
@@ -17,6 +17,12 @@ install_gcloud_cli() {
   sudo apt install -y google-cloud-cli
 }
 
+install_node_with_nvm() {
+  NODE_VERSION=$(awk 'NR==2 {gsub(/node:|-.*/,"", $2); print $2}' Dockerfile)
+  . "${NVM_DIR}/nvm.sh"
+  nvm install "$NODE_VERSION"
+}
+
 install_duos_cypress() {
   npm install
   npx cypress install
@@ -41,6 +47,7 @@ dev_container() {
   cypress_requirements
   gcloud_cli_requirements
   install_gcloud_cli
+  install_node_with_nvm
   install_duos_cypress
   install_duos_config
 }

--- a/scripts/setup-devcontainer.sh
+++ b/scripts/setup-devcontainer.sh
@@ -17,10 +17,14 @@ install_gcloud_cli() {
   sudo apt install -y google-cloud-cli
 }
 
-install_node_with_nvm() {
-  NODE_VERSION=$(awk 'NR==2 {gsub(/node:|-.*/,"", $2); print $2}' Dockerfile)
-  . "${NVM_DIR}/nvm.sh"
-  nvm install "$NODE_VERSION"
+install_node_with_volta() {
+  VOLTA_SHA256="fbdc4b8cb33fb6d19e5f07b22423265943d34e7e5c3d5a1efcecc9621854f9cb"
+  curl -O https://raw.githubusercontent.com/volta-cli/volta/v2.0.2/dev/unix/volta-install.sh
+  echo "${VOLTA_SHA256}  volta-install.sh" | sha256sum -c -
+  chmod +x volta-install.sh && ./volta-install.sh && rm volta-install.sh
+  export PATH="$HOME/.volta/bin:$PATH"
+  NODE_VERSION=$(awk 'NR==2 {gsub(/node:|-.*/,"", $2); print "node@" $2}' Dockerfile)
+  volta install "${NODE_VERSION}" pnpm
 }
 
 install_duos_cypress() {
@@ -47,7 +51,7 @@ dev_container() {
   cypress_requirements
   gcloud_cli_requirements
   install_gcloud_cli
-  install_node_with_nvm
+  install_node_with_volta
   install_duos_cypress
   install_duos_config
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2310

### Summary

Sorry for the version change fatigue. This sets up the DevContainer to use the same Node version as the one in the Dockerfile.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
