### PR TITLE
[DT-2883] Add support for Study and Dataset tags.

### DIFF
--- a/cypress/component/DataSubmission/v2/ds_study_information.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_information.spec.tsx
@@ -18,11 +18,12 @@ beforeEach(() => {
 describe('GeneralStudyInformation - Tests', () => {
   it('should mount with all the fields', () => {
     cy.mount(<GeneralStudyInformation {...propCopy} />)
-    cy.get('.formField-container').should('have.length', 12)
+    cy.get('.formField-container').should('have.length', 13)
 
     cy.get('.formField-name').should('have.length', 1)
     cy.get('.formField-studyType').should('have.length', 1)
     cy.get('.formField-description').should('have.length', 1)
+    cy.get('.formField-tags').should('have.length', 1)
     cy.get('.formField-dataTypes').should('have.length', 1)
     cy.get('.formField-phenotypeIndication').should('have.length', 1)
     cy.get('.formField-species').should('have.length', 1)
@@ -63,5 +64,7 @@ describe('GeneralStudyInformation - Tests', () => {
     cy.get('@setStudySpy').its('callCount').should('eq', 46)
     cy.get('.formField-piEmail').type('name@anywhere.biz')
     cy.get('@setStudySpy').its('callCount').should('eq', 63)
+    cy.get('.formField-tags').type('tag1{enter}tag2{enter}')
+    cy.get('@setStudySpy').its('callCount').should('eq', 65)
   })
 })

--- a/cypress/component/StudyAssets/consent_group_list.spec.tsx
+++ b/cypress/component/StudyAssets/consent_group_list.spec.tsx
@@ -82,6 +82,7 @@ function fillConsentGroupForm(overrides: Partial<ConsentGroup2> = {}) {
   cy.get('#dataLocation').click()
   cy.get('#dataLocation').type((overrides.dataLocation ?? 'Terra Workspace') + '{enter}')
   cy.get('#url').type(overrides.url ?? 'https://www.example.com')
+  cy.get('#tags').type('tag1{enter}tag2{enter}')
 }
 
 function mountAddEdit(overrides: Partial<React.ComponentProps<typeof ConsentGroupAddEdit>> = {}) {
@@ -117,6 +118,7 @@ describe('ConsentGroupList component', () => {
     mountAddEdit()
     cy.get('#consentGroupName').type('Hello!')
     cy.get('#url').type('https://www.asdf.gov')
+    cy.get('#tags').type('tag4{enter}tag5{enter}')
   })
 
   it('Shows conditional fields only when checked', () => {
@@ -178,6 +180,7 @@ describe('ConsentGroupList component', () => {
     cy.get('#consentGroupName').type('Test Consent Group Edited')
     cy.get('#numberOfParticipants').clear()
     cy.get('#numberOfParticipants').type('15')
+    cy.get('#tags').type('editedTag1{enter}editedTag2{enter}')
     clickSaveButton()
     cy.get('#consentGroupName').should('not.exist')
     verifyConsentGroupExists('Test Consent Group Edited')

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -185,6 +185,13 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
     setValidation(calcErrors(next))
   }
 
+  const onTagsChange = ({ key, value }: { key: string, value: unknown }) => {
+    const next = structuredClone(current)
+    next.data ??= {}
+    set(next.data, key, value)
+    setCurrent(next)
+  }
+
   const save = () => {
     const validationErrors = calcErrors(current)
     setValidation(validationErrors)
@@ -219,6 +226,26 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             onChange={onChange}
             validation={validation.consentGroupName}
             disabled={readOnly}
+          />
+          <FormField
+            id="tags"
+            name="tags"
+            title="Tags"
+            placeholder="Add tags to help others find your dataset (e.g. disease area, assay type, etc.)"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            onChange={onTagsChange}
+            disabled={readOnly}
+            defaultValue={current?.data?.tags || []}
+            selectOptions={(current?.data?.tags as string[]) || []}
+            selectConfig={{
+              components: {
+                DropdownIndicator: null,
+                Menu: () => null,
+              },
+            }}
           />
 
           {/* controlled, open and external access */}

--- a/src/components/forms/forms.jsx
+++ b/src/components/forms/forms.jsx
@@ -150,7 +150,7 @@ export const FormFieldTypes = {
       //   ^^^ can pass other fields in as extra info, e.g.:
       //  {displayText: 'Dac 1', dacId: 213}
       // ]
-      // can also be array of stirngs: ['Option 1', 'Option 2']
+      // can also be array of strings: ['Option 1', 'Option 2']
     ],
     requiredAsyncSelectProps: [
       'loadOptions',

--- a/src/pages/data_submission/consent_group/consentGroupUtils.ts
+++ b/src/pages/data_submission/consent_group/consentGroupUtils.ts
@@ -11,6 +11,7 @@ export interface ConsentGroup {
 }
 export type AccessManagementType = 'controlled' | 'open' | 'external'
 export interface ConsentGroup2 {
+  data?: Record<string, unknown>
   nihInstitutionalCertificationFile?: FileStorageObject
   addedNIHInstitutionalCertificationFile?: File
   name: string

--- a/src/pages/data_submission/v2/GeneralStudyInformation.tsx
+++ b/src/pages/data_submission/v2/GeneralStudyInformation.tsx
@@ -8,6 +8,7 @@ import {
   DataCustodianEmail,
   AlternativeDataSharingPlanTargetDeliveryDate,
   AlternativeDataSharingPlanTargetPublicReleaseDate,
+  StudyData,
 } from 'src/pages/data_submission/v2/v2-models'
 import {
   generateStudyInputFormTextField,
@@ -63,6 +64,27 @@ export const GeneralStudyInformation = (props: GeneralStudyInformationProps) => 
         defaultValue={study?.description}
         validators={[FormValidators.REQUIRED]}
         onChange={onChange}
+      />
+      <FormField
+        id="tags"
+        title="Tags"
+        placeholder="Add tags to help others find your study (e.g. disease area, assay type, etc.)"
+        type={FormFieldTypes.SELECT}
+        isCreatable={true}
+        isMulti={true}
+        optionsAreString={true}
+        defaultValue={(getStudyPropertyValueByKey(study, 'data') as Record<string, unknown> | undefined)?.tags || []}
+        selectOptions={study.data?.tags || []}
+        onChange={(input: { key: string[], value: unknown, isValid: boolean }) => {
+          const tags = input.value as string[]
+          setStudyPropertyByKey(study, setStudy, input, new StudyData({ ...getStudyPropertyValueByKey(study, 'data') as Record<string, unknown>, tags } as Record<string, unknown>))
+        }}
+        selectConfig={{
+          components: {
+            DropdownIndicator: null,
+            Menu: () => null,
+          },
+        }}
       />
       <FormField
         id="dataTypes"

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -40,7 +40,8 @@ import {
   DataLocationType,
   DataURL,
   FileTypes,
-  NumberOfParticipants } from 'src/pages/data_submission/v2/v2-models'
+  NumberOfParticipants, StudyData,
+  DatasetData } from 'src/pages/data_submission/v2/v2-models'
 import { FormField, FormFieldTypes } from 'src/components/forms/forms'
 import { set, isEmpty } from 'lodash'
 import { Storage } from 'src/libs/storage'
@@ -212,6 +213,7 @@ export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistratio
     alternativeDataSharingPlanTargetDeliveryDate: convertDateEpochToString(getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetDeliveryDate.key) as string || undefined),
     alternativeDataSharingPlanTargetPublicReleaseDate: convertDateEpochToString(getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetPublicReleaseDate.key) as string || undefined),
     consentGroups: structuredClone(study.assets?.consentGroups) || [],
+    data: getStudyPropertyValueByKey(study, StudyData.key) as Record<string, unknown> || {},
   }
   const assets = structuredClone(study.assets)
   if (assets) {
@@ -274,12 +276,14 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
     else {
       consentGroup.otherSecondary = dataset.dataUse.secondaryOther
     }
+    debugger
     consentGroup.dataAccessCommitteeId = dataset.dacId
     consentGroup.nihInstitutionalCertificationFile = dataset.nihInstitutionalCertificationFile
     consentGroup.dataLocation = getDatasetPropertyValueByKey(DataLocation.propertyName, dataset) as DataLocationType
     consentGroup.url = getDatasetPropertyValueByKey(DataURL.propertyName, dataset) as string
     consentGroup.fileTypes = fileTypeAdjustment(getDatasetPropertyValueByKey(FileTypes.propertyName, dataset) as Array<FileType>)
     consentGroup.numberOfParticipants = getDatasetPropertyValueByKey(NumberOfParticipants.propertyName, dataset) as number || 0
+    consentGroup.data = getDatasetPropertyValueByKey(DatasetData.propertyName, dataset) as Record<string, unknown> || {}
     consentGroups.push(consentGroup)
   })
   return consentGroups

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -276,7 +276,6 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
     else {
       consentGroup.otherSecondary = dataset.dataUse.secondaryOther
     }
-    debugger
     consentGroup.dataAccessCommitteeId = dataset.dacId
     consentGroup.nihInstitutionalCertificationFile = dataset.nihInstitutionalCertificationFile
     consentGroup.dataLocation = getDatasetPropertyValueByKey(DataLocation.propertyName, dataset) as DataLocationType

--- a/src/pages/data_submission/v2/v2-models.tsx
+++ b/src/pages/data_submission/v2/v2-models.tsx
@@ -346,6 +346,13 @@ export class ControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanat
   }
 }
 
+export class StudyData extends StudyProperty {
+  static readonly key = 'data'
+  constructor(value: Record<string, unknown>, studyId?: number, studyPropertyId?: number) {
+    super(StudyData.key, 'Json' as StudyPropertyType, value, studyId, studyPropertyId)
+  }
+}
+
 export interface Study {
   studyId?: number
   uuid?: string
@@ -375,6 +382,7 @@ export interface Study {
     intellectualProperties?: Array<IntellectualProperty>
     biospecimens?: Array<Biospecimen>
   }
+  data: Record<string, unknown>
 }
 export interface DatasetRegistrationSchemaV1 {
   /** @description The study name */
@@ -486,6 +494,7 @@ export interface DatasetRegistrationSchemaV1 {
     funding?: Array<FundingResource>
     intellectualProperties?: Array<IntellectualProperty>
   }
+  data: Record<string, unknown>
 }
 
 export type DatasetPropertyType = 'String' | 'Number' | 'Json'
@@ -588,5 +597,12 @@ export class NumberOfParticipants extends DatasetProperty {
   static readonly propertyName = '# of participants'
   constructor(value: number, datasetId?: number, propertyId?: number) {
     super(NumberOfParticipants.propertyName, NumberOfParticipants.schemaProperty, 'Number' as DatasetPropertyType, value, datasetId, propertyId)
+  }
+}
+export class DatasetData extends DatasetProperty {
+  static readonly schemaProperty = 'data'
+  static readonly propertyName = 'data'
+  constructor(value: Record<string, unknown>, datasetId?: number, propertyId?: number) {
+    super(DatasetData.propertyName, DatasetData.schemaProperty, 'Json' as DatasetPropertyType, value, datasetId, propertyId)
   }
 }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2883](https://broadworkbench.atlassian.net/browse/DT-2883)

### Summary

Adds tags to Study and Dataset forms so that users can adjust them.
Updates functions to ensure these properties are initialized and updated properly.

AFTER:
Study:
<img width="751" height="568" alt="image" src="https://github.com/user-attachments/assets/9e90b835-a3f6-43e6-9344-feb81cbec2d8" />

Dataset:
<img width="597" height="336" alt="image" src="https://github.com/user-attachments/assets/dbb4f2db-4a36-4db3-8c0e-9f1f254d0a06" />



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
