### PR TITLE
DT-2967: Update libraryVersions.ts to remove duplicate FGC logo

### DIFF
--- a/cypress/component/Home/home.spec.jsx
+++ b/cypress/component/Home/home.spec.jsx
@@ -30,7 +30,7 @@ describe('Home Page - Tests', function () {
     })
 
     it('interacts with library card links when not logged in', function () {
-      cy.get('.logo-card').should('have.length', 21)
+      cy.get('.logo-card').should('have.length', 22)
       cy.get('.logo-card').each(($card) => {
         cy.wrap($card).find('a').should('exist')
       })
@@ -104,14 +104,14 @@ describe('Home Page - Tests', function () {
     it('displays logos horizontally on desktop', function () {
       cy.viewport(1200, 800)
       cy.get('.logo-grid').should('have.css', 'flex-direction', 'row')
-      cy.get('.logo-card').should('have.length', 21)
+      cy.get('.logo-card').should('have.length', 22)
     })
 
     it('displays logos responsively on mobile', function () {
       cy.viewport(600, 800)
       cy.get('.logo-grid').should('have.css', 'display', 'flex')
       cy.get('.logo-grid').should('have.css', 'flex-wrap', 'wrap')
-      cy.get('.logo-card').should('have.length', 21)
+      cy.get('.logo-card').should('have.length', 22)
     })
   })
 
@@ -123,8 +123,8 @@ describe('Home Page - Tests', function () {
         </MemoryRouter>,
       )
 
-      // Should show 21 featured libraries
-      cy.get('.logo-card').should('have.length', 21)
+      // Should show 22 featured libraries
+      cy.get('.logo-card').should('have.length', 22)
 
       // Should not display terra or mgb (featured: false)
       cy.get('[data-for="terra"]').should('not.exist')
@@ -138,7 +138,7 @@ describe('Home Page - Tests', function () {
         </MemoryRouter>,
       )
 
-      cy.get('.logo-card').should('have.length', 21)
+      cy.get('.logo-card').should('have.length', 22)
 
       // Verify first three libraries are in correct order
       cy.get('.logo-card').eq(0).find('img').should('have.attr', 'alt', 'DUOS')
@@ -173,11 +173,11 @@ describe('Home Page - Tests', function () {
 
       // Tablet
       cy.viewport(768, 1024)
-      cy.get('.logo-card').should('have.length', 21)
+      cy.get('.logo-card').should('have.length', 22)
 
       // Mobile
       cy.viewport(480, 800)
-      cy.get('.logo-card').should('have.length', 21)
+      cy.get('.logo-card').should('have.length', 22)
     })
   })
 })

--- a/cypress/component/Home/home.spec.jsx
+++ b/cypress/component/Home/home.spec.jsx
@@ -30,7 +30,7 @@ describe('Home Page - Tests', function () {
     })
 
     it('interacts with library card links when not logged in', function () {
-      cy.get('.logo-card').should('have.length', 22)
+      cy.get('.logo-card').should('have.length', 21)
       cy.get('.logo-card').each(($card) => {
         cy.wrap($card).find('a').should('exist')
       })
@@ -104,14 +104,14 @@ describe('Home Page - Tests', function () {
     it('displays logos horizontally on desktop', function () {
       cy.viewport(1200, 800)
       cy.get('.logo-grid').should('have.css', 'flex-direction', 'row')
-      cy.get('.logo-card').should('have.length', 22)
+      cy.get('.logo-card').should('have.length', 21)
     })
 
     it('displays logos responsively on mobile', function () {
       cy.viewport(600, 800)
       cy.get('.logo-grid').should('have.css', 'display', 'flex')
       cy.get('.logo-grid').should('have.css', 'flex-wrap', 'wrap')
-      cy.get('.logo-card').should('have.length', 22)
+      cy.get('.logo-card').should('have.length', 21)
     })
   })
 
@@ -123,8 +123,8 @@ describe('Home Page - Tests', function () {
         </MemoryRouter>,
       )
 
-      // Should show 22 featured libraries
-      cy.get('.logo-card').should('have.length', 22)
+      // Should show 21 featured libraries
+      cy.get('.logo-card').should('have.length', 21)
 
       // Should not display terra or mgb (featured: false)
       cy.get('[data-for="terra"]').should('not.exist')
@@ -138,7 +138,7 @@ describe('Home Page - Tests', function () {
         </MemoryRouter>,
       )
 
-      cy.get('.logo-card').should('have.length', 22)
+      cy.get('.logo-card').should('have.length', 21)
 
       // Verify first three libraries are in correct order
       cy.get('.logo-card').eq(0).find('img').should('have.attr', 'alt', 'DUOS')
@@ -173,11 +173,11 @@ describe('Home Page - Tests', function () {
 
       // Tablet
       cy.viewport(768, 1024)
-      cy.get('.logo-card').should('have.length', 22)
+      cy.get('.logo-card').should('have.length', 21)
 
       // Mobile
       cy.viewport(480, 800)
-      cy.get('.logo-card').should('have.length', 22)
+      cy.get('.logo-card').should('have.length', 21)
     })
   })
 })

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -561,7 +561,7 @@ export const getLibraryVersions = (
       },
       icon: ncpiIcon,
       title: 'NCPI DUO Data Library',
-      featured: false,
+      featured: true,
       order: 22,
     },
     '/custom': {

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -509,17 +509,6 @@ export const getLibraryVersions = (
       featured: true,
       order: 17,
     },
-    'fgc': {
-      query: {
-        match_phrase: {
-          'study.description': 'FGC',
-        },
-      },
-      icon: broadIcon,
-      title: 'Fetal Genomics Consortium Data Library',
-      featured: true,
-      order: 18,
-    },
     'broadibd': {
       query: {
         match_phrase: {
@@ -529,7 +518,7 @@ export const getLibraryVersions = (
       icon: broadIcon,
       title: 'Broad Institute IBD Data Library',
       featured: true,
-      order: 19,
+      order: 18,
     },
     'helmsley': {
       query: {
@@ -540,7 +529,7 @@ export const getLibraryVersions = (
       icon: HelmsleyIcon,
       title: 'Helmsley Data Library',
       featured: true,
-      order: 20,
+      order: 19,
     },
     'ged': {
       query: {
@@ -551,7 +540,7 @@ export const getLibraryVersions = (
       icon: gedIcon,
       title: 'Genetics of Eating Disorders Data Library',
       featured: true,
-      order: 21,
+      order: 20,
     },
     'ccxdp': {
       query: {
@@ -562,7 +551,7 @@ export const getLibraryVersions = (
       icon: ccxdpIcon,
       title: 'CCXDP Data Library',
       featured: true,
-      order: 22,
+      order: 21,
     },
     'ncpi-duo': {
       query: {
@@ -573,7 +562,7 @@ export const getLibraryVersions = (
       icon: ncpiIcon,
       title: 'NCPI DUO Data Library',
       featured: false,
-      order: 999,
+      order: 22,
     },
     '/custom': {
       query: {


### PR DESCRIPTION
### Addresses 

https://broadworkbench.atlassian.net/browse/DT-2967

### Summary

This PR removes FGC icon from homepage. Also intentionally bumps NCPI logo to homepage.


<img width="3600" height="5642" alt="After" src="https://github.com/user-attachments/assets/5550aa36-142f-4a4a-87d2-913b06022cae" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
