### PR TITLE
[DT-2871] Add `Biospecimens` Placeholder

### DIFF
--- a/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
@@ -28,6 +28,7 @@ describe('StudyAssetManagement component', () => {
       { title: 'Clinical Trials', desc: 'Add clinical trials associated with this study' },
       { title: 'Intellectual Property', desc: 'Add patents or other IP related to this study' },
       { title: 'Funding Resources', desc: 'Add grants and funding sources for this study' },
+      { title: 'Biospecimens', desc: 'View total biospecimens for this study' },
     ]
 
     cy.contains('Study Assets').should('exist')

--- a/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
@@ -1,6 +1,16 @@
 import React from 'react'
 import { StudyAssetManagement } from 'src/pages/data_submission/v2/StudyAssetManagement'
 import { Study } from 'src/pages/data_submission/v2/v2-models'
+import { Biospecimen, BioSpecimenPreservationMethod, BioSpecimenType } from 'src/types/model'
+
+const sampleBiospecimens: Biospecimen[] = [{
+  biospecimenId: 'SPEC-001',
+  studyId: 'STUDY-001',
+  donorId: 'DONOR-001',
+  specimenType: BioSpecimenType.BLOOD,
+  preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+  organization: 'Johns Hopkins Hospital',
+}]
 
 const baseStudy: Study = {
   assets: {
@@ -11,6 +21,7 @@ const baseStudy: Study = {
     clinicalTrials: [],
     intellectualProperty: [],
     funding: [],
+    biospecimens: sampleBiospecimens,
   },
 } as unknown as Study
 
@@ -38,5 +49,21 @@ describe('StudyAssetManagement component', () => {
       cy.contains('h3', title).should('exist')
       cy.contains(desc).should('exist')
     }
+  })
+
+  it('does not render biospecimens section when biospecimens array is empty', () => {
+    const baseStudyNoBiospecimens = {
+      ...baseStudy,
+      assets: {
+        ...baseStudy.assets,
+        biospecimens: [],
+      },
+    }
+
+    const setStudySpy = cy.spy().as('setStudySpy')
+    cy.mount(<StudyAssetManagement study={baseStudyNoBiospecimens} setStudy={setStudySpy} />)
+
+    cy.contains('h3', 'Biospecimens').should('not.exist')
+    cy.contains('View total biospecimens for this study').should('not.exist')
   })
 })

--- a/cypress/component/StudyAssets/StudyAssetList.spec.tsx
+++ b/cypress/component/StudyAssets/StudyAssetList.spec.tsx
@@ -79,6 +79,7 @@ function mountStudyAssetList(
   options: {
     disabled?: boolean
     columnsToShow?: (keyof TestAsset)[]
+    addButtonIcon?: React.ReactNode
   } = {},
 ) {
   return cy.mount(
@@ -91,6 +92,7 @@ function mountStudyAssetList(
       RowComponent={TestRowComponent}
       addButtonId="add-test-btn"
       addButtonLabel="Add Test Item"
+      addButtonIcon={options.addButtonIcon}
       getValidationState={getValidationState}
       getAddEditProps={getDefaultAddEditProps}
       getRowProps={getDefaultRowProps}
@@ -177,5 +179,21 @@ describe('StudyAssetList', () => {
   it('disables add button when disabled prop is true', () => {
     mountStudyAssetList([], cy.stub(), { disabled: true })
     cy.get('#add-test-btn').should('be.disabled')
+  })
+
+  it('renders button with custom icon', () => {
+    const customIcon = <span data-testid="custom-icon">★</span>
+    mountStudyAssetList([], cy.stub(), { addButtonIcon: customIcon })
+
+    cy.get('[data-testid="custom-icon"]').should('exist')
+    cy.get('[data-testid="custom-icon"]').should('contain', '★')
+  })
+
+  it('removes default icon when empty string is passed', () => {
+    mountStudyAssetList([], cy.stub(), { addButtonIcon: '' })
+
+    cy.get('#add-test-btn').within(() => {
+      cy.get('.glyphicon-plus').should('not.exist')
+    })
   })
 })

--- a/cypress/component/StudyAssets/biospecimen_list.spec.tsx
+++ b/cypress/component/StudyAssets/biospecimen_list.spec.tsx
@@ -1,0 +1,266 @@
+import React from 'react'
+import BiospecimenAddEdit from 'src/components/biospecimen_list/BiospecimenAddEdit'
+import BiospecimenList from 'src/components/biospecimen_list/BiospecimenList'
+import BiospecimenRow from 'src/components/biospecimen_list/BiospecimenRow'
+import BiospecimenSummary from 'src/components/biospecimen_list/BiospecimenSummary'
+import { Biospecimen, BioSpecimenPreservationMethod, BioSpecimenType } from 'src/types/model'
+import { testDeleteViaModal } from './testUtils'
+
+const sampleBiospecimen: Biospecimen = {
+  biospecimenId: 'SPEC-001',
+  studyId: 'STUDY-001',
+  donorId: 'DONOR-001',
+  specimenType: BioSpecimenType.BLOOD,
+  preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+  organization: 'Johns Hopkins Hospital',
+}
+
+const BiospecimenListHarness: React.FC<{ initial: Biospecimen[] }> = ({ initial }) => {
+  const [items, setItems] = React.useState<Biospecimen[]>(initial)
+  return (
+    <BiospecimenList
+      biospecimens={items}
+      columnsToShow={['donorId', 'specimenType', 'preservationMethod']}
+      onBiospecimenChange={setItems}
+      disabled={false}
+    />
+  )
+}
+
+describe('BiospecimenList component', () => {
+  it('renders custom button label with count', () => {
+    cy.mount(<BiospecimenListHarness initial={[sampleBiospecimen]} />)
+    cy.get('#add-biospecimen-btn').should('contain', '1')
+  })
+
+  it('renders button label with zero count when empty', () => {
+    cy.mount(<BiospecimenListHarness initial={[]} />)
+    cy.get('#add-biospecimen-btn').should('contain', '0')
+  })
+
+  it('renders button without default icon', () => {
+    cy.mount(<BiospecimenListHarness initial={[]} />)
+    cy.get('#add-biospecimen-btn').within(() => {
+      cy.get('.glyphicon-plus').should('not.exist')
+    })
+  })
+
+  it('updates button label when biospecimens count changes', () => {
+    const state: Biospecimen[] = [sampleBiospecimen]
+    cy.mount(
+      <BiospecimenList
+        biospecimens={state}
+        columnsToShow={['donorId']}
+        onBiospecimenChange={(b) => { state.splice(0, state.length, ...b) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-biospecimen-btn').should('contain', '1')
+  })
+
+  it('shows all default columns when none are provided', () => {
+    const state: Biospecimen[] = []
+    cy.mount(
+      <BiospecimenList
+        biospecimens={state}
+        onBiospecimenChange={(b) => { state.splice(0, state.length, ...b) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-biospecimen-btn').should('exist')
+  })
+
+  it('deletes a model via modal confirmation', () => {
+    testDeleteViaModal(
+      () => cy.mount(<BiospecimenListHarness initial={[sampleBiospecimen]} />),
+      sampleBiospecimen.biospecimenId,
+    )
+  })
+})
+
+describe('BiospecimenAddEdit component', () => {
+  it('renders null when not in read-only mode', () => {
+    cy.mount(
+      <BiospecimenAddEdit
+        id={-1}
+        biospecimen={undefined}
+        biospecimens={[]}
+        closeAction={cy.stub().as('close')}
+        onBiospecimensChange={cy.stub()}
+      />,
+    )
+    cy.get('body').should('exist')
+  })
+
+  it('renders null in edit mode', () => {
+    cy.mount(
+      <BiospecimenAddEdit
+        id={0}
+        biospecimen={sampleBiospecimen}
+        biospecimens={[sampleBiospecimen]}
+        closeAction={cy.stub().as('close')}
+        onBiospecimensChange={cy.stub()}
+      />,
+    )
+    cy.get('body').should('exist')
+  })
+
+  it('renders null even with readOnly prop', () => {
+    cy.mount(
+      <BiospecimenAddEdit
+        id={-1}
+        biospecimen={undefined}
+        biospecimens={[]}
+        closeAction={cy.stub().as('close')}
+        onBiospecimensChange={cy.stub()}
+        readOnly={true}
+      />,
+    )
+    cy.get('body').should('exist')
+  })
+})
+
+describe('BiospecimenSummary', () => {
+  it('renders biospecimen details', () => {
+    cy.mount(
+      <BiospecimenSummary
+        biospecimen={sampleBiospecimen}
+        columnsToShow={['donorId', 'specimenType', 'preservationMethod', 'organization']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains(sampleBiospecimen.donorId).should('exist')
+    cy.contains(sampleBiospecimen.specimenType).should('exist')
+    cy.contains(sampleBiospecimen.preservationMethod).should('exist')
+    cy.contains(sampleBiospecimen.organization).should('exist')
+  })
+
+  it('renders only specified columns', () => {
+    cy.mount(
+      <BiospecimenSummary
+        biospecimen={sampleBiospecimen}
+        columnsToShow={['specimenType', 'donorId']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains(sampleBiospecimen.specimenType).should('exist')
+    cy.contains(sampleBiospecimen.donorId).should('exist')
+  })
+
+  it('renders view button and triggers viewAction', () => {
+    cy.mount(
+      <BiospecimenSummary
+        biospecimen={sampleBiospecimen}
+        columnsToShow={['specimenType']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        viewAction={cy.stub().as('view')}
+        disabled={false}
+      />,
+    )
+    cy.get('.glyphicon-eye-open').should('exist')
+    cy.get('.glyphicon-eye-open').click({ force: true })
+    cy.get('@view').should('have.been.calledOnce')
+  })
+
+  it('renders edit button and triggers editAction', () => {
+    cy.mount(
+      <BiospecimenSummary
+        biospecimen={sampleBiospecimen}
+        columnsToShow={['specimenType']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('.glyphicon-pencil').should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+})
+
+describe('BiospecimenRow', () => {
+  it('shows summary when not in edit mode', () => {
+    cy.mount(
+      <BiospecimenRow
+        id={0}
+        editMode={false}
+        biospecimen={sampleBiospecimen}
+        biospecimens={[sampleBiospecimen]}
+        columnsToShow={['donorId', 'specimenType']}
+        editAction={cy.stub().as('edit')}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onBiospecimensChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.contains(sampleBiospecimen.specimenType).should('exist')
+    cy.get('.glyphicon-pencil').click({ force: true })
+    cy.get('@edit').should('have.been.calledOnce')
+  })
+
+  it('renders edit form when editMode true', () => {
+    cy.mount(
+      <BiospecimenRow
+        id={0}
+        editMode={true}
+        biospecimen={sampleBiospecimen}
+        biospecimens={[sampleBiospecimen]}
+        columnsToShow={['specimenType']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        onBiospecimensChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    // Since BiospecimenAddEdit returns null, verifying the component renders
+    cy.get('body').should('exist')
+  })
+
+  it('renders view form when viewMode true and is read-only', () => {
+    cy.mount(
+      <BiospecimenRow
+        id={0}
+        editMode={false}
+        viewMode={true}
+        biospecimen={sampleBiospecimen}
+        biospecimens={[sampleBiospecimen]}
+        columnsToShow={['specimenType']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        viewAction={cy.stub()}
+        onBiospecimensChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('body').should('exist')
+  })
+
+  it('triggers viewAction when view button is clicked', () => {
+    cy.mount(
+      <BiospecimenRow
+        id={0}
+        editMode={false}
+        viewMode={false}
+        biospecimen={sampleBiospecimen}
+        biospecimens={[sampleBiospecimen]}
+        columnsToShow={['donorId', 'specimenType']}
+        editAction={cy.stub()}
+        deleteAction={cy.stub()}
+        closeAction={cy.stub()}
+        viewAction={cy.stub().as('view')}
+        onBiospecimensChange={cy.stub()}
+        disabled={false}
+      />,
+    )
+    cy.get('.glyphicon-eye-open').click({ force: true })
+    cy.get('@view').should('have.been.calledOnce')
+  })
+})

--- a/src/components/biospecimen_list/BiospecimenAddEdit.tsx
+++ b/src/components/biospecimen_list/BiospecimenAddEdit.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Biospecimen } from 'src/types/model'
+
+interface BiospecimenAddEditProps {
+  readonly id: number
+  readonly biospecimen?: Biospecimen
+  readonly biospecimens: Biospecimen[]
+  readonly closeAction: () => void
+  readonly onBiospecimensChange: (models: Biospecimen[]) => void
+  readonly readOnly?: boolean
+}
+
+export default function BiospecimenAddEdit(_props: BiospecimenAddEditProps): React.JSX.Element | null {
+  return null
+}

--- a/src/components/biospecimen_list/BiospecimenList.tsx
+++ b/src/components/biospecimen_list/BiospecimenList.tsx
@@ -1,0 +1,58 @@
+import { Biospecimen } from 'src/types/model'
+import { DarErrors } from 'src/pages/dar_application/FormValidationState'
+import React from 'react'
+import StudyAssetList from 'src/components/study_asset/StudyAssetList'
+import BiospecimenAddEdit from 'src/components/biospecimen_list/BiospecimenAddEdit'
+import BiospecimenRow from 'src/components/biospecimen_list/BiospecimenRow'
+
+export default function BiospecimenList(props: {
+  readonly biospecimens: Biospecimen[]
+  readonly columnsToShow?: (keyof Biospecimen)[]
+  readonly onBiospecimenChange: (biospecimens: Biospecimen[]) => void
+  readonly disabled?: boolean
+  readonly validation?: DarErrors
+  readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
+}) {
+  return (
+    <StudyAssetList<
+      Biospecimen,
+      DarErrors,
+      React.ComponentProps<typeof BiospecimenAddEdit>,
+      React.ComponentProps<typeof BiospecimenRow>
+    >
+      items={[]} // Pass empty array to prevent listing biospecimens in the main list, as they are not managed by UI
+      columnsToShow={props.columnsToShow ?? ['donorId', 'specimenType', 'preservationMethod', 'organization']}
+      onItemsChange={props.onBiospecimenChange}
+      disabled={props.disabled}
+      validation={props.validation}
+      AddEditComponent={BiospecimenAddEdit}
+      RowComponent={BiospecimenRow}
+      addButtonId="add-biospecimen-btn"
+      addButtonLabel={`${props.biospecimens.length}`}
+      addButtonIcon=""
+      getValidationState={v => v?.aiModels}
+      studyAssetWrapper={props.studyAssetWrapper}
+      getAddEditProps={(items, closeAction, onItemsChange) => ({
+        id: -1,
+        biospecimens: items,
+        closeAction,
+        onBiospecimensChange: onItemsChange,
+      })}
+      getRowProps={baseProps => ({
+        id: baseProps.index,
+        editMode: baseProps.editMode,
+        viewMode: baseProps.viewMode,
+        biospecimen: baseProps.item,
+        biospecimens: baseProps.items,
+        viewAction: baseProps.viewAction,
+        editAction: baseProps.editAction,
+        deleteAction: baseProps.deleteAction,
+        closeAction: baseProps.closeAction,
+        onBiospecimensChange: baseProps.onItemsChange,
+        columnsToShow: baseProps.columnsToShow,
+        disabled: baseProps.disabled,
+      })}
+      getItemKey={item => item.biospecimenId}
+    />
+  )
+}

--- a/src/components/biospecimen_list/BiospecimenRow.tsx
+++ b/src/components/biospecimen_list/BiospecimenRow.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import BiospecimenAddEdit from './BiospecimenAddEdit'
+import BiospecimenSummary from './BiospecimenSummary'
+import { Biospecimen } from 'src/types/model'
+import StudyAssetRow from 'src/components/study_asset/StudyAssetRow'
+
+interface BiospecimenRowProps {
+  readonly id: number
+  readonly editMode: boolean
+  readonly viewMode?: boolean
+  readonly biospecimen: Biospecimen
+  readonly biospecimens: Biospecimen[]
+  readonly columnsToShow?: (keyof Biospecimen)[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly closeAction: () => void
+  readonly viewAction?: () => void
+  readonly onBiospecimensChange: (models: Biospecimen[]) => void
+  readonly disabled: boolean
+}
+
+export default function BiospecimenRow(props: BiospecimenRowProps): React.JSX.Element {
+  const {
+    id,
+    editMode,
+    viewMode,
+    biospecimen,
+    biospecimens,
+    columnsToShow,
+    editAction,
+    deleteAction,
+    closeAction,
+    viewAction,
+    onBiospecimensChange,
+    disabled,
+  } = props
+
+  return (
+    <StudyAssetRow
+      id={id}
+      editMode={editMode}
+      viewMode={viewMode}
+      asset={biospecimen}
+      assets={biospecimens}
+      columnsToShow={columnsToShow}
+      editAction={editAction}
+      deleteAction={deleteAction}
+      closeAction={closeAction}
+      viewAction={viewAction}
+      onAssetsChange={onBiospecimensChange}
+      disabled={disabled}
+      AddEditComponent={BiospecimenAddEdit}
+      SummaryComponent={BiospecimenSummary}
+      addEditProps={{
+        id,
+        biospecimen,
+        biospecimens,
+        closeAction,
+        onBiospecimensChange,
+      }}
+      summaryProps={{
+        biospecimen,
+        columnsToShow,
+        editAction,
+        deleteAction,
+        viewAction,
+        disabled,
+      }}
+    />
+  )
+}

--- a/src/components/biospecimen_list/BiospecimenSummary.tsx
+++ b/src/components/biospecimen_list/BiospecimenSummary.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Biospecimen } from 'src/types/model'
+import StudyAssetSummary from 'src/components/study_asset/StudyAssetSummary'
+
+export default function BiospecimenSummary(props: {
+  readonly biospecimen: Biospecimen
+  readonly columnsToShow?: (keyof Biospecimen)[]
+  readonly editAction: () => void
+  readonly deleteAction: () => void
+  readonly viewAction?: () => void
+  readonly disabled?: boolean
+}) {
+  const { biospecimen, columnsToShow, editAction, deleteAction, viewAction, disabled } = props
+
+  return (
+    <StudyAssetSummary
+      asset={biospecimen}
+      columnsToShow={columnsToShow}
+      name={biospecimen.specimenType}
+      objectName="Biospecimen"
+      editAction={editAction}
+      deleteAction={deleteAction}
+      viewAction={viewAction}
+      disabled={disabled}
+    />
+  )
+}

--- a/src/components/study_asset/StudyAssetList.tsx
+++ b/src/components/study_asset/StudyAssetList.tsx
@@ -17,6 +17,7 @@ interface StudyAssetListProps<
   readonly RowComponent: React.ComponentType<RowProps>
   readonly addButtonId: string
   readonly addButtonLabel: string
+  readonly addButtonIcon?: React.ReactNode
   readonly getValidationState: (validation?: V) => ValidationError | undefined
   readonly studyAssetWrapper?: (content: React.ReactNode, button: React.ReactNode) => React.ReactNode
   readonly getAddEditProps: (items: T[], closeAction: () => void, onItemsChange: (items: T[]) => void) => AddEditProps
@@ -52,6 +53,7 @@ export default function StudyAssetList<
   RowComponent,
   addButtonId,
   addButtonLabel,
+  addButtonIcon,
   getValidationState,
   studyAssetWrapper,
   getAddEditProps,
@@ -104,6 +106,7 @@ export default function StudyAssetList<
       onClick={() => setShowAddEdit(true)}
       disabled={disabled}
       hasValidationError={!!getValidationState(validation)}
+      icon={addButtonIcon}
     />
   )
 

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -5,7 +5,6 @@ import PresentationList from 'src/components/presentations_list/PresentationList
 import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
 import {
   AiModel,
-  Biospecimen,
   ClinicalTrial,
   FundingResource,
   IntellectualProperty,
@@ -201,22 +200,25 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
         )}
       />
 
-      <BiospecimenList
-        biospecimens={biospecimens}
-        onBiospecimenChange={(biospecimens: Biospecimen[]) => onAssetChange('biospecimens', biospecimens)}
-        disabled={false}
-        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
-          <StudyAsset
-            config={{
-              icon: <Biotech fontSize="large" />,
-              title: 'Biospecimens',
-              description: 'View total biospecimens for this study',
-              children: content,
-              button: button,
-            }}
-          />
-        )}
-      />
+      {/* Only show biospecimen section if there are biospecimens to display */}
+      {biospecimens.length > 0 && (
+        <BiospecimenList
+          biospecimens={biospecimens}
+          onBiospecimenChange={() => {}} // Biospecimens are not editable through the UI, so we pass an empty change handler
+          disabled={false}
+          studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+            <StudyAsset
+              config={{
+                icon: <Biotech fontSize="large" />,
+                title: 'Biospecimens',
+                description: 'View total biospecimens for this study',
+                children: content,
+                button: button,
+              }}
+            />
+          )}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -5,6 +5,7 @@ import PresentationList from 'src/components/presentations_list/PresentationList
 import IntellectualPropertyList from 'src/components/intellectual_property_list/IntellectualPropertyList'
 import {
   AiModel,
+  Biospecimen,
   ClinicalTrial,
   FundingResource,
   IntellectualProperty,
@@ -27,6 +28,8 @@ import LaptopMacIcon from '@mui/icons-material/LaptopMac'
 import LocalHospitalIcon from '@mui/icons-material/LocalHospital'
 import ConsentGroupList from 'src/components/consent_group_list/ConsentGroupList'
 import { ConsentGroup2 } from '../consent_group/consentGroupUtils'
+import BiospecimenList from 'src/components/biospecimen_list/BiospecimenList'
+import { Biotech } from '@mui/icons-material'
 
 export interface StudyAssetManagementProps {
   study: Study
@@ -55,6 +58,7 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
   const intellectualProperties = study.assets?.intellectualProperties || []
   const fundingResources = study.assets?.funding || []
   const consentGroups = study.assets?.consentGroups || []
+  const biospecimens = study.assets?.biospecimens || []
 
   return (
     <div className="data-submitter-section">
@@ -190,6 +194,23 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
               icon: <AttachMoneyIcon fontSize="large" />,
               title: 'Funding Resources',
               description: 'Add grants and funding sources for this study',
+              children: content,
+              button: button,
+            }}
+          />
+        )}
+      />
+
+      <BiospecimenList
+        biospecimens={biospecimens}
+        onBiospecimenChange={(biospecimens: Biospecimen[]) => onAssetChange('biospecimens', biospecimens)}
+        disabled={false}
+        studyAssetWrapper={(content: ReactNode, button: ReactNode) => (
+          <StudyAsset
+            config={{
+              icon: <Biotech fontSize="large" />,
+              title: 'Biospecimens',
+              description: 'View total biospecimens for this study',
               children: content,
               button: button,
             }}

--- a/src/pages/data_submission/v2/v2-models.tsx
+++ b/src/pages/data_submission/v2/v2-models.tsx
@@ -1,5 +1,6 @@
 import {
   AiModel,
+  Biospecimen,
   ClinicalTrial,
   Dataset,
   FileStorageObject,
@@ -372,6 +373,7 @@ export interface Study {
     clinicalTrials?: Array<ClinicalTrial>
     funding?: Array<FundingResource>
     intellectualProperties?: Array<IntellectualProperty>
+    biospecimens?: Array<Biospecimen>
   }
 }
 export interface DatasetRegistrationSchemaV1 {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2871

### Summary

Adds a Biospecimens section that appears only when biospecimens exist, showing a count. 

Also ensures that biospecimens are preserved when updating datasets or studies, even though there is no dedicated biospecimens UI in the S4R forms.

Linking to the Data Library cannot be achieved until these tickets are completed:
- https://broadworkbench.atlassian.net/browse/DT-2854
- https://broadworkbench.atlassian.net/browse/DT-2510

<img width="3600" height="7024" alt="After" src="https://github.com/user-attachments/assets/91aa8d44-77de-4896-ab12-9dfb4b8ac06e" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
