### PR TITLE
[DT-2654] Fix incomplete dependency arrays

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -67,7 +67,6 @@ export default defineConfig([
       '@stylistic/jsx-one-expression-per-line': ['off'],
       // TODO: these issues should be fixed
       'react-hooks/static-components': 'warn',
-      'react-hooks/preserve-manual-memoization': 'warn',
       'react-hooks/immutability': 'warn',
       'react-hooks/set-state-in-effect': 'warn',
     },

--- a/src/components/forms/DraftFileUpload.tsx
+++ b/src/components/forms/DraftFileUpload.tsx
@@ -36,6 +36,17 @@ export const DraftFileUpload = (props: DraftFileUploadProps) => {
     await onDeleteFile(draftId, defaultValue!.fileStorageObjectId, id)
   }
 
+  const toggleSpinnerRef = useCallback((visible: boolean) => {
+    if (spinnerRef?.current) {
+      if (visible) {
+        spinnerRef.current.style.display = 'inline'
+      }
+      else {
+        spinnerRef.current.style.display = 'none'
+      }
+    }
+  }, [])
+
   const deleteButton = (defaultValue)
     ? (
         <>
@@ -69,17 +80,6 @@ export const DraftFileUpload = (props: DraftFileUploadProps) => {
   const handleUploadButtonClick = () => {
     inputRef.current?.click()
   }
-
-  const toggleSpinnerRef = useCallback((visible: boolean) => {
-    if (spinnerRef?.current) {
-      if (visible) {
-        spinnerRef.current.style.display = 'inline'
-      }
-      else {
-        spinnerRef.current.style.display = 'none'
-      }
-    }
-  }, [])
 
   return (
     <div>

--- a/src/components/forms/DraftFileUpload.tsx
+++ b/src/components/forms/DraftFileUpload.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useRef, useState } from 'react'
+import React, { ChangeEvent, useCallback, useRef, useState } from 'react'
 import loadingIndicator from '../../images/loading-indicator.svg'
 import { Link } from 'react-router-dom'
 import { ConfirmationDialog } from '../../components/modals/ConfirmationDialog'
@@ -70,7 +70,7 @@ export const DraftFileUpload = (props: DraftFileUploadProps) => {
     inputRef.current?.click()
   }
 
-  const toggleSpinnerRef = (visible: boolean) => {
+  const toggleSpinnerRef = useCallback((visible: boolean) => {
     if (spinnerRef?.current) {
       if (visible) {
         spinnerRef.current.style.display = 'inline'
@@ -79,7 +79,7 @@ export const DraftFileUpload = (props: DraftFileUploadProps) => {
         spinnerRef.current.style.display = 'none'
       }
     }
-  }
+  }, [])
 
   return (
     <div>

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -223,8 +223,14 @@ const DataAccessRequestApplication = (props) => {
 
   const { fetchWithCache } = useAsyncCacheFetch(initialCache)
 
-  const getDarCollection = collectionId => fetchWithCache(collectionId, Collections.getCollectionById)
-  const getPartialDarRequest = darId => fetchWithCache(darId, DAR.getPartialDarRequest)
+  const getDarCollection = useCallback(
+    collectionId => fetchWithCache(collectionId, Collections.getCollectionById),
+    [fetchWithCache],
+  )
+  const getPartialDarRequest = useCallback(
+    darId => fetchWithCache(darId, DAR.getPartialDarRequest),
+    [fetchWithCache],
+  )
 
   const [reverseOrderedDARs, setReverseOrderedDARs] = useState([])
   const [datasets, setDatasets] = useState([])
@@ -269,7 +275,7 @@ const DataAccessRequestApplication = (props) => {
       }
     }
     fetchData()
-  }, [existingDarsReadOnlyMode])
+  }, [existingDarsReadOnlyMode, collectionId, getDarCollection])
 
   const init = useCallback(async () => {
     let formData = {}

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -190,14 +190,14 @@ const DataAccessRequestApplication = (props) => {
     })
   }, [])
 
-  const batchFormFieldChange = (updates) => {
+  const batchFormFieldChange = useCallback((updates) => {
     setFormData((formData) => {
       return {
         ...formData,
         ...updates,
       }
     })
-  }
+  }, [])
 
   const updateCollaborationLetter = (letter) => {
     batchFormFieldChange({
@@ -315,7 +315,7 @@ const DataAccessRequestApplication = (props) => {
 
     batchFormFieldChange(formData)
     setIsLoading(false)
-  }, [researcher, existingDarsReadOnlyMode])
+  }, [researcher, existingDarsReadOnlyMode, collectionId, dataRequestId, getDarCollection, getPartialDarRequest, batchFormFieldChange])
 
   useEffect(() => {
     if (existingDarsReadOnlyMode) {

--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -74,16 +74,16 @@ export default function DatasetSubmissionsTable(props) {
   const [rows, setRows] = useState([])
   const [open, setOpen] = useState(false)
 
-  const handleClick = (term) => {
+  const handleClick = useCallback((term) => {
     setOpen(true)
     setSelectedTerm(term)
-  }
+  }, [])
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setOpen(false)
-  }
+  }, [])
 
-  const removeDataset = async (termToDelete) => {
+  const removeDataset = useCallback(async (termToDelete) => {
     const termName = termToDelete.datasetName
     const termId = termToDelete.datasetId
     setOpen(false)
@@ -100,7 +100,7 @@ export default function DatasetSubmissionsTable(props) {
         text: `Error removing ${termName} as a dataset`,
       })
     }
-  }
+  }, [navigate])
 
   // Datasets can be filtered from the parent component and redrawn frequently.
   const redrawRows = useCallback((open, selectedTerm) => {
@@ -160,7 +160,7 @@ export default function DatasetSubmissionsTable(props) {
       }
     })
     setRows(rows)
-  }, [removeDataset, terms])
+  }, [removeDataset, terms, handleClose, handleClick])
 
   useEffect(() => {
     const init = async () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2654

### Summary

We have incomplete dependency arrays in our `useCallback`s and `useEffect`s. The missing dependencies are often functions that get recreated on every render:

```
function Component() {
  const handleClick = () => { /* ... */ }  // New function every render
  
  useEffect(() => {
    // This runs on EVERY render because handleClick is always "new"
  }, [handleClick])  // ⚠️ handleClick changes every render
}
```

This pattern can cause infinite loops. The fix requires two steps:

1. Wrap functions in `useCallback` to memoize them to create a stable reference
2. Add them to the dependency arrays (now safe because they're stable)

Once memoized with `useCallback`, these functions have stable identities and only recreate when their own dependencies change, breaking the loop.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
