### PR TITLE
DT-400: Replace validator.isFQDN with local copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "react-tooltip": "4.5.1",
     "stackdriver-errors-js": "0.12.0",
     "tss-react": "4.9.19",
-    "uuid": "13.0.0",
-    "validator": "13.15.15"
+    "uuid": "13.0.0"
   },
   "scripts": {
     "analyze": "VISUALIZER_PLUGIN=true vite build",
@@ -54,7 +53,6 @@
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@types/react-router-dom": "5.3.3",
-    "@types/validator": "^13.15.3",
     "@vitejs/plugin-react": "5.0.4",
     "buffer": "6.0.3",
     "cypress": "15.3.0",

--- a/src/components/institution_table/components/InstitutionDomainEditor.tsx
+++ b/src/components/institution_table/components/InstitutionDomainEditor.tsx
@@ -1,7 +1,7 @@
 import { Button, Chip, TextField } from '@mui/material'
 import React, { useState } from 'react'
 import { Institution } from 'src/types/model'
-import validator from 'validator'
+import isFQDN from 'src/utils/isFQDN'
 
 interface DomainEditorProps {
   domains: string[]
@@ -24,7 +24,7 @@ export const InstitutionDomainEditor = ({ domains, isEditing, onDomainsChange, i
   const validateDomain = (domain: string): string | null => {
     try {
       // Check if it's a valid FQDN (Fully Qualified Domain Name)
-      if (!validator.isFQDN(domain, {
+      if (!isFQDN(domain, {
         require_tld: true,
         allow_underscores: false,
         allow_trailing_dot: false,

--- a/src/utils/isFQDN.js
+++ b/src/utils/isFQDN.js
@@ -1,3 +1,5 @@
+// Code from https://github.com/validatorjs/validator.js
+// Original license: https://github.com/validatorjs/validator.js/blob/master/LICENSE
 const default_fqdn_options = {
   require_tld: true,
   allow_underscores: false,

--- a/src/utils/isFQDN.js
+++ b/src/utils/isFQDN.js
@@ -1,0 +1,87 @@
+const default_fqdn_options = {
+  require_tld: true,
+  allow_underscores: false,
+  allow_trailing_dot: false,
+  allow_numeric_tld: false,
+  allow_wildcard: false,
+  ignore_max_length: false,
+}
+
+function merge(obj = { }, defaults) {
+  for (const key in defaults) {
+    if (typeof obj[key] === 'undefined') {
+      obj[key] = defaults[key]
+    }
+  }
+  return obj
+}
+
+function assertString(input) {
+  if (input === undefined || input === null) throw new TypeError(`Expected a string but received a ${input}`)
+  if (input.constructor.name !== 'String') throw new TypeError(`Expected a string but received a ${input.constructor.name}`)
+}
+
+export default function isFQDN(str, options) {
+  assertString(str)
+  options = merge(options, default_fqdn_options)
+
+  /* Remove the optional trailing dot before checking validity */
+  if (options.allow_trailing_dot && str[str.length - 1] === '.') {
+    str = str.substring(0, str.length - 1)
+  }
+
+  /* Remove the optional wildcard before checking validity */
+  if (options.allow_wildcard === true && str.indexOf('*.') === 0) {
+    str = str.substring(2)
+  }
+
+  const parts = str.split('.')
+  const tld = parts[parts.length - 1]
+
+  if (options.require_tld) {
+    // disallow fqdns without tld
+    if (parts.length < 2) {
+      return false
+    }
+
+    if (!options.allow_numeric_tld && !/^([a-z\u00A1-\u00A8\u00AA-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]{2,}|xn[a-z0-9-]{2,})$/i.test(tld)) {
+      return false
+    }
+
+    // disallow spaces
+    if (/\s/.test(tld)) {
+      return false
+    }
+  }
+
+  // reject numeric TLDs
+  if (!options.allow_numeric_tld && /^\d+$/.test(tld)) {
+    return false
+  }
+
+  return parts.every((part) => {
+    if (part.length > 63 && !options.ignore_max_length) {
+      return false
+    }
+
+    if (!/^[a-z_\u00a1-\uffff0-9-]+$/i.test(part)) {
+      return false
+    }
+
+    // disallow full-width chars
+    if (/[\uff01-\uff5e]/.test(part)) {
+      return false
+    }
+
+    // disallow parts starting or ending with hyphen
+    if (/^-|-$/.test(part)) {
+      return false
+    }
+
+    if (!options.allow_underscores && /_/.test(part)) {
+      return false
+    }
+
+    return true
+  })
+}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-400

### Summary
Remove the validator library and copy current usage to a local utility function. See https://github.com/validatorjs/validator.js/blob/6f436be36945e460ee624bf72a935a06daded859/src/lib/isFQDN.js, https://github.com/validatorjs/validator.js/blob/6f436be36945e460ee624bf72a935a06daded859/src/lib/util/assertString.js, and https://github.com/validatorjs/validator.js/blob/6f436be36945e460ee624bf72a935a06daded859/src/lib/util/merge.js for the original source.

This PR can be reverted once the validator library vulnerabilities are updated.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
