### PR TITLE
[DT-2158] Add Models for New Asset Types

### DIFF
--- a/cypress/component/utils/render_utlls.spec.tsx
+++ b/cypress/component/utils/render_utlls.spec.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { renderColumnContent } from 'src/utils/RenderUtils'
+
+describe('renderColumnContent', () => {
+  it('renders with custom renderer', () => {
+    const customRenderers = {
+      test: (value: unknown) => <span>{value as string}</span>,
+    }
+    const result = renderColumnContent('test', 'abc', customRenderers)
+    expect(result).to.deep.equal(<span>abc</span>)
+  })
+
+  it('renders array of objects', () => {
+    const arr = [{ a: 1 }, { b: 2 }]
+    const result = renderColumnContent('col', arr)
+    expect(result).to.equal(JSON.stringify(arr[0]) + ', ' + JSON.stringify(arr[1]))
+  })
+
+  it('renders array of strings', () => {
+    const arr = ['a', 'b']
+    const result = renderColumnContent('col', arr)
+    expect(result).to.equal('a, b')
+  })
+
+  it('renders null and undefined', () => {
+    expect(renderColumnContent('col', null)).to.equal(null)
+    expect(renderColumnContent('col', undefined)).to.equal(null)
+  })
+
+  it('renders object', () => {
+    expect(renderColumnContent('col', { a: 1 })).to.equal(JSON.stringify({ a: 1 }))
+  })
+
+  it('renders string and number', () => {
+    expect(renderColumnContent('col', 'abc')).to.equal('abc')
+    expect(renderColumnContent('col', 123)).to.equal('123')
+  })
+})

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -3,16 +3,6 @@ import { DeletePresentationOrPublication } from 'src/components/presentation_pub
 import { Presentation, Presenter } from 'src/types/model'
 import { renderColumnContent } from 'src/utils/RenderUtils'
 
-function PresenterCell({ presenter }: { readonly presenter: Presenter | null }) {
-  if (!presenter || typeof presenter !== 'object') return null
-  return (
-    <span>
-      {presenter.name}
-      {presenter.email ? ` (${presenter.email})` : ''}
-    </span>
-  )
-}
-
 interface PresentationSummaryProps {
   presentation: Presentation
   readonly columnsToShow: string[]
@@ -34,7 +24,16 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
   const buttonStyle = disabled ? disabledStyle : {}
 
   const customRenderers = {
-    presenter: (value: unknown) => <PresenterCell presenter={value as Presenter} />,
+    presenter: (value: unknown) => {
+      const presenter = value as Presenter
+      if (!presenter || typeof presenter !== 'object') return null
+      return (
+        <span>
+          {presenter.name}
+          {presenter.email ? ` (${presenter.email})` : ''}
+        </span>
+      )
+    },
   }
 
   return (

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -23,23 +23,13 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
   const buttonStyle = disabled ? disabledStyle : {}
 
   const renderPresentationColumnContent = (column: string, presentation: Presentation): React.ReactNode => {
-    const value: string | boolean | string[] | { name: string, email: string } | undefined = presentation[column as keyof Presentation]
+    const value = presentation[column as keyof Presentation]
     if (column === 'presenter' && value && typeof value === 'object' && !Array.isArray(value)) {
       return <span>{value.name}{value.email ? ` (${value.email})` : ''}</span>
     }
-    if (Array.isArray(value)) {
-      return value.join(', ')
-    }
+    if (Array.isArray(value)) return value.join(', ')
     if (value == null) return null
-    if (typeof value === 'object') {
-      try {
-        return JSON.stringify(value)
-      }
-      catch {
-        return '[unserializable object]'
-      }
-    }
-    return String(value)
+    return typeof value === 'object' ? JSON.stringify(value) : String(value)
   }
 
   return (

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -11,6 +11,16 @@ interface PresentationSummaryProps {
   readonly disabled: boolean
 }
 
+function PresenterCell({ presenter }: { presenter: Presenter | null }) {
+  if (!presenter || typeof presenter !== 'object') return null
+  return (
+    <span>
+      {presenter.name}
+      {presenter.email ? ` (${presenter.email})` : ''}
+    </span>
+  )
+}
+
 export default function PresentationSummary(props: PresentationSummaryProps): React.JSX.Element {
   const { presentation, columnsToShow, editAction, deleteAction, disabled } = props
 
@@ -24,16 +34,7 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
   const buttonStyle = disabled ? disabledStyle : {}
 
   const customRenderers = {
-    presenter: (value: unknown) => {
-      const presenter = value as Presenter
-      if (!presenter || typeof presenter !== 'object') return null
-      return (
-        <span>
-          {presenter.name}
-          {presenter.email ? ` (${presenter.email})` : ''}
-        </span>
-      )
-    },
+    presenter: (value: unknown) => <PresenterCell presenter={value as Presenter} />,
   }
 
   return (

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -31,6 +31,14 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
       return value.join(', ')
     }
     if (value == null) return null
+    if (typeof value === 'object') {
+      try {
+        return JSON.stringify(value)
+      }
+      catch {
+        return '[unserializable object]'
+      }
+    }
     return String(value)
   }
 

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
-import { Presentation } from 'src/types/model'
+import { Presentation, Presenter } from 'src/types/model'
+import { renderColumnContent } from 'src/utils/RenderUtils'
 
 interface PresentationSummaryProps {
   presentation: Presentation
@@ -22,21 +23,24 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
 
   const buttonStyle = disabled ? disabledStyle : {}
 
-  const renderPresentationColumnContent = (column: string, presentation: Presentation): React.ReactNode => {
-    const value = presentation[column as keyof Presentation]
-    if (column === 'presenter' && value && typeof value === 'object' && !Array.isArray(value)) {
-      return <span>{value.name}{value.email ? ` (${value.email})` : ''}</span>
-    }
-    if (Array.isArray(value)) return value.join(', ')
-    if (value == null) return null
-    return typeof value === 'object' ? JSON.stringify(value) : String(value)
+  const customRenderers = {
+    presenter: (value: unknown) => {
+      const presenter = value as Presenter
+      if (!presenter || typeof presenter !== 'object') return null
+      return (
+        <span>
+          {presenter.name}
+          {presenter.email ? ` (${presenter.email})` : ''}
+        </span>
+      )
+    },
   }
 
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = renderPresentationColumnContent(column, presentation)
+        const columnContent = renderColumnContent(column, presentation[column as keyof Presentation], customRenderers)
         return columnContent && (
           <div key={'presentation_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -22,11 +22,22 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
 
   const buttonStyle = disabled ? disabledStyle : {}
 
+  const renderPresentationColumnContent = (column: string, presentation: Presentation): React.ReactNode => {
+    const value: string | boolean | string[] | { name: string, email: string } | undefined = presentation[column as keyof Presentation]
+    if (column === 'presenter' && value && typeof value === 'object' && !Array.isArray(value)) {
+      return <span>{value.name}{value.email ? ` (${value.email})` : ''}</span>
+    }
+    if (Array.isArray(value)) {
+      return value.join(', ')
+    }
+    return value != null ? String(value) : null
+  }
+
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = presentation[column as keyof Presentation]
+        const columnContent = renderPresentationColumnContent(column, presentation)
         return columnContent && (
           <div key={'presentation_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -3,15 +3,7 @@ import { DeletePresentationOrPublication } from 'src/components/presentation_pub
 import { Presentation, Presenter } from 'src/types/model'
 import { renderColumnContent } from 'src/utils/RenderUtils'
 
-interface PresentationSummaryProps {
-  presentation: Presentation
-  readonly columnsToShow: string[]
-  readonly editAction: () => void
-  readonly deleteAction: () => void
-  readonly disabled: boolean
-}
-
-function PresenterCell({ presenter }: { presenter: Presenter | null }) {
+function PresenterCell({ presenter }: { readonly presenter: Presenter | null }) {
   if (!presenter || typeof presenter !== 'object') return null
   return (
     <span>
@@ -19,6 +11,14 @@ function PresenterCell({ presenter }: { presenter: Presenter | null }) {
       {presenter.email ? ` (${presenter.email})` : ''}
     </span>
   )
+}
+
+interface PresentationSummaryProps {
+  presentation: Presentation
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly disabled: boolean
 }
 
 export default function PresentationSummary(props: PresentationSummaryProps): React.JSX.Element {

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -22,22 +22,11 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
 
   const buttonStyle = disabled ? disabledStyle : {}
 
-  const renderPresentationColumnContent = (column: string, presentation: Presentation): React.ReactNode => {
-    const value: string | boolean | string[] | { name: string, email: string } | undefined = presentation[column as keyof Presentation]
-    if (column === 'presenter' && value && typeof value === 'object' && !Array.isArray(value)) {
-      return <span>{value.name}{value.email ? ` (${value.email})` : ''}</span>
-    }
-    if (Array.isArray(value)) {
-      return value.join(', ')
-    }
-    return value != null ? String(value) : null
-  }
-
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = renderPresentationColumnContent(column, presentation)
+        const columnContent = presentation[column as keyof Presentation]
         return columnContent && (
           <div key={'presentation_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -22,11 +22,23 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
 
   const buttonStyle = disabled ? disabledStyle : {}
 
+  const renderPresentationColumnContent = (column: string, presentation: Presentation): React.ReactNode => {
+    const value: string | boolean | string[] | { name: string, email: string } | undefined = presentation[column as keyof Presentation]
+    if (column === 'presenter' && value && typeof value === 'object' && !Array.isArray(value)) {
+      return <span>{value.name}{value.email ? ` (${value.email})` : ''}</span>
+    }
+    if (Array.isArray(value)) {
+      return value.join(', ')
+    }
+    if (value == null) return null
+    return String(value)
+  }
+
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = presentation[column as keyof Presentation]
+        const columnContent = renderPresentationColumnContent(column, presentation)
         return columnContent && (
           <div key={'presentation_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -22,11 +22,27 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
 
   const buttonStyle = disabled ? disabledStyle : {}
 
+  const renderPublicationColumnContent = (column: string, publication: Publication): React.ReactNode => {
+    const value = publication[column as keyof Publication]
+    if (column === 'authors') {
+      if (Array.isArray(value)) {
+        return value.map((author: string | { name: string, orcId: string }, i: number) =>
+          typeof author === 'object' && author !== null
+            ? <span key={author.orcId || i}>{author.name}{i < value.length - 1 ? ', ' : ''}</span>
+            : String(author),
+        )
+      }
+      if (value == null) return null
+      return String(value)
+    }
+    return value as React.ReactNode
+  }
+
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = publication[column as keyof Publication]
+        const columnContent = renderPublicationColumnContent(column, publication)
         return columnContent && (
           <div key={'publication_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -22,11 +22,26 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
 
   const buttonStyle = disabled ? disabledStyle : {}
 
+  const renderPublicationColumnContent = (column: string, publication: Publication): React.ReactNode => {
+    const value = publication[column as keyof Publication]
+    if (column === 'authors') {
+      if (Array.isArray(value)) {
+        return value.map((author: string | { name: string, orcId: string }, i: number) =>
+          typeof author === 'object' && author !== null
+            ? <span key={author.orcId || i}>{author.name}{i < value.length - 1 ? ', ' : ''}</span>
+            : String(author),
+        )
+      }
+      return value ? String(value) : null
+    }
+    return value as React.ReactNode
+  }
+
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = publication[column as keyof Publication]
+        const columnContent = renderPublicationColumnContent(column, publication)
         return columnContent && (
           <div key={'publication_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -22,26 +22,11 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
 
   const buttonStyle = disabled ? disabledStyle : {}
 
-  const renderPublicationColumnContent = (column: string, publication: Publication): React.ReactNode => {
-    const value = publication[column as keyof Publication]
-    if (column === 'authors') {
-      if (Array.isArray(value)) {
-        return value.map((author: string | { name: string, orcId: string }, i: number) =>
-          typeof author === 'object' && author !== null
-            ? <span key={author.orcId || i}>{author.name}{i < value.length - 1 ? ', ' : ''}</span>
-            : String(author),
-        )
-      }
-      return value ? String(value) : null
-    }
-    return value as React.ReactNode
-  }
-
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = renderPublicationColumnContent(column, publication)
+        const columnContent = publication[column as keyof Publication]
         return columnContent && (
           <div key={'publication_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
-import { Publication } from 'src/types/model'
+import { Author, Publication } from 'src/types/model'
+import { renderColumnContent } from 'src/utils/RenderUtils'
 
 interface PublicationSummaryProps {
   publication: Publication
@@ -22,29 +23,26 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
 
   const buttonStyle = disabled ? disabledStyle : {}
 
-  const renderPublicationColumnContent = (column: string, publication: Publication): React.ReactNode => {
-    const value = publication[column as keyof Publication]
-    if (column === 'authors') {
+  const customRenderers = {
+    authors: (value: unknown) => {
       if (Array.isArray(value)) {
-        return value.map((author, i) =>
-          typeof author === 'object' && author !== null
-            ? <span key={author.orcId || i}>{author.name}{i < value.length - 1 ? ', ' : ''}</span>
-            : String(author),
-        )
+        return (value as Author[]).map((author, i) => (
+          <span key={author.orcId || i}>
+            {author.name}{i < (value as Author[]).length - 1 ? ', ' : ''}
+          </span>
+        ))
       }
+      if (typeof value === 'string') return value
       if (value == null) return null
-      return typeof value === 'object' ? JSON.stringify(value) : String(value)
-    }
-    if (Array.isArray(value)) return value.join(', ')
-    if (value == null) return null
-    return typeof value === 'object' ? JSON.stringify(value) : String(value)
+      return JSON.stringify(value)
+    },
   }
 
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = renderPublicationColumnContent(column, publication)
+        const columnContent = renderColumnContent(column, publication[column as keyof Publication], customRenderers)
         return columnContent && (
           <div key={'publication_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -22,11 +22,35 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
 
   const buttonStyle = disabled ? disabledStyle : {}
 
+  const renderPublicationColumnContent = (column: string, publication: Publication): React.ReactNode => {
+    const value = publication[column as keyof Publication]
+    if (column === 'authors') {
+      if (Array.isArray(value)) {
+        return value.map((author: string | { name: string, orcId: string }, i: number) =>
+          typeof author === 'object' && author !== null
+            ? <span key={author.orcId || i}>{author.name}{i < value.length - 1 ? ', ' : ''}</span>
+            : String(author),
+        )
+      }
+      if (value == null) return null
+      if (typeof value === 'object') {
+        try {
+          return JSON.stringify(value)
+        }
+        catch {
+          return '[unserializable object]'
+        }
+      }
+      return String(value)
+    }
+    return value as React.ReactNode
+  }
+
   return (
     <div className="collaborator-summary-card">
       {/* data elements to show in the row summary */}
       {columnsToShow.map((column, index) => {
-        const columnContent = publication[column as keyof Publication]
+        const columnContent = renderPublicationColumnContent(column, publication)
         return columnContent && (
           <div key={'publication_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
             <span>

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -26,24 +26,18 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
     const value = publication[column as keyof Publication]
     if (column === 'authors') {
       if (Array.isArray(value)) {
-        return value.map((author: string | { name: string, orcId: string }, i: number) =>
+        return value.map((author, i) =>
           typeof author === 'object' && author !== null
             ? <span key={author.orcId || i}>{author.name}{i < value.length - 1 ? ', ' : ''}</span>
             : String(author),
         )
       }
       if (value == null) return null
-      if (typeof value === 'object') {
-        try {
-          return JSON.stringify(value)
-        }
-        catch {
-          return '[unserializable object]'
-        }
-      }
-      return String(value)
+      return typeof value === 'object' ? JSON.stringify(value) : String(value)
     }
-    return value as React.ReactNode
+    if (Array.isArray(value)) return value.join(', ')
+    if (value == null) return null
+    return typeof value === 'object' ? JSON.stringify(value) : String(value)
   }
 
   return (

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -312,12 +312,12 @@ interface Contact extends Person {
   email: string
 }
 
-interface Author extends Person {
+export interface Author extends Person {
   orcId: string
 }
 
-type Maintainer = Contact
-type Presenter = Contact
+export type Maintainer = Contact
+export type Presenter = Contact
 
 export interface Study {
   studyId: number

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -304,6 +304,21 @@ export interface DatasetProperty {
   propertyValue: string
 }
 
+interface Person {
+  name: string
+}
+
+interface Contact extends Person {
+  email: string
+}
+
+interface Author extends Person {
+  orcId: string
+}
+
+type Maintainer = Contact
+type Presenter = Contact
+
 export interface Study {
   studyId: number
   name: string
@@ -339,10 +354,7 @@ export interface AiModel {
   format: string
   license: string
   trainedOnDatasets: string[]
-  maintainer: {
-    name: string
-    email: string
-  }
+  maintainer: Maintainer
   tags?: string[]
 }
 
@@ -672,7 +684,7 @@ interface BasePresentation {
 export interface StudyPresentation extends BasePresentation {
   presentationId: string
   studyId: string
-  presenter: { name: string, email: string }
+  presenter: Presenter
   event: string
   location: string
   url: string
@@ -695,11 +707,11 @@ interface BasePublication {
 export interface StudyPublication extends BasePublication {
   publicationId: string
   studyId: string
-  authors: Array<{ name: string, orcId: string }>
+  authors: Array<Author>
   journal: string
   doi: string
   url: string
-  published_date: string
+  publishedDate: string
   access: string
   tags?: string[]
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -319,6 +319,86 @@ export interface Study {
   createUserId: number
   updateDate?: string // Date?
   updateUserId?: number
+  assets?: {
+    models?: Array<AiModel>
+    workspaces?: Array<Workspace>
+    publications?: Array<Publication>
+    presentations?: Array<Presentation>
+    clinicalTrials?: Array<ClinicalTrial>
+    funding?: Array<FundingResource>
+    intellectualProperty?: Array<IntellectualProperty>
+  }
+}
+
+export interface AiModel {
+  modelId: string
+  studyId: string
+  name: string
+  description: string
+  url: string
+  format: string
+  license: string
+  trainedOnDatasets: string[]
+  maintainer: {
+    name: string
+    email: string
+  }
+  tags?: string[]
+}
+
+export interface Workspace {
+  workspaceId: string
+  studyId: string
+  name: string
+  platform: string
+  url: string
+  description: string
+  tools: string[]
+  access: string
+  tags?: string[]
+}
+
+export interface ClinicalTrial {
+  clinicalTrialId: string
+  studyId: string
+  title: string
+  registry: string
+  identifier: string
+  status: string
+  sponsor: string
+  startDate: string
+  endDate: string
+  interventionType: string
+  description: string
+  phase: string
+  url: string
+  tags?: string[]
+}
+
+export interface FundingResource {
+  fundingId: string
+  studyId: string
+  funderName: string
+  funderProgram: string
+  projectTitle: string
+  startDate: string
+  endDate: string
+  url: string
+  tags?: string[]
+}
+
+export interface IntellectualProperty {
+  ipId: string
+  studyId: string
+  type: string
+  title: string
+  assignee: string
+  patentNumber: string
+  filingDate: string
+  status: string
+  url: string
+  contact: string
+  tags?: string[]
 }
 
 export interface StudyProperty {
@@ -585,22 +665,43 @@ export interface Closeout {
 }
 
 export interface Presentation {
+  // Existing fields
   title: string
-  link: string
+  link?: string
   date: string
-  authors: string
-  datasetCitation: string
-  citation: boolean
+  authors?: string
+  datasetCitation?: string
+  citation?: boolean
+  // New study fields
+  presentationId?: string
+  studyId?: string
+  presenter?: { name: string, email: string }
+  event?: string
+  location?: string
+  url?: string
+  format?: string
+  access?: string
+  tags?: string[]
 }
 
 export interface Publication {
+  // Existing fields
   title: string
-  pubmedId: string
-  date: string
-  authors: string
-  bibliographicCitation: string
-  datasetCitation: string
-  citation: boolean
+  pubmedId?: string
+  date?: string
+  authors: string | Array<{ name: string, orcId: string }>
+  bibliographicCitation?: string
+  datasetCitation?: string
+  citation?: boolean
+  // New study fields
+  publicationId?: string
+  studyId?: string
+  journal?: string
+  doi?: string
+  url?: string
+  publicationDate?: string
+  access?: string
+  tags?: string[]
 }
 
 export interface Collaborator {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -338,7 +338,7 @@ export interface Study {
     models?: Array<AiModel>
     workspaces?: Array<Workspace>
     publications?: Array<StudyPublication>
-    presentations?: Array<StudyPresentation>
+    presentations?: Array<Presentation>
     clinicalTrials?: Array<ClinicalTrial>
     funding?: Array<FundingResource>
     intellectualProperty?: Array<IntellectualProperty>
@@ -676,28 +676,23 @@ export interface Closeout {
   signingOfficialId: number
 }
 
-interface BasePresentation {
+export interface Presentation {
   title: string
   date: string
-}
-
-export interface StudyPresentation extends BasePresentation {
-  presentationId: string
-  studyId: string
-  presenter: Presenter
-  event: string
-  location: string
-  url: string
-  format: string
-  access: string
+  // ToDO: Make existing Progress Report fields required in DT-2361
+  link?: string // ToDo: Remove in DT-2361 to be replaced by url
+  authors?: string
+  datasetCitation?: string
+  citation?: boolean
+  // ToDo: Make new study fields required in DT-2361 except for tags
+  presentationId?: string
+  studyId?: string
+  presenter?: Presenter
+  event?: string
+  location?: string
+  format?: string
+  access?: string
   tags?: string[]
-}
-
-export interface Presentation extends BasePresentation {
-  link: string
-  authors: string
-  datasetCitation: string
-  citation: boolean
 }
 
 interface BasePublication {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -337,7 +337,7 @@ export interface Study {
   assets?: {
     models?: Array<AiModel>
     workspaces?: Array<Workspace>
-    publications?: Array<StudyPublication>
+    publications?: Array<Publication>
     presentations?: Array<Presentation>
     clinicalTrials?: Array<ClinicalTrial>
     funding?: Array<FundingResource>
@@ -695,29 +695,24 @@ export interface Presentation {
   tags?: string[]
 }
 
-interface BasePublication {
+export interface Publication {
   title: string
-}
-
-export interface StudyPublication extends BasePublication {
-  publicationId: string
-  studyId: string
-  authors: Array<Author>
-  journal: string
-  doi: string
-  url: string
-  publishedDate: string
-  access: string
+  // ToDO: Make existing Progress Report fields required in DT-2358
+  pubmedId?: string
+  date?: string
+  authors?: string | Array<Author> // ToDo: Remove string option in DT-2358 to be replaced by Array<Author>
+  bibliographicCitation?: string
+  datasetCitation?: string
+  citation?: boolean
+  // ToDo: Make new study fields required in DT-2358except for tags
+  publicationId?: string
+  studyId?: string
+  journal?: string
+  doi?: string
+  url?: string
+  publishedDate?: string
+  access?: string
   tags?: string[]
-}
-
-export interface Publication extends BasePublication {
-  pubmedId: string
-  date: string
-  authors: string
-  bibliographicCitation: string
-  datasetCitation: string
-  citation: boolean
 }
 
 export interface Collaborator {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -700,11 +700,11 @@ export interface Publication {
   // ToDO: Make existing Progress Report fields required in DT-2358
   pubmedId?: string
   date?: string
-  authors?: string | Array<Author> // ToDo: Remove string option in DT-2358 to be replaced by Array<Author>
+  authors?: string | Array<Author> // ToDo: Remove string option in DT-2358
   bibliographicCitation?: string
   datasetCitation?: string
   citation?: boolean
-  // ToDo: Make new study fields required in DT-2358except for tags
+  // ToDo: Make new study fields required in DT-2358 except for tags
   publicationId?: string
   studyId?: string
   journal?: string

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -322,8 +322,8 @@ export interface Study {
   assets?: {
     models?: Array<AiModel>
     workspaces?: Array<Workspace>
-    publications?: Array<Publication>
-    presentations?: Array<Presentation>
+    publications?: Array<StudyPublication>
+    presentations?: Array<StudyPresentation>
     clinicalTrials?: Array<ClinicalTrial>
     funding?: Array<FundingResource>
     intellectualProperty?: Array<IntellectualProperty>
@@ -664,44 +664,53 @@ export interface Closeout {
   signingOfficialId: number
 }
 
-export interface Presentation {
-  // Existing fields
+interface BasePresentation {
   title: string
-  link?: string
   date: string
-  authors?: string
-  datasetCitation?: string
-  citation?: boolean
-  // New study fields
-  presentationId?: string
-  studyId?: string
-  presenter?: { name: string, email: string }
-  event?: string
-  location?: string
-  url?: string
-  format?: string
-  access?: string
+}
+
+export interface StudyPresentation extends BasePresentation {
+  presentationId: string
+  studyId: string
+  presenter: { name: string, email: string }
+  event: string
+  location: string
+  url: string
+  format: string
+  access: string
   tags?: string[]
 }
 
-export interface Publication {
-  // Existing fields
+export interface Presentation extends BasePresentation {
+  link: string
+  authors: string
+  datasetCitation: string
+  citation: boolean
+}
+
+interface BasePublication {
   title: string
-  date: string
-  pubmedId?: string
-  authors: string | Array<{ name: string, orcId: string }>
-  bibliographicCitation?: string
-  datasetCitation?: string
-  citation?: boolean
-  // New study fields
-  publicationId?: string
-  studyId?: string
-  journal?: string
-  doi?: string
-  url?: string
-  publicationDate?: string
-  access?: string
+}
+
+export interface StudyPublication extends BasePublication {
+  publicationId: string
+  studyId: string
+  authors: Array<{ name: string, orcId: string }>
+  journal: string
+  doi: string
+  url: string
+  published_date: string
+  access: string
   tags?: string[]
+}
+
+export interface Publication extends BasePublication {
+  pubmedId: string
+  date: string
+  authors: string
+  bibliographicCitation: string
+  datasetCitation: string
+  citation: boolean
 }
 
 export interface Collaborator {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -687,8 +687,8 @@ export interface Presentation {
 export interface Publication {
   // Existing fields
   title: string
+  date: string
   pubmedId?: string
-  date?: string
   authors: string | Array<{ name: string, orcId: string }>
   bibliographicCitation?: string
   datasetCitation?: string

--- a/src/utils/RenderUtils.ts
+++ b/src/utils/RenderUtils.ts
@@ -5,7 +5,7 @@ export function renderColumnContent(
   value: unknown,
   customRenderers?: Record<string, (value: unknown) => React.ReactNode>,
 ): React.ReactNode {
-  if (customRenderers && customRenderers[column]) {
+  if (customRenderers?.[column]) {
     return customRenderers[column](value)
   }
   if (Array.isArray(value)) {

--- a/src/utils/RenderUtils.ts
+++ b/src/utils/RenderUtils.ts
@@ -5,15 +5,15 @@ export function renderColumnContent(
   value: unknown,
   customRenderers?: Record<string, (value: unknown) => React.ReactNode>,
 ): React.ReactNode {
-  if (customRenderers?.[column]) {
-    return customRenderers[column](value)
-  }
-  if (Array.isArray(value)) {
-    return value.map(v => typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v)).join(', ')
-  }
+  // Use custom renderer if provided
+  if (customRenderers?.[column]) return customRenderers[column](value)
+
+  // Handle null/undefined
   if (value == null) return null
-  if (typeof value === 'object') {
-    return JSON.stringify(value)
-  }
-  return String(value)
+
+  // Stringify objects in arrays, convert primitives to strings
+  if (Array.isArray(value)) return value.map(v => v && typeof v === 'object' ? JSON.stringify(v) : String(v)).join(', ')
+
+  // Stringify objects, convert primitives to strings
+  return typeof value === 'object' ? JSON.stringify(value) : String(value)
 }

--- a/src/utils/RenderUtils.ts
+++ b/src/utils/RenderUtils.ts
@@ -12,5 +12,8 @@ export function renderColumnContent(
     return value.map(v => typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v)).join(', ')
   }
   if (value == null) return null
-  return typeof value === 'object' ? JSON.stringify(value) : String(value)
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  return String(value)
 }

--- a/src/utils/RenderUtils.ts
+++ b/src/utils/RenderUtils.ts
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export function renderColumnContent(
+  column: string,
+  value: unknown,
+  customRenderers?: Record<string, (value: unknown) => React.ReactNode>,
+): React.ReactNode {
+  if (customRenderers && customRenderers[column]) {
+    return customRenderers[column](value)
+  }
+  if (Array.isArray(value)) {
+    return value.map(v => typeof v === 'object' && v !== null ? JSON.stringify(v) : String(v)).join(', ')
+  }
+  if (value == null) return null
+  return typeof value === 'object' ? JSON.stringify(value) : String(value)
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2158

### Summary

This PR adds front-end models for new asset types — AI Models, Workspaces, Publications, Presentations, Clinical Trials, Intellectual Property, and Funding Resources. These models follow patterns from the [Self Service Single Study Registration (S4R design)](https://docs.google.com/document/d/1ZnmPSCn7ec814_SDJt5dr4_AYJ984TcrKVMitWCVnYU/edit?usp=sharing) to keep them clear, consistent, and easy to extend. Also includes updates to align Publications and Presentations with existing models.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
