### PR TITLE
[DT-2849] Read feature flags from Consent

### DIFF
--- a/cypress/component/libs/ajax/FeatureFlag.spec.ts
+++ b/cypress/component/libs/ajax/FeatureFlag.spec.ts
@@ -1,0 +1,42 @@
+import { Config } from 'src/libs/config'
+import { getAllFeatureFlags, getFeatureFlag } from 'src/libs/ajax/FeatureFlag'
+
+describe('FeatureFlag ajax', () => {
+  let fetchStub: ReturnType<typeof cy.stub>
+
+  beforeEach(() => {
+    cy.initApplicationConfig()
+    cy.stub(Config, 'getApiUrl').resolves('')
+    cy.window().then((win) => {
+      fetchStub = cy.stub(win, 'fetch')
+    })
+  })
+
+  afterEach(() => {
+    cy.window().then(() => {
+      fetchStub.restore()
+    })
+  })
+
+  it('getAllFeatureFlags returns a map of flags', () => {
+    const response = { featureAlpha: 'on', featureBeta: 'off' }
+    cy.window().then((win) => {
+      fetchStub.resolves(new win.Response(JSON.stringify(response), { status: 200, headers: { 'content-type': 'application/json' } }))
+      cy.wrap(getAllFeatureFlags()).should('deep.equal', response)
+    })
+  })
+
+  it('getFeatureFlag returns the per-key value when available', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(new win.Response(JSON.stringify('enabled'), { status: 200, headers: { 'content-type': 'application/json' } }))
+      cy.wrap(getFeatureFlag('someFlag')).should('equal', 'enabled')
+    })
+  })
+
+  it('getFeatureFlag returns undefined when per-key endpoint errors', () => {
+    cy.window().then(() => {
+      fetchStub.rejects(new Error('Not found'))
+      cy.wrap(getFeatureFlag('missingFlag')).should('be.undefined')
+    })
+  })
+})

--- a/src/libs/ajax/FeatureFlag.ts
+++ b/src/libs/ajax/FeatureFlag.ts
@@ -1,0 +1,21 @@
+import { Config } from 'src/libs/config'
+import { fetchGet } from 'src/libs/ajax/fetchAdapter'
+
+type FeatureFlagValue = string
+
+export async function getAllFeatureFlags(): Promise<Record<string, FeatureFlagValue> | FeatureFlagValue[]> {
+  const url = `${await Config.getApiUrl()}/api/featureFlags`
+  const res = await fetchGet<Record<string, FeatureFlagValue> | FeatureFlagValue[]>(url, Config.authOpts())
+  return res.data
+}
+
+export async function getFeatureFlag(key: string): Promise<FeatureFlagValue | undefined> {
+  const url = `${await Config.getApiUrl()}/api/featureFlags/${encodeURIComponent(key)}`
+  try {
+    const res = await fetchGet<FeatureFlagValue>(url, Config.authOpts())
+    return res.data
+  }
+  catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2849

### Summary

Adds the ability for code to read feature flags from Consent.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
