### PR TITLE
[DT-2832] Switch to dynamic elasticsearch index flag

### DIFF
--- a/cypress/component/DataSearch/dataset_search_table.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_table.spec.jsx
@@ -23,7 +23,7 @@ const datasets = [
 ]
 
 const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery) => {
-  const base = [{ match: { _type: 'dataset' } }, { exists: { field: 'study' } }]
+  const base = []
   if (!isSigningOfficial || !isInstitutionQuery) base.push({ term: { 'study.publicVisibility': true } })
   if (subQuery) base.push(subQuery)
   return { from: 0, size: 10000, query: { bool: { must: base } } }

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -12,6 +12,7 @@ import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel
 import { DatasetSearchFooter } from 'src/components/data_search/DatasetSearchFooter'
 import { applyForAccess } from 'src/utils/accessUtils'
 import { usePageTitle } from 'src/hooks/usePageTitle'
+import { getFlagEsIndexKeyName } from 'src/libs/ajax/FeatureFlag'
 
 interface SectionProps {
   style?: React.CSSProperties
@@ -84,35 +85,39 @@ export const StudyDetails = () => {
   }
 
   useEffect(() => {
-    const query = {
-      from: 0,
-      size: 10000,
-      query: {
-        bool: {
-          must: [
-            {
-              match: {
-                _type: 'dataset',
+    const init = async () => {
+      const esIndexKeyName = await getFlagEsIndexKeyName()
+      const query = {
+        from: 0,
+        size: 10000,
+        query: {
+          bool: {
+            must: [
+              {
+                match: {
+                  [esIndexKeyName]: 'dataset',
+                },
               },
-            },
-            {
-              match: {
-                'study.studyId': studyId,
+              {
+                match: {
+                  'study.studyId': studyId,
+                },
               },
-            },
-            {
-              exists: {
-                field: 'study',
+              {
+                exists: {
+                  field: 'study',
+                },
               },
-            },
-          ],
+            ],
+          },
         },
-      },
+      }
+      DataSet.searchDatasetIndex(query).then((datasets) => {
+        setDatasets(datasets)
+        setLoading(false)
+      })
     }
-    DataSet.searchDatasetIndex(query).then((datasets) => {
-      setDatasets(datasets)
-      setLoading(false)
-    })
+    init()
   }, [studyId, setDatasets])
 
   useEffect(() => {

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -10,13 +10,13 @@ import { Metrics } from 'src/libs/ajax/Metrics'
 import eventList from 'src/libs/events'
 import { useParams, useNavigate } from 'react-router-dom'
 import { usePageTitle } from 'src/hooks/usePageTitle'
-import { getFlagNhgriDacId } from 'src/libs/ajax/FeatureFlag.ts'
+import { getFlagEsIndexKeyName, getFlagNhgriDacId } from 'src/libs/ajax/FeatureFlag'
 
-const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery, nhgriDacId) => {
+const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery, nhgriDacId, esIndexKeyName) => {
   const queryChunks = [
     {
       match: {
-        _type: 'dataset',
+        [esIndexKeyName]: 'dataset',
       },
     },
     {
@@ -93,6 +93,7 @@ export const DatasetSearch = (props) => {
   const [queryState, setQueryState] = useState(query)
   const [loading, setLoading] = useState(true)
   const [nhgriDacId, setNhgriDacId] = useState(null)
+  const [esIndexKeyName, setEsIndexKeyName] = useState(null)
   const user = Storage.getCurrentUser()
 
   const isSigningOfficial = user.isSigningOfficial
@@ -112,13 +113,24 @@ export const DatasetSearch = (props) => {
 
   // Memoize fullQuery to prevent recreation on every render
   const fullQuery = useMemo(
-    () => assembleFullQuery(isSigningOfficial, isInstitutionQuery, version.query, nhgriDacId),
-    [isSigningOfficial, isInstitutionQuery, version.query, nhgriDacId],
+    () => {
+      if (!esIndexKeyName) return null
+      return assembleFullQuery(isSigningOfficial, isInstitutionQuery, version.query, nhgriDacId, esIndexKeyName)
+    },
+    [isSigningOfficial, isInstitutionQuery, version.query, nhgriDacId, esIndexKeyName],
   )
 
   const isInstitutionSet = institutionId === undefined && isInstitutionQuery
 
   const hasChangedPage = query !== queryState
+
+  useEffect(() => {
+    const init = async () => {
+      const keyName = await getFlagEsIndexKeyName()
+      setEsIndexKeyName(keyName)
+    }
+    init()
+  }, [])
 
   useEffect(() => {
     const init = async () => {
@@ -137,7 +149,7 @@ export const DatasetSearch = (props) => {
 
   useEffect(() => {
     const init = async () => {
-      if (loading || hasChangedPage) {
+      if ((loading || hasChangedPage) && fullQuery) {
         if (isInstitutionSet) {
           Notifications.showError({ text: 'You must set an institution in your profile to view the `myinstitution` data library' })
           navigate('/profile')

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -16,6 +16,7 @@ import { getDataLocationLink } from 'src/utils/DataLocationUtils'
 import { createDataUseDisplay } from 'src/utils/DataUseUtils'
 import { useParams, useNavigate } from 'react-router-dom'
 import { usePageTitle } from 'src/hooks/usePageTitle'
+import { getFlagEsIndexKeyName } from 'src/libs/ajax/FeatureFlag'
 
 const LINE = <div style={{ borderTop: '1px solid #BABEC1', height: 0 }} />
 
@@ -94,12 +95,13 @@ export default function DatasetStatistics() {
   useEffect(() => {
     const init = async () => {
       try {
+        const esIndexKeyName = await getFlagEsIndexKeyName()
         const datasetTerms: DatasetTerm[] = await DataSet.searchDatasetIndex({ query: {
           bool: {
             must: [
               {
                 match: {
-                  _type: 'dataset',
+                  [esIndexKeyName]: 'dataset',
                 },
               },
               {

--- a/src/pages/researcher_console/DatasetSubmissions.jsx
+++ b/src/pages/researcher_console/DatasetSubmissions.jsx
@@ -10,6 +10,7 @@ import { Storage } from 'src/libs/storage'
 import styles from './DatasetTerms.module.css'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import AddObjectButton from 'src/components/AddObjectButton.tsx'
+import { getFlagEsIndexKeyName } from 'src/libs/ajax/FeatureFlag'
 
 export default function DatasetSubmissions() {
   const [terms, setTerms] = useState([])
@@ -23,6 +24,7 @@ export default function DatasetSubmissions() {
     const init = async () => {
       const user = Storage.getCurrentUser()
       setCurrentUser(user)
+      const esIndexKeyName = await getFlagEsIndexKeyName()
       const query = {
         from: 0,
         size: 10000,
@@ -31,7 +33,7 @@ export default function DatasetSubmissions() {
             must: [
               {
                 match: {
-                  _type: 'dataset',
+                  [esIndexKeyName]: 'dataset',
                 },
               },
               {

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -20,6 +20,7 @@ import {
 import { Notifications } from 'src/libs/utils'
 import { extractError } from 'src/utils/ErrorUtils'
 import { ControlledAccessType } from 'src/libs/dataUseTranslation'
+import { getFlagEsIndexKeyName } from 'src/libs/ajax/FeatureFlag'
 
 export interface Bucket {
   key: string
@@ -334,6 +335,7 @@ const createRpVoteStructureFromBuckets = (buckets: Bucket[]): Array<{ rp: VoteGr
  * data use information so the UI doesn't have to reprocess it.
  */
 const getDatasetTerms = async (datasets: Dataset[]): Promise<DatasetTerm[]> => {
+  const esIndexKeyName = await getFlagEsIndexKeyName()
   const datasetQuery = DataSet.searchDatasetIndex({
     from: 0,
     size: 10000,
@@ -342,7 +344,7 @@ const getDatasetTerms = async (datasets: Dataset[]): Promise<DatasetTerm[]> => {
         must: [
           {
             match: {
-              _type: 'dataset',
+              [esIndexKeyName]: 'dataset',
             },
           },
           {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2832

### Summary

Dynamically switches the Elasticsearch index key name based on the appropriate feature flag.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
