### PR TITLE
[DT-2745] Load assets from property, format numbers into dates

### DIFF
--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -10,7 +10,7 @@ import { Styles } from 'src/libs/theme'
 import { StudyAssetManagement } from 'src/pages/data_submission/v2/StudyAssetManagement'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { Notifications } from 'src/libs/utils'
-import { studyToDatasetSchemaSubmission, buildConsentGroupsFromStudy } from 'src/pages/data_submission/v2/v2-common-functions'
+import { studyToDatasetSchemaSubmission, buildConsentGroupsFromStudy, getStudyPropertyValueByKey } from 'src/pages/data_submission/v2/v2-common-functions'
 import AsyncSpinnerButton from 'src/components/AsyncSpinnerButton'
 import { ConsentGroup2 } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 
@@ -33,7 +33,8 @@ export const DataSubmissionFormV2 = () => {
     if (studyId) {
       DataSet.getStudyById(studyId).then((study) => {
         const consentGroupAssets: ConsentGroup2[] = buildConsentGroupsFromStudy(study)
-        study.assets = { ...study.assets, consentGroups: consentGroupAssets }
+        const studyAssets = getStudyPropertyValueByKey(study, 'assets') as object || {}
+        study.assets = { ...studyAssets, consentGroups: consentGroupAssets }
         setStudy(study)
         setIsEditing(true)
       }).catch(() => {

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -17,7 +17,7 @@ import {
   setStudyPropertyByKey,
 } from 'src/pages/data_submission/v2/v2-common-functions'
 import { ALTERNATIVE_DATA_SHARING_PLAN_FILE } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
-import { unset } from 'lodash'
+import { set, unset } from 'lodash'
 
 export interface NihAnvilUseRelatedProps {
   study: Study
@@ -42,15 +42,12 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
         validators={[FormValidators.REQUIRED]}
         onChange={(input: { key: string, value: string | undefined, isValid: boolean }) => {
           setStudyPropertyByKey(study, setStudy, input, new NihAnvilUse(input.value as string))
-          if (NihAnvilUse.requiresNIHAdministrativeInformation(input.value)) {
+          if (!NihAnvilUse.requiresNIHAdministrativeInformation(input.value)) {
             setStudy((val) => {
               const newVal = structuredClone(val)
               removeStudyPropertiesByKeys(newVal,
                 new Set(
-                  [DbGaPPhsID.key,
-                    DbGaPStudyRegistrationName.key,
-                    EmbargoReleaseDate.key,
-                    SequencingCenter.key,
+                  [
                     PiInstitution.key,
                     NihGrantContractNumber.key,
                     NihICsSupportingStudy.key,
@@ -67,9 +64,20 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
                     AlternativeDataSharingPlanDataSubmitted.key,
                     AlternativeDataSharingPlanDataReleased.key,
                   ]))
+
               unset(newVal, ALTERNATIVE_DATA_SHARING_PLAN_FILE)
               return newVal
             })
+            if (input.value !== NihAnvilUse.YES_NHGRI_YES_PHS_ID) {
+              setStudy((val) => {
+                const newVal = structuredClone(val)
+                removeStudyPropertiesByKeys(newVal, new Set([DbGaPPhsID.key,
+                  DbGaPStudyRegistrationName.key,
+                  EmbargoReleaseDate.key,
+                  SequencingCenter.key]))
+                return newVal
+              })
+            }
           }
         }}
       />

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -17,7 +17,7 @@ import {
   setStudyPropertyByKey,
 } from 'src/pages/data_submission/v2/v2-common-functions'
 import { ALTERNATIVE_DATA_SHARING_PLAN_FILE } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
-import { set, unset } from 'lodash'
+import { unset } from 'lodash'
 
 export interface NihAnvilUseRelatedProps {
   study: Study

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -47,6 +47,7 @@ import { Storage } from 'src/libs/storage'
 import { NIHInstituteAndCenterAbbreviations } from 'src/components/forms/NIHInstitutesAndCenters'
 import { AccessManagementType, ConsentGroup2, FileType } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 import { Dataset } from 'src/types/model'
+import dayjs from 'dayjs'
 export type MasterChangeHandler = ({ key, value, isValid, remove }: { key: string, value: unknown, isValid: boolean, remove?: boolean }) => void
 
 export const generateStudyPropertyYesNoField = (formData: Study, setStudy: React.Dispatch<React.SetStateAction<Study>>, studyProperty: BooleanStudyProperty) => {
@@ -107,7 +108,7 @@ export const generateStudyPropertyFormDateField = (formData: Study, setStudy: Re
       placeholder={studyProperty.fieldPlaceholderText}
       validators={validators}
       style={style}
-      defaultValue={getStudyPropertyValueByKey(formData, studyProperty.key)}
+      defaultValue={typeof getStudyPropertyValueByKey(formData, studyProperty.key) === 'number' ? dayjs(getStudyPropertyValueByKey(formData, studyProperty.key) as number).format('YYYY-MM-DD') : getStudyPropertyValueByKey(formData, studyProperty.key) as string}
       onChange={(input: { key: string, value: unknown, isValid: boolean }) => {
         studyProperty.value = input.value as Date
         setStudyPropertyByKey(formData, setStudy, input, studyProperty)

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -108,7 +108,7 @@ export const generateStudyPropertyFormDateField = (formData: Study, setStudy: Re
       placeholder={studyProperty.fieldPlaceholderText}
       validators={validators}
       style={style}
-      defaultValue={typeof getStudyPropertyValueByKey(formData, studyProperty.key) === 'number' ? dayjs(getStudyPropertyValueByKey(formData, studyProperty.key) as number).format('YYYY-MM-DD') : getStudyPropertyValueByKey(formData, studyProperty.key) as string}
+      defaultValue={convertDateEpochToString(getStudyPropertyValueByKey(formData, studyProperty.key))}
       onChange={(input: { key: string, value: unknown, isValid: boolean }) => {
         studyProperty.value = input.value as Date
         setStudyPropertyByKey(formData, setStudy, input, studyProperty)

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -166,6 +166,16 @@ export const getStudyPropertyValueByKey = (formData: Study, key: string): unknow
   }
 }
 
+const convertDateEpochToString = (dateEpoch: unknown): string | undefined => {
+  if (typeof dateEpoch === 'number') {
+    return dayjs(dateEpoch).format('YYYY-MM-DD')
+  }
+  if (typeof dateEpoch === 'string') {
+    return dateEpoch
+  }
+  return undefined
+}
+
 export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistrationSchemaV1 => {
   const datasetSchema: DatasetRegistrationSchemaV1 = {
     studyName: study.name || '',
@@ -182,7 +192,7 @@ export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistratio
     submittingToAnvil: getStudyPropertyValueByKey(study, SubmittingToAnvil.key) as boolean || undefined,
     dbGaPPhsID: getStudyPropertyValueByKey(study, DbGaPPhsID.key) as string || undefined,
     dbGaPStudyRegistrationName: getStudyPropertyValueByKey(study, DbGaPStudyRegistrationName.key) as string || undefined,
-    embargoReleaseDate: getStudyPropertyValueByKey(study, EmbargoReleaseDate.key) as string || undefined,
+    embargoReleaseDate: convertDateEpochToString(getStudyPropertyValueByKey(study, EmbargoReleaseDate.key) as string || undefined),
     sequencingCenter: getStudyPropertyValueByKey(study, SequencingCenter.key) as string || undefined,
     piInstitution: getStudyPropertyValueByKey(study, PiInstitution.key) as number || Storage.getCurrentUser().institutionId,
     nihGrantContractNumber: getStudyPropertyValueByKey(study, NihGrantContractNumber.key) as string || undefined,
@@ -199,8 +209,8 @@ export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistratio
     alternativeDataSharingPlanExplanation: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanExplanation.key) as string || undefined,
     alternativeDataSharingPlanDataSubmitted: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanDataSubmitted.key) as AlternativeDataSharingPlanDataSubmittedValues || undefined,
     alternativeDataSharingPlanDataReleased: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanDataReleased.key) as boolean || undefined,
-    alternativeDataSharingPlanTargetDeliveryDate: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetDeliveryDate.key) as string || undefined,
-    alternativeDataSharingPlanTargetPublicReleaseDate: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetPublicReleaseDate.key) as string || undefined,
+    alternativeDataSharingPlanTargetDeliveryDate: convertDateEpochToString(getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetDeliveryDate.key) as string || undefined),
+    alternativeDataSharingPlanTargetPublicReleaseDate: convertDateEpochToString(getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetPublicReleaseDate.key) as string || undefined),
     consentGroups: structuredClone(study.assets?.consentGroups) || [],
   }
   const assets = structuredClone(study.assets)


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2745](https://broadworkbench.atlassian.net/browse/DT-2745)
1. Study assets are stored in a StudyProperty, but the load process wasn't fully accounting for that.
2. Although dates are sent to consent as strings, they are returned in properties as numbers.
3. Fixes the case where changing the NIH and Anvil Use selected option would incorrectly clear values when certain options were selected.

### Summary

Loaded study assets:
<img width="2261" height="1000" alt="image" src="https://github.com/user-attachments/assets/52cc0755-0d3f-4d55-ac67-a6d0653c64f3" />

Loaded dates correctly:

<img width="2261" height="241" alt="image" src="https://github.com/user-attachments/assets/d9c4e8eb-4975-4425-8f72-3f850b12f647" />

and

<img width="1086" height="350" alt="image" src="https://github.com/user-attachments/assets/276e3534-6ef5-46d9-bd50-fe44e803f44e" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
