### PR TITLE
[DT-2832] Add feature flag for newer versions of ElasticSearch

### DIFF
--- a/cypress/component/libs/ajax/FeatureFlag.spec.ts
+++ b/cypress/component/libs/ajax/FeatureFlag.spec.ts
@@ -1,5 +1,5 @@
 import { Config } from 'src/libs/config'
-import { getAllFeatureFlags, getFeatureFlag } from 'src/libs/ajax/FeatureFlag'
+import { getAllFeatureFlags, getFeatureFlag, getFlagEsIndexKeyName, resetEsIndexKeyNamePromise } from 'src/libs/ajax/FeatureFlag'
 
 describe('FeatureFlag ajax', () => {
   let fetchStub: ReturnType<typeof cy.stub>
@@ -21,14 +21,24 @@ describe('FeatureFlag ajax', () => {
   it('getAllFeatureFlags returns a map of flags', () => {
     const response = { featureAlpha: 'on', featureBeta: 'off' }
     cy.window().then((win) => {
-      fetchStub.resolves(new win.Response(JSON.stringify(response), { status: 200, headers: { 'content-type': 'application/json' } }))
+      fetchStub.resolves(
+        new win.Response(JSON.stringify(response), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
       cy.wrap(getAllFeatureFlags()).should('deep.equal', response)
     })
   })
 
   it('getFeatureFlag returns the per-key value when available', () => {
     cy.window().then((win) => {
-      fetchStub.resolves(new win.Response(JSON.stringify('enabled'), { status: 200, headers: { 'content-type': 'application/json' } }))
+      fetchStub.resolves(
+        new win.Response(JSON.stringify('enabled'), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
       cy.wrap(getFeatureFlag('someFlag')).should('equal', 'enabled')
     })
   })
@@ -37,6 +47,49 @@ describe('FeatureFlag ajax', () => {
     cy.window().then(() => {
       fetchStub.rejects(new Error('Not found'))
       cy.wrap(getFeatureFlag('missingFlag')).should('be.undefined')
+    })
+  })
+})
+
+describe('FeatureFlag tests for ES_TYPE_TO_INDEX_ENABLED flag', () => {
+  let fetchStub: ReturnType<typeof cy.stub>
+
+  beforeEach(() => {
+    resetEsIndexKeyNamePromise()
+    cy.initApplicationConfig()
+    cy.stub(Config, 'getApiUrl').resolves('')
+    cy.window().then((win) => {
+      fetchStub = cy.stub(win, 'fetch')
+    })
+  })
+
+  afterEach(() => {
+    cy.window().then(() => {
+      fetchStub.restore()
+    })
+  })
+
+  it('getFlagEsIndexKeyName returns "_index" when the ES_TYPE_TO_INDEX_ENABLED flag is "true"', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify('true'), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      cy.wrap(getFlagEsIndexKeyName()).should('equal', '_index')
+    })
+  })
+
+  it('getFlagEsIndexKeyName returns "_type" when the ES_TYPE_TO_INDEX_ENABLED flag is not "true"', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify('false'), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+      cy.wrap(getFlagEsIndexKeyName()).should('equal', '_type')
     })
   })
 })

--- a/src/libs/ajax/FeatureFlag.ts
+++ b/src/libs/ajax/FeatureFlag.ts
@@ -4,13 +4,13 @@ import { fetchGet } from 'src/libs/ajax/fetchAdapter'
 type FeatureFlagValue = string
 
 export async function getAllFeatureFlags(): Promise<Record<string, FeatureFlagValue> | FeatureFlagValue[]> {
-  const url = `${await Config.getApiUrl()}/api/featureFlags`
+  const url = `${await Config.getApiUrl()}/feature`
   const res = await fetchGet<Record<string, FeatureFlagValue> | FeatureFlagValue[]>(url, Config.authOpts())
   return res.data
 }
 
 export async function getFeatureFlag(key: string): Promise<FeatureFlagValue | undefined> {
-  const url = `${await Config.getApiUrl()}/api/featureFlags/${encodeURIComponent(key)}`
+  const url = `${await Config.getApiUrl()}/feature/${encodeURIComponent(key)}`
   try {
     const res = await fetchGet<FeatureFlagValue>(url, Config.authOpts())
     return res.data
@@ -18,4 +18,23 @@ export async function getFeatureFlag(key: string): Promise<FeatureFlagValue | un
   catch {
     return undefined
   }
+}
+
+// Cache the ES index key name to avoid repeated feature flag lookups
+let esIndexKeyNamePromise: Promise<string> | undefined = undefined
+
+export const getFlagEsIndexKeyName = (): Promise<string> => {
+  if (esIndexKeyNamePromise === undefined) {
+    esIndexKeyNamePromise = getFeatureFlag('ES_TYPE_TO_INDEX_ENABLED').then((flag) => {
+      return flag === 'true' ? '_index' : '_type'
+    }).catch(() => {
+      return '_type'
+    })
+  }
+  return esIndexKeyNamePromise
+}
+
+// Function to reset the cached ES index key name for testing
+export const resetEsIndexKeyNamePromise = () => {
+  esIndexKeyNamePromise = undefined
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2832

### Summary

Add a feature flag for newer versions of ElasticSearch.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
