### PR TITLE
DT-2357: Fix rendering error for ToS page

### DIFF
--- a/cypress/component/Support/SupportRequestModal.spec.jsx
+++ b/cypress/component/Support/SupportRequestModal.spec.jsx
@@ -168,4 +168,64 @@ describe('Support Request Modal Tests', () => {
       cy.get('[data-cy="supportFormAttachmentContainer"]').should('contain', '2 files selected')
     })
   })
+
+  describe('When a user is logged in but current user values are undefined:', () => {
+    beforeEach(() => {
+      cy.stub(Storage, 'userIsLogged').returns(true)
+      cy.stub(Storage, 'getCurrentUser').returns({
+        displayName: undefined,
+        email: undefined,
+      })
+    })
+
+    it('Renders form correctly', () => {
+      mount(
+        <SupportRequestModal
+          onCloseRequest={handler}
+          onOKRequest={handler}
+          url="url"
+          showModal={true}
+        />,
+      )
+      // These fields should exist
+      cy.get('[data-cy="closeButton"]').should('exist')
+      cy.get('[data-cy="supportForm"]').should('exist')
+      cy.get('[data-cy="supportFormEmail"]').should('not.exist')
+      cy.get('[data-cy="supportFormName"]').should('not.exist')
+      cy.get('[data-cy="supportFormType"]').should('exist')
+      cy.get('[data-cy="supportFormSubject"]').should('exist')
+      cy.get('[data-cy="supportFormDescription"]').should('exist')
+      cy.get('[data-cy="supportFormAttachment"]').should('exist')
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled')
+      cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled')
+    })
+
+    it('Submits properly', () => {
+      mount(
+        <SupportRequestModal
+          onCloseRequest={handler}
+          onOKRequest={handler}
+          url="url"
+          showModal={true}
+        />,
+      )
+      // Ensure that all required fields are filled out before submit becomes available
+      cy.get('[data-cy="supportFormType"]').select('bug')
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled')
+      cy.get('[data-cy="supportFormSubject"]').type('Subject')
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled')
+      cy.get('[data-cy="supportFormDescription"]').type('Description')
+      // Form is complete:
+      cy.get('[data-cy="supportFormSubmit"]').should('not.be.disabled')
+      cy.get('[data-cy="supportFormCancel"]').should('not.be.disabled')
+      cy.intercept({ method: 'POST', url: '**/support/request' }, { statusCode: 201 }).as('request')
+      cy.intercept({ method: 'POST', url: '**/support/upload' }, { statusCode: 201, body: { token: 'token_string' } }).as('upload')
+      // {force: true} is necessary here due to the surrounding div that covers the input.
+      cy.get('[data-cy="supportFormAttachment"]').selectFile(['cypress/fixtures/example.json'], { force: true })
+      cy.get('[data-cy="supportFormSubmit"]').click()
+      cy.wait(['@request', '@upload']).then((interceptions) => {
+        assert(interceptions.length === 2)
+      })
+    })
+  })
 })

--- a/src/components/modals/SupportRequestModal.jsx
+++ b/src/components/modals/SupportRequestModal.jsx
@@ -29,7 +29,7 @@ const getInitialState = () => {
     description: '',
     attachment: '',
     email: Storage.userIsLogged() ? Storage.getCurrentUser().email : '',
-    first_name: Storage.userIsLogged() ? Storage.getCurrentUser().displayName.split(' ')[0] : '',
+    first_name: Storage.userIsLogged() ? Storage.getCurrentUser().displayName?.split(' ')[0] : '',
     height: Storage.userIsLogged() ? (window.innerHeight < 550 ? window.innerHeight : '550px') : (window.innerHeight < 700 ? window.innerHeight : '700px'),
     top: Storage.userIsLogged() ? '400px' : '1',
     valid: Storage.userIsLogged(),


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2357

### Summary
When a user is signed in, but hasn't accepted ToS, the current user display name can possibly be undefined which breaks the `SupportRequestModal` component.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
