### PR TITLE
[DT-2769] Reduce required fields in v2 Study Registration

### DIFF
--- a/cypress/component/StudyAssets/presentation_list.spec.tsx
+++ b/cypress/component/StudyAssets/presentation_list.spec.tsx
@@ -39,7 +39,6 @@ describe('PresentationList component', () => {
   it('renders existing presentations', () => {
     cy.mount(<PresentationListHarness initial={[samplePresentation]} />)
     cy.contains(samplePresentation.title).should('exist')
-    cy.contains(samplePresentation.event).should('exist')
   })
 
   it('opens add form and enforces validation disabling save then adds', () => {
@@ -139,8 +138,6 @@ describe('PresentationSummary', () => {
       />,
     )
     cy.contains(samplePresentation.title).should('exist')
-    cy.contains(samplePresentation.event).should('exist')
-    cy.contains(samplePresentation.presenter.name).should('exist')
     cy.get(`a[href="${samplePresentation.url}"]`).should('exist')
   })
 

--- a/cypress/component/utils/darFormUtils.spec.ts
+++ b/cypress/component/utils/darFormUtils.spec.ts
@@ -289,26 +289,6 @@ describe('darFormUtils - Publication & Presentation Validation', () => {
       expect(errors.title).to.be.an('object')
     })
 
-    it('should return error for missing presenter name', () => {
-      const presentation: Partial<Presentation> = {
-        title: 'Test Presentation',
-        presenter: { name: '', email: 'test@example.com' } as { name: string, email: string },
-      }
-      const errors = calcPresentationErrors(presentation)
-      const presenterErrors = errors.presenter as Record<string, unknown>
-      expect(presenterErrors?.name).to.be.an('object')
-    })
-
-    it('should return error for missing presenter email', () => {
-      const presentation: Partial<Presentation> = {
-        title: 'Test Presentation',
-        presenter: { name: 'John Doe', email: '' } as { name: string, email: string },
-      }
-      const errors = calcPresentationErrors(presentation)
-      const presenterErrors = errors.presenter as Record<string, unknown>
-      expect(presenterErrors?.email).to.be.an('object')
-    })
-
     it('should return errors for multiple missing fields', () => {
       const presentation: Partial<Presentation> = {}
       const errors = calcPresentationErrors(presentation)

--- a/src/components/presentations_list/PresentationAddEdit.tsx
+++ b/src/components/presentations_list/PresentationAddEdit.tsx
@@ -160,7 +160,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Presentation URL"
             defaultValue={newPresentation.url}
             placeholder="https://..."
-            validators={[FormValidators.REQUIRED, FormValidators.URL]}
+            validators={[FormValidators.URL]}
             onChange={onChange}
             validation={(submitted || touched.url) ? validation.url : undefined}
             disabled={readOnly}
@@ -170,9 +170,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Authors"
             defaultValue={newPresentation.authors}
             placeholder="Authors"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.authors) ? validation.authors : undefined}
             disabled={readOnly}
           />
           <FormField
@@ -180,9 +178,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Dataset Citation"
             defaultValue={newPresentation.datasetCitation}
             placeholder="Dataset Citation"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.datasetCitation) ? validation.datasetCitation : undefined}
             disabled={readOnly}
           />
           <FormField
@@ -200,9 +196,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Presenter Name"
             defaultValue={newPresentation.presenter?.name}
             placeholder="Name"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.presenterName) ? validation.presenter?.name : undefined}
             disabled={readOnly}
           />
           <FormField
@@ -210,7 +204,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Presenter Email"
             defaultValue={newPresentation.presenter?.email}
             placeholder="email@example.org"
-            validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+            validators={[FormValidators.EMAIL]}
             onChange={onChange}
             validation={(submitted || touched.presenterEmail) ? validation.presenter?.email : undefined}
             disabled={readOnly}
@@ -220,9 +214,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Event"
             defaultValue={newPresentation.event}
             placeholder="Event"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.event) ? validation.event : undefined}
             disabled={readOnly}
           />
           <FormField
@@ -230,9 +222,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Location"
             defaultValue={newPresentation.location}
             placeholder="Location"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.location) ? validation.location : undefined}
             disabled={readOnly}
           />
           <FormField
@@ -240,9 +230,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Format"
             defaultValue={newPresentation.format}
             placeholder="Format"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.format) ? validation.format : undefined}
             disabled={readOnly}
           />
           <FormField
@@ -250,9 +238,7 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
             title="Access"
             defaultValue={newPresentation.access}
             placeholder="Access"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.access) ? validation.access : undefined}
             disabled={readOnly}
           />
           <FormField

--- a/src/components/presentations_list/PresentationList.tsx
+++ b/src/components/presentations_list/PresentationList.tsx
@@ -23,7 +23,7 @@ export default function PresentationList(props: PresentationListProps): React.JS
       React.ComponentProps<typeof PresentationRow>
     >
       items={props.presentations}
-      columnsToShow={props.columnsToShow ?? ['title', 'date', 'event', 'location', 'url', 'format', 'access']}
+      columnsToShow={props.columnsToShow ?? ['title', 'date']}
       onItemsChange={props.onPresentationChange}
       disabled={props.disabled}
       validation={props.validation}

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -20,15 +20,12 @@ interface PublicationAddEditProps {
 
 interface Validation {
   title?: ValidationError
-  pubmedId?: ValidationError
   publishedDate?: ValidationError
   authors?: ValidationError
-  bibliographicCitation?: ValidationError
   datasetCitation?: ValidationError
   journal?: ValidationError
   doi?: ValidationError
   url?: ValidationError
-  access?: ValidationError
 }
 
 const defaultPublication: Publication = {
@@ -288,9 +285,7 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
             title="PubMed ID"
             defaultValue={newPublication.pubmedId}
             placeholder="PubMed ID"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.pubmedId) ? validation.pubmedId : undefined}
             disabled={readOnly}
           />
 
@@ -299,9 +294,7 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
             title="Bibliographic Citation"
             defaultValue={newPublication.bibliographicCitation}
             placeholder="Citation"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.bibliographicCitation) ? validation.bibliographicCitation : undefined}
             disabled={readOnly}
           />
 
@@ -343,7 +336,7 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
             title="URL"
             defaultValue={newPublication.url}
             placeholder="https://example.org"
-            validators={[FormValidators.REQUIRED, FormValidators.URL]}
+            validators={[FormValidators.URL]}
             onChange={onChange}
             validation={(submitted || touched.url) ? validation.url : undefined}
             disabled={readOnly}
@@ -354,9 +347,7 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
             title="Access"
             defaultValue={newPublication.access}
             placeholder="Access"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={(submitted || touched.access) ? validation.access : undefined}
             disabled={readOnly}
           />
 

--- a/src/components/publications_list/PublicationList.tsx
+++ b/src/components/publications_list/PublicationList.tsx
@@ -23,7 +23,7 @@ export default function PublicationList(props: PublicationListProps): React.JSX.
       React.ComponentProps<typeof PublicationRow>
     >
       items={props.publications}
-      columnsToShow={props.columnsToShow ?? ['title', 'publishedDate', 'journal', 'url', 'doi', 'access']}
+      columnsToShow={props.columnsToShow ?? ['title', 'publishedDate', 'journal', 'doi']}
       onItemsChange={props.onPublicationChange}
       disabled={props.disabled}
       validation={props.validation}

--- a/src/components/workspaces_list/WorkspaceAddEdit.tsx
+++ b/src/components/workspaces_list/WorkspaceAddEdit.tsx
@@ -17,7 +17,6 @@ interface Validation {
   platform?: ValidationError
   url?: ValidationError
   description?: ValidationError
-  access?: ValidationError
 }
 
 const defaultWorkspace: Workspace = {
@@ -45,7 +44,6 @@ const calcErrors = (w: Workspace): Validation => {
     v.url = makeError('uri')
   }
   if (!w.description?.trim()) v.description = makeError('required')
-  if (!w.access?.trim()) v.access = makeError('required')
   return v
 }
 
@@ -145,17 +143,15 @@ export default function WorkspaceAddEdit(props: WorkspaceAddEditProps): React.JS
           />
           <FormField
             id="tools"
-            title="Tools (comma separated)"
-            defaultValue={workspace?.tools?.join(', ')}
-            placeholder="tool1, tool2"
-            onChange={({ value }: { value: string }) =>
-              onChange({
-                key: 'tools',
-                value: value
-                  .split(',')
-                  .map(t => t.trim())
-                  .filter(Boolean),
-              })}
+            title="Tools"
+            placeholder="Select or enter tools"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={[]}
+            defaultValue={workspace?.tools}
+            onChange={onChange}
             disabled={readOnly}
           />
           <FormField
@@ -163,9 +159,7 @@ export default function WorkspaceAddEdit(props: WorkspaceAddEditProps): React.JS
             title="Access"
             defaultValue={workspace?.access}
             placeholder="Access Type"
-            validators={[FormValidators.REQUIRED]}
             onChange={onChange}
-            validation={validation.access}
             disabled={readOnly}
           />
           <FormField

--- a/src/components/workspaces_list/WorkspaceList.tsx
+++ b/src/components/workspaces_list/WorkspaceList.tsx
@@ -23,7 +23,7 @@ export default function WorkspaceList(props: WorkspaceListProps): React.JSX.Elem
       React.ComponentProps<typeof WorkspaceRow>
     >
       items={props.workspaces}
-      columnsToShow={props.columnsToShow ?? ['name', 'platform', 'url', 'description', 'tools', 'access']}
+      columnsToShow={props.columnsToShow ?? ['name', 'platform', 'url', 'description']}
       onItemsChange={props.onWorkspaceChange}
       disabled={props.disabled}
       validation={props.validation}

--- a/src/pages/data_submission/v2/GeneralStudyInformation.tsx
+++ b/src/pages/data_submission/v2/GeneralStudyInformation.tsx
@@ -48,7 +48,6 @@ export const GeneralStudyInformation = (props: GeneralStudyInformationProps) => 
         type={FormFieldTypes.SELECT}
         selectOptions={StudyTypeProperty.STUDY_TYPE_OPTIONS}
         isCreatable={true}
-        validators={[FormValidators.REQUIRED]}
         selectConfig={{}}
         defaultValue={getStudyPropertyValueByKey(study, 'studyType')}
         onChange={(input: { key: string, value: unknown, isValid: boolean }) => {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -320,7 +320,6 @@ export interface Author extends Person {
 }
 
 export type Maintainer = Contact
-export type Presenter = Contact
 
 export interface Study {
   studyId: number
@@ -369,7 +368,7 @@ export interface Workspace {
   url: string
   description: string
   tools?: string[]
-  access: string
+  access?: string
   tags?: string[]
 }
 
@@ -719,37 +718,42 @@ export interface Closeout {
   signingOfficialId: number
 }
 
+export interface Presenter {
+  name?: string
+  email?: string
+}
+
 export interface Presentation {
   title: string
   date: string
-  url: string
-  authors: string
-  datasetCitation: string
+  url?: string
+  authors?: string
+  datasetCitation?: string
   citation: boolean
   presentationId: string
   studyId: string
-  presenter: Presenter
-  event: string
-  location: string
-  format: string
-  access: string
+  presenter?: Presenter
+  event?: string
+  location?: string
+  format?: string
+  access?: string
   tags?: string[]
 }
 
 export interface Publication {
   title: string
-  pubmedId: string
+  pubmedId?: string
   publishedDate: string
   authors: Array<Author>
-  bibliographicCitation: string
+  bibliographicCitation?: string
   datasetCitation: string
   citation: boolean
   publicationId: string
   studyId: string
   journal: string
   doi: string
-  url: string
-  access: string
+  url?: string
+  access?: string
   tags?: string[]
 }
 

--- a/src/utils/darFormUtils.ts
+++ b/src/utils/darFormUtils.ts
@@ -385,18 +385,10 @@ export const calcPublicationErrors = (newPublication: Partial<Publication>): Pub
       validation.authors = { valid: false, failed: failedCodes, perAuthor } as unknown as ValidationError
     }
   }
-  if (isStringEmpty(newPublication?.pubmedId)) validation.pubmedId = requiredError
-  if (isStringEmpty(newPublication?.bibliographicCitation)) validation.bibliographicCitation = requiredError
   if (isStringEmpty(newPublication?.datasetCitation)) validation.datasetCitation = requiredError
   if (isStringEmpty(newPublication?.journal)) validation.journal = requiredError
   if (isStringEmpty(newPublication?.doi)) validation.doi = requiredError
-  if (isStringEmpty(newPublication?.url)) {
-    validation.url = requiredError
-  }
-  else if (!FormValidators.URL.isValid(newPublication.url as string)) {
-    validation.url = { valid: false, failed: ['url'] }
-  }
-  if (isStringEmpty(newPublication?.access)) validation.access = requiredError
+
   return validation
 }
 
@@ -408,35 +400,8 @@ export const calcPresentationErrors = (newPresentation: Partial<Presentation>): 
     validation.title = requiredError
   }
   validation.date = <ValidationError>validateDate(newPresentation?.date)
-  if (isEmpty(newPresentation?.authors)) {
-    validation.authors = requiredError
-  }
-  if (isEmpty(newPresentation?.url)) {
-    validation.url = requiredError
-  }
-  if (isEmpty(newPresentation?.datasetCitation)) {
-    validation.datasetCitation = requiredError
-  }
   if (newPresentation?.citation === undefined || newPresentation?.citation === null) {
     validation.citation = requiredError
-  }
-  if (isEmpty(newPresentation?.presenter?.name)) {
-    validation.presenter.name = requiredError
-  }
-  if (isEmpty(newPresentation?.presenter?.email)) {
-    validation.presenter.email = requiredError
-  }
-  if (isEmpty(newPresentation?.event)) {
-    validation.event = requiredError
-  }
-  if (isEmpty(newPresentation?.location)) {
-    validation.location = requiredError
-  }
-  if (isEmpty(newPresentation?.format)) {
-    validation.format = requiredError
-  }
-  if (isEmpty(newPresentation?.access)) {
-    validation.access = requiredError
   }
   return validation
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2769

### Summary

This PR reduces submission friction by removing required-field validation for selected fields in Study Registration and related asset types (Featured Workspaces, Publications, and Presentations).

- **Study**: Study Type is no longer required.
- **Featured Workspace**: Access is no longer required.
- **Publication**: Bibliographic Citation, PubMed ID, URL, and Access are now optional.
- **Presentation**: URL, Authors/Author, Dataset Citation, Presenter Name, Presenter Email, Event, Location, Format, and Access are now optional.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
