### PR TITLE
DT-2460, DT-2538, DT-2591: Cookie Banner Implementation

### DIFF
--- a/cypress/component/CookieBanner.spec.tsx
+++ b/cypress/component/CookieBanner.spec.tsx
@@ -13,7 +13,7 @@ describe('CookieBanner', () => {
   })
 
   it('hides banner and sets accepted when close button is clicked', () => {
-    cy.stub(CookieUtils, 'setAccepted').as('setAcceptedStub')
+    cy.stub(CookieUtils, 'setAcknowledged').as('setAcceptedStub')
     mount(<BrowserRouter><CookieBanner visible={true} /></BrowserRouter>)
     cy.get('#cookie_banner').should('be.visible')
     cy.get('button').click()

--- a/cypress/component/CookieBanner.spec.tsx
+++ b/cypress/component/CookieBanner.spec.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+
+import { CookieBanner } from 'src/components/CookieBanner'
+import { BrowserRouter } from 'react-router-dom'
+import { CookieUtils } from 'src/utils/CookieUtils'
+
+describe('CookieBanner', () => {
+  it('renders the banner text and close button', () => {
+    mount(<BrowserRouter><CookieBanner visible={true} /></BrowserRouter>)
+    cy.contains('We care about your privacy').should('exist')
+    cy.get('button').should('exist')
+  })
+
+  it('hides banner and sets accepted when close button is clicked', () => {
+    cy.stub(CookieUtils, 'setAccepted').as('setAcceptedStub')
+    mount(<BrowserRouter><CookieBanner visible={true} /></BrowserRouter>)
+    cy.get('#cookie_banner').should('be.visible')
+    cy.get('button').click()
+    cy.get('#cookie_banner').should('not.be.visible')
+    cy.get('@setAcceptedStub').should('have.been.calledOnce')
+  })
+
+  it('does not render the banner text when visible is set false', () => {
+    mount(<BrowserRouter><CookieBanner visible={false} /></BrowserRouter>)
+    cy.get('#cookie_banner').should('not.be.visible')
+  })
+})

--- a/cypress/component/DuosFooter.spec.tsx
+++ b/cypress/component/DuosFooter.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { mount } from 'cypress/react'
+
+import DuosFooter from 'src/components/DuosFooter'
+
+describe('DuosFooter', () => {
+  beforeEach(() => {
+    mount(<DuosFooter />)
+  })
+
+  it('renders the Broad Institute logo', () => {
+    cy.get('img[alt="Broad Institute logo"]').should('exist')
+  })
+
+  it('renders all footer links', () => {
+    cy.contains('© Broad Institute').should('exist')
+    cy.contains('a', 'Privacy Policy').should('have.attr', 'href', '/privacy')
+    cy.contains('a', 'Terms of Service').should('have.attr', 'href', '/tos')
+    cy.contains('a', 'Cookie Policy').should('have.attr', 'href', '/cookie_policy')
+    cy.contains('a', 'Status').should('have.attr', 'href', '/status')
+  })
+})

--- a/cypress/component/DuosFooter.spec.tsx
+++ b/cypress/component/DuosFooter.spec.tsx
@@ -7,16 +7,16 @@ import { BrowserRouter } from 'react-router-dom'
 
 describe('DuosFooter', () => {
   it('renders the Broad Institute logo', () => {
-    cy.stub(CookieUtils, 'getAccepted').returns(true)
+    cy.stub(CookieUtils, 'getAcknowledged').returns(true)
     mount(<BrowserRouter><DuosFooter /></BrowserRouter>)
-    cy.get('#cookie_banner').should('not.exist')
+    cy.get('#cookie_banner').should('not.be.visible')
     cy.get('img[alt="Broad Institute logo"]').should('exist')
   })
 
   it('renders all footer links', () => {
-    cy.stub(CookieUtils, 'getAccepted').returns(true)
+    cy.stub(CookieUtils, 'getAcknowledged').returns(true)
     mount(<BrowserRouter><DuosFooter /></BrowserRouter>)
-    cy.get('#cookie_banner').should('not.exist')
+    cy.get('#cookie_banner').should('not.be.visible')
     cy.contains('© Broad Institute').should('exist')
     cy.contains('a', 'Privacy Policy').should('have.attr', 'href', '/privacy')
     cy.contains('a', 'Terms of Service').should('have.attr', 'href', '/tos')
@@ -25,7 +25,7 @@ describe('DuosFooter', () => {
   })
 
   it('shows Cookie Banner when cookies have not been acknowledged', () => {
-    cy.stub(CookieUtils, 'getAccepted').returns(false)
+    cy.stub(CookieUtils, 'getAcknowledged').returns(false)
     mount(<BrowserRouter><DuosFooter /></BrowserRouter>)
     cy.get('#cookie_banner').should('be.visible')
   })

--- a/cypress/component/DuosFooter.spec.tsx
+++ b/cypress/component/DuosFooter.spec.tsx
@@ -2,21 +2,31 @@ import React from 'react'
 import { mount } from 'cypress/react'
 
 import DuosFooter from 'src/components/DuosFooter'
+import { CookieUtils } from 'src/utils/CookieUtils'
+import { BrowserRouter } from 'react-router-dom'
 
 describe('DuosFooter', () => {
-  beforeEach(() => {
-    mount(<DuosFooter />)
-  })
-
   it('renders the Broad Institute logo', () => {
+    cy.stub(CookieUtils, 'getAccepted').returns(true)
+    mount(<BrowserRouter><DuosFooter /></BrowserRouter>)
+    cy.get('#cookie_banner').should('not.exist')
     cy.get('img[alt="Broad Institute logo"]').should('exist')
   })
 
   it('renders all footer links', () => {
+    cy.stub(CookieUtils, 'getAccepted').returns(true)
+    mount(<BrowserRouter><DuosFooter /></BrowserRouter>)
+    cy.get('#cookie_banner').should('not.exist')
     cy.contains('© Broad Institute').should('exist')
     cy.contains('a', 'Privacy Policy').should('have.attr', 'href', '/privacy')
     cy.contains('a', 'Terms of Service').should('have.attr', 'href', '/tos')
     cy.contains('a', 'Cookie Policy').should('have.attr', 'href', '/cookie_policy')
     cy.contains('a', 'Status').should('have.attr', 'href', '/status')
+  })
+
+  it('shows Cookie Banner when cookies have not been acknowledged', () => {
+    cy.stub(CookieUtils, 'getAccepted').returns(false)
+    mount(<BrowserRouter><DuosFooter /></BrowserRouter>)
+    cy.get('#cookie_banner').should('be.visible')
   })
 })

--- a/cypress/component/utils/CookieUtils.spec.ts
+++ b/cypress/component/utils/CookieUtils.spec.ts
@@ -1,0 +1,46 @@
+import { CookieUtils } from 'src/utils/CookieUtils'
+
+describe('CookieUtils', () => {
+  beforeEach(() => {
+    // Reset document.cookie before each test
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: '',
+    })
+  })
+
+  describe('getCookiePairs', () => {
+    it('should return an object of cookie key-value pairs', () => {
+      document.cookie = 'foo=bar; baz=qux'
+      const pairs = CookieUtils.getCookiePairs()
+      expect(pairs).to.deep.equal({ foo: 'bar', baz: 'qux' })
+    })
+  })
+
+  describe('getAccepted', () => {
+    it('should return true if accepted', () => {
+      const control = { accepted: true }
+      document.cookie = `cookie_control=${encodeURIComponent(JSON.stringify(control))}`
+      cy.wrap(CookieUtils.getAccepted()).should('be.true')
+    })
+
+    it('should return false if not accepted', () => {
+      const control = { accepted: false }
+      document.cookie = `cookie_control=${encodeURIComponent(JSON.stringify(control))}`
+      cy.wrap(CookieUtils.getAccepted()).should('be.false')
+    })
+
+    it('should return false if cookie_control is missing', () => {
+      document.cookie = 'foo=bar'
+      cy.wrap(CookieUtils.getAccepted()).should('be.false')
+    })
+  })
+
+  describe('setAccepted', () => {
+    it('should set cookie_control cookie when accepted', () => {
+      CookieUtils.setAccepted()
+      cy.wrap(document.cookie).should('contain', 'cookie_control')
+      cy.wrap(document.cookie).should('contain', '"accepted":true')
+    })
+  })
+})

--- a/cypress/component/utils/CookieUtils.spec.ts
+++ b/cypress/component/utils/CookieUtils.spec.ts
@@ -17,30 +17,30 @@ describe('CookieUtils', () => {
     })
   })
 
-  describe('getAccepted', () => {
-    it('should return true if accepted', () => {
-      const control = { accepted: true }
+  describe('getAcknowledged', () => {
+    it('should return true if acknowledged', () => {
+      const control = { acknowledged: true }
       document.cookie = `cookie_control=${encodeURIComponent(JSON.stringify(control))}`
-      cy.wrap(CookieUtils.getAccepted()).should('be.true')
+      cy.wrap(CookieUtils.getAcknowledged()).should('be.true')
     })
 
-    it('should return false if not accepted', () => {
-      const control = { accepted: false }
+    it('should return false if not acknowledged', () => {
+      const control = { acknowledged: false }
       document.cookie = `cookie_control=${encodeURIComponent(JSON.stringify(control))}`
-      cy.wrap(CookieUtils.getAccepted()).should('be.false')
+      cy.wrap(CookieUtils.getAcknowledged()).should('be.false')
     })
 
     it('should return false if cookie_control is missing', () => {
       document.cookie = 'foo=bar'
-      cy.wrap(CookieUtils.getAccepted()).should('be.false')
+      cy.wrap(CookieUtils.getAcknowledged()).should('be.false')
     })
   })
 
   describe('setAccepted', () => {
-    it('should set cookie_control cookie when accepted', () => {
-      CookieUtils.setAccepted()
+    it('should set cookie_control cookie when acknowledged', () => {
+      CookieUtils.setAcknowledged()
       cy.wrap(document.cookie).should('contain', 'cookie_control')
-      cy.wrap(document.cookie).should('contain', '"accepted":true')
+      cy.wrap(document.cookie).should('contain', '"acknowledged":true')
     })
   })
 })

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import CloseIcon from '@mui/icons-material/Close'
+import { IconButton } from '@mui/material'
 import { Link } from 'react-router-dom'
 import { CookieUtils } from 'src/utils/CookieUtils'
+import Tooltip from '@mui/material/Tooltip'
 
 export interface CookieBannerProps {
   visible?: boolean
@@ -14,24 +16,35 @@ export const CookieBanner = (props: CookieBannerProps) => {
       id="cookie_banner"
       className="cookie-banner"
       style={{
-        border: '1px solid',
+        position: 'fixed',
+        bottom: 0,
+        marginBottom: 10,
+        left: 15,
+        right: 15,
+        zIndex: 1000,
+        border: '1px solid gray',
         borderRadius: '5px',
-        padding: '10px',
+        padding: '15px',
         backgroundColor: '#f9f9f9',
         display: visible ? 'block' : 'none',
       }}
     >
 
-      <button
-        type="button"
-        style={{ float: 'right', fontWeight: 'bolder', fontSize: 24, cursor: 'pointer' }}
-        onClick={() => {
-          CookieUtils.setAccepted()
-          setVisible(false)
-        }}
-      >
-        <CloseIcon />
-      </button>
+      <Tooltip title="Acknowledge Cookies">
+        <IconButton
+          edge="end"
+          color="inherit"
+          aria-label="Acknowledge Cookies"
+          data-cy="closeButton"
+          onClick={() => {
+            CookieUtils.setAcknowledged()
+            setVisible(false)
+          }}
+          sx={{ float: 'right', marginRight: '5px' }}
+        >
+          <CloseIcon />
+        </IconButton>
+      </Tooltip>
 
       <p><strong>We care about your privacy</strong></p>
       <p>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import CloseIcon from '@mui/icons-material/Close'
+import CheckIcon from '@mui/icons-material/Check'
 import { IconButton } from '@mui/material'
 import { Link } from 'react-router-dom'
 import { CookieUtils } from 'src/utils/CookieUtils'
@@ -42,7 +42,7 @@ export const CookieBanner = (props: CookieBannerProps) => {
           }}
           sx={{ float: 'right', marginRight: '5px' }}
         >
-          <CloseIcon />
+          <CheckIcon />
         </IconButton>
       </Tooltip>
 

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import CloseIcon from '@mui/icons-material/Close'
+import { Link } from 'react-router-dom'
+import { CookieUtils } from 'src/utils/CookieUtils'
+
+export interface CookieBannerProps {
+  visible?: boolean
+}
+
+export const CookieBanner = (props: CookieBannerProps) => {
+  const [visible, setVisible] = React.useState(props.visible)
+  return (
+    <div
+      id="cookie_banner"
+      className="cookie-banner"
+      style={{
+        border: '1px solid',
+        borderRadius: '5px',
+        padding: '10px',
+        backgroundColor: '#f9f9f9',
+        display: visible ? 'block' : 'none',
+      }}
+    >
+
+      <button
+        type="button"
+        style={{ float: 'right', fontWeight: 'bolder', fontSize: 24, cursor: 'pointer' }}
+        onClick={() => {
+          CookieUtils.setAccepted()
+          setVisible(false)
+        }}
+      >
+        <CloseIcon />
+      </button>
+
+      <p><strong>We care about your privacy</strong></p>
+      <p>
+        DUOS uses cookies to enable the proper functioning and security of our website. We only use cookies
+        that are strictly necessary for the site to function normally. Not allowing strictly necessary cookies
+        means that the DUOS site won’t be able to operate and you won’t be able to use it. By continuing to use
+        our site, you are agreeing to the use of these strictly necessary cookies. We do not sell your data to
+        third-parties. To find out more, read our <Link to="/privacy">privacy policy</Link> and&nbsp;
+        <Link to="/cookie_policy">cookie policy</Link>.
+      </p>
+    </div>
+  )
+}

--- a/src/components/DuosFooter.tsx
+++ b/src/components/DuosFooter.tsx
@@ -1,27 +1,27 @@
-import React from 'react'
-import footerLogo from '../images/broad_logo_allwhite.png'
+import React, { CSSProperties } from 'react'
+import footerLogo from 'src/images/broad_logo_allwhite.png'
+
+const footerStyle: CSSProperties = {
+  position: 'relative',
+  clear: 'both',
+  backgroundColor: '#000000',
+  minHeight: '64px',
+}
+
+const mainFooterStyle: CSSProperties = {
+  display: 'block',
+  width: '100%',
+  padding: '0 20px',
+}
+
+const footerLogoStyle: CSSProperties = {
+  float: 'left',
+  height: '32px',
+  marginTop: '15px',
+  marginRight: '35px',
+}
 
 function DuosFooter() {
-  const footerStyle = {
-    position: 'relative',
-    clear: 'both',
-    backgroundColor: '#000000',
-    minHeight: '64px',
-  }
-
-  const mainFooterStyle = {
-    display: 'block',
-    width: '100%',
-    padding: '0 20px',
-  }
-
-  const footerLogoStyle = {
-    float: 'left',
-    height: '32px',
-    marginTop: '15px',
-    marginRight: '35px',
-  }
-
   return (
     <div style={footerStyle}>
       <footer style={mainFooterStyle}>

--- a/src/components/DuosFooter.tsx
+++ b/src/components/DuosFooter.tsx
@@ -1,5 +1,7 @@
 import React, { CSSProperties } from 'react'
 import footerLogo from 'src/images/broad_logo_allwhite.png'
+import { CookieBanner } from 'src/components/CookieBanner'
+import { CookieUtils } from 'src/utils/CookieUtils'
 
 const footerStyle: CSSProperties = {
   position: 'relative',
@@ -22,20 +24,22 @@ const footerLogoStyle: CSSProperties = {
 }
 
 function DuosFooter() {
-  return (
-    <div style={footerStyle}>
-      <footer style={mainFooterStyle}>
-        <img src={footerLogo} style={footerLogoStyle} alt="Broad Institute logo" />
-        <ul className="footer-links">
-          <li className="footer-links__item">© Broad Institute</li>
-          <li className="footer-links__item"><a href="/privacy">Privacy Policy</a></li>
-          <li className="footer-links__item"><a href="/tos">Terms of Service</a></li>
-          <li className="footer-links__item"><a href="/cookie_policy">Cookie Policy</a></li>
-          <li className="footer-links__item"><a href="/status">Status</a></li>
-        </ul>
-      </footer>
-    </div>
-  )
+  return CookieUtils.getAccepted()
+    ? (
+        <div style={footerStyle}>
+          <footer style={mainFooterStyle}>
+            <img src={footerLogo} style={footerLogoStyle} alt="Broad Institute logo" />
+            <ul className="footer-links">
+              <li className="footer-links__item">© Broad Institute</li>
+              <li className="footer-links__item"><a href="/privacy">Privacy Policy</a></li>
+              <li className="footer-links__item"><a href="/tos">Terms of Service</a></li>
+              <li className="footer-links__item"><a href="/cookie_policy">Cookie Policy</a></li>
+              <li className="footer-links__item"><a href="/status">Status</a></li>
+            </ul>
+          </footer>
+        </div>
+      )
+    : <CookieBanner visible={true} />
 }
 
 export default DuosFooter

--- a/src/components/DuosFooter.tsx
+++ b/src/components/DuosFooter.tsx
@@ -24,22 +24,21 @@ const footerLogoStyle: CSSProperties = {
 }
 
 function DuosFooter() {
-  return CookieUtils.getAccepted()
-    ? (
-        <div style={footerStyle}>
-          <footer style={mainFooterStyle}>
-            <img src={footerLogo} style={footerLogoStyle} alt="Broad Institute logo" />
-            <ul className="footer-links">
-              <li className="footer-links__item">© Broad Institute</li>
-              <li className="footer-links__item"><a href="/privacy">Privacy Policy</a></li>
-              <li className="footer-links__item"><a href="/tos">Terms of Service</a></li>
-              <li className="footer-links__item"><a href="/cookie_policy">Cookie Policy</a></li>
-              <li className="footer-links__item"><a href="/status">Status</a></li>
-            </ul>
-          </footer>
-        </div>
-      )
-    : <CookieBanner visible={true} />
+  return (
+    <div style={footerStyle}>
+      <CookieBanner visible={!CookieUtils.getAcknowledged()} />
+      <footer style={mainFooterStyle}>
+        <img src={footerLogo} style={footerLogoStyle} alt="Broad Institute logo" />
+        <ul className="footer-links">
+          <li className="footer-links__item">© Broad Institute</li>
+          <li className="footer-links__item"><a href="/privacy">Privacy Policy</a></li>
+          <li className="footer-links__item"><a href="/tos">Terms of Service</a></li>
+          <li className="footer-links__item"><a href="/cookie_policy">Cookie Policy</a></li>
+          <li className="footer-links__item"><a href="/status">Status</a></li>
+        </ul>
+      </footer>
+    </div>
+  )
 }
 
 export default DuosFooter

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -9,19 +9,19 @@ export const getCookiePairs = () => {
   return cookiePairs
 }
 
-export const getAccepted = () => {
+export const getAcknowledged = () => {
   for (const [key, value] of Object.entries(getCookiePairs())) {
     if (key === 'cookie_control') {
       const control = JSON.parse(value)
-      return (control?.accepted === true)
+      return (control?.acknowledged === true)
     }
   }
   return false
 }
 
-export const setAccepted = () => {
+export const setAcknowledged = () => {
   // Base cookie control object
-  const control = { accepted: true, timestamp: Date.now() }
+  const control = { acknowledged: true, timestamp: Date.now() }
   // 400 - day cookie expiration (days * hours * minutes * seconds)
   const expiration = 400 * 24 * 60 * 60
   document.cookie = `cookie_control=${JSON.stringify(control)}; path=/; max-age=` + expiration
@@ -29,6 +29,6 @@ export const setAccepted = () => {
 
 export const CookieUtils = {
   getCookiePairs,
-  getAccepted,
-  setAccepted,
+  getAcknowledged,
+  setAcknowledged,
 }

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,0 +1,34 @@
+export const getCookiePairs = () => {
+  const cookies = document.cookie
+  const cookiePairs: Record<string, string> = {}
+  for (const cookieStr of cookies
+    .split(';')) {
+    const [name, ...rest] = cookieStr.split('=')
+    cookiePairs[name.trim()] = decodeURIComponent(rest.join('=').trim())
+  }
+  return cookiePairs
+}
+
+export const getAccepted = () => {
+  for (const [key, value] of Object.entries(getCookiePairs())) {
+    if (key === 'cookie_control') {
+      const control = JSON.parse(value)
+      return (control?.accepted === true)
+    }
+  }
+  return false
+}
+
+export const setAccepted = () => {
+  // Base cookie control object
+  const control = { accepted: true, timestamp: Date.now() }
+  // 400 - day cookie expiration (days * hours * minutes * seconds)
+  const expiration = 400 * 24 * 60 * 60
+  document.cookie = `cookie_control=${JSON.stringify(control)}; path=/; max-age=` + expiration
+}
+
+export const CookieUtils = {
+  getCookiePairs,
+  getAccepted,
+  setAccepted,
+}


### PR DESCRIPTION
## Addresses
Cookie Banner:
* https://broadworkbench.atlassian.net/browse/DT-2460
* https://broadworkbench.atlassian.net/browse/DT-2538

DuosFooter Typescript Migration:
* https://broadworkbench.atlassian.net/browse/DT-2591

## Summary
This PR adds the following features:
* Display a new cookie banner when a user visits DUOS and has no acknowledgement cookie set.
* Set an accepted cookie when the user closes the banner
* Remembers the banner for the maximum expiration (400 days for Chrome/Firefox; Safari will only honor a 7 day max expiration).
* New utility class and tests for managing cookies.
* Migrate `DuosFooter` to typescript

### Screen
<img width="1043" height="1036" alt="Screenshot 2025-12-11 at 11 31 01 AM" src="https://github.com/user-attachments/assets/4d95303b-5858-4ab4-80e1-546573ddcfd9" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
