### PR TITLE
[DT-2440] Add Guidance Text to Researcher Data Submissions Page

### DIFF
--- a/src/pages/researcher_console/DatasetSubmissions.jsx
+++ b/src/pages/researcher_console/DatasetSubmissions.jsx
@@ -94,7 +94,8 @@ export default function DatasetSubmissions() {
     alignItems: 'center',
     justifyContent: 'center',
     fontSize: '1.45rem',
-    padding: '3%',
+    height: 44,
+    padding: '0 16px',
     cursor: 'default',
     textTransform: 'uppercase',
     fontWeight: 600,
@@ -119,7 +120,7 @@ export default function DatasetSubmissions() {
   return (
     <div style={Styles.PAGE}>
       <div className={styles['submitted-datasets-header']}>
-        <div className="left-header-section" style={Styles.LEFT_HEADER_SECTION}>
+        <div className="left-header-section" style={{ ...Styles.LEFT_HEADER_SECTION, maxWidth: '70%' }}>
           <div
             style={Styles.ICON_CONTAINER}
           >
@@ -143,15 +144,18 @@ export default function DatasetSubmissions() {
             >
               View the status of datasets registered in DUOS
             </div>
+            <div style={({ ...Styles.MEDIUM_DESCRIPTION, fontSize: '16px', marginTop: '1rem', textAlign: 'justify' })}>
+              <p>DUOS accepts registration of either <b>Open Access</b> or <b>Controlled Access data</b>.</p>
+              <p>Controlled access data registered in DUOS can be managed by a DAC within DUOS or by an external system that the dataset information in DUOS links to [ex. dbGaP, EGA etc]. To register controlled access data with a DAC in DUOS, may need to provide the receiving DAC with documentation and/or agreements. These agreements can be submitted during the DUOS registration process or handled externally through direct communication with the DAC. DUOS is not responsible for the content, review, offer, or acceptance of such agreements.</p>
+            </div>
             <div>{addDatasetButton}</div>
           </div>
         </div>
-        <div className={`right-header-section ${styles['search-box-container']}`}>
-          <SearchBar
-            handleSearchChange={handleSearchChange}
-            searchRef={searchRef}
-          />
-        </div>
+        <SearchBar
+          handleSearchChange={handleSearchChange}
+          searchRef={searchRef}
+          style={{ marginRight: '8%' }}
+        />
       </div>
       <div className={styles['term-table-container']}>
         <DatasetSubmissionsTable terms={filteredTerms} isLoading={isLoading} />


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2440

### Summary

This PR adds clear guidance to the Researcher – Data Submissions page to help Data Submitters understand their responsibilities when registering datasets in DUOS.

<img width="1939" height="455" alt="Researcher Text" src="https://github.com/user-attachments/assets/ef44d103-1121-43c7-b2cd-00601146d37d" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
