### PR TITLE
DT-2429: Navigate to not found

### DIFF
--- a/cypress/component/Routing/EnvRoute.spec.tsx
+++ b/cypress/component/Routing/EnvRoute.spec.tsx
@@ -5,7 +5,6 @@ import EnvRoute from 'src/routing/EnvRoute'
 import { Storage } from 'src/libs/storage'
 
 const TestProtectedComponent = () => <div data-cy="protected-content">Protected Content</div>
-const HomeComponent = () => <div data-cy="home-content">Home Page</div>
 
 const allowedEnvs = ['dev', 'staging']
 const currentAllowedEnv = 'dev'
@@ -21,16 +20,15 @@ describe('EnvRoute', () => {
           <Route path="/protected" element={<EnvRoute env={allowedEnvs} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
     cy.get('[data-cy="protected-content"]').should('be.visible')
-    cy.get('[data-cy="home-content"]').should('not.exist')
+    cy.get('[data-cy="not-found"]').should('not.exist')
   })
 
-  it('should redirect to the home page if the current environment is not in the allowed list', () => {
+  it('should redirect to the not found page if the current environment is not in the allowed list', () => {
     cy.stub(Storage, 'getEnv').returns(currentDisallowedEnv)
 
     mount(
@@ -39,16 +37,15 @@ describe('EnvRoute', () => {
           <Route path="/protected" element={<EnvRoute env={allowedEnvs} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
-    cy.get('[data-cy="home-content"]').should('be.visible')
+    cy.get('[data-cy="not-found"]').should('be.visible')
     cy.get('[data-cy="protected-content"]').should('not.exist')
   })
 
-  it('should redirect to the home page if the environment is not set', () => {
+  it('should redirect to the not found page if the environment is not set', () => {
     cy.stub(Storage, 'getEnv').returns(null)
 
     mount(
@@ -57,12 +54,11 @@ describe('EnvRoute', () => {
           <Route path="/protected" element={<EnvRoute env={allowedEnvs} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
-    cy.get('[data-cy="home-content"]').should('be.visible')
+    cy.get('[data-cy="not-found"]').should('be.visible')
     cy.get('[data-cy="protected-content"]').should('not.exist')
   })
 })

--- a/cypress/component/Routing/RoleBAC.spec.tsx
+++ b/cypress/component/Routing/RoleBAC.spec.tsx
@@ -6,7 +6,6 @@ import { Storage } from 'src/libs/storage'
 import { USER_ROLES } from 'src/libs/utils'
 
 const TestProtectedComponent = () => <div data-cy="protected-content">Protected Content</div>
-const HomeComponent = () => <div data-cy="home-content">Home Page</div>
 
 const researcherUser = {
   roles: [{ name: USER_ROLES.researcher }],
@@ -30,16 +29,15 @@ describe('RoleBAC', () => {
           <Route path="/protected" element={<RoleBAC rolesAllowed={[USER_ROLES.researcher]} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
     cy.get('[data-cy="protected-content"]').should('be.visible')
-    cy.get('[data-cy="home-content"]').should('not.exist')
+    cy.get('[data-cy="not-found"]').should('not.exist')
   })
 
-  it('should redirect to the home page if the user does not have the required role', () => {
+  it('should redirect to the not found page if the user does not have the required role', () => {
     cy.stub(Storage, 'getCurrentUser').returns(adminUser)
 
     mount(
@@ -48,16 +46,15 @@ describe('RoleBAC', () => {
           <Route path="/protected" element={<RoleBAC rolesAllowed={[USER_ROLES.researcher]} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
-    cy.get('[data-cy="home-content"]').should('be.visible')
+    cy.get('[data-cy="not-found"]').should('be.visible')
     cy.get('[data-cy="protected-content"]').should('not.exist')
   })
 
-  it('should redirect to the home page if the user has no roles', () => {
+  it('should redirect to the not found page if the user has no roles', () => {
     cy.stub(Storage, 'getCurrentUser').returns(noRolesUser)
 
     mount(
@@ -66,12 +63,11 @@ describe('RoleBAC', () => {
           <Route path="/protected" element={<RoleBAC rolesAllowed={[USER_ROLES.researcher]} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
-    cy.get('[data-cy="home-content"]').should('be.visible')
+    cy.get('[data-cy="not-found"]').should('be.visible')
     cy.get('[data-cy="protected-content"]').should('not.exist')
   })
 
@@ -84,12 +80,11 @@ describe('RoleBAC', () => {
           <Route path="/protected" element={<RoleBAC rolesAllowed={[USER_ROLES.all]} />}>
             <Route index element={<TestProtectedComponent />} />
           </Route>
-          <Route path="/" element={<HomeComponent />} />
         </Routes>
       </MemoryRouter>,
     )
 
     cy.get('[data-cy="protected-content"]').should('be.visible')
-    cy.get('[data-cy="home-content"]').should('not.exist')
+    cy.get('[data-cy="not-found"]').should('not.exist')
   })
 })

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -18,7 +18,7 @@ export default function NotFound() {
     }
     else {
       return (
-        <div className="container container-wide">
+        <div className="container container-wide" data-cy="not-found">
           <div className="row no-margin">
             <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 no-padding">
               <PageHeading

--- a/src/routing/EnvRoute.tsx
+++ b/src/routing/EnvRoute.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { Navigate, Outlet } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 import { checkEnv } from 'src/utils/EnvironmentUtils'
+import NotFound from 'src/pages/NotFound'
 
 interface EnvRouteProps {
   readonly env: Array<string>
@@ -9,7 +10,7 @@ interface EnvRouteProps {
 const EnvRoute = ({ env }: EnvRouteProps) => {
   return checkEnv(env)
     ? <Outlet />
-    : <Navigate to="/" state={{ from: location }} replace />
+    : <NotFound />
 }
 
 export default EnvRoute

--- a/src/routing/RoleBAC.tsx
+++ b/src/routing/RoleBAC.tsx
@@ -3,6 +3,7 @@ import { USER_ROLES } from 'src/libs/utils'
 import { Storage } from 'src/libs/storage'
 import { UserRole } from 'src/types/model'
 import { Navigate, Outlet } from 'react-router-dom'
+import NotFound from 'src/pages/NotFound'
 
 interface RoleBACProps {
   readonly rolesAllowed: string[]
@@ -20,7 +21,7 @@ const RoleBAC = ({ rolesAllowed }: RoleBACProps) => {
 
   return checkRoles(rolesAllowed)
     ? <Outlet />
-    : <Navigate to="/" />
+    : <NotFound />
 }
 
 export default RoleBAC

--- a/src/routing/RoleBAC.tsx
+++ b/src/routing/RoleBAC.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { USER_ROLES } from 'src/libs/utils'
 import { Storage } from 'src/libs/storage'
 import { UserRole } from 'src/types/model'
-import { Navigate, Outlet } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
 import NotFound from 'src/pages/NotFound'
 
 interface RoleBACProps {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2429

### Summary
When a route is not available due to environment or missing user role, navigate to the Not Found page instead of home. This way, an appropriate error message is displayed.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
