### PR TITLE
[DT-2830] If there's no DAA associated with the DAR, return '-'

### DIFF
--- a/src/pages/dar_application/RequiredDAAs.jsx
+++ b/src/pages/dar_application/RequiredDAAs.jsx
@@ -11,6 +11,9 @@ export default function RequiredDAAs(props) {
       return <div key={dataset.dataSetId + '-' + index}></div>
     }
     const daa = daas.find(daa => daa.dacs?.some(d => d.dacId === datasetDacId))
+    if (!daa) {
+      return <div key={dataset.dataSetId + '-' + index}></div>
+    }
     const id = daa.daaId
     const fileName = daa.file.fileName.split('.')[0]
     if (fileNames.has(fileName)) {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2830](https://broadworkbench.atlassian.net/browse/DT-2830) - See console bug screenshot in ticket.

### Summary

Simple patch to allow me to continue to evaluate DAA features.  This bug was preventing new DARs from being created when the feature was turned on.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
