### PR TITLE
[DT-2438] Move Signing Officials List Below Library Card Instructions

### DIFF
--- a/src/pages/user_profile/ResearcherStatus.tsx
+++ b/src/pages/user_profile/ResearcherStatus.tsx
@@ -121,22 +121,6 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
       })}
       <div style={{ marginTop: '20px' }} />
       <p style={subheadStyle}>Library Card issued to you</p>
-      {signingOfficialUsers.length === 0
-        ? (
-            <p>
-              No Signing Official found for your institution. Please refer to <a href="https://duos.blog/2025/08/06/how-to-get-a-library-card-from-your-signing-official/" target="_blank" rel="noreferrer">this help article</a> for instructions on how to get a Library Card.
-            </p>
-          )
-        : (
-            <>
-              <p>Signing Official(s):</p>
-              <ul>
-                {signingOfficialUsers.map(so => (
-                  <li key={so.userId}>{so.displayName} - {so.email}</li>
-                ))}
-              </ul>
-            </>
-          )}
       <p>
         A Library Card is a Signing Official’s pre-authorization of a researcher to submit Data Access Requests (DARs)
         in DUOS. A valid Library Card is required to initiate a DAR.
@@ -157,6 +141,22 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
                 you a Library Card.
               </p>
             </div>
+          )}
+      {signingOfficialUsers.length === 0
+        ? (
+            <p>
+              No Signing Official found for your institution. Please refer to <a href="https://duos.blog/2025/08/06/how-to-get-a-library-card-from-your-signing-official/" target="_blank" rel="noreferrer">this help article</a> for instructions on how to get a Library Card.
+            </p>
+          )
+        : (
+            <>
+              <p>Signing Official(s):</p>
+              <ul>
+                {signingOfficialUsers.map(so => (
+                  <li key={so.userId}>{so.displayName} - {so.email}</li>
+                ))}
+              </ul>
+            </>
           )}
     </div>
   )


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2438

### Summary

This PR updates the DUOS Profile page so the Signing Officials list appears directly below the Library Card Instructions section. This improves the information flow and helps users understand the instructions before seeing who can issue Library Cards.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
