### PR TITLE
[DT-2829] Part 2: Switch from `lodash/fp` to `lodash`

### DIFF
--- a/cypress/component/utils/dar_collection_utils.spec.js
+++ b/cypress/component/utils/dar_collection_utils.spec.js
@@ -13,7 +13,7 @@ import {
 } from '../../../src/utils/DarCollectionUtils'
 import { Collections } from '../../../src/libs/ajax/Collections'
 import { formatDate, Notifications, USER_ROLES } from '../../../src/libs/utils'
-import { forEach, includes, concat } from 'lodash/fp'
+import { forEach, includes, concat } from 'lodash'
 
 describe('updateCollectionFn', () => {
   it('generates an update callback function for consoles to use', () => {
@@ -595,11 +595,11 @@ describe('updateFinalVote()', () => {
     const setDataUseBuckets = newBucketArray => dataUseBuckets = newBucketArray
     const updatedBuckets = updateFinalVote({ key, votePayload, voteIds, dataUseBuckets, setDataUseBuckets })
 
-    forEach((bucket) => {
+    forEach(updatedBuckets, (bucket) => {
       const voteObj = bucket.votes[0].dataAccess
       const votes = concat(voteObj.finalVotes, voteObj.chairpersonVotes)
-      forEach((vote) => {
-        if (includes(vote.voteId)(voteIds)) {
+      forEach(votes, (vote) => {
+        if (includes(voteIds, vote.voteId)) {
           cy.wrap(vote.vote).should('equal', votePayload.vote)
           cy.wrap(vote.rationale).should('equal', votePayload.rationale)
         }
@@ -607,8 +607,8 @@ describe('updateFinalVote()', () => {
           cy.wrap(vote.vote).should('equal', undefined)
           cy.wrap(vote.rationale).should('equal', undefined)
         }
-      })(votes)
-    })(updatedBuckets)
+      })
+    })
 
     cy.wrap(dataUseBuckets).should('deep.equal', updatedBuckets)
   })
@@ -624,11 +624,11 @@ describe('updateFinalVote()', () => {
     const setDataUseBuckets = newBucketArray => dataUseBuckets = newBucketArray
     const updatedBuckets = updateFinalVote({ key, votePayload, voteIds, dataUseBuckets, setDataUseBuckets })
 
-    forEach((bucket) => {
+    forEach(updatedBuckets, (bucket) => {
       const voteObj = bucket.votes[0].rp
       const votes = concat(voteObj.finalVotes, voteObj.chairpersonVotes)
-      forEach((vote) => {
-        if (includes(vote.voteId)(voteIds)) {
+      forEach(votes, (vote) => {
+        if (includes(voteIds, vote.voteId)) {
           cy.wrap(vote.vote).should('equal', votePayload.vote)
           cy.wrap(vote.rationale).should('equal', votePayload.rationale)
         }
@@ -636,8 +636,8 @@ describe('updateFinalVote()', () => {
           cy.wrap(vote.vote).should('equal', undefined)
           cy.wrap(vote.rationale).should('equal', undefined)
         }
-      })(votes)
-    })(updatedBuckets)
+      })
+    })
 
     cy.wrap(dataUseBuckets).should('deep.equal', updatedBuckets)
   })

--- a/src/components/NavigationTabsComponent.tsx
+++ b/src/components/NavigationTabsComponent.tsx
@@ -1,7 +1,7 @@
 import Box from '@mui/material/Box'
 import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
-import { isFunction, isNil } from 'lodash/fp.js'
+import { isFunction, isNil } from 'lodash'
 import React from 'react'
 import { Link } from 'react-router-dom'
 import SignInButton from 'src/components/SignInButton.js'

--- a/src/components/RadioButton.jsx
+++ b/src/components/RadioButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { merge } from 'lodash/fp'
+import { merge } from 'lodash'
 
 export const RadioButton = (props) => {
   const basicWrapperStyle = {

--- a/src/components/collection_voting_slab/DataUseAlertBox.jsx
+++ b/src/components/collection_voting_slab/DataUseAlertBox.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { isEmpty, map } from 'lodash/fp'
+import { isEmpty, map } from 'lodash'
 
 const styles = {
   box: {
@@ -28,14 +28,14 @@ const styles = {
 const dataUseDescriptions = (translatedDataUse) => {
   return Object.keys(translatedDataUse).flatMap((key) => {
     const dataUses = translatedDataUse[key]
-    return map.convert({ cap: false })((dataUse, index) => {
+    return map(manuallyReviewedDataUses(dataUses), (dataUse, index) => {
       const uniqKey = key + '-' + dataUse.code + '-' + index
       return (
         <div key={uniqKey}>
           {dataUse.description}
         </div>
       )
-    })(manuallyReviewedDataUses(dataUses))
+    })
   })
 }
 

--- a/src/components/collection_voting_slab/DatasetsRequestedPanel.tsx
+++ b/src/components/collection_voting_slab/DatasetsRequestedPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import { filter, includes } from 'lodash/fp'
+import { filter, includes } from 'lodash'
 import { DacTerm, Dataset } from 'src/types/model'
 import SectionHeading from 'src/components/collection_voting_slab/SectionHeading'
 import DatasetList from 'src/components/collection_voting_slab/DatasetList'
@@ -34,10 +34,10 @@ export default function DatasetsRequestedPanel(props: DatasetsRequestedPanelProp
   useEffect(() => {
     const datasets = adminPage
       ? bucketDatasets
-      : filter((dataset: Dataset) => {
+      : filter(bucketDatasets, (dataset: Dataset) => {
           const { datasetId } = dataset
-          return includes(datasetId)(dacDatasetIds)
-        })(bucketDatasets)
+          return includes(dacDatasetIds, datasetId)
+        })
 
     setFilteredDatasets(datasets)
     setDatasetCount(datasets.length)

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.jsx
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { DataUseTranslation } from '../../libs/dataUseTranslation'
-import { isEmpty, isNil, flatMap, keys, get } from 'lodash/fp'
+import { isEmpty, isNil, flatMap, keys, get } from 'lodash'
 import { DataUsePills } from './DataUsePill'
 import DataUseAlertBox from './DataUseAlertBox'
 import CollectionSubmitVoteBox from '../collection_vote_box/CollectionSubmitVoteBox'
@@ -93,10 +93,10 @@ const highlightedWords = [
 ]
 
 const DataUseSummary = ({ translatedDataUse }) => {
-  return flatMap((key) => {
+  return flatMap(keys(translatedDataUse), (key) => {
     const dataUses = translatedDataUse[key]
     return <div key={key}>{DataUsePills(dataUses)}</div>
-  })(keys(translatedDataUse))
+  })
 }
 
 const SkeletonLoader = () => {
@@ -175,7 +175,7 @@ export default function ResearchProposalVoteSlab(props) {
 
   return (
     <div data-cy="rp-slab" style={styles.baseStyle}>
-      <div style={styles.slabTitle} id={convertLabelToKey(get('key')(bucket))}>
+      <div style={styles.slabTitle} id={convertLabelToKey(get(bucket, 'key'))}>
         RUS (GA4GH DUO)
       </div>
       {isLoading && (

--- a/src/components/dar_collection_table/Actions.jsx
+++ b/src/components/dar_collection_table/Actions.jsx
@@ -4,7 +4,7 @@ import { Styles, Theme } from 'src/libs/theme'
 import { Block, Delete } from '@mui/icons-material'
 import SimpleButton from 'src/components/SimpleButton'
 import { useNavigate } from 'react-router-dom'
-import { includes, toLower } from 'lodash/fp'
+import { includes, toLower } from 'lodash'
 import './dar_collection_table.css'
 
 const duosBlue = '#0948B7'
@@ -31,7 +31,7 @@ export default function Actions(props) {
 
   const openButtonAttributes = {
     keyProp: `${consoleType}-open-${uniqueId}`,
-    label: includes(toLower(status), ['complete', 'canceled']) ? 'Re-Open' : 'Open',
+    label: includes(['complete', 'canceled'], toLower(status)) ? 'Re-Open' : 'Open',
     onClick: () => showConfirmationModal(collection, 'open'),
     baseColor: duosBlue,
     hoverStyle: {

--- a/src/components/dar_collection_table/DarCollectionTableCellData.jsx
+++ b/src/components/dar_collection_table/DarCollectionTableCellData.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { includes, isEmpty, isNil, toLower, uniq } from 'lodash/fp'
+import { includes, isEmpty, isNil, toLower, uniq } from 'lodash'
 import { formatDate } from '../../libs/utils'
 import { ExpandMore, ExpandLess } from '@mui/icons-material'
 import Actions from './Actions'
@@ -68,7 +68,7 @@ export function darCodeCellData({ darCode = '- -', darCollectionId, collectionIs
 }
 
 const dacLinkToCollection = (darCode, status = '', darCollectionId) => {
-  const hasOpenElections = includes('open')(toLower(status))
+  const hasOpenElections = includes(toLower(status), 'open')
   const path = hasOpenElections
     ? `/dar_collection/${darCollectionId}`
     : `/dar_vote_review/${darCollectionId}`

--- a/src/components/dar_dataset_table/DarDatasetTable.jsx
+++ b/src/components/dar_dataset_table/DarDatasetTable.jsx
@@ -4,11 +4,10 @@ import PaginationBar from '../PaginationBar'
 import { recalculateVisibleTable, goToPage as updatePage } from '../../libs/utils'
 import SimpleTable from '../SimpleTable'
 import cellData from './DarDatasetTableCellData'
-import { compact, isNil, map, uniq } from 'lodash/fp'
+import { compact, isEmpty, isNil, map, uniq } from 'lodash'
 import { binCollectionToBuckets } from '../../utils/BucketUtils'
 import { styles } from '../../utils/darDatasetUtils'
 import { Notifications } from '../../libs/utils'
-import { isEmpty } from 'lodash'
 
 const storageDarDatasetSort = 'storageDarDatasetSort'
 
@@ -108,7 +107,7 @@ export const DarDatasetTable = (props) => {
         return
       }
       // If this is NOT an admin view, we need to filter buckets by the user's DACs
-      const dacIds = isUnfilteredView ? [] : uniq(compact(map(r => r.dacId)(user.roles)))
+      const dacIds = isUnfilteredView ? [] : uniq(compact(map(user.roles, r => r.dacId)))
       const buckets = await binCollectionToBuckets(collection, dacIds)
       const dataAccessBuckets = buckets.filter(
         b => b.isRP !== true,

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useCallback, useState, useEffect } from 'react'
-import { find, isNil } from 'lodash/fp'
-import { cloneDeep } from 'lodash'
+import { cloneDeep, find, isNil } from 'lodash'
 import { FormFieldTypes, FormField, FormValidators } from '../forms/forms'
 import { DataSet } from '../../libs/ajax/DataSet'
 import { DAR } from '../../libs/ajax/DAR'
@@ -48,7 +47,7 @@ export const DatasetUpdate = (props) => {
   }
 
   const extract = useCallback((propertyName) => {
-    const property = find({ propertyName })(dataset.properties)
+    const property = find(dataset.properties, { propertyName })
     return property?.propertyValue
   }, [dataset])
 

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -8,7 +8,7 @@ import {
   Notifications,
   searchOnFilteredList,
 } from 'src/libs/utils'
-import { cloneDeep, findIndex, isEmpty, isNaN, isNil } from 'lodash/fp'
+import { cloneDeep, findIndex, isEmpty, isNaN, isNil } from 'lodash'
 import { Styles } from 'src/libs/theme'
 import PaginationBar from 'src/components/PaginationBar'
 import SearchBar from 'src/components/SearchBar'
@@ -137,7 +137,7 @@ const deleteOnClick = (
     if (id) {
       LibraryCardAPI.deleteLibraryCard(id)
       const libraryCardsCopy = cloneDeep(libraryCards)
-      const targetIndex = findIndex((card: LibraryCard) => card.id === id)(libraryCardsCopy)
+      const targetIndex = findIndex(libraryCardsCopy, (card: LibraryCard) => card.id === id)
       libraryCardsCopy.splice(targetIndex, 1)
       setLibraryCards(libraryCardsCopy)
       setShowConfirmation(false)

--- a/src/components/manage_dac_table/ManageDacTable.jsx
+++ b/src/components/manage_dac_table/ManageDacTable.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import ReactTooltip from 'react-tooltip'
 import { DAC } from 'src/libs/ajax/DAC'
-import { filter, isNil } from 'lodash/fp'
+import { filter, isNil } from 'lodash'
 import { recalculateVisibleTable, goToPage as updatePage } from 'src/libs/utils'
 import cellData from 'src/components/manage_dac_table/ManageDacTableCellData'
 import { styles } from 'src/components/manage_dac_table/manageDacTableUtils'
@@ -121,7 +121,7 @@ export const ManageDacTable = function ManageDacTable(props) {
 
   const viewDatasets = useCallback(async (selectedDac) => {
     const datasets = await DAC.datasets(selectedDac.dacId)
-    const approvedDatasets = filter({ dacApproval: true })(datasets)
+    const approvedDatasets = filter(datasets, { dacApproval: true })
     setShowDatasetsPage(true)
     setSelectedDac(selectedDac)
     setSelectedDatasets(approvedDatasets)

--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -1,5 +1,5 @@
 import { fileDownload } from '../../utils/FileDownload'
-import { omit } from 'lodash/fp'
+import { omit } from 'lodash'
 import { Config } from '../config'
 import { isFileEmpty } from '../utils'
 import { DAAUtils } from '../../utils/DAAUtils'
@@ -47,7 +47,7 @@ export const DAR = {
   postDar: async (dar) => {
     // noinspection ES6MissingAwait
     Metrics.captureEvent(eventList.dar, { action: 'submit' })
-    const filteredDar = omit(['createDate', 'data_access_request_id'])(dar)
+    const filteredDar = omit(dar, ['createDate', 'data_access_request_id'])
     const url = DAAUtils.isEnabled()
       ? `${await Config.getApiUrl()}/api/dar/v3`
       : `${await Config.getApiUrl()}/api/dar/v2`

--- a/src/libs/ajax/User.ts
+++ b/src/libs/ajax/User.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, flow, unset } from 'lodash/fp'
+import { cloneDeep, unset } from 'lodash'
 import { Config } from 'src/libs/config'
 import { fetchGet, fetchPost, fetchPut, fetchDelete } from 'src/libs/ajax/fetchAdapter'
 import { CreateDuosUserRequest, UpdateDuosUserRequestV1, UpdateDuosUserRequestV2 } from 'src/types/requestTypes'
@@ -60,12 +60,11 @@ export const User = {
     // does not seem appropriate for this request anyway.
     // The UpdateDuosUserRequestV2 is not the same shape as a DuosUser
     // like this flow suggests.
-    const filteredUser = flow(
-      cloneDeep,
-      unset('updatedUser.createDate'),
-      unset('updatedUser.institution'),
-      unset('updatedUser.libraryCard'),
-    )(user)
+    const filteredUser = cloneDeep(user)
+    unset(filteredUser, 'updatedUser.createDate')
+    unset(filteredUser, 'updatedUser.institution')
+    unset(filteredUser, 'updatedUser.libraryCard')
+
     try {
       const res = await fetchPut<DuosUser, UpdateDuosUserRequestV2>(url, filteredUser, Config.authOpts())
       return res.data

--- a/src/libs/dataUseTranslation.js
+++ b/src/libs/dataUseTranslation.js
@@ -1,4 +1,4 @@
-import { isNil, isEmpty, filter, join, concat, clone, uniq, head } from 'lodash/fp'
+import { isNil, isEmpty, filter, join, concat, clone, uniq, head } from 'lodash'
 import { OntologyService } from './ontologyService'
 import { Notifications } from './utils'
 
@@ -34,7 +34,7 @@ export const srpTranslations = {
     }
     if (!isEmpty(diseases)) {
       const diseaseArray = diseases.sort().map(disease => disease.label)
-      const diseaseString = diseaseArray.length > 1 ? join('; ')(diseaseArray) : diseaseArray[0]
+      const diseaseString = diseaseArray.length > 1 ? join(diseaseArray, '; ') : diseaseArray[0]
       outputStruct.description = outputStruct.description + ` (${diseaseString})`
     }
     return outputStruct
@@ -339,7 +339,7 @@ const translateDataUseRestrictions = async (dataUse) => {
   const targetKeys = Object.keys(consentTranslations)
   restrictionStatements = targetKeys.map(async key =>
     await processRestrictionStatements(key, dataUse))
-  restrictionStatements = filter(statement => !isNil(statement))(restrictionStatements)
+  restrictionStatements = filter(restrictionStatements, statement => !isNil(statement))
   restrictionStatements = processOtherInDataUse(dataUse, restrictionStatements)
   return (await Promise.all(restrictionStatements)).filter(value => !isEmpty(value))
 }
@@ -354,8 +354,9 @@ export const translateDataUseRestrictionsFromDataUseArray = async (dataUses) => 
       return Promise.all(restrictionStatementPromises)
     })
     return filter(
+      await Promise.all(translationPromises),
       restriction => !isEmpty(restriction),
-    ) (await Promise.all(translationPromises))
+    )
   }
   catch (_error) {
     throw new Error('Failed to translate Data Use Restrictions from list')
@@ -398,71 +399,71 @@ export const DataUseTranslation = {
 
     // NOTE: additional check on hmb, diseases, and other are needed for older DARs where populationMigration - poa link was not established
     if ((darInfo.poa || darInfo.populationMigration) && (!darInfo.hmb && !darInfo.diseases && !darInfo.other)) {
-      dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.poa)
+      dataUseSummary.primary = concat(dataUseSummary.primary, srpTranslations.poa)
     }
 
     if (darInfo.diseases) {
       const diseaseTranslation = srpTranslations.diseases(clone(darInfo.ontologies))
-      dataUseSummary.primary = uniq(concat(dataUseSummary.primary)(diseaseTranslation))
+      dataUseSummary.primary = uniq(concat(dataUseSummary.primary, diseaseTranslation))
     }
     if (darInfo.other) {
-      dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.other(darInfo.otherText))
+      dataUseSummary.primary = concat(dataUseSummary.primary, srpTranslations.other(darInfo.otherText))
     }
 
     // **FALLBACK CHECK**
     // If no primary codes were added, add an "OTHER: Not provided" code
     if (isEmpty(dataUseSummary.primary)) {
-      dataUseSummary.primary = concat(dataUseSummary.primary)(srpTranslations.other(null))
+      dataUseSummary.primary = concat(dataUseSummary.primary, srpTranslations.other(null))
     }
 
     // Secondary Codes
     if (darInfo.methods) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.methods)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.methods)
     }
     if (darInfo.aiLlmUse) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.aiLlmUse)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.aiLlmUse)
     }
     if (darInfo.controls) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.controls)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.controls)
     }
     if (darInfo.forProfit) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.forProfit)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.forProfit)
     }
     else {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.notForProfit)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.notForProfit)
     }
     if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'f') {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.genderFemale)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.genderFemale)
     }
     if (darInfo.gender && darInfo.gender.slice(0, 1).toLowerCase() === 'm') {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.genderFemale)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.genderFemale)
     }
     if (darInfo.pediatric) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.pediatric)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.pediatric)
     }
     if (darInfo.illegalBehavior) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.illegalBehavior)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.illegalBehavior)
     }
     if (darInfo.addiction) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.addiction)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.addiction)
     }
     if (darInfo.sexualDiseases) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.sexualDiseases)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.sexualDiseases)
     }
     if (darInfo.stigmatizedDiseases) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.stigmatizedDiseases)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.stigmatizedDiseases)
     }
     if (darInfo.vulnerablePopulation) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.vulnerablePopulation)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.vulnerablePopulation)
     }
     if (darInfo.population) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.population)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.population)
     }
     if (darInfo.psychiatricTraits) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.psychiatricTraits)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.psychiatricTraits)
     }
     if (darInfo.notHealth) {
-      dataUseSummary.secondary = concat(dataUseSummary.secondary)(srpTranslations.notHealth)
+      dataUseSummary.secondary = concat(dataUseSummary.secondary, srpTranslations.notHealth)
     }
 
     return dataUseSummary

--- a/src/libs/notificationService.js
+++ b/src/libs/notificationService.js
@@ -1,5 +1,4 @@
-import { find, isEmpty } from 'lodash/fp'
-import { filter } from 'lodash'
+import { filter, find, isEmpty } from 'lodash'
 import { Config } from './config'
 import { fetchGet } from 'src/libs/ajax/fetchAdapter'
 
@@ -46,7 +45,7 @@ export const NotificationService = {
     try {
       const banners = await NotificationService.getBanners()
       if (!isEmpty(banners)) {
-        return find({ active: true, id: id })(banners)
+        return find(banners, { active: true, id: id })
       }
     }
     catch (_error) {

--- a/src/pages/AdminEditUser.jsx
+++ b/src/pages/AdminEditUser.jsx
@@ -1,5 +1,4 @@
-import { concat, filter, map as lodashMap, matches as lodashMatches } from 'lodash'
-import { contains, isEmpty, map, union } from 'lodash/fp'
+import { concat, filter, includes, isEmpty, map, union, matches as lodashMatches } from 'lodash'
 import React, { useEffect, useRef, useState } from 'react'
 import { User } from 'src/libs/ajax/User'
 import { Notifications, USER_ROLES } from 'src/libs/utils'
@@ -35,7 +34,7 @@ export const AdminEditUser = () => {
     const fetchData = async () => {
       try {
         const user = await User.getById(userId)
-        const currentRoles = lodashMap(user.roles, (ur) => {
+        const currentRoles = map(user.roles, (ur) => {
           return { roleId: ur.roleId, name: ur.name }
         })
         const updatedRoles = isEmpty(currentRoles) ? [researcherRole] : currentRoles
@@ -92,18 +91,18 @@ export const AdminEditUser = () => {
 
   const updateRolesIfDifferent = async (userId, updatedRoles) => {
     const user = await User.getById(userId)
-    const currentRoleIds = map('roleId')(user.roles)
+    const currentRoleIds = map(user.roles, 'roleId')
     // Always make sure researcher is a role we already have or need to add.
-    const updatedRoleIds = union([researcherRole.roleId])(map('roleId')(updatedRoles))
+    const updatedRoleIds = union([researcherRole.roleId], map(updatedRoles, 'roleId'))
 
-    await Promise.all(lodashMap(updatedRoleIds, async (roleId) => {
-      if (!contains(roleId)(currentRoleIds)) {
+    await Promise.all(map(updatedRoleIds, async (roleId) => {
+      if (!includes(currentRoleIds, roleId)) {
         await User.addRoleToUser(userId, roleId)
       }
     }))
 
-    await Promise.all(lodashMap(currentRoleIds, async (roleId) => {
-      if (!contains(roleId)(updatedRoleIds)) {
+    await Promise.all(map(currentRoleIds, async (roleId) => {
+      if (!includes(updatedRoleIds, roleId)) {
         // Safety check ... never delete the researcher role!!!
         if (roleId !== researcherRole.roleId) {
           await User.deleteRoleFromUser(userId, roleId)

--- a/src/pages/Translator.jsx
+++ b/src/pages/Translator.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { cloneDeep, groupBy, isNil } from 'lodash/fp'
+import { cloneDeep, groupBy, isNil } from 'lodash'
 import { Translate } from '../libs/ajax/Translate'
 import homeHeaderBackground from '../images/home_header_background.png'
 import { Spinner } from '../components/Spinner'
@@ -54,7 +54,7 @@ export default function Translator() {
         normalizedRaw.urlDomain = splitArr[2]
         return normalizedRaw
       })
-    setResults(groupBy('category', normalizedObjects))
+    setResults(groupBy(normalizedObjects, 'category'))
     setIsLoading(false)
   }
 

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -15,7 +15,6 @@ import { DAR } from 'src/libs/ajax/DAR'
 import { Collections } from 'src/libs/ajax/Collections'
 import { NotificationService } from 'src/libs/notificationService'
 import { Storage } from 'src/libs/storage'
-import { get, map } from 'lodash/fp'
 import 'src/pages/dar_application/DataAccessRequestApplication.css'
 import DucAddendum from 'src/pages/dar_application/DucAddendum'
 import { DAAUtils } from 'src/utils/DAAUtils'
@@ -28,7 +27,7 @@ import { ConditionalAccordion } from 'src/components/forms/ConditionalAccordion'
 import { ProgressReportApplication } from 'src/pages/dar_application/ProgressReportApplication'
 import { ScrollableTabs } from 'src/pages/dar_application/ScrollableTabs'
 import { validateDARFormData, validationFailed } from 'src/utils/darFormUtils'
-import { assign, cloneDeep, isArray, isEmpty, isNil, isString, merge, set } from 'lodash'
+import { assign, cloneDeep, get, isArray, isEmpty, isNil, isString, map, merge, set } from 'lodash'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import { Countries } from 'src/libs/ajax/Countries'
 import PropTypes from 'prop-types'
@@ -300,7 +299,7 @@ const DataAccessRequestApplication = (props) => {
       formData = darId ? await getPartialDarRequest(darId) : {}
 
       // This is a collection, so we need to get the datasets and datasetIds from the collection
-      formData.datasetIds = map(ds => get('datasetId')(ds))(datasets)
+      formData.datasetIds = map(datasets, ds => get(ds, 'datasetId'))
     }
     else if (!isNil(dataRequestId)) {
       // Handle the case where we have an existing DAR id
@@ -824,7 +823,7 @@ const DataAccessRequestApplication = (props) => {
                   defaultExpanded={reverseOrderedDARs.length === 1}
                 >
                   <ResearcherInfo
-                    completed={!isNil(get('institutionId', researcher))}
+                    completed={!isNil(get(researcher, 'institutionId'))}
                     readOnlyMode={existingDarsReadOnlyMode || isAttested}
                     includeInstructions={!existingDarsReadOnlyMode}
                     darCode={formData.darCode}

--- a/src/pages/dar_application/ResearchPurposeStatement.jsx
+++ b/src/pages/dar_application/ResearchPurposeStatement.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import isEmpty from 'lodash/fp/isEmpty'
+import { isEmpty } from 'lodash'
 import './dar_application.css'
 import { FormField, FormFieldTypes, FormValidators } from '../../components/forms/forms'
 

--- a/src/pages/dar_application/ScrollableTabs.tsx
+++ b/src/pages/dar_application/ScrollableTabs.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef } from 'react'
 import Tabs from '@mui/material/Tabs'
 import Tab from '@mui/material/Tab'
-import { findIndex } from 'lodash/fp'
+import { findIndex } from 'lodash'
 
 type ApplicationTab = {
   id: string
@@ -19,7 +19,7 @@ export const ScrollableTabs = ({ applicationTabs, formSelectedTabId, onTabChange
   // Use positive check for clarity (suggested improvement)
   const selectedStepNumber
     = typeof formSelectedTabId === 'string'
-      ? findIndex(tab => tab.id === formSelectedTabId, applicationTabs) + 1
+      ? findIndex(applicationTabs, tab => tab.id === formSelectedTabId) + 1
       : 1
 
   const goToStep = useCallback((tabId: string) => {

--- a/src/pages/dar_collection_review/ApplicationInformation.jsx
+++ b/src/pages/dar_collection_review/ApplicationInformation.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { chunk, filter, isEmpty } from 'lodash/fp'
+import { chunk, filter, isEmpty } from 'lodash'
 import { DAR } from '../../libs/ajax/DAR'
 import { DownloadLink } from '../../components/DownloadLink'
 
@@ -91,13 +91,13 @@ const generateLinkContents = (key, id, type, text, fileName, location) => {
 const dynamicRowGeneration = (rowElementMaxCount, appDetailLabels, loading, cloudComputing) => {
   // lodash/fp filter (non-empty string, non-empty object, non-empty array, booleans)
   // also filter out the cloud-provider element if cloudComputing is false
-  const labels = filter((label) => {
+  const labels = filter(appDetailLabels, (label) => {
     return (
       (typeof label.value === 'boolean')
       || (!isEmpty(label.value) && label.key !== 'cloud-provider')
       || (label.key === 'cloud-provider' && cloudComputing === true)
     )
-  }) (appDetailLabels)
+  })
 
   const labelArray = labels.map((label) => {
     if (typeof label.value === 'boolean') {
@@ -109,7 +109,7 @@ const dynamicRowGeneration = (rowElementMaxCount, appDetailLabels, loading, clou
     }
   })
   // use the chunk method to organize them in arrays of two
-  const chunkedArr = chunk(rowElementMaxCount)(labelArray)
+  const chunkedArr = chunk(labelArray, rowElementMaxCount)
 
   // use a map function to generate a new array that wraps each chunk in the row style
   // template that you can then plug into the component's return statement

--- a/src/pages/dar_collection_review/ApplicationInformation.jsx
+++ b/src/pages/dar_collection_review/ApplicationInformation.jsx
@@ -89,7 +89,7 @@ const generateLinkContents = (key, id, type, text, fileName, location) => {
 
 // function to generate application details content
 const dynamicRowGeneration = (rowElementMaxCount, appDetailLabels, loading, cloudComputing) => {
-  // lodash/fp filter (non-empty string, non-empty object, non-empty array, booleans)
+  // lodash filter (non-empty string, non-empty object, non-empty array, booleans)
   // also filter out the cloud-provider element if cloudComputing is false
   const labels = filter(appDetailLabels, (label) => {
     return (

--- a/src/pages/dar_collection_review/DarCollectionReview.jsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.jsx
@@ -3,7 +3,7 @@ import { User } from '../../libs/ajax/User'
 import TabControl from '../../components/TabControl'
 import ReviewHeader from './ReviewHeader'
 import ApplicationInformation from './ApplicationInformation'
-import { compact, filter, flatMap, flow, get, isEmpty, map, toLower, uniq } from 'lodash/fp'
+import { chain, compact, filter, get, isEmpty, map, toLower, uniq } from 'lodash'
 import { updateFinalVote } from '../../utils/DarCollectionUtils'
 import { binCollectionToBuckets } from '../../utils/BucketUtils'
 import { Navigation, Notifications } from '../../libs/utils'
@@ -60,21 +60,19 @@ const tabsForUser = (user, buckets, adminPage = false) => {
       votingHistory: 'Voting History',
     }
   }
-  const dataAccessBuckets = filter(
-    bucket => get('isRP')(bucket) !== true,
-  )(buckets)
-  const myMemberVotes = flow(
-    flatMap(b => b.votes),
-    flatMap(v => v.dataAccess),
-    flatMap(da => da.memberVotes),
-    filter(v => v.userId === user.userId),
-  )(dataAccessBuckets)
-  const myChairVotes = flow(
-    flatMap(b => b.votes),
-    flatMap(v => v.dataAccess),
-    flatMap(da => da.chairpersonVotes),
-    filter(v => v.userId === user.userId),
-  )(dataAccessBuckets)
+  const dataAccessBuckets = filter(buckets, bucket => get(bucket, 'isRP') !== true)
+  const myMemberVotes = chain(dataAccessBuckets)
+    .flatMap(b => b.votes)
+    .flatMap(v => v.dataAccess)
+    .flatMap(da => da.memberVotes)
+    .filter(v => v.userId === user.userId)
+    .value()
+  const myChairVotes = chain(dataAccessBuckets)
+    .flatMap(b => b.votes)
+    .flatMap(v => v.dataAccess)
+    .flatMap(da => da.chairpersonVotes)
+    .filter(v => v.userId === user.userId)
+    .value()
   const updatedTabs = { applicationInformation: 'Application Information', fullDAR: 'Full DAR' }
   if (!isEmpty(myMemberVotes)) {
     updatedTabs.memberVote = 'Member Vote'
@@ -188,7 +186,7 @@ export default function DarCollectionReview(props) {
       }
 
       // If this is NOT an admin view, we need to filter buckets by the user's DACs
-      const dacIds = adminPage ? [] : uniq(compact(map(r => r.dacId)(user.roles)))
+      const dacIds = adminPage ? [] : uniq(compact(map(user.roles, r => r.dacId)))
 
       // Parallelize async calls
       const [researcherProfile, processedBuckets] = await Promise.all([
@@ -261,7 +259,7 @@ export default function DarCollectionReview(props) {
           darCode={collection.darCode || '- -'}
           projectTitle={darInfo.projectTitle || '- -'}
           userName={researcherProfile.displayName || '- -'}
-          institutionName={get('institution.name')(researcherProfile) || '- -'}
+          institutionName={get(researcherProfile, 'institution.name') || '- -'}
           approvedDatasets={approvedDatasets}
           isLoading={isLoading}
           readOnly={readOnly || adminPage}
@@ -287,7 +285,7 @@ export default function DarCollectionReview(props) {
         />
         {selectedTab === tabs.applicationInformation && (
           <ApplicationInformation
-            institution={get('institution.name')(researcherProfile)}
+            institution={get(researcherProfile, 'institution.name')}
             researcher={researcherProfile.displayName}
             email={researcherProfile.email}
             nonTechSummary={darInfo.nonTechRus}

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.jsx
@@ -1,4 +1,4 @@
-import { filter, find, flow, get, isNil, map } from 'lodash/fp'
+import { chain, filter, find, get, isNil } from 'lodash'
 import React, { useEffect, useState } from 'react'
 import { Alert } from '../../components/Alert'
 import AILLMWarningBanner from 'src/components/AILLMWarningBanner'
@@ -52,26 +52,23 @@ export default function MultiDatasetVotingTab(props) {
   const missingLibraryCardMessage = 'The Researcher must have a Library Card before data access can be granted.\n'
     + (!adminPage ? 'You can still deny this request and/or vote on the Structured Research Purpose.' : '')
 
-  const rpBucket = find(bucket => get('isRP')(bucket))(buckets) || {}
-  const dataBuckets = filter(bucket => get('isRP')(bucket) !== true)(buckets)
+  const rpBucket = find(buckets, bucket => get(bucket, 'isRP')) || {}
+  const dataBuckets = filter(buckets, bucket => get(bucket, 'isRP') !== true)
 
   useEffect(() => {
     const init = async () => {
       const dacDatasets = adminPage ? [] : await User.getUserRelevantDatasets()
-      const datasetIds = flow(
-        map(dataset => get('datasetId')(dataset)),
-        filter(datasetId => !isNil(datasetId)),
-      )(dacDatasets)
+      const datasetIds = chain(dacDatasets)
+        .map(dataset => get(dataset, 'datasetId'))
+        .filter(datasetId => !isNil(datasetId))
+        .value()
       setDacDatasetIds(datasetIds)
     }
     init()
   }, [adminPage])
 
   const dataAccessApprovalDisabled = () => {
-    const researcherLibraryCard = flow(
-      get('createUser'),
-      get('libraryCard'),
-    )(collection)
+    const researcherLibraryCard = get(collection, 'createUser.libraryCard')
     const researcherMissingLibraryCards = isNil(researcherLibraryCard)
     return isChair && researcherMissingLibraryCards
   }

--- a/src/pages/data_submission/DataAccessGovernance.jsx
+++ b/src/pages/data_submission/DataAccessGovernance.jsx
@@ -1,6 +1,6 @@
 import ConsentGroupForm from './consent_group/ConsentGroupForm'
 import React, { useEffect, useState, useCallback } from 'react'
-import { isNil, every, cloneDeep, isEmpty, find } from 'lodash/fp'
+import { isNil, every, cloneDeep, isEmpty, find } from 'lodash'
 import { DAR } from '../../libs/ajax/DAR'
 import { DAC } from '../../libs/ajax/DAC'
 
@@ -54,7 +54,7 @@ export const DataAccessGovernance = (props) => {
   }, [])
 
   const extractFileTypes = useCallback((propertyName, dataset) => {
-    const property = find({ propertyName })(dataset.properties)
+    const property = find(dataset.properties, { propertyName })
     let fileTypes = []
 
     property?.propertyValue.forEach((propValue) => {
@@ -69,7 +69,7 @@ export const DataAccessGovernance = (props) => {
   }, [])
 
   const extract = useCallback((propertyName, dataset) => {
-    const property = find({ propertyName })(dataset.properties)
+    const property = find(dataset.properties, { propertyName })
     return property?.propertyValue
   }, [])
 

--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { Notifications } from 'src/libs/utils'
 import loadingIndicator from 'src/images/loading-indicator.svg'
 import SortableTable from 'src/components/sortable_table/SortableTable'
-import { concat, isNil, join } from 'lodash/fp'
+import { concat, isNil, join } from 'lodash'
 import Button from '@mui/material/Button'
 import { Link, useNavigate } from 'react-router-dom'
 import { DataSet } from 'src/libs/ajax/DataSet'
@@ -147,14 +147,14 @@ export default function DatasetSubmissionsTable(props) {
             </div>
           )
         : <div />
-      const custodians = join(', ')(term.study?.dataCustodianEmail)
+      const custodians = join(term.study?.dataCustodianEmail, ', ')
       return {
         datasetIdentifier: term.datasetIdentifier,
         datasetName: term.datasetName,
         dataSubmitter: term.createUserDisplayName,
         datasetCustodians: custodians,
         dac: term.dac?.dacName,
-        dataUse: join(', ')(concat(primaryCodes)(secondaryCodes)),
+        dataUse: join(concat(primaryCodes, secondaryCodes), ', '),
         status: status,
         actions: editButton, deleteButton,
       }

--- a/src/pages/researcher_console/ResearcherConsole.jsx
+++ b/src/pages/researcher_console/ResearcherConsole.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { cloneDeep, findIndex } from 'lodash/fp'
+import { cloneDeep, findIndex } from 'lodash'
 import { Styles } from 'src/libs/theme'
 import { DAR } from 'src/libs/ajax/DAR'
 import { Collections } from 'src/libs/ajax/Collections'
@@ -109,9 +109,9 @@ export default function ResearcherConsole() {
   const deleteDraftById = async ({ referenceId }) => {
     const collectionsClone = cloneDeep(researcherCollections)
     await DAR.deleteDar(referenceId)
-    const targetIndex = findIndex((draft) => {
+    const targetIndex = findIndex(collectionsClone, (draft) => {
       return draft.referenceIds[0] === referenceId
-    })(collectionsClone)
+    })
 
     // if deleted index, remove it from the collections array
     collectionsClone.splice(targetIndex, 1)

--- a/src/pages/signing_official_console/DataCustodianTable.jsx
+++ b/src/pages/signing_official_console/DataCustodianTable.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { Styles, Theme } from 'src/libs/theme'
-import { cloneDeep, findIndex, join, map, sortedUniq, sortBy, isNil, flow } from 'lodash/fp'
+import { chain, cloneDeep, findIndex, isNil } from 'lodash'
 import SimpleTable from 'src/components/SimpleTable'
 import SimpleButton from 'src/components/SimpleButton'
 import PaginationBar from 'src/components/PaginationBar'
@@ -137,12 +137,12 @@ const SubmitterCell = ({
 }
 
 const roleCell = (roles, id) => {
-  const roleString = flow(
-    map(role => role.name),
-    sortBy(name => name),
-    sortedUniq,
-    join(', '),
-  )(roles)
+  const roleString = chain(roles)
+    .map(role => role.name)
+    .sortBy(name => name)
+    .sortedUniq()
+    .join(', ')
+    .value()
 
   return {
     data: roleString || '- -',
@@ -295,9 +295,9 @@ export default function DataCustodianTable(props) {
     try {
       const updatedResearcher = await User.addRoleToUser(userId, 8)
       const listCopy = cloneDeep(researchers)
-      const targetIndex = findIndex(
+      const targetIndex = findIndex(listCopy,
         researcher => userId === researcher.userId,
-      )(listCopy)
+      )
       if (targetIndex === -1) {
         const targetResearcher = selectedResearcher
         listCopy.unshift(targetResearcher)
@@ -328,9 +328,9 @@ export default function DataCustodianTable(props) {
     const listCopy = cloneDeep(researchers)
     const messageName = displayName || email
     try {
-      const targetIndex = findIndex((researcher) => {
+      const targetIndex = findIndex(listCopy, (researcher) => {
         return !isNil(researcher) && selectedResearcher[searchableKey] === researcher[searchableKey]
-      })(listCopy)
+      })
       if (
         isNil(userId)
         || researchers[targetIndex].institutionId !== signingOfficial.institutionId

--- a/src/pages/signing_official_console/SigningOfficialTable.jsx
+++ b/src/pages/signing_official_console/SigningOfficialTable.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Info } from '@mui/icons-material'
 import { Styles, Theme } from 'src/libs/theme'
-import { cloneDeep, findIndex, flow, isNil, join, map, sortBy, sortedUniq } from 'lodash/fp'
+import { chain, cloneDeep, findIndex, isNil } from 'lodash'
 import SimpleTable from 'src/components/SimpleTable'
 import SimpleButton from 'src/components/SimpleButton'
 import PaginationBar from 'src/components/PaginationBar'
@@ -144,12 +144,12 @@ const LibraryCardCell = ({
 }
 
 const roleCell = (roles, id) => {
-  const roleString = flow(
-    map(role => role.name),
-    sortBy(name => name),
-    sortedUniq,
-    join(', '),
-  )(roles)
+  const roleString = chain(roles)
+    .map(role => role.name)
+    .sortBy(name => name)
+    .sortedUniq()
+    .join(', ')
+    .value()
 
   return {
     data: roleString || '- -',
@@ -310,7 +310,7 @@ export default function SigningOfficialTable(props) {
       const listCopy = cloneDeep(researchers)
       successfulCards.forEach((newCard) => {
         const { userEmail, userName, userId } = newCard
-        const targetIndex = findIndex(researcher => userId === researcher.userId)(listCopy)
+        const targetIndex = findIndex(listCopy, researcher => userId === researcher.userId)
         if (targetIndex === -1) { // if card is not found, push new user to top of list
           listCopy.unshift({
             email: userEmail,
@@ -350,10 +350,10 @@ export default function SigningOfficialTable(props) {
     const messageName = userName || userEmail
     try {
       await LibraryCard.deleteLibraryCard(id)
-      const targetIndex = findIndex((researcher) => {
+      const targetIndex = findIndex(researchers, (researcher) => {
         const card = researcher.libraryCard
         return !isNil(card) && id === card.id
-      })(researchers)
+      })
       if (isNil(userId) || researchers[targetIndex].institutionId !== signingOfficial.institutionId) {
         listCopy.splice(targetIndex, 1)
       }

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -1,4 +1,4 @@
-import { filter, flatMap, flow, includes, isEmpty, map, uniq, values } from 'lodash/fp'
+import { chain, filter, includes, isEmpty, map, values } from 'lodash'
 import { isNil } from 'lodash'
 import { Match } from 'src/libs/ajax/Match'
 import { DataSet } from 'src/libs/ajax/DataSet.js'
@@ -189,9 +189,7 @@ const findElectionsForDatasets = (dar: DataAccessRequest, datasetIds: number[]):
 const filterDatasetsByDACs = (dacIds: number[], datasets: Dataset[]): Dataset[] => {
   return isEmpty(dacIds)
     ? datasets
-    : filter(
-        (dataset: Dataset) => includes(dataset.dacId)(dacIds),
-      )(datasets)
+    : filter(datasets, (dataset: Dataset) => includes(dacIds, dataset.dacId))
 }
 
 /**
@@ -213,10 +211,10 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
   // If they are not all the same, we have to punt this decision solely to the DAC.
   // Check algorithm version: V3 does not need to be checked for 'unmatchable'
   const matchVals: boolean[] = (algorithmVersionV3 || !unmatchable)
-    ? flow(
-        map((m: MatchResult) => m.match),
-        uniq,
-      )(bucket.matchResults)
+    ? chain(bucket.matchResults)
+        .map((m: MatchResult) => m.match)
+        .uniq()
+        .value()
     : []
 
   const abstain = processV3Abstain(bucket.matchResults)
@@ -226,10 +224,10 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
     return { result: 'N/A', createDate: undefined, rationales: undefined, id: bucket.key }
   }
   else if ((matchVals.length === 1)) {
-    const rationales: string[] = flow(
-      flatMap((match: MatchResult) => match.rationales),
-      uniq,
-    )(bucket.matchResults)
+    const rationales: string[] = chain(bucket.matchResults)
+      .flatMap((match: MatchResult) => match.rationales)
+      .uniq()
+      .value()
     const { createDate, failed, id, match } = bucket.matchResults[0]
     const matchResult = { createDate, rationales, failed, id, match }
     if (abstain) {
@@ -265,8 +263,8 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
  * an ABSTAIN case, we can return true if the number of abstentions > 0
  */
 const processV3Abstain = (matchResults: MatchResult[]): boolean => {
-  const abstainList = map((m: MatchResult) => m.abstain)(matchResults)
-  const abstainValList = filter((a: boolean | undefined) => a === true)(abstainList)
+  const abstainList = map(matchResults, (m: MatchResult) => m.abstain)
+  const abstainValList = filter(abstainList, (a: boolean | undefined) => a === true)
   return abstainValList.length > 0
 }
 
@@ -299,13 +297,13 @@ const createRpVoteStructureFromBuckets = (buckets: Bucket[]): Array<{ rp: VoteGr
   // List of rp vote groups broken out by election into chair, member, and final votes.
   const rpVotes: Array<{ rp: VoteGroup }> = []
 
-  const rpElectionVoteArrays: Vote[][] = flow(
-    flatMap((b: Bucket) => b.elections),
-    filter((e: Election) => e.electionType.toLowerCase() === 'rp'),
-    map((e: Election) => e.votes),
+  const rpElectionVoteArrays: Vote[][] = chain(buckets)
+    .flatMap((b: Bucket) => b.elections)
+    .filter((e: Election) => e.electionType.toLowerCase() === 'rp')
+    .map((e: Election) => e.votes)
     // election.votes is a hash of vote id => vote object
-    map((hash: Record<string, Vote>) => values(hash)),
-  )(buckets)
+    .map((hash: Record<string, Vote>) => values(hash))
+    .value()
 
   for (const vArray of rpElectionVoteArrays) {
     const rpVoteGroup: VoteGroup = {

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -1,5 +1,4 @@
-import { chain, filter, includes, isEmpty, map, values } from 'lodash'
-import { isNil } from 'lodash'
+import { chain, filter, includes, isEmpty, isNil, map, values } from 'lodash'
 import { Match } from 'src/libs/ajax/Match'
 import { DataSet } from 'src/libs/ajax/DataSet.js'
 import { processVotesForBucket } from './DarCollectionUtils'

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -1,4 +1,4 @@
-import { cloneDeep, concat, filter, find, findIndex, flatMap, flatten, flow, forEach, groupBy, includes, isEmpty, isNil, map, toLower } from 'lodash/fp'
+import { chain, cloneDeep, concat, filter, find, findIndex, flatMap, flatten, groupBy, includes, isEmpty, isNil, map, toLower } from 'lodash'
 import { Styles } from 'src/libs/theme.js'
 import { formatDate, Notifications } from '../libs/utils'
 import { Collections } from '../libs/ajax/Collections'
@@ -73,11 +73,11 @@ export const processVotesForBucket = (darElections = []) => {
 export const extractDacDataAccessVotesFromBucket = (bucket, user, adminPage) => {
   const votes = bucket?.votes ?? []
 
-  let memberVotesArrays = flow(
-    map(voteData => voteData.dataAccess),
-    filter(dataAccessData => !isEmpty(dataAccessData)),
-    map(filteredData => filteredData.memberVotes),
-  )(votes)
+  let memberVotesArrays = chain(votes)
+    .map(voteData => voteData.dataAccess)
+    .filter(dataAccessData => !isEmpty(dataAccessData))
+    .map(filteredData => filteredData.memberVotes)
+    .value()
 
   if (!adminPage) {
     memberVotesArrays = filterVoteArraysForUsersDac(memberVotesArrays, user)
@@ -89,11 +89,11 @@ export const extractDacDataAccessVotesFromBucket = (bucket, user, adminPage) => 
 // Note that filtering by DAC does not occur for users viewing through admin review page
 export const extractDacRPVotesFromBucket = (bucket, user, adminPage) => {
   const votes = !isNil(bucket) ? bucket.votes : []
-  let rpVoteArrays = flow(
-    map(voteData => voteData.rp),
-    filter(rpData => !isEmpty(rpData)),
-    map(filteredData => filteredData.memberVotes),
-  )(votes)
+  let rpVoteArrays = chain(votes)
+    .map(voteData => voteData.rp)
+    .filter(rpData => !isEmpty(rpData))
+    .map(filteredData => filteredData.memberVotes)
+    .value()
 
   if (!adminPage) {
     rpVoteArrays = filterVoteArraysForUsersDac(rpVoteArrays, user)
@@ -105,12 +105,10 @@ export const extractDacRPVotesFromBucket = (bucket, user, adminPage) => {
 // only keeps arrays where at least one vote has the userId of the provided user
 const filterVoteArraysForUsersDac = (voteArrays = [], user) => {
   const userIdsOfVotes = (votes) => {
-    return map(vote => vote.userId)(votes)
+    return map(votes, vote => vote.userId)
   }
 
-  return filter(
-    voteArray => includes(user.userId, userIdsOfVotes(voteArray)),
-  )(voteArrays)
+  return filter(voteArrays, voteArray => includes(userIdsOfVotes(voteArray), user.userId))
 }
 
 // Gets this user's data access votes from this bucket; radar, final and chairperson votes if isChair is true, member votes if false
@@ -162,12 +160,12 @@ export const extractUserRPVotesFromBucket = (bucket, user, isChair = false, admi
 
 // collapses votes by the same user with same vote (true/false) into a singular vote with appended rationales / dates if different
 export const collapseVotesByUser = (votes) => {
-  const votesGroupedByUser = groupBy(vote => vote.userId)(cloneDeep(votes))
-  return flatMap((userIdKey) => {
+  const votesGroupedByUser = groupBy(cloneDeep(votes), vote => vote.userId)
+  return flatMap(Object.keys(votesGroupedByUser), (userIdKey) => {
     const votesByUser = votesGroupedByUser[userIdKey]
     const collapsedVotes = collapseVotes({ votes: votesByUser })
     return convertToVoteObjects({ collapsedVotes })
-  })(Object.keys(votesGroupedByUser))
+  })
 }
 
 // helper method to collapse votes by converting them to an object with differing rationales and dates in arrays
@@ -196,10 +194,10 @@ const collapseVotes = ({ votes }) => {
 
 // helper method to follow collapseVotes in flow
 const convertToVoteObjects = ({ collapsedVotes }) => {
-  return map((key) => {
+  return map(Object.keys(collapsedVotes), (key) => {
     const collapsedVote = collapsedVotes[key]
     const collapsedRationale = appendAll(collapsedVote.rationales)
-    const collapsedDate = appendAll(map(date => formatDate(date))(collapsedVote.lastUpdates))
+    const collapsedDate = appendAll(map(collapsedVote.lastUpdates, date => formatDate(date)))
 
     return {
       userId: collapsedVote.userId,
@@ -209,7 +207,7 @@ const convertToVoteObjects = ({ collapsedVotes }) => {
       rationale: collapsedRationale,
       lastUpdated: collapsedDate,
     }
-  })(Object.keys(collapsedVotes))
+  })
 }
 
 const appendAll = (values) => {
@@ -221,17 +219,17 @@ const appendAll = (values) => {
 }
 
 const addIfUnique = (newValue, existingValues) => {
-  if (!isNil(newValue) && !includes(newValue, existingValues)) {
+  if (!isNil(newValue) && !includes(existingValues, newValue)) {
     existingValues.push(newValue)
   }
 }
 
 export const updateCollectionFn = ({ collections, filterFn, searchRef, setCollections, setFilteredList }) =>
   (updatedCollection) => {
-    const targetIndex = findIndex(
+    const targetIndex = findIndex(collections,
       collection =>
         collection.darCollectionId === updatedCollection.darCollectionId,
-    )(collections)
+    )
     if (targetIndex < 0) {
       Notifications.showError({
         text: `Error: Could not find ${updatedCollection.darCode} collection`,
@@ -290,28 +288,28 @@ export const updateFinalVote = ({ key, votePayload, voteIds, dataUseBuckets, set
     // clone entire bucket to trigger page re-render on bucket update (setDataUseBuckets)
     const clonedBuckets = cloneDeep(dataUseBuckets)
     const isRPBucket = toLower(key) === toLower(rpVoteKey)
-    const targetBucket = find(bucket => toLower(bucket.key) === toLower(key))(clonedBuckets)
+    const targetBucket = find(clonedBuckets, bucket => toLower(bucket.key) === toLower(key))
     // source of votes will differ depending on the bucket (rp vs non-rp), so determine the callback function for flow here
-    const voteObjectCallback = isRPBucket ? map(voteObj => voteObj.rp) : map(voteObj => voteObj.dataAccess)
+    const voteObjectCallback = isRPBucket ? voteObj => voteObj.rp : voteObj => voteObj.dataAccess
     // to keep local source of truth updated without a fetch, we will need to update both the final and the chairperson votes
     // to make searching on the votes easier, concatenate and then flatten the finalVotes and chairpersonVotes into one array
     // NOTE: For the RP bucket the chairperson votes and the final votes are the same (RP has no final vote)
     // This was a conscious choice in order to keep processing the same between RP and non-RP buckets
-    const votes = flow([
-      voteObjectCallback,
-      flatMap(voteObj => concat(voteObj.finalVotes, voteObj.chairpersonVotes)),
-    ])(targetBucket.votes)
+    const votes = chain(targetBucket.votes)
+      .map(voteObjectCallback)
+      .flatMap(voteObj => concat(voteObj.finalVotes, voteObj.chairpersonVotes))
+      .value()
 
     // perform in place update of vote and vote rationale based on voteIds arguments
     // updates to the vote here will be reflected in clonedBuckets since the vote references are the same
-    flow([
-      filter(vote => includes(vote.voteId, voteIds)),
-      forEach((currentVote) => {
+    chain(votes)
+      .filter(vote => includes(voteIds, vote.voteId))
+      .forEach((currentVote) => {
         const { rationale, vote } = votePayload
         currentVote.rationale = rationale
         currentVote.vote = vote
-      }),
-    ])(votes)
+      })
+      .value()
     // set new bucket to trigger re-render, return clonedBuckets for debugging/testing efforts
     setDataUseBuckets(clonedBuckets)
     return clonedBuckets

--- a/src/utils/EnvironmentUtils.js
+++ b/src/utils/EnvironmentUtils.js
@@ -1,5 +1,5 @@
 import { Storage } from 'src/libs/storage'
-import { includes } from 'lodash/fp'
+import { includes } from 'lodash'
 
 /**
  * Predefined groups of environments for which certain features might be valid for.
@@ -33,7 +33,7 @@ export const envGroups = {
  */
 export const checkEnv = (envGroup) => {
   const env = Storage.getEnv()
-  return env ? includes(env)(envGroup) : false
+  return env ? includes(envGroup, env) : false
 }
 
 /**


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2829

### Summary

See also #3281 . 

`lodash/fp` is deprecated as of January 2023. It is partially responsible for making our `lodash` bundle size so large (16% of total Javascript bundle size).

This set of changes makes code changes and switches the imports from `lodash/fp` -> `lodash` for those components where it is possible.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
