### PR TITLE
[DT-2445][DT-2489] Set isMultipart to true for attachment upload and add tests

### DIFF
--- a/cypress/component/libs/Support.spec.ts
+++ b/cypress/component/libs/Support.spec.ts
@@ -1,0 +1,45 @@
+import { Support } from 'src/libs/ajax/Support'
+
+describe('Support', () => {
+  beforeEach(() => {
+    cy.initApplicationConfig()
+  })
+
+  describe('uploadAttachment', () => {
+    it('should send multipart request with correct headers', () => {
+      const mockFile = new File(['file content'], 'test.pdf', { type: 'application/pdf' })
+
+      cy.intercept('POST', '**/support/upload', (req) => {
+        expect(req.headers['content-type']).to.equal('application/binary')
+
+        req.reply({
+          statusCode: 200,
+          body: { token: 'token-123' },
+        })
+      }).as('uploadRequest')
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cy.wrap(Support.uploadAttachment(mockFile)).then((response: any) => {
+        cy.wrap(response.data).should('have.property', 'token')
+      })
+
+      cy.wait('@uploadRequest')
+    })
+
+    it('should successfully upload a file and return token', () => {
+      const mockFile = new File(['test content'], 'document.pdf', { type: 'application/pdf' })
+
+      cy.intercept('POST', '**/support/upload', {
+        statusCode: 200,
+        body: { token: 'token-456' },
+      }).as('uploadRequest')
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cy.wrap(Support.uploadAttachment(mockFile)).then((response: any) => {
+        expect(response.data.token).to.equal('token-456')
+      })
+
+      cy.wait('@uploadRequest')
+    })
+  })
+})

--- a/src/libs/ajax/Support.js
+++ b/src/libs/ajax/Support.js
@@ -29,7 +29,7 @@ export const Support = {
   uploadAttachment: async (file) => {
     const url = `${await getApiUrl()}/support/upload`
     try {
-      return await fetchPost(url, file, { headers: { 'Content-Type': 'application/binary' } })
+      return await fetchPost(url, file, { headers: { 'Content-Type': 'application/binary' }, isMultipart: true })
     }
     catch (error) {
       throw extractConsentError(error) || new Error(extractError(error))


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2445

### Summary

If this property is not set, it will try to upload the file metadata instead of the file.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
