### PR TITLE
[DT-2437] Add DAC Setting for Automatic DAR Opening

### DIFF
--- a/src/pages/manage_dac/ManageRadar.tsx
+++ b/src/pages/manage_dac/ManageRadar.tsx
@@ -83,12 +83,12 @@ const ManageRadar = () => {
           id="link_manage_dac"
           to="/manage_dac"
           className="navbar-brand"
-          style={{ paddingRight: '16px', marginTop: '3rem' }}
+          style={{ paddingRight: '16px' }}
         >
           <img id="back-arrow-icon" src={backArrowIcon} style={{ ...Styles.HEADER_IMG, width: '30px' }} alt="Back" />
         </Link>
         <TableHeaderSection
-          title="Manage Rule Automation for DARs (RADAR)"
+          title="DAC Configurations"
           description={fetchedDac ? fetchedDac.name : ''}
         />
       </div>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2437

### Summary

This PR updates the DAC Configurations page (formerly Manage RADAR) and supports a new rule that lets DACs choose whether new DARs automatically open to all members or stay restricted until the Chair opens them after this backend PR merges https://github.com/DataBiosphere/consent/pull/2753

<img width="1776" height="641" alt="After" src="https://github.com/user-attachments/assets/4ab38131-37b2-4544-b341-285a1f7eda40" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
