### PR TITLE
[DT-2358] Updated Publication Components with New Fields

### DIFF
--- a/cypress/component/ProgressReports/summary_section.spec.tsx
+++ b/cypress/component/ProgressReports/summary_section.spec.tsx
@@ -42,21 +42,41 @@ describe('Summary Section - Component Tests', () => {
   const initialPublications: Publication[] = [
     {
       title: 'Test Publication 1',
-      date: '2022-01-01',
-      bibliographicCitation: 'Citation 1',
-      citation: true,
       pubmedId: '12345',
-      authors: 'Author 1, Author 2',
+      publishedDate: '2022-01-01',
+      authors: [
+        { name: 'Author 1', orcId: '0000-0000-0000-0001' },
+        { name: 'Author 2', orcId: '0000-0000-0000-0002' },
+      ],
+      bibliographicCitation: 'Citation 1',
       datasetCitation: 'Dataset Citation 1',
+      citation: true,
+      publicationId: '',
+      studyId: '',
+      journal: 'Journal 1',
+      doi: '10.1000/xyz123',
+      url: 'https://example.org/pub1',
+      access: 'open',
+      tags: [],
     },
     {
       title: 'Test Publication 2',
-      date: '2022-02-01',
-      bibliographicCitation: 'Citation 2',
-      citation: true,
       pubmedId: '67890',
-      authors: 'Author 3, Author 4',
+      publishedDate: '2022-02-01',
+      authors: [
+        { name: 'Author 3', orcId: '0000-0000-0000-0003' },
+        { name: 'Author 4', orcId: '0000-0000-0000-0004' },
+      ],
+      bibliographicCitation: 'Citation 2',
       datasetCitation: 'Dataset Citation 2',
+      citation: true,
+      publicationId: '',
+      studyId: '',
+      journal: 'Journal 2',
+      doi: '10.1000/xyz456',
+      url: 'https://example.org/pub2',
+      access: 'open',
+      tags: [],
     },
   ]
 
@@ -179,17 +199,6 @@ describe('Summary Section - Component Tests', () => {
 
     cy.contains('Test Publication 1').should('be.visible')
     cy.contains('Test Publication 2').should('be.visible')
-    cy.contains('2022-01-01').should('be.visible')
-    cy.contains('2022-02-01').should('be.visible')
-  })
-
-  it('displays preloaded presentations', () => {
-    mountComponent({ presentationsYesNo: true, presentations: initialPublications })
-
-    cy.contains('Test Publication 1').should('be.visible')
-    cy.contains('Test Publication 2').should('be.visible')
-    cy.contains('2022-01-01').should('be.visible')
-    cy.contains('2022-02-01').should('be.visible')
   })
 
   it('shows era authenticated researcher commons id', () => {

--- a/cypress/component/StudyAssets/publication_list.spec.tsx
+++ b/cypress/component/StudyAssets/publication_list.spec.tsx
@@ -1,0 +1,209 @@
+// Adjusted tests for author validation and ORCID format error
+import React from 'react'
+import { mount } from 'cypress/react'
+import PublicationList from 'src/components/publications_list/PublicationList'
+import PublicationAddEdit from 'src/components/publications_list/PublicationAddEdit'
+import PublicationRow from 'src/components/publications_list/PublicationRow'
+import PublicationSummary from 'src/components/publications_list/PublicationSummary'
+import { Publication, Author } from 'src/types/model'
+
+const authorsSample: Author[] = [
+  { name: 'Author One', orcId: '0000-0000-0000-0001' },
+  { name: 'Author Two', orcId: '0000-0000-0000-0002' },
+]
+
+const samplePublication: Publication = {
+  title: 'Sample Publication',
+  pubmedId: '123456',
+  publishedDate: '2024-06-01',
+  authors: authorsSample,
+  bibliographicCitation: 'Sample Citation',
+  datasetCitation: 'Sample Dataset Citation',
+  citation: true,
+  publicationId: 'pub-1',
+  studyId: 'study-1',
+  journal: 'Journal Name',
+  doi: '10.1000/sample.doi',
+  url: 'https://example.org/pub',
+  access: 'Open',
+  tags: ['tag1', 'tag2'],
+}
+
+const PublicationListHarness: React.FC<{ initial: Publication[] }> = ({ initial }) => {
+  const [items, setItems] = React.useState<Publication[]>(initial)
+  return (
+    <PublicationList
+      publications={items}
+      columnsToShow={['title', 'publishedDate', 'journal', 'url', 'access']}
+      onPublicationChange={setItems}
+      disabled={false}
+    />
+  )
+}
+
+describe('PublicationList component', () => {
+  it('renders existing publications', () => {
+    mount(<PublicationListHarness initial={[samplePublication]} />)
+    cy.contains('Sample Publication').should('exist')
+    cy.contains('Journal Name').should('exist')
+  })
+
+  it('fills in and saves a new publication', () => {
+    const collected: Publication[] = []
+    mount(
+      <PublicationAddEdit
+        id={-1}
+        publications={[]}
+        closeAction={cy.stub().as('close')}
+        onPublicationChange={(items) => {
+          collected.splice(0, collected.length, ...items)
+        }}
+      />,
+    )
+
+    // Fill fields
+    cy.get('#title').type('New Pub')
+    cy.get('#publishedDate').type('2024-07-15')
+    cy.get('#pubmedId').type('99999')
+    cy.get('#bibliographicCitation').type('Bib Cit X')
+    cy.get('#datasetCitation').type('Dataset Cit X')
+    cy.get('#journal').type('Journal X')
+    cy.get('#doi').type('10.1000/xyz')
+    cy.get('#url').type('https://example.org/newpub')
+    cy.get('#access').type('Public')
+    cy.get('input[placeholder="Author Name"]').type('First Author')
+    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').type('0000-0000-0000-0003')
+
+    cy.contains('Add Author').should('not.be.disabled')
+    cy.contains('Save').click()
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].title).to.eq('New Pub')
+      expect(collected[0].authors).to.have.length(1)
+      expect(collected[0].authors[0].name).to.eq('First Author')
+    })
+  })
+
+  it('shows validation errors on empty form', () => {
+    mount(
+      <PublicationAddEdit
+        id={-1}
+        publications={[]}
+        closeAction={cy.stub()}
+        onPublicationChange={cy.stub()}
+      />,
+    )
+    cy.contains('Save').click()
+    // Verify some error indicators appear
+    cy.get('.error-message').should('have.length.greaterThan', 0)
+  })
+
+  it('disables Add Author until first row valid', () => {
+    mount(
+      <PublicationAddEdit
+        id={-1}
+        publications={[]}
+        closeAction={cy.stub()}
+        onPublicationChange={cy.stub()}
+      />,
+    )
+    cy.contains('Add Author').should('be.disabled')
+    cy.get('input[placeholder="Author Name"]').type('Temp Author')
+    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').type('BAD-ORCID')
+    cy.contains('Add Author').should('be.disabled')
+    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').clear()
+    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').type('0000-0000-0000-0004')
+    cy.contains('Add Author').should('not.be.disabled').click()
+    cy.get('input[placeholder="Author Name"]').should('have.length', 2)
+  })
+
+  it('shows per-author ORCID format error', () => {
+    mount(
+      <PublicationAddEdit
+        id={-1}
+        publications={[]}
+        closeAction={cy.stub()}
+        onPublicationChange={cy.stub()}
+      />,
+    )
+    cy.get('input[placeholder="Author Name"]').type('Author Bad Orcid')
+    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').type('1111-2222-3333-444') // invalid
+    cy.contains('Save').click()
+    // Avoid .within() on multiple elements; directly locate the error token
+    cy.get('.error-message').contains(/orcIdFormat@0/i).should('exist')
+  })
+})
+
+describe('PublicationSummary', () => {
+  it('renders columns including authors list', () => {
+    mount(
+      <PublicationSummary
+        publication={samplePublication}
+        columnsToShow={['title', 'journal', 'authors', 'url', 'tags']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Sample Publication').should('exist')
+    cy.contains('Journal Name').should('exist')
+    cy.contains('Author One').should('exist')
+    cy.get(`a[href="${samplePublication.url}"]`).should('exist')
+  })
+})
+
+describe('PublicationRow', () => {
+  it('shows summary when not in edit mode and triggers editAction', () => {
+    mount(
+      <PublicationRow
+        id={0}
+        editMode={false}
+        publication={samplePublication}
+        publications={[samplePublication]}
+        columnsToShow={['title', 'journal']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onPublicationChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Sample Publication').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    mount(
+      <PublicationRow
+        id={0}
+        editMode={true}
+        publication={samplePublication}
+        publications={[samplePublication]}
+        columnsToShow={['title']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onPublicationChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('#title').should('have.value', 'Sample Publication')
+  })
+})
+
+describe('Publication delete flow', () => {
+  it('deletes a publication via modal confirmation', () => {
+    const list: Publication[] = [samplePublication]
+    mount(<PublicationListHarness initial={list} />)
+    cy.contains('Sample Publication').should('exist')
+    cy.get('.glyphicon-trash').click({ force: true })
+    cy.get('.ReactModal__Content')
+      .should('be.visible')
+      .within(() => {
+        cy.get('button').filter(':visible').contains(/delete/i).click({ force: true })
+      })
+    cy.get('.ReactModal__Content').should('not.exist')
+    cy.contains('Sample Publication').should('not.exist')
+  })
+})

--- a/cypress/component/StudyAssets/publication_list.spec.tsx
+++ b/cypress/component/StudyAssets/publication_list.spec.tsx
@@ -98,7 +98,7 @@ describe('PublicationList component', () => {
     cy.get('.error-message').should('have.length.greaterThan', 0)
   })
 
-  it('disables Add Author until first row valid', () => {
+  it('disables Add Author until first row has name filled', () => {
     mount(
       <PublicationAddEdit
         id={-1}
@@ -109,10 +109,10 @@ describe('PublicationList component', () => {
     )
     cy.contains('Add Author').should('be.disabled')
     cy.get('input[placeholder="Author Name"]').type('Temp Author')
+    // ORCID is optional, so Add Author should be enabled even without ORCID
+    cy.contains('Add Author').should('not.be.disabled')
+    // Test that invalid ORCID format doesn't prevent adding (validation happens on save)
     cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').type('BAD-ORCID')
-    cy.contains('Add Author').should('be.disabled')
-    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').clear()
-    cy.get('input[placeholder="ORCID (0000-0000-0000-0000)"]').type('0000-0000-0000-0004')
     cy.contains('Add Author').should('not.be.disabled').click()
     cy.get('input[placeholder="Author Name"]').should('have.length', 2)
   })

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -1,22 +1,12 @@
 import React, { useState } from 'react'
-import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
+import { FormField, FormValidators } from 'src/components/forms/forms'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
-import { validationFailed, calcPublicationErrors } from 'src/utils/darFormUtils'
-import { Publication } from 'src/types/model'
-
-const defaultPublication: Publication = {
-  title: '',
-  date: '',
-  authors: '',
-  pubmedId: '',
-  bibliographicCitation: '',
-  datasetCitation: '',
-  citation: false,
-}
+import { validationFailed, calcPublicationErrors, ORCID_REGEX } from 'src/utils/darFormUtils'
+import { Author, Publication } from 'src/types/model'
 
 interface FormFieldChange {
   key: string
-  value: string
+  value: string | boolean
 }
 
 interface PublicationAddEditProps {
@@ -29,118 +19,333 @@ interface PublicationAddEditProps {
 
 interface Validation {
   title?: ValidationError
-  date?: ValidationError
-  authors?: ValidationError
   pubmedId?: ValidationError
+  publishedDate?: ValidationError
+  authors?: ValidationError
   bibliographicCitation?: ValidationError
+  datasetCitation?: ValidationError
+  journal?: ValidationError
+  doi?: ValidationError
+  url?: ValidationError
+  access?: ValidationError
 }
+
+const defaultPublication: Publication = {
+  title: '',
+  publishedDate: '',
+  authors: [],
+  pubmedId: '',
+  bibliographicCitation: '',
+  datasetCitation: '',
+  citation: false,
+  publicationId: '',
+  studyId: '',
+  journal: '',
+  doi: '',
+  url: '',
+  access: '',
+  tags: [],
+}
+
 export default function PublicationAddEdit(props: PublicationAddEditProps): React.JSX.Element {
   const { id, publication, publications, closeAction, onPublicationChange } = props
+  const initialPublication = publication || defaultPublication
 
-  const [newPublication, setNewPublication] = useState<Publication>(publication || defaultPublication)
+  // Ensure at least one author row is present and bound to state
+  const [newPublication, setNewPublication] = useState<Publication>({
+    ...initialPublication,
+    authors:
+            Array.isArray(initialPublication.authors) && initialPublication.authors.length > 0
+              ? initialPublication.authors
+              : [{ name: '', orcId: '' }],
+  })
+
   const [validation, setValidation] = useState<Validation>({})
+  const [submitted, setSubmitted] = useState<boolean>(false)
+  const [touched, setTouched] = useState<Record<string, boolean>>({})
+  const [tagsInput, setTagsInput] = useState<string>((publication?.tags ?? []).join(', '))
+
+  const applyValidation = (draft: Publication, full: boolean) => {
+    const all = calcPublicationErrors(draft)
+    if (full) {
+      setValidation(all)
+      return
+    }
+    const filtered: Validation = {}
+    Object.entries(all).forEach(([k, v]) => {
+      if (touched[k]) filtered[k as keyof Validation] = v
+    })
+    setValidation(filtered)
+  }
+
+  const updatePublication = (updated: Publication) => {
+    setNewPublication(updated)
+    if (submitted) applyValidation(updated, false)
+  }
+
+  const markTouched = (key: string) => {
+    setTouched(prev => (prev[key] ? prev : { ...prev, [key]: true }))
+  }
 
   const onChange = ({ key, value }: FormFieldChange) => {
-    const publicationToSet: Publication = { ...newPublication, [key]: value }
-    setNewPublication(publicationToSet)
-    setValidation(calcPublicationErrors(publicationToSet))
+    markTouched(key)
+    if (key === 'tags') {
+      const text = String(value)
+      setTagsInput(text)
+      updatePublication({
+        ...newPublication,
+        tags: text.split(',').map(t => t.trim()).filter(Boolean),
+      })
+    }
+    else {
+      updatePublication({ ...newPublication, [key]: value })
+    }
+  }
+
+  // Enable Add only when all current authors have name + valid ORCID
+  const disableAddAuthor = newPublication.authors.some(
+    a => a.name.trim() === '' || a.orcId.trim() === '' || !ORCID_REGEX.test(a.orcId),
+  )
+
+  const addAuthor = () => {
+    if (disableAddAuthor) return
+    markTouched('authors')
+    updatePublication({
+      ...newPublication,
+      authors: [...newPublication.authors, { name: '', orcId: '' }],
+    })
+  }
+
+  const removeAuthor = (index: number) => {
+    markTouched('authors')
+    const next = newPublication.authors.filter((_, i) => i !== index)
+    updatePublication({
+      ...newPublication,
+      authors: next.length ? next : [{ name: '', orcId: '' }],
+    })
+  }
+
+  const updateAuthorField = (index: number, field: keyof Author, value: string) => {
+    markTouched('authors')
+    const next = newPublication.authors.map((a, i) => (i === index ? { ...a, [field]: value } : a))
+    updatePublication({ ...newPublication, authors: next })
+  }
+
+  const save = () => {
+    setSubmitted(true)
+    applyValidation(newPublication, true)
+    if (validationFailed(calcPublicationErrors(newPublication))) return
+    if (id < 0) {
+      onPublicationChange([...publications, newPublication])
+    }
+    else {
+      const publicationsCopy = [...publications]
+      publicationsCopy[id] = newPublication
+      onPublicationChange(publicationsCopy)
+    }
+    closeAction()
+  }
+
+  const renderAuthorsError = () => {
+    if (!submitted && !touched.authors) return null
+    if (!validation.authors) return null
+    const failed = validation.authors.failed || []
+    if (failed.includes('required')) {
+      return (
+        <div className="error-message">
+          At least one author with name and valid ORCID is required.
+        </div>
+      )
+    }
+    return (
+      <div className="error-message">
+        {failed.map(f => (
+          <div key={f}>{f}</div>
+        ))}
+      </div>
+    )
   }
 
   return (
     <div className="form-group row no-margin">
       <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
         <div className="row">
-          <h2>{publication === undefined ? `New Publication Information` : `Edit ${publication.title} Information`}</h2>
+          <h2>
+            {publication === undefined
+              ? 'New Publication Information'
+              : `Edit ${publication.title} Information`}
+          </h2>
+
           <FormField
             id="title"
             title="Publication Title"
-            defaultValue={publication?.title}
+            defaultValue={newPublication.title}
             placeholder="Title"
             validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={validation.title}
+            validation={(submitted || touched.title) ? validation.title : undefined}
           />
+
           <FormField
-            id="date"
+            id="publishedDate"
             title="Publication Date"
-            defaultValue={publication?.date}
-            placeholder="Date"
+            defaultValue={newPublication.publishedDate}
+            placeholder="YYYY-MM-DD"
             validators={[FormValidators.REQUIRED, FormValidators.DATE]}
             onChange={onChange}
-            validation={validation.date}
+            validation={(submitted || touched.publishedDate) ? validation.publishedDate : undefined}
           />
-          <FormField
-            id="authors"
-            title="Publication Authors"
-            defaultValue={publication?.authors}
-            placeholder="Authors"
-            validators={[FormValidators.REQUIRED]}
-            onChange={onChange}
-            validation={validation.authors}
-          />
+
+          <div style={{ marginBottom: '1rem', width: '100%' }}>
+            <label style={{ fontWeight: 600, marginTop: '1rem' }}>Authors (Name + ORCID)*</label>
+            {renderAuthorsError()}
+            {newPublication.authors.map((a, idx) => (
+              <div
+                key={idx}
+                className="row"
+                style={{
+                  display: 'flex',
+                  gap: '0.75rem',
+                  marginTop: idx === 0 ? '0.5rem' : '0.75rem',
+                  alignItems: 'flex-start',
+                }}
+              >
+                <input
+                  type="text"
+                  className="form-control"
+                  style={{ flex: 1 }}
+                  value={a.name}
+                  placeholder="Author Name"
+                  onChange={e => updateAuthorField(idx, 'name', e.target.value)}
+                />
+                <input
+                  type="text"
+                  className="form-control"
+                  style={{ flex: 1 }}
+                  value={a.orcId}
+                  placeholder="ORCID (0000-0000-0000-0000)"
+                  onChange={e => updateAuthorField(idx, 'orcId', e.target.value)}
+                />
+                <button
+                  type="button"
+                  className="btn btn-danger"
+                  onClick={() => removeAuthor(idx)}
+                  disabled={newPublication.authors.length === 1}
+                  title={
+                    newPublication.authors.length === 1
+                      ? 'At least one author required'
+                      : 'Remove author'
+                  }
+                >
+                  <span className="glyphicon glyphicon-minus" aria-hidden="true" />
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="btn btn-primary"
+              style={{ marginTop: '0.75rem', width: '100%' }}
+              onClick={addAuthor}
+              disabled={disableAddAuthor}
+              title={
+                disableAddAuthor
+                  ? 'Fill all existing author name and valid ORCID first'
+                  : 'Add another author'
+              }
+            >
+              <span className="glyphicon glyphicon-plus" aria-hidden="true" /> Add Author
+            </button>
+          </div>
+
           <FormField
             id="pubmedId"
-            title="Publication PubMed ID"
-            defaultValue={publication?.pubmedId}
+            title="PubMed ID"
+            defaultValue={newPublication.pubmedId}
             placeholder="PubMed ID"
             validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={validation.pubmedId}
+            validation={(submitted || touched.pubmedId) ? validation.pubmedId : undefined}
           />
+
           <FormField
             id="bibliographicCitation"
-            title="Publication Bibliographic Citation"
-            defaultValue={publication?.bibliographicCitation}
-            placeholder="Bibliographic Citation"
+            title="Bibliographic Citation"
+            defaultValue={newPublication.bibliographicCitation}
+            placeholder="Citation"
             validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={validation.bibliographicCitation}
+            validation={(submitted || touched.bibliographicCitation) ? validation.bibliographicCitation : undefined}
           />
+
           <FormField
             id="datasetCitation"
-            title="Dataset citation used in this publication"
-            defaultValue={publication?.datasetCitation}
+            title="Dataset Citation"
+            defaultValue={newPublication.datasetCitation}
             placeholder="Dataset Citation"
+            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
+            validation={(submitted || touched.datasetCitation) ? validation.datasetCitation : undefined}
           />
+
           <FormField
-            id="citation"
-            type={FormFieldTypes.YESNORADIOGROUP}
-            defaultValue={publication?.citation}
-            title="Did you cite the dataset(s) used in this publication?"
-            orientation="horizontal"
+            id="journal"
+            title="Journal"
+            defaultValue={newPublication.journal}
+            placeholder="Journal"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={(submitted || touched.journal) ? validation.journal : undefined}
+          />
+
+          <FormField
+            id="doi"
+            title="DOI"
+            defaultValue={newPublication.doi}
+            placeholder="DOI"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={(submitted || touched.doi) ? validation.doi : undefined}
+          />
+
+          <FormField
+            id="url"
+            title="URL"
+            defaultValue={newPublication.url}
+            placeholder="https://example.org"
+            validators={[FormValidators.REQUIRED, FormValidators.URL]}
+            onChange={onChange}
+            validation={(submitted || touched.url) ? validation.url : undefined}
+          />
+
+          <FormField
+            id="access"
+            title="Access"
+            defaultValue={newPublication.access}
+            placeholder="Access"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={(submitted || touched.access) ? validation.access : undefined}
+          />
+
+          <FormField
+            id="tags"
+            title="Tags (comma separated)"
+            defaultValue={tagsInput}
+            placeholder="tag1, tag2"
             onChange={onChange}
           />
         </div>
         <div className="row" style={{ marginTop: 20 }}>
-          {/* add/save button */}
-          <button
-            className="collaborator-form-add-save-button f-left btn"
-            type="button"
-            onClick={() => {
-              if (id < 0 && newPublication !== undefined) {
-                onPublicationChange([...publications, newPublication])
-                setNewPublication(defaultPublication)
-              }
-              else if (newPublication !== undefined) {
-                const publicationsCopy = [...publications]
-                publicationsCopy[id] = newPublication
-                onPublicationChange(publicationsCopy)
-                setNewPublication(defaultPublication)
-              }
-              closeAction()
-            }}
-            disabled={validationFailed(calcPublicationErrors(newPublication))}
-          >
-            {publication === undefined ? 'Add' : 'Save'}
+          <button type="button" className="btn btn-primary" onClick={save}>
+            <span className="glyphicon glyphicon-floppy-disk" aria-hidden="true" /> Save
           </button>
-          {/* cancel button */}
           <button
-            className="collaborator-form-cancel-button f-left btn"
             type="button"
+            className="btn btn-default"
+            style={{ marginLeft: '1rem' }}
             onClick={closeAction}
           >
-            Cancel
+            <span className="glyphicon glyphicon-remove" aria-hidden="true" /> Cancel
           </button>
         </div>
       </div>

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -197,66 +197,66 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
           />
 
           <div style={{ marginBottom: '1rem', width: '100%' }}>
-            <div style={{ fontWeight: 600, marginTop: '1rem' }} role="group" aria-label="Authors (Name + ORCID)">
-              Authors (Name + ORCID)*
-            </div>
-            {renderAuthorsError()}
-            {newPublication.authors.map((a: Author, idx) => (
-              <div
-                key={`${a.name}-${a.orcId}`}
-                className="row"
-                style={{
-                  display: 'flex',
-                  gap: '0.75rem',
-                  marginTop: idx === 0 ? '0.5rem' : '0.75rem',
-                  alignItems: 'flex-start',
-                }}
-              >
-                <input
-                  type="text"
-                  className="form-control"
-                  style={{ flex: 1 }}
-                  value={a.name}
-                  placeholder="Author Name"
-                  onChange={e => updateAuthorField(idx, 'name', e.target.value)}
-                />
-                <input
-                  type="text"
-                  className="form-control"
-                  style={{ flex: 1 }}
-                  value={a.orcId}
-                  placeholder="ORCID (0000-0000-0000-0000)"
-                  onChange={e => updateAuthorField(idx, 'orcId', e.target.value)}
-                />
-                <button
-                  type="button"
-                  className="btn btn-danger"
-                  onClick={() => removeAuthor(idx)}
-                  disabled={newPublication.authors.length === 1}
-                  title={
-                    newPublication.authors.length === 1
-                      ? 'At least one author required'
-                      : 'Remove author'
-                  }
+            <fieldset style={{ fontWeight: 600, marginTop: '1rem' }} aria-label="Authors (Name + ORCID)">
+              <legend style={{ fontSize: 16 }}>Authors (Name + ORCID)*</legend>
+              {renderAuthorsError()}
+              {newPublication.authors.map((a: Author, idx) => (
+                <div
+                  key={`${a.name}-${a.orcId}`}
+                  className="row"
+                  style={{
+                    display: 'flex',
+                    gap: '0.75rem',
+                    marginTop: idx === 0 ? '0.5rem' : '0.75rem',
+                    alignItems: 'flex-start',
+                  }}
                 >
-                  <span className="glyphicon glyphicon-minus" aria-hidden="true" />
-                </button>
-              </div>
-            ))}
-            <button
-              type="button"
-              className="btn btn-primary"
-              style={{ marginTop: '0.75rem', width: '100%' }}
-              onClick={addAuthor}
-              disabled={disableAddAuthor}
-              title={
-                disableAddAuthor
-                  ? 'Fill all existing author name and valid ORCID first'
-                  : 'Add another author'
-              }
-            >
-              <span className="glyphicon glyphicon-plus" aria-hidden="true" /> Add Author
-            </button>
+                  <input
+                    type="text"
+                    className="form-control"
+                    style={{ flex: 1 }}
+                    value={a.name}
+                    placeholder="Author Name"
+                    onChange={e => updateAuthorField(idx, 'name', e.target.value)}
+                  />
+                  <input
+                    type="text"
+                    className="form-control"
+                    style={{ flex: 1 }}
+                    value={a.orcId}
+                    placeholder="ORCID (0000-0000-0000-0000)"
+                    onChange={e => updateAuthorField(idx, 'orcId', e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-danger"
+                    onClick={() => removeAuthor(idx)}
+                    disabled={newPublication.authors.length === 1}
+                    title={
+                      newPublication.authors.length === 1
+                        ? 'At least one author required'
+                        : 'Remove author'
+                    }
+                  >
+                    <span className="glyphicon glyphicon-minus" aria-hidden="true" />
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                className="btn btn-primary"
+                style={{ marginTop: '0.75rem', width: '100%' }}
+                onClick={addAuthor}
+                disabled={disableAddAuthor}
+                title={
+                  disableAddAuthor
+                    ? 'Fill all existing author name and valid ORCID first'
+                    : 'Add another author'
+                }
+              >
+                <span className="glyphicon glyphicon-plus" aria-hidden="true" /> Add Author
+              </button>
+            </fieldset>
           </div>
 
           <FormField

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -202,7 +202,7 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
               {renderAuthorsError()}
               {newPublication.authors.map((a: Author, idx) => (
                 <div
-                  key={`${a.name}-${a.orcId}`}
+                  key={idx}
                   className="row"
                   style={{
                     display: 'flex',

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { FormField, FormValidators } from 'src/components/forms/forms'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
-import { validationFailed, calcPublicationErrors, ORCID_REGEX } from 'src/utils/darFormUtils'
+import { validationFailed, calcPublicationErrors } from 'src/utils/darFormUtils'
 import { Author, Publication } from 'src/types/model'
 
 interface FormFieldChange {
@@ -102,9 +102,9 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
     }
   }
 
-  // Enable Add only when all current authors have name + valid ORCID
+  // Enable Add only when all current authors have a name
   const disableAddAuthor = newPublication.authors.some(
-    a => a.name.trim() === '' || a.orcId.trim() === '' || !ORCID_REGEX.test(a.orcId),
+    a => a.name.trim() === '',
   )
 
   const addAuthor = () => {

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -72,9 +72,9 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
       return
     }
     const filtered: Validation = {}
-    Object.entries(all).forEach(([k, v]) => {
+    for (const [k, v] of Object.entries(all)) {
       if (touched[k]) filtered[k as keyof Validation] = v
-    })
+    }
     setValidation(filtered)
   }
 
@@ -197,11 +197,13 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
           />
 
           <div style={{ marginBottom: '1rem', width: '100%' }}>
-            <label style={{ fontWeight: 600, marginTop: '1rem' }}>Authors (Name + ORCID)*</label>
+            <div style={{ fontWeight: 600, marginTop: '1rem' }} role="group" aria-label="Authors (Name + ORCID)">
+              Authors (Name + ORCID)*
+            </div>
             {renderAuthorsError()}
-            {newPublication.authors.map((a, idx) => (
+            {newPublication.authors.map((a: Author, idx) => (
               <div
-                key={idx}
+                key={`${a.name}-${a.orcId}`}
                 className="row"
                 style={{
                   display: 'flex',

--- a/src/components/publications_list/PublicationSummary.tsx
+++ b/src/components/publications_list/PublicationSummary.tsx
@@ -36,6 +36,15 @@ export default function PublicationSummary(props: PublicationSummaryProps): Reac
       if (value == null) return null
       return JSON.stringify(value)
     },
+    url: (value: unknown) => {
+      const href = typeof value === 'string' ? value : ''
+      if (!href) return null
+      return (
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          {href}
+        </a>
+      )
+    },
   }
 
   return (

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -313,7 +313,7 @@ interface Contact extends Person {
 }
 
 export interface Author extends Person {
-  orcId: string
+  orcId?: string
 }
 
 export type Maintainer = Contact

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -697,21 +697,18 @@ export interface Presentation {
 
 export interface Publication {
   title: string
-  // ToDO: Make existing Progress Report fields required in DT-2358
-  pubmedId?: string
-  date?: string
-  authors?: string | Array<Author> // ToDo: Remove string option in DT-2358
-  bibliographicCitation?: string
-  datasetCitation?: string
-  citation?: boolean
-  // ToDo: Make new study fields required in DT-2358 except for tags
-  publicationId?: string
-  studyId?: string
-  journal?: string
-  doi?: string
-  url?: string
-  publishedDate?: string
-  access?: string
+  pubmedId: string
+  publishedDate: string
+  authors: Array<Author>
+  bibliographicCitation: string
+  datasetCitation: string
+  citation: boolean
+  publicationId: string
+  studyId: string
+  journal: string
+  doi: string
+  url: string
+  access: string
   tags?: string[]
 }
 

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -1,4 +1,5 @@
 import {
+  Author,
   Closeout,
   CombinedDataAccessRequest, DarCollection, DataAccessRequest,
   DataManagementIncident,
@@ -73,17 +74,22 @@ export function convertFormStateToDAR(formState: FormState): Partial<CombinedDat
 
 export function getPublicationList(formState: FormState): Publication[] {
   const publications: Publication[] = formState.publications ?? []
-  return publications.map((pub: Publication) => {
-    const expectedPublication: Publication = {} as Publication
-    expectedPublication.title = pub.title
-    expectedPublication.pubmedId = pub.pubmedId
-    expectedPublication.date = pub.date
-    expectedPublication.authors = pub.authors
-    expectedPublication.bibliographicCitation = pub.bibliographicCitation
-    expectedPublication.datasetCitation = pub.datasetCitation
-    expectedPublication.citation = pub.citation
-    return expectedPublication
-  })
+  return publications.map((p: Publication) => ({
+    title: p.title,
+    pubmedId: p.pubmedId,
+    publishedDate: p.publishedDate,
+    authors: (p.authors ?? []).map((a: Author) => ({ name: a.name, orcId: a.orcId })),
+    bibliographicCitation: p.bibliographicCitation,
+    datasetCitation: p.datasetCitation,
+    citation: p.citation,
+    publicationId: p.publicationId,
+    studyId: p.studyId,
+    journal: p.journal,
+    doi: p.doi,
+    url: p.url,
+    access: p.access,
+    tags: p.tags ? [...p.tags] : [],
+  }))
 }
 
 export function getPresentationList(formState: FormState): Presentation[] {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -307,22 +307,57 @@ const validateDate = (date) => {
   return undefined
 }
 
+export const ORCID_REGEX = /^(\d{4}-){3}\d{3}[\dX]$/
+
 export const calcPublicationErrors = (newPublication) => {
   const validation = {}
+
   if (isEmpty(newPublication?.title)) {
     validation.title = requiredError
   }
-  validation.date = validateDate(newPublication?.date)
-  if (isEmpty(newPublication?.authors)) {
+  validation.publishedDate = validateDate(newPublication?.publishedDate)
+
+  const authorsArr = Array.isArray(newPublication?.authors) ? newPublication.authors : []
+  if (authorsArr.length === 0) {
     validation.authors = requiredError
   }
-  if (isEmpty(newPublication?.pubmedId)) {
-    validation.pubmedId = requiredError
-  }
-  if (isEmpty(newPublication?.bibliographicCitation)) {
-    validation.bibliographicCitation = requiredError
+  else {
+    const failedCodes = []
+    const perAuthor = authorsArr.map((a, idx) => {
+      const name = a?.name ?? ''
+      const orcId = a?.orcId ?? ''
+      const row = {}
+      if (isStringEmpty(name)) {
+        row.name = requiredError
+        failedCodes.push(`name@${idx}`)
+      }
+      if (isStringEmpty(orcId)) {
+        row.orcId = requiredError
+        failedCodes.push(`orcIdMissing@${idx}`)
+      }
+      else if (!ORCID_REGEX.test(orcId)) {
+        row.orcId = validationError('orcIdFormat')
+        failedCodes.push(`orcIdFormat@${idx}`)
+      }
+      return row
+    })
+    if (failedCodes.length) {
+      validation.authors = { valid: false, failed: failedCodes, perAuthor }
+    }
   }
 
+  if (isStringEmpty(newPublication?.pubmedId)) validation.pubmedId = requiredError
+  if (isStringEmpty(newPublication?.bibliographicCitation)) validation.bibliographicCitation = requiredError
+  if (isStringEmpty(newPublication?.datasetCitation)) validation.datasetCitation = requiredError
+  if (isStringEmpty(newPublication?.journal)) validation.journal = requiredError
+  if (isStringEmpty(newPublication?.doi)) validation.doi = requiredError
+  if (isStringEmpty(newPublication?.url)) {
+    validation.url = requiredError
+  }
+  else if (!FormValidators.URL.isValid(newPublication.url)) {
+    validation.url = validationError('url')
+  }
+  if (isStringEmpty(newPublication?.access)) validation.access = requiredError
   return validation
 }
 
@@ -339,10 +374,6 @@ export const calcPresentationErrors = (newPresentation) => {
     validation.link = requiredError
   }
   return validation
-}
-
-export const isPublication = (publicationText) => {
-  return publicationText === 'Publication'
 }
 
 const requiredRusFields = [

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -331,11 +331,7 @@ export const calcPublicationErrors = (newPublication) => {
         row.name = requiredError
         failedCodes.push(`name@${idx}`)
       }
-      if (isStringEmpty(orcId)) {
-        row.orcId = requiredError
-        failedCodes.push(`orcIdMissing@${idx}`)
-      }
-      else if (!ORCID_REGEX.test(orcId)) {
+      if (!isStringEmpty(orcId) && !ORCID_REGEX.test(orcId)) { // only validate if not empty
         row.orcId = validationError('orcIdFormat')
         failedCodes.push(`orcIdFormat@${idx}`)
       }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2358

### Summary

This refactors the existing Publication forms, adding an updated model schema and TypeScript interface with field-level validation and updated data bindings.

**New**
<img width="1479" height="876" alt="New" src="https://github.com/user-attachments/assets/29615f8e-e29d-4294-b452-ba07a3298649" />

**Edit**
<img width="1479" height="891" alt="Edit" src="https://github.com/user-attachments/assets/5a168246-9fb8-4174-b15e-677670fa8c57" />

**List**
<img width="1479" height="85" alt="List" src="https://github.com/user-attachments/assets/8bb9d981-b92c-4539-8bbf-009151cf1fb3" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
