### PR TITLE
[DT-400] Add default options for server and preview

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,18 @@ import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 import tsconfig from './tsconfig.json'
 
+const defaultOptions = {
+  host: 'local.dsde-dev.broadinstitute.org',
+  port: 3000,
+  https: (process.env.CI || process.env.CYPRESS)
+    ? undefined
+    : {
+        key: 'server.key',
+        cert: 'server.crt',
+      },
+  open: true,
+}
+
 function aliases_from_tsconfig() {
   const paths: Record<string, string[]> = tsconfig.compilerOptions.paths
   const aliases: Record<string, string> = {}
@@ -26,17 +38,8 @@ export default defineConfig({
     outDir: 'build',
     target: 'es2022',
   },
-  server: {
-    host: 'local.dsde-dev.broadinstitute.org',
-    port: 3000,
-    https: (process.env.CI || process.env.CYPRESS)
-      ? undefined
-      : {
-          key: 'server.key',
-          cert: 'server.crt',
-        },
-    open: true,
-  },
+  server: defaultOptions,
+  preview: defaultOptions,
   resolve: {
     alias: aliases_from_tsconfig(),
   },


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

Makes the options used by the `server` block also usable by `preview`. This is useful when looking at the production build instead of the development build.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
