### PR TITLE
[DT-2592] Fix subTab selection and menu

### DIFF
--- a/src/components/DuosHeader.tsx
+++ b/src/components/DuosHeader.tsx
@@ -318,22 +318,13 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
       subtab => (subtab.isRenderedForUser ?? subtab.isRendered ?? (() => true))(currentUser),
     ) || []
     // Find index of matching subtab
-    const subtabIndex = renderedSubtabs.findIndex(
+    initialSubTab = renderedSubtabs.findIndex(
       subtab => subtab.link === location.pathname || (subtab.search && location.pathname.includes(subtab.search)),
     )
-    if (subtabIndex === -1) {
-      initialSubTab = -1
-    }
-    else {
-      initialSubTab = subtabIndex
-    }
   }
 
   if (initialTab === -1) {
     initialTab = 0
-  }
-  if (initialSubTab === -1) {
-    initialSubTab = 0
   }
 
   return (

--- a/src/components/NavigationTabsComponent.tsx
+++ b/src/components/NavigationTabsComponent.tsx
@@ -125,7 +125,7 @@ export const NavigationTabsComponent: React.FC<NavigationTabsComponentProps> = (
             isLogged && (
               <Box className="duos-navigation-box" sx={{ minWidth: 0, flex: 1 }}>
                 <Tabs
-                  value={selectedMenuTab}
+                  value={selectedMenuTab >= 0 ? selectedMenuTab : false}
                   variant="scrollable"
                   scrollButtons="auto"
                   allowScrollButtonsMobile
@@ -264,11 +264,11 @@ export const NavigationTabsComponent: React.FC<NavigationTabsComponentProps> = (
         )}
       </ul>
 
-      {/* Sub Tabs */}
-      {tabs[selectedMenuTab as number]?.children && (
+      {/* Sub Tabs - only show if a valid subtab is selected */}
+      {tabs[selectedMenuTab as number]?.children && selectedSubTab >= 0 && (
         <Box className="duos-navigation-box navbar-sub">
           <Tabs
-            value={selectedSubTab}
+            value={selectedSubTab >= 0 ? selectedSubTab : false}
             variant="scrollable"
             scrollButtons="auto"
             orientation={orientation}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2592

### Summary
This PR fixes the changes made in [https://github.com/DataBiosphere/duos-ui/pull/3263](https://github.com/DataBiosphere/duos-ui/pull/3263) and [https://github.com/DataBiosphere/duos-ui/pull/3262](https://github.com/DataBiosphere/duos-ui/pull/3262) by hiding the subTab menu if no sub-menus match the path instead of defaulting to the first subTab. Also fixes a console error where the `Nav` tabs do not accept `-1`.

**Before**

<img width="1772" height="897" alt="Before" src="https://github.com/user-attachments/assets/55989bb8-214e-4c0e-a5e4-68a077d9b7b0" />

**After**

<img width="1772" height="897" alt="After" src="https://github.com/user-attachments/assets/53069ab2-759f-4f54-b4ed-f8f6e1e04857" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
