### PR TITLE
[DT-2856] Add PMID help text with Through.Bio link to Publications form

### DIFF
--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -241,6 +241,8 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
 
   const headerTitle = getHeaderTitle(readOnly, publication)
 
+  const throughBioLink = (<a href="https://through.bio" target="_blank" rel="noopener noreferrer">Through.Bio</a>)
+
   return (
     <div className="form-group row no-margin">
       <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12 collaborator-form-card">
@@ -283,6 +285,15 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
           <FormField
             id="pubmedId"
             title="PubMed ID"
+            helpText={(
+              <>Tip: Adding a PubMed ID (PMID) helps DUOS link your publication to your
+                {' '}
+                {throughBioLink}
+                {' '}
+                page and promote your research. Learn more at{' '}
+                {throughBioLink}.
+              </>
+            )}
             defaultValue={newPublication.pubmedId}
             placeholder="PubMed ID"
             onChange={onChange}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2856

### Summary

Adds contextual help text next to the PMID field on the Publications form to encourage users to enter a PubMed ID. The text explains that PMIDs help DUOS link publications to Through.Bio pages and promote research visibility.

Includes a clickable [Through.Bio](https://through.bio/) link that opens in a new tab.

<img width="1563" height="916" alt="After" src="https://github.com/user-attachments/assets/7e48807c-9ce7-488a-bd83-0cb9ebc23653" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
