### PR TITLE
DT-2941: Remove unused ontology configs

### DIFF
--- a/cypress/component/App.spec.tsx
+++ b/cypress/component/App.spec.tsx
@@ -88,23 +88,6 @@ describe('Main App Functions', () => {
           },
         },
       }))
-
-    cy.stub(ServiceStatus, 'getOntologyStatus').returns(Promise.resolve({
-      ok: true,
-      degraded: false,
-      systems: {
-        'elastic-search': {
-          healthy: true,
-          message: 'ClusterHealth is GREEN',
-          error: null,
-          details: null,
-          time: 1756131890182,
-          duration: 4,
-          timestamp: '2025-08-25T14:24:50.182Z',
-        },
-      },
-    },
-    ))
   })
 
   it('should render main layout components on the home page', () => {

--- a/cypress/component/libs/config.spec.ts
+++ b/cypress/component/libs/config.spec.ts
@@ -1,4 +1,4 @@
-import { Config, getEnv, getApiUrl, getBardApiUrl, getEcmApiUrl, getECMUrl, getErrorApiKey, getGaId, getHash, getNihUrl, getOntologyApiUrl, getOntologyUrl, getProfileUrl, getProject, getSamApiUrl, getTag, getTdrApiUrl, getTerraUrl, Token, authOpts, jsonBody, multiPartOpts, textPlain } from 'src/libs/config'
+import { Config, getEnv, getApiUrl, getBardApiUrl, getEcmApiUrl, getECMUrl, getErrorApiKey, getGaId, getHash, getNihUrl, getProfileUrl, getProject, getSamApiUrl, getTag, getTdrApiUrl, getTerraUrl, Token, authOpts, jsonBody, multiPartOpts, textPlain } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
 
 describe('Config', () => {
@@ -11,7 +11,6 @@ describe('Config', () => {
     gaId: 'GA-TEST-123',
     hash: 'test-hash-123',
     nihUrl: 'https://test.nih.gov',
-    ontologyApiUrl: 'https://test.ontology.com',
     profileUrl: 'https://test.profile.com',
     samApiUrl: 'https://test.sam.com',
     tag: 'v1.0.0-test',
@@ -90,18 +89,6 @@ describe('Config', () => {
     it('should get nihUrl', () => {
       cy.wrap(Config.getNihUrl()).then((result) => {
         expect(result).to.equal('https://test.nih.gov')
-      })
-    })
-
-    it('should get ontologyApiUrl', () => {
-      cy.wrap(Config.getOntologyApiUrl()).then((result) => {
-        expect(result).to.equal('https://test.ontology.com')
-      })
-    })
-
-    it('should get ontologyUrl', () => {
-      cy.wrap(Config.getOntologyUrl()).then((result) => {
-        expect(result).to.equal('https://test.ontology.com')
       })
     })
 
@@ -194,18 +181,6 @@ describe('Config', () => {
     it('getNihUrl should return NIH URL', () => {
       cy.wrap(getNihUrl()).then((result) => {
         expect(result).to.equal('https://test.nih.gov')
-      })
-    })
-
-    it('getOntologyApiUrl should return Ontology API URL', () => {
-      cy.wrap(getOntologyApiUrl()).then((result) => {
-        expect(result).to.equal('https://test.ontology.com')
-      })
-    })
-
-    it('getOntologyUrl should return Ontology URL', () => {
-      cy.wrap(getOntologyUrl()).then((result) => {
-        expect(result).to.equal('https://test.ontology.com')
       })
     })
 

--- a/cypress/component/libs/config.spec.ts
+++ b/cypress/component/libs/config.spec.ts
@@ -1,4 +1,4 @@
-import { Config, getEnv, getApiUrl, getBardApiUrl, getEcmApiUrl, getECMUrl, getErrorApiKey, getGaId, getHash, getNihUrl, getProject, getSamApiUrl, getTag, getTdrApiUrl, getTerraUrl, Token, authOpts, jsonBody, multiPartOpts, textPlain } from 'src/libs/config'
+import { Config, getEnv, getApiUrl, getBardApiUrl, getEcmApiUrl, getECMUrl, getErrorApiKey, getGaId, getHash, getProject, getSamApiUrl, getTag, getTdrApiUrl, getTerraUrl, Token, authOpts, jsonBody, multiPartOpts, textPlain } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
 
 describe('Config', () => {
@@ -86,12 +86,6 @@ describe('Config', () => {
       })
     })
 
-    it('should get nihUrl', () => {
-      cy.wrap(Config.getNihUrl()).then((result) => {
-        expect(result).to.equal('https://test.nih.gov')
-      })
-    })
-
     it('should get project', () => {
       cy.wrap(Config.getProject()).then((result) => {
         expect(result).to.equal('broad-duos-test')
@@ -169,12 +163,6 @@ describe('Config', () => {
     it('getHash should return hash', () => {
       cy.wrap(getHash()).then((result) => {
         expect(result).to.equal('test-hash-123')
-      })
-    })
-
-    it('getNihUrl should return NIH URL', () => {
-      cy.wrap(getNihUrl()).then((result) => {
-        expect(result).to.equal('https://test.nih.gov')
       })
     })
 

--- a/cypress/component/libs/config.spec.ts
+++ b/cypress/component/libs/config.spec.ts
@@ -10,8 +10,6 @@ describe('Config', () => {
     errorApiKey: 'test-error-key',
     gaId: 'GA-TEST-123',
     hash: 'test-hash-123',
-    nihUrl: 'https://test.nih.gov',
-    profileUrl: 'https://test.profile.com',
     samApiUrl: 'https://test.sam.com',
     tag: 'v1.0.0-test',
     tdrApiUrl: 'https://test.tdr.com',

--- a/cypress/component/libs/config.spec.ts
+++ b/cypress/component/libs/config.spec.ts
@@ -1,4 +1,4 @@
-import { Config, getEnv, getApiUrl, getBardApiUrl, getEcmApiUrl, getECMUrl, getErrorApiKey, getGaId, getHash, getNihUrl, getProfileUrl, getProject, getSamApiUrl, getTag, getTdrApiUrl, getTerraUrl, Token, authOpts, jsonBody, multiPartOpts, textPlain } from 'src/libs/config'
+import { Config, getEnv, getApiUrl, getBardApiUrl, getEcmApiUrl, getECMUrl, getErrorApiKey, getGaId, getHash, getNihUrl, getProject, getSamApiUrl, getTag, getTdrApiUrl, getTerraUrl, Token, authOpts, jsonBody, multiPartOpts, textPlain } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
 
 describe('Config', () => {
@@ -92,12 +92,6 @@ describe('Config', () => {
       })
     })
 
-    it('should get profileUrl', () => {
-      cy.wrap(Config.getProfileUrl()).then((result) => {
-        expect(result).to.equal('https://test.profile.com')
-      })
-    })
-
     it('should get project', () => {
       cy.wrap(Config.getProject()).then((result) => {
         expect(result).to.equal('broad-duos-test')
@@ -181,12 +175,6 @@ describe('Config', () => {
     it('getNihUrl should return NIH URL', () => {
       cy.wrap(getNihUrl()).then((result) => {
         expect(result).to.equal('https://test.nih.gov')
-      })
-    })
-
-    it('getProfileUrl should return Profile URL', () => {
-      cy.wrap(getProfileUrl()).then((result) => {
-        expect(result).to.equal('https://test.profile.com')
       })
     })
 

--- a/public/config-example.json
+++ b/public/config-example.json
@@ -3,7 +3,6 @@
   "tag": "dev",
   "hash": "dev",
   "apiUrl": "http://localhost:8180/api",
-  "ontologyApiUrl": "https://ontologyURL.org/",
   "terraUrl": "https://terraURL.org/",
   "tdrApiUrl": "https://tdrApiUrl.org/",
   "ecmApiUrl": "https://ecmApiUrl.org",

--- a/src/libs/ajax/ServiceStatus.ts
+++ b/src/libs/ajax/ServiceStatus.ts
@@ -76,12 +76,6 @@ export const ServiceStatus = {
     return result.data
   },
 
-  getOntologyStatus: async (): Promise<OntologyStatus> => {
-    const url = `${await Config.getOntologyUrl()}/status`
-    const result = await fetchGet<OntologyStatus>(url)
-    return result.data
-  },
-
   isConsentHealthy: async (): Promise<boolean> => {
     const status = await ServiceStatus.getConsentStatus()
     return status.ok || false

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -67,10 +67,6 @@ class ConfigClass {
     return getNihUrl()
   }
 
-  async getProfileUrl(): Promise<string> {
-    return getProfileUrl()
-  }
-
   async getProject(): Promise<string> {
     return getProject()
   }
@@ -152,11 +148,6 @@ export const getHash = async (): Promise<string> => {
 export const getNihUrl = async (): Promise<string> => {
   const config = await loadConfig()
   return config.nihUrl
-}
-
-export const getProfileUrl = async (): Promise<string> => {
-  const config = await loadConfig()
-  return config.profileUrl
 }
 
 export const getProject = async (): Promise<string> => {

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -67,14 +67,6 @@ class ConfigClass {
     return getNihUrl()
   }
 
-  async getOntologyApiUrl(): Promise<string> {
-    return getOntologyApiUrl()
-  }
-
-  async getOntologyUrl(): Promise<string> {
-    return getOntologyUrl()
-  }
-
   async getProfileUrl(): Promise<string> {
     return getProfileUrl()
   }
@@ -160,15 +152,6 @@ export const getHash = async (): Promise<string> => {
 export const getNihUrl = async (): Promise<string> => {
   const config = await loadConfig()
   return config.nihUrl
-}
-
-export const getOntologyApiUrl = async (): Promise<string> => {
-  const config = await loadConfig()
-  return config.ontologyApiUrl
-}
-
-export const getOntologyUrl = async (): Promise<string> => {
-  return await getOntologyApiUrl()
 }
 
 export const getProfileUrl = async (): Promise<string> => {

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -63,10 +63,6 @@ class ConfigClass {
     return getHash()
   }
 
-  async getNihUrl(): Promise<string> {
-    return getNihUrl()
-  }
-
   async getProject(): Promise<string> {
     return getProject()
   }
@@ -143,11 +139,6 @@ export const getGaId = async (): Promise<string> => {
 export const getHash = async (): Promise<string> => {
   const config = await loadConfig()
   return config.hash
-}
-
-export const getNihUrl = async (): Promise<string> => {
-  const config = await loadConfig()
-  return config.nihUrl
 }
 
 export const getProject = async (): Promise<string> => {

--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -1,11 +1,9 @@
-import React, { useState, useEffect } from 'react'
-import { TaskAltOutlined, ErrorOutline } from '@mui/icons-material'
-import { ServiceStatus } from '../libs/ajax/ServiceStatus'
-import { ConsentStatus, OntologyStatus, SamDetails } from '../libs/ajax/ServiceStatus'
+import React, { useEffect, useState } from 'react'
+import { ErrorOutline, TaskAltOutlined } from '@mui/icons-material'
+import { ConsentStatus, SamDetails, ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 
 const Status = () => {
   const [consentStatus, setConsentStatus] = useState<ConsentStatus | undefined>(undefined)
-  const [ontologyStatus, setOntologyStatus] = useState<OntologyStatus | undefined>(undefined)
   const [samStatus, setSamStatus] = useState<SamDetails | undefined>(undefined)
 
   useEffect(() => {
@@ -13,8 +11,6 @@ const Status = () => {
       const consentData = await ServiceStatus.getConsentStatus()
       setConsentStatus(consentData)
       setSamStatus(consentData?.systems?.sam?.details)
-      const ontologyData = await ServiceStatus.getOntologyStatus()
-      setOntologyStatus(ontologyData)
     }
     fetchStatus()
   }, [])
@@ -23,7 +19,6 @@ const Status = () => {
   const unhealthyState = <ErrorOutline sx={{ marginLeft: '2rem', verticalAlign: 'middle', fontSize: '24px', color: 'red' }} />
 
   const consentHealthy = consentStatus?.ok ? healthyState : unhealthyState
-  const ontologyHealthy = ontologyStatus?.ok ? healthyState : unhealthyState
   const samHealthy = samStatus?.ok ? healthyState : unhealthyState
 
   return (
@@ -35,11 +30,6 @@ const Status = () => {
           {consentHealthy}
         </li>
         <li>
-          <a href="#ontology">Ontology</a>
-          {' '}
-          {ontologyHealthy}
-        </li>
-        <li>
           <a href="#sam">Sam</a>
           {' '}
           {samHealthy}
@@ -48,8 +38,6 @@ const Status = () => {
       <hr />
       <h2><a id="consent">Consent Status</a></h2>
       <pre>{JSON.stringify(consentStatus, null, 4)}</pre>
-      <h2><a id="ontology">Ontology Status</a></h2>
-      <pre>{JSON.stringify(ontologyStatus, null, 4)}</pre>
     </div>
   )
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2941

### Summary
Removes all configuration for the Ontology server as those features are now replicated in Consent. Also removes the separate Ontology status section on the Status page.

While we're here, there are two other unused configurations, profile url and nih url. These were used to communicate with Shibboleth and are no longer necessary.

This PR blocks https://github.com/broadinstitute/terra-helmfile/pull/6381

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
