### PR TITLE
[DT-2139] Add Researcher Voting History View

### DIFF
--- a/cypress/component/dar_application/ScrollableTabs.spec.tsx
+++ b/cypress/component/dar_application/ScrollableTabs.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { mount } from 'cypress/react'
 import { ScrollableTabs } from 'src/pages/dar_application/ScrollableTabs'
 import { BrowserRouter } from 'react-router-dom'
@@ -9,6 +9,18 @@ const mockApplicationTabs = [
   { id: 'data-access-request', name: 'Data Access Request', showStep: true },
   { id: 'research-purpose-statement', name: 'Research Purpose Statement', showStep: true },
 ]
+
+// Wrapped ScrollableTabs
+const WrappedScrollableTabs = ({ initialTabId }: { initialTabId?: string }) => {
+  const [selectedTab, setSelectedTab] = useState(initialTabId)
+  return (
+    <ScrollableTabs
+      applicationTabs={mockApplicationTabs}
+      formSelectedTabId={selectedTab}
+      onTabChange={setSelectedTab}
+    />
+  )
+}
 
 describe('ScrollableTabs - Basic Tests', () => {
   it('should render without crashing', () => {
@@ -38,7 +50,7 @@ describe('ScrollableTabs Component - Integration Tests', () => {
     mount(
       <BrowserRouter>
         <div style={{ display: 'inline-flex' }}>
-          <ScrollableTabs applicationTabs={mockApplicationTabs} />
+          <WrappedScrollableTabs />
           <div>
             <div id="researcher-info" style={{ height: '1000px', backgroundColor: 'red' }}>Researcher Info</div>
             <div id="data-access-request" style={{ height: '1000px', backgroundColor: 'blue' }}>Data Access Request</div>
@@ -50,38 +62,37 @@ describe('ScrollableTabs Component - Integration Tests', () => {
   })
 
   it('Case 1 - change tabs based on formSelectedTabId', () => {
-    // Test with formSelectedTabId set to data-access-request
     mount(
       <BrowserRouter>
-        <ScrollableTabs applicationTabs={mockApplicationTabs} formSelectedTabId="data-access-request" />
+        <WrappedScrollableTabs initialTabId="data-access-request" />
       </BrowserRouter>,
     )
     cy.get('.Mui-selected').contains('Data Access Request').should('exist')
     cy.get('.Mui-selected').contains('Researcher Information').should('not.exist')
 
-    // Test with formSelectedTabId set to research-purpose-statement
     mount(
       <BrowserRouter>
-        <ScrollableTabs applicationTabs={mockApplicationTabs} formSelectedTabId="research-purpose-statement" />
+        <WrappedScrollableTabs initialTabId="research-purpose-statement" />
       </BrowserRouter>,
     )
     cy.get('.Mui-selected').contains('Research Purpose Statement').should('exist')
   })
 
   it('Case 2 - Auto-scroll to section on scroll', () => {
-    cy.scrollTo(0, 2000)
-    cy.get('.Mui-selected').contains('Research Purpose Statement').should('exist')
-    cy.window().then(($window) => {
-      expect($window.scrollY).to.be.closeTo(2000, 500)
+    cy.get('#research-purpose-statement').then(($el) => {
+      cy.window().then((win) => {
+        win.scrollTo(0, $el[0].offsetTop)
+      })
     })
+    cy.get('.Mui-selected').contains('Research Purpose Statement', { timeout: 2000 }).should('exist')
   })
 
   it('Case 3 - First tab selected by default and can click and select another tab', () => {
     cy.get('.Mui-selected').contains('Researcher Information').should('exist')
     cy.get('.Mui-selected').contains('Data Access Request').should('not.exist')
 
-    cy.get('button').contains('Data Access Request').click()
-    cy.get('.Mui-selected').contains('Data Access Request').should('exist')
+    cy.get('[role="tab"]').contains('Data Access Request').click()
+    cy.get('.Mui-selected').contains('Data Access Request', { timeout: 2000 }).should('exist')
   })
 
   it('should handle tab structure with step numbers', () => {

--- a/cypress/component/dar_application/VotingHistoryOverview.spec.tsx
+++ b/cypress/component/dar_application/VotingHistoryOverview.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import VotingHistoryOverview from 'src/pages/dar_application/VotingHistoryOverview'
+
+describe('VotingHistoryOverview', () => {
+  const mockDar = {
+    referenceId: 'DAR-123',
+    piName: 'Jane Doe',
+    institution: 'Test University',
+    status: 'Closed',
+  }
+
+  const mockVotes = [
+    {
+      datasetName: 'Dataset A',
+      voteDate: 'June 1, 2024',
+      requestType: 'Initial DAR',
+      linkedDarId: 'COLL-1',
+      voteResult: {
+        decision: 'Approved',
+        rationale: 'This is a detailed rationale for approval that is quite long and should be truncated in the table view.',
+      },
+      status: 'Closed',
+    },
+    {
+      datasetName: 'Dataset B',
+      voteDate: 'June 2, 2024',
+      requestType: 'Progress Report',
+      linkedDarId: 'COLL-2',
+      voteResult: {
+        decision: 'Denied',
+        rationale: 'Short rationale.',
+      },
+      status: 'Closed',
+    },
+  ]
+
+  beforeEach(() => {
+    mount(
+      <VotingHistoryOverview dar={mockDar} votes={mockVotes} />,
+    )
+  })
+
+  it('renders the DAR overview and voting history table', () => {
+    cy.contains('Voting History')
+    cy.contains('Application/DAR ID:')
+    cy.contains('DAR-123')
+    cy.contains('Jane Doe (Test University)')
+    cy.contains('Current Status:')
+    cy.contains('Closed')
+    cy.contains('DAR and Progress Report Voting History')
+    cy.contains('Dataset A')
+    cy.contains('Dataset B')
+  })
+
+  it('renders vote results with truncated rationale and toggles full rationale', () => {
+    cy.contains('View Rationale').first().click()
+    cy.contains('Hide Rationale')
+    cy.contains(mockVotes[0].voteResult.rationale)
+    cy.contains('Hide Rationale').click()
+    cy.contains('View Rationale')
+  })
+
+  it('renders correct links for linked DAR IDs', () => {
+    cy.get('a[href="/dar_application_review/COLL-1"]').should('contain', 'DAR-123')
+    cy.get('a[href="/dar_application_review/COLL-2"]').should('contain', 'DAR-123')
+  })
+
+  it('renders all vote statuses', () => {
+    cy.get('td').contains('Closed')
+  })
+})

--- a/cypress/component/dar_application/VotingHistoryOverview.spec.tsx
+++ b/cypress/component/dar_application/VotingHistoryOverview.spec.tsx
@@ -67,6 +67,6 @@ describe('VotingHistoryOverview', () => {
   })
 
   it('renders all vote statuses', () => {
-    cy.get('td').contains('Closed')
+    cy.get('div[role="cell"]').filter(':contains("Closed")').should('have.length', 2)
   })
 })

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -33,6 +33,7 @@ import { Countries } from 'src/libs/ajax/Countries.js'
 import PropTypes from 'prop-types'
 import useAsyncCacheFetch from 'src/hooks/useAsyncCacheFetch'
 import VotingHistoryOverview from 'src/pages/dar_application/VotingHistoryOverview.js'
+import { ElectionStatus, VOTE_TYPES } from 'src/utils/DarUtils.js'
 
 // Constants
 const RESEARCHER_INFO_TAB_ID = 'researcher-info'
@@ -550,20 +551,41 @@ const DataAccessRequestApplication = (props) => {
       ? Object.values(dar.elections).find(e => e.electionType === 'DataAccess')
       : undefined
 
+    // Find the Final vote for decision and rationale
+    let finalVoteDecision = 'Pending'
+    let finalVoteRationale = 'No rationale provided.'
+    let finalVoteDate = election?.createDate
+    if (election?.votes) {
+      const votesArr = Array.isArray(election.votes)
+        ? election.votes
+        : Object.values(election.votes)
+      const finalVote = votesArr.find(v => v.type === VOTE_TYPES.FINAL)
+      if (finalVote) {
+        finalVoteDate = finalVote.createDate
+        finalVoteDecision = finalVote.vote === true ? 'Approved' : finalVote.vote === false ? 'Denied' : 'Pending'
+        finalVoteRationale = finalVote.rationale || 'No rationale provided.'
+      }
+    }
+
     return {
-      datasetName: datasets.find(d => d.datasetId === election?.datasetId)?.name || '1000Genomes',
-      voteDate: new Date(election?.createDate).toLocaleDateString(),
+      datasetName: datasets.find(d => d.datasetId === election?.datasetId)?.name || 'Unknown Dataset',
+      voteDate: new Date(finalVoteDate).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }),
       requestType: dar.progressReport ? 'Progress Report' : 'Initial DAR',
-      linkedDarId: election?.referenceId,
+      linkedDarId: dar?.collectionId,
       voteResult: {
-        decision: election?.finalVote || 'Pending',
-        rationale: election?.rationale || 'No rationale provided.',
+        decision: finalVoteDecision,
+        rationale: finalVoteRationale,
       },
       status: election?.status || 'Completed',
     }
   })
 
-  console.log(datasets)
+  const dar = {
+    referenceId: formData?.darCode || '',
+    piName: formData?.piName || '',
+    institution: formData?.institution || '',
+    status: votes.some(vote => vote.status === ElectionStatus.OPEN) ? ElectionStatus.OPEN : ElectionStatus.CLOSED,
+  }
 
   const back = () => {
     history.goBack()
@@ -816,7 +838,7 @@ const DataAccessRequestApplication = (props) => {
               {!isEmpty(votes)
                 && (
                   <div id={VOTING_HISTORY_TAB_ID} className={existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
-                    <VotingHistoryOverview votes={votes} />
+                    <VotingHistoryOverview dar={dar} votes={votes} />
                   </div>
                 )}
             </div>

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -32,6 +32,7 @@ import { assign, cloneDeep, isArray, isEmpty, isNil, isString, merge, set } from
 import { Countries } from 'src/libs/ajax/Countries.js'
 import PropTypes from 'prop-types'
 import useAsyncCacheFetch from 'src/hooks/useAsyncCacheFetch'
+import VotingHistoryOverview from 'src/pages/dar_application/VotingHistoryOverview.js'
 
 // Constants
 const RESEARCHER_INFO_TAB_ID = 'researcher-info'
@@ -41,6 +42,7 @@ const DATA_ACCESS_AGREEMENTS_TAB_ID = 'data-access-agreements'
 const DAR_UPDATE_TAB_ID_PREFIX = 'dar-update-'
 const PROGRESS_REPORT_APPLICATION_TAB_ID = 'progress-report-app'
 const ADDENDUM_TAB_ID = 'addendum'
+const VOTING_HISTORY_TAB_ID = 'voting-history-info'
 const ApplicationTabs = [
   { name: 'Researcher Information', id: RESEARCHER_INFO_TAB_ID },
   { name: 'Data Access Request', id: DATA_ACCESS_REQUEST_TAB_ID },
@@ -320,7 +322,9 @@ const DataAccessRequestApplication = (props) => {
           const isLast = index === reverseOrderedDARs.length - 1
           const itemLabel = isLast ? formData?.darCode : 'DAR Update ' + whichPRIsThis
           return { name: itemLabel, id: `${DAR_UPDATE_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false }
-        })])
+        }),
+        { name: 'Voting History', id: VOTING_HISTORY_TAB_ID, showStep: false },
+      ])
     }
   }, [formData?.darCode, isProgressReportApplication, existingDarsReadOnlyMode, reverseOrderedDARs])
 
@@ -541,6 +545,26 @@ const DataAccessRequestApplication = (props) => {
     }
   }
 
+  const votes = reverseOrderedDARs.map((dar) => {
+    const election = dar.elections
+      ? Object.values(dar.elections).find(e => e.electionType === 'DataAccess')
+      : undefined
+
+    return {
+      datasetName: datasets.find(d => d.datasetId === election?.datasetId)?.name || '1000Genomes',
+      voteDate: new Date(election?.createDate).toLocaleDateString(),
+      requestType: dar.progressReport ? 'Progress Report' : 'Initial DAR',
+      linkedDarId: election?.referenceId,
+      voteResult: {
+        decision: election?.finalVote || 'Pending',
+        rationale: election?.rationale || 'No rationale provided.',
+      },
+      status: election?.status || 'Completed',
+    }
+  })
+
+  console.log(datasets)
+
   const back = () => {
     history.goBack()
   }
@@ -662,7 +686,6 @@ const DataAccessRequestApplication = (props) => {
                 })}
               </div>
             )}
-
             <div id={`${DAR_UPDATE_TAB_ID_PREFIX}0`} className={existingDarsReadOnlyMode ? 'dar-summary' : 'dar-steps'}>
               {existingDarsReadOnlyMode && (
                 <h3>
@@ -788,6 +811,12 @@ const DataAccessRequestApplication = (props) => {
                       datasets={selectedDatasets}
                       dataUseTranslations={dataUseTranslations}
                     />
+                  </div>
+                )}
+              {!isEmpty(votes)
+                && (
+                  <div id={VOTING_HISTORY_TAB_ID} className={existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'}>
+                    <VotingHistoryOverview votes={votes} />
                   </div>
                 )}
             </div>

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -635,7 +635,7 @@ const DataAccessRequestApplication = (props) => {
 
         <div style={{ clear: 'both' }} />
         <form name="form" noValidate={true} className="forms-v2">
-          <ScrollableTabs applicationTabs={applicationTabs} formSelectedTabId={tab} />
+          <ScrollableTabs applicationTabs={applicationTabs} formSelectedTabId={tab} onTabChange={setTab} />
 
           <div id="form-views">
             <ConfirmationDialog

--- a/src/pages/dar_application/ScrollableTabs.tsx
+++ b/src/pages/dar_application/ScrollableTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
 import { findIndex } from 'lodash/fp'
@@ -12,70 +12,90 @@ type ApplicationTab = {
 type ScrollableTabsProps = {
   applicationTabs: ApplicationTab[]
   formSelectedTabId?: string
+  onTabChange?: (tabId: string) => void
 }
 
-export const ScrollableTabs = ({ applicationTabs, formSelectedTabId }: ScrollableTabsProps) => {
-  const [selectedStepNumber, setSelectedStepNumber] = useState<number>(1)
+export const ScrollableTabs = ({ applicationTabs, formSelectedTabId, onTabChange }: ScrollableTabsProps) => {
+  // Use positive check for clarity (suggested improvement)
+  const selectedStepNumber
+    = typeof formSelectedTabId === 'string'
+      ? findIndex(tab => tab.id === formSelectedTabId, applicationTabs) + 1
+      : 1
 
   const goToStep = useCallback((tabId: string) => {
-    window.scrollTo({
-      top: document.getElementById(tabId)?.offsetTop,
-      behavior: 'smooth',
-    })
+    const el = document.getElementById(tabId)
+    if (el) {
+      window.scrollTo({
+        top: el.offsetTop,
+        behavior: 'smooth',
+      })
+    }
   }, [])
+
+  // Track pending tab selection after click
+  const pendingTabId = useRef<string | null>(null)
+  const scrollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // CASE 1 - the form scrolls to a new tab based on validation errors
   useEffect(() => {
-    if (formSelectedTabId !== undefined) {
-      setSelectedStepNumber(findIndex(tab => tab.id === formSelectedTabId, applicationTabs) + 1)
+    if (typeof formSelectedTabId === 'string') {
       goToStep(formSelectedTabId)
     }
-  }, [goToStep, formSelectedTabId, applicationTabs])
+  }, [goToStep, formSelectedTabId])
 
   // CASE 2 - the user scrolls on the page, so we auto-select a new tab
-  // but, we don't adjust the scroll position
-  const onScroll = () => {
-    const scrollPos = window.scrollY
-    const scrollBuffer = window.innerHeight * 0.5
-
-    // Find the section that is currently most visible
-    let currentSectionIndex = 1 // Start with 1 since MUI Tabs expects 1-based indexing
-
-    for (let i = 0; i < applicationTabs.length; i++) {
-      const element = document.getElementById(applicationTabs[i].id)
-      if (!element) continue
-
-      const elementTop = element.offsetTop
-      const elementHeight = element.offsetHeight
-      const elementBottom = elementTop + elementHeight
-
-      // Check if this section is in the viewport with the scroll buffer
-      if (scrollPos + scrollBuffer >= elementTop && scrollPos + scrollBuffer < elementBottom) {
-        currentSectionIndex = i + 1
-        break
-      }
-      // If we've scrolled past the current section, check if we should move to the next one
-      else if (scrollPos + scrollBuffer >= elementTop) {
-        currentSectionIndex = i + 1
-      }
-    }
-
-    // Ensure the index is within valid bounds for MUI Tabs (1 to applicationTabs.length)
-    currentSectionIndex = Math.max(1, Math.min(currentSectionIndex, applicationTabs.length))
-
-    setSelectedStepNumber(currentSectionIndex)
-  }
-
   useEffect(() => {
-    window.removeEventListener('scroll', onScroll)
-    window.addEventListener('scroll', onScroll)
+    const onScroll = () => {
+      if (scrollTimeout.current) clearTimeout(scrollTimeout.current)
+      scrollTimeout.current = setTimeout(() => {
+        const scrollPos = window.scrollY
+        const scrollBuffer = window.innerHeight * 0.5
+        let currentSectionIndex = 1
 
-    return () => {
-      // Cleanup listener on unmount
-      window.removeEventListener('scroll', onScroll)
+        for (let i = 0; i < applicationTabs.length; i++) {
+          const element = document.getElementById(applicationTabs[i].id)
+          if (!element) continue
+          const elementTop = element.offsetTop
+          const elementHeight = element.offsetHeight
+          const elementBottom = elementTop + elementHeight
+          if (scrollPos + scrollBuffer >= elementTop && scrollPos + scrollBuffer < elementBottom) {
+            currentSectionIndex = i + 1
+            break
+          }
+        }
+
+        // If buffer is past the last section's top, select the last tab
+        const lastTabId = applicationTabs.at(-1)?.id
+        const lastElement = lastTabId ? document.getElementById(lastTabId) : null
+        if (lastElement && scrollPos + scrollBuffer >= lastElement.offsetTop) {
+          currentSectionIndex = applicationTabs.length
+        }
+
+        currentSectionIndex = Math.max(1, Math.min(currentSectionIndex, applicationTabs.length))
+        const tabId = applicationTabs[currentSectionIndex - 1]?.id
+
+        if (pendingTabId.current) {
+          if (tabId === pendingTabId.current) {
+            pendingTabId.current = null
+            if (pendingTimeout.current) clearTimeout(pendingTimeout.current)
+          }
+          return
+        }
+
+        if (tabId && tabId !== formSelectedTabId && onTabChange) {
+          onTabChange(tabId)
+        }
+      }, 80)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [applicationTabs])
+
+    window.addEventListener('scroll', onScroll)
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      if (scrollTimeout.current) clearTimeout(scrollTimeout.current)
+      if (pendingTimeout.current) clearTimeout(pendingTimeout.current)
+    }
+  }, [applicationTabs, formSelectedTabId, onTabChange])
 
   return (
     <div className="multi-step-buttons-container">
@@ -89,27 +109,32 @@ export const ScrollableTabs = ({ applicationTabs, formSelectedTabId }: Scrollabl
         }}
         // CASE 3 - the user selects a new tab by clicking on it
         onChange={(_event, step) => {
-          setSelectedStepNumber(step)
-          goToStep(applicationTabs[step - 1].id)
+          const tabId = applicationTabs[step - 1].id
+          if (onTabChange) onTabChange(tabId)
+          goToStep(tabId)
+          pendingTabId.current = tabId
+          if (pendingTimeout.current) clearTimeout(pendingTimeout.current)
+          // Fallback: clear pending after 1s if scroll never lands
+          pendingTimeout.current = setTimeout(() => {
+            pendingTabId.current = null
+          }, 1000)
         }}
       >
-        {
-          applicationTabs.map((tabConfig, index) => {
-            const { name, showStep = true } = tabConfig
-            return (
-              <Tab
-                key={`step-${index}-${name}`}
-                label={(
-                  <div>
-                    {showStep && <div className="step">{`Step ${index + 1}`}</div>}
-                    <div className="title">{name}</div>
-                  </div>
-                )}
-                value={index + 1}
-              />
-            )
-          })
-        }
+        {applicationTabs.map((tabConfig, index) => {
+          const { name, showStep = true } = tabConfig
+          return (
+            <Tab
+              key={`step-${index}-${name}`}
+              label={(
+                <div>
+                  {showStep && <div className="step">{`Step ${index + 1}`}</div>}
+                  <div className="title">{name}</div>
+                </div>
+              )}
+              value={index + 1}
+            />
+          )
+        })}
       </Tabs>
     </div>
   )

--- a/src/pages/dar_application/VotingHistoryOverview.css
+++ b/src/pages/dar_application/VotingHistoryOverview.css
@@ -1,0 +1,61 @@
+/* src/pages/dar_application/VotingHistoryOverview.css */
+.voting-history-container {
+    background: #fff;
+    border-radius: 8px;
+    padding: 2em;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    margin-bottom: 2em;
+}
+
+.voting-history-title,
+.voting-history-subtitle {
+    margin-bottom: 1em;
+    color: #2c3e50;
+}
+
+.dar-overview {
+    margin-bottom: 2em;
+    padding: 1em;
+    background: #f8f9fa;
+    border-radius: 6px;
+    border: 1px solid #e1e4e8;
+}
+
+.voting-history-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: #fafbfc;
+    margin-bottom: 1em;
+}
+
+.voting-history-table th,
+.voting-history-table td {
+    border: 1px solid #e1e4e8;
+    padding: 0.75em 1em;
+    text-align: left;
+    vertical-align: top;
+}
+
+.voting-history-table th {
+    background: #f1f3f6;
+    font-weight: 600;
+}
+
+.header-subtext {
+    color: #888;
+    font-size: 0.9em;
+}
+
+.rationale-btn {
+    background: none;
+    border: none;
+    color: #007bff;
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.95em;
+    margin-left: 0.5em;
+}
+
+.rationale-btn:hover {
+    text-decoration: underline;
+}

--- a/src/pages/dar_application/VotingHistoryOverview.css
+++ b/src/pages/dar_application/VotingHistoryOverview.css
@@ -1,5 +1,4 @@
 .voting-history-container {
-    background: #eeeeee;
     padding: 32px;
     border-radius: 8px;
 }

--- a/src/pages/dar_application/VotingHistoryOverview.css
+++ b/src/pages/dar_application/VotingHistoryOverview.css
@@ -1,10 +1,7 @@
-/* src/pages/dar_application/VotingHistoryOverview.css */
 .voting-history-container {
-    background: #fff;
+    background: #eeeeee;
+    padding: 32px;
     border-radius: 8px;
-    padding: 2em;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-    margin-bottom: 2em;
 }
 
 .voting-history-title,

--- a/src/pages/dar_application/VotingHistoryOverview.tsx
+++ b/src/pages/dar_application/VotingHistoryOverview.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
+import SimpleTable from 'src/components/SimpleTable'
 import './VotingHistoryOverview.css'
 
 type Dar = {
@@ -28,9 +29,85 @@ type VotingHistoryOverviewProps = {
 }
 
 const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ dar, votes }) => {
-  const [showFullRationale, setShowFullRationale] = useState<boolean>(false)
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set())
 
-  const handleRationaleClick = () => setShowFullRationale(!showFullRationale)
+  const handleRationaleClick = (idx: number) => {
+    setExpandedRows((prev) => {
+      const next = new Set(prev)
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      next.has(idx) ? next.delete(idx) : next.add(idx)
+      return next
+    })
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const headerStyle = {
+    fontWeight: 600,
+    fontSize: '1.1rem',
+    background: '#f5f7fa',
+    color: '#2a3b4d',
+    padding: '8px 0',
+    whiteSpace: 'normal',
+    wordBreak: 'break-word',
+    overflowWrap: 'anywhere',
+  }
+
+  const cellWrapStyle = {
+    whiteSpace: 'normal',
+    wordBreak: 'break-word',
+    overflowWrap: 'anywhere',
+  }
+
+  const styles = {
+    baseStyle: { display: 'flex', alignItems: 'center', minHeight: 40, ...cellWrapStyle },
+    columnStyle: { display: 'flex', background: '#f5f7fa', ...cellWrapStyle },
+    containerOverride: { width: '100%', overflowX: 'visible' },
+  }
+
+  const columnHeaders = useMemo(() => [
+    { label: 'Dataset Name', cellStyle: { ...headerStyle, width: 200 } },
+    { label: 'Vote Date', cellStyle: { ...headerStyle, width: 180 } },
+    { label: 'Request Type', cellStyle: { ...headerStyle, width: 160 } },
+    { label: 'Linked DAR ID', cellStyle: { ...headerStyle, width: 140 } },
+    { label: 'Vote Result', cellStyle: { ...headerStyle, width: 400 } },
+    { label: 'Status', cellStyle: { ...headerStyle, width: 180 } },
+  ], [headerStyle])
+
+  const rowData = votes.map((vote, idx) => [
+    { data: vote.datasetName },
+    { data: vote.voteDate },
+    { data: vote.requestType },
+    {
+      data: (
+        <a href={`/dar_application_review/${vote.linkedDarId}`} target="_blank" rel="noopener noreferrer">
+          {dar.referenceId}
+        </a>
+      ),
+    },
+    {
+      data: (
+        <div>
+          <strong>Decision:</strong> {vote.voteResult.decision}
+          <br />
+          <strong>Rationale:</strong>{' '}
+          {expandedRows.has(idx)
+            ? vote.voteResult.rationale
+            : `${vote.voteResult.rationale.substring(0, 80)}... `}
+          <button
+            type="button"
+            className="btn-link rationale-btn"
+            onClick={(e) => {
+              e.preventDefault()
+              handleRationaleClick(idx)
+            }}
+          >
+            {expandedRows.has(idx) ? 'Hide Rationale' : 'View Rationale'}
+          </button>
+        </div>
+      ),
+    },
+    { data: vote.status },
+  ])
 
   return (
     <div className="voting-history-container">
@@ -48,76 +125,14 @@ const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ dar, vote
         </div>
       </div>
       <h4 className="voting-history-subtitle">DAR and Progress Report Voting History</h4>
-      <table className="voting-history-table">
-        <thead>
-          <tr>
-            <th scope="col">
-              Dataset Name
-              <br />
-              <small className="header-subtext">Name of the dataset voted on</small>
-            </th>
-            <th scope="col">
-              Vote Date
-              <br />
-              <small className="header-subtext">Date the vote occurred</small>
-            </th>
-            <th scope="col">
-              Request Type
-              <br />
-              <small className="header-subtext">Type of data access request</small>
-            </th>
-            <th scope="col">
-              Linked DAR ID
-              <br />
-              <small className="header-subtext">Reference to related DAR</small>
-            </th>
-            <th scope="col">
-              Vote Result
-              <br />
-              <small className="header-subtext">Decision and rationale</small>
-            </th>
-            <th scope="col">
-              Status
-              <br />
-              <small className="header-subtext">Current vote status</small>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {votes.map((vote, idx) => (
-            <tr key={'id_' + idx}>
-              <td>{vote.datasetName}</td>
-              <td>{vote.voteDate}</td>
-              <td>{vote.requestType}</td>
-              <td>
-                <a href={`/dar_application_review/${vote.linkedDarId}`} target="_blank" rel="noopener noreferrer">
-                  {dar.referenceId}
-                </a>
-              </td>
-              <td>
-                <div>
-                  <strong>Decision:</strong> {vote.voteResult.decision}<br />
-                  <strong>Rationale:</strong>{' '}
-                  {showFullRationale
-                    ? vote.voteResult.rationale
-                    : `${vote.voteResult.rationale.substring(0, 80)}... `}
-                  <button
-                    type="button"
-                    className="btn-link rationale-btn"
-                    onClick={(e) => {
-                      e.preventDefault()
-                      handleRationaleClick()
-                    }}
-                  >
-                    {showFullRationale ? 'Hide Rationale' : 'View Rationale'}
-                  </button>
-                </div>
-              </td>
-              <td>{vote.status}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <SimpleTable
+        className="voting-history-table"
+        rowData={rowData}
+        columnHeaders={columnHeaders}
+        styles={styles}
+        tableSize={rowData.length}
+        isLoading={false}
+      />
     </div>
   )
 }

--- a/src/pages/dar_application/VotingHistoryOverview.tsx
+++ b/src/pages/dar_application/VotingHistoryOverview.tsx
@@ -1,4 +1,12 @@
 import React, { useState } from 'react'
+import './VotingHistoryOverview.css'
+
+type Dar = {
+  referenceId: string
+  piName: string
+  institution: string
+  status: string
+}
 
 type VoteResult = {
   decision: string
@@ -15,33 +23,64 @@ type Vote = {
 }
 
 type VotingHistoryOverviewProps = {
+  dar: Dar
   votes: Vote[]
 }
 
-const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ votes }) => {
+const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ dar, votes }) => {
   const [showFullRationale, setShowFullRationale] = useState<boolean>(false)
 
   const handleRationaleClick = () => setShowFullRationale(!showFullRationale)
 
   return (
-    <div>
-      <h2><strong>Voting History</strong></h2>
-      <div style={{ marginBottom: '1em' }}>
+    <div className="voting-history-container">
+      <h3 className="voting-history-title">Voting History</h3>
+      <div className="dar-overview">
         <strong>Application/DAR Overview</strong>
-        <div><strong>Application/DAR ID:</strong> DAR-001234</div>
-        <div><strong>Applicant:</strong> Dr. Jane Doe (University Medical Center)</div>
-        <div><strong>Current Status:</strong> Completed</div>
+        <div>
+          <strong>Application/DAR ID:</strong> {dar.referenceId}
+        </div>
+        <div>
+          <strong>Applicant:</strong> {dar.piName} ({dar.institution})
+        </div>
+        <div>
+          <strong>Current Status:</strong> {dar.status}
+        </div>
       </div>
-      <h3><strong>DAR and Progress Report Voting History</strong></h3>
-      <table className="table table-bordered">
+      <h4 className="voting-history-subtitle">DAR and Progress Report Voting History</h4>
+      <table className="voting-history-table">
         <thead>
           <tr>
-            <th>Dataset Name</th>
-            <th>Vote Date</th>
-            <th>Request Type</th>
-            <th>Linked DAR ID</th>
-            <th>Vote Result</th>
-            <th>Status</th>
+            <th scope="col">
+              Dataset Name
+              <br />
+              <small className="header-subtext">Name of the dataset voted on</small>
+            </th>
+            <th scope="col">
+              Vote Date
+              <br />
+              <small className="header-subtext">Date the vote occurred</small>
+            </th>
+            <th scope="col">
+              Request Type
+              <br />
+              <small className="header-subtext">Type of data access request</small>
+            </th>
+            <th scope="col">
+              Linked DAR ID
+              <br />
+              <small className="header-subtext">Reference to related DAR</small>
+            </th>
+            <th scope="col">
+              Vote Result
+              <br />
+              <small className="header-subtext">Decision and rationale</small>
+            </th>
+            <th scope="col">
+              Status
+              <br />
+              <small className="header-subtext">Current vote status</small>
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -51,8 +90,8 @@ const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ votes }) 
               <td>{vote.voteDate}</td>
               <td>{vote.requestType}</td>
               <td>
-                <a href={`/dar_application/${vote.linkedDarId}`} target="_blank" rel="noopener noreferrer">
-                  {vote.linkedDarId}
+                <a href={`/dar_application_review/${vote.linkedDarId}`} target="_blank" rel="noopener noreferrer">
+                  {dar.referenceId}
                 </a>
               </td>
               <td>
@@ -64,7 +103,7 @@ const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ votes }) 
                     : `${vote.voteResult.rationale.substring(0, 80)}... `}
                   <button
                     type="button"
-                    className="btn-link"
+                    className="btn-link rationale-btn"
                     onClick={(e) => {
                       e.preventDefault()
                       handleRationaleClick()

--- a/src/pages/dar_application/VotingHistoryOverview.tsx
+++ b/src/pages/dar_application/VotingHistoryOverview.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react'
+
+type VoteResult = {
+  decision: string
+  rationale: string
+}
+
+type Vote = {
+  datasetName: string
+  voteDate: string
+  requestType: string
+  linkedDarId: string
+  voteResult: VoteResult
+  status: string
+}
+
+type VotingHistoryOverviewProps = {
+  votes: Vote[]
+}
+
+const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ votes }) => {
+  const [showFullRationale, setShowFullRationale] = useState<boolean>(false)
+
+  const handleRationaleClick = () => setShowFullRationale(!showFullRationale)
+
+  return (
+    <div>
+      <h2><strong>Voting History</strong></h2>
+      <div style={{ marginBottom: '1em' }}>
+        <strong>Application/DAR Overview</strong>
+        <div><strong>Application/DAR ID:</strong> DAR-001234</div>
+        <div><strong>Applicant:</strong> Dr. Jane Doe (University Medical Center)</div>
+        <div><strong>Current Status:</strong> Completed</div>
+      </div>
+      <h3><strong>DAR and Progress Report Voting History</strong></h3>
+      <table className="table table-bordered">
+        <thead>
+          <tr>
+            <th>Dataset Name</th>
+            <th>Vote Date</th>
+            <th>Request Type</th>
+            <th>Linked DAR ID</th>
+            <th>Vote Result</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {votes.map((vote, idx) => (
+            <tr key={'id_' + idx}>
+              <td>{vote.datasetName}</td>
+              <td>{vote.voteDate}</td>
+              <td>{vote.requestType}</td>
+              <td>
+                <a href={`/dar_application/${vote.linkedDarId}`} target="_blank" rel="noopener noreferrer">
+                  {vote.linkedDarId}
+                </a>
+              </td>
+              <td>
+                <div>
+                  <strong>Decision:</strong> {vote.voteResult.decision}<br />
+                  <strong>Rationale:</strong>{' '}
+                  {showFullRationale
+                    ? vote.voteResult.rationale
+                    : `${vote.voteResult.rationale.substring(0, 80)}... `}
+                  <button
+                    type="button"
+                    className="btn-link"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      handleRationaleClick()
+                    }}
+                  >
+                    {showFullRationale ? 'Hide Rationale' : 'View Rationale'}
+                  </button>
+                </div>
+              </td>
+              <td>{vote.status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default VotingHistoryOverview


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2139

### Summary

This PR adds a Voting History tab that lets researchers see the outcomes of their DAR and Progress Report (PR) votes without exposing any PII, which is in line with NIH standards.

<img width="1788" height="1025" alt="After" src="https://github.com/user-attachments/assets/3dda97a6-029d-42b9-ae6c-b1663fe52097" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
