### PR TITLE
[DT-2351] Added AI Model Components

### DIFF
--- a/cypress/component/StudyAssets/ai_model_list.spec.tsx
+++ b/cypress/component/StudyAssets/ai_model_list.spec.tsx
@@ -1,0 +1,171 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import AiModelAddEdit from 'src/components/ai_models_list/AiModelAddEdit'
+import AiModelList from 'src/components/ai_models_list/AiModelList'
+import AiModelRow from 'src/components/ai_models_list/AiModelRow'
+import AiModelSummary from 'src/components/ai_models_list/AiModelSummary'
+import { AiModel } from 'src/types/model'
+
+const sampleModel: AiModel = {
+  modelId: 'm1',
+  studyId: 's1',
+  name: 'Baseline Model',
+  description: 'Desc',
+  url: 'https://example.com',
+  format: 'PyTorch',
+  license: 'MIT',
+  trainedOnDatasets: ['ds1', 'ds2'],
+  maintainer: { name: 'Alice', email: 'alice@example.com' },
+  tags: ['vision', 'baseline'],
+}
+
+describe('AiModelAddEdit', () => {
+  it('disables Add until required fields filled then adds', () => {
+    const onChangeSpy: AiModel[] = []
+    mount(
+      <AiModelAddEdit
+        id={-1}
+        aiModel={undefined}
+        aiModels={[]}
+        closeAction={cy.stub().as('close')}
+        onAiModelsChange={(models) => { onChangeSpy.push(...models) }}
+      />,
+    )
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+    cy.get('#name').type('My Model')
+    cy.get('#url').type('https://x.com')
+    cy.get('#format').type('ONNX')
+    cy.get('#license').type('Apache-2.0')
+    cy.get('#maintainerName').type('Bob')
+    cy.get('#maintainerEmail').type('bob@example.com')
+    cy.get('.collaborator-form-add-save-button').should('not.be.disabled').click()
+    cy.wrap(null).then(() => {
+      expect(onChangeSpy.length).to.eq(1)
+      expect(onChangeSpy[0].name).to.eq('My Model')
+      expect(onChangeSpy[0].maintainer.email).to.eq('bob@example.com')
+    })
+  })
+
+  it('edits existing model and saves changes', () => {
+    const models: AiModel[] = [sampleModel]
+    mount(
+      <AiModelAddEdit
+        id={0}
+        aiModel={sampleModel}
+        aiModels={models}
+        closeAction={cy.stub().as('close')}
+        onAiModelsChange={(updated) => {
+          expect(updated[0].name).to.eq('Baseline Model Edited')
+        }}
+      />,
+    )
+    cy.get('#name').clear()
+    cy.get('#name').type('Baseline Model Edited')
+    cy.get('.collaborator-form-add-save-button').click()
+  })
+})
+
+describe('AiModelSummary', () => {
+  it('renders arrays and maintainer formatting', () => {
+    mount(
+      <AiModelSummary
+        aiModel={sampleModel}
+        columnsToShow={['name', 'maintainer', 'trainedOnDatasets', 'tags', 'license']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Baseline Model').should('exist')
+    cy.contains('Alice (alice@example.com)').should('exist')
+    cy.contains('ds1, ds2').should('exist')
+    cy.contains('vision, baseline').should('exist')
+    cy.contains('MIT').should('exist')
+  })
+})
+
+describe('AiModelRow', () => {
+  it('shows summary when not in edit mode', () => {
+    mount(
+      <AiModelRow
+        id={0}
+        editMode={false}
+        aiModel={sampleModel}
+        aiModels={[sampleModel]}
+        columnsToShow={['name', 'format']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub().as('delete')}
+        closeAction={cy.stub()}
+        onAiModelsChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Baseline Model').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    mount(
+      <AiModelRow
+        id={0}
+        editMode={true}
+        aiModel={sampleModel}
+        aiModels={[sampleModel]}
+        columnsToShow={['name']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub().as('close')}
+        onAiModelsChange={cy.stub().as('change')}
+        disabled={false}
+      />,
+    )
+    cy.get('#name').should('have.value', 'Baseline Model')
+  })
+})
+
+describe('AiModelList', () => {
+  it('adds a new model', () => {
+    const state: AiModel[] = []
+    mount(
+      <AiModelList
+        aiModels={state}
+        columnsToShow={['name', 'license']}
+        onAiModelsChange={(m) => { state.splice(0, state.length, ...m) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-ai-model-btn').click()
+    cy.get('#name').type('Added Model')
+    cy.get('#url').type('https://m.com')
+    cy.get('#format').type('TensorFlow')
+    cy.get('#license').type('BSD')
+    cy.get('#maintainerName').type('Carol')
+    cy.get('#maintainerEmail').type('carol@example.com')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.wrap(null).then(() => {
+      expect(state.length).to.eq(1)
+      expect(state[0].name).to.eq('Added Model')
+    })
+  })
+
+  it('deletes a model', () => {
+    const state: AiModel[] = [sampleModel]
+    mount(
+      <AiModelList
+        aiModels={state}
+        columnsToShow={['name']}
+        onAiModelsChange={(m) => { state.splice(0, state.length, ...m) }}
+        disabled={false}
+      />,
+    )
+    cy.contains('Baseline Model').should('exist')
+    cy.window().then((win) => {
+      cy.stub(win, 'confirm').returns(true)
+    })
+    cy.get('.glyphicon-trash').click({ force: true })
+    cy.wrap(null).then(() => {
+      expect(state.length).to.eq(0)
+    })
+  })
+})

--- a/src/components/ai_models_list/AiModelAddEdit.tsx
+++ b/src/components/ai_models_list/AiModelAddEdit.tsx
@@ -1,0 +1,206 @@
+import React, { useState } from 'react'
+import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
+import { ValidationError } from 'src/pages/dar_application/FormValidationState'
+import { validationFailed } from 'src/utils/darFormUtils'
+import { AiModel, Maintainer } from 'src/types/model'
+
+const defaultMaintainer: Maintainer = {
+  name: '',
+  email: '',
+}
+
+const defaultAiModel: AiModel = {
+  modelId: '',
+  studyId: '',
+  name: '',
+  description: '',
+  url: '',
+  format: '',
+  license: '',
+  trainedOnDatasets: [],
+  maintainer: defaultMaintainer,
+  tags: [],
+}
+
+interface FormFieldChange {
+  key: string
+  value: string
+}
+
+interface AiModelAddEditProps {
+  readonly id: number
+  readonly aiModel?: AiModel
+  readonly aiModels: AiModel[]
+  readonly closeAction: () => void
+  readonly onAiModelsChange: (models: AiModel[]) => void
+}
+
+interface Validation {
+  name?: ValidationError
+  url?: ValidationError
+  format?: ValidationError
+  license?: ValidationError
+  maintainerName?: ValidationError
+  maintainerEmail?: ValidationError
+}
+
+const makeError = (message: string): ValidationError => ({ valid: true, failed: [message] })
+
+const calcAiModelErrors = (model: AiModel): Validation => {
+  const v: Validation = {}
+  if (!model.name?.trim()) v.name = makeError('Required')
+  if (!model.url?.trim()) v.url = makeError('Required')
+  if (!model.format?.trim()) v.format = makeError('Required')
+  if (!model.license?.trim()) v.license = makeError('Required')
+  if (!model.maintainer?.name?.trim()) v.maintainerName = makeError('Required')
+  if (!model.maintainer?.email?.trim()) v.maintainerEmail = makeError('Required')
+  return v
+}
+
+export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.Element {
+  const { id, aiModel, aiModels, closeAction, onAiModelsChange } = props
+
+  const [newAiModel, setNewAiModel] = useState<AiModel>(aiModel || defaultAiModel)
+  const [validation, setValidation] = useState<Validation>({})
+
+  const onChange = ({ key, value }: FormFieldChange) => {
+    let updated: AiModel = { ...newAiModel }
+
+    if (key === 'trainedOnDatasets') {
+      updated.trainedOnDatasets = value.split(',').map((s: string) => s.trim()).filter(Boolean)
+    }
+    else if (key === 'tags') {
+      updated.tags = value.split(',').map((s: string) => s.trim()).filter(Boolean)
+    }
+    else if (key === 'maintainerName') {
+      updated.maintainer = { ...updated.maintainer, name: value }
+    }
+    else if (key === 'maintainerEmail') {
+      updated.maintainer = { ...updated.maintainer, email: value }
+    }
+    else {
+      // generic assignment
+      updated = { ...updated, [key]: value }
+    }
+
+    setNewAiModel(updated)
+    setValidation(calcAiModelErrors(updated))
+  }
+
+  const handleSave = () => {
+    if (id < 0) {
+      onAiModelsChange([...aiModels, newAiModel])
+    }
+    else {
+      const copy = [...aiModels]
+      copy[id] = newAiModel
+      onAiModelsChange(copy)
+    }
+    setNewAiModel(defaultAiModel)
+    closeAction()
+  }
+
+  return (
+    <div className="form-group row no-margin">
+      <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
+        <div className="row">
+          <h2>{aiModel === undefined ? 'New AI Model Information' : `Edit ${aiModel.name} Information`}</h2>
+
+          <FormField
+            id="name"
+            title="Model Name"
+            defaultValue={aiModel?.name}
+            placeholder="Name"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.name}
+          />
+          <FormField
+            id="description"
+            title="Description"
+            defaultValue={aiModel?.description}
+            placeholder="Description"
+            onChange={onChange}
+            type={FormFieldTypes.TEXTAREA}
+          />
+          <FormField
+            id="url"
+            title="Model URL"
+            defaultValue={aiModel?.url}
+            placeholder="URL"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.url}
+          />
+          <FormField
+            id="format"
+            title="Model Format"
+            defaultValue={aiModel?.format}
+            placeholder="Format (e.g. PyTorch, ONNX)"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.format}
+          />
+          <FormField
+            id="license"
+            title="License"
+            defaultValue={aiModel?.license}
+            placeholder="License (e.g. MIT)"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.license}
+          />
+          <FormField
+            id="trainedOnDatasets"
+            title="Trained On Datasets"
+            defaultValue={aiModel?.trainedOnDatasets?.join(', ')}
+            placeholder="Comma separated dataset identifiers"
+            onChange={onChange}
+          />
+          <FormField
+            id="maintainerName"
+            title="Maintainer Name"
+            defaultValue={aiModel?.maintainer?.name}
+            placeholder="Maintainer Name"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.maintainerName}
+          />
+          <FormField
+            id="maintainerEmail"
+            title="Maintainer Email"
+            defaultValue={aiModel?.maintainer?.email}
+            placeholder="Maintainer Email"
+            validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+            onChange={onChange}
+            validation={validation.maintainerEmail}
+          />
+          <FormField
+            id="tags"
+            title="Tags"
+            defaultValue={aiModel?.tags?.join(', ')}
+            placeholder="Comma separated tags"
+            onChange={onChange}
+          />
+        </div>
+        <div className="row" style={{ marginTop: 20 }}>
+          <button
+            className="collaborator-form-add-save-button f-left btn"
+            type="button"
+            onClick={handleSave}
+            disabled={validationFailed(calcAiModelErrors(newAiModel))}
+          >
+            {aiModel === undefined ? 'Add' : 'Save'}
+          </button>
+          <button
+            className="collaborator-form-cancel-button f-left btn"
+            type="button"
+            onClick={closeAction}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ai_models_list/AiModelAddEdit.tsx
+++ b/src/components/ai_models_list/AiModelAddEdit.tsx
@@ -49,7 +49,12 @@ const makeError = (message: string): ValidationError => ({ valid: true, failed: 
 const calcAiModelErrors = (model: AiModel): Validation => {
   const v: Validation = {}
   if (!model.name?.trim()) v.name = makeError('Required')
-  if (!model.url?.trim()) v.url = makeError('Required')
+  if (!model.url?.trim()) {
+    v.url = makeError('Required')
+  }
+  else if (!FormValidators.URL.isValid(model.url)) {
+    v.url = makeError('Invalid URL format')
+  }
   if (!model.format?.trim()) v.format = makeError('Required')
   if (!model.license?.trim()) v.license = makeError('Required')
   if (!model.maintainer?.name?.trim()) v.maintainerName = makeError('Required')
@@ -128,7 +133,7 @@ export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.El
             title="Model URL"
             defaultValue={aiModel?.url}
             placeholder="URL"
-            validators={[FormValidators.REQUIRED]}
+            validators={[FormValidators.REQUIRED, FormValidators.URL]}
             onChange={onChange}
             validation={validation.url}
           />

--- a/src/components/ai_models_list/AiModelList.tsx
+++ b/src/components/ai_models_list/AiModelList.tsx
@@ -78,7 +78,7 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
       <div className="form-group row no-margin">
         {aiModels.map((model: AiModel, index: number) => (
           <AiModelRow
-            key={index}
+            key={model.modelId}
             id={index}
             editMode={editState[index]}
             aiModel={model}

--- a/src/components/ai_models_list/AiModelList.tsx
+++ b/src/components/ai_models_list/AiModelList.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react'
+import AiModelAddEdit from 'src/components/ai_models_list/AiModelAddEdit'
+import AiModelRow from 'src/components/ai_models_list/AiModelRow'
+import { AiModel } from 'src/types/model'
+import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+
+interface AiModelListProps {
+  readonly aiModels: AiModel[]
+  readonly columnsToShow?: string[]
+  readonly onAiModelsChange: (models: AiModel[]) => void
+  readonly disabled?: boolean
+  readonly validation?: DarErrors
+}
+
+export default function AiModelList(props: AiModelListProps): React.JSX.Element {
+  const {
+    aiModels,
+    columnsToShow = [],
+    onAiModelsChange,
+    disabled = false,
+    validation,
+  } = props
+
+  const [showAddEdit, setShowAddEdit] = useState(false)
+  const [editState, setEditState] = useState<boolean[]>(aiModels.map(() => false))
+
+  useEffect(() => {
+    // Sync edit state length with aiModels length
+    if (editState.length !== aiModels.length) {
+      setEditState(aiModels.map(() => false))
+    }
+  }, [aiModels, editState.length])
+
+  const toggleEditState = (index: number) => {
+    setEditState((es) => {
+      const copy = [...es]
+      copy[index] = !copy[index]
+      return copy
+    })
+  }
+
+  const handleDeleteAiModel = (index: number) => {
+    const updated = aiModels.filter((_, i) => i !== index)
+    onAiModelsChange(updated)
+  }
+
+  const getValidationState = () => validation?.aiModels
+
+  return (
+    <div className="ai-model-list-component">
+      <div className="row no-margin">
+        <button
+          id="add-ai-model-btn"
+          type="button"
+          className="button button-white"
+          style={{
+            marginTop: 25,
+            marginBottom: 5,
+            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+            ...(disabled ? { cursor: 'not-allowed' } : {}),
+          }}
+          onClick={() => !disabled && setShowAddEdit(true)}
+          disabled={disabled}
+        >
+          Add AI Model
+        </button>
+        {showAddEdit && (
+          <AiModelAddEdit
+            id={-1}
+            aiModel={undefined}
+            aiModels={aiModels}
+            closeAction={() => setShowAddEdit(false)}
+            onAiModelsChange={onAiModelsChange}
+          />
+        )}
+      </div>
+      <div className="form-group row no-margin">
+        {aiModels.map((model: AiModel, index: number) => (
+          <AiModelRow
+            key={index}
+            id={index}
+            editMode={editState[index]}
+            aiModel={model}
+            aiModels={aiModels}
+            columnsToShow={columnsToShow}
+            editAction={() => toggleEditState(index)}
+            deleteAction={() => { handleDeleteAiModel(index) }}
+            closeAction={() => {
+              toggleEditState(index)
+              setShowAddEdit(false)
+            }}
+            onAiModelsChange={onAiModelsChange}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/ai_models_list/AiModelRow.tsx
+++ b/src/components/ai_models_list/AiModelRow.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import AiModelAddEdit from 'src/components/ai_models_list/AiModelAddEdit'
+import { AiModel } from 'src/types/model'
+import AiModelSummary from 'src/components/ai_models_list/AiModelSummary'
+
+interface AiModelRowProps {
+  readonly id: number
+  readonly editMode: boolean
+  aiModel: AiModel
+  readonly aiModels: AiModel[]
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly closeAction: () => void
+  readonly onAiModelsChange: (models: AiModel[]) => void
+  readonly disabled: boolean
+}
+
+export default function AiModelRow(props: AiModelRowProps): React.JSX.Element {
+  const {
+    id,
+    editMode,
+    aiModel,
+    aiModels,
+    columnsToShow,
+    editAction,
+    deleteAction,
+    closeAction,
+    onAiModelsChange,
+    disabled,
+  } = props
+
+  return (
+    <div>
+      {editMode && (
+        <AiModelAddEdit
+          id={id}
+          aiModel={aiModel}
+          aiModels={aiModels}
+          closeAction={closeAction}
+          onAiModelsChange={onAiModelsChange}
+        />
+      )}
+      {!editMode && (
+        <AiModelSummary
+          aiModel={aiModel}
+          columnsToShow={columnsToShow}
+          editAction={editAction}
+          deleteAction={deleteAction}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/ai_models_list/AiModelRow.tsx
+++ b/src/components/ai_models_list/AiModelRow.tsx
@@ -6,7 +6,7 @@ import AiModelSummary from 'src/components/ai_models_list/AiModelSummary'
 interface AiModelRowProps {
   readonly id: number
   readonly editMode: boolean
-  aiModel: AiModel
+  readonly aiModel: AiModel
   readonly aiModels: AiModel[]
   readonly columnsToShow: string[]
   readonly editAction: () => void

--- a/src/components/ai_models_list/AiModelSummary.tsx
+++ b/src/components/ai_models_list/AiModelSummary.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import { AiModel, Maintainer } from 'src/types/model'
+import { renderColumnContent } from 'src/utils/RenderUtils'
+
+interface AiModelSummaryProps {
+  aiModel: AiModel
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly disabled: boolean
+}
+
+export default function AiModelSummary(props: AiModelSummaryProps): React.JSX.Element {
+  const { aiModel, columnsToShow, editAction, deleteAction, disabled } = props
+
+  const disabledStyle = {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  }
+
+  const buttonStyle = disabled ? disabledStyle : {}
+
+  const customRenderers = {
+    maintainer: (value: unknown) => {
+      const maintainer = value as Maintainer
+      if (!maintainer || typeof maintainer !== 'object') return null
+      return (
+        <span>
+          {maintainer.name}
+          {maintainer.email ? ` (${maintainer.email})` : ''}
+        </span>
+      )
+    },
+    trainedOnDatasets: (value: unknown) => {
+      const arr = value as string[]
+      return Array.isArray(arr) ? arr.join(', ') : ''
+    },
+    tags: (value: unknown) => {
+      const arr = value as string[]
+      return Array.isArray(arr) ? arr.join(', ') : ''
+    },
+  }
+
+  return (
+    <div className="collaborator-summary-card">
+      {columnsToShow.map((column, index) => {
+        const raw = aiModel[column as keyof AiModel]
+        const content = renderColumnContent(column, raw, customRenderers)
+        return content && (
+          <div key={'ai_model_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
+            <span>{content}</span>
+          </div>
+        )
+      })}
+      <div className="collaborator-summary-edit-delete-buttons">
+        <a
+          style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
+          onClick={() => !disabled && editAction()}
+        >
+          <span
+            className="glyphicon glyphicon-pencil caret-margin collaborator-edit-icon"
+            aria-hidden="true"
+            data-tip="Edit AI model"
+            data-for="tip_edit_ai_model"
+          />
+          <span style={{ marginLeft: '1rem' }}></span>
+        </a>
+      </div>
+      <a
+        style={{ marginLeft: 10, ...buttonStyle }}
+        onClick={() => {
+          if (disabled) return
+          if (window.confirm(`Delete AI model "${aiModel.name}"?`)) {
+            deleteAction()
+          }
+        }}
+      >
+        <span
+          className="glyphicon glyphicon-trash presentation-delete-icon"
+          aria-hidden="true"
+          data-tip="Delete AI model"
+          data-for="tip_delete_ai_model"
+        />
+        <span style={{ marginLeft: '1rem' }}></span>
+      </a>
+    </div>
+  )
+}

--- a/src/components/ai_models_list/AiModelSummary.tsx
+++ b/src/components/ai_models_list/AiModelSummary.tsx
@@ -3,7 +3,7 @@ import { AiModel, Maintainer } from 'src/types/model'
 import { renderColumnContent } from 'src/utils/RenderUtils'
 
 interface AiModelSummaryProps {
-  aiModel: AiModel
+  readonly aiModel: AiModel
   readonly columnsToShow: string[]
   readonly editAction: () => void
   readonly deleteAction: () => void
@@ -53,9 +53,12 @@ export default function AiModelSummary(props: AiModelSummaryProps): React.JSX.El
         )
       })}
       <div className="collaborator-summary-edit-delete-buttons">
-        <a
+        <button
+          type="button"
           style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
           onClick={() => !disabled && editAction()}
+          disabled={disabled}
+          aria-label="Edit AI model"
         >
           <span
             className="glyphicon glyphicon-pencil caret-margin collaborator-edit-icon"
@@ -64,16 +67,19 @@ export default function AiModelSummary(props: AiModelSummaryProps): React.JSX.El
             data-for="tip_edit_ai_model"
           />
           <span style={{ marginLeft: '1rem' }}></span>
-        </a>
+        </button>
       </div>
-      <a
+      <button
+        type="button"
         style={{ marginLeft: 10, ...buttonStyle }}
         onClick={() => {
           if (disabled) return
-          if (window.confirm(`Delete AI model "${aiModel.name}"?`)) {
+          if (globalThis.confirm(`Delete AI model "${aiModel.name}"?`)) {
             deleteAction()
           }
         }}
+        disabled={disabled}
+        aria-label={`Delete AI model ${aiModel.name}`}
       >
         <span
           className="glyphicon glyphicon-trash presentation-delete-icon"
@@ -82,7 +88,7 @@ export default function AiModelSummary(props: AiModelSummaryProps): React.JSX.El
           data-for="tip_delete_ai_model"
         />
         <span style={{ marginLeft: '1rem' }}></span>
-      </a>
+      </button>
     </div>
   )
 }

--- a/src/pages/dar_application/FormValidationState.tsx
+++ b/src/pages/dar_application/FormValidationState.tsx
@@ -61,6 +61,7 @@ export interface DarErrors {
   closeoutProjectSuperseded?: ValidationError
   closeoutOther?: ValidationError
   closeoutOtherText?: ValidationError
+  aiModels?: ValidationError
 }
 
 export interface RusErrors {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2351

### Summary

Adds a React TypeScript component that renders input fields for AI Models based on the defined schema and interface. Includes field-level validation, business logic for input validation, and unit tests.

**Add**
<img width="1452" height="871" alt="Add" src="https://github.com/user-attachments/assets/a0c1402e-089a-4678-8181-77e751227b19" />

**Edit**
<img width="1452" height="871" alt="Edit" src="https://github.com/user-attachments/assets/2dcfd527-acd0-4d4e-909d-b51e7b0d1932" />

**List**
<img width="1480" height="158" alt="Listing" src="https://github.com/user-attachments/assets/02eb474b-1096-4868-a9a9-9b052d914512" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
