### PR TITLE
[DT-2836] Fix dataset count plurality

### DIFF
--- a/src/components/data_search/DatasetSearchTableDisplay.tsx
+++ b/src/components/data_search/DatasetSearchTableDisplay.tsx
@@ -130,13 +130,14 @@ export const DatasetSearchTableDisplay = (props: DatasetSearchTableDisplayProps)
       >
         {rows.length}
         {' '}
-        {capitalize(rows.length < 1 ? tab.plural : tab.singular)}
+        {capitalize(rows.length === 1 ? tab.singular : tab.plural)}
       </div>
       {
         isEmpty(visibleRows)
           ? (
               <div style={{ fontWeight: 600, marginTop: '0.5rem' }}>
                 There are no
+                {' '}
                 {tab.plural}
                 {' '}
                 that fit these criteria.


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2836

### Summary

Updates the Data Library dataset count to use correct singular/plural formatting:

- 1 → “1 Dataset”
- 0 or >1 → “N Datasets”
- Ensures proper grammatical agreement in the UI.

**None**
<img width="1782" height="504" alt="None" src="https://github.com/user-attachments/assets/c02df09b-6ce7-4b54-a7d5-22bb19440ecd" />

**One**
<img width="1782" height="457" alt="One" src="https://github.com/user-attachments/assets/c65f1491-0725-4e13-bdc0-662dc7105e7f" />

**More than One**
<img width="1782" height="504" alt="More than One" src="https://github.com/user-attachments/assets/d8d45a21-9abc-4da6-8384-4c4828fc43ce" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
