### PR TITLE
[DT-2764] Set npm to use project's practice of the exact version on install commands.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+save-exact=true


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2764](https://broadworkbench.atlassian.net/browse/DT-2764)

### Summary

Updates the project npm [configuration](https://docs.npmjs.com/cli/v11/configuring-npm/npmrc) with the setting to match our team's practice of [pinning to a specific dependency version](https://docs.npmjs.com/cli/v11/using-npm/config#save-exact) by default.



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
