### PR TITLE
[DT-2746] Enable form for both DAC chairs and data submitter flows in local/dev.

### DIFF
--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -19,9 +19,14 @@ export type FileProperty = {
   value: File
 }
 
+export type DataSubmissionFormV2Props = {
+  onSaveRoute?: string
+}
+
 export const ALTERNATIVE_DATA_SHARING_PLAN_FILE = 'alternativeDataSharingPlanFile'
 
-export const DataSubmissionFormV2 = () => {
+export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
+  const { onSaveRoute } = props
   const { studyId } = useParams()
   const [isEditing, setIsEditing] = useState(false)
   const [study, setStudy] = useState({} as Study)
@@ -67,6 +72,10 @@ export const DataSubmissionFormV2 = () => {
   const onUpdateStudy = async () => {
     await DataSet.updateStudy(studyId as string, buildMultiPartFormData(study))
     Notifications.showNotification({ text: 'Study updated successfully', type: 'success' })
+    if (onSaveRoute) {
+      navigate(onSaveRoute)
+      return
+    }
     navigate('/datalibrary')
   }
 
@@ -78,6 +87,10 @@ export const DataSubmissionFormV2 = () => {
   const onSubmitStudy = async () => {
     await DataSet.registerDataset(buildMultiPartFormData(study))
     Notifications.showNotification({ text: 'Study created successfully', type: 'success' })
+    if (onSaveRoute) {
+      navigate(onSaveRoute)
+      return
+    }
     navigate('/datalibrary')
   }
 

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -3,7 +3,7 @@ import { Route, Routes } from 'react-router-dom'
 import Home from 'src/pages/Home'
 import UserProfile from 'src/pages/user_profile/UserProfile'
 import Authenticated from 'src/routing/Authenticated'
-import { envGroups } from 'src/utils/EnvironmentUtils'
+import { checkEnv, envGroups } from 'src/utils/EnvironmentUtils'
 import HealthCheck from 'src/pages/HealthCheck'
 import Status from 'src/pages/Status'
 import BackgroundSignIn from 'src/pages/BackgroundSignIn'
@@ -100,14 +100,22 @@ const AppRoutes = (props: AppRoutesProps) => {
         </Route>
         <Route element={<RoleBAC rolesAllowed={[USER_ROLES.dataSubmitter, USER_ROLES.chairperson, USER_ROLES.admin]} />}>
           <Route path="/dataset_submissions" element={<DatasetSubmissions />} />
-          <Route path="/data_submission_form" element={<DataSubmissionForm />} />
-          <Route element={<EnvRoute env={envGroups.NON_STAGING} />}>
-            <Route path="/data_submission_form2" element={<DataSubmissionFormV2 />}>
-              <Route path=":studyId" element={<DataSubmissionFormV2 />} />
-            </Route>
-          </Route>
+          {checkEnv(envGroups.NON_STAGING) && (
+            <>
+              <Route path="/data_submission_form" element={<DataSubmissionFormV2 />}>
+                <Route path=":studyId" element={<DataSubmissionFormV2 />} />
+              </Route>
+              <Route path="/study_update/:studyId" element={<DataSubmissionFormV2 onSaveRoute="/dataset_submissions" />} />
+            </>
+          )}
+          {checkEnv(envGroups.PROD_STAGING) && (
+            <>
+              <Route path="/data_submission_form" element={<DataSubmissionForm />}>
+              </Route>
+              <Route path="/study_update/:studyId" element={<StudyUpdateForm />} />
+            </>
+          )}
           <Route path="/dataset_update/:datasetId" element={<DatasetUpdateForm />} />
-          <Route path="/study_update/:studyId" element={<StudyUpdateForm />} />
         </Route>
         <Route element={<RoleBAC rolesAllowed={[USER_ROLES.member, USER_ROLES.signingOfficial, USER_ROLES.chairperson]} />}>
           <Route path="/dar_vote_review/:collectionId" element={<DarCollectionReview readOnly={true} />} />

--- a/src/utils/EnvironmentUtils.js
+++ b/src/utils/EnvironmentUtils.js
@@ -9,9 +9,10 @@ import { includes } from 'lodash/fp'
  *      * alpha
  *      * dev
  *      * local
- * @type {{NON_STAGING: string[], NON_PROD: string[]}}
+ * @type {{PROD_STAGING: string[], NON_STAGING: string[], NON_PROD: string[]}}
  */
 export const envGroups = {
+  PROD_STAGING: ['prod', 'staging'],
   NON_PROD: ['local', 'dev', 'staging'],
   NON_STAGING: ['local', 'dev'],
   DEV: ['local', 'dev'],


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2746](https://broadworkbench.atlassian.net/browse/DT-2746)

### Summary

- Updates logic in AppRoutes to add routes based on environment
- Adds new option to direct the S4R Form route after successful saving so that the Data Submitter routes back to the correct location in the application.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
