### PR TITLE
[DT-2654] Refs should not be accessed during render

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -69,8 +69,6 @@ export default defineConfig([
       'react-hooks/static-components': 'warn',
       'react-hooks/preserve-manual-memoization': 'warn',
       'react-hooks/immutability': 'warn',
-      'react-hooks/globals': 'warn',
-      'react-hooks/refs': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
     },
   },

--- a/src/pages/AdminManageDarCollections.jsx
+++ b/src/pages/AdminManageDarCollections.jsx
@@ -48,9 +48,18 @@ export default function AdminManageDarCollections() {
     init()
   }, [])
 
-  const updateCollections = updateCollectionFn({ collections, filterFn, searchRef, setCollections, setFilteredList })
-  const cancelCollection = cancelCollectionFn({ updateCollections, role: USER_ROLES.admin })
-  const openCollection = openCollectionFn({ updateCollections, role: USER_ROLES.admin })
+  const updateCollections = useCallback(
+    updatedCollection => updateCollectionFn({ collections, filterFn, searchRef, setCollections, setFilteredList })(updatedCollection),
+    [collections, filterFn, setCollections, setFilteredList],
+  )
+  const cancelCollection = useCallback(
+    params => cancelCollectionFn({ updateCollections, role: USER_ROLES.admin })(params),
+    [updateCollections],
+  )
+  const openCollection = useCallback(
+    params => openCollectionFn({ updateCollections, role: USER_ROLES.admin })(params),
+    [updateCollections],
+  )
 
   return (
     <div style={Styles.PAGE}>

--- a/src/pages/ChairConsole.jsx
+++ b/src/pages/ChairConsole.jsx
@@ -50,9 +50,18 @@ export default function ChairConsole() {
     init()
   }, [])
 
-  const updateCollections = updateCollectionFn({ collections, filterFn, searchRef, setCollections, setFilteredList })
-  const cancelCollection = cancelCollectionFn({ updateCollections, role: USER_ROLES.chairperson })
-  const openCollection = openCollectionFn({ updateCollections, role: USER_ROLES.chairperson })
+  const updateCollections = useCallback(
+    updatedCollection => updateCollectionFn({ collections, filterFn, searchRef, setCollections, setFilteredList })(updatedCollection),
+    [collections, filterFn, setCollections, setFilteredList],
+  )
+  const cancelCollection = useCallback(
+    params => cancelCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
+    [updateCollections],
+  )
+  const openCollection = useCallback(
+    params => openCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
+    [updateCollections],
+  )
   const goToVote = useCallback(collectionId => navigate(`/dar_collection/${collectionId}`), [navigate])
 
   return (


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2654

### Summary

This PR reduces the number of eslint error rules we need to ignore. Refs should not be accessed during a render. Instead:
1. `useCallback` defers execution
2. `searchRef` is passed at invocation time
3. `searchRef` is correctly excluded from dependencies
4. This is functionally equivalent to the previous approach, but with better performance.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
