### PR TITLE
DT-2739: Show all default columns in the list

### DIFF
--- a/cypress/component/StudyAssets/ai_model_list.spec.tsx
+++ b/cypress/component/StudyAssets/ai_model_list.spec.tsx
@@ -168,4 +168,28 @@ describe('AiModelList', () => {
       expect(state.length).to.eq(0)
     })
   })
+
+  it('shows all default columns when none are provided', () => {
+    const state: AiModel[] = [sampleModel]
+    mount(
+      <AiModelList
+        aiModels={state}
+        onAiModelsChange={(m) => { state.splice(0, state.length, ...m) }}
+        disabled={false}
+      />,
+    )
+    cy.contains(sampleModel.name).should('exist')
+    cy.contains(sampleModel.description).should('exist')
+    cy.contains(sampleModel.url).should('exist')
+    cy.contains(sampleModel.format).should('exist')
+    cy.contains(sampleModel.license).should('exist')
+    sampleModel.trainedOnDatasets?.forEach((t) => {
+      cy.contains(t).should('exist')
+    })
+    cy.contains(sampleModel.maintainer.name).should('exist')
+    cy.contains(sampleModel.maintainer.email).should('exist')
+    sampleModel.tags?.forEach((tag) => {
+      cy.contains(tag).should('exist')
+    })
+  })
 })

--- a/src/components/ai_models_list/AiModelList.tsx
+++ b/src/components/ai_models_list/AiModelList.tsx
@@ -17,7 +17,7 @@ interface AiModelListProps {
 export default function AiModelList(props: AiModelListProps): React.JSX.Element {
   const {
     aiModels,
-    columnsToShow = [],
+    columnsToShow = ['name', 'description', 'url', 'format', 'license', 'trainedOnDatasets', 'maintainer', 'tags'],
     onAiModelsChange,
     disabled = false,
     validation,
@@ -71,7 +71,7 @@ export default function AiModelList(props: AiModelListProps): React.JSX.Element 
       )}
       {aiModels.map((model: AiModel, index: number) => (
         <AiModelRow
-          key={model.modelId}
+          key={model.modelId || index}
           id={index}
           editMode={editState[index]}
           aiModel={model}


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2739

## Summary
* Set the default AI Model columns to display when in list format.
* Adds a conditional key check to be more in alignment with other as row components.

### Example
<img width="1326" height="940" alt="Screenshot 2025-12-11 at 1 20 39 PM" src="https://github.com/user-attachments/assets/26e77c84-c18d-4f96-9685-0777ed692509" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
