### PR TITLE
DT-2385: Use new endpoint to create user

### DIFF
--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -32,7 +32,7 @@ export const User = {
   },
 
   create: async (request: CreateDuosUserRequest): Promise<DuosUser | false | undefined> => {
-    const url = `${await getApiUrl()}/api/dacuser`
+    const url = `${await getApiUrl()}/api/user/create`
     try {
       const res = await fetchPost(url, request, Config.authOpts())
       return res.data


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-2385

## Summary
Small change to point the create user API to the newer version added in https://github.com/DataBiosphere/consent/pull/2751
This does not fully address the ticket as that will require more comprehensive UI updates for chairpersons. This does allow us to remove the outdated back end code so we can clean things up faster.

### Example screens showing this in action
<img width="1436" height="1373" alt="Screenshot 2025-11-21 at 10 26 51 AM" src="https://github.com/user-attachments/assets/f682bfa5-2888-4f78-bfb1-0e254c03ec8a" />

<img width="1436" height="1373" alt="Screenshot 2025-11-21 at 10 27 37 AM" src="https://github.com/user-attachments/assets/20ae3fd9-359b-44a0-becf-b4690f21299c" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
