### PR TITLE
[DT-2416] Fixing console warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3231,9 +3231,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001723",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
-      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
+      "version": "1.0.30001753",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001753.tgz",
+      "integrity": "sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==",
       "dev": true,
       "funding": [
         {

--- a/src/components/dac_dataset_table/DACDatasetsTable.jsx
+++ b/src/components/dac_dataset_table/DACDatasetsTable.jsx
@@ -83,7 +83,6 @@ export const DACDatasetsTable = function DACDatasetTable(props) {
       setVisibleList: setVisibleDatasets,
       sort,
     })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tableSize, currentPage, pageCount, datasets, sort, columns, consoleType])
 
   // Helper function to update page

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -207,7 +207,6 @@ export const DatasetSearchTable = (props) => {
       return
     }
     getExportableDatasets(datasets)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const searchAndFilter = useRef(

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -93,7 +93,6 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
       list: processVoteHistoryRowData(voteHistory),
       sort,
     }))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, voteHistory])
 
   return (

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -170,7 +170,6 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
       list: processElectionRowData(electionsWithMemberVotes),
       sort,
     }))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sort, expandedElections, electionsWithMemberVotes])
 
   return (

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -142,7 +142,6 @@ export const DatasetSearch = (props) => {
       }
     }
     init()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading, isInstitutionSet, fullQuery, navigate, hasChangedPage])
 
   return (

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -262,7 +262,6 @@ const DataAccessRequestApplication = (props) => {
       }
     }
     fetchData()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [existingDarsReadOnlyMode])
 
   const init = useCallback(async () => {
@@ -309,7 +308,6 @@ const DataAccessRequestApplication = (props) => {
 
     batchFormFieldChange(formData)
     setIsLoading(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [researcher, existingDarsReadOnlyMode])
 
   useEffect(() => {

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -222,8 +222,6 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
     onFormChange({ datasets: approvedDatasets }, false) // Mark as non-user interaction
     onSelectedDatasetChange(approvedDatasets)
     isMounted.current = true // Mark as mounted after initial setup
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [datasets])
 
   return (

--- a/src/pages/dar_application/VotingHistoryOverview.tsx
+++ b/src/pages/dar_application/VotingHistoryOverview.tsx
@@ -40,7 +40,6 @@ const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ dar, vote
     })
   }
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const headerStyle = {
     fontWeight: 600,
     fontSize: '1.1rem',

--- a/src/pages/progress_reports/DarCloseout.tsx
+++ b/src/pages/progress_reports/DarCloseout.tsx
@@ -37,7 +37,6 @@ export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element 
       }
     }
     init()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -160,7 +160,6 @@ export default function DatasetSubmissionsTable(props) {
       }
     })
     setRows(rows)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [terms])
 
   useEffect(() => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2416

### Summary

This PR fixes console warnings for: 

- [Fix: Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')](https://github.com/DataBiosphere/duos-ui/commit/9a7456cd629c68cf0c76022a95eaa2554106667c)
  <img width="920" height="286" alt="Eslint" src="https://github.com/user-attachments/assets/8ab5c7c2-d1d0-44e4-8a7f-1a31dc7eeee3" />
- [Fix: update caniuse-lite and browserslist-db](https://github.com/DataBiosphere/duos-ui/commit/0bb206ba957c542babf5eefbf22f695d5f6c8132)
  <img width="920" height="286" alt="npm" src="https://github.com/user-attachments/assets/344ea4c5-44e3-45c5-811e-c51f41b4fd5d" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
