### PR TITLE
[DT-2770] Use MultiSelect  for `Tags` in StudyAssets 

### DIFF
--- a/src/components/ai_models_list/AiModelAddEdit.tsx
+++ b/src/components/ai_models_list/AiModelAddEdit.tsx
@@ -82,9 +82,6 @@ export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.El
     if (key === 'trainedOnDatasets') {
       updated.trainedOnDatasets = value.split(',').map((s: string) => s.trim()).filter(Boolean)
     }
-    else if (key === 'tags') {
-      updated.tags = value.split(',').map((s: string) => s.trim()).filter(Boolean)
-    }
     else if (key === 'maintainerName') {
       updated.maintainer = { ...updated.maintainer, name: value }
     }
@@ -203,8 +200,13 @@ export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.El
           <FormField
             id="tags"
             title="Tags"
-            defaultValue={aiModel?.tags?.join(', ')}
-            placeholder="Comma separated tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={aiModel?.tags}
             onChange={onChange}
             disabled={readOnly}
           />

--- a/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
@@ -113,11 +113,6 @@ export default function ClinicalTrialAddEdit(props: ClinicalTrialAddEditProps): 
         ? (value as SelectEntry).key as ClinicalTrialInterventionType
         : value
     }
-    else if (key === 'tags') {
-      castValue = typeof value === 'string'
-        ? value.split(',').map(t => t.trim()).filter(Boolean)
-        : value
-    }
     const ctToSet: ClinicalTrial = { ...newClinicalTrial, [key]: castValue as never }
     setNewClinicalTrial(ctToSet)
     setValidation(calcClinicalTrialErrors(ctToSet))
@@ -262,8 +257,13 @@ export default function ClinicalTrialAddEdit(props: ClinicalTrialAddEditProps): 
           <FormField
             id="tags"
             title="Tags"
-            defaultValue={clinicalTrial?.tags?.join(', ')}
-            placeholder="Comma separated tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={clinicalTrial?.tags}
             onChange={onChange}
             disabled={readOnly}
           />

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -172,17 +172,15 @@ export default function FundingResourceAddEdit(props: FundingSourceAddEditProps)
           />
           <FormField
             id="tags"
-            title="Tags (comma separated)"
-            defaultValue={fundingResource?.tags?.join(', ')}
-            placeholder="tag1, tag2"
-            onChange={({ value }: { value: string }) =>
-              onChange({
-                key: 'tags',
-                value: value
-                  .split(',')
-                  .map(t => t.trim())
-                  .filter(Boolean),
-              })}
+            title="Tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={fundingResource?.tags}
+            onChange={onChange}
             disabled={readOnly}
           />
           <FormField

--- a/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
@@ -203,17 +203,15 @@ export default function IntellectualPropertyAddEdit(props: IntellectualPropertyA
           />
           <FormField
             id="tags"
-            title="Tags (comma separated)"
-            defaultValue={intellectualProperty?.tags?.join(', ')}
-            placeholder="tag1, tag2"
-            onChange={({ value }: { value: string }) =>
-              onChange({
-                key: 'tags',
-                value: value
-                  .split(',')
-                  .map(t => t.trim())
-                  .filter(Boolean),
-              })}
+            title="Tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={intellectualProperty?.tags}
+            onChange={onChange}
             disabled={readOnly}
           />
           <FormField

--- a/src/components/presentations_list/PresentationAddEdit.tsx
+++ b/src/components/presentations_list/PresentationAddEdit.tsx
@@ -107,11 +107,6 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
     else if (key === 'presenterEmail') {
       next = { ...newPresentation, presenter: { ...newPresentation.presenter, email: value as string } }
     }
-    else if (key === 'tags') {
-      const text = String(value)
-      setTagsInput(text)
-      next = { ...newPresentation, tags: text.split(',').map(t => t.trim()).filter(Boolean) }
-    }
     else {
       next = { ...newPresentation, [key]: value }
     }
@@ -263,9 +258,14 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
           />
           <FormField
             id="tags"
-            title="Tags (comma separated)"
-            defaultValue={tagsInput}
-            placeholder="tag1, tag2"
+            title="Tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={newPresentation?.tags}
             onChange={onChange}
             disabled={readOnly}
           />

--- a/src/components/presentations_list/PresentationAddEdit.tsx
+++ b/src/components/presentations_list/PresentationAddEdit.tsx
@@ -63,7 +63,6 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
   const [validation, setValidation] = useState<Validation>({ presenter: {} })
   const [submitted, setSubmitted] = useState<boolean>(false)
   const [touched, setTouched] = useState<Record<string, boolean>>({})
-  const [tagsInput, setTagsInput] = useState<string>((presentation?.tags ?? []).join(', '))
 
   const applyValidation = (draft: Presentation, full: boolean) => {
     const all = calcPresentationErrors(draft) as Validation

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { FormField, FormValidators } from 'src/components/forms/forms'
+import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
 import { validationFailed, calcPublicationErrors } from 'src/utils/darFormUtils'
 import { Author, Publication } from 'src/types/model'
@@ -177,7 +177,6 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
   const [validation, setValidation] = useState<Validation>({})
   const [submitted, setSubmitted] = useState<boolean>(false)
   const [touched, setTouched] = useState<Record<string, boolean>>({})
-  const [tagsInput, setTagsInput] = useState<string>((publication?.tags ?? []).join(', '))
 
   const applyValidation = (draft: Publication, full: boolean) => {
     const all = calcPublicationErrors(draft)
@@ -199,17 +198,7 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
 
   const onChange = ({ key, value }: FormFieldChange) => {
     markTouched(key)
-    if (key === 'tags') {
-      const text = String(value)
-      setTagsInput(text)
-      updatePublication({
-        ...newPublication,
-        tags: text.split(',').map(t => t.trim()).filter(Boolean),
-      })
-    }
-    else {
-      updatePublication({ ...newPublication, [key]: value })
-    }
+    updatePublication({ ...newPublication, [key]: value })
   }
 
   const disableAddAuthor = newPublication.authors.some(a => a.name.trim() === '')
@@ -373,9 +362,14 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
 
           <FormField
             id="tags"
-            title="Tags (comma separated)"
-            defaultValue={tagsInput}
-            placeholder="tag1, tag2"
+            title="Tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={newPublication?.tags}
             onChange={onChange}
             disabled={readOnly}
           />

--- a/src/components/workspaces_list/WorkspaceAddEdit.tsx
+++ b/src/components/workspaces_list/WorkspaceAddEdit.tsx
@@ -170,17 +170,15 @@ export default function WorkspaceAddEdit(props: WorkspaceAddEditProps): React.JS
           />
           <FormField
             id="tags"
-            title="Tags (comma separated)"
-            defaultValue={workspace?.tags?.join(', ')}
-            placeholder="tag1, tag2"
-            onChange={({ value }: { value: string }) =>
-              onChange({
-                key: 'tags',
-                value: value
-                  .split(',')
-                  .map(t => t.trim())
-                  .filter(Boolean),
-              })}
+            title="Tags"
+            placeholder="Select or enter tags"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={workspace?.tags}
+            onChange={onChange}
             disabled={readOnly}
           />
           <FormField


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2770

### Summary

This PR makes all `Tags` fields consistent with the existing `Data Types` implementation for improved UX.

<img width="1402" height="175" alt="New Tags" src="https://github.com/user-attachments/assets/ba2e48c4-7f41-4016-aecf-b490251c4de9" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
