### PR TITLE
[DT-2848] Set-state-in-effect part 1: Add init functions to address state updates

### DIFF
--- a/src/components/dar_dataset_table/DarDatasetTable.jsx
+++ b/src/components/dar_dataset_table/DarDatasetTable.jsx
@@ -124,12 +124,15 @@ export const DarDatasetTable = (props) => {
   }, [collection, isUnfilteredView, user])
 
   useEffect(() => {
-    try {
-      init()
+    const callInit = async () => {
+      try {
+        await init()
+      }
+      catch (_error) {
+        Notifications.showError({ text: 'Failed to initialize collection' })
+      }
     }
-    catch (_error) {
-      Notifications.showError({ text: 'Failed to initialize collection' })
-    }
+    callInit()
   }, [init])
 
   const changeTableSize = useCallback((value) => {

--- a/src/components/data_update/DatasetUpdate.jsx
+++ b/src/components/data_update/DatasetUpdate.jsx
@@ -140,9 +140,12 @@ export const DatasetUpdate = (props) => {
   }, [extract, normalizeDataUse])
 
   useEffect(() => {
-    if (isNil(formData.datasetName)) {
-      prefillFormData(dataset)
+    const init = async () => {
+      if (isNil(formData.datasetName)) {
+        await prefillFormData(dataset)
+      }
     }
+    init()
   }, [prefillFormData, dataset, formData])
 
   return (

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -116,7 +116,10 @@ export const StudyDetails = () => {
   }, [studyId, setDatasets])
 
   useEffect(() => {
-    getExportableDatasets(datasets)
+    const init = async () => {
+      await getExportableDatasets(datasets)
+    }
+    init()
   }, [datasets])
 
   const participantCount = datasets

--- a/src/pages/StudyUpdateForm.jsx
+++ b/src/pages/StudyUpdateForm.jsx
@@ -142,9 +142,12 @@ export const StudyUpdateForm = () => {
   }, [extractAllProperties])
 
   useEffect(() => {
-    if (isNil(formData.studyName) && !isEmpty(study)) {
-      prefillFormData(study)
+    const init = async () => {
+      if (isNil(formData.studyName) && !isEmpty(study)) {
+        await prefillFormData(study)
+      }
     }
+    init()
   }, [prefillFormData, study, formData])
 
   const datasets = formData.datasets

--- a/src/pages/dar_application/DucAddendum.jsx
+++ b/src/pages/dar_application/DucAddendum.jsx
@@ -112,7 +112,10 @@ export default function DucAddendum(props) {
   }, [datasets])
 
   useEffect(() => {
-    getBuckets()
+    const init = async () => {
+      await getBuckets()
+    }
+    init()
   }, [getBuckets])
 
   const buildDucAddendumTable = useCallback(async () => {
@@ -199,7 +202,10 @@ export default function DucAddendum(props) {
   }, [buckets, isLoading, dacs])
 
   useEffect(() => {
-    buildDucAddendumTable()
+    const init = async () => {
+      await buildDucAddendumTable()
+    }
+    init()
   }, [buildDucAddendumTable])
 
   return (

--- a/src/pages/dar_application/collaborator/CollaboratorForm.jsx
+++ b/src/pages/dar_application/collaborator/CollaboratorForm.jsx
@@ -38,19 +38,22 @@ export default function CollaboratorForm(props) {
   }
 
   useEffect(() => {
-    if (!isEmpty(collaborator)) {
-      setName(collaborator.name)
-      setEmail(collaborator.email)
-      setEraCommonsId(collaborator.eraCommonsId)
-      setTitle(collaborator.title)
-      setApproverStatus(collaborator.approverStatus)
-      setUuid(collaborator.uuid)
-      setCountryOfOperation(collaborator.countryOfOperation)
+    const init = async () => {
+      if (!isEmpty(collaborator)) {
+        setName(collaborator.name)
+        setEmail(collaborator.email)
+        setEraCommonsId(collaborator.eraCommonsId)
+        setTitle(collaborator.title)
+        setApproverStatus(collaborator.approverStatus)
+        setUuid(collaborator.uuid)
+        setCountryOfOperation(collaborator.countryOfOperation)
+      }
+      else {
+        setUuid(uuidV4())
+        setCountryOfOperation(Countries.DEFAULT_COUNTRY)
+      }
     }
-    else {
-      setUuid(uuidV4())
-      setCountryOfOperation(Countries.DEFAULT_COUNTRY)
-    }
+    init()
   }, [collaborator])
 
   const saveUpdate = () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2848

### Summary

The goal of this set of PRs is to decrease the number of warnings from ESLint to zero.

When you call state setters or async functions that update state directly in useEffect without wrapping them in an async function, it can cause React to warn about setting state during render or cause race conditions. By wrapping the logic in an async init function and calling it, the state updates happen properly after the effect runs, preventing these warnings and ensuring correct async behavior. This is the documented way to approach this problem: https://react.dev/reference/react/useEffect#fetching-data-with-effects

This decreases the number of ESLint warnings from 24 to 17 (-7).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
