### PR TITLE
[DT-2848] Set-state-in-effect part 3: Mirror props to state

### DIFF
--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { isEmpty, isNil } from 'lodash'
 import CollectionVoteYesButton from './CollectionVoteYesButton'
 import CollectionVoteNoButton from './CollectionVoteNoButton'
@@ -143,6 +143,8 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
     reloadFn = () => {},
   } = props
 
+  const [prevVotes, setPrevVotes] = useState<Vote[] | undefined>(undefined)
+
   const isElectionClosed = useMemo(() => {
     return votes.filter(v => v.electionStatus?.toLowerCase() === 'open').length === 0
   }, [votes])
@@ -151,7 +153,8 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
     return props.isDisabled || (isFinal && submitted) || adminPage
   }, [props.isDisabled, isFinal, submitted, adminPage])
 
-  useEffect(() => {
+  if (votes !== prevVotes) {
+    setPrevVotes(votes)
     if (!isEmpty(votes)) {
       const prevVote = votes[0]
 
@@ -169,7 +172,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
       const radar = votes.some(vote => vote.type === VOTE_TYPES.RADAR_APPROVE)
       setIsRadar(radar)
     }
-  }, [votes])
+  }
 
   const updateVote = async (newVote: boolean, isChair: boolean) => {
     setVoteInProgress(true)

--- a/src/components/forms/forms.jsx
+++ b/src/components/forms/forms.jsx
@@ -252,14 +252,14 @@ export const FormField = (config) => {
 
   const typeDefaultValue = isFunction(type.defaultValue) ? type.defaultValue(config) : type.defaultValue
   const [formValue, setFormValue] = useState(typeDefaultValue || '')
+  const [prevDefaultValue, setPrevDefaultValue] = useState(defaultValue)
 
   const required = (validators || []).includes(FormValidators.REQUIRED)
 
-  useEffect(() => {
-    if (defaultValue !== undefined) {
-      setFormValue(defaultValue)
-    }
-  }, [defaultValue, type])
+  if (defaultValue !== undefined && defaultValue !== prevDefaultValue) {
+    setPrevDefaultValue(defaultValue)
+    setFormValue(defaultValue)
+  }
 
   useEffect(() => {
     validateFormProps(config)

--- a/src/components/study_asset/StudyAssetList.tsx
+++ b/src/components/study_asset/StudyAssetList.tsx
@@ -1,5 +1,5 @@
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import AddObjectButton from 'src/components/AddObjectButton'
 
 interface StudyAssetListProps<
@@ -64,17 +64,13 @@ export default function StudyAssetList<
 
   const filteredColumnsToShow = columnsToShow.filter((c): c is keyof T => typeof c === 'string')
 
-  useEffect(() => {
-    if (editState.length !== items.length) {
-      setEditState(items.map(() => false))
-    }
-  }, [items, editState.length])
+  if (editState.length !== items.length) {
+    setEditState(items.map(() => false))
+  }
 
-  useEffect(() => {
-    if (viewState.length !== items.length) {
-      setViewState(items.map(() => false))
-    }
-  }, [items, viewState.length])
+  if (viewState.length !== items.length) {
+    setViewState(items.map(() => false))
+  }
 
   const toggleEditState = (index: number) => {
     setEditState((es) => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2848

### Summary

The goal of this set of PRs is to decrease the number of warnings from ESLint to zero.

This PR removes a number of set-state-in-effect anti-patterns which cause extra renders and stale state bugs. In this case, the `useEffect` hooks are replaced with state from derived props directly, preventing state updates inside render cycles.

This decreases the number of ESLint warnings from 12 to 8 (-4).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
