### PR TITLE
DT-2964: Handle undefined finalVote

### DIFF
--- a/src/pages/dar_application/DataAccessRequestApplication.jsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.jsx
@@ -590,10 +590,10 @@ const DataAccessRequestApplication = (props) => {
 
     const getVoteDate = () => {
       if (finalVote?.updateDate) {
-        return formatDate(finalVote.updateDate)
+        return formatDate(finalVote?.updateDate)
       }
       if (isElectionClosed) {
-        return formatDate(finalVote.createDate)
+        return formatDate(finalVote?.createDate)
       }
       return NO_FINAL_VOTE_STATUS
     }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2964

### Summary
For researchers, the PR form can throw undefined errors when reading the `finalVote` value. In other places, we assume the possibility of undefined, but not in the `getVoteDate` method. This fix allows the page to load normally.

Note: While testing, there were subsequent submission errors when I assumed ownership of the DAR Collection noted in the ticket.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
