### PR TITLE
DT-2535: Point to consent version of the autocomplete API

### DIFF
--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -56,7 +56,7 @@ export const DAR = {
   },
 
   getAutoCompleteOT: async (partial) => {
-    const url = `${await Config.getOntologyUrl()}/autocomplete?q=${partial}`
+    const url = `${await Config.getApiUrl()}/ontology/autocomplete?q=${partial}`
     const res = await fetchGet(url, Config.authOpts())
     return res.data
   },


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2535

## Summary
Update the UI to use the new autocomplete API in Consent
Requires https://github.com/DataBiosphere/consent/pull/2804

### Example Usage
<img width="1430" height="1068" alt="Screenshot 2026-02-12 at 9 03 34 AM" src="https://github.com/user-attachments/assets/3f47809d-dc73-48f5-b23c-e37c8003f469" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
