### PR TITLE
[DT-2397] Integrate New Study Asset Components into S4R Form

### DIFF
--- a/cypress/component/DataSubmission/v2/ds_study_asset.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import { StudyAsset } from 'src/pages/data_submission/v2/StudyAsset'
+
+describe('StudyAsset component', () => {
+  it('renders all configured elements (icon, title, description, children, button)', () => {
+    const clickSpy = cy.spy().as('clickSpy')
+    mount(
+      <StudyAsset
+        config={{
+          icon: <span data-cy="icon">ICON</span>,
+          title: 'Models',
+          description: 'Add computational models or algorithms derived from this study',
+          children: <div data-cy="children">Child Content</div>,
+          button: <button data-cy="action" onClick={() => clickSpy()}>Add</button>,
+        }}
+      />,
+    )
+
+    cy.get('[data-cy="icon"]').should('contain.text', 'ICON')
+    cy.contains('Models').should('exist')
+    cy.contains('Add computational models or algorithms derived from this study').should('exist')
+    cy.get('[data-cy="children"]').should('contain.text', 'Child Content')
+    cy.get('[data-cy="action"]').click()
+    cy.get('@clickSpy').should('have.been.calledOnce')
+  })
+
+  it('renders without optional children and button', () => {
+    mount(
+      <StudyAsset
+        config={{
+          icon: <span data-cy="icon-min">I</span>,
+          title: 'Empty Section',
+          description: 'No children here',
+        }}
+      />,
+    )
+    cy.contains('Empty Section').should('exist')
+    cy.contains('No children here').should('exist')
+    cy.get('[data-cy="icon-min"]').should('exist')
+    cy.get('button').should('not.exist')
+  })
+  it('applies expected container styles', () => {
+    mount(
+      <StudyAsset
+        config={{
+          icon: <span>Icon</span>,
+          title: 'Style Check',
+          description: 'Style test',
+          children: <div>Content</div>,
+        }}
+      />,
+    )
+
+    cy.contains('h3', 'Style Check')
+      .parents('div')
+      .eq(3)
+      .as('assetContainer')
+
+    cy.get('@assetContainer')
+      .should('have.css', 'background-color', 'rgb(234, 240, 250)')
+      .and('have.css', 'border-radius', '12px')
+
+    cy.get('@assetContainer')
+      .should('have.css', 'box-shadow')
+      .and('match', /rgba\(0, 0, 0, 0\.08\)/)
+  })
+})

--- a/cypress/component/DataSubmission/v2/ds_study_asset_add_button.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset_add_button.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
+
+describe('StudyAssetAddButton', () => {
+  it('renders with required props', () => {
+    const onClickSpy = cy.spy().as('onClickSpy')
+
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={onClickSpy}
+      />,
+    )
+
+    cy.get('#test-button').should('exist')
+    cy.get('#test-button').should('contain.text', 'Add Test')
+    cy.get('#test-button').find('svg').should('exist') // AddIcon
+  })
+
+  it('calls onClick when clicked', () => {
+    const onClickSpy = cy.spy().as('onClickSpy')
+
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={onClickSpy}
+      />,
+    )
+
+    cy.get('#test-button').click()
+    cy.get('@onClickSpy').should('have.been.calledOnce')
+  })
+
+  it('does not call onClick when disabled', () => {
+    const onClickSpy = cy.spy().as('onClickSpy')
+
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={onClickSpy}
+        disabled={true}
+      />,
+    )
+
+    cy.get('#test-button').should('be.disabled')
+    cy.get('#test-button').click({ force: true })
+    cy.get('@onClickSpy').should('not.have.been.called')
+  })
+
+  it('applies correct styling when disabled', () => {
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={() => {}}
+        disabled={true}
+      />,
+    )
+
+    cy.get('#test-button').should('have.css', 'cursor', 'not-allowed')
+  })
+
+  it('shows validation error styling', () => {
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={() => {}}
+        hasValidationError={true}
+      />,
+    )
+
+    cy.get('#test-button').should('have.css', 'border', '1px solid rgb(255, 0, 0)')
+    cy.get('#test-button').should('have.css', 'box-shadow').and('include', 'rgb(255, 0, 0)')
+  })
+
+  it('shows default styling without validation error', () => {
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={() => {}}
+        hasValidationError={false}
+      />,
+    )
+
+    cy.get('#test-button').should('have.css', 'border').and('include', 'rgb(9, 72, 183)')
+    cy.get('#test-button').should('have.css', 'box-shadow', 'none')
+  })
+
+  it('applies button-white class', () => {
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={() => {}}
+      />,
+    )
+
+    cy.get('#test-button').should('have.class', 'button')
+    cy.get('#test-button').should('have.class', 'button-white')
+  })
+
+  it('applies correct layout styles', () => {
+    mount(
+      <StudyAssetAddButton
+        id="test-button"
+        label="Add Test"
+        onClick={() => {}}
+      />,
+    )
+
+    cy.get('#test-button').should('have.css', 'display', 'flex')
+    cy.get('#test-button').should('have.css', 'align-items', 'center')
+    cy.get('#test-button').should('have.css', 'margin-top', '0px')
+    cy.get('#test-button').should('have.css', 'margin-bottom', '5px')
+  })
+})

--- a/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
@@ -33,9 +33,9 @@ describe('StudyAssetManagement component', () => {
     cy.contains('Study Assets').should('exist')
     cy.contains('Add datasets, models, workspaces, and other resources associated with this study').should('exist')
 
-    sections.forEach((s) => {
-      cy.contains('h3', s.title).should('exist')
-      cy.contains(s.desc).should('exist')
-    })
+    for (const { title, desc } of sections) {
+      cy.contains('h3', title).should('exist')
+      cy.contains(desc).should('exist')
+    }
   })
 })

--- a/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+import { StudyAssetManagement } from 'src/pages/data_submission/v2/StudyAssetManagement'
+import { Study } from 'src/pages/data_submission/v2/v2-models'
+
+const baseStudy: Study = {
+  assets: {
+    models: [],
+    workspaces: [],
+    publications: [],
+    presentations: [],
+    clinicalTrials: [],
+    intellectualProperty: [],
+    funding: [],
+  },
+} as Study
+
+describe('StudyAssetManagement component', () => {
+  it('renders all asset sections with titles and descriptions', () => {
+    const setStudySpy = cy.spy().as('setStudySpy')
+    mount(<StudyAssetManagement study={baseStudy} setStudy={setStudySpy} />)
+
+    const sections = [
+      { title: 'Models', desc: 'Add computational models or algorithms derived from this study' },
+      { title: 'Featured Workspaces', desc: 'Add computational workspaces for data analysis' },
+      { title: 'Publications', desc: 'Add published research papers related to this study' },
+      { title: 'Presentations', desc: 'Add conference presentations or talks about this study' },
+      { title: 'Clinical Trials', desc: 'Add clinical trials associated with this study' },
+      { title: 'Intellectual Property', desc: 'Add patents or other IP related to this study' },
+      { title: 'Funding Resources', desc: 'Add grants and funding sources for this study' },
+    ]
+
+    cy.contains('Study Assets').should('exist')
+    cy.contains('Add datasets, models, workspaces, and other resources associated with this study').should('exist')
+
+    sections.forEach((s) => {
+      cy.contains('h3', s.title).should('exist')
+      cy.contains(s.desc).should('exist')
+    })
+  })
+})

--- a/cypress/component/ProgressReports/summary_section.spec.tsx
+++ b/cypress/component/ProgressReports/summary_section.spec.tsx
@@ -159,7 +159,7 @@ describe('Summary Section - Component Tests', () => {
 
   it('shows intellectualProperties list when "Yes" is selected', () => {
     mountComponent({ intellectualPropertiesYesNo: true })
-    cy.contains('Add Intellectual Property').should('exist')
+    cy.contains('Add IP').should('exist')
   })
 
   it('handles publications radio buttons', () => {

--- a/src/components/ai_models_list/AiModelList.tsx
+++ b/src/components/ai_models_list/AiModelList.tsx
@@ -10,6 +10,7 @@ interface AiModelListProps {
   readonly onAiModelsChange: (models: AiModel[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
 }
 
 export default function AiModelList(props: AiModelListProps): React.JSX.Element {
@@ -19,13 +20,13 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
     onAiModelsChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
   const [showAddEdit, setShowAddEdit] = useState(false)
   const [editState, setEditState] = useState<boolean[]>(aiModels.map(() => false))
 
   useEffect(() => {
-    // Sync edit state length with aiModels length
     if (editState.length !== aiModels.length) {
       setEditState(aiModels.map(() => false))
     }
@@ -46,55 +47,67 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
 
   const getValidationState = () => validation?.aiModels
 
+  const button = (
+    <button
+      id="add-ai-model-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add AI Model
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <AiModelAddEdit
+          id={-1}
+          aiModel={undefined}
+          aiModels={aiModels}
+          closeAction={() => setShowAddEdit(false)}
+          onAiModelsChange={onAiModelsChange}
+        />
+      )}
+      {aiModels.map((model: AiModel, index: number) => (
+        <AiModelRow
+          key={model.modelId}
+          id={index}
+          editMode={editState[index]}
+          aiModel={model}
+          aiModels={aiModels}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => { handleDeleteAiModel(index) }}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onAiModelsChange={onAiModelsChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="ai-model-list-component">
       <div className="row no-margin">
-        <button
-          id="add-ai-model-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add AI Model
-        </button>
-        {showAddEdit && (
-          <AiModelAddEdit
-            id={-1}
-            aiModel={undefined}
-            aiModels={aiModels}
-            closeAction={() => setShowAddEdit(false)}
-            onAiModelsChange={onAiModelsChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {aiModels.map((model: AiModel, index: number) => (
-          <AiModelRow
-            key={model.modelId}
-            id={index}
-            editMode={editState[index]}
-            aiModel={model}
-            aiModels={aiModels}
-            columnsToShow={columnsToShow}
-            editAction={() => toggleEditState(index)}
-            deleteAction={() => { handleDeleteAiModel(index) }}
-            closeAction={() => {
-              toggleEditState(index)
-              setShowAddEdit(false)
-            }}
-            onAiModelsChange={onAiModelsChange}
-            disabled={disabled}
-          />
-        ))}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/ai_models_list/AiModelList.tsx
+++ b/src/components/ai_models_list/AiModelList.tsx
@@ -3,7 +3,7 @@ import AiModelAddEdit from 'src/components/ai_models_list/AiModelAddEdit'
 import AiModelRow from 'src/components/ai_models_list/AiModelRow'
 import { AiModel } from 'src/types/model'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface AiModelListProps {
   readonly aiModels: AiModel[]
@@ -49,25 +49,13 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
   const getValidationState = () => validation?.aiModels
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-ai-model-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add Model"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add Model
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/components/ai_models_list/AiModelList.tsx
+++ b/src/components/ai_models_list/AiModelList.tsx
@@ -3,6 +3,7 @@ import AiModelAddEdit from 'src/components/ai_models_list/AiModelAddEdit'
 import AiModelRow from 'src/components/ai_models_list/AiModelRow'
 import { AiModel } from 'src/types/model'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+import AddIcon from '@mui/icons-material/Add'
 
 interface AiModelListProps {
   readonly aiModels: AiModel[]
@@ -53,6 +54,8 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -62,7 +65,8 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
-      Add AI Model
+      <AddIcon fontSize="medium" />
+      Add Model
     </button>
   )
 

--- a/src/components/clinical_trial_list/ClinicalTrialList.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialList.tsx
@@ -9,22 +9,25 @@ import {
   parseLegacyInterventionType,
 } from 'src/utils/ClinicalTrialEnumUtils'
 
-export default function ClinicalTrialList(props: {
+interface ClinicalTrialListProps {
   readonly clinicalTrials: ClinicalTrial[]
   readonly columnsToShow?: string[]
   readonly onClinicalTrialChange: (clinicalTrials: ClinicalTrial[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
-}): React.JSX.Element {
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
+}
+
+export default function ClinicalTrialList(props: ClinicalTrialListProps): React.JSX.Element {
   const {
     clinicalTrials,
     columnsToShow = [],
     onClinicalTrialChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
-  // Normalize any legacy string values on render
   const normalized = clinicalTrials.map(ct => ({
     ...ct,
     status: parseLegacyStatus(ct.status as unknown as string),
@@ -48,54 +51,66 @@ export default function ClinicalTrialList(props: {
 
   const getValidationState = () => validation?.clinicalTrials
 
+  const button = (
+    <button
+      id="add-clinical-trial-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add Clinical Trial
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <ClinicalTrialAddEdit
+          id={-1}
+          clinicalTrials={normalized}
+          closeAction={() => setShowAddEdit(false)}
+          onClinicalTrialChange={onClinicalTrialChange}
+        />
+      )}
+      {normalized.map((clinicalTrial: ClinicalTrial, index: number) => (
+        <ClinicalTrialRow
+          key={clinicalTrial.clinicalTrialId || index}
+          id={index}
+          editMode={editState[index]}
+          clinicalTrial={clinicalTrial}
+          clinicalTrials={normalized}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => { handleDelete(index) }}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onClinicalTrialChange={onClinicalTrialChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="presentation-list-component">
       <div className="row no-margin">
-        <button
-          id="add-clinical-trial-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add Clinical Trial
-        </button>
-        {showAddEdit && (
-          <ClinicalTrialAddEdit
-            id={-1}
-            clinicalTrials={normalized}
-            closeAction={() => setShowAddEdit(false)}
-            onClinicalTrialChange={onClinicalTrialChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {normalized.map((clinicalTrial: ClinicalTrial, index: number) => (
-          <ClinicalTrialRow
-            key={clinicalTrial.clinicalTrialId || index}
-            id={index}
-            editMode={editState[index]}
-            clinicalTrial={clinicalTrial}
-            clinicalTrials={normalized}
-            columnsToShow={columnsToShow}
-            editAction={() => toggleEditState(index)}
-            deleteAction={() => { handleDelete(index) }}
-            closeAction={() => {
-              toggleEditState(index)
-              setShowAddEdit(false)
-            }}
-            onClinicalTrialChange={onClinicalTrialChange}
-            disabled={disabled}
-          />
-        ))}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/clinical_trial_list/ClinicalTrialList.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialList.tsx
@@ -8,7 +8,7 @@ import {
   parseLegacyPhase,
   parseLegacyInterventionType,
 } from 'src/utils/ClinicalTrialEnumUtils'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface ClinicalTrialListProps {
   readonly clinicalTrials: ClinicalTrial[]
@@ -53,25 +53,13 @@ export default function ClinicalTrialList(props: ClinicalTrialListProps): React.
   const getValidationState = () => validation?.clinicalTrials
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-clinical-trial-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add Clinical Trial"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add Clinical Trial
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/components/clinical_trial_list/ClinicalTrialList.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialList.tsx
@@ -8,6 +8,7 @@ import {
   parseLegacyPhase,
   parseLegacyInterventionType,
 } from 'src/utils/ClinicalTrialEnumUtils'
+import AddIcon from '@mui/icons-material/Add'
 
 interface ClinicalTrialListProps {
   readonly clinicalTrials: ClinicalTrial[]
@@ -57,6 +58,8 @@ export default function ClinicalTrialList(props: ClinicalTrialListProps): React.
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -66,6 +69,7 @@ export default function ClinicalTrialList(props: ClinicalTrialListProps): React.
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
+      <AddIcon fontSize="medium" />
       Add Clinical Trial
     </button>
   )

--- a/src/components/funding_resource_list/FundingResourceList.tsx
+++ b/src/components/funding_resource_list/FundingResourceList.tsx
@@ -10,6 +10,7 @@ interface FundingResourceListProps {
   readonly onFundingResourceChange: (items: FundingResource[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
 }
 
 export default function FundingResourceList(props: FundingResourceListProps): React.JSX.Element {
@@ -19,6 +20,7 @@ export default function FundingResourceList(props: FundingResourceListProps): Re
     onFundingResourceChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
   const [showAddEdit, setShowAddEdit] = useState(false)
@@ -37,54 +39,66 @@ export default function FundingResourceList(props: FundingResourceListProps): Re
 
   const getValidationState = () => validation?.fundingResources
 
+  const button = (
+    <button
+      id="add-funding-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add Funding Resource
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <FundingResourceAddEdit
+          id={-1}
+          fundingResources={fundingResources}
+          closeAction={() => setShowAddEdit(false)}
+          onFundingChange={onFundingResourceChange}
+        />
+      )}
+      {fundingResources.map((f: FundingResource, index: number) => (
+        <FundingResourceRow
+          key={f.fundingId || index}
+          id={index}
+          editMode={editState[index]}
+          funding={f}
+          fundingResources={fundingResources}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => handleDeleteFunding(index)}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onFundingChange={onFundingResourceChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="presentation-list-component">
       <div className="row no-margin">
-        <button
-          id="add-funding-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add Funding Resource
-        </button>
-        {showAddEdit && (
-          <FundingResourceAddEdit
-            id={-1}
-            fundingResources={fundingResources}
-            closeAction={() => setShowAddEdit(false)}
-            onFundingChange={onFundingResourceChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {fundingResources.map((f: FundingResource, index: number) => (
-          <FundingResourceRow
-            key={f.fundingId || index}
-            id={index}
-            editMode={editState[index]}
-            funding={f}
-            fundingResources={fundingResources}
-            columnsToShow={columnsToShow}
-            editAction={() => toggleEditState(index)}
-            deleteAction={() => handleDeleteFunding(index)}
-            closeAction={() => {
-              toggleEditState(index)
-              setShowAddEdit(false)
-            }}
-            onFundingChange={onFundingResourceChange}
-            disabled={disabled}
-          />
-        ))}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/funding_resource_list/FundingResourceList.tsx
+++ b/src/components/funding_resource_list/FundingResourceList.tsx
@@ -3,7 +3,7 @@ import { FundingResource } from 'src/types/model'
 import { FundingResourceAddEdit } from 'src/components/funding_resource_list/FundingResourceAddEdit'
 import FundingResourceRow from 'src/components/funding_resource_list/FundingResourceRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface FundingResourceListProps {
   readonly fundingResources: FundingResource[]
@@ -41,25 +41,13 @@ export default function FundingResourceList(props: FundingResourceListProps): Re
   const getValidationState = () => validation?.fundingResources
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-funding-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add Funding"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add Funding
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/components/funding_resource_list/FundingResourceList.tsx
+++ b/src/components/funding_resource_list/FundingResourceList.tsx
@@ -3,6 +3,7 @@ import { FundingResource } from 'src/types/model'
 import { FundingResourceAddEdit } from 'src/components/funding_resource_list/FundingResourceAddEdit'
 import FundingResourceRow from 'src/components/funding_resource_list/FundingResourceRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+import AddIcon from '@mui/icons-material/Add'
 
 interface FundingResourceListProps {
   readonly fundingResources: FundingResource[]
@@ -45,6 +46,8 @@ export default function FundingResourceList(props: FundingResourceListProps): Re
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -54,7 +57,8 @@ export default function FundingResourceList(props: FundingResourceListProps): Re
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
-      Add Funding Resource
+      <AddIcon fontSize="medium" />
+      Add Funding
     </button>
   )
 

--- a/src/components/intellectual_property_list/IntellectualPropertyList.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyList.tsx
@@ -3,7 +3,7 @@ import { IntellectualProperty } from 'src/types/model'
 import { IntellectualPropertyAddEdit } from 'src/components/intellectual_property_list/IntellectualPropertyAddEdit'
 import IntellectualPropertyRow from 'src/components/intellectual_property_list/IntellectualPropertyRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface IntellectualPropertyListProps {
   readonly intellectualProperties: IntellectualProperty[]
@@ -41,25 +41,13 @@ export default function IntellectualPropertyList(props: IntellectualPropertyList
   const getValidationState = () => validation?.intellectualProperties
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-ip-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add IP"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add IP
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/components/intellectual_property_list/IntellectualPropertyList.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyList.tsx
@@ -3,6 +3,7 @@ import { IntellectualProperty } from 'src/types/model'
 import { IntellectualPropertyAddEdit } from 'src/components/intellectual_property_list/IntellectualPropertyAddEdit'
 import IntellectualPropertyRow from 'src/components/intellectual_property_list/IntellectualPropertyRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+import AddIcon from '@mui/icons-material/Add'
 
 interface IntellectualPropertyListProps {
   readonly intellectualProperties: IntellectualProperty[]
@@ -45,6 +46,8 @@ export default function IntellectualPropertyList(props: IntellectualPropertyList
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -54,7 +57,8 @@ export default function IntellectualPropertyList(props: IntellectualPropertyList
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
-      Add Intellectual Property
+      <AddIcon fontSize="medium" />
+      Add IP
     </button>
   )
 

--- a/src/components/intellectual_property_list/IntellectualPropertyList.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyList.tsx
@@ -10,6 +10,7 @@ interface IntellectualPropertyListProps {
   readonly onIntellectualPropertyChange: (items: IntellectualProperty[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
 }
 
 export default function IntellectualPropertyList(props: IntellectualPropertyListProps): React.JSX.Element {
@@ -19,6 +20,7 @@ export default function IntellectualPropertyList(props: IntellectualPropertyList
     onIntellectualPropertyChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
   const [showAddEdit, setShowAddEdit] = useState(false)
@@ -37,54 +39,66 @@ export default function IntellectualPropertyList(props: IntellectualPropertyList
 
   const getValidationState = () => validation?.intellectualProperties
 
+  const button = (
+    <button
+      id="add-ip-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add Intellectual Property
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <IntellectualPropertyAddEdit
+          id={-1}
+          intellectualProperties={intellectualProperties}
+          closeAction={() => setShowAddEdit(false)}
+          onIpChange={onIntellectualPropertyChange}
+        />
+      )}
+      {intellectualProperties.map((ip: IntellectualProperty, index: number) => (
+        <IntellectualPropertyRow
+          key={ip.ipId || index}
+          id={index}
+          editMode={editState[index]}
+          ip={ip}
+          intellectualProperties={intellectualProperties}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => handleDeleteIp(index)}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onIpChange={onIntellectualPropertyChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="presentation-list-component">
       <div className="row no-margin">
-        <button
-          id="add-ip-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add Intellectual Property
-        </button>
-        {showAddEdit && (
-          <IntellectualPropertyAddEdit
-            id={-1}
-            intellectualProperties={intellectualProperties}
-            closeAction={() => setShowAddEdit(false)}
-            onIpChange={onIntellectualPropertyChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {intellectualProperties.map((ip: IntellectualProperty, index: number) => (
-          <IntellectualPropertyRow
-            key={ip.ipId || index}
-            id={index}
-            editMode={editState[index]}
-            ip={ip}
-            intellectualProperties={intellectualProperties}
-            columnsToShow={columnsToShow}
-            editAction={() => toggleEditState(index)}
-            deleteAction={() => handleDeleteIp(index)}
-            closeAction={() => {
-              toggleEditState(index)
-              setShowAddEdit(false)
-            }}
-            onIpChange={onIntellectualPropertyChange}
-            disabled={disabled}
-          />
-        ))}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/presentations_list/PresentationList.tsx
+++ b/src/components/presentations_list/PresentationList.tsx
@@ -10,6 +10,7 @@ interface PresentationListProps {
   readonly onPresentationChange: (presentations: Presentation[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
 }
 
 export default function PresentationList(props: PresentationListProps): React.JSX.Element {
@@ -19,6 +20,7 @@ export default function PresentationList(props: PresentationListProps): React.JS
     onPresentationChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
   const [showAddEdit, setShowAddEdit] = useState(false)
@@ -37,56 +39,66 @@ export default function PresentationList(props: PresentationListProps): React.JS
 
   const getValidationState = () => validation?.presentations
 
+  const button = (
+    <button
+      id="add-presentation-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add Presentation
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <PresentationAddEdit
+          id={-1}
+          presentations={presentations}
+          closeAction={() => setShowAddEdit(false)}
+          onPresentationChange={onPresentationChange}
+        />
+      )}
+      {presentations.map((presentation: Presentation, index: number) => (
+        <PresentationRow
+          key={index}
+          id={index}
+          editMode={editState[index]}
+          presentation={presentation}
+          presentations={presentations}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => { handleDeletePresentation(index) }}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onPresentationChange={onPresentationChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="presentation-list-component">
       <div className="row no-margin">
-        <button
-          id="add-presentation-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add Presentation
-        </button>
-        {showAddEdit && (
-          <PresentationAddEdit
-            id={-1}
-            presentations={presentations}
-            closeAction={() => setShowAddEdit(false)}
-            onPresentationChange={onPresentationChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {presentations.map((presentation: Presentation, index: number) => {
-          return (
-            <PresentationRow
-              key={index}
-              id={index}
-              editMode={editState[index]}
-              presentation={presentation}
-              presentations={presentations}
-              columnsToShow={columnsToShow}
-              editAction={() => toggleEditState(index)}
-              deleteAction={() => { handleDeletePresentation(index) }}
-              closeAction={() => {
-                toggleEditState(index)
-                setShowAddEdit(false)
-              }}
-              onPresentationChange={onPresentationChange}
-              disabled={disabled}
-            />
-          )
-        })}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/presentations_list/PresentationList.tsx
+++ b/src/components/presentations_list/PresentationList.tsx
@@ -3,7 +3,7 @@ import PresentationAddEdit from './PresentationAddEdit'
 import PresentationRow from './PresentationRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
 import { Presentation } from 'src/types/model'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface PresentationListProps {
   readonly presentations: Presentation[]
@@ -41,25 +41,13 @@ export default function PresentationList(props: PresentationListProps): React.JS
   const getValidationState = () => validation?.presentations
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-presentation-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add Presentation"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add Presentation
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/components/presentations_list/PresentationList.tsx
+++ b/src/components/presentations_list/PresentationList.tsx
@@ -3,6 +3,7 @@ import PresentationAddEdit from './PresentationAddEdit'
 import PresentationRow from './PresentationRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
 import { Presentation } from 'src/types/model'
+import AddIcon from '@mui/icons-material/Add'
 
 interface PresentationListProps {
   readonly presentations: Presentation[]
@@ -45,6 +46,8 @@ export default function PresentationList(props: PresentationListProps): React.JS
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -54,6 +57,7 @@ export default function PresentationList(props: PresentationListProps): React.JS
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
+      <AddIcon fontSize="medium" />
       Add Presentation
     </button>
   )

--- a/src/components/publications_list/PublicationList.tsx
+++ b/src/components/publications_list/PublicationList.tsx
@@ -10,6 +10,7 @@ interface PublicationListProps {
   readonly onPublicationChange: (publications: Publication[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
 }
 
 export default function PublicationList(props: PublicationListProps): React.JSX.Element {
@@ -19,6 +20,7 @@ export default function PublicationList(props: PublicationListProps): React.JSX.
     onPublicationChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
   const [showAddEdit, setShowAddEdit] = useState(false)
@@ -37,56 +39,66 @@ export default function PublicationList(props: PublicationListProps): React.JSX.
 
   const getValidationState = () => validation?.publications
 
+  const button = (
+    <button
+      id="add-publication-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add Publication
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <PublicationAddEdit
+          id={-1}
+          publications={publications}
+          closeAction={() => setShowAddEdit(false)}
+          onPublicationChange={onPublicationChange}
+        />
+      )}
+      {publications.map((publication: Publication, index: number) => (
+        <PublicationRow
+          key={index}
+          id={index}
+          editMode={editState[index]}
+          publication={publication}
+          publications={publications}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => { handleDeletePublication(index) }}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onPublicationChange={onPublicationChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="publication-list-component">
       <div className="row no-margin">
-        <button
-          id="add-publication-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add Publication
-        </button>
-        {showAddEdit && (
-          <PublicationAddEdit
-            id={-1}
-            publications={publications}
-            closeAction={() => setShowAddEdit(false)}
-            onPublicationChange={onPublicationChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {publications.map((publication: Publication, index: number) => {
-          return (
-            <PublicationRow
-              key={index}
-              id={index}
-              editMode={editState[index]}
-              publication={publication}
-              publications={publications}
-              columnsToShow={columnsToShow}
-              editAction={() => toggleEditState(index)}
-              deleteAction={() => { handleDeletePublication(index) }}
-              closeAction={() => {
-                toggleEditState(index)
-                setShowAddEdit(false)
-              }}
-              onPublicationChange={onPublicationChange}
-              disabled={disabled}
-            />
-          )
-        })}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/publications_list/PublicationList.tsx
+++ b/src/components/publications_list/PublicationList.tsx
@@ -3,6 +3,7 @@ import PublicationAddEdit from './PublicationAddEdit'
 import PublicationRow from './PublicationRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
 import { Publication } from 'src/types/model'
+import AddIcon from '@mui/icons-material/Add'
 
 interface PublicationListProps {
   readonly publications: Publication[]
@@ -45,6 +46,8 @@ export default function PublicationList(props: PublicationListProps): React.JSX.
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -54,6 +57,7 @@ export default function PublicationList(props: PublicationListProps): React.JSX.
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
+      <AddIcon fontSize="medium" />
       Add Publication
     </button>
   )

--- a/src/components/publications_list/PublicationList.tsx
+++ b/src/components/publications_list/PublicationList.tsx
@@ -3,7 +3,7 @@ import PublicationAddEdit from './PublicationAddEdit'
 import PublicationRow from './PublicationRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
 import { Publication } from 'src/types/model'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface PublicationListProps {
   readonly publications: Publication[]
@@ -41,25 +41,13 @@ export default function PublicationList(props: PublicationListProps): React.JSX.
   const getValidationState = () => validation?.publications
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-publication-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add Publication"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add Publication
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/components/workspaces_list/WorkspaceList.tsx
+++ b/src/components/workspaces_list/WorkspaceList.tsx
@@ -3,6 +3,7 @@ import { Workspace } from 'src/types/model'
 import { WorkspaceAddEdit } from 'src/components/workspaces_list/WorkspaceAddEdit'
 import WorkspaceRow from 'src/components/workspaces_list/WorkspaceRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+import AddIcon from '@mui/icons-material/Add'
 
 interface WorkspaceListProps {
   readonly workspaces: Workspace[]
@@ -45,6 +46,8 @@ export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Elem
       type="button"
       className="button button-white"
       style={{
+        display: 'flex',
+        alignItems: 'center',
         marginTop: 0,
         marginBottom: 5,
         border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
@@ -54,6 +57,7 @@ export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Elem
       onClick={() => !disabled && setShowAddEdit(true)}
       disabled={disabled}
     >
+      <AddIcon fontSize="medium" />
       Add Workspace
     </button>
   )

--- a/src/components/workspaces_list/WorkspaceList.tsx
+++ b/src/components/workspaces_list/WorkspaceList.tsx
@@ -10,6 +10,7 @@ interface WorkspaceListProps {
   readonly onWorkspaceChange: (items: Workspace[]) => void
   readonly disabled?: boolean
   readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
 }
 
 export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Element {
@@ -19,6 +20,7 @@ export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Elem
     onWorkspaceChange,
     disabled = false,
     validation,
+    studyAssetWrapper,
   } = props
 
   const [showAddEdit, setShowAddEdit] = useState(false)
@@ -37,54 +39,66 @@ export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Elem
 
   const getValidationState = () => validation?.workspaces
 
+  const button = (
+    <button
+      id="add-workspace-btn"
+      type="button"
+      className="button button-white"
+      style={{
+        marginTop: 0,
+        marginBottom: 5,
+        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && setShowAddEdit(true)}
+      disabled={disabled}
+    >
+      Add Workspace
+    </button>
+  )
+
+  const content = (
+    <div className="form-group row no-margin">
+      {showAddEdit && (
+        <WorkspaceAddEdit
+          id={-1}
+          workspaces={workspaces}
+          closeAction={() => setShowAddEdit(false)}
+          onWorkspaceChange={onWorkspaceChange}
+        />
+      )}
+      {workspaces.map((w: Workspace, index: number) => (
+        <WorkspaceRow
+          key={w.workspaceId || index}
+          id={index}
+          editMode={editState[index]}
+          workspace={w}
+          workspaces={workspaces}
+          columnsToShow={columnsToShow}
+          editAction={() => toggleEditState(index)}
+          deleteAction={() => handleDeleteWorkspace(index)}
+          closeAction={() => {
+            toggleEditState(index)
+            setShowAddEdit(false)
+          }}
+          onWorkspaceChange={onWorkspaceChange}
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  )
+
+  if (studyAssetWrapper) {
+    return <>{studyAssetWrapper(content, button)}</>
+  }
+
   return (
     <div className="presentation-list-component">
       <div className="row no-margin">
-        <button
-          id="add-workspace-btn"
-          type="button"
-          className="button button-white"
-          style={{
-            marginTop: 25,
-            marginBottom: 5,
-            border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-            boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-            ...(disabled ? { cursor: 'not-allowed' } : {}),
-          }}
-          onClick={() => !disabled && setShowAddEdit(true)}
-          disabled={disabled}
-        >
-          Add Workspace
-        </button>
-        {showAddEdit && (
-          <WorkspaceAddEdit
-            id={-1}
-            workspaces={workspaces}
-            closeAction={() => setShowAddEdit(false)}
-            onWorkspaceChange={onWorkspaceChange}
-          />
-        )}
+        {button}
       </div>
-      <div className="form-group row no-margin">
-        {workspaces.map((w: Workspace, index: number) => (
-          <WorkspaceRow
-            key={w.workspaceId || index}
-            id={index}
-            editMode={editState[index]}
-            workspace={w}
-            workspaces={workspaces}
-            columnsToShow={columnsToShow}
-            editAction={() => toggleEditState(index)}
-            deleteAction={() => handleDeleteWorkspace(index)}
-            closeAction={() => {
-              toggleEditState(index)
-              setShowAddEdit(false)
-            }}
-            onWorkspaceChange={onWorkspaceChange}
-            disabled={disabled}
-          />
-        ))}
-      </div>
+      {content}
     </div>
   )
 }

--- a/src/components/workspaces_list/WorkspaceList.tsx
+++ b/src/components/workspaces_list/WorkspaceList.tsx
@@ -3,7 +3,7 @@ import { Workspace } from 'src/types/model'
 import { WorkspaceAddEdit } from 'src/components/workspaces_list/WorkspaceAddEdit'
 import WorkspaceRow from 'src/components/workspaces_list/WorkspaceRow'
 import { DarErrors } from 'src/pages/dar_application/FormValidationState'
-import AddIcon from '@mui/icons-material/Add'
+import StudyAssetAddButton from 'src/pages/data_submission/v2/StudyAssetAddButton'
 
 interface WorkspaceListProps {
   readonly workspaces: Workspace[]
@@ -41,25 +41,13 @@ export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Elem
   const getValidationState = () => validation?.workspaces
 
   const button = (
-    <button
+    <StudyAssetAddButton
       id="add-workspace-btn"
-      type="button"
-      className="button button-white"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        marginTop: 0,
-        marginBottom: 5,
-        border: getValidationState() ? '1px solid red' : '1px solid #0948B7',
-        boxShadow: getValidationState() ? '0 0 5px red' : 'none',
-        ...(disabled ? { cursor: 'not-allowed' } : {}),
-      }}
-      onClick={() => !disabled && setShowAddEdit(true)}
+      label="Add Workspace"
+      onClick={() => setShowAddEdit(true)}
       disabled={disabled}
-    >
-      <AddIcon fontSize="medium" />
-      Add Workspace
-    </button>
+      hasValidationError={!!getValidationState()}
+    />
   )
 
   const content = (

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { DataSet } from 'src/libs/ajax/DataSet'
+import { cloneDeep, set } from 'lodash'
 import { GeneralStudyInformation } from 'src/pages/data_submission/v2/GeneralStudyInformation'
 import { NihAnvilUseRelated } from 'src/pages/data_submission/v2/NihAnvilUseRelated'
 import { Study } from 'src/pages/data_submission/v2/v2-models'
@@ -8,6 +9,7 @@ import { NihAdministrativeInformation } from 'src/pages/data_submission/v2/NihAd
 import { NihDataManagement } from 'src/pages/data_submission/v2/NihDataManagement'
 import { Styles } from 'src/libs/theme'
 import lockIcon from 'src/images/lock-icon.png'
+import { StudyAssetManagement } from 'src/pages/data_submission/v2/StudyAssetManagement'
 
 export type FileProperty = {
   key: string
@@ -65,6 +67,7 @@ export const DataSubmissionFormV2 = () => {
         <NihAnvilUseRelated study={study} setStudy={setStudy} setFiles={setFormFiles} />
         <NihAdministrativeInformation study={study} setStudy={setStudy} />
         <NihDataManagement study={study} setStudy={setStudy} files={formFiles} setFiles={setFormFiles} />
+        <StudyAssetManagement study={study} setStudy={setStudy} />
       </div>
     </>
   )

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router'
 import { DataSet } from 'src/libs/ajax/DataSet'
-import { cloneDeep, set } from 'lodash'
 import { GeneralStudyInformation } from 'src/pages/data_submission/v2/GeneralStudyInformation'
 import { NihAnvilUseRelated } from 'src/pages/data_submission/v2/NihAnvilUseRelated'
 import { Study } from 'src/pages/data_submission/v2/v2-models'

--- a/src/pages/data_submission/v2/StudyAsset.tsx
+++ b/src/pages/data_submission/v2/StudyAsset.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+export interface StudyAssetConfig {
+  icon: string
+  title: string
+  description: string
+  component: React.ReactNode
+}
+
+export interface StudyAssetProps {
+  config: StudyAssetConfig
+}
+
+export const StudyAsset: React.FC<StudyAssetProps> = ({ config }) => {
+  const { icon, title, description, component } = config
+
+  return (
+    <div style={{ marginTop: '2rem' }}>
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '1rem',
+        marginBottom: '1rem',
+      }}
+      >
+        <span
+          className={icon}
+          style={{ fontSize: '32px', flexShrink: 0 }}
+          aria-hidden="true"
+        />
+        <div style={{ flex: 1 }}>
+          <h3 style={{ margin: 0 }}>{title}</h3>
+          <p style={{ margin: '0.25rem 0 0 0', color: '#666' }}>{description}</p>
+        </div>
+        <div style={{ flexShrink: 0 }}>
+          {component}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/data_submission/v2/StudyAsset.tsx
+++ b/src/pages/data_submission/v2/StudyAsset.tsx
@@ -4,7 +4,8 @@ export interface StudyAssetConfig {
   icon: string
   title: string
   description: string
-  component: React.ReactNode
+  children?: React.ReactNode
+  button?: React.ReactNode
 }
 
 export interface StudyAssetProps {
@@ -12,29 +13,34 @@ export interface StudyAssetProps {
 }
 
 export const StudyAsset: React.FC<StudyAssetProps> = ({ config }) => {
-  const { icon, title, description, component } = config
+  const { icon, title, description, children, button } = config
 
   return (
-    <div style={{ marginTop: '2rem' }}>
+    <div style={{ marginTop: '2rem', width: '100%' }}>
       <div style={{
         display: 'flex',
-        alignItems: 'center',
-        gap: '1rem',
+        alignItems: 'flex-start',
+        gap: '2rem',
         marginBottom: '1rem',
       }}
       >
-        <span
-          className={icon}
-          style={{ fontSize: '32px', flexShrink: 0 }}
-          aria-hidden="true"
-        />
-        <div style={{ flex: 1 }}>
-          <h3 style={{ margin: 0 }}>{title}</h3>
-          <p style={{ margin: '0.25rem 0 0 0', color: '#666' }}>{description}</p>
+        <div style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: '1rem',
+          flex: 1,
+        }}
+        >
+          <span className={icon} style={{ fontSize: '32px', flexShrink: 0 }} aria-hidden="true" />
+          <div>
+            <h3 style={{ margin: 0 }}>{title}</h3>
+            <p style={{ margin: '0.25rem 0 0 0', color: '#666' }}>{description}</p>
+          </div>
         </div>
-        <div style={{ flexShrink: 0 }}>
-          {component}
-        </div>
+        {button && <div style={{ flexShrink: 0 }}>{button}</div>}
+      </div>
+      <div style={{ width: '100%' }}>
+        {children}
       </div>
     </div>
   )

--- a/src/pages/data_submission/v2/StudyAsset.tsx
+++ b/src/pages/data_submission/v2/StudyAsset.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export interface StudyAssetConfig {
-  icon: string
+  icon: string | React.ReactNode
   title: string
   description: string
   children?: React.ReactNode
@@ -26,12 +26,12 @@ export const StudyAsset: React.FC<StudyAssetProps> = ({ config }) => {
       >
         <div style={{
           display: 'flex',
-          alignItems: 'flex-start',
+          alignItems: 'center',
           gap: '1rem',
           flex: 1,
         }}
         >
-          <span className={icon} style={{ fontSize: '32px', flexShrink: 0 }} aria-hidden="true" />
+          <div>{icon}</div>
           <div>
             <h3 style={{ margin: 0 }}>{title}</h3>
             <p style={{ margin: '0.25rem 0 0 0', color: '#666' }}>{description}</p>

--- a/src/pages/data_submission/v2/StudyAsset.tsx
+++ b/src/pages/data_submission/v2/StudyAsset.tsx
@@ -22,7 +22,7 @@ export const StudyAsset: React.FC<StudyAssetProps> = ({ config }) => {
         width: '100%',
         background: '#eaf0fa',
         borderRadius: '12px',
-        padding: '1rem',
+        padding: '1rem 2rem',
         boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
       }}
     >

--- a/src/pages/data_submission/v2/StudyAsset.tsx
+++ b/src/pages/data_submission/v2/StudyAsset.tsx
@@ -16,20 +16,32 @@ export const StudyAsset: React.FC<StudyAssetProps> = ({ config }) => {
   const { icon, title, description, children, button } = config
 
   return (
-    <div style={{ marginTop: '2rem', width: '100%' }}>
-      <div style={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        gap: '2rem',
-        marginBottom: '1rem',
+    <div
+      style={{
+        marginTop: '1rem',
+        width: '100%',
+        background: '#eaf0fa',
+        borderRadius: '12px',
+        padding: '1rem',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.08)',
       }}
-      >
-        <div style={{
+    >
+      <div
+        style={{
           display: 'flex',
-          alignItems: 'center',
-          gap: '1rem',
-          flex: 1,
+          alignItems: 'flex-start',
+          gap: '2rem',
+          marginTop: '1rem',
+          marginBottom: '1rem',
         }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '1rem',
+            flex: 1,
+          }}
         >
           <div>{icon}</div>
           <div>

--- a/src/pages/data_submission/v2/StudyAssetAddButton.tsx
+++ b/src/pages/data_submission/v2/StudyAssetAddButton.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import AddIcon from '@mui/icons-material/Add'
 
 interface StudyAssetAddButtonProps {
-  id: string
-  label: string
-  onClick: () => void
-  disabled?: boolean
-  hasValidationError?: boolean
+  readonly id: string
+  readonly label: string
+  readonly onClick: () => void
+  readonly disabled?: boolean
+  readonly hasValidationError?: boolean
 }
 
 export default function StudyAssetAddButton(props: StudyAssetAddButtonProps): React.JSX.Element {

--- a/src/pages/data_submission/v2/StudyAssetAddButton.tsx
+++ b/src/pages/data_submission/v2/StudyAssetAddButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import AddIcon from '@mui/icons-material/Add'
+
+interface StudyAssetAddButtonProps {
+  id: string
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  hasValidationError?: boolean
+}
+
+export default function StudyAssetAddButton(props: StudyAssetAddButtonProps): React.JSX.Element {
+  const { id, label, onClick, disabled = false, hasValidationError = false } = props
+
+  return (
+    <button
+      id={id}
+      type="button"
+      className="button button-white"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        marginTop: 0,
+        marginBottom: 5,
+        border: hasValidationError ? '1px solid red' : '1px solid #0948B7',
+        boxShadow: hasValidationError ? '0 0 5px red' : 'none',
+        ...(disabled ? { cursor: 'not-allowed' } : {}),
+      }}
+      onClick={() => !disabled && onClick()}
+      disabled={disabled}
+    >
+      <AddIcon fontSize="medium" />
+      {label}
+    </button>
+  )
+}

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -17,6 +17,13 @@ import AiModelList from 'src/components/ai_models_list/AiModelList'
 import WorkspaceList from 'src/components/workspaces_list/WorkspaceList'
 import ClinicalTrialList from 'src/components/clinical_trial_list/ClinicalTrialList'
 import FundingResourceList from 'src/components/funding_resource_list/FundingResourceList'
+import AttachMoneyIcon from '@mui/icons-material/AttachMoney'
+import DescriptionIcon from '@mui/icons-material/Description'
+import MonitorIcon from '@mui/icons-material/Monitor'
+import VerifiedUserIcon from '@mui/icons-material/VerifiedUser'
+import StorageIcon from '@mui/icons-material/Storage'
+import LaptopMacIcon from '@mui/icons-material/LaptopMac'
+import LocalHospitalIcon from '@mui/icons-material/LocalHospital'
 
 export interface StudyAssetManagementProps {
   study: Study
@@ -95,6 +102,10 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
       <h2>Study Assets</h2>
       <p>Add datasets, models, workspaces, and other resources associated with this study</p>
 
+      {/*
+        TODO: DT-2382: Add DatasetList component here
+        */}
+
       <AiModelList
         aiModels={models}
         onAiModelsChange={onModelChange}
@@ -102,7 +113,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-cog',
+              icon: <StorageIcon fontSize="large" />,
               title: 'Models',
               description: 'Add computational models or algorithms derived from this study',
               children: content,
@@ -119,7 +130,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-briefcase',
+              icon: <LaptopMacIcon fontSize="large" />,
               title: 'Featured Workspaces',
               description: 'Add computational workspaces for data analysis',
               children: content,
@@ -136,7 +147,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-file',
+              icon: <DescriptionIcon fontSize="large" />,
               title: 'Publications',
               description: 'Add published research papers related to this study',
               children: content,
@@ -153,7 +164,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-bullhorn',
+              icon: <MonitorIcon fontSize="large" />,
               title: 'Presentations',
               description: 'Add conference presentations or talks about this study',
               children: content,
@@ -170,7 +181,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-stats',
+              icon: <LocalHospitalIcon fontSize="large" />,
               title: 'Clinical Trials',
               description: 'Add clinical trials associated with this study',
               children: content,
@@ -187,7 +198,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-copyright-mark',
+              icon: <VerifiedUserIcon fontSize="large" />,
               title: 'Intellectual Property',
               description: 'Add patents or other IP related to this study',
               children: content,
@@ -204,7 +215,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
             config={{
-              icon: 'glyphicon glyphicon-usd',
+              icon: <AttachMoneyIcon fontSize="large" />,
               title: 'Funding Resources',
               description: 'Add grants and funding sources for this study',
               children: content,

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -1,0 +1,175 @@
+import { Study } from 'src/pages/data_submission/v2/v2-models'
+import React, { useState } from 'react'
+import PublicationList from 'src/components/publications_list/PublicationList'
+import PresentationList from 'src/components/presentations_list/PresentationList'
+import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
+import {
+  AiModel,
+  ClinicalTrial,
+  FundingResource,
+  IntellectualProperty,
+  Presentation,
+  Publication,
+  Workspace,
+} from 'src/types/model'
+import { StudyAsset, StudyAssetConfig } from 'src/pages/data_submission/v2/StudyAsset'
+import AiModelList from 'src/components/ai_models_list/AiModelList'
+import WorkspaceList from 'src/components/workspaces_list/WorkspaceList'
+import ClinicalTrialList from 'src/components/clinical_trial_list/ClinicalTrialList'
+import FundingResourceList from 'src/components/funding_resource_list/FundingResourceList'
+
+export interface StudyAssetManagementProps {
+  study: Study
+  setStudy: React.Dispatch<React.SetStateAction<Study>>
+}
+
+export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
+  const { setStudy, study } = props
+
+  const [models, setModels] = useState<AiModel[]>(study.assets?.models || [])
+  const [workspaces, setWorkspaces] = useState<Workspace[]>(study.assets?.workspaces || [])
+  const [publications, setPublications] = useState<Publication[]>(study.assets?.publications || [])
+  const [presentations, setPresentations] = useState<Presentation[]>(study.assets?.presentations || [])
+  const [clinicalTrials, setClinicalTrials] = useState<ClinicalTrial[]>(study.assets?.clinicalTrials || [])
+  const [intellectualProperties, setIntellectualProperties] = useState<IntellectualProperty[]>(study.assets?.intellectualProperty || [])
+  const [fundingResources, setFundingResources] = useState<FundingResource[]>(study.assets?.funding || [])
+
+  const onModelChange = (models: AiModel[]) => {
+    setModels(models)
+    setStudy(prev => ({ ...prev, models }))
+  }
+
+  const onWorkspaceChange = (workspaces: Workspace[]) => {
+    setWorkspaces(workspaces)
+    setStudy(prev => ({ ...prev, workspaces }))
+  }
+
+  const onPublicationChange = (publications: Publication[]) => {
+    setPublications(publications)
+    setStudy(prev => ({ ...prev, publications }))
+  }
+
+  const onPresentationChange = (presentations: Presentation[]) => {
+    setPresentations(presentations)
+    setStudy(prev => ({ ...prev, presentations }))
+  }
+
+  const onClinicalTrialChange = (clinicalTrials: ClinicalTrial[]) => {
+    setClinicalTrials(clinicalTrials)
+    setStudy(prev => ({ ...prev, clinicalTrials }))
+  }
+
+  const onIntellectualPropertyChange = (intellectualProperties: IntellectualProperty[]) => {
+    setIntellectualProperties(intellectualProperties)
+    setStudy(prev => ({ ...prev, intellectualProperties }))
+  }
+
+  const onFundingResourceChange = (fundingResources: FundingResource[]) => {
+    setFundingResources(fundingResources)
+    setStudy(prev => ({ ...prev, fundingResources }))
+  }
+
+  const assetConfigs: StudyAssetConfig[] = [
+    {
+      icon: 'glyphicon glyphicon-hdd',
+      title: 'Datasets',
+      description: 'Add datasets associated with this study',
+      component: <button type="button">Add Dataset</button>,
+    },
+    {
+      icon: 'glyphicon glyphicon-cog',
+      title: 'Models',
+      description: 'Add computational models or algorithms derived from this study',
+      component: (
+        <AiModelList
+          aiModels={models}
+          onAiModelsChange={onModelChange}
+          disabled={false}
+        />
+      ),
+    },
+    {
+      icon: 'glyphicon glyphicon-briefcase',
+      title: 'Featured Workspaces',
+      description: 'Add computational workspaces for data analysis',
+      component: (
+        <WorkspaceList
+          workspaces={workspaces}
+          onWorkspaceChange={onWorkspaceChange}
+          disabled={false}
+        />
+      ),
+    },
+    {
+      icon: 'glyphicon glyphicon-file',
+      title: 'Publications',
+      description: 'Add published research papers related to this study',
+      component: (
+        <PublicationList
+          publications={publications}
+          onPublicationChange={onPublicationChange}
+          disabled={false}
+        />
+      ),
+    },
+    {
+      icon: 'glyphicon glyphicon-bullhorn',
+      title: 'Presentations',
+      description: 'Add conference presentations or talks about this study',
+      component: (
+        <PresentationList
+          presentations={presentations}
+          onPresentationChange={onPresentationChange}
+          disabled={false}
+        />
+      ),
+    },
+    {
+      icon: 'glyphicon glyphicon-stats',
+      title: 'Clinical Trials',
+      description: 'Add clinical trials associated with this study',
+      component: (
+        <ClinicalTrialList
+          clinicalTrials={clinicalTrials}
+          onClinicalTrialChange={onClinicalTrialChange}
+          disabled={false}
+        />
+      ),
+    },
+    {
+      icon: 'glyphicon glyphicon-copyright-mark',
+      title: 'Intellectual Property',
+      description: 'Add patents or other IP related to this study',
+      component: (
+        <IntellectualPropertyList
+          intellectualProperties={intellectualProperties}
+          onIntellectualPropertyChange={onIntellectualPropertyChange}
+          disabled={false}
+        />
+      ),
+    },
+    {
+      icon: 'glyphicon glyphicon-usd',
+      title: 'Funding Resources',
+      description: 'Add grants and funding sources for this study',
+      component: (
+        <FundingResourceList
+          fundingResources={fundingResources}
+          onFundingResourceChange={onFundingResourceChange}
+          disabled={false}
+        />
+      ),
+    },
+  ]
+
+  return (
+    <div className="data-submitter-section">
+      <h2>Study Assets</h2>
+      <p>Add datasets, models, workspaces, and other resources associated with this study</p>
+
+      {assetConfigs.map((config, index) => (
+        <StudyAsset key={index} config={config} />
+      ))}
+    </div>
+  )
+}

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -1,5 +1,5 @@
 import { Study } from 'src/pages/data_submission/v2/v2-models'
-import React, { ReactNode, useState } from 'react'
+import React, { ReactNode } from 'react'
 import PublicationList from 'src/components/publications_list/PublicationList'
 import PresentationList from 'src/components/presentations_list/PresentationList'
 import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
@@ -33,69 +33,23 @@ export interface StudyAssetManagementProps {
 export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
   const { setStudy, study } = props
 
-  const [models, setModels] = useState<AiModel[]>(study.assets?.models || [])
-  const [workspaces, setWorkspaces] = useState<Workspace[]>(study.assets?.workspaces || [])
-  const [publications, setPublications] = useState<Publication[]>(study.assets?.publications || [])
-  const [presentations, setPresentations] = useState<Presentation[]>(study.assets?.presentations || [])
-  const [clinicalTrials, setClinicalTrials] = useState<ClinicalTrial[]>(study.assets?.clinicalTrials || [])
-  const [intellectualProperties, setIntellectualProperties] = useState<IntellectualProperty[]>(study.assets?.intellectualProperty || [])
-  const [fundingResources, setFundingResources] = useState<FundingResource[]>(study.assets?.funding || [])
-
-  const onModelChange = (models: AiModel[]) => {
-    setModels(models)
+  const onAssetChange = <K extends keyof NonNullable<Study['assets']>>(
+    assetType: K,
+    value: NonNullable<Study['assets']>[K],
+  ) => {
     setStudy(prev => ({
       ...prev,
-      assets: { ...prev.assets, models },
+      assets: { ...prev.assets, [assetType]: value },
     }))
   }
 
-  const onWorkspaceChange = (workspaces: Workspace[]) => {
-    setWorkspaces(workspaces)
-    setStudy(prev => ({
-      ...prev,
-      assets: { ...prev.assets, workspaces },
-    }))
-  }
-
-  const onPublicationChange = (publications: Publication[]) => {
-    setPublications(publications)
-    setStudy(prev => ({
-      ...prev,
-      assets: { ...prev.assets, publications },
-    }))
-  }
-
-  const onPresentationChange = (presentations: Presentation[]) => {
-    setPresentations(presentations)
-    setStudy(prev => ({
-      ...prev,
-      assets: { ...prev.assets, presentations },
-    }))
-  }
-
-  const onClinicalTrialChange = (clinicalTrials: ClinicalTrial[]) => {
-    setClinicalTrials(clinicalTrials)
-    setStudy(prev => ({
-      ...prev,
-      assets: { ...prev.assets, clinicalTrials },
-    }))
-  }
-
-  const onIntellectualPropertyChange = (intellectualProperties: IntellectualProperty[]) => {
-    setIntellectualProperties(intellectualProperties)
-    setStudy(prev => ({
-      ...prev,
-      assets: { ...prev.assets, intellectualProperty: intellectualProperties },
-    }))
-  }
-
-  const onFundingResourceChange = (fundingResources: FundingResource[]) => {
-    setFundingResources(fundingResources)
-    setStudy(prev => ({
-      ...prev,
-      assets: { ...prev.assets, funding: fundingResources },
-    }))
-  }
+  const models = study.assets?.models || []
+  const workspaces = study.assets?.workspaces || []
+  const publications = study.assets?.publications || []
+  const presentations = study.assets?.presentations || []
+  const clinicalTrials = study.assets?.clinicalTrials || []
+  const intellectualProperties = study.assets?.intellectualProperty || []
+  const fundingResources = study.assets?.funding || []
 
   return (
     <div className="data-submitter-section">
@@ -108,7 +62,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <AiModelList
         aiModels={models}
-        onAiModelsChange={onModelChange}
+        onAiModelsChange={(models: AiModel[]) => onAssetChange('models', models)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
@@ -125,7 +79,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <WorkspaceList
         workspaces={workspaces}
-        onWorkspaceChange={onWorkspaceChange}
+        onWorkspaceChange={(workspaces: Workspace[]) => onAssetChange('workspaces', workspaces)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
@@ -142,7 +96,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <PublicationList
         publications={publications}
-        onPublicationChange={onPublicationChange}
+        onPublicationChange={(publications: Publication[]) => onAssetChange('publications', publications)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
@@ -159,7 +113,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <PresentationList
         presentations={presentations}
-        onPresentationChange={onPresentationChange}
+        onPresentationChange={(presentations: Presentation[]) => onAssetChange('presentations', presentations)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
@@ -176,7 +130,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <ClinicalTrialList
         clinicalTrials={clinicalTrials}
-        onClinicalTrialChange={onClinicalTrialChange}
+        onClinicalTrialChange={(clinicalTrials: ClinicalTrial[]) => onAssetChange('clinicalTrials', clinicalTrials)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
@@ -193,7 +147,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <IntellectualPropertyList
         intellectualProperties={intellectualProperties}
-        onIntellectualPropertyChange={onIntellectualPropertyChange}
+        onIntellectualPropertyChange={(intellectualProperties: IntellectualProperty[]) => onAssetChange('intellectualProperty', intellectualProperties)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset
@@ -210,7 +164,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
       <FundingResourceList
         fundingResources={fundingResources}
-        onFundingResourceChange={onFundingResourceChange}
+        onFundingResourceChange={(fundingResources: FundingResource[]) => onAssetChange('funding', fundingResources)}
         disabled={false}
         studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
           <StudyAsset

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -1,5 +1,5 @@
 import { Study } from 'src/pages/data_submission/v2/v2-models'
-import React, { useState } from 'react'
+import React, { ReactNode, useState } from 'react'
 import PublicationList from 'src/components/publications_list/PublicationList'
 import PresentationList from 'src/components/presentations_list/PresentationList'
 import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
@@ -12,7 +12,7 @@ import {
   Publication,
   Workspace,
 } from 'src/types/model'
-import { StudyAsset, StudyAssetConfig } from 'src/pages/data_submission/v2/StudyAsset'
+import { StudyAsset } from 'src/pages/data_submission/v2/StudyAsset'
 import AiModelList from 'src/components/ai_models_list/AiModelList'
 import WorkspaceList from 'src/components/workspaces_list/WorkspaceList'
 import ClinicalTrialList from 'src/components/clinical_trial_list/ClinicalTrialList'
@@ -36,140 +36,183 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
 
   const onModelChange = (models: AiModel[]) => {
     setModels(models)
-    setStudy(prev => ({ ...prev, models }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, models },
+    }))
   }
 
   const onWorkspaceChange = (workspaces: Workspace[]) => {
     setWorkspaces(workspaces)
-    setStudy(prev => ({ ...prev, workspaces }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, workspaces },
+    }))
   }
 
   const onPublicationChange = (publications: Publication[]) => {
     setPublications(publications)
-    setStudy(prev => ({ ...prev, publications }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, publications },
+    }))
   }
 
   const onPresentationChange = (presentations: Presentation[]) => {
     setPresentations(presentations)
-    setStudy(prev => ({ ...prev, presentations }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, presentations },
+    }))
   }
 
   const onClinicalTrialChange = (clinicalTrials: ClinicalTrial[]) => {
     setClinicalTrials(clinicalTrials)
-    setStudy(prev => ({ ...prev, clinicalTrials }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, clinicalTrials },
+    }))
   }
 
   const onIntellectualPropertyChange = (intellectualProperties: IntellectualProperty[]) => {
     setIntellectualProperties(intellectualProperties)
-    setStudy(prev => ({ ...prev, intellectualProperties }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, intellectualProperty: intellectualProperties },
+    }))
   }
 
   const onFundingResourceChange = (fundingResources: FundingResource[]) => {
     setFundingResources(fundingResources)
-    setStudy(prev => ({ ...prev, fundingResources }))
+    setStudy(prev => ({
+      ...prev,
+      assets: { ...prev.assets, funding: fundingResources },
+    }))
   }
-
-  const assetConfigs: StudyAssetConfig[] = [
-    {
-      icon: 'glyphicon glyphicon-hdd',
-      title: 'Datasets',
-      description: 'Add datasets associated with this study',
-      component: <button type="button">Add Dataset</button>,
-    },
-    {
-      icon: 'glyphicon glyphicon-cog',
-      title: 'Models',
-      description: 'Add computational models or algorithms derived from this study',
-      component: (
-        <AiModelList
-          aiModels={models}
-          onAiModelsChange={onModelChange}
-          disabled={false}
-        />
-      ),
-    },
-    {
-      icon: 'glyphicon glyphicon-briefcase',
-      title: 'Featured Workspaces',
-      description: 'Add computational workspaces for data analysis',
-      component: (
-        <WorkspaceList
-          workspaces={workspaces}
-          onWorkspaceChange={onWorkspaceChange}
-          disabled={false}
-        />
-      ),
-    },
-    {
-      icon: 'glyphicon glyphicon-file',
-      title: 'Publications',
-      description: 'Add published research papers related to this study',
-      component: (
-        <PublicationList
-          publications={publications}
-          onPublicationChange={onPublicationChange}
-          disabled={false}
-        />
-      ),
-    },
-    {
-      icon: 'glyphicon glyphicon-bullhorn',
-      title: 'Presentations',
-      description: 'Add conference presentations or talks about this study',
-      component: (
-        <PresentationList
-          presentations={presentations}
-          onPresentationChange={onPresentationChange}
-          disabled={false}
-        />
-      ),
-    },
-    {
-      icon: 'glyphicon glyphicon-stats',
-      title: 'Clinical Trials',
-      description: 'Add clinical trials associated with this study',
-      component: (
-        <ClinicalTrialList
-          clinicalTrials={clinicalTrials}
-          onClinicalTrialChange={onClinicalTrialChange}
-          disabled={false}
-        />
-      ),
-    },
-    {
-      icon: 'glyphicon glyphicon-copyright-mark',
-      title: 'Intellectual Property',
-      description: 'Add patents or other IP related to this study',
-      component: (
-        <IntellectualPropertyList
-          intellectualProperties={intellectualProperties}
-          onIntellectualPropertyChange={onIntellectualPropertyChange}
-          disabled={false}
-        />
-      ),
-    },
-    {
-      icon: 'glyphicon glyphicon-usd',
-      title: 'Funding Resources',
-      description: 'Add grants and funding sources for this study',
-      component: (
-        <FundingResourceList
-          fundingResources={fundingResources}
-          onFundingResourceChange={onFundingResourceChange}
-          disabled={false}
-        />
-      ),
-    },
-  ]
 
   return (
     <div className="data-submitter-section">
       <h2>Study Assets</h2>
       <p>Add datasets, models, workspaces, and other resources associated with this study</p>
 
-      {assetConfigs.map((config, index) => (
-        <StudyAsset key={index} config={config} />
-      ))}
+      <AiModelList
+        aiModels={models}
+        onAiModelsChange={onModelChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-cog',
+              title: 'Models',
+              description: 'Add computational models or algorithms derived from this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <WorkspaceList
+        workspaces={workspaces}
+        onWorkspaceChange={onWorkspaceChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-briefcase',
+              title: 'Featured Workspaces',
+              description: 'Add computational workspaces for data analysis',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <PublicationList
+        publications={publications}
+        onPublicationChange={onPublicationChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-file',
+              title: 'Publications',
+              description: 'Add published research papers related to this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <PresentationList
+        presentations={presentations}
+        onPresentationChange={onPresentationChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-bullhorn',
+              title: 'Presentations',
+              description: 'Add conference presentations or talks about this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <ClinicalTrialList
+        clinicalTrials={clinicalTrials}
+        onClinicalTrialChange={onClinicalTrialChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-stats',
+              title: 'Clinical Trials',
+              description: 'Add clinical trials associated with this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <IntellectualPropertyList
+        intellectualProperties={intellectualProperties}
+        onIntellectualPropertyChange={onIntellectualPropertyChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-copyright-mark',
+              title: 'Intellectual Property',
+              description: 'Add patents or other IP related to this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <FundingResourceList
+        fundingResources={fundingResources}
+        onFundingResourceChange={onFundingResourceChange}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: 'glyphicon glyphicon-usd',
+              title: 'Funding Resources',
+              description: 'Add grants and funding sources for this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
     </div>
   )
 }

--- a/src/pages/data_submission/v2/v2-models.tsx
+++ b/src/pages/data_submission/v2/v2-models.tsx
@@ -1,4 +1,13 @@
-import { Dataset, FileStorageObject } from 'src/types/model'
+import {
+  AiModel,
+  ClinicalTrial,
+  Dataset,
+  FileStorageObject,
+  FundingResource, IntellectualProperty,
+  Presentation,
+  Publication,
+  Workspace,
+} from 'src/types/model'
 import { StudyType } from 'src/components/forms/StudyType'
 import React from 'react'
 
@@ -339,4 +348,13 @@ export interface Study {
   createUserId?: number
   updateDate?: string // Date?
   updateUserId?: number
+  assets?: {
+    models?: Array<AiModel>
+    workspaces?: Array<Workspace>
+    publications?: Array<Publication>
+    presentations?: Array<Presentation>
+    clinicalTrials?: Array<ClinicalTrial>
+    funding?: Array<FundingResource>
+    intellectualProperty?: Array<IntellectualProperty>
+  }
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2397

### Summary

This PR adds new Study Assets to the S4R (v2) Study Form, enabling users to create and edit assets during data submission.

<img width="3600" height="5370" alt="After" src="https://github.com/user-attachments/assets/ebb2798b-69d1-4d43-ad8a-021cbc4698c4" />

N/B: Dataset Assets will be added in this ticket: https://broadworkbench.atlassian.net/browse/DT-2382

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
