### PR TITLE
[DT-2950] Fix Remaining ESLint Warnings

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -65,8 +65,6 @@ export default defineConfig([
       ],
       'react/prop-types': 'off',
       '@stylistic/jsx-one-expression-per-line': ['off'],
-      // TODO: these issues should be fixed
-      'react-hooks/set-state-in-effect': 'warn',
     },
   },
 ])

--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { isEmpty, isNil } from 'lodash'
 import CollectionVoteYesButton from './CollectionVoteYesButton'
 import CollectionVoteNoButton from './CollectionVoteNoButton'
@@ -151,7 +151,7 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
     return props.isDisabled || (isFinal && submitted) || adminPage
   }, [props.isDisabled, isFinal, submitted, adminPage])
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (!isEmpty(votes)) {
       const prevVote = votes[0]
 

--- a/src/components/collection_vote_box/CollectionVoteButton.tsx
+++ b/src/components/collection_vote_box/CollectionVoteButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { votingColors } from 'src/libs/VotingColors'
 import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton'
 
@@ -66,7 +66,7 @@ export default function CollectionVoteButton({
     updateStyle(baseColor, votingColors.default, true, disabled)
   }, [baseColor, disabled, updateStyle])
 
-  useEffect(() =>
+  React.useEffect(() =>
     isSelected ? selectedButtonStyle() : defaultButtonStyle(),
   [defaultButtonStyle, isSelected, selectedButtonStyle])
 

--- a/src/components/collection_voting_slab/DatasetsRequestedPanel.tsx
+++ b/src/components/collection_voting_slab/DatasetsRequestedPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { filter, includes } from 'lodash'
 import { DacTerm, Dataset } from 'src/types/model'
 import SectionHeading from 'src/components/collection_voting_slab/SectionHeading'
@@ -31,7 +31,7 @@ export default function DatasetsRequestedPanel(props: DatasetsRequestedPanelProp
     setVisibleDatasets(collapsedViewDatasets)
   }, [collapsedDatasetCapacity])
 
-  useEffect(() => {
+  React.useEffect(() => {
     const datasets = adminPage
       ? bucketDatasets
       : filter(bucketDatasets, (dataset: Dataset) => {

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.tsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { get, isEmpty, isNil } from 'lodash'
 import { Storage } from 'src/libs/storage'
 import { convertLabelToKey } from 'src/libs/utils'
@@ -166,7 +166,7 @@ export default function MultiDatasetVoteSlab({
     return 'Other DAC Member\'s Votes'
   }
 
-  useEffect(() => {
+  React.useEffect(() => {
     const sorted = Object.values(collection.dars).sort(
       (a, b) => new Date(b.submissionDate).getTime() - new Date(a.submissionDate).getTime(),
     )

--- a/src/components/collection_voting_slab/ResearchProposalVoteSlab.jsx
+++ b/src/components/collection_voting_slab/ResearchProposalVoteSlab.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { DataUseTranslation } from '../../libs/dataUseTranslation'
 import { isEmpty, isNil, flatMap, keys, get } from 'lodash'
 import { DataUsePills } from './DataUsePill'
@@ -167,7 +167,7 @@ export default function ResearchProposalVoteSlab(props) {
   const [dacVotes, setDacVotes] = useState([])
   const { darInfo, bucket, isChair, isLoading, readOnly, adminPage, updateFinalVote } = props
   const translatedDataUse = !isNil(darInfo) ? DataUseTranslation.translateDarInfo(darInfo) : {}
-  useEffect(() => {
+  React.useEffect(() => {
     const user = Storage.getCurrentUser()
     setDacVotes(extractDacRPVotesFromBucket(bucket, user, adminPage))
     setCurrentUserVotes(extractUserRPVotesFromBucket(bucket, user, isChair, adminPage))

--- a/src/components/forms/forms.jsx
+++ b/src/components/forms/forms.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { cloneDeep, isFunction, isNil, isArray } from 'lodash'
 import {
   getKey,
@@ -257,13 +257,13 @@ export const FormField = (config) => {
 
   const required = (validators || []).includes(FormValidators.REQUIRED)
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (defaultValue !== undefined) {
       setFormValue(defaultValue)
     }
   }, [defaultValue, type])
 
-  useEffect(() => {
+  React.useEffect(() => {
     validateFormProps(config)
   }, [config])
 

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import ReactTooltip from 'react-tooltip'
 import {
   calcTablePageCount,
@@ -187,7 +187,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
     columnHeaderFormat.actions,
   ]
 
-  useEffect(() => {
+  React.useEffect(() => {
     const init = async () => {
       try {
         setPageCount(calcTablePageCount(tableSize, filteredCards))
@@ -213,7 +213,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   }, [filteredCards, tableSize, currentPage, pageCount])
 
   // Hook to execute on initialization and card creation/deletion, applies filter on updated collection list
-  useEffect(() => {
+  React.useEffect(() => {
     if (searchRef.current) {
       const searchTerms = searchRef.current.value ?? ''
       let filteredList = libraryCards
@@ -225,7 +225,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   }, [props.libraryCards, libraryCards])
 
   // Hook that executes on prop load (initialization hook)
-  useEffect(() => {
+  React.useEffect(() => {
     setLibraryCards(props.libraryCards ?? [])
     if (!isNil(props.libraryCards)) {
       setIsLoading(false)

--- a/src/components/study_asset/StudyAssetList.tsx
+++ b/src/components/study_asset/StudyAssetList.tsx
@@ -1,5 +1,5 @@
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import AddObjectButton from 'src/components/AddObjectButton'
 
 interface StudyAssetListProps<
@@ -66,13 +66,13 @@ export default function StudyAssetList<
 
   const filteredColumnsToShow = columnsToShow.filter((c): c is keyof T => typeof c === 'string')
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (editState.length !== items.length) {
       setEditState(items.map(() => false))
     }
   }, [items, editState.length])
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (viewState.length !== items.length) {
       setViewState(items.map(() => false))
     }
@@ -142,7 +142,7 @@ export default function StudyAssetList<
 
         return (
           <RowComponent
-            key={getItemKey(item, index)}
+            key={getItemKey(item, index) || index}
             {...getRowProps(baseProps)}
           />
         )

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { VoteHistoryRow } from 'src/types/model'
 import { Styles } from 'src/libs/theme'
@@ -75,8 +75,13 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
   const processVoteHistoryRowData = useCallback((voteHistory: VoteHistoryRow[]) => {
     if (!voteHistory) return []
 
-    const rowData = voteHistory.map((row: VoteHistoryRow, i) => [
-      { data: row.progressReport ? 'Progress Report' : 'Initial DAR', cellStyle: { width: '15%' }, label: 'Request Type', id: i },
+    return voteHistory.map((row: VoteHistoryRow, i) => [
+      {
+        data: row.progressReport ? 'Progress Report' : 'Initial DAR',
+        cellStyle: { width: '15%' },
+        label: 'Request Type',
+        id: i,
+      },
       { data: row.datasetIdentifier, cellStyle: { width: '20%' }, label: 'Dataset ID', id: i },
       { data: formatDate(row.electionDate), cellStyle: { width: '15%' }, label: 'Election Date', id: i },
       { data: getVoteText(row.vote), cellStyle: { width: '10%' }, label: 'Vote', id: i },
@@ -85,10 +90,9 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
       { data: row.type, cellStyle: { width: '15%' }, label: 'Vote Type', id: i },
       { data: row.rationale || '--', cellStyle: { width: '15%' }, label: 'Rationale', id: i },
     ])
-    return rowData
   }, [])
 
-  useEffect(() => {
+  React.useEffect(() => {
     setSortedVotes(sortVisibleTable({
       list: processVoteHistoryRowData(voteHistory),
       sort,

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -1,7 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { Styles } from 'src/libs/theme'
-import { formatDate, sortVisibleTable } from '../../libs/utils'
+import { formatDate, sortVisibleTable } from 'src/libs/utils'
 import { ElectionWithMemberVotes, Vote } from 'src/types/model'
 import { ExpandMore, ExpandLess } from '@mui/icons-material'
 import VoteSummaryTable from '../vote_summary_table/VoteSummaryTable'
@@ -165,7 +165,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
     return renderedRow
   }, [electionIsExpanded])
 
-  useEffect(() => {
+  React.useEffect(() => {
     setSortedElections(sortVisibleTable({
       list: processElectionRowData(electionsWithMemberVotes),
       sort,

--- a/src/components/vote_summary_table/VoteSummaryTable.jsx
+++ b/src/components/vote_summary_table/VoteSummaryTable.jsx
@@ -1,8 +1,7 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { Styles } from 'src/libs/theme'
-import { isNil, isEmpty } from 'lodash'
-import { useEffect, useState } from 'react'
+import { isEmpty, isNil } from 'lodash'
 import { formatDate, Notifications, sortVisibleTable } from 'src/libs/utils'
 import { Email } from 'src/libs/ajax/Email'
 
@@ -156,17 +155,16 @@ export default function VoteSummaryTable(props) {
 
   const updateReminderState = (voteId, sentState) => {
     setReminderSentState((state) => {
-      const newState = {
+      return {
         ...state,
         ...{
           [voteId]: sentState,
         },
       }
-      return newState
     })
   }
 
-  useEffect(() => {
+  React.useEffect(() => {
     const sendReminder = (voteId) => {
       updateReminderState(voteId, ReminderStates.SENDING)
 

--- a/src/pages/AdminManageUsers.jsx
+++ b/src/pages/AdminManageUsers.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 import { AddUserModal } from 'src/components/modals/AddUserModal'
 import { User } from 'src/libs/ajax/User'
 import { USER_ROLES } from 'src/libs/utils'
@@ -40,7 +40,7 @@ export const AdminManageUsers = function AdminManageUsers() {
 
   const searchRef = useRef('')
 
-  useEffect(() => {
+  React.useEffect(() => {
     setIsLoading(true)
     getUserList().then((userList) => {
       setIsLoading(false)

--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -236,7 +236,7 @@ const DataAccessRequestApplication = (props) => {
   const [selectedDatasets, setSelectedDatasets] = useState([])
   const [dataUseTranslations, setDataUseTranslations] = useState([])
 
-  useEffect(() => {
+  React.useEffect(() => {
     fetchAllDatasets(formData.datasetIds).then((datasets) => {
       setDatasets(datasets)
       setSelectedDatasets(datasets)
@@ -322,7 +322,7 @@ const DataAccessRequestApplication = (props) => {
     setIsLoading(false)
   }, [researcher, existingDarsReadOnlyMode, collectionId, dataRequestId, getDarCollection, getPartialDarRequest, batchFormFieldChange])
 
-  useEffect(() => {
+  React.useEffect(() => {
     if (existingDarsReadOnlyMode) {
       let appTabs = []
       if (isProgressReportApplication) {
@@ -341,7 +341,7 @@ const DataAccessRequestApplication = (props) => {
     }
   }, [formData?.darCode, isProgressReportApplication, existingDarsReadOnlyMode, reverseOrderedDARs])
 
-  useEffect(() => {
+  React.useEffect(() => {
     init()
     NotificationService.getBannerObjectById('eRACommonsOutage').then((notificationData) => {
       setNotificationData(notificationData)


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2950

### Summary

This PR fixes the remaining 17 ESLint warnings on the error below:
```
Error: Calling setState synchronously within an effect can trigger cascading renders
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
