### PR TITLE
[DT-2361] Updated Presentation Components with New Fields

### DIFF
--- a/cypress/component/StudyAssets/presentation_list.spec.tsx
+++ b/cypress/component/StudyAssets/presentation_list.spec.tsx
@@ -1,0 +1,180 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import PresentationList from 'src/components/presentations_list/PresentationList'
+import PresentationAddEdit from 'src/components/presentations_list/PresentationAddEdit'
+import PresentationRow from 'src/components/presentations_list/PresentationRow'
+import PresentationSummary from 'src/components/presentations_list/PresentationSummary'
+import { Presentation } from 'src/types/model'
+
+const samplePresentation: Presentation = {
+  presentationId: 'p1',
+  studyId: 's1',
+  title: 'Sample Talk',
+  date: '2024-06-01',
+  url: 'https://example.org/presentation',
+  authors: 'Author A; Author B',
+  datasetCitation: 'Dataset X',
+  citation: true,
+  presenter: { name: 'Dr. Presenter', email: 'presenter@example.org' },
+  event: 'Conference 2024',
+  location: 'City',
+  format: 'Oral',
+  access: 'Open',
+  tags: ['tagA', 'tagB'],
+}
+
+const PresentationListHarness: React.FC<{ initial: Presentation[] }> = ({ initial }) => {
+  const [items, setItems] = React.useState<Presentation[]>(initial)
+  return (
+    <PresentationList
+      presentations={items}
+      columnsToShow={['title', 'date', 'url', 'presenter', 'event']}
+      onPresentationChange={setItems}
+      disabled={false}
+    />
+  )
+}
+
+describe('PresentationList component', () => {
+  it('renders existing presentations', () => {
+    mount(<PresentationListHarness initial={[samplePresentation]} />)
+    cy.contains('Sample Talk').should('exist')
+    cy.contains('Conference 2024').should('exist')
+  })
+
+  it('opens add form and enforces validation disabling save then adds', () => {
+    const collected: Presentation[] = []
+    mount(
+      <PresentationAddEdit
+        id={-1}
+        presentations={[]}
+        closeAction={cy.stub().as('close')}
+        onPresentationChange={(items) => { collected.splice(0, collected.length, ...items) }}
+      />,
+    )
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+    cy.get('#title').type('New Title')
+    cy.get('#date').type('2024-07-15')
+    cy.get('#url').type('https://example.org/new')
+    cy.get('#authors').type('Author One; Author Two')
+    cy.get('#datasetCitation').type('Dataset Y')
+    // citation yes/no radio group (pick first option)
+    cy.get('input[type="radio"]').first().check({ force: true })
+    cy.get('#presenterName').type('Presenter X')
+    cy.get('#presenterEmail').type('presenterx@example.org')
+    cy.get('#event').type('Event 2024')
+    cy.get('#location').type('Location Z')
+    cy.get('#format').type('Poster')
+    cy.get('#access').type('Public')
+    cy.get('.collaborator-form-add-save-button').should('not.be.disabled').click()
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].title).to.eq('New Title')
+    })
+  })
+
+  it('adds a presentation through list harness', () => {
+    const state: Presentation[] = []
+    mount(<PresentationListHarness initial={state} />)
+    cy.get('#add-presentation-btn').click()
+    cy.contains('New Presentation').should('exist')
+    cy.get('#title').type('Added Talk')
+    cy.get('#date').type('2024-08-20')
+    cy.get('#url').type('https://example.org/added')
+    cy.get('#authors').type('Auth A')
+    cy.get('#datasetCitation').type('Dataset Added')
+    cy.get('input[type="radio"]').first().check({ force: true })
+    cy.get('#presenterName').type('Added Presenter')
+    cy.get('#presenterEmail').type('added.presenter@example.org')
+    cy.get('#event').type('Added Event')
+    cy.get('#location').type('Added City')
+    cy.get('#format').type('Poster')
+    cy.get('#access').type('Open')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.contains('Added Talk').should('exist')
+  })
+
+  it('edits a presentation', () => {
+    mount(<PresentationListHarness initial={[samplePresentation]} />)
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('#title').clear()
+    cy.get('#title').type('Sample Talk Edited')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.contains('Sample Talk Edited').should('exist')
+  })
+
+  it('deletes a presentation via modal confirmation', () => {
+    mount(<PresentationListHarness initial={[samplePresentation]} />)
+    cy.contains('Sample Talk').should('exist')
+    cy.get('.glyphicon-trash').click({ force: true })
+    cy.get('.ReactModal__Content')
+      .should('be.visible')
+      .within(() => {
+        cy.get('button')
+          .filter(':visible')
+          .contains(/delete/i)
+          .click({ force: true })
+      })
+    cy.get('.ReactModal__Content').should('not.exist')
+    cy.contains('Sample Talk').should('not.exist')
+    cy.get('.collaborator-summary-card').should('have.length', 0)
+  })
+})
+
+describe('PresentationSummary', () => {
+  it('renders columns including presenter composite', () => {
+    mount(
+      <PresentationSummary
+        presentation={samplePresentation}
+        columnsToShow={['title', 'event', 'presenter', 'url', 'tags']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Sample Talk').should('exist')
+    cy.contains('Conference 2024').should('exist')
+    cy.contains('Dr. Presenter').should('exist')
+    cy.get('a[href="https://example.org/presentation"]').should('exist')
+  })
+})
+
+describe('PresentationRow', () => {
+  it('shows summary when not in edit mode and triggers editAction', () => {
+    mount(
+      <PresentationRow
+        id={0}
+        editMode={false}
+        presentation={samplePresentation}
+        presentations={[samplePresentation]}
+        columnsToShow={['title', 'event']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onPresentationChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Sample Talk').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    mount(
+      <PresentationRow
+        id={0}
+        editMode={true}
+        presentation={samplePresentation}
+        presentations={[samplePresentation]}
+        columnsToShow={['title']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onPresentationChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('#title').should('have.value', 'Sample Talk')
+  })
+})

--- a/src/components/presentations_list/PresentationAddEdit.tsx
+++ b/src/components/presentations_list/PresentationAddEdit.tsx
@@ -7,10 +7,18 @@ import { Presentation } from 'src/types/model'
 const defaultPresentation: Presentation = {
   title: '',
   date: '',
+  url: '',
   authors: '',
   datasetCitation: '',
   citation: false,
-  link: '',
+  presentationId: '',
+  studyId: '',
+  presenter: { name: '', email: '' },
+  event: '',
+  location: '',
+  format: '',
+  access: '',
+  tags: [],
 }
 
 interface FormFieldChange {
@@ -29,27 +37,65 @@ interface PresentationAddEditProps {
 interface Validation {
   title?: ValidationError
   date?: ValidationError
+  url?: ValidationError
   authors?: ValidationError
-  bibliographicCitation?: ValidationError
-  link?: ValidationError
+  datasetCitation?: ValidationError
+  citation?: ValidationError
+  presenter: { name?: ValidationError, email?: ValidationError }
+  event?: ValidationError
+  location?: ValidationError
+  format?: ValidationError
+  access?: ValidationError
 }
+
 export default function PresentationAddEdit(props: PresentationAddEditProps): React.JSX.Element {
   const { id, presentation, presentations, closeAction, onPresentationChange } = props
 
   const [newPresentation, setNewPresentation] = useState<Presentation>(presentation || defaultPresentation)
-  const [validation, setValidation] = useState<Validation>({})
+  const [validation, setValidation] = useState<Validation>(() => ({
+    presenter: {},
+  }))
+
+  const applyValidation = (p: Presentation) => setValidation(calcPresentationErrors(p) as Validation)
 
   const onChange = ({ key, value }: FormFieldChange) => {
-    const presentationToSet: Presentation = { ...newPresentation, [key]: value }
-    setNewPresentation(presentationToSet)
-    setValidation(calcPresentationErrors(presentationToSet))
+    let next: Presentation
+    if (key === 'presenterName') {
+      next = { ...newPresentation, presenter: { ...newPresentation.presenter, name: value } }
+    }
+    else if (key === 'presenterEmail') {
+      next = { ...newPresentation, presenter: { ...newPresentation.presenter, email: value } }
+    }
+    else if (key === 'tags') {
+      next = { ...newPresentation, tags: value.split(',').map(t => t.trim()).filter(Boolean) }
+    }
+    else {
+      next = { ...newPresentation, [key]: value }
+    }
+    setNewPresentation(next)
+    applyValidation(next)
+  }
+
+  const save = () => {
+    const current = { ...newPresentation, presentationId: newPresentation.presentationId || crypto.randomUUID?.() || Date.now().toString() }
+    if (validationFailed(calcPresentationErrors(current))) return
+    if (id < 0) {
+      onPresentationChange([...presentations, current])
+    }
+    else {
+      const copy = [...presentations]
+      copy[id] = current
+      onPresentationChange(copy)
+    }
+    setNewPresentation(defaultPresentation)
+    closeAction()
   }
 
   return (
     <div className="form-group row no-margin">
       <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
         <div className="row">
-          <h2>{presentation === undefined ? `New Presentation Information` : `Edit ${presentation.title} Information`}</h2>
+          <h2>{presentation === undefined ? 'New Presentation' : `Edit ${presentation.title}`}</h2>
           <FormField
             id="title"
             title="Presentation Title"
@@ -63,14 +109,23 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             id="date"
             title="Presentation Date"
             defaultValue={presentation?.date}
-            placeholder="Date"
+            placeholder="YYYY-MM-DD"
             validators={[FormValidators.REQUIRED, FormValidators.DATE]}
             onChange={onChange}
             validation={validation.date}
           />
           <FormField
+            id="url"
+            title="Presentation URL"
+            defaultValue={presentation?.url}
+            placeholder="https://..."
+            validators={[FormValidators.REQUIRED, FormValidators.URL]}
+            onChange={onChange}
+            validation={validation.url}
+          />
+          <FormField
             id="authors"
-            title="Presentation Authors"
+            title="Authors"
             defaultValue={presentation?.authors}
             placeholder="Authors"
             validators={[FormValidators.REQUIRED]}
@@ -78,20 +133,13 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             validation={validation.authors}
           />
           <FormField
-            id="link"
-            title="Presentation Link"
-            defaultValue={presentation?.link}
-            placeholder="Link"
-            validators={[FormValidators.REQUIRED]}
-            onChange={onChange}
-            validation={validation.link}
-          />
-          <FormField
             id="datasetCitation"
-            title="Dataset citation used in this presentation"
+            title="Dataset Citation"
             defaultValue={presentation?.datasetCitation}
             placeholder="Dataset Citation"
+            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
+            validation={validation.datasetCitation}
           />
           <FormField
             id="citation"
@@ -100,31 +148,86 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Did you cite the dataset(s) used in this presentation?"
             orientation="horizontal"
             onChange={onChange}
+            validation={validation.citation}
+          />
+          <FormField
+            id="presenterName"
+            title="Presenter Name"
+            defaultValue={presentation?.presenter?.name}
+            placeholder="Name"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.presenter?.name}
+          />
+          <FormField
+            id="presenterEmail"
+            title="Presenter Email"
+            defaultValue={presentation?.presenter?.email}
+            placeholder="email@example.org"
+            validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+            onChange={onChange}
+            validation={validation.presenter?.email}
+          />
+          <FormField
+            id="event"
+            title="Event"
+            defaultValue={presentation?.event}
+            placeholder="Event"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.event}
+          />
+          <FormField
+            id="location"
+            title="Location"
+            defaultValue={presentation?.location}
+            placeholder="Location"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.location}
+          />
+          <FormField
+            id="format"
+            title="Format"
+            defaultValue={presentation?.format}
+            placeholder="Format"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.format}
+          />
+          <FormField
+            id="access"
+            title="Access"
+            defaultValue={presentation?.access}
+            placeholder="Access"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.access}
+          />
+          <FormField
+            id="tags"
+            title="Tags (comma separated)"
+            defaultValue={presentation?.tags?.join(', ')}
+            placeholder="tag1, tag2"
+            onChange={({ value }: { value: string }) => onChange({ key: 'tags', value })}
+          />
+          <FormField
+            id="hidden"
+            type={FormFieldTypes.TEXT}
+            style={{ display: 'none' }}
+            title=""
+            onChange={() => {}}
           />
         </div>
         <div className="row" style={{ marginTop: 20 }}>
-          {/* add/save button */}
           <button
             className="collaborator-form-add-save-button f-left btn"
             type="button"
-            onClick={() => {
-              if (id < 0 && newPresentation !== undefined) {
-                onPresentationChange([...presentations, newPresentation])
-                setNewPresentation(defaultPresentation)
-              }
-              else if (newPresentation !== undefined) {
-                const presentationsCopy = [...presentations]
-                presentationsCopy[id] = newPresentation
-                onPresentationChange(presentationsCopy)
-                setNewPresentation(defaultPresentation)
-              }
-              closeAction()
-            }}
+            onClick={save}
             disabled={validationFailed(calcPresentationErrors(newPresentation))}
           >
             {presentation === undefined ? 'Add' : 'Save'}
           </button>
-          {/* cancel button */}
           <button
             className="collaborator-form-cancel-button f-left btn"
             type="button"

--- a/src/components/presentations_list/PresentationSummary.tsx
+++ b/src/components/presentations_list/PresentationSummary.tsx
@@ -34,6 +34,15 @@ export default function PresentationSummary(props: PresentationSummaryProps): Re
         </span>
       )
     },
+    url: (value: unknown) => {
+      const href = typeof value === 'string' ? value : ''
+      if (!href) return null
+      return (
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          {href}
+        </a>
+      )
+    },
   }
 
   return (

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -679,19 +679,17 @@ export interface Closeout {
 export interface Presentation {
   title: string
   date: string
-  // ToDO: Make existing Progress Report fields required in DT-2361
-  link?: string // ToDo: Remove in DT-2361 to be replaced by url
-  authors?: string
-  datasetCitation?: string
-  citation?: boolean
-  // ToDo: Make new study fields required in DT-2361 except for tags
-  presentationId?: string
-  studyId?: string
-  presenter?: Presenter
-  event?: string
-  location?: string
-  format?: string
-  access?: string
+  url: string
+  authors: string
+  datasetCitation: string
+  citation: boolean
+  presentationId: string
+  studyId: string
+  presenter: Presenter
+  event: string
+  location: string
+  format: string
+  access: string
   tags?: string[]
 }
 

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -88,16 +88,24 @@ export function getPublicationList(formState: FormState): Publication[] {
 
 export function getPresentationList(formState: FormState): Presentation[] {
   const presentations: Presentation[] = formState.presentations ?? []
-  return presentations.map((presentation: Presentation) => {
-    const expectedPresentation: Presentation = {} as Presentation
-    expectedPresentation.title = presentation.title
-    expectedPresentation.date = presentation.date
-    expectedPresentation.authors = presentation.authors
-    expectedPresentation.datasetCitation = presentation.datasetCitation
-    expectedPresentation.citation = presentation.citation
-    expectedPresentation.link = presentation.link
-    return expectedPresentation
-  })
+  return presentations.map((p: Presentation): Presentation => ({
+    title: p.title,
+    date: p.date,
+    url: p.url,
+    authors: p.authors,
+    datasetCitation: p.datasetCitation,
+    citation: p.citation,
+    presentationId: p.presentationId,
+    studyId: p.studyId,
+    presenter: p.presenter
+      ? { name: p.presenter.name, email: p.presenter.email }
+      : { name: '', email: '' },
+    event: p.event,
+    location: p.location,
+    format: p.format,
+    access: p.access,
+    tags: p.tags ? [...p.tags] : [],
+  }))
 }
 
 export function getDataManagementIncidents(formState: FormState): DataManagementIncident {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -343,7 +343,7 @@ export const calcPresentationErrors = (newPresentation) => {
   if (isEmpty(newPresentation?.datasetCitation)) {
     validation.datasetCitation = requiredError
   }
-  if (typeof newPresentation?.citation === 'undefined' || newPresentation?.citation === null) {
+  if (newPresentation?.citation === undefined || newPresentation?.citation === null) {
     validation.citation = requiredError
   }
   if (isEmpty(newPresentation?.presenter?.name)) {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -327,7 +327,9 @@ export const calcPublicationErrors = (newPublication) => {
 }
 
 export const calcPresentationErrors = (newPresentation) => {
-  const validation = {}
+  const validation = {
+    presenter: {},
+  }
   if (isEmpty(newPresentation?.title)) {
     validation.title = requiredError
   }
@@ -335,8 +337,32 @@ export const calcPresentationErrors = (newPresentation) => {
   if (isEmpty(newPresentation?.authors)) {
     validation.authors = requiredError
   }
-  if (isEmpty(newPresentation?.link)) {
-    validation.link = requiredError
+  if (isEmpty(newPresentation?.url)) {
+    validation.url = requiredError
+  }
+  if (isEmpty(newPresentation?.datasetCitation)) {
+    validation.datasetCitation = requiredError
+  }
+  if (typeof newPresentation?.citation === 'undefined' || newPresentation?.citation === null) {
+    validation.citation = requiredError
+  }
+  if (isEmpty(newPresentation?.presenter?.name)) {
+    validation.presenter.name = requiredError
+  }
+  if (isEmpty(newPresentation?.presenter?.email)) {
+    validation.presenter.email = requiredError
+  }
+  if (isEmpty(newPresentation?.event)) {
+    validation.event = requiredError
+  }
+  if (isEmpty(newPresentation?.location)) {
+    validation.location = requiredError
+  }
+  if (isEmpty(newPresentation?.format)) {
+    validation.format = requiredError
+  }
+  if (isEmpty(newPresentation?.access)) {
+    validation.access = requiredError
   }
   return validation
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2361

### Summary

Refactors the existing Presentation forms with an updated model schema and TypeScript interface with field-level validation and updated data bindings.

**Add**
<img width="1495" height="1027" alt="Add" src="https://github.com/user-attachments/assets/162d39d3-ce92-4914-aaa0-b1880abbc490" />

**Edit**
<img width="1495" height="1027" alt="Edit" src="https://github.com/user-attachments/assets/ecc6cd1b-0944-4d4c-822f-3da2de8935c3" />

**List**
<img width="1482" height="94" alt="List" src="https://github.com/user-attachments/assets/d4e00acd-b32d-439c-a368-d39b47cc5f8d" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
