### PR TITLE
[DT-2352] Added Workspace Components

### DIFF
--- a/cypress/component/StudyAssets/workspace_list.spec.tsx
+++ b/cypress/component/StudyAssets/workspace_list.spec.tsx
@@ -1,0 +1,182 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import { Workspace } from 'src/types/model'
+import { WorkspaceAddEdit } from 'src/components/workspaces_list/WorkspaceAddEdit'
+import WorkspaceSummary from 'src/components/workspaces_list/WorkspaceSummary'
+import WorkspaceRow from 'src/components/workspaces_list/WorkspaceRow'
+import WorkspaceList from 'src/components/workspaces_list/WorkspaceList'
+
+const sampleWorkspace: Workspace = {
+  workspaceId: 'w1',
+  studyId: 's1',
+  name: 'Analysis Workspace',
+  platform: 'Terra',
+  url: 'https://terra.bio/workspace',
+  description: 'Main analysis workspace',
+  tools: ['R', 'Python'],
+  access: 'controlled',
+  tags: ['genomics', 'analysis'],
+}
+
+const WorkspaceListHarness: React.FC<{ initial: Workspace[] }> = ({ initial }) => {
+  const [items, setItems] = React.useState<Workspace[]>(initial)
+  return (
+    <WorkspaceList
+      workspaces={items}
+      columnsToShow={['name']}
+      onWorkspaceChange={setItems}
+      disabled={false}
+    />
+  )
+}
+
+describe('WorkspaceAddEdit', () => {
+  it('disables Add until required fields filled then adds', () => {
+    const collected: Workspace[] = []
+    mount(
+      <WorkspaceAddEdit
+        id={-1}
+        workspace={undefined}
+        workspaces={[]}
+        closeAction={cy.stub().as('close')}
+        onWorkspaceChange={(items) => { collected.splice(0, collected.length, ...items) }}
+      />,
+    )
+    cy.get('.collaborator-form-add-save-button').should('be.disabled')
+    cy.get('#name').type('New Workspace')
+    cy.get('#platform').type('New Platform')
+    cy.get('#url').type('https://example.com')
+    cy.get('#description').type('New Description')
+    cy.get('#access').type('open')
+    cy.get('.collaborator-form-add-save-button').should('not.be.disabled').click()
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].name).to.eq('New Workspace')
+      expect(collected[0].platform).to.eq('New Platform')
+    })
+  })
+
+  it('edits existing workspace and saves changes', () => {
+    const workspaces: Workspace[] = [sampleWorkspace]
+    mount(
+      <WorkspaceAddEdit
+        id={0}
+        workspace={sampleWorkspace}
+        workspaces={workspaces}
+        closeAction={cy.stub().as('close')}
+        onWorkspaceChange={(updated) => {
+          expect(updated[0].name).to.eq('Analysis Workspace Edited')
+        }}
+      />,
+    )
+    cy.get('#name').clear()
+    cy.get('#name').type('Analysis Workspace Edited')
+    cy.get('.collaborator-form-add-save-button').click()
+  })
+})
+
+describe('WorkspaceSummary', () => {
+  it('renders columns including arrays and url', () => {
+    mount(
+      <WorkspaceSummary
+        workspace={sampleWorkspace}
+        columnsToShow={['name', 'platform', 'description', 'url', 'tools', 'tags']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Analysis Workspace').should('exist')
+    cy.contains('Terra').should('exist')
+    cy.contains('Main analysis workspace').should('exist')
+    cy.contains('R, Python').should('exist')
+    cy.contains('genomics, analysis').should('exist')
+    cy.get('a[href="https://terra.bio/workspace"]').should('exist')
+  })
+})
+
+describe('WorkspaceRow', () => {
+  it('shows summary when not in edit mode and triggers editAction', () => {
+    mount(
+      <WorkspaceRow
+        id={0}
+        editMode={false}
+        workspace={sampleWorkspace}
+        workspaces={[sampleWorkspace]}
+        columnsToShow={['name', 'platform']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onWorkspaceChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains('Analysis Workspace').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    mount(
+      <WorkspaceRow
+        id={0}
+        editMode={true}
+        workspace={sampleWorkspace}
+        workspaces={[sampleWorkspace]}
+        columnsToShow={['name']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onWorkspaceChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('#name').should('have.value', 'Analysis Workspace')
+  })
+})
+
+describe('WorkspaceList', () => {
+  it('adds a new workspace', () => {
+    const state: Workspace[] = []
+    mount(
+      <WorkspaceList
+        workspaces={state}
+        columnsToShow={['name', 'platform']}
+        onWorkspaceChange={(items) => { state.splice(0, state.length, ...items) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-workspace-btn').click()
+    cy.get('#name').type('Added Workspace')
+    cy.get('#platform').type('Added Platform')
+    cy.get('#url').type('https://added.com')
+    cy.get('#description').type('Added Description')
+    cy.get('#access').type('open')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.wrap(null).then(() => {
+      expect(state.length).to.eq(1)
+      expect(state[0].name).to.eq('Added Workspace')
+    })
+  })
+
+  it('deletes a workspace via modal confirmation', () => {
+    mount(<WorkspaceListHarness initial={[sampleWorkspace]} />)
+
+    cy.contains('Analysis Workspace').should('exist')
+
+    cy.get('.glyphicon-trash').click({ force: true })
+
+    cy.get('.ReactModal__Content')
+      .should('be.visible')
+      .within(() => {
+        cy.get('button')
+          .filter(':visible')
+          .contains(/delete/i)
+          .click({ force: true })
+      })
+
+    cy.get('.ReactModal__Content').should('not.exist')
+    cy.contains('Analysis Workspace').should('not.exist')
+    cy.get('.collaborator-summary-card').should('have.length', 0)
+  })
+})

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { FundingResource } from 'src/types/model'
+import { ValidationError } from 'src/pages/dar_application/FormValidationState'
 
 interface FundingSourceAddEditProps {
   readonly id: number
@@ -11,13 +12,13 @@ interface FundingSourceAddEditProps {
 }
 
 interface Validation {
-  funderName?: unknown
-  funderProgram?: unknown
-  grantNumber?: unknown
-  projectTitle?: unknown
-  startDate?: unknown
-  endDate?: unknown
-  url?: unknown
+  funderName?: ValidationError
+  funderProgram?: ValidationError
+  grantNumber?: ValidationError
+  projectTitle?: ValidationError
+  startDate?: ValidationError
+  endDate?: ValidationError
+  url?: ValidationError
 }
 
 const defaultFunding: FundingResource = {
@@ -33,10 +34,12 @@ const defaultFunding: FundingResource = {
   tags: [],
 }
 
+const makeError = (message: string): ValidationError => ({ valid: true, failed: [message] })
+
 const calcErrors = (f: FundingResource): Validation => {
   const v: Validation = {}
-  if (!f.funderName?.trim()) v.funderName = { error: 'Required' }
-  if (!f.projectTitle?.trim()) v.projectTitle = { error: 'Required' }
+  if (!f.funderName?.trim()) v.funderName = makeError('Required')
+  if (!f.projectTitle?.trim()) v.projectTitle = makeError('Required')
   return v
 }
 

--- a/src/components/workspaces_list/WorkspaceAddEdit.tsx
+++ b/src/components/workspaces_list/WorkspaceAddEdit.tsx
@@ -1,0 +1,200 @@
+import React, { useState } from 'react'
+import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
+import { Workspace } from 'src/types/model'
+import { ValidationError } from 'src/pages/dar_application/FormValidationState'
+
+interface WorkspaceAddEditProps {
+  readonly id: number
+  readonly workspace?: Workspace
+  readonly workspaces: Workspace[]
+  readonly closeAction: () => void
+  readonly onWorkspaceChange: (items: Workspace[]) => void
+}
+
+interface Validation {
+  name?: ValidationError
+  platform?: ValidationError
+  url?: ValidationError
+  description?: ValidationError
+  access?: ValidationError
+}
+
+const defaultWorkspace: Workspace = {
+  workspaceId: '',
+  studyId: '',
+  name: '',
+  platform: '',
+  url: '',
+  description: '',
+  tools: [],
+  access: '',
+  tags: [],
+}
+
+const makeError = (message: string): ValidationError => ({ valid: true, failed: [message] })
+
+const calcErrors = (w: Workspace): Validation => {
+  const v: Validation = {}
+  if (!w.name?.trim()) v.name = makeError('Required')
+  if (!w.platform?.trim()) v.platform = makeError('Required')
+  if (!w.url?.trim()) {
+    v.url = makeError('Required')
+  }
+  else if (!FormValidators.URL.isValid(w.url)) {
+    v.url = makeError('Invalid URL format')
+  }
+  if (!w.description?.trim()) v.description = makeError('Required')
+  if (!w.access?.trim()) v.access = makeError('Required')
+  return v
+}
+
+const validationFailed = (v: Validation) => Object.values(v).some(e => !!e)
+
+type WorkspaceFieldValue = string | string[]
+
+interface FormFieldChange {
+  key: string
+  value: WorkspaceFieldValue
+}
+
+export const WorkspaceAddEdit: React.FC<WorkspaceAddEditProps> = ({
+  id,
+  workspace,
+  workspaces,
+  closeAction,
+  onWorkspaceChange,
+}) => {
+  const [current, setCurrent] = useState<Workspace>(workspace || defaultWorkspace)
+  const [validation, setValidation] = useState<Validation>({})
+
+  const onChange = ({ key, value }: FormFieldChange) => {
+    const next = { ...current, [key]: value } as Workspace
+    setCurrent(next)
+    setValidation(calcErrors(next))
+  }
+
+  const save = () => {
+    if (validationFailed(calcErrors(current))) return
+    const toSave: Workspace = {
+      ...current,
+      workspaceId: current.workspaceId || crypto.randomUUID?.() || Date.now().toString(),
+    }
+    if (id < 0) {
+      onWorkspaceChange([...workspaces, toSave])
+    }
+    else {
+      const copy = [...workspaces]
+      copy[id] = toSave
+      onWorkspaceChange(copy)
+    }
+    setCurrent(defaultWorkspace)
+    closeAction()
+  }
+
+  return (
+    <div className="form-group row no-margin">
+      <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
+        <div className="row">
+          <h2>{workspace === undefined ? 'New Workspace' : `Edit ${workspace.name || 'Workspace'}`}</h2>
+          <FormField
+            id="name"
+            title="Workspace Name"
+            defaultValue={workspace?.name}
+            placeholder="Workspace Name"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.name}
+          />
+          <FormField
+            id="platform"
+            title="Platform"
+            defaultValue={workspace?.platform}
+            placeholder="Platform"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.platform}
+          />
+          <FormField
+            id="url"
+            title="URL"
+            defaultValue={workspace?.url}
+            placeholder="https://..."
+            validators={[FormValidators.REQUIRED, FormValidators.URL]}
+            onChange={onChange}
+            validation={validation.url}
+          />
+          <FormField
+            id="description"
+            title="Description"
+            defaultValue={workspace?.description}
+            placeholder="Description"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.description}
+          />
+          <FormField
+            id="tools"
+            title="Tools (comma separated)"
+            defaultValue={workspace?.tools?.join(', ')}
+            placeholder="tool1, tool2"
+            onChange={({ value }: { value: string }) =>
+              onChange({
+                key: 'tools',
+                value: value
+                  .split(',')
+                  .map(t => t.trim())
+                  .filter(Boolean),
+              })}
+          />
+          <FormField
+            id="access"
+            title="Access"
+            defaultValue={workspace?.access}
+            placeholder="Access Type"
+            validators={[FormValidators.REQUIRED]}
+            onChange={onChange}
+            validation={validation.access}
+          />
+          <FormField
+            id="tags"
+            title="Tags (comma separated)"
+            defaultValue={workspace?.tags?.join(', ')}
+            placeholder="tag1, tag2"
+            onChange={({ value }: { value: string }) =>
+              onChange({
+                key: 'tags',
+                value: value
+                  .split(',')
+                  .map(t => t.trim())
+                  .filter(Boolean),
+              })}
+          />
+          <FormField
+            id="citation"
+            type={FormFieldTypes.TEXT}
+            style={{ display: 'none' }}
+            title=""
+            onChange={() => {}}
+          />
+        </div>
+        <div className="row" style={{ marginTop: 20 }}>
+          <button
+            className="collaborator-form-add-save-button f-left btn"
+            type="button"
+            onClick={save}
+            disabled={validationFailed(calcErrors(current))}
+          >
+            {workspace === undefined ? 'Add' : 'Save'}
+          </button>
+          <button
+            className="collaborator-form-cancel-button f-left btn"
+            type="button"
+            onClick={closeAction}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/workspaces_list/WorkspaceList.tsx
+++ b/src/components/workspaces_list/WorkspaceList.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react'
+import { Workspace } from 'src/types/model'
+import { WorkspaceAddEdit } from 'src/components/workspaces_list/WorkspaceAddEdit'
+import WorkspaceRow from 'src/components/workspaces_list/WorkspaceRow'
+import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+
+interface WorkspaceListProps {
+  readonly workspaces: Workspace[]
+  readonly columnsToShow?: string[]
+  readonly onWorkspaceChange: (items: Workspace[]) => void
+  readonly disabled?: boolean
+  readonly validation?: DarErrors
+}
+
+export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Element {
+  const {
+    workspaces,
+    columnsToShow = ['name', 'platform', 'url', 'description', 'tools', 'access', 'tags'],
+    onWorkspaceChange,
+    disabled = false,
+    validation,
+  } = props
+
+  const [showAddEdit, setShowAddEdit] = useState(false)
+  const [editState, setEditState] = useState(workspaces.map(() => false))
+
+  const toggleEditState = (index: number) => {
+    const editStateCopy = [...editState]
+    editStateCopy[index] = !editStateCopy[index]
+    setEditState(editStateCopy)
+  }
+
+  const handleDeleteWorkspace = (index: number) => {
+    const updated = workspaces.filter((_, i) => i !== index)
+    onWorkspaceChange(updated)
+  }
+
+  const getValidationState = () => validation?.workspaces
+
+  return (
+    <div className="presentation-list-component">
+      <div className="row no-margin">
+        <button
+          id="add-workspace-btn"
+          type="button"
+          className="button button-white"
+          style={{
+            marginTop: 25,
+            marginBottom: 5,
+            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+            ...(disabled ? { cursor: 'not-allowed' } : {}),
+          }}
+          onClick={() => !disabled && setShowAddEdit(true)}
+          disabled={disabled}
+        >
+          Add Workspace
+        </button>
+        {showAddEdit && (
+          <WorkspaceAddEdit
+            id={-1}
+            workspaces={workspaces}
+            closeAction={() => setShowAddEdit(false)}
+            onWorkspaceChange={onWorkspaceChange}
+          />
+        )}
+      </div>
+      <div className="form-group row no-margin">
+        {workspaces.map((w: Workspace, index: number) => (
+          <WorkspaceRow
+            key={w.workspaceId || index}
+            id={index}
+            editMode={editState[index]}
+            workspace={w}
+            workspaces={workspaces}
+            columnsToShow={columnsToShow}
+            editAction={() => toggleEditState(index)}
+            deleteAction={() => handleDeleteWorkspace(index)}
+            closeAction={() => {
+              toggleEditState(index)
+              setShowAddEdit(false)
+            }}
+            onWorkspaceChange={onWorkspaceChange}
+            disabled={disabled}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/workspaces_list/WorkspaceRow.tsx
+++ b/src/components/workspaces_list/WorkspaceRow.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Workspace } from 'src/types/model'
+import { WorkspaceAddEdit } from 'src/components/workspaces_list/WorkspaceAddEdit'
+import { WorkspaceSummary } from 'src/components/workspaces_list/WorkspaceSummary'
+
+interface WorkspaceRowProps {
+  readonly id: number
+  readonly editMode: boolean
+  readonly workspace: Workspace
+  readonly workspaces: Workspace[]
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly closeAction: () => void
+  readonly onWorkspaceChange: (items: Workspace[]) => void
+  readonly disabled: boolean
+}
+
+export default function WorkspaceRow(props: WorkspaceRowProps): React.JSX.Element {
+  const {
+    id,
+    editMode,
+    workspace,
+    workspaces,
+    columnsToShow,
+    editAction,
+    deleteAction,
+    closeAction,
+    onWorkspaceChange,
+    disabled,
+  } = props
+
+  return (
+    <div>
+      {editMode && (
+        <WorkspaceAddEdit
+          id={id}
+          workspace={workspace}
+          workspaces={workspaces}
+          closeAction={closeAction}
+          onWorkspaceChange={onWorkspaceChange}
+        />
+      )}
+      {!editMode && (
+        <WorkspaceSummary
+          workspace={workspace}
+          columnsToShow={columnsToShow}
+          editAction={editAction}
+          deleteAction={deleteAction}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/workspaces_list/WorkspaceSummary.tsx
+++ b/src/components/workspaces_list/WorkspaceSummary.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react'
+import { Workspace } from 'src/types/model'
+import { DeletePresentationOrPublication } from 'src/components/presentation_publication_shared/DeletePresentationOrPublication'
+import { renderColumnContent } from 'src/utils/RenderUtils'
+
+interface WorkspaceSummaryProps {
+  readonly workspace: Workspace
+  readonly columnsToShow: string[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly disabled: boolean
+}
+
+export const WorkspaceSummary: React.FC<WorkspaceSummaryProps> = ({
+  workspace,
+  columnsToShow,
+  editAction,
+  deleteAction,
+  disabled,
+}) => {
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  const disabledStyle = {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  }
+
+  const buttonStyle = disabled ? disabledStyle : {}
+
+  const customRenderers = {
+    url: (value: unknown) => {
+      if (typeof value === 'string' && value) {
+        return (
+          <a href={value} target="_blank" rel="noreferrer">
+            {value}
+          </a>
+        )
+      }
+      return '—'
+    },
+    tools: (value: unknown) => {
+      if (Array.isArray(value) && value.length > 0) {
+        return value.join(', ')
+      }
+      return '—'
+    },
+    tags: (value: unknown) => {
+      if (Array.isArray(value) && value.length > 0) {
+        return value.join(', ')
+      }
+      return '—'
+    },
+  }
+
+  return (
+    <div className="collaborator-summary-card">
+      {columnsToShow.map((column, index) => {
+        const rawValue = workspace[column as keyof Workspace]
+        const columnContent = renderColumnContent(column, rawValue as unknown, customRenderers)
+        return columnContent && (
+          <div key={'workspace_summary_column_' + index} style={{ flex: '1 1 100%', marginRight: '1.5rem' }}>
+            <span>{columnContent}</span>
+          </div>
+        )
+      })}
+      <div className="collaborator-summary-edit-delete-buttons">
+        <button
+          type="button"
+          style={{ marginLeft: 10, marginRight: 10, ...buttonStyle }}
+          onClick={() => !disabled && editAction()}
+          disabled={disabled}
+          aria-label="Edit workspace"
+        >
+          <span
+            className="glyphicon glyphicon-pencil caret-margin collaborator-edit-icon"
+            aria-hidden="true"
+            data-tip="Edit workspace"
+            data-for="tip_edit_workspace"
+          />
+          <span style={{ marginLeft: '1rem' }} />
+        </button>
+      </div>
+      <button
+        type="button"
+        style={{ marginLeft: 10, ...buttonStyle }}
+        onClick={() => !disabled && setShowDeleteModal(true)}
+        disabled={disabled}
+        aria-label="Delete workspace"
+      >
+        <span
+          className="glyphicon glyphicon-trash presentation-delete-icon"
+          aria-hidden="true"
+          data-tip="Delete workspace"
+          data-for="tip_delete_workspace"
+        />
+        <span style={{ marginLeft: '1rem' }} />
+      </button>
+      <DeletePresentationOrPublication
+        name={workspace.name}
+        objectName="workspace"
+        showDelete={showDeleteModal}
+        confirmAction={() => {
+          deleteAction()
+          setShowDeleteModal(false)
+        }}
+        closeAction={() => setShowDeleteModal(false)}
+      />
+    </div>
+  )
+}
+
+export default WorkspaceSummary

--- a/src/pages/dar_application/FormValidationState.tsx
+++ b/src/pages/dar_application/FormValidationState.tsx
@@ -64,6 +64,7 @@ export interface DarErrors {
   aiModels?: ValidationError
   clinicalTrials?: ValidationError
   fundingResources?: ValidationError
+  workspaces?: ValidationError
 }
 
 export interface RusErrors {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -365,7 +365,7 @@ export interface Workspace {
   platform: string
   url: string
   description: string
-  tools: string[]
+  tools?: string[]
   access: string
   tags?: string[]
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2352

### Summary

Adds a React TypeScript component that renders input fields for Workspaces based on the defined schema and interface. Includes field-level validation, business logic for input validation, and unit tests.

**New**
<img width="1476" height="666" alt="New" src="https://github.com/user-attachments/assets/a1ef096b-8d19-43e9-9218-773ae030d79c" />

**Edit**
<img width="1466" height="663" alt="Edit" src="https://github.com/user-attachments/assets/c69a4a45-78f2-4001-ba1f-d03afe286478" />

**List**
<img width="1466" height="102" alt="List" src="https://github.com/user-attachments/assets/c4262707-2bc0-4f9a-9567-9071b148a2b0" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
