### PR TITLE
[DT-2755] Adds showing file name + errata

### DIFF
--- a/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
+++ b/cypress/component/ProgressReports/ProgressReportApplication.spec.tsx
@@ -153,7 +153,7 @@ describe('ProgressReportApplication - Component Tests', () => {
       alias: 2,
       datasetIdentifier: '',
       objectId: '',
-      nihCertificationFile: fso,
+      nihInstitutionalCertificationFile: fso,
       study: {
         description: 'Test Dataset Submission',
         studyId: 39,

--- a/cypress/component/ProgressReports/dar_closeout.spec.tsx
+++ b/cypress/component/ProgressReports/dar_closeout.spec.tsx
@@ -32,7 +32,7 @@ describe('DAR Closeout - Component Tests', () => {
     objectId: '12345',
     dataUse: {} as DataUse,
     dacApproval: true,
-    nihCertificationFile: {} as FileStorageObject,
+    nihInstitutionalCertificationFile: {} as FileStorageObject,
   }
 
   const mountComponent = (customState = {}, customProps = {}) => {

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -97,6 +97,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
   const [showMORText, setShowMORText] = useState(consentGroup?.mor)
   const [morText, setMORText] = useState(consentGroup?.morDate || undefined)
   const disableAccessAdjustment = isEditingExistingStudy && current.accessManagement === 'controlled'
+  const [editDataLocationUrl, setEditDataLocationUrl] = useState(consentGroup?.dataLocation === 'Not Determined')
 
   const onAccessTypeChange = ({ _key, value }: { _key: string, value: string }) => {
     const clearedFields = {} as ConsentGroup2
@@ -604,6 +605,10 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               onChange({ key, value })
               if (current?.dataLocation === 'Not Determined') {
                 onChange({ key: 'url', value: undefined })
+                setEditDataLocationUrl(false)
+              }
+              else {
+                setEditDataLocationUrl(true)
               }
             }}
             disabled={readOnly}
@@ -613,7 +618,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             id="url"
             name="url"
             validators={[FormValidators.URL]}
-            disabled={current?.dataLocation === 'Not Determined' || readOnly}
+            disabled={editDataLocationUrl || readOnly}
             placeholder="Enter a URL for your data location here"
             defaultValue={current?.dataLocation === 'Not Determined' ? undefined : consentGroup?.url}
             onChange={onChange}

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -664,8 +664,9 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
         <div className="row" style={{ marginTop: 20 }}>
           <FileInput
             description="If an Institutional Certification for this consent group exists, please upload it here"
-            id="nihInstitutionalCertificationFile"
-            defaultValue={current.nihInstitutionalCertificationFile}
+            id="addedNIHInstitutionalCertificationFile"
+            defaultValue={current.addedNIHInstitutionalCertificationFile}
+            storedValue={current.nihInstitutionalCertificationFile}
             onAddFile={function (file: File, id: string): void {
               onChange({ key: id, value: file })
             }}

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -6,6 +6,7 @@ import { ValidationError } from 'src/pages/dar_application/FormValidationState'
 import { AccessManagementType, ConsentGroup, ConsentGroup2, selectedPrimaryGroup } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 import { DacPicker } from 'src/components/forms/DacPicker'
 import { FileInput } from 'src/components/forms/FileInput'
+import { DataSet } from 'src/libs/ajax/DataSet'
 
 interface ConsentGroupAddEditProps {
   readonly id: number
@@ -14,7 +15,6 @@ interface ConsentGroupAddEditProps {
   readonly closeAction: () => void
   readonly onConsentGroupChange: (items: ConsentGroup2[]) => void
   readonly readOnly?: boolean
-  readonly isEditingExistingStudy?: boolean
 }
 
 interface Validation {
@@ -56,7 +56,7 @@ const getHeaderTitle = (readOnly: boolean, consentGroup?: ConsentGroup2) => {
 }
 
 export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): React.JSX.Element {
-  const { id, consentGroup, consentGroups, closeAction, onConsentGroupChange, readOnly = false, isEditingExistingStudy = false } = props
+  const { id, consentGroup, consentGroups, closeAction, onConsentGroupChange, readOnly = false } = props
 
   const [current, setCurrent] = useState<ConsentGroup2>(consentGroup || defaultConsentGroup)
   const [validation, setValidation] = useState<Validation>({})
@@ -96,8 +96,8 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
 
   const [showMORText, setShowMORText] = useState(consentGroup?.mor)
   const [morText, setMORText] = useState(consentGroup?.morDate || undefined)
-  const disableAccessAdjustment = isEditingExistingStudy && current.accessManagement === 'controlled'
-  const [editDataLocationUrl, setEditDataLocationUrl] = useState(consentGroup?.dataLocation === 'Not Determined')
+  const disableAccessAdjustment = consentGroup?.datasetId !== undefined && current.accessManagement === 'controlled'
+  const [editDataLocationUrl, setEditDataLocationUrl] = useState(consentGroup?.dataLocation !== 'Not Determined')
 
   const onAccessTypeChange = ({ _key, value }: { _key: string, value: string }) => {
     const clearedFields = {} as ConsentGroup2
@@ -178,7 +178,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
   }
 
   const onChange = ({ key, value }: FormFieldChange) => {
-    const next = structuredClone(current) as ConsentGroup2
+    const next = structuredClone(current)
     set(next, key, value)
     setCurrent(next)
     setValidation(calcErrors(next))
@@ -571,7 +571,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                 onChange={({ key, value }: { key: string, value: number, isValid: boolean }) => {
                   onChange({ key: key, value: value })
                 }}
-                disabled={readOnly || isEditingExistingStudy}
+                disabled={readOnly || (current?.datasetId !== undefined)}
               />
             )
           }
@@ -603,7 +603,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             validation={validation.dataLocation}
             onChange={({ key, value }: { key: string, value: string }) => {
               onChange({ key, value })
-              if (current?.dataLocation === 'Not Determined') {
+              if (value === 'Not Determined') {
                 onChange({ key: 'url', value: undefined })
                 setEditDataLocationUrl(false)
               }
@@ -618,7 +618,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             id="url"
             name="url"
             validators={[FormValidators.URL]}
-            disabled={editDataLocationUrl || readOnly}
+            disabled={!editDataLocationUrl || readOnly}
             placeholder="Enter a URL for your data location here"
             defaultValue={current?.dataLocation === 'Not Determined' ? undefined : consentGroup?.url}
             onChange={onChange}
@@ -680,6 +680,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             }}
             title="NIH Institutional Certification"
             disabled={readOnly}
+            onClick={current.nihInstitutionalCertificationFile ? () => { DataSet.getNIHInstitutionalCertification(current.datasetId) } : undefined}
           />
         </div>
         <div className="row" style={{ marginTop: 20 }}>

--- a/src/components/consent_group_list/ConsentGroupList.tsx
+++ b/src/components/consent_group_list/ConsentGroupList.tsx
@@ -67,7 +67,6 @@ export default function ConsentGroupList(props: ConsentGroupListProps): React.JS
           consentGroups={consentGroups}
           closeAction={() => setShowAddEdit(false)}
           onConsentGroupChange={onConsentGroupChange}
-          isEditingExistingStudy={isEditingExistingStudy}
         />
       )}
       <div className="form-group row no-margin">

--- a/src/components/consent_group_list/ConsentGroupRow.tsx
+++ b/src/components/consent_group_list/ConsentGroupRow.tsx
@@ -46,7 +46,6 @@ export default function ConsentGroupRow(props: ConsentGroupRowProps): React.JSX.
           closeAction={closeAction}
           onConsentGroupChange={onConsentGroupChange}
           readOnly={viewMode}
-          isEditingExistingStudy={isEditingExistingStudy}
         />
       )}
       {!editMode && !viewMode && (

--- a/src/components/forms/FileInput.tsx
+++ b/src/components/forms/FileInput.tsx
@@ -2,10 +2,12 @@ import React, { ChangeEvent, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ConfirmationDialog } from 'src/components/modals/ConfirmationDialog'
 import { FormFieldTitle } from 'src/components/forms/forms'
+import { FileStorageObject } from 'src/types/model'
 
 export type FileInputProps = {
   description?: string
   defaultValue?: File
+  storedValue?: FileStorageObject
   id: string
   onAddFile: (file: File, id: string) => void
   onDeleteFile: (id: string) => void
@@ -15,7 +17,7 @@ export type FileInputProps = {
 }
 
 export const FileInput = (props: FileInputProps) => {
-  const { id, title, description, onAddFile, onDeleteFile, defaultValue, required, disabled = false } = props
+  const { id, title, description, onAddFile, onDeleteFile, defaultValue, storedValue, required, disabled = false } = props
   const [file, setFile] = useState<File | undefined>(defaultValue)
   const inputRef = useRef<HTMLInputElement>(null)
   const [open, setOpen] = useState<boolean>(false)
@@ -104,6 +106,11 @@ export const FileInput = (props: FileInputProps) => {
             {file.name}
             {' '}
             {deleteButton}
+          </span>
+        )}
+        {!file && storedValue && (
+          <span style={{ marginLeft: '15px' }}>
+            {storedValue.fileName}
           </span>
         )}
       </div>

--- a/src/components/forms/FileInput.tsx
+++ b/src/components/forms/FileInput.tsx
@@ -11,13 +11,14 @@ export type FileInputProps = {
   id: string
   onAddFile: (file: File, id: string) => void
   onDeleteFile: (id: string) => void
+  onClick?: () => void
   required?: boolean
   title: string
   disabled?: boolean
 }
 
 export const FileInput = (props: FileInputProps) => {
-  const { id, title, description, onAddFile, onDeleteFile, defaultValue, storedValue, required, disabled = false } = props
+  const { id, title, description, onAddFile, onClick, onDeleteFile, defaultValue, storedValue, required, disabled = false } = props
   const [file, setFile] = useState<File | undefined>(defaultValue)
   const inputRef = useRef<HTMLInputElement>(null)
   const [open, setOpen] = useState<boolean>(false)
@@ -110,7 +111,12 @@ export const FileInput = (props: FileInputProps) => {
         )}
         {!file && storedValue && (
           <span style={{ marginLeft: '15px' }}>
-            {storedValue.fileName}
+            {onClick && (
+              <Link to="#" onClick={onClick}>
+                {storedValue.fileName}
+              </Link>
+            )}
+            {!onClick && (storedValue.fileName)}
           </span>
         )}
       </div>

--- a/src/pages/data_submission/consent_group/consentGroupUtils.ts
+++ b/src/pages/data_submission/consent_group/consentGroupUtils.ts
@@ -1,5 +1,6 @@
 import { isNil, isString } from 'lodash/fp'
 import { DataLocationType } from 'src/pages/data_submission/v2/v2-models'
+import { FileStorageObject } from 'src/types/model'
 
 export interface ConsentGroup {
   generalResearchUse?: boolean
@@ -10,7 +11,8 @@ export interface ConsentGroup {
 }
 export type AccessManagementType = 'controlled' | 'open' | 'external'
 export interface ConsentGroup2 {
-  nihInstitutionalCertificationFile?: File
+  nihInstitutionalCertificationFile?: FileStorageObject
+  addedNIHInstitutionalCertificationFile?: File
   name: string
   consentGroupName: string
   consentGroupId: string | number

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -87,7 +87,6 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   }
 
   const onSubmitStudy = async () => {
-    debugger
     await DataSet.registerDataset(buildMultiPartFormData(study))
     Notifications.showNotification({ text: 'Study created successfully', type: 'success' })
     if (onSaveRoute) {

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -56,17 +56,19 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
 
   const buildMultiPartFormData = (study: Study) => {
     const multiPartFormData = new FormData()
-    multiPartFormData.append('dataset', JSON.stringify(studyToDatasetSchemaSubmission(structuredClone(study))))
     if (study.alternativeDataSharingPlanFile) {
       multiPartFormData.append('alternativeDataSharingPlan', study.alternativeDataSharingPlanFile, study.alternativeDataSharingPlanFile.name)
+      delete study.alternativeDataSharingPlanFile
     }
 
     study.assets?.consentGroups?.forEach((consentGroup, idx) => {
-      if (consentGroup?.nihInstitutionalCertificationFile) {
+      if (consentGroup?.addedNIHInstitutionalCertificationFile) {
         const fieldKey = `consentGroups[${idx}].nihInstitutionalCertificationFile`
-        multiPartFormData.append(fieldKey, consentGroup.nihInstitutionalCertificationFile, consentGroup.nihInstitutionalCertificationFile.name)
+        multiPartFormData.append(fieldKey, consentGroup.addedNIHInstitutionalCertificationFile, consentGroup.addedNIHInstitutionalCertificationFile.name)
+        delete consentGroup.addedNIHInstitutionalCertificationFile
       }
     })
+    multiPartFormData.append('dataset', JSON.stringify(studyToDatasetSchemaSubmission(structuredClone(study))))
     return multiPartFormData
   }
   const onUpdateStudy = async () => {
@@ -85,6 +87,7 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   }
 
   const onSubmitStudy = async () => {
+    debugger
     await DataSet.registerDataset(buildMultiPartFormData(study))
     Notifications.showNotification({ text: 'Study created successfully', type: 'success' })
     if (onSaveRoute) {

--- a/src/pages/data_submission/v2/NihDataManagement.tsx
+++ b/src/pages/data_submission/v2/NihDataManagement.tsx
@@ -156,6 +156,7 @@ export const NihDataManagement = (props: NihDataManagementProps) => {
                     })
                   }}
                   defaultValue={study.alternativeDataSharingPlanFile}
+                  storedValue={study.alternativeDataSharingPlan}
                   title="Upload your alternative sharing plan."
                 />
 

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -268,11 +268,11 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
       consentGroup.morDate = dataset.dataUse.publicationMoratorium
     }
     consentGroup.npu = dataset.dataUse.nonProfitUse
-    if (consentGroup.otherSecondary && consentGroup.otherSecondary.length > 0) {
-      consentGroup.otherSecondary = dataset.dataUse.secondaryOther
+    if (isEmpty(consentGroup.otherSecondary)) {
+      consentGroup.otherSecondary = undefined
     }
     else {
-      consentGroup.otherSecondary = undefined
+      consentGroup.otherSecondary = dataset.dataUse.secondaryOther
     }
     consentGroup.dataAccessCommitteeId = dataset.dacId
     consentGroup.nihInstitutionalCertificationFile = dataset.nihInstitutionalCertificationFile

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -242,17 +242,38 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
     consentGroup.hmb = dataset.dataUse.hmbResearch
     consentGroup.diseaseSpecificUse = dataset.dataUse.diseaseRestrictions
     consentGroup.poa = dataset.dataUse.populationOriginsAncestry
-    consentGroup.otherPrimary = dataset.dataUse.other
+    if (isEmpty(dataset.dataUse.other)) {
+      consentGroup.otherPrimary = undefined
+    }
+    else {
+      consentGroup.otherPrimary = dataset.dataUse.other
+    }
     consentGroup.nmds = dataset.dataUse.methodsResearch === false
     consentGroup.gso = dataset.dataUse.geneticStudiesOnly
     consentGroup.pub = dataset.dataUse.publicationResults
     consentGroup.col = dataset.dataUse.collaboratorRequired
     consentGroup.irb = dataset.dataUse.ethicsApprovalRequired
-    consentGroup.gs = dataset.dataUse.geographicalRestrictions
+    if (isEmpty(dataset.dataUse.geographicalRestrictions)) {
+      consentGroup.gs = undefined
+    }
+    else {
+      consentGroup.gs = dataset.dataUse.geographicalRestrictions
+    }
+
     consentGroup.mor = !isEmpty(dataset.dataUse.publicationMoratorium)
-    consentGroup.morDate = dataset.dataUse.publicationMoratorium
+    if (isEmpty(dataset.dataUse.publicationMoratorium)) {
+      consentGroup.morDate = undefined
+    }
+    else {
+      consentGroup.morDate = dataset.dataUse.publicationMoratorium
+    }
     consentGroup.npu = dataset.dataUse.nonProfitUse
-    consentGroup.otherSecondary = dataset.dataUse.secondaryOther
+    if (consentGroup.otherSecondary && consentGroup.otherSecondary.length > 0) {
+      consentGroup.otherSecondary = dataset.dataUse.secondaryOther
+    }
+    else {
+      consentGroup.otherSecondary = undefined
+    }
     consentGroup.dataAccessCommitteeId = dataset.dacId
     consentGroup.nihInstitutionalCertificationFile = dataset.nihInstitutionalCertificationFile
     consentGroup.dataLocation = getDatasetPropertyValueByKey(DataLocation.propertyName, dataset) as DataLocationType
@@ -265,7 +286,7 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
 }
 
 const fileTypeAdjustment = (fileTypes: Array<FileType>) => {
-  if (!fileTypes) {
+  if (isEmpty(fileTypes)) {
     return [] as FileType[]
   }
   const adjustedFileTypes: Array<FileType> = []

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -254,6 +254,7 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
     consentGroup.npu = dataset.dataUse.nonProfitUse
     consentGroup.otherSecondary = dataset.dataUse.secondaryOther
     consentGroup.dataAccessCommitteeId = dataset.dacId
+    consentGroup.nihInstitutionalCertificationFile = dataset.nihInstitutionalCertificationFile
     consentGroup.dataLocation = getDatasetPropertyValueByKey(DataLocation.propertyName, dataset) as DataLocationType
     consentGroup.url = getDatasetPropertyValueByKey(DataURL.propertyName, dataset) as string
     consentGroup.fileTypes = fileTypeAdjustment(getDatasetPropertyValueByKey(FileTypes.propertyName, dataset) as Array<FileType>)

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -163,7 +163,7 @@ export interface Dataset {
   objectId?: string
   dataUse: DataUse
   dacApproval?: boolean
-  nihCertificationFile?: FileStorageObject
+  nihInstitutionalCertificationFile?: FileStorageObject
   updateUserId?: number
   updateDate?: Date
   indexedDate?: Date


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2755](https://broadworkbench.atlassian.net/browse/DT-2755)

- Displays the filename for the file previously uploaded
- Ensures the front end does not send the FileStorageObject to the backend because the backend will try to interpret it as a file (bug in current form in production as well)
- Update nihCertificationFile to match backend name: nihInstitutionalCertificationFile
- Makes NIH Institutional File a downloadable link when it is saved in consent.

### Summary

- Alternative Sharing Plan (text since we don't have a download API for this)

<img width="560" height="79" alt="image" src="https://github.com/user-attachments/assets/7bd9e178-8db7-41da-85fc-e521d8cbbf3a" />


- Link for NIH Institutional Certification Document

<img width="647" height="137" alt="image" src="https://github.com/user-attachments/assets/21001b03-2d49-4a9e-b6bf-957a18872bd4" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
