### PR TITLE
[DT-2772] Add `Other` Data Location option and update URL handling

### DIFF
--- a/cypress/component/StudyAssets/consent_group_list.spec.tsx
+++ b/cypress/component/StudyAssets/consent_group_list.spec.tsx
@@ -5,14 +5,15 @@ import ConsentGroupList from 'src/components/consent_group_list/ConsentGroupList
 import ConsentGroupSummary from 'src/components/consent_group_list/ConsentGroupSummary'
 import ConsentGroupRow from 'src/components/consent_group_list/ConsentGroupRow'
 import {
-  testDeleteViaModal,
-  testViewModeFlow,
   testCloseViewMode,
+  testDeleteViaModal,
   testEditModeRender,
-  testViewModeRender,
-  testViewActionTrigger,
   testSummaryViewActionTrigger,
+  testViewActionTrigger,
+  testViewModeFlow,
+  testViewModeRender,
 } from './testUtils'
+import { DataLocationType } from 'src/pages/data_submission/v2/v2-models'
 
 const sampleConsentGroup: ConsentGroup2 = {
   consentGroupId: 'cg1',
@@ -22,7 +23,7 @@ const sampleConsentGroup: ConsentGroup2 = {
   generalResearchUse: true,
   irb: false,
   accessManagement: 'open',
-  dataLocation: 'Not Determined',
+  dataLocation: DataLocationType.NotDetermined,
 }
 
 const ConsentGroupListHarness: React.FC<{ initial: ConsentGroup2[] }> = ({ initial }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@types/react-dom": "18.3.1",
         "@types/react-modal": "3.16.3",
         "@vitejs/plugin-react": "5.1.2",
-        "cypress": "15.8.2",
+        "cypress": "15.9.0",
         "cypress-vite": "1.8.0",
         "eslint": "9.39.2",
         "eslint-plugin-cypress": "5.2.0",
@@ -96,7 +96,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -481,7 +480,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -525,7 +523,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1372,7 +1369,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.6.tgz",
       "integrity": "sha512-R4DaYF3dgCQCUAkr4wW1w26GHXcf5rCmBRHVBuuvJvaGLmZdD8EjatP80Nz5JCw0KxORAzwftnHzXVnjR8HnFw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -1483,7 +1479,6 @@
       "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.6.tgz",
       "integrity": "sha512-8fehAazkHNP1imMrdD2m2hbA9sl7Ur6jfuNweh5o4l9YPty4iaZzRXqYvBCWQNwFaSHmMEj2KPbyXGp7Bt73Rg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/private-theming": "^7.3.6",
@@ -2205,7 +2200,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2330,7 +2324,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -2588,7 +2581,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3149,7 +3141,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3652,9 +3643,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.8.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.2.tgz",
-      "integrity": "sha512-KGpuiE8o9l9eyVLPkig574t8zOXkEDKzI0a+RQwy4cfXzpaLipvTOv0t+QEEkLiw/8HbgMNZ0fbPKakJAB3USA==",
+      "version": "15.9.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.9.0.tgz",
+      "integrity": "sha512-Ks6Bdilz3TtkLZtTQyqYaqtL/WT3X3APKaSLhTV96TmTyudzSjc6EJsJCHmBb7DxO+3R12q3Jkbjgm/iPgmwfg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3836,8 +3827,7 @@
       "version": "1.11.19",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -4061,7 +4051,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -4332,7 +4321,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6224,7 +6212,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7848,7 +7835,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7930,7 +7916,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7943,7 +7928,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -8353,7 +8337,6 @@
       "integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9390,7 +9373,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9682,7 +9664,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9994,7 +9975,6 @@
       "integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/react-dom": "18.3.1",
     "@types/react-modal": "3.16.3",
     "@vitejs/plugin-react": "5.1.2",
-    "cypress": "15.8.2",
+    "cypress": "15.9.0",
     "cypress-vite": "1.8.0",
     "eslint": "9.39.2",
     "eslint-plugin-cypress": "5.2.0",

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -22,7 +22,6 @@ interface Validation {
   accessManagement?: ValidationError
   numberOfParticipants?: ValidationError
   dataAccessCommitteeId?: ValidationError
-  dataLocation?: ValidationError
   primaryConsent?: ValidationError
   gs?: ValidationError
   mor?: ValidationError
@@ -584,7 +583,6 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
           {/* location */}
           <div style={{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }}>
             <FormFieldTitle
-              required={true}
               title="Data Location"
               description="Please provide the location of your data resource for this consent group"
               disabled={readOnly}

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -616,10 +616,6 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                   setValidation(calcErrors(next))
                   setEditDataLocationUrl(false)
                 }
-                else if (value === 'Other') {
-                  onChange({ key, value })
-                  setEditDataLocationUrl(true)
-                }
                 else {
                   onChange({ key, value })
                   setEditDataLocationUrl(true)

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -602,6 +602,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                 'Terra Workspace',
                 'TDR Location',
                 'Not Determined',
+                'Other',
               ]}
               placeholder="Data Location(s)"
               defaultValue={current?.dataLocation}
@@ -614,6 +615,10 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                   setCurrent(next)
                   setValidation(calcErrors(next))
                   setEditDataLocationUrl(false)
+                }
+                else if (value === 'Other') {
+                  onChange({ key, value })
+                  setEditDataLocationUrl(true)
                 }
                 else {
                   onChange({ key, value })

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -166,7 +166,6 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
     if (showOtherPrimaryText && (!cg.otherPrimary?.trim())) {
       v.otherPrimary = makeError('required')
     }
-    if (!cg.dataLocation?.trim()) v.dataLocation = makeError('required')
     if (showGSText && (!cg.gs?.trim())) {
       v.gs = makeError('required')
     }
@@ -606,7 +605,6 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               ]}
               placeholder="Data Location(s)"
               defaultValue={current?.dataLocation}
-              validation={validation.dataLocation}
               onChange={({ key, value }: { key: string, value: string }) => {
                 if (value === 'Not Determined') {
                   const next = structuredClone(current)

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -7,6 +7,7 @@ import { AccessManagementType, ConsentGroup, ConsentGroup2, selectedPrimaryGroup
 import { DacPicker } from 'src/components/forms/DacPicker'
 import { FileInput } from 'src/components/forms/FileInput'
 import { DataSet } from 'src/libs/ajax/DataSet'
+import { DataLocationType } from 'src/pages/data_submission/v2/v2-models'
 
 interface ConsentGroupAddEditProps {
   readonly id: number
@@ -595,11 +596,11 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               name="dataLocation"
               type={FormFieldTypes.SELECT}
               selectOptions={[
-                'AnVIL Workspace',
-                'Terra Workspace',
-                'TDR Location',
-                'Not Determined',
-                'Other',
+                DataLocationType.AnVILWorkspace,
+                DataLocationType.TerraWorkspace,
+                DataLocationType.TDRLocation,
+                DataLocationType.NotDetermined,
+                DataLocationType.Other,
               ]}
               placeholder="Data Location(s)"
               defaultValue={current?.dataLocation}

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -431,6 +431,9 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
         else if (dataset.dataLocation === 'Not Determined') {
           dataLocation = 'Not Determined'
         }
+        else if (dataset.dataLocation === 'Other') {
+          dataLocation = dataset.url ? new URL(dataset.url).hostname : ''
+        }
         else {
           dataLocation = dataset.url
             ? <Link href={dataset.url}>External to DUOS</Link>

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -8,6 +8,7 @@ import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
 import { dataUseCellData } from 'src/components/dac_dataset_table/DACDatasetTableCellData'
 import 'src/components/data_search/DatasetSearch.css'
 import { muiCheckboxFix } from 'src/libs/muiThemeFix'
+import { DataLocationType } from 'src/pages/data_submission/v2/v2-models'
 
 export interface DatasetSearchTableTab<T> {
   key: string
@@ -420,18 +421,19 @@ export const makeDatasetTableHeader = (datasets: DatasetTerm[], selected: number
       cellStyle: makeHeaderStyle(cellWidths.dataLocation),
       cellDataFn: (dataset: DatasetTerm) => {
         let dataLocation
-        if (dataset.dataLocation === 'TDR Location') {
-          dataLocation = 'Terra Data Repo'
+        const TERRA_DATA_REPO = 'Terra Data Repo'
+        if (dataset.dataLocation === DataLocationType.TDRLocation) {
+          dataLocation = TERRA_DATA_REPO
         }
-        else if (dataset.dataLocation === 'Terra Workspace') {
+        else if (dataset.dataLocation === DataLocationType.TerraWorkspace) {
           dataLocation = dataset.url
-            ? <Link href={dataset.url}>Terra Workspace</Link>
-            : 'Terra Data Repo'
+            ? <Link href={dataset.url}>{DataLocationType.TerraWorkspace}</Link>
+            : TERRA_DATA_REPO
         }
-        else if (dataset.dataLocation === 'Not Determined') {
-          dataLocation = 'Not Determined'
+        else if (dataset.dataLocation === DataLocationType.NotDetermined) {
+          dataLocation = DataLocationType.NotDetermined
         }
-        else if (dataset.dataLocation === 'Other') {
+        else if (dataset.dataLocation === DataLocationType.Other) {
           dataLocation = dataset.url ? new URL(dataset.url).hostname : ''
         }
         else {

--- a/src/pages/data_submission/v2/v2-models.tsx
+++ b/src/pages/data_submission/v2/v2-models.tsx
@@ -541,16 +541,29 @@ export class AccessManagement extends StringDatasetProperty {
   }
 }
 
+export enum DataLocationType {
+  AnVILWorkspace = 'AnVIL Workspace',
+  TerraWorkspace = 'Terra Workspace',
+  TDRLocation = 'TDR Location',
+  NotDetermined = 'Not Determined',
+  Other = 'Other',
+}
+
 export class DataLocation extends StringDatasetProperty {
   static readonly schemaProperty = 'dataLocation'
   static readonly propertyName = 'Data Location'
-  static readonly VALUES = ['AnVIL Workspace', 'Terra Workspace', 'TDR Location', 'Not Determined', 'Other']
+  static readonly VALUES = [
+    DataLocationType.AnVILWorkspace,
+    DataLocationType.TerraWorkspace,
+    DataLocationType.TDRLocation,
+    DataLocationType.NotDetermined,
+    DataLocationType.Other,
+  ]
+
   constructor(value?: string, datasetId?: number, propertyId?: number) {
     super('Data Location', '', DataLocation.propertyName, DataLocation.schemaProperty, value, datasetId, propertyId)
   }
 }
-
-export type DataLocationType = 'AnVIL Workspace' | 'Terra Workspace' | 'TDR Location' | 'Not Determined' | 'Other'
 
 export class DataURL extends StringDatasetProperty {
   static readonly schemaProperty = 'url'

--- a/src/pages/data_submission/v2/v2-models.tsx
+++ b/src/pages/data_submission/v2/v2-models.tsx
@@ -544,13 +544,13 @@ export class AccessManagement extends StringDatasetProperty {
 export class DataLocation extends StringDatasetProperty {
   static readonly schemaProperty = 'dataLocation'
   static readonly propertyName = 'Data Location'
-  static readonly VALUES = ['AnVIL Workspace', 'Terra Workspace', 'TDR Location', 'Not Determined']
+  static readonly VALUES = ['AnVIL Workspace', 'Terra Workspace', 'TDR Location', 'Not Determined', 'Other']
   constructor(value?: string, datasetId?: number, propertyId?: number) {
     super('Data Location', '', DataLocation.propertyName, DataLocation.schemaProperty, value, datasetId, propertyId)
   }
 }
 
-export type DataLocationType = 'AnVIL Workspace' | 'Terra Workspace' | 'TDR Location' | 'Not Determined'
+export type DataLocationType = 'AnVIL Workspace' | 'Terra Workspace' | 'TDR Location' | 'Not Determined' | 'Other'
 
 export class DataURL extends StringDatasetProperty {
   static readonly schemaProperty = 'url'


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2772

### Summary

Adds an “Other” dropdown option, allows blank or valid URLs, and displays the URL domain in the Data Library when “Other” is selected.

<img width="1486" height="338" alt="After" src="https://github.com/user-attachments/assets/3ab58408-2884-4d0c-9b59-487548cf1874" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
