### PR TITLE
[DT-2512] Add async spinner button to support form

### DIFF
--- a/cypress/component/AsyncSpinnerButton.spec.tsx
+++ b/cypress/component/AsyncSpinnerButton.spec.tsx
@@ -76,7 +76,7 @@ describe('AsyncSpinnerButton', () => {
     cy.get('[data-cy="async-action-button-loading-button"]')
       .should('be.disabled')
       .should('have.attr', 'aria-busy', 'true')
-      .find('img[alt="spinner"]')
+      .find('.MuiCircularProgress-root')
       .should('be.visible')
 
     // Text should not be visible during loading
@@ -318,7 +318,7 @@ describe('AsyncSpinnerButton', () => {
     cy.get('[data-cy="async-action-button-loading-stay-button"]')
       .should('be.disabled')
       .should('have.attr', 'aria-busy', 'true')
-      .find('img[alt="spinner"]')
+      .find('.MuiCircularProgress-root')
       .should('be.visible')
     cy.then(() => {
       resolvePromise()

--- a/cypress/component/AsyncSpinnerMuiButton.spec.tsx
+++ b/cypress/component/AsyncSpinnerMuiButton.spec.tsx
@@ -1,0 +1,491 @@
+import { mount } from 'cypress/react'
+import React from 'react'
+import { AsyncSpinnerMuiButton } from 'src/components/AsyncSpinnerMuiButton'
+
+describe('AsyncSpinnerMuiButton', () => {
+  it('renders the button with children', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <AsyncSpinnerMuiButton onClick={mockOnClick}>
+        Test Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.contains('button', 'Test Button')
+      .should('be.visible')
+      .should('not.be.disabled')
+  })
+
+  it('applies MUI Button props correctly', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        variant="contained"
+        color="primary"
+        data-cy="custom-mui-button"
+      >
+        Styled Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="custom-mui-button"]')
+      .should('be.visible')
+      .should('have.class', 'MuiButton-contained')
+      .should('have.class', 'MuiButton-colorPrimary')
+  })
+
+  it('accepts custom className and sx props', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        className="custom-button-class"
+        sx={{ textTransform: 'none' }}
+        data-cy="custom-styled-button"
+      >
+        Custom Styled Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="custom-styled-button"]')
+      .should('have.class', 'custom-button-class')
+      .should('have.css', 'text-transform', 'none')
+  })
+
+  it('shows spinner during async operation', () => {
+    let resolvePromise: () => void
+    const asyncAction = new Promise<void>((resolve) => {
+      resolvePromise = resolve
+    })
+    const mockOnClick = cy.stub().returns(asyncAction)
+
+    mount(
+      <AsyncSpinnerMuiButton onClick={mockOnClick} data-cy="loading-button">
+        Loading Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="loading-button"]').click()
+
+    // Should show spinner and be disabled
+    cy.get('[data-cy="loading-button"]')
+      .should('be.disabled')
+      .find('.MuiCircularProgress-root')
+      .should('be.visible')
+
+    // Text should not be visible during loading
+    cy.get('[data-cy="loading-button"]')
+      .should('not.contain', 'Loading Button')
+
+    // Resolve the promise
+    cy.then(() => {
+      resolvePromise()
+    })
+
+    // Should be re-enabled after completion
+    cy.get('[data-cy="loading-button"]')
+      .should('not.be.disabled')
+  })
+
+  it('disappears after successful action when hideOnSuccess is true', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        hideOnSuccess={true}
+        data-cy="success-hide-button"
+      >
+        Success Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="success-hide-button"]')
+      .should('be.visible')
+      .click()
+
+    // Button should disappear after successful completion
+    cy.get('[data-cy="success-hide-button"]')
+      .should('not.exist')
+  })
+
+  it('remains visible after successful action when hideOnSuccess is false', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        hideOnSuccess={false}
+        data-cy="success-visible-button"
+      >
+        Stay Visible Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="success-visible-button"]')
+      .should('be.visible')
+      .click()
+
+    // Button should remain visible after successful completion
+    cy.get('[data-cy="success-visible-button"]')
+      .should('be.visible')
+      .should('not.be.disabled')
+      .should('contain', 'Stay Visible Button')
+  })
+
+  it('becomes clickable again after action failure', () => {
+    const error = new Error('Test error')
+    let shouldReject = true
+    const mockOnClick = cy.stub().callsFake(() => {
+      if (shouldReject) {
+        return Promise.reject(error)
+      }
+      return Promise.resolve()
+    })
+
+    mount(
+      <AsyncSpinnerMuiButton onClick={mockOnClick} data-cy="error-button">
+        Error Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    // First click should fail
+    cy.get('[data-cy="error-button"]').click()
+
+    // Should become clickable again after error
+    cy.get('[data-cy="error-button"]')
+      .should('not.be.disabled')
+      .should('contain', 'Error Button')
+
+    // Should be able to click again
+    cy.then(() => {
+      shouldReject = false // Next click will succeed
+    })
+
+    cy.get('[data-cy="error-button"]').click()
+
+    // Should remain visible since hideOnSuccess defaults to false
+    cy.get('[data-cy="error-button"]')
+      .should('be.visible')
+  })
+
+  it('respects disabled prop', () => {
+    const mockOnClick = cy.stub()
+    cy.wrap(mockOnClick).as('mockOnClick')
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        disabled={true}
+        data-cy="disabled-button"
+      >
+        Disabled Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="disabled-button"]')
+      .should('be.disabled')
+      .click({ force: true }) // Force click since it's disabled
+
+    cy.get('@mockOnClick').should('not.have.been.called')
+  })
+
+  it('prevents multiple clicks during loading state', () => {
+    let resolvePromise: () => void
+    const asyncAction = new Promise<void>((resolve) => {
+      resolvePromise = resolve
+    })
+    const mockOnClick = cy.stub().returns(asyncAction)
+    cy.wrap(mockOnClick).as('mockOnClick')
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        data-cy="multi-click-button"
+      >
+        Multi Click Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    // First click starts the action
+    cy.get('[data-cy="multi-click-button"]').click()
+
+    // Multiple additional clicks should not trigger the action
+    cy.get('[data-cy="multi-click-button"]')
+      .click({ force: true })
+    cy.get('[data-cy="multi-click-button"]')
+      .click({ force: true })
+    cy.get('[data-cy="multi-click-button"]')
+      .click({ force: true })
+
+    cy.get('@mockOnClick').should('have.been.calledOnce')
+
+    cy.then(() => {
+      resolvePromise()
+    })
+  })
+
+  it('calls onError callback when action fails', () => {
+    const error = new Error('Test callback error')
+    const mockOnClick = cy.stub().rejects(error)
+    const mockOnError = cy.stub()
+    cy.wrap(mockOnError).as('mockOnError')
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        onError={mockOnError}
+        data-cy="error-callback-button"
+      >
+        Error Callback Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="error-callback-button"]').click()
+
+    cy.get('@mockOnError').should('have.been.calledOnceWith', error)
+  })
+
+  it('does not call onError callback when action succeeds', () => {
+    const mockOnClick = cy.stub().resolves()
+    const mockOnError = cy.stub()
+    cy.wrap(mockOnError).as('mockOnError')
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        onError={mockOnError}
+        data-cy="success-callback-button"
+      >
+        Success Callback Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="success-callback-button"]').click()
+
+    cy.get('@mockOnError').should('not.have.been.called')
+  })
+
+  it('allows multiple clicks when hideOnSuccess is false', () => {
+    const mockOnClick = cy.stub().resolves()
+    cy.wrap(mockOnClick).as('mockOnClick')
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        hideOnSuccess={false}
+        data-cy="multi-use-button"
+      >
+        Multi Use Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="multi-use-button"]').click()
+
+    cy.get('[data-cy="multi-use-button"]')
+      .should('be.visible')
+      .should('not.be.disabled')
+
+    cy.get('[data-cy="multi-use-button"]').click()
+    cy.get('@mockOnClick').should('have.been.calledTwice')
+  })
+
+  it('shows loading state correctly when hideOnSuccess is false', () => {
+    let resolvePromise: () => void
+    const asyncAction = new Promise<void>((resolve) => {
+      resolvePromise = resolve
+    })
+    const mockOnClick = cy.stub().returns(asyncAction)
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        hideOnSuccess={false}
+        data-cy="loading-stay-button"
+      >
+        Loading Stay Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="loading-stay-button"]').click()
+
+    cy.get('[data-cy="loading-stay-button"]')
+      .should('be.disabled')
+      .find('.MuiCircularProgress-root')
+      .should('be.visible')
+
+    cy.then(() => {
+      resolvePromise()
+    })
+
+    cy.get('[data-cy="loading-stay-button"]')
+      .should('be.visible')
+      .should('not.be.disabled')
+      .should('contain', 'Loading Stay Button')
+  })
+
+  it('keeps button visible after error regardless of hideOnSuccess value', () => {
+    const error = new Error('Test error')
+    const mockOnClick = cy.stub().rejects(error)
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        hideOnSuccess={true}
+        data-cy="error-with-hide-button"
+      >
+        Error With Hide Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="error-with-hide-button"]').click()
+
+    cy.get('[data-cy="error-with-hide-button"]')
+      .should('be.visible')
+      .should('not.be.disabled')
+      .should('contain', 'Error With Hide Button')
+  })
+
+  it('applies MUI variant and color props', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <div>
+        <AsyncSpinnerMuiButton
+          onClick={mockOnClick}
+          variant="outlined"
+          color="secondary"
+          data-cy="outlined-button"
+        >
+          Outlined Button
+        </AsyncSpinnerMuiButton>
+        <AsyncSpinnerMuiButton
+          onClick={mockOnClick}
+          variant="text"
+          color="error"
+          data-cy="text-button"
+        >
+          Text Button
+        </AsyncSpinnerMuiButton>
+      </div>,
+    )
+
+    cy.get('[data-cy="outlined-button"]')
+      .should('have.class', 'MuiButton-outlined')
+      .should('have.class', 'MuiButton-colorSecondary')
+
+    cy.get('[data-cy="text-button"]')
+      .should('have.class', 'MuiButton-text')
+      .should('have.class', 'MuiButton-colorError')
+  })
+
+  it('supports MUI size prop', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <div>
+        <AsyncSpinnerMuiButton
+          onClick={mockOnClick}
+          size="small"
+          data-cy="small-button"
+        >
+          Small Button
+        </AsyncSpinnerMuiButton>
+        <AsyncSpinnerMuiButton
+          onClick={mockOnClick}
+          size="large"
+          data-cy="large-button"
+        >
+          Large Button
+        </AsyncSpinnerMuiButton>
+      </div>,
+    )
+
+    cy.get('[data-cy="small-button"]')
+      .should('have.class', 'MuiButton-sizeSmall')
+
+    cy.get('[data-cy="large-button"]')
+      .should('have.class', 'MuiButton-sizeLarge')
+  })
+
+  it('supports MUI fullWidth prop', () => {
+    const mockOnClick = cy.stub().resolves()
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        fullWidth
+        data-cy="full-width-button"
+      >
+        Full Width Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="full-width-button"]')
+      .should('have.class', 'MuiButton-fullWidth')
+  })
+
+  it('shows CircularProgress with correct size during loading', () => {
+    let resolvePromise: () => void
+    const asyncAction = new Promise<void>((resolve) => {
+      resolvePromise = resolve
+    })
+    const mockOnClick = cy.stub().returns(asyncAction)
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        data-cy="spinner-size-button"
+      >
+        Check Spinner Size
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="spinner-size-button"]').click()
+
+    cy.get('[data-cy="spinner-size-button"]')
+      .find('.MuiCircularProgress-root')
+      .should('be.visible')
+      .should('have.attr', 'role', 'progressbar')
+
+    cy.then(() => {
+      resolvePromise()
+    })
+  })
+
+  it('maintains disabled state from props during async operation', () => {
+    let resolvePromise: () => void
+    const asyncAction = new Promise<void>((resolve) => {
+      resolvePromise = resolve
+    })
+    const mockOnClick = cy.stub().returns(asyncAction)
+
+    mount(
+      <AsyncSpinnerMuiButton
+        onClick={mockOnClick}
+        disabled={false}
+        data-cy="prop-disabled-button"
+      >
+        Prop Disabled Button
+      </AsyncSpinnerMuiButton>,
+    )
+
+    cy.get('[data-cy="prop-disabled-button"]').click()
+
+    // Should be disabled during loading
+    cy.get('[data-cy="prop-disabled-button"]')
+      .should('be.disabled')
+
+    cy.then(() => {
+      resolvePromise()
+    })
+
+    // Should return to original disabled state (false)
+    cy.get('[data-cy="prop-disabled-button"]')
+      .should('not.be.disabled')
+  })
+})

--- a/src/components/AsyncSpinnerButton.tsx
+++ b/src/components/AsyncSpinnerButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from 'react'
-import { Spinner } from 'src/components/Spinner'
+import { CircularProgress } from '@mui/material'
 
 export interface AsyncSpinnerButtonProps {
   /** The text to display on the button */
@@ -105,19 +105,7 @@ export const AsyncSpinnerButton: React.FC<AsyncSpinnerButtonProps> = ({
       {isLoading
         ? (
             <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-              <div style={{
-                transform: 'scale(0.6)',
-                transformOrigin: 'center',
-                width: '1em',
-                height: '1em',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                marginTop: '-0.5em',
-              }}
-              >
-                <Spinner />
-              </div>
+              <CircularProgress size={28} />
             </div>
           )
         : (

--- a/src/components/AsyncSpinnerMuiButton.tsx
+++ b/src/components/AsyncSpinnerMuiButton.tsx
@@ -1,0 +1,68 @@
+import React, { useState, useCallback } from 'react'
+import { Button, ButtonProps, CircularProgress } from '@mui/material'
+
+export interface AsyncSpinnerMuiButtonProps extends Omit<ButtonProps, 'onClick'> {
+  /** Function to execute when button is clicked - should return a Promise */
+  onClick: () => Promise<void>
+  /** Optional error handler function called when onClick fails */
+  onError?: (error: unknown) => void
+  /** Whether to hide the button after successful completion */
+  hideOnSuccess?: boolean
+}
+
+/**
+ * An async button component that wraps MUI Button with loading state and spinner.
+ * Displays a circular progress indicator while the async operation is in progress.
+ * Inherits all MUI Button props for consistent styling.
+ */
+export const AsyncSpinnerMuiButton: React.FC<AsyncSpinnerMuiButtonProps> = ({
+  children,
+  onClick,
+  onError,
+  hideOnSuccess = false,
+  disabled = false,
+  ...buttonProps
+}) => {
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSuccess, setIsSuccess] = useState(false)
+
+  const handleClick = useCallback(async () => {
+    if (isLoading || disabled) return
+    setIsLoading(true)
+    try {
+      await onClick()
+      setIsSuccess(true)
+      setIsLoading(false)
+    }
+    catch (error) {
+      setIsLoading(false)
+      onError?.(error)
+    }
+  }, [onClick, isLoading, disabled, onError])
+
+  // Don't render if the action was successful and hideOnSuccess is true
+  if (isSuccess && hideOnSuccess) {
+    return null
+  }
+
+  return (
+    <Button
+      {...buttonProps}
+      onClick={handleClick}
+      disabled={isLoading || disabled}
+    >
+      {isLoading
+        ? (
+            <CircularProgress
+              sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+              size={24}
+            />
+          )
+        : (
+            children
+          )}
+    </Button>
+  )
+}
+
+export default AsyncSpinnerMuiButton

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -27,6 +27,7 @@ import { Support } from 'src/libs/ajax/Support'
 import { Storage } from 'src/libs/storage'
 import { Notifications, isEmailAddress } from 'src/libs/utils'
 import { handleSignIn } from 'src/libs/signInUtils'
+import { AsyncSpinnerMuiButton } from 'src/components/AsyncSpinnerMuiButton'
 
 interface SupportRequestModalProps {
   showModal: boolean
@@ -361,14 +362,15 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
         >
           Cancel
         </Button>
-        <Button
+        <AsyncSpinnerMuiButton
           onClick={submitHandler}
           variant="contained"
           disabled={disableSubmitBtn}
           data-cy="supportFormSubmit"
+          sx={{ minWidth: 90 }}
         >
           Submit
-        </Button>
+        </AsyncSpinnerMuiButton>
       </DialogActions>
     </Dialog>
   )


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2512

### Summary

The support form can take quite a while to submit. This adds a new async spinner button specifically for Material UI forms, and makes the support form use it. It also updates the old spinner button to use the same spinner for visual consistency.

<img width="204" height="55" alt="Screenshot 2025-12-11 at 10 32 11 AM" src="https://github.com/user-attachments/assets/136cf1eb-f1ca-4784-89b1-28da587c4ce0" />

<img width="198" height="50" alt="Screenshot 2025-12-11 at 10 32 26 AM" src="https://github.com/user-attachments/assets/65932c8f-37f0-4df0-bb08-29e675bbb412" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
