### PR TITLE
[DT-2870] Cancel in-progress tests when pushing new commits

### DIFF
--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -1,5 +1,8 @@
 on: [pull_request]
 name: cypress component tests
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,8 @@
 on: [pull_request]
 name: cypress integration tests
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   cypress-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 on: [pull_request]
 name: Lint Changed Files
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2870

### Summary

This wastes compute time, causes errors, and otherwise sends unnecessary notifications if there’s a failure.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
