### PR TITLE
[DT-2459] Start of new data library

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { DataLibrary } from 'src/pages/DataLibrary'
+
+describe('DataLibrary', () => {
+  it('renders the data library page', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/']}>
+        <DataLibrary />
+      </MemoryRouter>,
+    )
+
+    cy.contains('DUOS Data Library').should('be.visible')
+    cy.contains('Search, filter, and select datasets').should('be.visible')
+    cy.get('input[placeholder="Enter search terms"]').should('exist')
+  })
+
+  it('initializes tab based on URL search params', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/?tab=datasets']}>
+        <DataLibrary />
+      </MemoryRouter>,
+    )
+
+    // Should be on Datasets tab (bold font-weight: 700)
+    cy.get('button').contains('Datasets').should('have.css', 'font-weight', '700')
+    cy.get('button').contains('Studies').should('have.css', 'font-weight', '400')
+  })
+
+  it('switches tabs and updates URL state', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/']}>
+        <DataLibrary />
+      </MemoryRouter>,
+    )
+
+    // Initially on Studies
+    cy.get('button').contains('Studies').should('have.css', 'font-weight', '700')
+
+    // Click Datasets
+    cy.get('button').contains('Datasets').click()
+
+    // Now on Datasets
+    cy.get('button').contains('Datasets').should('have.css', 'font-weight', '700')
+    cy.get('button').contains('Studies').should('have.css', 'font-weight', '400')
+  })
+})

--- a/cypress/component/Hooks/useLibraryUrlState.spec.tsx
+++ b/cypress/component/Hooks/useLibraryUrlState.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
+import { AssetType } from 'src/types/library'
+
+const TestComponent = () => {
+  const [state, updateState] = useLibraryUrlState()
+  return (
+    <div>
+      <div id="library">{state.library}</div>
+      <div id="tab">{state.tab}</div>
+      <button id="update-tab" onClick={() => updateState({ tab: AssetType.DATASETS })}>Update Tab</button>
+      <button id="update-library" onClick={() => updateState({ library: 'test' })}>Update Library</button>
+      <button id="clear-library" onClick={() => updateState({ library: '' })}>Clear Library</button>
+    </div>
+  )
+}
+
+describe('useLibraryUrlState', () => {
+  it('initializes with default values when no search params are present', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+    cy.get('#library').should('have.text', 'duos')
+    cy.get('#tab').should('have.text', AssetType.STUDIES)
+  })
+
+  it('initializes with values from search params', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/?library=test&tab=datasets']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+    cy.get('#library').should('have.text', 'test')
+    cy.get('#tab').should('have.text', AssetType.DATASETS)
+  })
+
+  it('updates state via updateState', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+
+    cy.get('#update-tab').click()
+    cy.get('#tab').should('have.text', AssetType.DATASETS)
+
+    cy.get('#update-library').click()
+    cy.get('#library').should('have.text', 'test')
+
+    // Test clearing a value (deleting from params)
+    cy.get('#clear-library').click()
+    cy.get('#library').should('have.text', 'duos') // back to default
+  })
+})

--- a/cypress/component/data_library/LibraryTabs.spec.tsx
+++ b/cypress/component/data_library/LibraryTabs.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { LibraryTabs } from 'src/components/data_library/LibraryTabs'
+import { AssetType } from 'src/types/library'
+
+describe('LibraryTabs', () => {
+  const tabs = [
+    { key: AssetType.STUDIES, label: 'Studies' },
+    { key: AssetType.DATASETS, label: 'Datasets' },
+  ]
+
+  it('renders all tabs', () => {
+    cy.mount(
+      <LibraryTabs
+        value={AssetType.STUDIES}
+        onChange={() => {}}
+        tabs={tabs}
+      />,
+    )
+    cy.contains('Studies').should('be.visible')
+    cy.contains('Datasets').should('be.visible')
+  })
+
+  it('highlights the active tab', () => {
+    // Note: Mui Tab uses 'font-weight: 700' for bold and '400' for normal
+    cy.mount(
+      <LibraryTabs
+        value={AssetType.DATASETS}
+        onChange={() => {}}
+        tabs={tabs}
+      />,
+    )
+    cy.contains('Datasets').should('have.css', 'font-weight', '700')
+    cy.contains('Studies').should('have.css', 'font-weight', '400')
+  })
+
+  it('calls onChange when a tab is clicked', () => {
+    const onChange = cy.stub().as('onChange')
+    cy.mount(
+      <LibraryTabs
+        value={AssetType.STUDIES}
+        onChange={onChange}
+        tabs={tabs}
+      />,
+    )
+
+    cy.contains('Datasets').click()
+    cy.get('@onChange').should('have.been.calledWith', AssetType.DATASETS)
+  })
+})

--- a/src/components/data_library/LibraryTabs.tsx
+++ b/src/components/data_library/LibraryTabs.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Tabs, Tab, Box } from '@mui/material'
+import { LibraryTabsProps } from 'src/types/library'
+
+export const LibraryTabs: React.FC<LibraryTabsProps> = ({
+  value,
+  onChange,
+  tabs,
+}) => {
+  return (
+    <Box
+      sx={{
+        borderBottom: 1,
+        borderColor: 'divider',
+        paddingLeft: '5rem',
+        paddingRight: '5rem',
+      }}
+    >
+      <Tabs
+        value={value}
+        onChange={(_event, newValue) => onChange(newValue)}
+        aria-label="library view tabs"
+        slotProps={{
+          indicator: {
+            style: { backgroundColor: '#00609f' },
+          },
+        }}
+      >
+        {tabs.map(tab => (
+          <Tab
+            key={tab.key}
+            value={tab.key}
+            label={tab.label}
+            sx={{
+              textTransform: 'none',
+              fontSize: '15px',
+              fontFamily: 'Montserrat, sans-serif',
+              color: '#00609f',
+              fontWeight: value === tab.key ? 'bold' : 'normal',
+              padding: '0 25px',
+            }}
+          />
+        ))}
+      </Tabs>
+    </Box>
+  )
+}
+
+export default LibraryTabs

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -1,0 +1,39 @@
+import { useSearchParams } from 'react-router-dom'
+import { AssetType, LibraryUrlState } from 'src/types/library'
+
+const updateParams = (params: URLSearchParams, updates: Partial<LibraryUrlState>, key: string) => {
+  const value = updates[key as keyof LibraryUrlState]
+  if (value !== undefined) {
+    if (value) {
+      params.set(key, value)
+    }
+    else {
+      params.delete(key)
+    }
+  }
+  return params
+}
+
+/**
+ * Custom hook to manage library state in URL search params
+ * @returns [state, updateState] tuple
+ */
+export const useLibraryUrlState = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const state: LibraryUrlState = {
+    library: searchParams.get('library') || 'duos',
+    tab: (searchParams.get('tab') as AssetType) || AssetType.STUDIES,
+  }
+
+  const updateState = (updates: Partial<LibraryUrlState>) => {
+    let newParams = new URLSearchParams(searchParams)
+
+    newParams = updateParams(newParams, updates, 'library')
+    newParams = updateParams(newParams, updates, 'tab')
+
+    setSearchParams(newParams)
+  }
+
+  return [state, updateState] as const
+}

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -1,0 +1,68 @@
+import React, { useRef } from 'react'
+import { Box } from '@mui/material'
+import LibraryTabs from 'src/components/data_library/LibraryTabs'
+import SearchBar from 'src/components/SearchBar'
+import TableHeaderSection from 'src/components/TableHeaderSection'
+import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
+import { AssetType, TabConfig } from 'src/types/library'
+
+/**
+ * DataLibrary Page Component
+ *
+ * Main page for browsing and searching datasets and studies in DUOS.
+ * Features:
+ * - Tabbed interface for Studies vs Datasets views
+ * - Advanced filtering sidebar
+ * - Server-side pagination and sorting
+ * - Multi-select with Apply for Access functionality
+ * - URL-based state for shareability
+ *
+ * State Management:
+ * - URL state: filters, pagination, sort, search, active tab (managed by useLibraryUrlState)
+ * - Server state: data fetching, caching (managed by React Query via useLibraryData)
+ * - Local UI state: selection tracking (useState)
+ */
+export const DataLibrary: React.FC = () => {
+  const [urlState, updateUrlState] = useLibraryUrlState()
+
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  const tabs: TabConfig[] = [
+    { key: AssetType.STUDIES, label: 'Studies' },
+    { key: AssetType.DATASETS, label: 'Datasets' },
+  ]
+
+  const handleTabChange = (newAssetType: AssetType) => {
+    updateUrlState({ tab: newAssetType })
+  }
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      {/* Header */}
+      <Box>
+        <TableHeaderSection
+          title="DUOS Data Library"
+          description="Search, filter, and select datasets, then click 'Apply for Access' to request access"
+        />
+        <SearchBar
+          handleSearchChange={() => {}}
+          searchRef={searchRef}
+          style={{
+            paddingTop: '10px',
+          }}
+        />
+      </Box>
+
+      {/* Tabs */}
+      <Box sx={{ px: 3, pt: 2 }}>
+        <LibraryTabs
+          value={urlState.tab}
+          onChange={handleTabChange}
+          tabs={tabs}
+        />
+      </Box>
+    </Box>
+  )
+}
+
+export default DataLibrary

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -55,6 +55,7 @@ import SigningOfficialDataSubmitters from 'src/pages/signing_official_console/Si
 import Translator from 'src/pages/Translator'
 import { DataSubmissionFormV2 } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
 import SigningOfficialDarApprovals from 'src/pages/signing_official_console/SigningOfficialDarApprovals'
+import { DataLibrary } from 'src/pages/DataLibrary'
 
 interface AppRoutesProps {
   isLogged: boolean
@@ -85,6 +86,9 @@ const AppRoutes = (props: AppRoutesProps) => {
         <Route path="/request_role" element={<RequestForm />} />
         <Route path="/datalibrary" element={<DatasetSearch {...props} />}>
           <Route path=":query" element={<DatasetSearch {...props} />} />
+        </Route>
+        <Route path="/datalibrary2" element={<DataLibrary />}>
+          <Route path=":query" element={<DataLibrary />} />
         </Route>
         <Route path="/studies/:studyId" element={<StudyDetails />} />
         <Route path="/dataset/:datasetIdentifier" element={<DatasetStatistics />} />

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -1,0 +1,26 @@
+/**
+ * Type definitions for the Data Library feature
+ */
+
+export enum AssetType {
+  STUDIES = 'studies',
+  DATASETS = 'datasets',
+  MODELS = 'models',
+}
+
+export interface LibraryUrlState {
+  library: string
+  tab: AssetType
+}
+
+export interface TabConfig {
+  key: AssetType
+  label: string
+  count?: number
+}
+
+export interface LibraryTabsProps {
+  value: AssetType
+  onChange: (assetType: AssetType) => void
+  tabs: TabConfig[]
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2459

### Summary

Begins adding the new data library piece by piece. This part adds the header and the new tabs, along with the logic to track URL state.

<img width="485" height="284" alt="Screenshot 2026-02-12 at 9 40 13 AM" src="https://github.com/user-attachments/assets/cb0927e9-814d-4586-a8b0-e36aa0f9fb8d" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
