### PR TITLE
DT-2349: Update accept header for ECM auth url call

### DIFF
--- a/src/libs/ajax/AuthenticateNIH.js
+++ b/src/libs/ajax/AuthenticateNIH.js
@@ -21,7 +21,7 @@ export const AuthenticateNIH = {
   getECMProviderAuthUrl: async (redirectUri, redirectTo) => {
     const url = `${await getECMUrl()}/api/oauth/v1/${provider}/authorization-url?redirectUri=${redirectUri}`
     // ECM returns a `text/plain` response and expects an `Accept: */*` request header
-    const authOpts = merge(Config.authOpts(), { headers: { Accept: '*/*' } })
+    const authOpts = merge({}, Config.authOpts(), { headers: { Accept: '*/*' } })
     const res = await fetchPost(url, { redirectTo: redirectTo }, authOpts)
     if (res?.data) {
       return res.data

--- a/src/libs/ajax/AuthenticateNIH.js
+++ b/src/libs/ajax/AuthenticateNIH.js
@@ -1,6 +1,7 @@
 import { Config } from 'src/libs/config'
 import { getECMUrl, getApiUrl } from 'src/libs/ajax'
 import { fetchGet, fetchPost, fetchDelete } from 'src/libs/ajax/fetchAdapter'
+import { merge } from 'lodash'
 
 /**
  * ECM has several different providers such as `era-commons`, `ras`, `gitHub`, `fence`, and others. DUOS has
@@ -19,9 +20,8 @@ export const AuthenticateNIH = {
 
   getECMProviderAuthUrl: async (redirectUri, redirectTo) => {
     const url = `${await getECMUrl()}/api/oauth/v1/${provider}/authorization-url?redirectUri=${redirectUri}`
-    const authOpts = Config.authOpts()
     // ECM returns a `text/plain` response and expects an `Accept: */*` request header
-    authOpts.headers.Accept = '*/*'
+    const authOpts = merge(Config.authOpts(), { headers: { Accept: '*/*' } })
     const res = await fetchPost(url, { redirectTo: redirectTo }, authOpts)
     if (res?.data) {
       return res.data

--- a/src/libs/ajax/AuthenticateNIH.js
+++ b/src/libs/ajax/AuthenticateNIH.js
@@ -19,7 +19,10 @@ export const AuthenticateNIH = {
 
   getECMProviderAuthUrl: async (redirectUri, redirectTo) => {
     const url = `${await getECMUrl()}/api/oauth/v1/${provider}/authorization-url?redirectUri=${redirectUri}`
-    const res = await fetchPost(url, { redirectTo: redirectTo }, Config.authOpts())
+    const configs = Config.authOpts()
+    // ECM returns a `text/plain` response and expects an `Accept: */*` request header
+    configs.headers.Accept = '*/*'
+    const res = await fetchPost(url, { redirectTo: redirectTo }, configs)
     if (res?.data) {
       return res.data
     }

--- a/src/libs/ajax/AuthenticateNIH.js
+++ b/src/libs/ajax/AuthenticateNIH.js
@@ -19,10 +19,10 @@ export const AuthenticateNIH = {
 
   getECMProviderAuthUrl: async (redirectUri, redirectTo) => {
     const url = `${await getECMUrl()}/api/oauth/v1/${provider}/authorization-url?redirectUri=${redirectUri}`
-    const configs = Config.authOpts()
+    const authOpts = Config.authOpts()
     // ECM returns a `text/plain` response and expects an `Accept: */*` request header
-    configs.headers.Accept = '*/*'
-    const res = await fetchPost(url, { redirectTo: redirectTo }, configs)
+    authOpts.headers.Accept = '*/*'
+    const res = await fetchPost(url, { redirectTo: redirectTo }, authOpts)
     if (res?.data) {
       return res.data
     }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2349

### Summary
The fetch call to ECM was not setting the request `Accept` header correctly.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
