### PR TITLE
[DT-2542] When methodsResearch is false, it means NMDS is selected

### DIFF
--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -301,7 +301,7 @@ export const DatasetUpdate = (props) => {
           type={FormFieldTypes.CHECKBOX}
           id="methodsResearch"
           toggleText="No methods development or validation studies (NMDS)"
-          defaultValue={formData.dataUse.methodsResearch === true}
+          defaultValue={formData.dataUse.methodsResearch === false}
           disabled={true}
         />
         <FormField

--- a/src/pages/data_submission/DataAccessGovernance.jsx
+++ b/src/pages/data_submission/DataAccessGovernance.jsx
@@ -133,7 +133,8 @@ export const DataAccessGovernance = (props) => {
           otherPrimary: dataUse.other,
 
           // secondary
-          nmds: dataUse.methodsResearch,
+          // when methodsResearch is false, it indicates NMDS
+          nmds: dataUse.methodsResearch === false,
           gso: dataUse.geneticStudiesOnly,
           pub: dataUse.publicationResults,
           col: dataUse.collaboratorRequired,

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -277,7 +277,7 @@ export interface DataUse {
   hmbResearch?: boolean
   diseaseRestrictions?: string[]
   populationOriginsAncestry?: boolean
-  methodsResearch?: boolean
+  methodsResearch?: boolean // when this value is false, it indicates NMDS.
   nonProfitUse?: boolean
   other?: string
   secondaryOther?: string


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2542](https://broadworkbench.atlassian.net/browse/DT-2542)

### Summary

See backend implementation in: https://github.com/DataBiosphere/consent/pull/2764

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
