### PR TITLE
[DT-2388] Fix: update AppRoutes.tsx to use `react-router-dom`

### DIFF
--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Routes } from 'react-router'
+import { Route, Routes } from 'react-router-dom'
 import Home from 'src/pages/Home'
 import UserProfile from 'src/pages/user_profile/UserProfile'
 import Authenticated from 'src/routing/Authenticated'


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2388

### Summary

Currently, AppRoutes.tsx imports `react-router`, but the functionality is actually in the package `react-router-dom`. When using alternate runtimes which are more strict such as `pnpm` the `pnpm install` fails as a result.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
