### PR TITLE
[DT-2317] Ensure Primary Research Use Term is Validated and Displayed

### DIFF
--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -409,6 +409,12 @@ export const DataUseTranslation = {
       dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.other(darInfo.otherText))
     }
 
+    // **FALLBACK CHECK**
+    // If no primary codes were added, add an "OTHER: Not provided" code
+    if (isEmpty(dataUseSummary.primary)) {
+      dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.other(null))
+    }
+
     // Secondary Codes
     if (darInfo.methods) {
       dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.methods)

--- a/src/pages/dar_application/DataAccessRequest.jsx
+++ b/src/pages/dar_application/DataAccessRequest.jsx
@@ -167,11 +167,12 @@ export default function DataAccessRequest(props) {
         <FormField
           id="diseases"
           key="diseases"
-          title={<h4>Is the primary purpose of this research to investigate a specific disease(s)?</h4>}
+          title="Is the primary purpose of this research to investigate a specific disease(s)?"
           disabled={readOnlyMode}
           type={FormFieldTypes.YESNORADIOGROUP}
           orientation="horizontal"
           defaultValue={formData.diseases}
+          validators={[FormValidators.REQUIRED]}
           validation={validation.diseases}
           onValidationChange={onValidationChange}
           onChange={primaryChange}
@@ -207,9 +208,10 @@ export default function DataAccessRequest(props) {
               key="hmb"
               type={FormFieldTypes.YESNORADIOGROUP}
               disabled={readOnlyMode}
-              title={<h4>Is the primary purpose health/medical/biomedical research in nature?</h4>}
+              title="Is the primary purpose health/medical/biomedical research in nature?"
               orientation="horizontal"
               defaultValue={formData.hmb}
+              validators={[FormValidators.REQUIRED]}
               validation={validation.hmb}
               onValidationChange={onValidationChange}
               onChange={primaryChange}
@@ -222,9 +224,10 @@ export default function DataAccessRequest(props) {
               key="poa"
               type={FormFieldTypes.YESNORADIOGROUP}
               disabled={readOnlyMode}
-              title={<h4>Is the primary purpose of this research regarding population origins or ancestry?</h4>}
+              title="Is the primary purpose of this research regarding population origins or ancestry?"
               orientation="horizontal"
               defaultValue={formData.poa}
+              validators={[FormValidators.REQUIRED]}
               validation={validation.poa}
               onValidationChange={onValidationChange}
               onChange={primaryChange}
@@ -238,9 +241,10 @@ export default function DataAccessRequest(props) {
               key="methods"
               type={FormFieldTypes.YESNORADIOGROUP}
               disabled={readOnlyMode}
-              title={<h4>Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?</h4>}
+              title="Is the primary purpose of this research to develop or validate new methods for analyzing/interpreting data?"
               orientation="horizontal"
               defaultValue={formData.methods}
+              validators={[FormValidators.REQUIRED]}
               validation={validation.methods}
               onValidationChange={onValidationChange}
               onChange={primaryChange}
@@ -253,9 +257,10 @@ export default function DataAccessRequest(props) {
               id="otherText"
               key="otherText"
               disabled={readOnlyMode}
-              title={<h4>If none of the above, please describe the primary purpose of your research:</h4>}
+              title="If none of the above, please describe the primary purpose of your research:"
               placeholder="Please specify..."
               defaultValue={formData.otherText}
+              validators={[FormValidators.REQUIRED]}
               validation={validation.otherText}
               onValidationChange={onValidationChange}
               onChange={onChange}

--- a/src/utils/darFormUtils.js
+++ b/src/utils/darFormUtils.js
@@ -187,6 +187,26 @@ const calcDarErrors = (formData, datasets, dataUseTranslations, irbDocument, col
     errors.ontologies = requiredError
   }
 
+  // Only validate visible fields based on previous selections
+  if (formData.diseases === false) {
+    if (isNil(formData.hmb)) {
+      errors.hmb = requiredError
+    }
+    else if (formData.hmb === false) {
+      if (isNil(formData.poa)) {
+        errors.poa = requiredError
+      }
+      else if (formData.poa === false) {
+        if (isNil(formData.methods)) {
+          errors.methods = requiredError
+        }
+        else if (formData.methods === false && isEmpty(formData.otherText)) {
+          errors.otherText = requiredError
+        }
+      }
+    }
+  }
+
   if (isStringEmpty(formData.nonTechRus)) {
     errors.nonTechRus = requiredError
   }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2317

### Summary

Fixes an issue where some Data Access Requests were missing a primary research use term (e.g., HMB, DS). 

- Adds validation to require a primary term
- Verifies that the frontend correctly displays at least one primary use term.

**Validation**
<img width="1792" height="1033" alt="Vslidation" src="https://github.com/user-attachments/assets/a0ebf395-a5e5-41c1-a62e-325a2cd40dca" />

**Display**
<img width="1781" height="436" alt="Display" src="https://github.com/user-attachments/assets/58ff38b1-921d-43c5-8792-e7acd31c568c" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
