### PR TITLE
[DT-2434] Update search bar styling

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -25,7 +25,8 @@ const Search = styled('div')(({ theme }) => ({
 }))
 
 const SearchIconWrapper = styled('div')(({ theme }) => ({
-  padding: theme.spacing(0, 2),
+  color: '#777777',
+  padding: theme.spacing(0, 1),
   height: '100%',
   position: 'absolute',
   top: 0,
@@ -54,7 +55,6 @@ const StyledInputBase = styled(InputBase, {
   'color': 'inherit',
   'width': '30ch',
   'border': '1px solid #cecece',
-  'backgroundColor': '#f3f6f7',
   'borderRadius': '5px',
   'height': '4rem',
   'fontFamily': 'Montserrat',


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2434

### Summary

Minor styling updates to the search bar so it matches the Material UI style a little more.

Before:

<img width="305" height="51" alt="Screenshot 2025-12-01 at 2 20 51 PM" src="https://github.com/user-attachments/assets/b3f2d7c5-afa2-4b3e-b774-186fdd641eba" />

After:

<img width="308" height="53" alt="Screenshot 2025-12-01 at 2 20 39 PM" src="https://github.com/user-attachments/assets/82a3010d-208c-45f5-9ac2-07541ace7113" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
