### PR TITLE
[DT-2467] Address Material UI incompatibilities with Bootstrap

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import Modal from 'react-modal'
+import { ThemeProvider } from '@mui/material/styles'
 import 'src/App.css'
+import { muiThemeFix } from 'src/libs/muiThemeFix'
 import { AuthenticateNIH } from 'src/libs/ajax/AuthenticateNIH.js'
 import { Config } from 'src/libs/config'
 import DuosFooter from 'src/components/DuosFooter'
@@ -93,16 +95,18 @@ function App() {
     left: '45%',
   }
   return (
-    <div className="body">
-      <div className="wrap">
-        <div className="main">
-          <DuosHeader />
-          {isLoading && <div style={loadingSyle}><Spinner /></div>}
-          {!isLoading && <AppRoutes isLogged={isLoggedIn} env={env} />}
+    <ThemeProvider theme={muiThemeFix}>
+      <div className="body">
+        <div className="wrap">
+          <div className="main">
+            <DuosHeader />
+            {isLoading && <div style={loadingSyle}><Spinner /></div>}
+            {!isLoading && <AppRoutes isLogged={isLoggedIn} env={env} />}
+          </div>
         </div>
+        <DuosFooter />
       </div>
-      <DuosFooter />
-    </div>
+    </ThemeProvider>
   )
 }
 

--- a/src/components/data_search/DatasetFilterList.tsx
+++ b/src/components/data_search/DatasetFilterList.tsx
@@ -10,14 +10,15 @@ import Divider from '@mui/material/Divider'
 import { flatten, uniq, compact, orderBy } from 'lodash'
 import { DatasetTerm, getAccessManagementSummary } from 'src/types/model'
 import { FiltersTypes, generateDefaultParticipantCountValues } from 'src/components/data_search/DatasetFilterConstants'
-import { muiCheckboxFix } from 'src/libs/muiThemeFix'
+import { muiSmallButtonFix, muiCheckboxFix, muiListItemTextFix, muiTextFieldFix, muiH5Fix, muiHeaderFix } from 'src/libs/muiThemeFix'
 
 interface FilterItemHeaderProps {
   title: React.ReactNode
   headerStyle?: React.CSSProperties
 }
+
 export const FilterItemHeader = (props: FilterItemHeaderProps) => {
-  const { title, headerStyle = { fontFamily: 'Montserrat', fontWeight: '600', marginTop: '1em' } } = props
+  const { title, headerStyle = muiHeaderFix } = props
   return (
     <Typography variant="h6" gutterBottom component="div" sx={headerStyle}>
       {title}
@@ -49,7 +50,10 @@ export const FilterItemList = (props: FilterItemListProps) => {
                     sx={muiCheckboxFix}
                   />
                 </ListItemIcon>
-                <ListItemText sx={{ fontFamily: 'Montserrat', transform: 'scale(1.2)' }}>
+                <ListItemText
+                  sx={{ marginLeft: '-1.5em' }}
+                  slotProps={muiListItemTextFix}
+                >
                   {filterDisplayFn ? filterDisplayFn(filterOption) : filterName}
                 </ListItemText>
               </ListItemButton>
@@ -93,9 +97,9 @@ export const FilterItemRange = (props: FilterItemRangeProps) => {
         margin="dense"
         variant="outlined"
         helperText="minimum"
-        FormHelperTextProps={{ style: { transform: 'scale(1.5)' } }}
         inputProps={minInputPropsComplete}
         onChange={event => filterHandler(minCategory, Number(event.target.value))}
+        slotProps={muiTextFieldFix}
       />
       <Box padding="0rem 1rem 1rem"> - </Box>
       <TextField
@@ -106,9 +110,9 @@ export const FilterItemRange = (props: FilterItemRangeProps) => {
         margin="dense"
         variant="outlined"
         helperText="maximum"
-        FormHelperTextProps={{ style: { transform: 'scale(1.5)' } }}
         inputProps={maxInputPropsComplete}
         onChange={event => filterHandler(maxCategory, Number(event.target.value))}
+        slotProps={muiTextFieldFix}
       />
     </Box>
   )
@@ -132,10 +136,10 @@ export const DatasetFilterList = (props: DatasetFilterListProps) => {
   return (
     <Box sx={{ bgcolor: 'background.paper' }}>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <Typography variant="h5" gutterBottom component="div" sx={{ fontFamily: 'Montserrat', fontWeight: '600' }}>
+        <Typography variant="h5" gutterBottom component="div" sx={muiH5Fix}>
           Filters
         </Typography>
-        <Button onClick={onClear}>
+        <Button onClick={onClear} sx={muiSmallButtonFix}>
           Clear Filters
         </Button>
       </Box>
@@ -151,7 +155,7 @@ export const DatasetFilterList = (props: DatasetFilterListProps) => {
           const accessManagementSummary = getAccessManagementSummary(filter)
           return (
             <div style={{ display: 'flex', alignItems: 'center' }}>
-              <img src={accessManagementSummary.icon} alt={accessManagementSummary.name} style={{ width: '10px', marginRight: 6 }} />
+              <img src={accessManagementSummary.icon} alt={accessManagementSummary.name} style={{ width: '12px', marginRight: 6 }} />
               {accessManagementSummary.name}
             </div>
           )
@@ -168,12 +172,11 @@ export const DatasetFilterList = (props: DatasetFilterListProps) => {
       <FilterItemHeader
         title={(
           <>
-            <span style={{ fontWeight: '600' }}>Data Access Committee</span>
+            <span>Data Access Committee</span>
             {' '}
-            <span>(DACs)</span>
+            <span style={{ fontWeight: 400 }}>(DACs)</span>
           </>
         )}
-        headerStyle={{ fontFamily: 'Montserrat', marginTop: '1em' }}
       />
       <FilterItemList
         category="dac"

--- a/src/components/data_search/DatasetFilterList.tsx
+++ b/src/components/data_search/DatasetFilterList.tsx
@@ -10,6 +10,7 @@ import Divider from '@mui/material/Divider'
 import { flatten, uniq, compact, orderBy } from 'lodash'
 import { DatasetTerm, getAccessManagementSummary } from 'src/types/model'
 import { FiltersTypes, generateDefaultParticipantCountValues } from 'src/components/data_search/DatasetFilterConstants'
+import { muiCheckboxFix } from 'src/libs/muiThemeFix'
 
 interface FilterItemHeaderProps {
   title: React.ReactNode
@@ -43,7 +44,10 @@ export const FilterItemList = (props: FilterItemListProps) => {
             <ListItem disablePadding key={filterOption}>
               <ListItemButton sx={{ padding: '0' }} onClick={() => filterHandler(category, filterOption)}>
                 <ListItemIcon>
-                  <Checkbox checked={isFiltered(filterOption, category)} />
+                  <Checkbox
+                    checked={isFiltered(filterOption, category)}
+                    sx={muiCheckboxFix}
+                  />
                 </ListItemIcon>
                 <ListItemText sx={{ fontFamily: 'Montserrat', transform: 'scale(1.2)' }}>
                   {filterDisplayFn ? filterDisplayFn(filterOption) : filterName}

--- a/src/components/data_search/DatasetSearchFooter.tsx
+++ b/src/components/data_search/DatasetSearchFooter.tsx
@@ -44,7 +44,7 @@ export const DatasetSearchFooter = (props: DatasetSearchFooterProps) => {
       <Button
         variant="contained"
         onClick={onClick}
-        sx={{ fontSize: 14, height: 35, marginRight: 5 }}
+        sx={{ fontWeight: 600, marginRight: 5 }}
       >
         Apply for Access
       </Button>

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -254,7 +254,7 @@ export const DatasetSearchTable = (props) => {
             />
             <div />
             <Box sx={{ display: 'flex', flexDirection: 'row', justifyContent: 'flex-end', paddingLeft: '1em', height: '4rem' }}>
-              <Button variant="contained" onClick={() => setSearchTerm('')} sx={{ width: '10em', fontSize: 14 }}>
+              <Button variant="contained" onClick={() => setSearchTerm('')} sx={{ width: '10em', padding: '0' }}>
                 Clear Search
               </Button>
             </Box>

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -7,6 +7,7 @@ import { SnapshotSummaryModel } from 'src/types/tdrModel'
 import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
 import { dataUseCellData } from 'src/components/dac_dataset_table/DACDatasetTableCellData'
 import 'src/components/data_search/DatasetSearch.css'
+import { muiCheckboxFix } from 'src/libs/muiThemeFix'
 
 export interface DatasetSearchTableTab<T> {
   key: string
@@ -81,6 +82,7 @@ export const makeStudyTableHeaders = (datasets: DatasetTerm[], selected: number[
           checked={datasets.length === selected.length}
           indeterminate={selected.length > 0 && selected.length < selectableDatasetIds.length}
           onClick={() => onSelect(selectableDatasetIds.length === selected.length ? [] : selectableDatasetIds)}
+          sx={muiCheckboxFix}
         />
       ),
       sortable: false,
@@ -102,6 +104,7 @@ export const makeStudyTableHeaders = (datasets: DatasetTerm[], selected: number[
                   indeterminate={indeterminate}
                   disabled={!isSelectableStudy}
                   onClick={() => onSelect(fullySelected ? without(selected, ...studyDatasetIds) : indeterminate ? xor(without(selected, ...studyDatasetIds), studyDatasetIds) : [...selected, ...studyDatasetIds])}
+                  sx={muiCheckboxFix}
                 />
               </span>
             </div>
@@ -267,6 +270,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
           checked={datasets.length === selected.length}
           indeterminate={selected.length > 0 && selected.length < datasets.length}
           onClick={() => onSelect(selectableDatasetIds.length === selected.length ? [] : selectableDatasetIds)}
+          sx={muiCheckboxFix}
         />
       ),
       sortable: false,
@@ -283,6 +287,7 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
                   checked={isSelected}
                   disabled={!isSelectable(dataset)}
                   onClick={() => onSelect(xor([dataset.datasetId], selected))}
+                  sx={muiCheckboxFix}
                 />
               </span>
             </div>

--- a/src/components/modals/ConfirmationDialog.jsx
+++ b/src/components/modals/ConfirmationDialog.jsx
@@ -1,33 +1,35 @@
 import * as React from 'react'
 import Button from '@mui/material/Button'
-import { Dialog } from '@mui/material'
+import { Dialog, ThemeProvider } from '@mui/material'
 import DialogTitle from '@mui/material/DialogTitle'
 import DialogContent from '@mui/material/DialogContent'
 import DialogActions from '@mui/material/DialogActions'
 import DialogContentText from '@mui/material/DialogContentText'
+import { muiThemeFix } from 'src/libs/muiThemeFix'
 
 export const ConfirmationDialog = (props) => {
   const { title, openState, close, action, description } = props
   return (
-    <Dialog
-      open={openState}
-      onClose={close}
-      aria-labelledby="alert-dialog-title"
-      aria-describedby="alert-dialog-description"
-      sx={{ transform: 'scale(1.5)' }}
-    >
-      <DialogTitle id="alert-dialog-title">
-        {title}
-      </DialogTitle>
-      <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          {description}
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={close} variant="outlined">Cancel</Button>
-        <Button onClick={action} autoFocus color="error" variant="contained">Confirm</Button>
-      </DialogActions>
-    </Dialog>
+    <ThemeProvider theme={muiThemeFix}>
+      <Dialog
+        open={openState}
+        onClose={close}
+        aria-labelledby="alert-dialog-title"
+        aria-describedby="alert-dialog-description"
+      >
+        <DialogTitle id="alert-dialog-title">
+          {title}
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText id="alert-dialog-description">
+            {description}
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={close} variant="outlined">Cancel</Button>
+          <Button onClick={action} autoFocus color="error" variant="contained">Confirm</Button>
+        </DialogActions>
+      </Dialog>
+    </ThemeProvider>
   )
 }

--- a/src/libs/ToastNotifications.tsx
+++ b/src/libs/ToastNotifications.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { createRoot } from 'react-dom/client'
-import { AlertColor, Alert, Snackbar, SnackbarOrigin } from '@mui/material'
+import { AlertColor, Alert, Snackbar, SnackbarOrigin, ThemeProvider } from '@mui/material'
+import { muiThemeFix } from 'src/libs/muiThemeFix'
 
 export type ToastPosition = 'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight'
 
@@ -71,30 +72,25 @@ export const ToastNotifications = {
       }
 
       return (
-        <Snackbar
-          anchorOrigin={snackbarLayout}
-          autoHideDuration={timeout}
-          open={open}
-          onClose={handleClose}
-          // these transforms are required because the rule `html { font-size: 10px }` exists in bootstrap_replacement.css
-          sx={{
-            transform: 'scale(1.5)',
-            transformOrigin: `${snackbarLayout.vertical} ${snackbarLayout.horizontal}`,
-            maxWidth: '30vw',
-            width: 'fit-content',
-          }}
-          {...props}
-        >
-          <Alert
-            data-cy="notification-alert"
+        <ThemeProvider theme={muiThemeFix}>
+          <Snackbar
+            anchorOrigin={snackbarLayout}
+            autoHideDuration={timeout}
+            open={open}
             onClose={handleClose}
-            severity={severity}
-            variant="filled"
-            sx={{ width: '100%' }}
+            {...props}
           >
-            {text}
-          </Alert>
-        </Snackbar>
+            <Alert
+              data-cy="notification-alert"
+              onClose={handleClose}
+              severity={severity}
+              variant="filled"
+              sx={{ width: '100%' }}
+            >
+              {text}
+            </Alert>
+          </Snackbar>
+        </ThemeProvider>
       )
     }
 

--- a/src/libs/muiThemeFix.ts
+++ b/src/libs/muiThemeFix.ts
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles'
+
+/**
+ * Global Material UI Theme Configuration
+ *
+ * This theme configures MUI to work correctly despite the root HTML font-size
+ * being 10px due to bootstrap_replacement.css. Since rem units are calculated
+ * relative to root font-size, all MUI default sizes need to be adjusted
+ * proportionally.
+ *
+ * This file should be removed once bootstrap_replacement.css is removed.
+ */
+export const muiThemeFix = createTheme({
+  typography: {
+    htmlFontSize: 10,
+    fontFamily: 'Montserrat, Helvetica Neue, Helvetica, Arial, sans-serif',
+  },
+})

--- a/src/libs/muiThemeFix.ts
+++ b/src/libs/muiThemeFix.ts
@@ -8,7 +8,8 @@ import { createTheme } from '@mui/material/styles'
  * relative to root font-size, all MUI default sizes need to be adjusted
  * proportionally.
  *
- * This file should be removed once bootstrap_replacement.css is removed.
+ * This file should be removed once bootstrap_replacement.css and the custom
+ * style overrides set by `sx={ ... }` are removed.
  */
 export const muiThemeFix = createTheme({
   typography: {
@@ -16,6 +17,47 @@ export const muiThemeFix = createTheme({
     fontFamily: 'Montserrat, Helvetica Neue, Helvetica, Arial, sans-serif',
   },
 })
+
+/**
+ * Style to set MUI h5 font properties correctly for the Data Library
+ */
+export const muiH5Fix = { fontSize: '1.5rem', fontWeight: '600' }
+
+/**
+ * Style to set MUI filter item font size correctly for the Data Library
+ */
+const muiDefaultItemFix = { fontSize: '1.3rem' }
+
+/**
+ * Style to set MUI Button font properties correctly for the Data Library
+ */
+export const muiSmallButtonFix = { fontSize: '1rem', fontWeight: '600' }
+
+/**
+ * Style to set MUI default header font properties correctly for the Data Library
+ */
+export const muiHeaderFix = { ...muiDefaultItemFix, fontWeight: '600', marginTop: '1em' }
+
+/**
+ * SlotProps style to set MUI TextField font size correctly for the Data Library
+ */
+export const muiTextFieldFix = {
+  input: {
+    sx: muiDefaultItemFix,
+  },
+  inputLabel: {
+    sx: muiDefaultItemFix,
+  },
+}
+
+/**
+ * SlotProps style to set MUI ListItemText font size correctly for the Data Library
+ */
+export const muiListItemTextFix = {
+  primary: {
+    sx: { ...muiDefaultItemFix, fontWeight: 400 },
+  },
+}
 
 /**
  * Style to set MUI Checkbox icon size correctly for the Data Library

--- a/src/libs/muiThemeFix.ts
+++ b/src/libs/muiThemeFix.ts
@@ -16,3 +16,10 @@ export const muiThemeFix = createTheme({
     fontFamily: 'Montserrat, Helvetica Neue, Helvetica, Arial, sans-serif',
   },
 })
+
+/**
+ * Style to set MUI Checkbox icon size correctly for the Data Library
+ */
+export const muiCheckboxFix = {
+  '& .MuiSvgIcon-root': { fontSize: '1.5rem' },
+}

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useParams } from 'react-router'
+import { useParams } from 'react-router-dom'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { GeneralStudyInformation } from 'src/pages/data_submission/v2/GeneralStudyInformation'
 import { NihAnvilUseRelated } from 'src/pages/data_submission/v2/NihAnvilUseRelated'


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2467

### Summary

We currently need special hacks for our Material UI components because of the remnants from the previous Bootstrap UI.

This replaces these hacks with a more robust and holistic solution so that we can benefit from the full Material UI framework.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
