### PR TITLE
[DT-2354] Added Funding Resources Components

### DIFF
--- a/cypress/component/StudyAssets/funding_resource_list.spec.tsx
+++ b/cypress/component/StudyAssets/funding_resource_list.spec.tsx
@@ -11,6 +11,7 @@ const sampleFunding: FundingResource = {
   studyId: 's1',
   funderName: 'Funder A',
   funderProgram: 'Program Z',
+  grantNumber: 'GN12345',
   projectTitle: 'Project Alpha',
   startDate: '2024-01-01',
   endDate: '2024-12-31',

--- a/cypress/component/StudyAssets/funding_resource_list.spec.tsx
+++ b/cypress/component/StudyAssets/funding_resource_list.spec.tsx
@@ -1,0 +1,183 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import { FundingResource } from 'src/types/model'
+import { FundingResourceAddEdit } from 'src/components/funding_resource_list/FundingResourceAddEdit'
+import FundingResourceSummary from 'src/components/funding_resource_list/FundingResourceSummary'
+import FundingResourceRow from 'src/components/funding_resource_list/FundingResourceRow'
+import FundingResourceList from 'src/components/funding_resource_list/FundingResourceList'
+
+const sampleFunding: FundingResource = {
+  fundingId: 'f1',
+  studyId: 's1',
+  funderName: 'Funder A',
+  funderProgram: 'Program Z',
+  projectTitle: 'Project Alpha',
+  startDate: '2024-01-01',
+  endDate: '2024-12-31',
+  url: 'https://example.org',
+  tags: ['tag1', 'tag2'],
+}
+
+const FundingResourceListHarness: React.FC<{ initial: FundingResource[] }> = ({ initial }) => {
+  const [items, setItems] = React.useState<FundingResource[]>(initial)
+  return (
+    <FundingResourceList
+      fundingResources={items}
+      columnsToShow={['funderName']}
+      onFundingResourceChange={setItems}
+      disabled={false}
+    />
+  )
+}
+
+describe('FundingResourceAddEdit', () => {
+  it('disables Add until required fields filled then adds', () => {
+    const collected: FundingResource[] = []
+    mount(
+      <FundingResourceAddEdit
+        id={-1}
+        funding={undefined}
+        fundingResources={[]}
+        closeAction={cy.stub().as('close')}
+        onFundingChange={(items) => { collected.splice(0, collected.length, ...items) }}
+      />,
+    )
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+    cy.get('#funderName').type('New Funder')
+    cy.get('#projectTitle').type('New Project')
+    // funderProgram is marked required in validators, include it for consistency
+    cy.get('#funderProgram').type('New Program')
+    cy.get('.collaborator-form-add-save-button').should('not.be.disabled').click()
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].funderName).to.eq('New Funder')
+      expect(collected[0].projectTitle).to.eq('New Project')
+    })
+  })
+
+  it('edits existing funding resource and saves changes', () => {
+    const resources: FundingResource[] = [sampleFunding]
+    mount(
+      <FundingResourceAddEdit
+        id={0}
+        funding={sampleFunding}
+        fundingResources={resources}
+        closeAction={cy.stub().as('close')}
+        onFundingChange={(updated) => {
+          expect(updated[0].funderName).to.eq('Funder A Edited')
+        }}
+      />,
+    )
+    cy.get('#funderName').clear()
+    cy.get('#funderName').type('Funder A Edited')
+    cy.get('.collaborator-form-add-save-button').click()
+  })
+})
+
+describe('FundingResourceSummary', () => {
+  it('renders columns including arrays and url', () => {
+    mount(
+      <FundingResourceSummary
+        funding={sampleFunding}
+        columnsToShow={['funderName', 'funderProgram', 'projectTitle', 'url', 'tags']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Funder A').should('exist')
+    cy.contains('Program Z').should('exist')
+    cy.contains('Project Alpha').should('exist')
+    cy.contains('tag1, tag2').should('exist')
+    cy.get('a[href="https://example.org"]').should('exist')
+  })
+})
+
+describe('FundingResourceRow', () => {
+  it('shows summary when not in edit mode and triggers editAction', () => {
+    mount(
+      <FundingResourceRow
+        id={0}
+        editMode={false}
+        funding={sampleFunding}
+        fundingResources={[sampleFunding]}
+        columnsToShow={['funderName', 'projectTitle']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onFundingChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Funder A').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    mount(
+      <FundingResourceRow
+        id={0}
+        editMode={true}
+        funding={sampleFunding}
+        fundingResources={[sampleFunding]}
+        columnsToShow={['funderName']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onFundingChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('#funderName').should('have.value', 'Funder A')
+  })
+})
+
+describe('FundingResourceList', () => {
+  it('adds a new funding resource', () => {
+    const state: FundingResource[] = []
+    mount(
+      <FundingResourceList
+        fundingResources={state}
+        columnsToShow={['funderName', 'projectTitle']}
+        onFundingResourceChange={(items) => { state.splice(0, state.length, ...items) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-funding-btn').click()
+    cy.get('#funderName').type('Added Funder')
+    cy.get('#projectTitle').type('Added Project')
+    cy.get('#funderProgram').type('Added Program')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.wrap(null).then(() => {
+      expect(state.length).to.eq(1)
+      expect(state[0].funderName).to.eq('Added Funder')
+    })
+  })
+
+  it('deletes a funding resource via modal confirmation', () => {
+    mount(<FundingResourceListHarness initial={[sampleFunding]} />)
+
+    // Ensure the item exists first
+    cy.contains('Funder A').should('exist')
+
+    // Open the delete modal
+    cy.get('.glyphicon-trash').click({ force: true })
+
+    // Wait for Modal content to appear
+    cy.get('.ReactModal__Content')
+      .should('be.visible')
+      .within(() => {
+        // Click the visible Delete button inside the modal
+        cy.get('button')
+          .filter(':visible')
+          .contains(/delete/i)
+          .click({ force: true })
+      })
+
+    // Modal should close and the funding resource should be removed
+    cy.get('.ReactModal__Content').should('not.exist')
+    cy.contains('Funder A').should('not.exist')
+    cy.get('.collaborator-summary-card').should('have.length', 0)
+  })
+})

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -13,6 +13,7 @@ interface FundingSourceAddEditProps {
 interface Validation {
   funderName?: unknown
   funderProgram?: unknown
+  grantNumber?: unknown
   projectTitle?: unknown
   startDate?: unknown
   endDate?: unknown
@@ -24,6 +25,7 @@ const defaultFunding: FundingResource = {
   studyId: '',
   funderName: '',
   funderProgram: '',
+  grantNumber: '',
   projectTitle: '',
   startDate: '',
   endDate: '',
@@ -97,12 +99,21 @@ export const FundingResourceAddEdit: React.FC<FundingSourceAddEditProps> = ({
           />
           <FormField
             id="funderProgram"
-            title="Program"
+            title="Funder Program"
             defaultValue={funding?.funderProgram}
-            placeholder="Program"
+            placeholder="Funder Program"
             validators={[FormValidators.REQUIRED]}
             onChange={onChange}
             validation={validation.funderProgram}
+          />
+          <FormField
+            id="grantNumber"
+            title="Grant Number"
+            defaultValue={funding?.grantNumber}
+            placeholder="Grant Number"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.grantNumber}
           />
           <FormField
             id="projectTitle"

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -1,0 +1,185 @@
+import React, { useState } from 'react'
+import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
+import { FundingResource } from 'src/types/model'
+
+interface FundingSourceAddEditProps {
+  readonly id: number
+  readonly funding?: FundingResource
+  readonly fundingResources: FundingResource[]
+  readonly closeAction: () => void
+  readonly onFundingChange: (items: FundingResource[]) => void
+}
+
+interface Validation {
+  funderName?: unknown
+  funderProgram?: unknown
+  projectTitle?: unknown
+  startDate?: unknown
+  endDate?: unknown
+  url?: unknown
+}
+
+const defaultFunding: FundingResource = {
+  fundingId: '',
+  studyId: '',
+  funderName: '',
+  funderProgram: '',
+  projectTitle: '',
+  startDate: '',
+  endDate: '',
+  url: '',
+  tags: [],
+}
+
+const calcErrors = (f: FundingResource): Validation => {
+  const v: Validation = {}
+  if (!f.funderName?.trim()) v.funderName = { error: 'Required' }
+  if (!f.projectTitle?.trim()) v.projectTitle = { error: 'Required' }
+  return v
+}
+
+const validationFailed = (v: Validation) => Object.values(v).some(e => !!e)
+
+type FundingFieldValue = string | string[]
+
+interface FormFieldChange {
+  key: string
+  value: FundingFieldValue
+}
+
+export const FundingResourceAddEdit: React.FC<FundingSourceAddEditProps> = ({
+  id,
+  funding,
+  fundingResources,
+  closeAction,
+  onFundingChange,
+}) => {
+  const [current, setCurrent] = useState<FundingResource>(funding || defaultFunding)
+  const [validation, setValidation] = useState<Validation>({})
+
+  const onChange = ({ key, value }: FormFieldChange) => {
+    const next = { ...current, [key]: value } as FundingResource
+    setCurrent(next)
+    setValidation(calcErrors(next))
+  }
+
+  const save = () => {
+    if (validationFailed(calcErrors(current))) return
+    const toSave: FundingResource = {
+      ...current,
+      fundingId: current.fundingId || crypto.randomUUID?.() || Date.now().toString(),
+    }
+    if (id < 0) {
+      onFundingChange([...fundingResources, toSave])
+    }
+    else {
+      const copy = [...fundingResources]
+      copy[id] = toSave
+      onFundingChange(copy)
+    }
+    setCurrent(defaultFunding)
+    closeAction()
+  }
+
+  return (
+    <div className="form-group row no-margin">
+      <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
+        <div className="row">
+          <h2>{funding === undefined ? 'New Funding Resource' : `Edit ${funding.funderName || 'Funding Resource'}`}</h2>
+          <FormField
+            id="funderName"
+            title="Funder Name"
+            defaultValue={funding?.funderName}
+            placeholder="Funder"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.funderName}
+          />
+          <FormField
+            id="funderProgram"
+            title="Program"
+            defaultValue={funding?.funderProgram}
+            placeholder="Program"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.funderProgram}
+          />
+          <FormField
+            id="projectTitle"
+            title="Project Title"
+            defaultValue={funding?.projectTitle}
+            placeholder="Project Title"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.projectTitle}
+          />
+          <FormField
+            id="startDate"
+            title="Start Date"
+            defaultValue={funding?.startDate}
+            placeholder="YYYY-MM-DD"
+            validators={[FormValidators.DATE]}
+            onChange={onChange}
+            validation={validation.startDate}
+          />
+          <FormField
+            id="endDate"
+            title="End Date"
+            defaultValue={funding?.endDate}
+            placeholder="YYYY-MM-DD"
+            validators={[FormValidators.DATE]}
+            onChange={onChange}
+            validation={validation.endDate}
+          />
+          <FormField
+            id="url"
+            title="URL"
+            defaultValue={funding?.url}
+            placeholder="https://..."
+            validators={[FormValidators.URL]}
+            onChange={onChange}
+            validation={validation.url}
+          />
+          <FormField
+            id="tags"
+            title="Tags (comma separated)"
+            defaultValue={funding?.tags?.join(', ')}
+            placeholder="tag1, tag2"
+            onChange={({ value }: { value: string }) =>
+              onChange({
+                key: 'tags',
+                value: value
+                  .split(',')
+                  .map(t => t.trim())
+                  .filter(Boolean),
+              })}
+          />
+          <FormField
+            id="citation"
+            type={FormFieldTypes.TEXT}
+            style={{ display: 'none' }}
+            title=""
+            onChange={() => {}}
+          />
+        </div>
+        <div className="row" style={{ marginTop: 20 }}>
+          <button
+            className="collaborator-form-add-save-button f-left btn"
+            type="button"
+            onClick={save}
+            disabled={validationFailed(calcErrors(current))}
+          >
+            {funding === undefined ? 'Add' : 'Save'}
+          </button>
+          <button
+            className="collaborator-form-cancel-button f-left btn"
+            type="button"
+            onClick={closeAction}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/funding_resource_list/FundingResourceList.tsx
+++ b/src/components/funding_resource_list/FundingResourceList.tsx
@@ -15,7 +15,7 @@ interface FundingResourceListProps {
 export default function FundingResourceList(props: FundingResourceListProps): React.JSX.Element {
   const {
     fundingResources,
-    columnsToShow = ['funderName', 'funderProgram', 'projectTitle', 'startDate', 'endDate', 'url', 'tags'],
+    columnsToShow = ['funderName', 'funderProgram', 'grantNumber', 'projectTitle', 'startDate', 'endDate', 'url', 'tags'],
     onFundingResourceChange,
     disabled = false,
     validation,

--- a/src/components/funding_resource_list/FundingResourceList.tsx
+++ b/src/components/funding_resource_list/FundingResourceList.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { FundingResource } from 'src/types/model'
+import { FundingResourceAddEdit } from 'src/components/funding_resource_list/FundingResourceAddEdit'
+import FundingResourceRow from 'src/components/funding_resource_list/FundingResourceRow'
+import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+
+interface FundingResourceListProps {
+  readonly fundingResources: FundingResource[]
+  readonly columnsToShow?: string[]
+  readonly onFundingResourceChange: (items: FundingResource[]) => void
+  readonly disabled?: boolean
+  readonly validation?: DarErrors
+}
+
+export default function FundingResourceList(props: FundingResourceListProps): React.JSX.Element {
+  const {
+    fundingResources,
+    columnsToShow = ['funderName', 'funderProgram', 'projectTitle', 'startDate', 'endDate', 'url', 'tags'],
+    onFundingResourceChange,
+    disabled = false,
+    validation,
+  } = props
+
+  const [showAddEdit, setShowAddEdit] = useState(false)
+  const [editState, setEditState] = useState(fundingResources.map(() => false))
+
+  const toggleEditState = (index: number) => {
+    const editStateCopy = [...editState]
+    editStateCopy[index] = !editStateCopy[index]
+    setEditState(editStateCopy)
+  }
+
+  const handleDeleteFunding = (index: number) => {
+    const updated = fundingResources.filter((_, i) => i !== index)
+    onFundingResourceChange(updated)
+  }
+
+  const getValidationState = () => validation?.fundingResources
+
+  return (
+    <div className="presentation-list-component">
+      <div className="row no-margin">
+        <button
+          id="add-funding-btn"
+          type="button"
+          className="button button-white"
+          style={{
+            marginTop: 25,
+            marginBottom: 5,
+            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+            ...(disabled ? { cursor: 'not-allowed' } : {}),
+          }}
+          onClick={() => !disabled && setShowAddEdit(true)}
+          disabled={disabled}
+        >
+          Add Funding Resource
+        </button>
+        {showAddEdit && (
+          <FundingResourceAddEdit
+            id={-1}
+            fundingResources={fundingResources}
+            closeAction={() => setShowAddEdit(false)}
+            onFundingChange={onFundingResourceChange}
+          />
+        )}
+      </div>
+      <div className="form-group row no-margin">
+        {fundingResources.map((f: FundingResource, index: number) => (
+          <FundingResourceRow
+            key={f.fundingId || index}
+            id={index}
+            editMode={editState[index]}
+            funding={f}
+            fundingResources={fundingResources}
+            columnsToShow={columnsToShow}
+            editAction={() => toggleEditState(index)}
+            deleteAction={() => handleDeleteFunding(index)}
+            closeAction={() => {
+              toggleEditState(index)
+              setShowAddEdit(false)
+            }}
+            onFundingChange={onFundingResourceChange}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/funding_resource_list/FundingResourceRow.tsx
+++ b/src/components/funding_resource_list/FundingResourceRow.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { FundingResource } from 'src/types/model'
+import { FundingResourceAddEdit } from 'src/components/funding_resource_list/FundingResourceAddEdit'
+import { FundingResourceSummary } from 'src/components/funding_resource_list/FundingResourceSummary'
+
+interface fundingResourceRowProps {
+  readonly id: number
+  readonly editMode: boolean
+  funding: FundingResource
+  readonly fundingResources: FundingResource[]
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly closeAction: () => void
+  readonly onFundingChange: (items: FundingResource[]) => void
+  readonly disabled: boolean
+}
+
+export default function FundingResourceRow(props: fundingResourceRowProps): React.JSX.Element {
+  const {
+    id,
+    editMode,
+    funding,
+    fundingResources,
+    columnsToShow,
+    editAction,
+    deleteAction,
+    closeAction,
+    onFundingChange,
+    disabled,
+  } = props
+
+  return (
+    <div>
+      {editMode && (
+        <FundingResourceAddEdit
+          id={id}
+          funding={funding}
+          fundingResources={fundingResources}
+          closeAction={closeAction}
+          onFundingChange={onFundingChange}
+        />
+      )}
+      {!editMode && (
+        <FundingResourceSummary
+          funding={funding}
+          columnsToShow={columnsToShow}
+          editAction={editAction}
+          deleteAction={deleteAction}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/funding_resource_list/FundingResourceRow.tsx
+++ b/src/components/funding_resource_list/FundingResourceRow.tsx
@@ -3,10 +3,10 @@ import { FundingResource } from 'src/types/model'
 import { FundingResourceAddEdit } from 'src/components/funding_resource_list/FundingResourceAddEdit'
 import { FundingResourceSummary } from 'src/components/funding_resource_list/FundingResourceSummary'
 
-interface fundingResourceRowProps {
+interface FundingResourceRowProps {
   readonly id: number
   readonly editMode: boolean
-  funding: FundingResource
+  readonly funding: FundingResource
   readonly fundingResources: FundingResource[]
   readonly columnsToShow: string[]
   readonly editAction: () => void
@@ -16,7 +16,7 @@ interface fundingResourceRowProps {
   readonly disabled: boolean
 }
 
-export default function FundingResourceRow(props: fundingResourceRowProps): React.JSX.Element {
+export default function FundingResourceRow(props: FundingResourceRowProps): React.JSX.Element {
   const {
     id,
     editMode,

--- a/src/components/funding_resource_list/FundingResourceSummary.tsx
+++ b/src/components/funding_resource_list/FundingResourceSummary.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react'
+import { FundingResource } from 'src/types/model'
+import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
+import { renderColumnContent } from 'src/utils/RenderUtils'
+
+interface fundingResourceSummaryProps {
+  funding: FundingResource
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly disabled: boolean
+}
+
+export const FundingResourceSummary: React.FC<fundingResourceSummaryProps> = ({
+  funding,
+  columnsToShow,
+  editAction,
+  deleteAction,
+  disabled,
+}) => {
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  const disabledStyle = {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  }
+
+  const buttonStyle = disabled ? disabledStyle : {}
+
+  const customRenderers = {
+    url: (value: unknown) => {
+      if (typeof value === 'string' && value) {
+        return (
+          <a href={value} target="_blank" rel="noreferrer">
+            {value}
+          </a>
+        )
+      }
+      return '—'
+    },
+    tags: (value: unknown) => {
+      if (Array.isArray(value) && value.length > 0) {
+        return value.join(', ')
+      }
+      return '—'
+    },
+  }
+
+  return (
+    <div className="collaborator-summary-card">
+      {columnsToShow.map((column, index) => {
+        const rawValue = funding[column as keyof FundingResource]
+        const columnContent = renderColumnContent(column, rawValue as unknown, customRenderers)
+        return columnContent && (
+          <div key={'funding_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
+            <span>{columnContent}</span>
+          </div>
+        )
+      })}
+      <div className="collaborator-summary-edit-delete-buttons">
+        <a
+          style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
+          onClick={() => !disabled && editAction()}
+        >
+          <span
+            className="glyphicon glyphicon-pencil caret-margin collaborator-edit-icon"
+            aria-hidden="true"
+            data-tip="Edit funding resource"
+            data-for="tip_edit_funding"
+          />
+          <span style={{ marginLeft: '1rem' }} />
+        </a>
+      </div>
+      <a
+        style={{ marginLeft: 10, ...buttonStyle }}
+        onClick={() => !disabled && setShowDeleteModal(true)}
+      >
+        <span
+          className="glyphicon glyphicon-trash presentation-delete-icon"
+          aria-hidden="true"
+          data-tip="Delete funding resource"
+          data-for="tip_delete_funding"
+        />
+        <span style={{ marginLeft: '1rem' }} />
+      </a>
+      <DeletePresentationOrPublication
+        name={funding.funderName || funding.projectTitle}
+        objectName="funding resource"
+        showDelete={showDeleteModal}
+        confirmAction={() => {
+          deleteAction()
+          setShowDeleteModal(false)
+        }}
+        closeAction={() => setShowDeleteModal(false)}
+      />
+    </div>
+  )
+}
+
+export default FundingResourceSummary

--- a/src/components/funding_resource_list/FundingResourceSummary.tsx
+++ b/src/components/funding_resource_list/FundingResourceSummary.tsx
@@ -3,21 +3,6 @@ import { FundingResource } from 'src/types/model'
 import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
 import { renderColumnContent } from 'src/utils/RenderUtils'
 
-interface FundingResourceUrlProps {
-  readonly url: string | undefined
-}
-
-const FundingResourceUrl: React.FC<FundingResourceUrlProps> = ({ url }) => {
-  if (typeof url === 'string' && url) {
-    return (
-      <a href={url} target="_blank" rel="noreferrer">
-        {url}
-      </a>
-    )
-  }
-  return <>—</>
-}
-
 interface FundingResourceSummaryProps {
   readonly funding: FundingResource
   readonly columnsToShow: string[]
@@ -43,7 +28,16 @@ export const FundingResourceSummary: React.FC<FundingResourceSummaryProps> = ({
   const buttonStyle = disabled ? disabledStyle : {}
 
   const customRenderers = {
-    url: (value: unknown) => <FundingResourceUrl url={value as string | undefined} />,
+    url: (value: unknown) => {
+      if (typeof value === 'string' && value) {
+        return (
+          <a href={value} target="_blank" rel="noreferrer">
+            {value}
+          </a>
+        )
+      }
+      return '—'
+    },
     tags: (value: unknown) => {
       if (Array.isArray(value) && value.length > 0) {
         return value.join(', ')

--- a/src/components/funding_resource_list/FundingResourceSummary.tsx
+++ b/src/components/funding_resource_list/FundingResourceSummary.tsx
@@ -3,6 +3,21 @@ import { FundingResource } from 'src/types/model'
 import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
 import { renderColumnContent } from 'src/utils/RenderUtils'
 
+interface FundingResourceUrlProps {
+  readonly url: string | undefined
+}
+
+const FundingResourceUrl: React.FC<FundingResourceUrlProps> = ({ url }) => {
+  if (typeof url === 'string' && url) {
+    return (
+      <a href={url} target="_blank" rel="noreferrer">
+        {url}
+      </a>
+    )
+  }
+  return <>—</>
+}
+
 interface FundingResourceSummaryProps {
   readonly funding: FundingResource
   readonly columnsToShow: string[]
@@ -28,16 +43,7 @@ export const FundingResourceSummary: React.FC<FundingResourceSummaryProps> = ({
   const buttonStyle = disabled ? disabledStyle : {}
 
   const customRenderers = {
-    url: (value: unknown) => {
-      if (typeof value === 'string' && value) {
-        return (
-          <a href={value} target="_blank" rel="noreferrer">
-            {value}
-          </a>
-        )
-      }
-      return '—'
-    },
+    url: (value: unknown) => <FundingResourceUrl url={value as string | undefined} />,
     tags: (value: unknown) => {
       if (Array.isArray(value) && value.length > 0) {
         return value.join(', ')

--- a/src/components/funding_resource_list/FundingResourceSummary.tsx
+++ b/src/components/funding_resource_list/FundingResourceSummary.tsx
@@ -3,15 +3,15 @@ import { FundingResource } from 'src/types/model'
 import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
 import { renderColumnContent } from 'src/utils/RenderUtils'
 
-interface fundingResourceSummaryProps {
-  funding: FundingResource
+interface FundingResourceSummaryProps {
+  readonly funding: FundingResource
   readonly columnsToShow: string[]
   readonly editAction: () => void
   readonly deleteAction: () => void
   readonly disabled: boolean
 }
 
-export const FundingResourceSummary: React.FC<fundingResourceSummaryProps> = ({
+export const FundingResourceSummary: React.FC<FundingResourceSummaryProps> = ({
   funding,
   columnsToShow,
   editAction,
@@ -58,9 +58,12 @@ export const FundingResourceSummary: React.FC<fundingResourceSummaryProps> = ({
         )
       })}
       <div className="collaborator-summary-edit-delete-buttons">
-        <a
+        <button
+          type="button"
           style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
           onClick={() => !disabled && editAction()}
+          disabled={disabled}
+          aria-label="Edit funding resource"
         >
           <span
             className="glyphicon glyphicon-pencil caret-margin collaborator-edit-icon"
@@ -69,11 +72,14 @@ export const FundingResourceSummary: React.FC<fundingResourceSummaryProps> = ({
             data-for="tip_edit_funding"
           />
           <span style={{ marginLeft: '1rem' }} />
-        </a>
+        </button>
       </div>
-      <a
+      <button
+        type="button"
         style={{ marginLeft: 10, ...buttonStyle }}
         onClick={() => !disabled && setShowDeleteModal(true)}
+        disabled={disabled}
+        aria-label="Delete funding resource"
       >
         <span
           className="glyphicon glyphicon-trash presentation-delete-icon"
@@ -82,7 +88,7 @@ export const FundingResourceSummary: React.FC<fundingResourceSummaryProps> = ({
           data-for="tip_delete_funding"
         />
         <span style={{ marginLeft: '1rem' }} />
-      </a>
+      </button>
       <DeletePresentationOrPublication
         name={funding.funderName || funding.projectTitle}
         objectName="funding resource"

--- a/src/pages/dar_application/FormValidationState.tsx
+++ b/src/pages/dar_application/FormValidationState.tsx
@@ -61,6 +61,7 @@ export interface DarErrors {
   closeoutProjectSuperseded?: ValidationError
   closeoutOther?: ValidationError
   closeoutOtherText?: ValidationError
+  fundingResources?: ValidationError
 }
 
 export interface RusErrors {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -392,6 +392,7 @@ export interface FundingResource {
   studyId: string
   funderName: string
   funderProgram: string
+  grantNumber: string
   projectTitle: string
   startDate: string
   endDate: string


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2354

### Summary

This PR adds a React TypeScript component for the Funding Resources form. The component renders all required user input fields based on the defined schema, including field-level validation and business logic.

**Add**
<img width="1409" height="865" alt="Add" src="https://github.com/user-attachments/assets/36577bdb-6e98-4696-af66-465eaca8afc2" />

**Edit**
<img width="1409" height="865" alt="Edit" src="https://github.com/user-attachments/assets/de4c1154-6453-4294-b25d-557481d0f762" />

**List**
<img width="1409" height="118" alt="List" src="https://github.com/user-attachments/assets/f402d18c-17d4-47a2-a6d4-9e7a8aa63577" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
