### PR TITLE
[DT-2265] Add coverage for broken conditions, fix broken conditions in calendar picker

### DIFF
--- a/cypress/component/Forms/forms.spec.jsx
+++ b/cypress/component/Forms/forms.spec.jsx
@@ -87,6 +87,38 @@ describe('FormField - Tests', () => {
       cy.get('.formField-fixedDate .error-message').should('not.exist')
       cy.get('@onChange').should('be.calledOnce')
     })
+    it('initialized with an specific date.', () => {
+      props = {
+        ...baseProps,
+        id: 'fixedDate',
+        title: 'Fixed Date',
+        type: FormFieldTypes.CALENDAR,
+        defaultValue: '1970-01-01',
+        validators: [FormValidators.DATEJS],
+      }
+      mount(<FormField {...props} />)
+      cy.get('#lbl_fixedDate').contains('Fixed Date')
+      cy.get('input.MuiInputBase-input').should('have.value', '1970-01-01')
+    })
+    it('Select closes calendar as expected.', () => {
+      props = {
+        ...baseProps,
+        id: 'fixedDate',
+        title: 'Fixed Date',
+        type: FormFieldTypes.CALENDAR,
+        defaultValue: '1970-01-01',
+        validators: [FormValidators.DATEJS],
+      }
+      mount(<FormField {...props} />)
+      cy.get('#lbl_fixedDate').contains('Fixed Date')
+      cy.get('input.MuiInputBase-input').should('have.value', '1970-01-01')
+      cy.get('button').click()
+      cy.get('button').contains('5').click()
+      cy.get('button').contains('Select').should('be.visible')
+      cy.get('button').contains('Select').click()
+      cy.get('button').contains('Select').should('not.be.visible')
+      cy.get('.formField-fixedDate .error-message').should('not.exist')
+    })
   })
   describe('Validation', () => {
     it('should render required indicator', () => {

--- a/src/components/DuosDatePicker.tsx
+++ b/src/components/DuosDatePicker.tsx
@@ -210,11 +210,9 @@ export const DuosDatePicker = (props: DUOSDatePickerProps) => {
             format={inputFormat}
             value={defaultValueAsDayjs}
             onChange={(value) => {
-              console.error('onChange', value)
               onChange(value?.format(inputFormat))
             }}
             onAccept={(value) => {
-              console.error('onAccept', value)
               onChange(value?.format(inputFormat))
             }}
             onError={value => onError && onError(value?.toString() === 'Invalid Date' ? 'Invalid Date' : '', value?.toString())}

--- a/src/components/DuosDatePicker.tsx
+++ b/src/components/DuosDatePicker.tsx
@@ -7,6 +7,7 @@ import {
   PickersDay,
   PickersDayProps,
   DateValidationError,
+  usePickerContext,
 } from '@mui/x-date-pickers'
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { Button } from '@mui/material'
@@ -28,7 +29,7 @@ export const DuosDatePicker = (props: DUOSDatePickerProps) => {
 
   // Convert defaultValue to Dayjs object if it's a string, or use it directly if it's already Dayjs
   const defaultValueAsDayjs = useMemo(() => {
-    if (!defaultValue) return null
+    if (!defaultValue) return dayjs()
     if (typeof defaultValue === 'string') {
       const parsed = dayjs(defaultValue, inputFormat)
       return parsed.isValid() ? parsed : null
@@ -165,21 +166,21 @@ export const DuosDatePicker = (props: DUOSDatePickerProps) => {
   const CancelSelectActionBar = (props: PickersActionBarProps) => {
     // Quirk of this control's usage pattern is the need to destructure the unused onSetToday and onClear from 'other'
     // props.  This is in part because per mockup, this control does not support 'clear' or 'go to today' style buttons.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const { onAccept, onCancel, onSetToday, onClear, actions, ...other } = props
+    const { actions, ...other } = props
+    const { acceptValueChanges,
+      cancelValueChanges } = usePickerContext()
     const buttons = actions?.map((actionType: React.Key | null | undefined) => {
       switch (actionType) {
         case 'cancel':
           return (
-            <Button color="secondary" variant="contained" onClick={onCancel} key={actionType}>
+            <Button color="secondary" variant="contained" onClick={cancelValueChanges} key={actionType}>
               Cancel
             </Button>
           )
 
         case 'accept':
           return (
-            <Button color="primary" variant="contained" onClick={onAccept} key={actionType}>
+            <Button color="primary" variant="contained" onClick={acceptValueChanges} key={actionType}>
               Select
             </Button>
           )
@@ -190,9 +191,8 @@ export const DuosDatePicker = (props: DUOSDatePickerProps) => {
     })
     return <DialogActions {...other}>{buttons}</DialogActions>
   }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  const WeekendFormattedDay = (props: PickersDayProps<Dayjs>) => {
+
+  const WeekendFormattedDay = (props: PickersDayProps) => {
     const isWeekendDay = props.day.day() === 0 || props.day.day() === 6
     const weekendStyle = isWeekendDay
       ? { color: 'var(--weekend)' }
@@ -208,11 +208,13 @@ export const DuosDatePicker = (props: DUOSDatePickerProps) => {
             closeOnSelect={false}
             label="Select a date"
             format={inputFormat}
-            defaultValue={defaultValueAsDayjs}
+            value={defaultValueAsDayjs}
             onChange={(value) => {
+              console.error('onChange', value)
               onChange(value?.format(inputFormat))
             }}
             onAccept={(value) => {
+              console.error('onAccept', value)
               onChange(value?.format(inputFormat))
             }}
             onError={value => onError && onError(value?.toString() === 'Invalid Date' ? 'Invalid Date' : '', value?.toString())}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2265](https://broadworkbench.atlassian.net/browse/DT-2265)

### Summary

Observed the calendar picker wasn't initializing to the expected date and that the control wasn't behaving as expected when the "Select" button was clicked (e.g. the calendar picker popup wasn't closing).  Added tests for both cases and fixed the control so that both cases work as expected.

BEFORE:

https://github.com/user-attachments/assets/b087b816-e86f-4a57-ac34-fc6734c0c7f9

AFTER:

https://github.com/user-attachments/assets/43b7f57b-b994-4c16-9023-9f8128cae8ee




----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
