### PR TITLE
[DT-2250] Consolidate sort date update date

### DIFF
--- a/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
+++ b/cypress/component/DarCollectionReview/dar_collection_review.spec.jsx
@@ -264,7 +264,6 @@ const dar = {
         ],
         darCode: 'DAR-XXX',
         createDate: 1667971415440,
-        sortDate: 1667971415440,
         datasetIds: [
           13,
         ],
@@ -292,7 +291,6 @@ const dar = {
       draft: false,
       userId: 7,
       createDate: 1667970929000,
-      sortDate: 1669229413840,
       submissionDate: 1669229413840,
       updateDate: 1669229413840,
       elections: {

--- a/cypress/component/DarCollectionTable/darCollection.json
+++ b/cypress/component/DarCollectionTable/darCollection.json
@@ -205,7 +205,6 @@
         "hmb": true,
         "darCode": "DAR-672",
         "createDate": 1730825497654,
-        "sortDate": 1730825497654,
         "datasetIds": [
           2352
         ],
@@ -280,7 +279,6 @@
       "draft": false,
       "userId": 3351,
       "createDate": 1730825175328,
-      "sortDate": 1730825497654,
       "submissionDate": 1730825497654,
       "updateDate": 1730825497654,
       "elections": {

--- a/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
+++ b/cypress/component/MultiDatasetVoteTab/multi_dataset_vote_slab.spec.jsx
@@ -85,7 +85,6 @@ const collection = {
       expiresAt: 1782319085180,
       userId: 3351,
       createDate: 1750783027276,
-      sortDate: 1750783085180,
       submissionDate: 1750783085180,
       updateDate: 1750783085180,
       datasetIds: [
@@ -118,7 +117,6 @@ const collection = {
       expiresAt: 1782323548285,
       userId: 3351,
       createDate: 1750787548285,
-      sortDate: 1750787548285,
       submissionDate: 1750787548285,
       updateDate: 1750787548285,
       datasetIds: [
@@ -158,7 +156,6 @@ const collection = {
       expiresAt: 1784753184281,
       userId: 3351,
       createDate: 1753217184281,
-      sortDate: 1753217184281,
       submissionDate: 1753217184281,
       updateDate: 1753217184281,
       datasetIds: [

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -184,7 +184,6 @@ describe('ProgressReportApplication - Component Tests', () => {
     collectionId: 1,
     elections: {},
     createDate: 1748736000,
-    sortDate: 1748736000,
     submissionDate: 1748736000,
     updateDate: 1748736000,
   }

--- a/cypress/component/VoteHistoryTable/voting_history.spec.tsx
+++ b/cypress/component/VoteHistoryTable/voting_history.spec.tsx
@@ -83,7 +83,6 @@ const darCollection: DarCollection = {
       draft: false,
       userId: 7,
       createDate: 1667970929000,
-      sortDate: 1669229413840,
       submissionDate: 1669229413840,
       updateDate: 1669229413840,
       datasetIds: [13, 14],

--- a/cypress/component/utils/bucket_utils.spec.ts
+++ b/cypress/component/utils/bucket_utils.spec.ts
@@ -127,7 +127,6 @@ const dar_collection = {
       eraCommonsId: 'test-era-commons-id',
       expiresAt: time,
       createDate: time,
-      sortDate: time,
       submissionDate: time,
       updateDate: time,
       elections: {
@@ -1007,7 +1006,6 @@ describe('BucketUtils', () => {
           eraCommonsId: 'test-era-commons-id',
           expiresAt: time,
           createDate: time,
-          sortDate: time,
           submissionDate: time,
           updateDate: time,
           elections: {

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -46,8 +46,9 @@ export const DAR = {
 
   // v2, v3 DAR Creation
   postDar: async (dar) => {
-    await Metrics.captureEvent(eventList.dar, { action: 'submit' })
-    const filteredDar = omit(['createDate', 'sortDate', 'data_access_request_id'])(dar)
+    // noinspection ES6MissingAwait
+    Metrics.captureEvent(eventList.dar, { action: 'submit' })
+    const filteredDar = omit(['createDate', 'data_access_request_id'])(dar)
     const url = DAAUtils.isEnabled()
       ? `${await getApiUrl()}/api/dar/v3`
       : `${await getApiUrl()}/api/dar/v2`

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -571,7 +571,6 @@ export interface DataAccessRequest {
   expiresAt: number
   userId: number
   createDate: number
-  sortDate: number
   submissionDate: number
   updateDate: number
   datasetIds: number[]


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2250
### Summary
Remove the redundant `sortDate` field from DataAccessRequest. It was duplicating the functionality of `updateDate` and has no UI usage.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
