### PR TITLE
DT-2342: Update auth sync flow documentation

### DIFF
--- a/docs/eRA_Commons.md
+++ b/docs/eRA_Commons.md
@@ -27,8 +27,10 @@ sequenceDiagram
     Note over DUOS, ECM: include state, oauthcode
     ECM ->> DUOS: return LinkInfo
     Note over ECM, DUOS: response includes externalUserId redirectTo
-    DUOS ->> DUOS: Decode/validate ECM response
-    DUOS ->> Consent: Save eRA Commons state to Consent for local purposes
+    DUOS ->> Consent: Request sync Consent <-> ECM
+    Consent ->> ECM: Sync eRA Commons state between Consent and ECM
+    ECM ->> Consent: Return sync status
+    Consent ->> Consent: Save status
     DUOS ->> User: Redirect user to original redirectTo
     User ->> DUOS: Original page is refreshed
     DUOS ->> User: Updates user display

--- a/docs/eRA_Commons.md
+++ b/docs/eRA_Commons.md
@@ -28,7 +28,7 @@ sequenceDiagram
     ECM ->> DUOS: return LinkInfo
     Note over ECM, DUOS: response includes externalUserId and redirectTo
     DUOS ->> Consent: Request sync Consent <-> ECM
-    Consent ->> ECM: Sync eRA Commons state between Consent and ECM
+    Consent ->> ECM: Sync RAS state between Consent and ECM
     ECM ->> Consent: Return sync status
     Consent ->> Consent: Save status
     DUOS ->> User: Redirect user to original redirectTo

--- a/docs/eRA_Commons.md
+++ b/docs/eRA_Commons.md
@@ -4,14 +4,14 @@ DUOS uses ECM as an intermediary to allow users to authenticate
 with NIH. ECM provides a redirect url that we point the user to.
 Once authenticated, the user is redirected back to ECM which saves
 the authentication information and then redirects the user back to 
-the originating URL. DUOS, historically, also saved this information
-locally in Consent. This allows Data Access Committees the ability to
+the originating URL. The DUOS back end then synchronizes the user
+state with ECM. This allows Data Access Committees the ability to
 see if a researcher is an NIH user. 
 
 ```mermaid
 %%{init: { 'theme': 'forest' } }%%
 sequenceDiagram
-    User ->> DUOS: clicks the eRA Commons button
+    User ->> DUOS: clicks the RAS Authenticate button
     DUOS ->> ECM: Get authorization url
     Note over DUOS, ECM: POST /api/oauth/v1/{provider}/authorization-url
     Note over DUOS, ECM: include a redirectUri query parameter
@@ -21,12 +21,12 @@ sequenceDiagram
     User ->> NIH: User is forwarded to NIH
     NIH ->> NIH: User Auths
     NIH ->> DUOS: Return with user state
-    Note over DUOS, NIH: Gets the oauth code from NIH
+    Note over DUOS, NIH: Gets an oauthcode from NIH
     DUOS ->> ECM: Post oauthcode to ECM
     Note over DUOS, ECM: POST /api/oauth/v1/{provider}/oauthcode
     Note over DUOS, ECM: include state, oauthcode
     ECM ->> DUOS: return LinkInfo
-    Note over ECM, DUOS: response includes externalUserId redirectTo
+    Note over ECM, DUOS: response includes externalUserId and redirectTo
     DUOS ->> Consent: Request sync Consent <-> ECM
     Consent ->> ECM: Sync eRA Commons state between Consent and ECM
     ECM ->> Consent: Return sync status


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2342

## Summary
Minor update to the documentation for eRA Commons, now RAS, authentication flow.

The primary change is an update to how the new RAS auth state is synchronized via the back end instead of via the front end.

### New
<img width="1168" height="511" alt="Screenshot 2025-10-14 at 8 50 37 AM" src="https://github.com/user-attachments/assets/9e44f154-f875-409c-b0ed-0275e9676629" />

### Old
<img width="1200" height="432" alt="Screenshot 2025-10-14 at 8 51 12 AM" src="https://github.com/user-attachments/assets/888dba7a-4bc4-486a-ab5e-b46d38aad3a3" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
