### PR TITLE
Label "Progress Report" consistently in user-facing text

### DIFF
--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -16,7 +16,7 @@ export const DAR = {
     return await res.json()
   },
 
-  // v2, v3 Draft DAR Update
+  // v2, v3 Draft Progress Report
   updateDarDraft: async (dar, referenceId) => {
     // noinspection ES6MissingAwait
     Metrics.captureEvent(eventList.dar, { action: 'update' })

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -16,7 +16,7 @@ export const DAR = {
     return await res.json()
   },
 
-  // v2, v3 Draft Progress Report
+  // v2, v3 Draft DAR Update
   updateDarDraft: async (dar, referenceId) => {
     // noinspection ES6MissingAwait
     Metrics.captureEvent(eventList.dar, { action: 'update' })

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -40,7 +40,7 @@ const RESEARCHER_INFO_TAB_ID = 'researcher-info'
 const DATA_ACCESS_REQUEST_TAB_ID = 'data-access-request'
 const RESEARCH_PURPOSE_STATEMENT_TAB_ID = 'research-purpose'
 const DATA_ACCESS_AGREEMENTS_TAB_ID = 'data-access-agreements'
-const DAR_UPDATE_TAB_ID_PREFIX = 'dar-update-'
+const PROGRESS_REPORT_TAB_ID_PREFIX = 'progress-report-'
 const PROGRESS_REPORT_APPLICATION_TAB_ID = 'progress-report-app'
 const ADDENDUM_TAB_ID = 'addendum'
 const VOTING_HISTORY_TAB_ID = 'voting-history-info'
@@ -315,14 +315,14 @@ const DataAccessRequestApplication = (props) => {
       let appTabs = []
       if (isProgressReportApplication) {
         // if we are creating a new progress report, we need to add another tab for the application
-        appTabs = [{ name: 'DAR Update ' + reverseOrderedDARs.length, id: PROGRESS_REPORT_APPLICATION_TAB_ID, showStep: false }]
+        appTabs = [{ name: 'Progress Report ' + reverseOrderedDARs.length, id: PROGRESS_REPORT_APPLICATION_TAB_ID, showStep: false }]
       }
       setApplicationTabs([...appTabs,
         ...reverseOrderedDARs.map((_dar, index) => {
           const whichPRIsThis = reverseOrderedDARs.length - index - 1
           const isLast = index === reverseOrderedDARs.length - 1
-          const itemLabel = isLast ? formData?.darCode : 'DAR Update ' + whichPRIsThis
-          return { name: itemLabel, id: `${DAR_UPDATE_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false }
+          const itemLabel = isLast ? formData?.darCode : 'Progress Report ' + whichPRIsThis
+          return { name: itemLabel, id: `${PROGRESS_REPORT_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false }
         }),
         { name: 'Voting History', id: VOTING_HISTORY_TAB_ID, showStep: false },
       ])
@@ -668,7 +668,7 @@ const DataAccessRequestApplication = (props) => {
               <div id={PROGRESS_REPORT_APPLICATION_TAB_ID} className="dar-steps">
                 <ConditionalAccordion
                   condition={false}
-                  title={`DAR Report ${reverseOrderedDARs.length}`}
+                  title={`Progress Report ${reverseOrderedDARs.length}`}
                 >
                   <ProgressReportApplication
                     readOnlyMode={false}
@@ -687,11 +687,11 @@ const DataAccessRequestApplication = (props) => {
                 {reverseOrderedDARs.map((dar, index) => {
                   if ((index + 1 !== reverseOrderedDARs.length)) {
                     return (
-                      <div key={`dar-${index}`} id={`${DAR_UPDATE_TAB_ID_PREFIX}${reverseOrderedDARs.length - index - 1}`}>
+                      <div key={`dar-${index}`} id={`${PROGRESS_REPORT_TAB_ID_PREFIX}${reverseOrderedDARs.length - index - 1}`}>
                         <ConditionalAccordion
                           key={`dar-${index}`}
                           condition={true}
-                          title={`DAR Report ${reverseOrderedDARs.length - index - 1}`}
+                          title={`Progress Report ${reverseOrderedDARs.length - index - 1}`}
                           defaultExpanded={index === 0}
                         >
                           <ProgressReportApplication
@@ -708,7 +708,7 @@ const DataAccessRequestApplication = (props) => {
                 })}
               </div>
             )}
-            <div id={`${DAR_UPDATE_TAB_ID_PREFIX}0`} className={existingDarsReadOnlyMode ? 'dar-summary' : 'dar-steps'}>
+            <div id={`${PROGRESS_REPORT_TAB_ID_PREFIX}0`} className={existingDarsReadOnlyMode ? 'dar-summary' : 'dar-steps'}>
               {existingDarsReadOnlyMode && (
                 <h3>
                   {formData.darCode}


### PR DESCRIPTION
# Addresses
https://broadworkbench.atlassian.net/browse/DT-2249

# Summary
In team discussion, we consistently use the term “Progress Report” for the newly-required annual status update on DARs.  Previously, however, the UI used at least two other terms – “DAR Update” and “DAR Report” – for the same thing.  That was confusing.

Now the UI labels this thing as "Progress Report" consistently in user-facing text.

## Before

<img width="1512" height="817" alt="Screenshot 2025-10-09 at 10 23 53 AM" src="https://github.com/user-attachments/assets/3156f1b8-3ac2-4cb3-b513-f8a4b95f331c" />
<img width="1500" height="818" alt="Screenshot 2025-10-09 at 10 22 34 AM" src="https://github.com/user-attachments/assets/bf9d3596-9e59-47bc-b7a1-fd4af0f8f3ab" />

## After

<img width="1508" height="814" alt="Screenshot 2025-10-09 at 10 23 43 AM" src="https://github.com/user-attachments/assets/e1d18abe-7e1e-4510-b0d8-28189b09cff5" />
<img width="1512" height="815" alt="Screenshot 2025-10-09 at 10 18 23 AM" src="https://github.com/user-attachments/assets/8acc1fd4-6fcb-44d0-a663-853eb4e9939c" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
