### PR TITLE
[DT-2943] Simplify devcontainer build

### DIFF
--- a/scripts/setup-devcontainer.sh
+++ b/scripts/setup-devcontainer.sh
@@ -17,16 +17,6 @@ install_gcloud_cli() {
   sudo apt install -y google-cloud-cli
 }
 
-install_node_with_volta() {
-  VOLTA_SHA256="fbdc4b8cb33fb6d19e5f07b22423265943d34e7e5c3d5a1efcecc9621854f9cb"
-  curl -O https://raw.githubusercontent.com/volta-cli/volta/v2.0.2/dev/unix/volta-install.sh
-  echo "${VOLTA_SHA256}  volta-install.sh" | sha256sum -c -
-  chmod +x volta-install.sh && ./volta-install.sh && rm volta-install.sh
-  export PATH="$HOME/.volta/bin:$PATH"
-  NODE_VERSION=$(awk 'NR==2 {gsub(/node:|-.*/,"", $2); print "node@" $2}' Dockerfile)
-  volta install "${NODE_VERSION}" pnpm
-}
-
 install_duos_cypress() {
   npm install
   npx cypress install
@@ -51,7 +41,6 @@ dev_container() {
   cypress_requirements
   gcloud_cli_requirements
   install_gcloud_cli
-  install_node_with_volta
   install_duos_cypress
   install_duos_config
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2943

### Summary

Simplify devcontainer build. Remove Volta build since the container already includes Node and `pnpm`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
