### PR TITLE
[DT-2355] Added Intellectual Property Components 

### DIFF
--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -214,8 +214,8 @@ describe('ProgressReportApplication - Component Tests', () => {
     cy.get('.accordion-step-container').should('exist')
   })
 
-  it('defaults intellectualPropertyYesNo to false when dar.intellectualPropertySummary is undefined', () => {
-    // Mount component with DAR that has undefined intellectualPropertySummary
+  it('defaults intellectualPropertyYesNo to false when dar.intellectualProperties is undefined or empty', () => {
+    // Test with undefined intellectualProperties
     const darWithoutIntellectualProperty = {}
 
     mountComponent(darWithoutIntellectualProperty, true)
@@ -225,10 +225,47 @@ describe('ProgressReportApplication - Component Tests', () => {
     cy.get('#intellectualPropertyYesNo_yes').should('not.be.checked')
   })
 
-  it('sets intellectualPropertyYesNo to true when dar.intellectualPropertySummary has a value', () => {
-    // Mount component with DAR that has intellectualPropertySummary
+  it('defaults intellectualPropertyYesNo to false when dar.intellectualProperties is empty array', () => {
+    // Test with empty intellectualProperties array
+    const darWithEmptyIntellectualProperty = {
+      intellectualProperties: [],
+    }
+
+    mountComponent(darWithEmptyIntellectualProperty, true)
+
+    // Check that the intellectual property "No" radio button is checked (false state)
+    cy.get('#intellectualPropertyYesNo_no').should('be.checked')
+    cy.get('#intellectualPropertyYesNo_yes').should('not.be.checked')
+  })
+
+  it('sets intellectualPropertyYesNo to true when dar.intellectualProperties has items', () => {
+    // Test with intellectualProperties array containing items
     const darWithIntellectualProperty = {
-      intellectualPropertySummary: 'Some intellectual property description',
+      intellectualProperties: [{
+        ipId: 'ip-1',
+        studyId: 'study-1',
+        type: 'Patent',
+        title: 'IP 1',
+        assignee: 'Inventor A',
+        patentNumber: 'App123',
+        filingDate: '2023-01-01',
+        status: 'Filed',
+        url: 'https://example.com/ip',
+        contact: 'contact@example.com',
+        tags: [],
+      }, {
+        ipId: 'ip-2',
+        studyId: 'study-1',
+        type: 'Trademark',
+        title: 'IP 2',
+        assignee: 'Inventor B',
+        patentNumber: 'App456',
+        filingDate: '2023-02-01',
+        status: 'Granted',
+        url: 'https://example.com/ip2',
+        contact: 'contact2@example.com',
+        tags: [],
+      }],
     }
 
     mountComponent(darWithIntellectualProperty, true)
@@ -236,17 +273,10 @@ describe('ProgressReportApplication - Component Tests', () => {
     // Check that the intellectual property "Yes" radio button is checked (true state)
     cy.get('#intellectualPropertyYesNo_yes').should('be.checked')
     cy.get('#intellectualPropertyYesNo_no').should('not.be.checked')
-  })
 
-  it('in non-read-only mode, has neither intellectualPropertyYesNo radio button checked when dar.intellectualPropertySummary is undefined', () => {
-    // Mount component with DAR that has undefined intellectualPropertySummary
-    const darWithoutIntellectualProperty = {}
-
-    mountComponent(darWithoutIntellectualProperty, false)
-
-    // Check that neither radio button is checked when the value is undefined
-    cy.get('#intellectualPropertyYesNo_yes').should('not.be.checked')
-    cy.get('#intellectualPropertyYesNo_no').should('not.be.checked')
+    // Check that intellectual properties are actually displayed in the DOM
+    cy.contains('IP 1').should('be.visible')
+    cy.contains('IP 2').should('be.visible')
   })
 
   it('defaults publicationsYesNo to false when dar.publications is undefined or empty', () => {
@@ -469,21 +499,30 @@ describe('ProgressReportApplication - Component Tests', () => {
     cy.get('#closeoutYesNo_no').should('not.be.checked')
   })
 
-  it('displays intellectual property summary in read-only mode when it exists', () => {
-    // Test scenario where intellectual property summary exists
+  it('displays intellectual properties in read-only mode when they exist', () => {
     const darWithIntellectualProperty = {
-      intellectualPropertySummary: 'Test intellectual property description with important details',
+      intellectualProperties: [{
+        ipId: 'ip-1',
+        studyId: 'study-1',
+        type: 'Patent',
+        title: 'Test IP',
+        assignee: 'Inventor A',
+        patentNumber: 'App123',
+        filingDate: '2023-01-01',
+        status: 'Filed',
+        url: 'https://example.com/ip',
+        contact: 'contact@example.com',
+        tags: [],
+      }],
     }
 
     mountComponent(darWithIntellectualProperty, true)
 
-    // Check that the intellectual property "Yes" radio button is checked (true state)
     cy.get('#intellectualPropertyYesNo_yes').should('be.checked')
     cy.get('#intellectualPropertyYesNo_no').should('not.be.checked')
 
-    // Check that the intellectual property summary is visible in the form
-    cy.get('#intellectualPropertySummary').should('be.visible')
-    cy.get('#intellectualPropertySummary').should('contain.value', 'Test intellectual property description with important details')
+    // Check that IP is visible
+    cy.contains('Test IP').should('be.visible')
   })
 
   it('shows only approved datasets in create-mode progress report', () => {

--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -214,18 +214,18 @@ describe('ProgressReportApplication - Component Tests', () => {
     cy.get('.accordion-step-container').should('exist')
   })
 
-  it('defaults intellectualPropertyYesNo to false when dar.intellectualProperties is undefined or empty', () => {
+  it('defaults intellectualPropertiesYesNo to false when dar.intellectualProperties is undefined or empty', () => {
     // Test with undefined intellectualProperties
     const darWithoutIntellectualProperty = {}
 
     mountComponent(darWithoutIntellectualProperty, true)
 
-    // Check that the intellectual property "No" radio button is checked (false state)
-    cy.get('#intellectualPropertyYesNo_no').should('be.checked')
-    cy.get('#intellectualPropertyYesNo_yes').should('not.be.checked')
+    // Check that the intellectualProperties "No" radio button is checked (false state)
+    cy.get('#intellectualPropertiesYesNo_no').should('be.checked')
+    cy.get('#intellectualPropertiesYesNo_yes').should('not.be.checked')
   })
 
-  it('defaults intellectualPropertyYesNo to false when dar.intellectualProperties is empty array', () => {
+  it('defaults intellectualPropertiesYesNo to false when dar.intellectualProperties is empty array', () => {
     // Test with empty intellectualProperties array
     const darWithEmptyIntellectualProperty = {
       intellectualProperties: [],
@@ -233,12 +233,12 @@ describe('ProgressReportApplication - Component Tests', () => {
 
     mountComponent(darWithEmptyIntellectualProperty, true)
 
-    // Check that the intellectual property "No" radio button is checked (false state)
-    cy.get('#intellectualPropertyYesNo_no').should('be.checked')
-    cy.get('#intellectualPropertyYesNo_yes').should('not.be.checked')
+    // Check that the intellectualProperties "No" radio button is checked (false state)
+    cy.get('#intellectualPropertiesYesNo_no').should('be.checked')
+    cy.get('#intellectualPropertiesYesNo_yes').should('not.be.checked')
   })
 
-  it('sets intellectualPropertyYesNo to true when dar.intellectualProperties has items', () => {
+  it('sets intellectualPropertiesYesNo to true when dar.intellectualProperties has items', () => {
     // Test with intellectualProperties array containing items
     const darWithIntellectualProperty = {
       intellectualProperties: [{
@@ -270,9 +270,9 @@ describe('ProgressReportApplication - Component Tests', () => {
 
     mountComponent(darWithIntellectualProperty, true)
 
-    // Check that the intellectual property "Yes" radio button is checked (true state)
-    cy.get('#intellectualPropertyYesNo_yes').should('be.checked')
-    cy.get('#intellectualPropertyYesNo_no').should('not.be.checked')
+    // Check that the intellectualProperties "Yes" radio button is checked (true state)
+    cy.get('#intellectualPropertiesYesNo_yes').should('be.checked')
+    cy.get('#intellectualPropertiesYesNo_no').should('not.be.checked')
 
     // Check that intellectual properties are actually displayed in the DOM
     cy.contains('IP 1').should('be.visible')
@@ -518,8 +518,8 @@ describe('ProgressReportApplication - Component Tests', () => {
 
     mountComponent(darWithIntellectualProperty, true)
 
-    cy.get('#intellectualPropertyYesNo_yes').should('be.checked')
-    cy.get('#intellectualPropertyYesNo_no').should('not.be.checked')
+    cy.get('#intellectualPropertiesYesNo_yes').should('be.checked')
+    cy.get('#intellectualPropertiesYesNo_no').should('not.be.checked')
 
     // Check that IP is visible
     cy.contains('Test IP').should('be.visible')

--- a/cypress/component/ProgressReports/summary_section.spec.tsx
+++ b/cypress/component/ProgressReports/summary_section.spec.tsx
@@ -151,14 +151,14 @@ describe('Summary Section - Component Tests', () => {
 
   it('handles intellectual property radio buttons', () => {
     cy.contains('label', 'Yes').find('input[type="radio"]').first().click({ force: true })
-    cy.get('@formChangeStub').should('have.been.calledWith', { intellectualPropertyYesNo: true })
+    cy.get('@formChangeStub').should('have.been.calledWith', { intellectualPropertiesYesNo: true })
 
     cy.contains('label', 'No').find('input[type="radio"]').first().click({ force: true })
-    cy.get('@formChangeStub').should('have.been.calledWith', { intellectualPropertyYesNo: false })
+    cy.get('@formChangeStub').should('have.been.calledWith', { intellectualPropertiesYesNo: false })
   })
 
   it('shows intellectual property details form when "Yes" is selected', () => {
-    mountComponent({ intellectualPropertyYesNo: true })
+    mountComponent({ intellectualPropertiesYesNo: true })
     cy.get('#intellectualPropertySummary').should('exist')
 
     const testDetails = 'Details about intellectual property.'

--- a/cypress/component/ProgressReports/summary_section.spec.tsx
+++ b/cypress/component/ProgressReports/summary_section.spec.tsx
@@ -157,15 +157,9 @@ describe('Summary Section - Component Tests', () => {
     cy.get('@formChangeStub').should('have.been.calledWith', { intellectualPropertiesYesNo: false })
   })
 
-  it('shows intellectual property details form when "Yes" is selected', () => {
+  it('shows intellectualProperties list when "Yes" is selected', () => {
     mountComponent({ intellectualPropertiesYesNo: true })
-    cy.get('#intellectualPropertySummary').should('exist')
-
-    const testDetails = 'Details about intellectual property.'
-    cy.get('#intellectualPropertySummary').type(testDetails)
-    cy.get('#intellectualPropertySummary').should('have.value', testDetails)
-
-    cy.get('@formChangeStub').should('have.been.called')
+    cy.contains('Add Intellectual Property').should('exist')
   })
 
   it('handles publications radio buttons', () => {

--- a/cypress/component/StudyAssets/intellectual_property_list.spec.tsx
+++ b/cypress/component/StudyAssets/intellectual_property_list.spec.tsx
@@ -1,0 +1,236 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import { IntellectualProperty } from 'src/types/model'
+import { IntellectualPropertyAddEdit } from 'src/components/intellectual_property_list/IntellectualPropertyAddEdit'
+import IntellectualPropertySummary from 'src/components/intellectual_property_list/IntellectualPropertySummary'
+import IntellectualPropertyRow from 'src/components/intellectual_property_list/IntellectualPropertyRow'
+import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
+
+const sampleIp: IntellectualProperty = {
+  ipId: 'ip-1',
+  studyId: 'study-1',
+  type: 'Patent',
+  title: 'Test Patent',
+  assignee: 'Inventor A',
+  patentNumber: 'App123',
+  filingDate: '2023-01-01',
+  status: 'Filed',
+  url: 'https://example.com/ip',
+  contact: 'contact@example.com',
+  tags: ['tag1', 'tag2'],
+}
+
+const IntellectualPropertyListHarness: React.FC<{ initial: IntellectualProperty[] }> = ({ initial }) => {
+  const [items, setItems] = React.useState<IntellectualProperty[]>(initial)
+  return (
+    <IntellectualPropertyList
+      intellectualProperties={items}
+      columnsToShow={['title', 'type']}
+      onIntellectualPropertyChange={setItems}
+      disabled={false}
+    />
+  )
+}
+
+describe('IntellectualPropertyAddEdit', () => {
+  it('disables Add until required fields filled then adds', () => {
+    const collected: IntellectualProperty[] = []
+    mount(
+      <IntellectualPropertyAddEdit
+        id={-1}
+        ip={undefined}
+        intellectualProperties={[]}
+        closeAction={cy.stub().as('close')}
+        onIpChange={(items) => { collected.splice(0, collected.length, ...items) }}
+      />,
+    )
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+    cy.get('#type').type('Patent')
+    cy.get('#title').type('New IP')
+    cy.get('#assignee').type('Assignee Name')
+    cy.get('#patentNumber').type('PAT123')
+    cy.get('#filingDate').type('2024-01-01')
+    cy.get('#status').type('Pending')
+    cy.get('#url').type('https://example.com')
+    cy.get('#contact').type('contact@example.com')
+    cy.get('.collaborator-form-add-save-button').should('not.be.disabled').click()
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].type).to.eq('Patent')
+      expect(collected[0].title).to.eq('New IP')
+    })
+  })
+
+  it('edits existing intellectual property and saves changes', () => {
+    const ips: IntellectualProperty[] = [sampleIp]
+    mount(
+      <IntellectualPropertyAddEdit
+        id={0}
+        ip={sampleIp}
+        intellectualProperties={ips}
+        closeAction={cy.stub().as('close')}
+        onIpChange={(updated) => {
+          expect(updated[0].title).to.eq('Test Patent Edited')
+        }}
+      />,
+    )
+    cy.get('#title').clear()
+    cy.get('#title').type('Test Patent Edited')
+    cy.get('.collaborator-form-add-save-button').click()
+  })
+
+  it('validates date format', () => {
+    mount(
+      <IntellectualPropertyAddEdit
+        id={-1}
+        ip={undefined}
+        intellectualProperties={[]}
+        closeAction={cy.stub().as('close')}
+        onIpChange={cy.stub()}
+      />,
+    )
+    cy.get('#type').type('Patent')
+    cy.get('#title').type('New IP')
+    cy.get('#assignee').type('Assignee Name')
+    cy.get('#patentNumber').type('PAT123')
+    cy.get('#filingDate').type('invalid-date')
+    cy.get('#status').type('Pending')
+    cy.get('#url').type('https://example.com')
+    cy.get('#contact').type('contact@example.com')
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+  })
+
+  it('validates URL format', () => {
+    mount(
+      <IntellectualPropertyAddEdit
+        id={-1}
+        ip={undefined}
+        intellectualProperties={[]}
+        closeAction={cy.stub().as('close')}
+        onIpChange={cy.stub()}
+      />,
+    )
+    cy.get('#type').type('Patent')
+    cy.get('#title').type('New IP')
+    cy.get('#assignee').type('Assignee Name')
+    cy.get('#patentNumber').type('PAT123')
+    cy.get('#filingDate').type('2024-01-01')
+    cy.get('#status').type('Pending')
+    cy.get('#url').type('invalid-url')
+    cy.get('#contact').type('contact@example.com')
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+  })
+})
+
+describe('IntellectualPropertySummary', () => {
+  it('renders columns including arrays and url', () => {
+    mount(
+      <IntellectualPropertySummary
+        ip={sampleIp}
+        columnsToShow={['title', 'type', 'patentNumber', 'url', 'tags']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Test Patent').should('exist')
+    cy.contains('Patent').should('exist')
+    cy.contains('App123').should('exist')
+    cy.contains('tag1, tag2').should('exist')
+    cy.get('a[href="https://example.com/ip"]').should('exist')
+  })
+})
+
+describe('IntellectualPropertyRow', () => {
+  it('shows summary when not in edit mode and triggers editAction', () => {
+    mount(
+      <IntellectualPropertyRow
+        id={0}
+        editMode={false}
+        ip={sampleIp}
+        intellectualProperties={[sampleIp]}
+        columnsToShow={['title', 'type']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onIpChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Test Patent').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    mount(
+      <IntellectualPropertyRow
+        id={0}
+        editMode={true}
+        ip={sampleIp}
+        intellectualProperties={[sampleIp]}
+        columnsToShow={['title']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onIpChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('#title').should('have.value', 'Test Patent')
+  })
+})
+
+describe('IntellectualPropertyList', () => {
+  it('adds a new intellectual property', () => {
+    const state: IntellectualProperty[] = []
+    mount(
+      <IntellectualPropertyList
+        intellectualProperties={state}
+        columnsToShow={['title', 'type']}
+        onIntellectualPropertyChange={(items) => { state.splice(0, state.length, ...items) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-ip-btn').click()
+    cy.get('#type').type('Patent')
+    cy.get('#title').type('Added IP')
+    cy.get('#assignee').type('Assignee Name')
+    cy.get('#patentNumber').type('PAT456')
+    cy.get('#filingDate').type('2024-02-01')
+    cy.get('#status').type('Granted')
+    cy.get('#url').type('https://example.com/new')
+    cy.get('#contact').type('newcontact@example.com')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.wrap(null).then(() => {
+      expect(state.length).to.eq(1)
+      expect(state[0].title).to.eq('Added IP')
+    })
+  })
+
+  it('deletes an intellectual property via modal confirmation', () => {
+    mount(<IntellectualPropertyListHarness initial={[sampleIp]} />)
+
+    // Ensure the item exists first
+    cy.contains('Test Patent').should('exist')
+
+    // Open the delete modal
+    cy.get('.glyphicon-trash').click({ force: true })
+
+    // Wait for Modal content to appear
+    cy.get('.ReactModal__Content')
+      .should('be.visible')
+      .within(() => {
+        // Click the visible Delete button inside the modal
+        cy.get('button')
+          .filter(':visible')
+          .contains(/delete/i)
+          .click({ force: true })
+      })
+
+    // Modal should close and the intellectual property should be removed
+    cy.get('.ReactModal__Content').should('not.exist')
+    cy.contains('Test Patent').should('not.exist')
+    cy.get('.collaborator-summary-card').should('have.length', 0)
+  })
+})

--- a/cypress/component/utils/dar_utils.spec.ts
+++ b/cypress/component/utils/dar_utils.spec.ts
@@ -3,7 +3,7 @@ import {
   ElectionStatus, ElectionType,
   getApprovedElectionDatasetIds,
   getCloseoutInfo,
-  getDataManagementIncidents,
+  getDataManagementIncidents, getIntellectualPropertyList,
   getPresentationList,
   getPublicationList,
   userHasOpenDataAccessElection,
@@ -185,8 +185,20 @@ describe('DarUtils', () => {
     it('should convert FormState to DAR format', () => {
       const formState = {
         progressReportSummary: 'Test summary',
-        intellectualPropertyYesNo: true,
-        intellectualPropertySummary: 'IP summary',
+        intellectualPropertiesYesNo: true,
+        intellectualProperties: [{
+          ipId: 'ip-1',
+          studyId: 'study-1',
+          type: 'Patent',
+          title: 'IP 1',
+          assignee: 'Inventor A',
+          patentNumber: 'App123',
+          filingDate: '2023-01-01',
+          status: 'Filed',
+          url: 'https://example.com/ip',
+          contact: 'contact@example.com',
+          tags: [],
+        }],
         datasetIds: [1, 2],
         publicationsYesNo: true,
         publications: [{
@@ -248,7 +260,7 @@ describe('DarUtils', () => {
       } as unknown as FormState
       const result = convertFormStateToDAR(formState)
       expect(result.progressReportSummary).to.equal(formState.progressReportSummary)
-      expect(result.intellectualPropertySummary).to.equal(formState.intellectualPropertySummary)
+      expect(result.intellectualProperties).to.deep.equal(getIntellectualPropertyList(formState))
       expect(result.datasetIds).to.equal(formState.datasetIds)
       expect(result.publications).to.deep.equal(getPublicationList(formState))
       expect(result.presentations).to.deep.equal(getPresentationList(formState))

--- a/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
@@ -1,0 +1,234 @@
+import React, { useState } from 'react'
+import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
+import { IntellectualProperty } from 'src/types/model'
+import { ValidationError } from 'src/pages/dar_application/FormValidationState'
+
+interface IntellectualPropertyAddEditProps {
+  readonly id: number
+  readonly ip?: IntellectualProperty
+  readonly intellectualProperties: IntellectualProperty[]
+  readonly closeAction: () => void
+  readonly onIpChange: (items: IntellectualProperty[]) => void
+}
+
+interface Validation {
+  type?: ValidationError
+  title?: ValidationError
+  assignee?: ValidationError
+  patentNumber?: ValidationError
+  filingDate?: ValidationError
+  status?: ValidationError
+  url?: ValidationError
+  contact?: ValidationError
+}
+
+const defaultIp: IntellectualProperty = {
+  ipId: '',
+  studyId: '',
+  type: '',
+  title: '',
+  assignee: '',
+  patentNumber: '',
+  filingDate: '',
+  status: '',
+  url: '',
+  contact: '',
+  tags: [],
+}
+
+const makeError = (message: string): ValidationError => ({ valid: true, failed: [message] })
+
+const validationFailed = (v: Validation) => Object.values(v).some(e => !!e)
+
+const calcErrors = (ip: IntellectualProperty): Validation => {
+  const v: Validation = {}
+  if (!ip.type?.trim()) v.type = makeError('Required')
+  if (!ip.title?.trim()) v.title = makeError('Required')
+  if (!ip.assignee?.trim()) v.assignee = makeError('Required')
+  if (!ip.patentNumber?.trim()) v.patentNumber = makeError('Required')
+
+  // Date validation
+  if (!ip.filingDate?.trim()) {
+    v.filingDate = makeError('Required')
+  }
+  else if (!FormValidators.DATE.isValid(ip.filingDate)) {
+    v.filingDate = makeError('Invalid date format (YYYY-MM-DD)')
+  }
+
+  if (!ip.status?.trim()) v.status = makeError('Required')
+
+  // URL validation
+  if (!ip.url?.trim()) {
+    v.url = makeError('Required')
+  }
+  else if (!FormValidators.URL.isValid(ip.url)) {
+    v.url = makeError('Invalid URL format')
+  }
+
+  if (!ip.contact?.trim()) v.contact = makeError('Required')
+  return v
+}
+
+type IpFieldValue = string | string[]
+
+interface FormFieldChange {
+  key: string
+  value: IpFieldValue
+}
+
+export const IntellectualPropertyAddEdit: React.FC<IntellectualPropertyAddEditProps> = ({
+  id,
+  ip,
+  intellectualProperties,
+  closeAction,
+  onIpChange,
+}) => {
+  const [current, setCurrent] = useState<IntellectualProperty>(ip || defaultIp)
+  const [validation, setValidation] = useState<Validation>({})
+
+  const onChange = ({ key, value }: FormFieldChange) => {
+    const next = { ...current, [key]: value } as IntellectualProperty
+    setCurrent(next)
+    setValidation(calcErrors(next))
+  }
+
+  const save = () => {
+    if (validationFailed(calcErrors(current))) return
+    const toSave: IntellectualProperty = {
+      ...current,
+      ipId: current.ipId || crypto.randomUUID?.() || Date.now().toString(),
+    }
+    if (id < 0) {
+      onIpChange([...intellectualProperties, toSave])
+    }
+    else {
+      const copy = [...intellectualProperties]
+      copy[id] = toSave
+      onIpChange(copy)
+    }
+    setCurrent(defaultIp)
+    closeAction()
+  }
+
+  return (
+    <div className="form-group row no-margin">
+      <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
+        <div className="row">
+          <h2>{ip === undefined ? 'New Intellectual Property' : `Edit ${ip.title || 'Intellectual Property'}`}</h2>
+          <FormField
+            id="type"
+            title="Type"
+            defaultValue={ip?.type}
+            placeholder="e.g., Patent, Trademark"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.type}
+          />
+          <FormField
+            id="title"
+            title="Title"
+            defaultValue={ip?.title}
+            placeholder="IP Title"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.title}
+          />
+          <FormField
+            id="assignee"
+            title="Assignee"
+            defaultValue={ip?.assignee}
+            placeholder="Assignee Name"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.assignee}
+          />
+          <FormField
+            id="patentNumber"
+            title="Patent Number"
+            defaultValue={ip?.patentNumber}
+            placeholder="Patent Number"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.patentNumber}
+          />
+          <FormField
+            id="filingDate"
+            title="Filing Date"
+            defaultValue={ip?.filingDate}
+            placeholder="YYYY-MM-DD"
+            validators={[FormValidators.REQUIRED, FormValidators.DATE]}
+            onChange={onChange}
+            validation={validation.filingDate}
+          />
+          <FormField
+            id="status"
+            title="Status"
+            defaultValue={ip?.status}
+            placeholder="e.g., Pending, Granted"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.status}
+          />
+          <FormField
+            id="url"
+            title="URL"
+            defaultValue={ip?.url}
+            placeholder="https://..."
+            validators={[FormValidators.REQUIRED, FormValidators.URL]}
+            onChange={onChange}
+            validation={validation.url}
+          />
+          <FormField
+            id="contact"
+            title="Contact"
+            defaultValue={ip?.contact}
+            placeholder="Contact Information"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.contact}
+          />
+          <FormField
+            id="tags"
+            title="Tags (comma separated)"
+            defaultValue={ip?.tags?.join(', ')}
+            placeholder="tag1, tag2"
+            onChange={({ value }: { value: string }) =>
+              onChange({
+                key: 'tags',
+                value: value
+                  .split(',')
+                  .map(t => t.trim())
+                  .filter(Boolean),
+              })}
+          />
+          <FormField
+            id="citation"
+            type={FormFieldTypes.TEXT}
+            style={{ display: 'none' }}
+            title=""
+            onChange={() => {}}
+          />
+        </div>
+        <div className="row" style={{ marginTop: 20 }}>
+          <button
+            className="collaborator-form-add-save-button f-left btn"
+            type="button"
+            onClick={save}
+            disabled={validationFailed(calcErrors(current))}
+          >
+            {ip === undefined ? 'Add' : 'Save'}
+          </button>
+          <button
+            className="collaborator-form-cancel-button f-left btn"
+            type="button"
+            onClick={closeAction}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default IntellectualPropertyAddEdit

--- a/src/components/intellectual_property_list/IntellectualPropertyList.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyList.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { IntellectualProperty } from 'src/types/model'
+import { IntellectualPropertyAddEdit } from 'src/components/intellectual_property_list/IntellectualPropertyAddEdit'
+import IntellectualPropertyRow from 'src/components/intellectual_property_list/IntellectualPropertyRow'
+import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+
+interface IntellectualPropertyListProps {
+  readonly intellectualProperties: IntellectualProperty[]
+  readonly columnsToShow?: string[]
+  readonly onIntellectualPropertyChange: (items: IntellectualProperty[]) => void
+  readonly disabled?: boolean
+  readonly validation?: DarErrors
+}
+
+export default function IntellectualPropertyList(props: IntellectualPropertyListProps): React.JSX.Element {
+  const {
+    intellectualProperties,
+    columnsToShow = ['title', 'type', 'patentNumber', 'filingDate', 'status', 'url'],
+    onIntellectualPropertyChange,
+    disabled = false,
+    validation,
+  } = props
+
+  const [showAddEdit, setShowAddEdit] = useState(false)
+  const [editState, setEditState] = useState(intellectualProperties.map(() => false))
+
+  const toggleEditState = (index: number) => {
+    const editStateCopy = [...editState]
+    editStateCopy[index] = !editStateCopy[index]
+    setEditState(editStateCopy)
+  }
+
+  const handleDeleteIp = (index: number) => {
+    const updated = intellectualProperties.filter((_, i) => i !== index)
+    onIntellectualPropertyChange(updated)
+  }
+
+  const getValidationState = () => validation?.intellectualProperties
+
+  return (
+    <div className="presentation-list-component">
+      <div className="row no-margin">
+        <button
+          id="add-ip-btn"
+          type="button"
+          className="button button-white"
+          style={{
+            marginTop: 25,
+            marginBottom: 5,
+            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+            ...(disabled ? { cursor: 'not-allowed' } : {}),
+          }}
+          onClick={() => !disabled && setShowAddEdit(true)}
+          disabled={disabled}
+        >
+          Add Intellectual Property
+        </button>
+        {showAddEdit && (
+          <IntellectualPropertyAddEdit
+            id={-1}
+            intellectualProperties={intellectualProperties}
+            closeAction={() => setShowAddEdit(false)}
+            onIpChange={onIntellectualPropertyChange}
+          />
+        )}
+      </div>
+      <div className="form-group row no-margin">
+        {intellectualProperties.map((ip: IntellectualProperty, index: number) => (
+          <IntellectualPropertyRow
+            key={ip.ipId || index}
+            id={index}
+            editMode={editState[index]}
+            ip={ip}
+            intellectualProperties={intellectualProperties}
+            columnsToShow={columnsToShow}
+            editAction={() => toggleEditState(index)}
+            deleteAction={() => handleDeleteIp(index)}
+            closeAction={() => {
+              toggleEditState(index)
+              setShowAddEdit(false)
+            }}
+            onIpChange={onIntellectualPropertyChange}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/intellectual_property_list/IntellectualPropertyRow.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyRow.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { IntellectualProperty } from 'src/types/model'
+import { IntellectualPropertySummary } from 'src/components/intellectual_property_list/IntellectualPropertySummary'
+import { IntellectualPropertyAddEdit } from 'src/components/intellectual_property_list/IntellectualPropertyAddEdit'
+
+interface IntellectualPropertyRowProps {
+  readonly id: number
+  readonly editMode: boolean
+  readonly ip: IntellectualProperty
+  readonly intellectualProperties: IntellectualProperty[]
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly closeAction: () => void
+  readonly onIpChange: (items: IntellectualProperty[]) => void
+  readonly disabled: boolean
+}
+
+export const IntellectualPropertyRow: React.FC<IntellectualPropertyRowProps> = ({
+  id,
+  editMode,
+  ip,
+  intellectualProperties,
+  columnsToShow,
+  editAction,
+  deleteAction,
+  closeAction,
+  onIpChange,
+  disabled,
+}) => {
+  return editMode
+    ? (
+        <IntellectualPropertyAddEdit
+          id={id}
+          ip={ip}
+          intellectualProperties={intellectualProperties}
+          closeAction={closeAction}
+          onIpChange={onIpChange}
+        />
+      )
+    : (
+        <IntellectualPropertySummary
+          ip={ip}
+          columnsToShow={columnsToShow}
+          editAction={editAction}
+          deleteAction={deleteAction}
+          disabled={disabled}
+        />
+      )
+}
+
+export default IntellectualPropertyRow

--- a/src/components/intellectual_property_list/IntellectualPropertySummary.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertySummary.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react'
+import { IntellectualProperty } from 'src/types/model'
+import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
+import { renderColumnContent } from 'src/utils/RenderUtils'
+
+interface IntellectualPropertySummaryProps {
+  readonly ip: IntellectualProperty
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly disabled: boolean
+}
+
+export const IntellectualPropertySummary: React.FC<IntellectualPropertySummaryProps> = ({
+  ip,
+  columnsToShow,
+  editAction,
+  deleteAction,
+  disabled,
+}) => {
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  const disabledStyle = {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  }
+
+  const buttonStyle = disabled ? disabledStyle : {}
+
+  const customRenderers = {
+    url: (value: unknown) => {
+      if (typeof value === 'string' && value) {
+        return (
+          <a href={value} target="_blank" rel="noreferrer">
+            {value}
+          </a>
+        )
+      }
+      return '—'
+    },
+    tags: (value: unknown) => {
+      if (Array.isArray(value) && value.length > 0) {
+        return value.join(', ')
+      }
+      return '—'
+    },
+  }
+
+  return (
+    <div className="collaborator-summary-card">
+      {columnsToShow.map((column, index) => {
+        const rawValue = ip[column as keyof IntellectualProperty]
+        const columnContent = renderColumnContent(column, rawValue as unknown, customRenderers)
+        return columnContent && (
+          <div key={'ip_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
+            <span>{columnContent}</span>
+          </div>
+        )
+      })}
+      <div className="collaborator-summary-edit-delete-buttons">
+        <button
+          type="button"
+          style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
+          onClick={() => !disabled && editAction()}
+          disabled={disabled}
+          aria-label="Edit intellectual property"
+        >
+          <span
+            className="glyphicon glyphicon-pencil caret-margin collaborator-edit-icon"
+            aria-hidden="true"
+            data-tip="Edit intellectual property"
+            data-for="tip_edit_ip"
+          />
+          <span style={{ marginLeft: '1rem' }} />
+        </button>
+      </div>
+      <button
+        type="button"
+        style={{ marginLeft: 10, ...buttonStyle }}
+        onClick={() => !disabled && setShowDeleteModal(true)}
+        disabled={disabled}
+        aria-label="Delete intellectual property"
+      >
+        <span
+          className="glyphicon glyphicon-trash presentation-delete-icon"
+          aria-hidden="true"
+          data-tip="Delete intellectual property"
+          data-for="tip_delete_ip"
+        />
+        <span style={{ marginLeft: '1rem' }} />
+      </button>
+      <DeletePresentationOrPublication
+        name={ip.title || ip.type}
+        objectName="intellectual property"
+        showDelete={showDeleteModal}
+        confirmAction={() => {
+          deleteAction()
+          setShowDeleteModal(false)
+        }}
+        closeAction={() => setShowDeleteModal(false)}
+      />
+    </div>
+  )
+}
+
+export default IntellectualPropertySummary

--- a/src/pages/dar_application/FormValidationState.tsx
+++ b/src/pages/dar_application/FormValidationState.tsx
@@ -34,8 +34,8 @@ export interface DarErrors {
   pubAcknowledgement?: ValidationError
   dsAcknowledgement?: ValidationError
   progressReportSummary?: ValidationError
-  intellectualPropertyYesNo?: ValidationError
-  intellectualPropertySummary?: ValidationError
+  intellectualPropertiesYesNo?: ValidationError
+  intellectualProperties?: ValidationError
   publicationsYesNo?: ValidationError
   publications?: ValidationError
   presentationsYesNo?: ValidationError

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -39,6 +39,7 @@ type ProgressReportApplicationProps = {
 export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, history, researcher, countriesOfOperation }: ProgressReportApplicationProps) => {
   const initialState: FormState = {
     ...dar,
+    intellectualProperties: (dar.intellectualProperties || []),
     publications: (dar.publications || []),
     presentations: (dar.presentations || []),
     dmiCombination: false,
@@ -59,14 +60,14 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
     ...(readOnlyMode
       ? {
           // In read-only mode, check "No" when undefined
-          intellectualPropertyYesNo: !!dar.intellectualPropertySummary,
+          intellectualPropertiesYesNo: ((dar.intellectualProperties?.length ?? 0) > 0),
           publicationsYesNo: ((dar.publications?.length ?? 0) > 0),
           presentationsYesNo: ((dar.presentations?.length ?? 0) > 0),
         }
       : {
           // When not in read-only mode, don't check anything when undefined
-          ...(dar?.intellectualPropertySummary && {
-            intellectualPropertyYesNo: !!dar.intellectualPropertySummary,
+          ...(dar?.intellectualProperties && {
+            intellectualPropertiesYesNo: (dar.intellectualProperties.length > 0),
           }),
           ...(dar?.publications && {
             publicationsYesNo: (dar.publications.length > 0),

--- a/src/pages/progress_reports/ProgressReportFormState.tsx
+++ b/src/pages/progress_reports/ProgressReportFormState.tsx
@@ -1,4 +1,11 @@
-import { Collaborator, Dataset, Presentation, Publication, SimplifiedDuosUser } from 'src/types/model'
+import {
+  Collaborator,
+  Dataset,
+  IntellectualProperty,
+  Presentation,
+  Publication,
+  SimplifiedDuosUser,
+} from 'src/types/model'
 
 type FormStateKeys = keyof FormState
 
@@ -9,8 +16,8 @@ export type ValidFormState = {
 
 export interface FormState {
   progressReportSummary: string
-  intellectualPropertyYesNo: boolean
-  intellectualPropertySummary: string
+  intellectualPropertiesYesNo: boolean
+  intellectualProperties: IntellectualProperty[]
   datasetIds: number[]
   publicationsYesNo: boolean
   publications: Publication[]
@@ -52,8 +59,8 @@ export interface FormState {
 
 export enum FormStateKey {
   PROGRESS_REPORT_SUMMARY = 'progressReportSummary',
-  INTELLECTUAL_PROPERTY_YES_NO = 'intellectualPropertyYesNo',
-  INTELLECTUAL_PROPERTY_SUMMARY = 'intellectualPropertySummary',
+  INTELLECTUAL_PROPERTIES_YES_NO = 'intellectualPropertiesYesNo',
+  INTELLECTUAL_PROPERTIES = 'intellectualProperties',
   DATASET_IDS = 'datasetIds',
   PUBLICATIONS_YES_NO = 'publicationsYesNo',
   PUBLICATIONS = 'publications',

--- a/src/pages/progress_reports/SummarySection.tsx
+++ b/src/pages/progress_reports/SummarySection.tsx
@@ -4,11 +4,12 @@ import { FormField, FormFieldTitle, FormFieldTypes } from 'src/components/forms/
 import PublicationList from 'src/components/publications_list/PublicationList'
 import { ValidFormState, FormState, FormStateKey } from 'src/pages/progress_reports/ProgressReportFormState'
 import ERACommons from 'src/components/era_commons/ERACommons'
-import { DuosUser, Presentation, Publication } from 'src/types/model'
+import { DuosUser, IntellectualProperty, Presentation, Publication } from 'src/types/model'
 import { Location } from 'history'
 import { DarErrors, ValidationError } from 'src/pages/dar_application/FormValidationState'
 import { ERACommonsDisplay } from 'src/components/era_commons/ERACommonsDisplay'
 import PresentationList from 'src/components/presentations_list/PresentationList'
+import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
 
 interface SummarySectionProps {
   readonly readOnly: boolean
@@ -26,8 +27,14 @@ interface SummarySectionProps {
 export default function SummarySection(props: Readonly<SummarySectionProps>): React.JSX.Element {
   const { readOnly, formState, onFormChange, eRACommonsDestination, researcher, onValidationChange, validation, nihValid, onNihStatusUpdate } = props
 
+  const [intellectualProperties, setIntellectualProperties] = useState<IntellectualProperty[]>(formState.intellectualProperties || [])
   const [publications, setPublications] = useState<Publication[]>(formState.publications || [])
   const [presentations, setPresentations] = useState<Presentation[]>(formState.presentations || [])
+
+  const onIntellectualPropertyChange = (intellectualProperties: IntellectualProperty[]) => {
+    onFormChange({ [FormStateKey.INTELLECTUAL_PROPERTIES]: intellectualProperties } as Partial<FormState>)
+    setIntellectualProperties(intellectualProperties)
+  }
 
   const onPublicationChange = (publications: Publication[]) => {
     onFormChange({ [FormStateKey.PUBLICATIONS]: publications } as Partial<FormState>)
@@ -86,7 +93,7 @@ export default function SummarySection(props: Readonly<SummarySectionProps>): Re
         </div>
         <div className="progress-report-row">
           <FormField
-            id={FormStateKey.INTELLECTUAL_PROPERTY_YES_NO}
+            id={FormStateKey.INTELLECTUAL_PROPERTIES_YES_NO}
             type={FormFieldTypes.YESNORADIOGROUP}
             title="1.3 Intellectual Property"
             description={(
@@ -99,29 +106,20 @@ export default function SummarySection(props: Readonly<SummarySectionProps>): Re
               </span>
             )}
             orientation="horizontal"
-            defaultValue={formState.intellectualPropertyYesNo}
+            defaultValue={formState.intellectualPropertiesYesNo}
             onChange={({ key, value }: ValidFormState) => {
               onFormChange({ [key]: value } as Partial<FormState>)
             }}
             disabled={readOnly}
-            validation={validation?.intellectualPropertyYesNo}
+            validation={validation?.intellectualPropertiesYesNo}
             onValidationChange={onValidationChange}
           />
-          {formState.intellectualPropertyYesNo && (
-            <FormField
-              id={FormStateKey.INTELLECTUAL_PROPERTY_SUMMARY}
-              type={FormFieldTypes.TEXTAREA}
-              description="Please describe the intellectual property resulting from analysis of the requested dataset(s)."
-              placeholder="Please provide an update here."
-              rows={6}
-              maxLength={FORM_TEXT_AREA_MAX_LENGTH}
-              defaultValue={formState.intellectualPropertySummary}
-              onChange={({ key, value }: ValidFormState) => {
-                onFormChange({ [key]: value } as Partial<FormState>)
-              }}
+          {(formState.intellectualPropertiesYesNo || (readOnly && intellectualProperties.length > 0)) && (
+            <IntellectualPropertyList
+              intellectualProperties={intellectualProperties}
+              onIntellectualPropertyChange={onIntellectualPropertyChange}
               disabled={readOnly}
-              validation={validation?.intellectualPropertySummary}
-              onValidationChange={onValidationChange}
+              validation={validation}
             />
           )}
         </div>

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -551,7 +551,7 @@ export interface CombinedDataAccessRequest extends DataAccessRequest {
   darCode: string
   validRestriction: boolean
   progressReportSummary: string
-  intellectualPropertySummary: string
+  intellectualProperties?: Array<IntellectualProperty>
   publications?: Array<Publication>
   presentations?: Array<Presentation>
   dmi?: DataManagementIncident

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -3,7 +3,7 @@ import {
   Closeout,
   CombinedDataAccessRequest, DarCollection, DataAccessRequest,
   DataManagementIncident,
-  Election,
+  Election, IntellectualProperty,
   Presentation,
   Publication, Vote,
 } from 'src/types/model'
@@ -42,8 +42,8 @@ export function getApprovedElectionDatasetIds(elections: Array<Election>): Array
 export function convertFormStateToDAR(formState: FormState): Partial<CombinedDataAccessRequest> {
   const expectedForm: Partial<CombinedDataAccessRequest> = {} as Partial<CombinedDataAccessRequest>
   expectedForm.progressReportSummary = formState.progressReportSummary
-  if (formState.intellectualPropertyYesNo) {
-    expectedForm.intellectualPropertySummary = formState.intellectualPropertySummary
+  if (formState.intellectualPropertiesYesNo) {
+    expectedForm.intellectualProperties = formState.intellectualProperties
   }
   expectedForm.datasetIds = formState.datasetIds ?? []
   if (formState.publicationsYesNo) {
@@ -70,6 +70,23 @@ export function convertFormStateToDAR(formState: FormState): Partial<CombinedDat
   expectedForm.collaborationLetterLocation = formState.collaborationLetterLocation
   expectedForm.collaborationLetterName = formState.collaborationLetterName
   return expectedForm
+}
+
+export function getIntellectualPropertyList(formState: FormState): IntellectualProperty[] {
+  const intellectualProperties: IntellectualProperty[] = formState.intellectualProperties ?? []
+  return intellectualProperties.map((ip: IntellectualProperty) => ({
+    ipId: ip.ipId,
+    studyId: ip.studyId,
+    type: ip.type,
+    title: ip.title,
+    assignee: ip.assignee,
+    patentNumber: ip.patentNumber,
+    filingDate: ip.filingDate,
+    status: ip.status,
+    url: ip.url,
+    contact: ip.contact,
+    tags: ip.tags ? [...ip.tags] : [],
+  }))
 }
 
 export function getPublicationList(formState: FormState): Publication[] {

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -211,11 +211,11 @@ const calcSummaryErrors = (nihValid, errors, formData) => {
   if (isEmpty(formData.progressReportSummary)) {
     errors.progressReportSummary = requiredError
   }
-  if (isNil(formData.intellectualPropertyYesNo)) {
-    errors.intellectualPropertyYesNo = requiredError
+  if (isNil(formData.intellectualPropertiesYesNo)) {
+    errors.intellectualPropertiesYesNo = requiredError
   }
-  if (formData.intellectualPropertyYesNo && isEmpty(formData.intellectualPropertySummary)) {
-    errors.intellectualPropertySummary = requiredError
+  if (formData.intellectualPropertiesYesNo && isEmpty(formData.intellectualProperties)) {
+    errors.intellectualProperties = requiredError
   }
   if (isNil(formData.publicationsYesNo)) {
     errors.publicationsYesNo = requiredError


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2355

### Summary

Adds a React TypeScript component that renders input fields for Intellectual Property based on the defined schema and interface. Includes field-level validation, business logic for input validation, and unit tests.

**New** 
<img width="1448" height="802" alt="New" src="https://github.com/user-attachments/assets/4da27587-695f-4fe7-aedf-d25aa14a7d93" />


**Edit**
<img width="1445" height="802" alt="Edit" src="https://github.com/user-attachments/assets/02e3a2c7-5fd3-45eb-9530-dabc8685a725" />


**List**
<img width="1445" height="82" alt="List" src="https://github.com/user-attachments/assets/0e47f344-0782-4d8e-95a5-06507764ce30" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
