### PR TITLE
DT-2378: Show Data Submitter Management Page to SOs

### DIFF
--- a/cypress/component/SigningOfficialTable/dpa_text.spec.jsx
+++ b/cypress/component/SigningOfficialTable/dpa_text.spec.jsx
@@ -5,20 +5,6 @@ import DataCustodianTable from 'src/pages/signing_official_console/DataCustodian
 const dpaHeaderText = 'BROAD DATA USE OVERSIGHT SYSTEM (DUOS) - DATA PROVIDER AGREEMENT'
 
 describe('DataCustodianTable - Tests', function () {
-  it('Add New Data Submitter modal displays the DPA Text', function () {
-    cy.viewport(600, 300)
-    mount(
-      <DataCustodianTable
-        isLoading={false}
-        signingOfficial={{ institutionId: 1 }}
-        researchers={[]}
-        unregisteredResearchers={[]}
-      />,
-    )
-    cy.contains('ADD NEW DATA SUBMITTER', { matchCase: false }).should('exist').click()
-    cy.contains(dpaHeaderText, { matchCase: false }).should('exist')
-  })
-
   it('Issue modal displays the DPA Text', function () {
     cy.viewport(600, 300)
     mount(

--- a/src/components/DuosHeader.jsx
+++ b/src/components/DuosHeader.jsx
@@ -52,7 +52,7 @@ export const headerTabsConfig = [
     children: [
       { label: 'Library Cards', link: '/signing_official_console/library_cards' },
       { label: 'DAR Requests', link: '/signing_official_console/dar_requests' },
-      { label: 'Data Submitters', link: '/signing_official_console/data_submitters', isRendered: () => DAAUtils.isEnabled() },
+      { label: 'Data Submitters', link: '/signing_official_console/data_submitters' },
       { label: 'My Datasets', link: '/datalibrary/myinstitution' },
       { label: 'DAA Associations', link: '/signing_official_console/researchers_daa_associations', isRendered: () => DAAUtils.isEnabled() },
     ],

--- a/src/pages/signing_official_console/DataCustodianTable.jsx
+++ b/src/pages/signing_official_console/DataCustodianTable.jsx
@@ -290,11 +290,6 @@ export default function DataCustodianTable(props) {
     columnHeaderFormat.role,
   ]
 
-  const showModalOnClick = () => {
-    setSelectedResearcher({ institutionId: signingOfficial.institutionId })
-    setShowModal(true)
-  }
-
   const issueCustodian = async (selectedResearcher, researchers) => {
     let messageName
     const { userId, displayName } = selectedResearcher
@@ -408,25 +403,6 @@ export default function DataCustodianTable(props) {
           handleSearchChange={handleSearchChange}
           searchRef={searchRef}
         />
-        <div
-          style={{
-            marginLeft: 20,
-            marginTop: 50,
-            display: 'flex',
-            justifyContent: 'space-between',
-          }}
-        >
-          <SimpleButton
-            onClick={() => showModalOnClick()}
-            baseColor={Theme.palette.secondary}
-            label="Add New Data Submitter"
-            additionalStyle={{
-              width: '26rem',
-              padding: '4% 1%',
-              fontWeight: '600',
-            }}
-          />
-        </div>
       </div>
       <SimpleTable
         isLoading={isLoading}

--- a/src/pages/signing_official_console/DataCustodianTable.jsx
+++ b/src/pages/signing_official_console/DataCustodianTable.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
-import { Styles, Theme } from '../../libs/theme'
-import userIcon from '../../images/icon_manage_users.png'
+import { Styles, Theme } from 'src/libs/theme'
+import userIcon from 'src/images/icon_manage_users.png'
 import { cloneDeep, find, findIndex, join, map, sortedUniq, sortBy, isNil, flow } from 'lodash/fp'
-import SimpleTable from '../../components/SimpleTable'
-import SimpleButton from '../../components/SimpleButton'
-import PaginationBar from '../../components/PaginationBar'
-import SearchBar from '../../components/SearchBar'
+import SimpleTable from 'src/components/SimpleTable'
+import SimpleButton from 'src/components/SimpleButton'
+import PaginationBar from 'src/components/PaginationBar'
+import SearchBar from 'src/components/SearchBar'
 import {
   Notifications,
   tableSearchHandler,
@@ -13,13 +13,13 @@ import {
   getSearchFilterFunctions,
   searchOnFilteredList,
   hasDataSubmitterRole,
-} from '../../libs/utils'
-import { User } from '../../libs/ajax/User'
-import ConfirmationModal from '../../components/modals/ConfirmationModal'
-import DataCustodianFormModal from '../../components/modals/DataCustodianFormModal'
-import ScrollableMarkdownContainer from '../../components/ScrollableMarkdownContainer'
-import DpaMarkdown from '../../assets/DPA.md'
-import { confirmModalType } from '../../libs/libraryCardUtils'
+} from 'src/libs/utils'
+import { User } from 'src/libs/ajax/User'
+import ConfirmationModal from 'src/components/modals/ConfirmationModal'
+import DataCustodianFormModal from 'src/components/modals/DataCustodianFormModal'
+import ScrollableMarkdownContainer from 'src/components/ScrollableMarkdownContainer'
+import DpaMarkdown from 'src/assets/DPA.md'
+import { confirmModalType } from 'src/libs/libraryCardUtils'
 
 // Styles specific to this table
 const styles = {

--- a/src/pages/signing_official_console/SigningOfficialDataSubmitters.jsx
+++ b/src/pages/signing_official_console/SigningOfficialDataSubmitters.jsx
@@ -1,10 +1,9 @@
-import React from 'react'
-import { useState, useEffect } from 'react'
-import { Notifications } from '../../libs/utils'
-import { Styles } from '../../libs/theme'
-import { User } from '../../libs/ajax/User'
-import { USER_ROLES } from '../../libs/utils'
+import React, { useEffect, useState } from 'react'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
+import { Styles } from 'src/libs/theme'
+import { User } from 'src/libs/ajax/User'
 import DataCustodianTable from './DataCustodianTable'
+import { extractError } from 'src/utils/ErrorUtils.ts'
 
 export default function SigningOfficialConsole() {
   const [signingOfficial, setSigningOfficial] = useState({})
@@ -29,8 +28,9 @@ export default function SigningOfficialConsole() {
         setSigningOfficial(soUser)
         setIsLoading(false)
       }
-      catch (_error) {
-        Notifications.showError({ text: 'Error: Unable to retrieve current user from server' })
+      catch (error) {
+        const message = extractError(error)
+        Notifications.showError({ text: `Error: Unable to retrieve current user from server: ${message}` })
         setIsLoading(false)
       }
     }

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -117,13 +117,9 @@ const AppRoutes = (props: AppRoutesProps) => {
           <Route element={<SOAcknowledged />}>
             <Route path="/signing_official_console/library_cards" element={<SigningOfficialLibraryCards />} />
             <Route path="/signing_official_console/dar_requests" element={<SigningOfficialDarRequests />} />
+            <Route path="/signing_official_console/data_submitters" element={<SigningOfficialDataSubmitters />} />
             {DAAUtils.isEnabled()
-              && (
-                <>
-                  <Route path="/signing_official_console/researchers_daa_associations" element={<ManageResearcherDAAs />} />
-                  <Route path="/signing_official_console/data_submitters" element={<SigningOfficialDataSubmitters />} />
-                </>
-              )}
+              && <Route path="/signing_official_console/researchers_daa_associations" element={<ManageResearcherDAAs />} />}
           </Route>
         </Route>
       </Route>


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2378

## Summary
This PR moves a data submitter page that was developed for DAA functionality into the main branch. Originally, this page allowed for adding new users to the system. I've removed that feature to comply with current admin-only usage.

This page was originally added here: https://github.com/DataBiosphere/duos-ui/pull/1269

### Screen
<img width="3262" height="2614" alt="Screenshot 2025-11-04 at 10 27 23 AM" src="https://github.com/user-attachments/assets/d49e1c66-1822-4dad-bf04-2ba09b305ab4" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
