### PR TITLE
[DT-2807] Check that stackdriver context is defined

### DIFF
--- a/cypress/component/libs/stackdriverReporter.spec.ts
+++ b/cypress/component/libs/stackdriverReporter.spec.ts
@@ -1,0 +1,96 @@
+import StackdriverReporter from 'src/libs/stackdriverReporter'
+import { Storage } from 'src/libs/storage'
+import { Config } from 'src/libs/config'
+
+describe('StackdriverReporter', () => {
+  beforeEach(() => {
+    cy.window().then((win) => {
+      win.localStorage.clear()
+    })
+  })
+
+  afterEach(() => {
+    cy.window().then((win) => {
+      win.localStorage.clear()
+    })
+  })
+
+  describe('report', () => {
+    it('should not throw error when errorHandler context is undefined', () => {
+      // Setup: Mock Storage and Config
+      cy.stub(Storage, 'getCurrentUser').returns({ email: 'test@example.com' })
+      cy.stub(Config, 'getEnv').resolves('test')
+
+      // This test simulates the scenario where report() is called
+      // before start() has been called or when errorHandler is not initialized
+      // The errorHandler.context will be undefined in this case
+
+      // Call report without calling start first
+      cy.wrap(StackdriverReporter.report('Test error message')).then(() => {
+        // If the fix is working, this should not throw an error
+        // The test passing means the error was silently handled
+      })
+    })
+
+    it('should format message correctly', () => {
+      cy.stub(Config, 'getEnv').resolves('production')
+
+      cy.wrap(StackdriverReporter.format('Test message')).should('equal', '[production] Test message ')
+    })
+  })
+
+  describe('generateErrorConfig', () => {
+    it('should generate correct error configuration', () => {
+      const mockUser = { email: 'test@example.com' }
+      cy.stub(Storage, 'getCurrentUser').returns(mockUser)
+      cy.stub(Config, 'getErrorApiKey').resolves('test-api-key')
+      cy.stub(Config, 'getProject').resolves('test-project')
+      cy.stub(Config, 'getHash').resolves('abc123')
+      cy.stub(Config, 'getTag').resolves('production_v1.0')
+      cy.stub(Config, 'getEnv').resolves('prod')
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cy.wrap(StackdriverReporter.generateErrorConfig()).then((config: any) => {
+        expect(config).to.deep.include({
+          key: 'test-api-key',
+          projectId: 'test-project',
+          service: 'DUOS',
+          reportUncaughtExceptions: false,
+          reportUnhandledPromiseRejections: false,
+        })
+        expect(config.version).to.include('v1.0')
+        expect(config.version).to.include('abc123')
+        expect(config.version).to.include('prod')
+        expect(config.context.user).to.equal('test@example.com')
+      })
+    })
+
+    it('should use "anonymous" when user has no email', () => {
+      cy.stub(Storage, 'getCurrentUser').returns(null)
+      cy.stub(Config, 'getErrorApiKey').resolves('test-api-key')
+      cy.stub(Config, 'getProject').resolves('test-project')
+      cy.stub(Config, 'getHash').resolves('abc123')
+      cy.stub(Config, 'getTag').resolves('staging_v2.0')
+      cy.stub(Config, 'getEnv').resolves('staging')
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      cy.wrap(StackdriverReporter.generateErrorConfig()).then((config: any) => {
+        expect(config.context.user).to.equal('anonymous')
+      })
+    })
+  })
+
+  describe('start', () => {
+    it('should not start when config key is nil', () => {
+      cy.stub(Config, 'getErrorApiKey').resolves(null)
+      cy.stub(Config, 'getProject').resolves('test-project')
+      cy.stub(Storage, 'getCurrentUser').returns(null)
+      cy.stub(Config, 'getHash').resolves('abc123')
+      cy.stub(Config, 'getTag').resolves('production_v1.0')
+      cy.stub(Config, 'getEnv').resolves('test')
+
+      // Should not throw error even when key is nil
+      cy.wrap(StackdriverReporter.start())
+    })
+  })
+})

--- a/src/libs/stackdriverReporter.js
+++ b/src/libs/stackdriverReporter.js
@@ -1,7 +1,6 @@
 import { Storage } from './storage'
 import StackdriverErrorReporter from 'stackdriver-errors-js'
 import { Config } from './config'
-import { get } from 'lodash'
 import { isNil } from 'lodash/fp'
 
 const errorHandler = new StackdriverErrorReporter()
@@ -27,7 +26,7 @@ export const StackdriverReporter = {
       version: version,
       reportUncaughtExceptions: false,
       reportUnhandledPromiseRejections: false,
-      context: { user: get(user, 'email', 'anonymous') },
+      context: { user: user?.email || 'anonymous' },
     }
   },
 
@@ -41,9 +40,12 @@ export const StackdriverReporter = {
   report: async (msg) => {
     const user = Storage.getCurrentUser()
     const formattedMsg = await StackdriverReporter.format(msg)
-    errorHandler.setUser(get(user, 'email', 'anonymous'))
     try {
-      await errorHandler.report(formattedMsg)
+      // Only report if errorHandler has been initialized with context
+      if (errorHandler.context) {
+        errorHandler.setUser(user?.email || 'anonymous')
+        await errorHandler.report(formattedMsg)
+      }
     }
     catch (_error) {
       // swallow error to avoid user visible errors


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2807

### Summary

Small fix for when StackDriver context is null, as this prevents the entire page from loading. Also add basic tests for this issue.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
