### PR TITLE
[DT-2763] Use proper object to compute validation.

### DIFF
--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -120,7 +120,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
       setShowDiseaseSpecificUseSearchbar(false)
       setShowMORText(false)
     }
-    setValidation(calcErrors(current))
+    setValidation(calcErrors(clearedFields))
   }
 
   const onPrimaryChange = ({ key, value }: { key: string, value: boolean | string | string[] | { displayText: string, id: string }[] }) => {
@@ -144,7 +144,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
     setShowDiseaseSpecificUseSearchbar(key === 'diseaseSpecificUse')
     setShowOtherPrimaryText(key === 'otherPrimary')
 
-    setValidation(calcErrors(current))
+    setValidation(calcErrors(next))
   }
 
   const calcErrors = (cg: ConsentGroup2): Validation => {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2763](https://broadworkbench.atlassian.net/browse/DT-2763)

### Summary

Additional testing revealed that the radio buttons were validating on stale objects when these values were mutated.  This PR updates the objects to compute validation on the updated object.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
