### PR TITLE
[DT-2794] Show message and don't navigate upon DAR submission backend validation failure

### DIFF
--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -451,64 +451,68 @@ describe('fetchAdapter - Fetch methods', () => {
   })
 
   describe('Error handling with axios-like structure', () => {
-    it('fetchPost - should throw error with response.data structure on 400', () => {
-      cy.window().then((win) => {
-        const errorMessage = 'Validation failed: Email is required'
-        const errorBody = {
-          code: 400,
-          message: errorMessage,
-        }
+    // Helper to verify common error structure
+    const verifyErrorStructure = (error: Error & { response?: { status: number, data: unknown } }, expectedStatus: number, expectedMessage: string, expectedData?: unknown) => {
+      expect(error).to.have.property('message', expectedMessage)
+      expect(error).to.have.property('response')
+      expect(error.response).to.have.property('status', expectedStatus)
+      expect(error.response).to.have.property('data')
+      if (expectedData !== undefined) {
+        expect(error.response.data).to.deep.equal(expectedData)
+      }
+    }
 
+    it('fetchPost - should throw error with response.data structure on 400', () => {
+      const errorMessage = 'Validation failed: Email is required'
+      const errorBody = {
+        code: 400,
+        message: errorMessage,
+      }
+
+      cy.window().then((win) => {
         fetchStub.resolves(
           new win.Response(JSON.stringify(errorBody), {
             status: 400,
             headers: { 'content-type': 'application/json' },
           }),
         )
-
-        fetchPost('/api/dar/v2', { data: 'test' }).then(
-          () => {
-            throw new Error('Should have thrown')
-          },
-          (error) => {
-            // Verify error structure matches what handleResponse creates
-            expect(error).to.have.property('message', errorMessage)
-            expect(error).to.have.property('response')
-            expect(error.response).to.have.property('status', 400)
-            expect(error.response).to.have.property('data')
-            expect(error.response.data).to.deep.equal(errorBody)
-          },
-        )
       })
+
+      fetchPost('/api/dar/v2', { data: 'test' }).then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          verifyErrorStructure(error, 400, errorMessage, errorBody)
+        },
+      )
     })
 
     it('fetchPost - should throw error with response.data structure on 500', () => {
-      cy.window().then((win) => {
-        const errorMessage = 'Internal server error'
-        const errorBody = {
-          message: errorMessage,
-          code: 500,
-        }
+      const errorMessage = 'Internal server error'
+      const errorBody = {
+        message: errorMessage,
+        code: 500,
+      }
 
+      cy.window().then((win) => {
         fetchStub.resolves(
           new win.Response(JSON.stringify(errorBody), {
             status: 500,
             headers: { 'content-type': 'application/json' },
           }),
         )
-
-        fetchGet('/api/data').then(
-          () => {
-            throw new Error('Should have thrown')
-          },
-          (error) => {
-            expect(error).to.have.property('message', errorMessage)
-            expect(error).to.have.property('response')
-            expect(error.response).to.have.property('status', 500)
-            expect(error.response.data).to.have.property('message', errorMessage)
-          },
-        )
       })
+
+      fetchGet('/api/data').then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          verifyErrorStructure(error, 500, errorMessage)
+          expect(error.response.data).to.have.property('message', errorMessage)
+        },
+      )
     })
 
     it('should handle 400 error with non-JSON response', () => {
@@ -519,49 +523,45 @@ describe('fetchAdapter - Fetch methods', () => {
             headers: { 'content-type': 'text/html' },
           }),
         )
-
-        fetchPost('/api/test', { data: 'test' }).then(
-          () => {
-            throw new Error('Should have thrown')
-          },
-          (error) => {
-            expect(error).to.have.property('message', 'Request failed with status 400')
-            expect(error).to.have.property('response')
-            expect(error.response).to.have.property('status', 400)
-            expect(error.response).to.have.property('data')
-            expect(error.response.data).to.deep.equal({})
-          },
-        )
       })
+
+      fetchPost('/api/test', { data: 'test' }).then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          verifyErrorStructure(error, 400, 'Request failed with status 400', {})
+        },
+      )
     })
 
     it('should preserve error message from backend', () => {
-      cy.window().then((win) => {
-        const backendMessage = 'All listed personnel must share the same institutional affiliation'
-        const errorBody = {
-          code: 400,
-          message: backendMessage,
-        }
+      const backendMessage = 'All listed personnel must share the same institutional affiliation'
+      const errorBody = {
+        code: 400,
+        message: backendMessage,
+      }
 
+      cy.window().then((win) => {
         fetchStub.resolves(
           new win.Response(JSON.stringify(errorBody), {
             status: 400,
             headers: { 'content-type': 'application/json' },
           }),
         )
-
-        fetchPost('/api/dar/v2', {}).then(
-          () => {
-            throw new Error('Should have thrown')
-          },
-          (error) => {
-            // The error message should be the backend message
-            expect(error.message).to.equal(backendMessage)
-            // And it should also be in response.data.message for error handlers
-            expect(error.response.data.message).to.equal(backendMessage)
-          },
-        )
       })
+
+      fetchPost('/api/dar/v2', {}).then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          // The error message should be the backend message
+          expect(error.message).to.equal(backendMessage)
+          // And it should also be in response.data.message for error handlers
+          expect(error.response.data.message).to.equal(backendMessage)
+        },
+      )
     })
   })
 })

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -455,6 +455,9 @@ describe('fetchAdapter - Fetch methods', () => {
     const verifyErrorStructure = (error: Error & { response?: { status: number, data: unknown } }, expectedStatus: number, expectedMessage: string, expectedData?: unknown) => {
       expect(error).to.have.property('message', expectedMessage)
       expect(error).to.have.property('response')
+      if (!error.response) {
+        throw new Error('Expected error.response to be defined')
+      }
       expect(error.response).to.have.property('status', expectedStatus)
       expect(error.response).to.have.property('data')
       if (expectedData !== undefined) {
@@ -510,6 +513,9 @@ describe('fetchAdapter - Fetch methods', () => {
         },
         (error) => {
           verifyErrorStructure(error, 500, errorMessage)
+          if (!error.response) {
+            throw new Error('Expected error.response to be defined')
+          }
           expect(error.response.data).to.have.property('message', errorMessage)
         },
       )
@@ -559,6 +565,9 @@ describe('fetchAdapter - Fetch methods', () => {
           // The error message should be the backend message
           expect(error.message).to.equal(backendMessage)
           // And it should also be in response.data.message for error handlers
+          if (!error.response) {
+            throw new Error('Expected error.response to be defined')
+          }
           expect(error.response.data.message).to.equal(backendMessage)
         },
       )

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -449,4 +449,119 @@ describe('fetchAdapter - Fetch methods', () => {
       })
     })
   })
+
+  describe('Error handling with axios-like structure', () => {
+    it('fetchPost - should throw error with response.data structure on 400', () => {
+      cy.window().then((win) => {
+        const errorMessage = 'Validation failed: Email is required'
+        const errorBody = {
+          code: 400,
+          message: errorMessage,
+        }
+
+        fetchStub.resolves(
+          new win.Response(JSON.stringify(errorBody), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+
+        fetchPost('/api/dar/v2', { data: 'test' }).then(
+          () => {
+            throw new Error('Should have thrown')
+          },
+          (error) => {
+            // Verify error structure matches what handleResponse creates
+            expect(error).to.have.property('message', errorMessage)
+            expect(error).to.have.property('response')
+            expect(error.response).to.have.property('status', 400)
+            expect(error.response).to.have.property('data')
+            expect(error.response.data).to.deep.equal(errorBody)
+          },
+        )
+      })
+    })
+
+    it('fetchPost - should throw error with response.data structure on 500', () => {
+      cy.window().then((win) => {
+        const errorMessage = 'Internal server error'
+        const errorBody = {
+          message: errorMessage,
+          code: 500,
+        }
+
+        fetchStub.resolves(
+          new win.Response(JSON.stringify(errorBody), {
+            status: 500,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+
+        fetchGet('/api/data').then(
+          () => {
+            throw new Error('Should have thrown')
+          },
+          (error) => {
+            expect(error).to.have.property('message', errorMessage)
+            expect(error).to.have.property('response')
+            expect(error.response).to.have.property('status', 500)
+            expect(error.response.data).to.have.property('message', errorMessage)
+          },
+        )
+      })
+    })
+
+    it('should handle 400 error with non-JSON response', () => {
+      cy.window().then((win) => {
+        fetchStub.resolves(
+          new win.Response('Bad Request', {
+            status: 400,
+            headers: { 'content-type': 'text/html' },
+          }),
+        )
+
+        fetchPost('/api/test', { data: 'test' }).then(
+          () => {
+            throw new Error('Should have thrown')
+          },
+          (error) => {
+            expect(error).to.have.property('message', 'Request failed with status 400')
+            expect(error).to.have.property('response')
+            expect(error.response).to.have.property('status', 400)
+            expect(error.response).to.have.property('data')
+            expect(error.response.data).to.deep.equal({})
+          },
+        )
+      })
+    })
+
+    it('should preserve error message from backend', () => {
+      cy.window().then((win) => {
+        const backendMessage = 'All listed personnel must share the same institutional affiliation'
+        const errorBody = {
+          code: 400,
+          message: backendMessage,
+        }
+
+        fetchStub.resolves(
+          new win.Response(JSON.stringify(errorBody), {
+            status: 400,
+            headers: { 'content-type': 'application/json' },
+          }),
+        )
+
+        fetchPost('/api/dar/v2', {}).then(
+          () => {
+            throw new Error('Should have thrown')
+          },
+          (error) => {
+            // The error message should be the backend message
+            expect(error.message).to.equal(backendMessage)
+            // And it should also be in response.data.message for error handlers
+            expect(error.response.data.message).to.equal(backendMessage)
+          },
+        )
+      })
+    })
+  })
 })

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -65,6 +65,30 @@ async function handleResponse<T>(
       redirectOnLogout()
     }
     await reportError(url, res.status)
+
+    // Parse error response and throw with axios-like structure for compatibility
+    interface ErrorData {
+      message?: string
+      code?: number
+    }
+    let errorData: ErrorData = {}
+    const contentType = res.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      try {
+        errorData = await res.json()
+      }
+      catch {
+        // If JSON parsing fails, use empty object
+      }
+    }
+    const error = new Error(errorData.message || `Request failed with status ${res.status}`) as Error & {
+      response: { status: number, data: ErrorData }
+    }
+    error.response = {
+      status: res.status,
+      data: errorData,
+    }
+    throw error
   }
 
   if (responseType === 'blob') {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2794

### Summary
This ensures backend validation is honored by the frontend in the Data Access Request submission.

#### Before
Submitting a DAR with a validation issue not caught by the frontend would silently fail, not create the DAR, but proceed to the next page as if it were created.

https://github.com/user-attachments/assets/5193bd03-efeb-4391-95e1-8142263b8562

### After
Backend validation error message is displayed as expected, and browser doesn't navigate to next page until it is fixed.

https://github.com/user-attachments/assets/8a34183e-37de-451b-bb19-a5f5e02fe67d

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
