### PR TITLE
[DT-2781] Use `cy.mount` instead of `mount`

### DIFF
--- a/cypress/component/Admin/ManageUser/ResearcherReview.spec.tsx
+++ b/cypress/component/Admin/ManageUser/ResearcherReview.spec.tsx
@@ -1,4 +1,3 @@
-import { mount } from 'cypress/react'
 import React from 'react'
 import { ResearcherReview } from 'src/components/ResearcherReview'
 import { DuosUser } from 'src/types/model'
@@ -21,7 +20,7 @@ describe('ResearcherReview', () => {
 
   it('Renders user information correctly', () => {
     const user = createMockUser()
-    mount(<ResearcherReview user={user} />)
+    cy.mount(<ResearcherReview user={user} />)
 
     cy.get('[data-cy="display-name"]').should('contain', baseUser.displayName)
     cy.get('[data-cy="institution-name"]').should('contain', baseUser.institution?.name)
@@ -36,7 +35,7 @@ describe('ResearcherReview', () => {
         { propertyKey: 'eraAuthorized', propertyValue: 'false' },
       ],
     })
-    mount(<ResearcherReview user={user} />)
+    cy.mount(<ResearcherReview user={user} />)
 
     cy.get('[data-cy="nih-valid"]').should('contain', 'Not Authorized')
   })
@@ -47,7 +46,7 @@ describe('ResearcherReview', () => {
         { propertyKey: 'eraExpiration', propertyValue: Date.now() - 1000 },
       ],
     })
-    mount(<ResearcherReview user={user} />)
+    cy.mount(<ResearcherReview user={user} />)
 
     cy.get('[data-cy="nih-expiration"]').should('contain', 'Expired')
   })
@@ -59,7 +58,7 @@ describe('ResearcherReview', () => {
       eraCommonsId: null,
       properties: [],
     })
-    mount(<ResearcherReview user={user} />)
+    cy.mount(<ResearcherReview user={user} />)
 
     cy.get('[data-cy="display-name"]').should('be.empty')
     cy.get('[data-cy="institution-name"]').should('be.empty')


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2781

### Summary

Follow up to #3254 , an additional file that needs to be moved over.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
