### PR TITLE
[DT-2848] Set-state-in-effect part 2: Switch useEffect to useMemo

### DIFF
--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.tsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { get, isEmpty, isNil } from 'lodash'
 import { Storage } from 'src/libs/storage'
 import { convertLabelToKey } from 'src/libs/utils'
@@ -156,9 +156,6 @@ export default function MultiDatasetVoteSlab({
   updateFinalVote,
   reloadFn,
 }: MultiDatasetVoteSlabProps) {
-  const [currentUserVotes, setCurrentUserVotes] = useState<Vote[]>([])
-  const [dacVotes, setDacVotes] = useState<Vote[]>([])
-  const [isDMI, setIsDMI] = useState(false)
   const { algorithmResult } = bucket
   const getMemberVoteSectionTitle = () => {
     if (adminPage) return 'DAC Member Votes'
@@ -166,23 +163,23 @@ export default function MultiDatasetVoteSlab({
     return 'Other DAC Member\'s Votes'
   }
 
-  useEffect(() => {
+  const isDMI = React.useMemo(() => {
     const sorted = Object.values(collection.dars).sort(
       (a, b) => new Date(b.submissionDate).getTime() - new Date(a.submissionDate).getTime(),
     )
     const mostRecentDar = sorted.at(0)
     const darData = mostRecentDar?.data
 
-    if (darData && Object.keys(darData).includes('dmi')) {
-      setIsDMI(true)
-    }
+    return darData && Object.keys(darData).includes('dmi')
+  }, [collection.dars])
 
+  const { dacVotes, currentUserVotes } = React.useMemo(() => {
     const user = Storage.getCurrentUser()
-    setDacVotes(extractDacDataAccessVotesFromBucket(bucket, user, adminPage))
-    setCurrentUserVotes(
-      extractUserDataAccessVotesFromBucket(bucket, user, isChair, adminPage),
-    )
-  }, [bucket, isChair, adminPage, collection.dars])
+    return {
+      dacVotes: extractDacDataAccessVotesFromBucket(bucket, user, adminPage),
+      currentUserVotes: extractUserDataAccessVotesFromBucket(bucket, user, isChair, adminPage),
+    }
+  }, [bucket, isChair, adminPage])
 
   return (
     <div style={styles.baseStyle} data-cy="dataset-vote-slab">

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.jsx
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { DataUseTranslation } from '../../libs/dataUseTranslation'
 import { isEmpty, isNil, flatMap, keys, get } from 'lodash'
 import { DataUsePills } from './DataUsePill'
@@ -163,14 +163,15 @@ export const ChairVoteInfo = ({ dacVotes, isChair, adminPage = false }) => {
 
 export default function ResearchProposalVoteSlab(props) {
   const [expanded, setExpanded] = useState(false)
-  const [currentUserVotes, setCurrentUserVotes] = useState([])
-  const [dacVotes, setDacVotes] = useState([])
   const { darInfo, bucket, isChair, isLoading, readOnly, adminPage, updateFinalVote } = props
   const translatedDataUse = !isNil(darInfo) ? DataUseTranslation.translateDarInfo(darInfo) : {}
-  useEffect(() => {
+
+  const { dacVotes, currentUserVotes } = useMemo(() => {
     const user = Storage.getCurrentUser()
-    setDacVotes(extractDacRPVotesFromBucket(bucket, user, adminPage))
-    setCurrentUserVotes(extractUserRPVotesFromBucket(bucket, user, isChair, adminPage))
+    return {
+      dacVotes: extractDacRPVotesFromBucket(bucket, user, adminPage),
+      currentUserVotes: extractUserRPVotesFromBucket(bucket, user, isChair, adminPage),
+    }
   }, [bucket, isChair, adminPage])
 
   return (

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { VoteHistoryRow } from 'src/types/model'
 import { Styles } from 'src/libs/theme'
@@ -47,7 +47,6 @@ const styles = {
 }
 
 const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHistory }) => {
-  const [sortedVotes, setSortedVotes] = useState<RowData[][]>([])
   const [sort, setSort] = useState({ colIndex: 5, dir: -1 }) // Default sort by voteDate descending
 
   const columnHeaderFormat = {
@@ -88,11 +87,11 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
     return rowData
   }, [])
 
-  useEffect(() => {
-    setSortedVotes(sortVisibleTable({
+  const sortedVotes = useMemo(() => {
+    return sortVisibleTable({
       list: processVoteHistoryRowData(voteHistory),
       sort,
-    }) as RowData[][])
+    }) as RowData[][]
   }, [sort, voteHistory, processVoteHistoryRowData])
 
   return (

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { Styles } from 'src/libs/theme'
 import { formatDate, sortVisibleTable } from '../../libs/utils'
@@ -82,7 +82,6 @@ interface TableData {
 
 const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> = ({ electionsWithMemberVotes }) => {
   const [expandedElections, setExpandedElections] = useState<Set<number>>(new Set())
-  const [sortedElections, setSortedElections] = useState<RowData[][]>([])
   const [sort, setSort] = useState({ colIndex: 2, dir: -1 }) // Default sort by election date descending
 
   const toggleElectionExpansion = useCallback((electionId: number) => {
@@ -165,11 +164,11 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
     return renderedRow
   }, [electionIsExpanded])
 
-  useEffect(() => {
-    setSortedElections(sortVisibleTable({
+  const sortedElections = useMemo(() => {
+    return sortVisibleTable({
       list: processElectionRowData(electionsWithMemberVotes),
       sort,
-    }) as RowData[][])
+    }) as RowData[][]
   }, [sort, electionsWithMemberVotes, processElectionRowData])
 
   return (

--- a/src/components/vote_summary_table/VoteSummaryTable.jsx
+++ b/src/components/vote_summary_table/VoteSummaryTable.jsx
@@ -1,8 +1,7 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { Styles } from 'src/libs/theme'
 import { isNil, isEmpty } from 'lodash'
-import { useEffect, useState } from 'react'
 import { formatDate, Notifications, sortVisibleTable } from 'src/libs/utils'
 import { Email } from 'src/libs/ajax/Email'
 
@@ -143,7 +142,6 @@ function rationaleCellData({ rationale = '- -', voteId, label = 'rationale' }) {
 
 export default function VoteSummaryTable(props) {
   const [sort, setSort] = useState({ colIndex: 0, dir: -1 })
-  const [visibleVotes, setVisibleVotes] = useState([])
   const [tableSize, setTableSize] = useState(5)
   const { dacVotes, isLoading, isChair = false } = props
 
@@ -166,31 +164,36 @@ export default function VoteSummaryTable(props) {
     })
   }
 
+  const visibleVotes = React.useMemo(() => {
+    return sortVisibleTable({
+      list: processVoteSummaryRowData({ dacVotes, isChair, getReminderSentState, sendReminder: (voteId) => {
+        const sendReminder = (voteId) => {
+          updateReminderState(voteId, ReminderStates.SENDING)
+
+          Email.sendReminderEmail(voteId)
+            .then(() => {
+              Notifications.showSuccess({ text: 'Successfully sent reminder.' })
+              updateReminderState(voteId, ReminderStates.SENT)
+            })
+            .catch(() => {
+              Notifications.showError({ text: 'There was an issue sending the reminder. Please try again later.' })
+              updateReminderState(voteId, undefined)
+            })
+        }
+        sendReminder(voteId)
+      } }),
+      sort,
+    })
+  }, [dacVotes, isChair, getReminderSentState, sort])
+
   useEffect(() => {
-    const sendReminder = (voteId) => {
-      updateReminderState(voteId, ReminderStates.SENDING)
-
-      Email.sendReminderEmail(voteId)
-        .then(() => {
-          Notifications.showSuccess({ text: 'Successfully sent reminder.' })
-          updateReminderState(voteId, ReminderStates.SENT)
-        })
-        .catch(() => {
-          Notifications.showError({ text: 'There was an issue sending the reminder. Please try again later.' })
-          updateReminderState(voteId, undefined)
-        })
+    const init = async () => {
+      if (!isEmpty(dacVotes)) {
+        setTableSize(dacVotes.length)
+      }
     }
-
-    setVisibleVotes(
-      sortVisibleTable({
-        list: processVoteSummaryRowData({ dacVotes, isChair, getReminderSentState, sendReminder }),
-        sort,
-      }),
-    )
-    if (!isEmpty(dacVotes)) {
-      setTableSize(dacVotes.length)
-    }
-  }, [sort, dacVotes, isChair, getReminderSentState])
+    init()
+  }, [dacVotes])
 
   return (
     <SimpleTable


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2848

### Summary

The goal of this set of PRs is to decrease the number of warnings from ESLint to zero.

This PR removes a number of `set-state-in-effect` anti-patterns which cause extra renders and stale state bugs. This replaces several effect driven state updates with memoized computations or direct constants instead.

This decreases the number of ESLint warnings from 17 to 12 (-5).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
