### PR TITLE
DT-2374: Fix call to cancel collection from researcher console

### DIFF
--- a/src/pages/researcher_console/ResearcherConsole.jsx
+++ b/src/pages/researcher_console/ResearcherConsole.jsx
@@ -60,7 +60,7 @@ export default function ResearcherConsole() {
   const cancelCollection = async (darCollection) => {
     try {
       const { darCollectionId, darCode } = darCollection
-      await Collections.cancelCollection(darCollectionId)
+      await Collections.cancelCollection(darCollectionId, USER_ROLES.researcher)
       const updatedCollection = await Collections.getCollectionSummaryByRoleNameAndId({
         roleName: USER_ROLES.researcher,
         id: darCollectionId,


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2374

### Summary
Fixes the researcher console link to cancel a collection which was not calling the API correctly.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
