### PR TITLE
[DT-2561] Fix Minor Study Asset Bugs

### DIFF
--- a/src/components/ai_models_list/AiModelSummary.tsx
+++ b/src/components/ai_models_list/AiModelSummary.tsx
@@ -45,6 +45,16 @@ export default function AiModelSummary(props: AiModelSummaryProps): React.JSX.El
       const arr = value as string[]
       return Array.isArray(arr) ? arr.join(', ') : ''
     },
+    url: (value: unknown) => {
+      if (typeof value === 'string' && value) {
+        return (
+          <a href={value} target="_blank" rel="noreferrer">
+            {value}
+          </a>
+        )
+      }
+      return '—'
+    },
   }
 
   return (

--- a/src/components/clinical_trial_list/ClinicalTrialSummary.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialSummary.tsx
@@ -33,6 +33,16 @@ export default function ClinicalTrialSummary(props: ClinicalTrialSummaryProps): 
     status: () => statusToDisplay(clinicalTrial.status),
     phase: () => phaseToDisplay(clinicalTrial.phase),
     interventionType: () => interventionTypeToDisplay(clinicalTrial.interventionType),
+    url: (value: unknown) => {
+      if (typeof value === 'string' && value) {
+        return (
+          <a href={value} target="_blank" rel="noreferrer">
+            {value}
+          </a>
+        )
+      }
+      return '—'
+    },
   }
 
   return (

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -630,16 +630,18 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               title: 'File Type',
               type: FormFieldTypes.SELECT,
               selectOptions: ['Arrays', 'Genome', 'Exome', 'Survey', 'Phenotype'],
+              disabled: readOnly,
             },
             {
               id: 'functionalEquivalence',
               name: 'functionalEquivalence',
               title: 'Functional Equivalence',
               placeholder: 'Type',
+              disabled: readOnly,
             },
           ]}
           defaultValue={current?.fileTypes}
-          enableAddingRow={true}
+          enableAddingRow={!readOnly}
           addRowLabel="Add New File Type"
           minLength={1}
           onChange={onChange}
@@ -671,6 +673,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               onChange({ key: id, value: undefined })
             }}
             title="NIH Institutional Certification"
+            disabled={readOnly}
           />
         </div>
         <div className="row" style={{ marginTop: 20 }}>

--- a/src/components/consent_group_list/ConsentGroupSummary.tsx
+++ b/src/components/consent_group_list/ConsentGroupSummary.tsx
@@ -98,21 +98,6 @@ export default function ConsentGroupSummary(props: ConsentGroupSummaryProps): Re
           <span style={{ marginLeft: '1rem' }} />
         </button>
       </div>
-      <button
-        type="button"
-        style={{ marginLeft: 10, ...buttonStyle }}
-        onClick={() => !disabled && !isEditingExistingStudy && setShowDeleteModal(true)}
-        disabled={disabled || isEditingExistingStudy}
-        aria-label="Delete dataset"
-      >
-        <span
-          className="glyphicon glyphicon-trash presentation-delete-icon"
-          aria-hidden="true"
-          data-tip="Delete dataset"
-          data-for="tip_delete_conset_group"
-        />
-        <span style={{ marginLeft: '1rem' }} />
-      </button>
       <DeletePresentationOrPublication
         name={consentGroup.consentGroupName}
         objectName="consentGroup"

--- a/src/components/forms/FileInput.tsx
+++ b/src/components/forms/FileInput.tsx
@@ -11,10 +11,11 @@ export type FileInputProps = {
   onDeleteFile: (id: string) => void
   required?: boolean
   title: string
+  disabled?: boolean
 }
 
 export const FileInput = (props: FileInputProps) => {
-  const { id, title, description, onAddFile, onDeleteFile, defaultValue, required } = props
+  const { id, title, description, onAddFile, onDeleteFile, defaultValue, required, disabled = false } = props
   const [file, setFile] = useState<File | undefined>(defaultValue)
   const inputRef = useRef<HTMLInputElement>(null)
   const [open, setOpen] = useState<boolean>(false)
@@ -84,6 +85,7 @@ export const FileInput = (props: FileInputProps) => {
           setFile(event.currentTarget.files?.[0])
           handleAddFile(event, id)
         }}
+        disabled={disabled}
       />
       <div style={{ display: 'inline', margin: 'auto' }}>
         <button


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2561

### Summary

This PR fixes some minor bugs that were missed in this PR https://github.com/DataBiosphere/duos-ui/pull/3229

- Adds custom link renders for `AiModel` and `ClinicalTrial` assets
- Ensure upload buttons are disabled in the `ConsentGroup/Dataset` asset form when viewing
- Remove duplicate `delete` button for `ConsentGroup/Dataset` assets

<img width="3600" height="10984" alt="After" src="https://github.com/user-attachments/assets/b0e1e723-7098-4e8b-879e-17098a7c3c17" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
