### PR TITLE
[DT-2829] Fix the uses of `merge` with `lodash`.

### DIFF
--- a/cypress/component/RadioButton.spec.tsx
+++ b/cypress/component/RadioButton.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { RadioButton } from 'src/components/RadioButton'
+
+describe('RadioButton', () => {
+  it('renders correctly and does not mutate shared styles', () => {
+    cy.mount(
+      <div>
+        <RadioButton
+          id="radio-1"
+          name="test-group"
+          value="val-1"
+          defaultChecked={true}
+          label="Label 1"
+        />
+        <RadioButton
+          id="radio-2"
+          name="test-group"
+          value="val-2"
+          defaultChecked={false}
+          label="Label 2"
+        />
+      </div>,
+    )
+
+    // The checked radio button should have the blue background
+    // In RadioButton.jsx: backgroundColor: '#2196F3'
+    cy.get('#radio-1').siblings('span').should('have.css', 'background-color', 'rgb(33, 150, 243)')
+
+    // The unchecked radio button should have white background
+    // In RadioButton.jsx basicUnchecked: backgroundColor: 'white'
+    cy.get('#radio-2').siblings('span').should('have.css', 'background-color', 'rgb(255, 255, 255)')
+  })
+
+  it('maintains independent styles for multiple instances', () => {
+    cy.mount(
+      <div>
+        <RadioButton
+          id="radio-a"
+          name="group-a"
+          value="a"
+          defaultChecked={true}
+          label="A"
+        />
+        <RadioButton
+          id="radio-b"
+          name="group-b"
+          value="b"
+          defaultChecked={false}
+          label="B"
+        />
+        <RadioButton
+          id="radio-c"
+          name="group-c"
+          value="c"
+          defaultChecked={false}
+          label="C"
+        />
+      </div>,
+    )
+
+    // Verify checked one is blue
+    cy.get('#radio-a').siblings('span').should('have.css', 'background-color', 'rgb(33, 150, 243)')
+
+    // Verify others are white (not mutated by the first one)
+    cy.get('#radio-b').siblings('span').should('have.css', 'background-color', 'rgb(255, 255, 255)')
+    cy.get('#radio-c').siblings('span').should('have.css', 'background-color', 'rgb(255, 255, 255)')
+  })
+})

--- a/src/components/RadioButton.jsx
+++ b/src/components/RadioButton.jsx
@@ -10,7 +10,7 @@ export const RadioButton = (props) => {
     position: 'relative',
   }
 
-  const wrapperStyle = props.style ? merge(basicWrapperStyle, props.style) : basicWrapperStyle
+  const wrapperStyle = props.style ? merge({}, basicWrapperStyle, props.style) : basicWrapperStyle
 
   const basicUnchecked = {
     fontSize: 15,
@@ -28,9 +28,9 @@ export const RadioButton = (props) => {
     border: '1px solid #999999',
   }
 
-  const uncheckedStyle = props.style ? merge(basicUnchecked, props.style) : basicUnchecked
+  const uncheckedStyle = props.style ? merge({}, basicUnchecked, props.style) : basicUnchecked
 
-  const checkedStyle = merge(uncheckedStyle, {
+  const checkedStyle = merge({}, uncheckedStyle, {
     boxShadow: 'rgb(0, 0, 0) 0 0 0 1px',
     backgroundColor: '#2196F3',
     border: '2px solid white',
@@ -43,7 +43,7 @@ export const RadioButton = (props) => {
     fontWeight: '500',
 
   }
-  const labelStyle = props.style ? merge(basicLabelStyle, props.style) : basicLabelStyle
+  const labelStyle = props.style ? merge({}, basicLabelStyle, props.style) : basicLabelStyle
 
   const descriptionStyle = {
     marginLeft: '.25rem',

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -774,7 +774,7 @@ const DataAccessRequestApplication = (props) => {
                   <ProgressReportApplication
                     readOnlyMode={false}
                     datasets={datasets}
-                    dar={merge(reverseOrderedDARs[0]?.data, reverseOrderedDARs[0])}
+                    dar={merge({}, reverseOrderedDARs[0]?.data, reverseOrderedDARs[0])}
                     researcher={researcher}
                     countriesOfOperation={countriesOfOperation}
                   />
@@ -797,7 +797,7 @@ const DataAccessRequestApplication = (props) => {
                           <ProgressReportApplication
                             readOnlyMode={true}
                             datasets={datasets}
-                            dar={merge(dar?.data, dar)}
+                            dar={merge({}, dar?.data, dar)}
                             researcher={researcher}
                             countriesOfOperation={countriesOfOperation}
                           />


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2829

### Summary

Currently, all radio buttons are selected on all forms. This issue is due to `lodash.merge` mutating the `uncheckedStyle` object in `src/components/RadioButton.jsx`, causing it to inherit properties from `checkedStyle`.

This fixes that issue.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-2829]: https://broadworkbench.atlassian.net/browse/DT-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ