### PR TITLE
[DT-2434] Ensure data team owns Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # builder image
 FROM node:24.11.1-trixie AS builder
-LABEL maintainer="grushton@broadinstitute.org"
+LABEL maintainer="dsp-data-team@broadinstitute.org"
 
 # set working directory
 RUN mkdir /usr/src/app


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2434

### Summary

Small PR to ensure Data Team owns the Dockerfile.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
