### PR TITLE
[DT-2873] Switch _type to _index

### DIFF
--- a/cypress/component/DataSearch/dataset_search_table.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_table.spec.jsx
@@ -23,7 +23,7 @@ const datasets = [
 ]
 
 const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery) => {
-  const base = [{ match: { _type: 'dataset' } }, { exists: { field: 'study' } }]
+  const base = []
   if (!isSigningOfficial || !isInstitutionQuery) base.push({ term: { 'study.publicVisibility': true } })
   if (subQuery) base.push(subQuery)
   return { from: 0, size: 10000, query: { bool: { must: base } } }

--- a/cypress/component/libs/ajax/FeatureFlag.spec.ts
+++ b/cypress/component/libs/ajax/FeatureFlag.spec.ts
@@ -3,9 +3,8 @@ import {
   FeatureFlag,
   getAllFeatureFlags,
   getFeatureFlag,
-  getFlagEsIndexKeyName,
   getFlagNhgriDacId,
-  resetEsIndexKeyNamePromise, resetNhgriDacIdPromise,
+  resetNhgriDacIdPromise,
 } from 'src/libs/ajax/FeatureFlag'
 
 describe('FeatureFlag ajax', () => {
@@ -122,5 +121,4 @@ const createFlagTestSuite = <T>(
   })
 }
 
-createFlagTestSuite('ES_TYPE_TO_INDEX_ENABLED', getFlagEsIndexKeyName, resetEsIndexKeyNamePromise, { id: 'ES_TYPE_TO_INDEX_ENABLED', value: 'true', createDate: 123, updateDate: 456 }, '_index', '_type')
 createFlagTestSuite('NHGRI_RESTRICTED_DAC', getFlagNhgriDacId, resetNhgriDacIdPromise, { id: 'NHGRI_RESTRICTED_DAC', value: 'dac-id', createDate: 123, updateDate: 456 }, 'dac-id')

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -92,7 +92,7 @@ export const StudyDetails = () => {
           must: [
             {
               match: {
-                _type: 'dataset',
+                _index: 'dataset',
               },
             },
             {

--- a/src/libs/ajax/FeatureFlag.ts
+++ b/src/libs/ajax/FeatureFlag.ts
@@ -25,25 +25,6 @@ export async function getFeatureFlag(key: string): Promise<FeatureFlag | undefin
   }
 }
 
-// Cache the ES index key name to avoid repeated feature flag lookups
-let esIndexKeyNamePromise: Promise<string> | undefined = undefined
-
-export const getFlagEsIndexKeyName = (): Promise<string> => {
-  if (esIndexKeyNamePromise === undefined) {
-    esIndexKeyNamePromise = getFeatureFlag('ES_TYPE_TO_INDEX_ENABLED').then((flag: FeatureFlag | undefined) => {
-      return flag?.value === 'true' ? '_index' : '_type'
-    }).catch(() => {
-      return '_type'
-    })
-  }
-  return esIndexKeyNamePromise
-}
-
-// Function to reset the cached ES index key name for testing
-export const resetEsIndexKeyNamePromise = () => {
-  esIndexKeyNamePromise = undefined
-}
-
 // Cache the NHGRI DAC ID to avoid repeated feature flag lookups
 let nhgriDacIdPromise: Promise<string | undefined> | undefined = undefined
 

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -16,7 +16,7 @@ const assembleFullQuery = (isSigningOfficial, isInstitutionQuery, subQuery, nhgr
   const queryChunks = [
     {
       match: {
-        _type: 'dataset',
+        _index: 'dataset',
       },
     },
     {

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -99,7 +99,7 @@ export default function DatasetStatistics() {
             must: [
               {
                 match: {
-                  _type: 'dataset',
+                  _index: 'dataset',
                 },
               },
               {

--- a/src/pages/researcher_console/DatasetSubmissions.jsx
+++ b/src/pages/researcher_console/DatasetSubmissions.jsx
@@ -31,7 +31,7 @@ export default function DatasetSubmissions() {
             must: [
               {
                 match: {
-                  _type: 'dataset',
+                  _index: 'dataset',
                 },
               },
               {

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -342,7 +342,7 @@ const getDatasetTerms = async (datasets: Dataset[]): Promise<DatasetTerm[]> => {
         must: [
           {
             match: {
-              _type: 'dataset',
+              _index: 'dataset',
             },
           },
           {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2873

### Summary

Now that we changed the name of the index from `duos-dataset` to `dataset`, this simplifies how we can extract information out of the search index. This also prepares us for future use of Elasticsearch 9 or OpenSearch 3.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
