### PR TITLE
[DT-2459][DT-2434] New data library v5

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -36,7 +36,7 @@ describe('DataLibrary', () => {
       if (req.body.size === 0 && !req.body.queryTerm) {
         req.reply(mockMetadataResponse)
       }
-      else if (req.body.aggs && req.body.aggs.studies) {
+      else if (req.body.aggs?.studies) {
         req.reply(mockStudiesResponse)
       }
       else {

--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -5,7 +5,46 @@ import { DataLibrary } from 'src/pages/DataLibrary'
 
 const queryClient = new QueryClient()
 
+const mockMetadataResponse = {
+  aggregations: {
+    dac: { buckets: [{ key: 'DAC-1', doc_count: 5 }] },
+    data_type: { buckets: [{ key: 'Genomic', doc_count: 10 }] },
+  },
+}
+
+const mockStudiesResponse = {
+  aggregations: {
+    total_studies: { value: 2 },
+    studies: {
+      buckets: [
+        {
+          key: { study_id: 101 },
+          study_details: { hits: { hits: [{ _source: { study: { studyName: 'Study One', description: 'Desc One' } } }] } },
+          dataset_count: { value: 5 },
+          total_participants: { value: 100 },
+          dataset_ids: { buckets: [{ key: 1 }, { key: 2 }] },
+        },
+      ],
+    },
+  },
+}
+
 describe('DataLibrary', () => {
+  beforeEach(() => {
+    cy.initApplicationConfig()
+    cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
+      if (req.body.size === 0 && !req.body.queryTerm) {
+        req.reply(mockMetadataResponse)
+      }
+      else if (req.body.aggs && req.body.aggs.studies) {
+        req.reply(mockStudiesResponse)
+      }
+      else {
+        req.reply({ hits: { hits: [], total: { value: 0 } } })
+      }
+    }).as('searchApi')
+  })
+
   it('renders the data library page', () => {
     cy.mount(
       <QueryClientProvider client={queryClient}>
@@ -96,14 +135,12 @@ describe('DataLibrary', () => {
       </QueryClientProvider>,
     )
 
-    // Initially on Studies
-    cy.get('button').contains('Studies').should('have.css', 'font-weight', '700')
-
-    // Click Datasets
-    cy.get('button').contains('Datasets').click()
-
-    // Now on Datasets
+    // Initially on Datasets (due to default in useLibraryUrlState)
     cy.get('button').contains('Datasets').should('have.css', 'font-weight', '700')
-    cy.get('button').contains('Studies').should('have.css', 'font-weight', '400')
+
+    // Switch to Studies
+    cy.get('button').contains('Studies').click()
+    cy.get('button').contains('Studies').should('have.css', 'font-weight', '700')
+    cy.get('button').contains('Datasets').should('have.css', 'font-weight', '400')
   })
 })

--- a/cypress/component/Hooks/useDebouncedValue.spec.tsx
+++ b/cypress/component/Hooks/useDebouncedValue.spec.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import { useDebouncedValue } from 'src/hooks/useDebouncedValue'
+
+const TestComponent = ({ delay }: { delay?: number }) => {
+  const [value, setValue] = useState('initial')
+  const debouncedValue = useDebouncedValue(value, delay)
+
+  return (
+    <div>
+      <div id="value">{value}</div>
+      <div id="debounced">{debouncedValue}</div>
+      <input
+        id="input"
+        value={value}
+        onChange={e => setValue(e.target.value)}
+      />
+    </div>
+  )
+}
+
+describe('useDebouncedValue', () => {
+  it('returns initial value immediately', () => {
+    cy.mount(<TestComponent />)
+    cy.get('#value').should('have.text', 'initial')
+    cy.get('#debounced').should('have.text', 'initial')
+  })
+
+  it('debounces value updates', () => {
+    cy.mount(<TestComponent delay={100} />)
+
+    cy.get('#input').clear()
+    cy.get('#input').type('updated')
+    cy.get('#value').should('have.text', 'updated')
+
+    // Should still be initial immediately
+    cy.get('#debounced').should('have.text', 'initial')
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(150)
+    cy.get('#debounced').should('have.text', 'updated')
+  })
+
+  it('cancels previous timeout when value changes again', () => {
+    cy.mount(<TestComponent delay={1000} />)
+
+    cy.get('#input').clear()
+    cy.get('#input').type('first')
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(100)
+    cy.get('#input').clear()
+    cy.get('#input').type('second')
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(500)
+    cy.get('#debounced').should('have.text', 'initial')
+
+    // eslint-disable-next-line cypress/no-unnecessary-waiting
+    cy.wait(600)
+    cy.get('#debounced').should('have.text', 'second')
+  })
+})

--- a/cypress/component/Hooks/useLibraryData.spec.tsx
+++ b/cypress/component/Hooks/useLibraryData.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider, useQueryClient } from '@tanstack/react-query'
-import { useLibraryData } from 'src/hooks/useLibraryData'
+import { useLibraryData, buildElasticsearchQuery } from 'src/hooks/useLibraryData'
 import { AssetType, FilterState, LibraryVersionNew, PaginationState, SortState } from 'src/types/library'
+import { BoolQuery, ExistsQuery, MultiMatchQuery, TermQuery } from 'src/types/elastic'
 
 const TestComponent = ({
   libraryConfig,
@@ -16,12 +17,12 @@ const TestComponent = ({
   pagination?: PaginationState
   sort?: SortState
 }) => {
-  const { data, isLoading } = useLibraryData(libraryConfig, assetType, filters, pagination, sort)
+  const { data, isLoading } = useLibraryData(libraryConfig, assetType, filters, '', pagination, sort)
   const queryClient = useQueryClient()
 
   // Expose query cache for testing
   const query = queryClient.getQueryCache().find({
-    queryKey: ['library-data', libraryConfig.key, assetType, filters, pagination, sort],
+    queryKey: ['library-data', libraryConfig.key, assetType, filters, '', pagination, sort],
   })
 
   return (
@@ -94,5 +95,65 @@ describe('useLibraryData', () => {
 
     cy.mount(<Wrapper f={updatedFilters} p={updatedPagination} s={sort} />)
     cy.get('#has-query').should('have.text', 'yes')
+  })
+})
+
+describe('buildElasticsearchQuery', () => {
+  const libraryConfig: LibraryVersionNew = {
+    key: 'duos',
+    title: 'DUOS Data Library',
+    featured: true,
+    order: 0,
+  }
+
+  const filters: FilterState = {
+    accessManagement: [],
+    dataUse: [],
+    dataType: [],
+    dac: [],
+    participantCount: {},
+  }
+
+  const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+  it('builds a basic query for studies', () => {
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.STUDIES, filters, '', pagination)
+    expect(query.query?.bool.must).to.have.length(1)
+    const firstClause = query.query?.bool.must?.[0] as ExistsQuery
+    expect(firstClause.exists.field).to.equal('study')
+    expect(query.aggs).to.have.property('studies')
+    expect(query.aggs).to.have.property('total_studies')
+  })
+
+  it('builds a basic query for datasets', () => {
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination)
+    expect(query.query?.bool.must).to.have.length(1)
+    expect(query.from).to.equal(0)
+    expect(query.size).to.equal(25)
+    expect(query.aggs).to.have.property('access_management')
+  })
+
+  it('adds search term to query', () => {
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, 'breast cancer', pagination)
+    expect(query.query?.bool.must).to.have.length(2)
+    const secondClause = query.query?.bool.must?.[1] as MultiMatchQuery
+    expect(secondClause.multi_match.query).to.equal('breast cancer')
+  })
+
+  it('adds access management filters', () => {
+    const filtersWithAccess = { ...filters, accessManagement: ['controlled'] }
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filtersWithAccess, '', pagination)
+    expect(query.query?.bool.filter).to.have.length(1)
+    const firstFilter = query.query?.bool.filter?.[0] as BoolQuery
+    const termClause = firstFilter.bool.should?.[0] as TermQuery
+    expect(termClause.term['accessManagement.keyword']).to.equal('controlled')
+  })
+
+  it('adds sort to dataset query', () => {
+    const sort: SortState = { field: 'studyName', order: 'asc' }
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, sort)
+    expect(query.sort).to.have.length(1)
+    const firstSort = query.sort?.[0] as Record<string, { order: string }>
+    expect(firstSort.studyName.order).to.equal('asc')
   })
 })

--- a/cypress/component/Hooks/useLibraryUrlState.spec.tsx
+++ b/cypress/component/Hooks/useLibraryUrlState.spec.tsx
@@ -45,7 +45,7 @@ describe('useLibraryUrlState', () => {
       </MemoryRouter>,
     )
     cy.get('#library').should('have.text', 'duos')
-    cy.get('#tab').should('have.text', AssetType.STUDIES)
+    cy.get('#tab').should('have.text', AssetType.DATASETS)
     cy.get('#filters').then(($el) => {
       const filters = JSON.parse($el.text())
       expect(filters.accessManagement).to.have.length(0)

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -151,7 +151,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   }
 
   return (
-    <Box sx={{ width: '100%', height: 600 }}>
+    <Box sx={{ width: '100%', height: '100%' }}>
       <DataGrid
         rows={data as (StudyAggregation | DatasetTerm)[]}
         columns={columns}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Custom hook to debounce a value
+ * @param value - The value to debounce
+ * @param delay - Delay in milliseconds
+ * @returns The debounced value
+ */
+export const useDebouncedValue = <T>(value: T, delay: number = 300): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -22,6 +22,7 @@ export const buildElasticsearchQuery = (
   libraryConfig: LibraryVersionNew,
   assetType: AssetType,
   filters: FilterState,
+  queryTerm: string,
   pagination: PaginationState,
   sort?: SortState,
 ): ElasticsearchQuery => {
@@ -36,6 +37,30 @@ export const buildElasticsearchQuery = (
   // Add library-specific query
   if (libraryConfig.query) {
     queryChunks.push(libraryConfig.query as QueryClause)
+  }
+
+  // Add search modifier if search term exists
+  if (queryTerm.length > 0) {
+    queryChunks.push({
+      multi_match: {
+        query: queryTerm,
+        type: 'phrase_prefix',
+        fields: [
+          'datasetName',
+          'dataLocation',
+          'study.description',
+          'study.studyName',
+          'study.species',
+          'study.piName',
+          'study.dataCustodianEmail',
+          'study.dataTypes',
+          'dataUse.primary.code',
+          'dataUse.secondary.code',
+          'dac.dacName',
+          'datasetIdentifier',
+        ],
+      },
+    })
   }
 
   // Build filter query
@@ -265,6 +290,7 @@ export const useLibraryData = (
   libraryConfig: LibraryVersionNew,
   assetType: AssetType,
   filters: FilterState,
+  queryTerm: string,
   pagination: PaginationState,
   sort?: SortState,
 ) => {
@@ -274,6 +300,7 @@ export const useLibraryData = (
       libraryConfig.key,
       assetType,
       filters,
+      queryTerm,
       pagination,
       sort,
     ],
@@ -282,6 +309,7 @@ export const useLibraryData = (
         libraryConfig,
         assetType,
         filters,
+        queryTerm,
         pagination,
         sort,
       )

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -119,9 +119,14 @@ export const buildElasticsearchQuery = (
         },
       },
       aggs: {
+        total_studies: {
+          cardinality: {
+            field: 'study.studyId',
+          },
+        },
         studies: {
           composite: {
-            size: pagination.pageSize,
+            size: (pagination.page + 1) * pagination.pageSize,
             sources: [
               {
                 study_id: {
@@ -287,14 +292,21 @@ export const useLibraryData = (
 
       if (assetType === AssetType.STUDIES && actualData.aggregations) {
         const studies = transformStudyAggregations(actualData)
+        const totalResult = actualData.aggregations.total_studies as { value: number } | undefined
+        const total = totalResult?.value || studies.length
+        const start = pagination.page * pagination.pageSize
+        const slice = studies.slice(start, start + pagination.pageSize)
+
         return {
-          items: studies,
-          total: actualData.aggregations.studies?.buckets?.length || 0,
+          items: slice,
+          total,
           aggregations: actualData.aggregations,
         }
       }
 
-      const items = Array.isArray(actualData) ? actualData : (actualData.hits?.hits?.map((h: unknown) => h._source) || [])
+      const items = Array.isArray(actualData)
+        ? actualData
+        : (actualData.hits?.hits?.map((h: Record<string, unknown>) => h._source) || [])
       return {
         items,
         total: Array.isArray(actualData) ? actualData.length : (actualData.hits?.total?.value || 0),

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -338,7 +338,7 @@ export const useLibraryData = (
       return {
         items,
         total: Array.isArray(actualData) ? actualData.length : (actualData.hits?.total?.value || 0),
-        aggregations: {},
+        aggregations: actualData.aggregations || {},
       }
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
@@ -348,5 +348,33 @@ export const useLibraryData = (
       total: 0,
       aggregations: {},
     },
+  })
+}
+
+/**
+ * Custom hook for fetching library filter metadata (e.g. unique DACs)
+ */
+export const useLibraryMetadata = (libraryConfig: LibraryVersionNew) => {
+  return useQuery({
+    queryKey: ['library-metadata', libraryConfig.key],
+    queryFn: async () => {
+      const query = buildElasticsearchQuery(
+        libraryConfig,
+        AssetType.DATASETS,
+        {
+          accessManagement: [],
+          dataUse: [],
+          dataType: [],
+          dac: [],
+          participantCount: {},
+        },
+        '',
+        { page: 0, pageSize: 0 },
+      )
+
+      const response = await DataSet.searchDatasetIndexV2(query)
+      return response.aggregations || {}
+    },
+    staleTime: 24 * 60 * 60 * 1000, // 24 hours
   })
 }

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -1,5 +1,257 @@
 import { useQuery } from '@tanstack/react-query'
-import { AssetType, FilterState, LibraryVersionNew, PaginationState, SortState } from 'src/types/library'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import {
+  ElasticsearchQuery,
+  ElasticsearchResponse,
+  QueryClause,
+  StudyAggregationResponse,
+} from 'src/types/elastic'
+import {
+  AssetType,
+  FilterState,
+  LibraryVersionNew,
+  PaginationState,
+  SortState,
+  StudyAggregation,
+} from 'src/types/library'
+
+/**
+ * Build ElasticSearch query for datasets or studies
+ */
+export const buildElasticsearchQuery = (
+  libraryConfig: LibraryVersionNew,
+  assetType: AssetType,
+  filters: FilterState,
+  pagination: PaginationState,
+  sort?: SortState,
+): ElasticsearchQuery => {
+  const queryChunks: QueryClause[] = [
+    {
+      exists: {
+        field: 'study',
+      },
+    },
+  ]
+
+  // Add library-specific query
+  if (libraryConfig.query) {
+    queryChunks.push(libraryConfig.query as QueryClause)
+  }
+
+  // Build filter query
+  const filterQuery: QueryClause[] = []
+
+  if (filters.accessManagement.length > 0) {
+    filterQuery.push({
+      bool: {
+        should: filters.accessManagement.map(term => ({
+          term: {
+            'accessManagement.keyword': term,
+          },
+        })),
+      },
+    })
+  }
+
+  if (filters.dataUse.length > 0) {
+    filterQuery.push({
+      bool: {
+        should: filters.dataUse.map(term => ({
+          match: {
+            'dataUse.primary.code': term,
+          },
+        })),
+      },
+    })
+  }
+
+  if (filters.dataType.length > 0) {
+    filterQuery.push({
+      bool: {
+        should: filters.dataType.map(term => ({
+          match: {
+            'study.dataTypes': term,
+          },
+        })),
+      },
+    })
+  }
+
+  if (filters.dac.length > 0) {
+    filterQuery.push({
+      bool: {
+        should: filters.dac.map(term => ({
+          match_phrase: {
+            'dac.dacName': term,
+          },
+        })),
+      },
+    })
+  }
+
+  if (
+    filters.participantCount.min !== undefined
+    || filters.participantCount.max !== undefined
+  ) {
+    filterQuery.push({
+      range: {
+        participantCount: {
+          ...(filters.participantCount.min !== undefined && {
+            gte: filters.participantCount.min,
+          }),
+          ...(filters.participantCount.max !== undefined && {
+            lte: filters.participantCount.max,
+          }),
+        },
+      },
+    })
+  }
+
+  // Build different query structure for studies vs datasets
+  if (assetType === AssetType.STUDIES) {
+    // For studies, use aggregations
+    return {
+      size: 0, // Don't return documents
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        studies: {
+          composite: {
+            size: pagination.pageSize,
+            sources: [
+              {
+                study_id: {
+                  terms: {
+                    field: 'study.studyId',
+                  },
+                },
+              },
+            ],
+          },
+          aggs: {
+            study_details: {
+              top_hits: {
+                size: 1,
+                _source: ['study.*'],
+              },
+            },
+            dataset_count: {
+              value_count: {
+                field: 'datasetId',
+              },
+            },
+            total_participants: {
+              sum: {
+                field: 'participantCount',
+              },
+            },
+            dataset_ids: {
+              terms: {
+                field: 'datasetId',
+                size: 10000,
+              },
+            },
+          },
+        },
+        // Add filter aggregations
+        access_management: {
+          terms: {
+            field: 'accessManagement.keyword',
+          },
+        },
+        data_use: {
+          terms: {
+            field: 'dataUse.primary.code.keyword',
+          },
+        },
+        data_type: {
+          terms: {
+            field: 'study.dataTypes.keyword',
+          },
+        },
+        dac: {
+          terms: {
+            field: 'dac.dacName.keyword',
+          },
+        },
+      },
+    }
+  }
+
+  // For datasets, use standard pagination
+  return {
+    from: pagination.page * pagination.pageSize,
+    size: pagination.pageSize,
+    query: {
+      bool: {
+        must: queryChunks,
+        ...(filterQuery.length > 0 && { filter: filterQuery }),
+      },
+    },
+    ...(sort && {
+      sort: [
+        {
+          [sort.field]: {
+            order: sort.order,
+          },
+        },
+      ],
+    }),
+    // Add filter aggregations
+    aggs: {
+      access_management: {
+        terms: {
+          field: 'accessManagement.keyword',
+        },
+      },
+      data_use: {
+        terms: {
+          field: 'dataUse.primary.code.keyword',
+        },
+      },
+      data_type: {
+        terms: {
+          field: 'study.dataTypes.keyword',
+        },
+      },
+      dac: {
+        terms: {
+          field: 'dac.dacName.keyword',
+        },
+      },
+    },
+  }
+}
+
+/**
+ * Transform aggregation response to study rows
+ */
+export const transformStudyAggregations = (
+  response: ElasticsearchResponse,
+): StudyAggregation[] => {
+  const studiesAgg = response.aggregations?.studies as StudyAggregationResponse | undefined
+  const buckets = studiesAgg?.buckets || []
+
+  return buckets.map((bucket) => {
+    const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+    return {
+      studyId: bucket.key.study_id,
+      studyName: studyData.studyName || '',
+      studyDescription: studyData.description || '',
+      piName: studyData.piName || '',
+      species: studyData.species || '',
+      phenotype: studyData.phenotype || '',
+      dataCustodianEmail: studyData.dataCustodianEmail || [],
+      datasetCount: bucket.dataset_count?.value || 0,
+      totalParticipants: bucket.total_participants?.value || 0,
+      datasetIds: bucket.dataset_ids?.buckets?.map(b => b.key) || [],
+    }
+  })
+}
 
 /**
  * Custom hook for fetching library data
@@ -21,9 +273,31 @@ export const useLibraryData = (
       sort,
     ],
     queryFn: async () => {
+      const query = buildElasticsearchQuery(
+        libraryConfig,
+        assetType,
+        filters,
+        pagination,
+        sort,
+      )
+
+      const response = await DataSet.searchDatasetIndexV2(query)
+
+      const actualData = response.data || response
+
+      if (assetType === AssetType.STUDIES && actualData.aggregations) {
+        const studies = transformStudyAggregations(actualData)
+        return {
+          items: studies,
+          total: actualData.aggregations.studies?.buckets?.length || 0,
+          aggregations: actualData.aggregations,
+        }
+      }
+
+      const items = Array.isArray(actualData) ? actualData : (actualData.hits?.hits?.map((h: unknown) => h._source) || [])
       return {
-        items: [],
-        total: 0,
+        items,
+        total: Array.isArray(actualData) ? actualData.length : (actualData.hits?.total?.value || 0),
         aggregations: {},
       }
     },

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -85,6 +85,7 @@ export const useLibraryUrlState = () => {
     filters: parseFiltersFromUrl(searchParams),
     page: Number.parseInt(searchParams.get('page') || '0'),
     pageSize: Number.parseInt(searchParams.get('pageSize') || '25'),
+    query: searchParams.get('query') || undefined,
     sortField: searchParams.get('sort') || undefined,
     sortOrder: (searchParams.get('order') as SortOrder) || undefined,
   }
@@ -125,6 +126,15 @@ export const useLibraryUrlState = () => {
       }
       else {
         newParams.set('pageSize', updates.pageSize.toString())
+      }
+    }
+
+    if (updates.query !== undefined) {
+      if (updates.query) {
+        newParams.set('query', updates.query)
+      }
+      else {
+        newParams.delete('query')
       }
     }
 

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -81,7 +81,7 @@ export const useLibraryUrlState = () => {
 
   const state: LibraryUrlState = {
     library: searchParams.get('library') || 'duos',
-    tab: (searchParams.get('tab') as AssetType) || AssetType.STUDIES,
+    tab: (searchParams.get('tab') as AssetType) || AssetType.DATASETS,
     filters: parseFiltersFromUrl(searchParams),
     page: Number.parseInt(searchParams.get('page') || '0'),
     pageSize: Number.parseInt(searchParams.get('pageSize') || '25'),

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -68,6 +68,7 @@ export const DataLibrary: React.FC = () => {
         { value: 'HMB', label: 'Health/Medical/Biomedical' },
         { value: 'GRU', label: 'General Research Use' },
         { value: 'DS', label: 'Disease Specific' },
+        { value: 'OTHER', label: 'Other Restriction' },
         { value: 'NRES', label: 'No Restrictions' },
       ],
       dataType: dataTypeAgg

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -32,6 +32,12 @@ export const DataLibrary: React.FC = () => {
 
   const searchRef = useRef<HTMLInputElement>(null)
 
+  React.useEffect(() => {
+    if (searchRef.current && urlState.query) {
+      searchRef.current.value = urlState.query
+    }
+  }, [urlState.query])
+
   const libraryConfig: LibraryVersionNew = {
     key: 'duos',
     title: 'DUOS Data Library',
@@ -73,6 +79,7 @@ export const DataLibrary: React.FC = () => {
     libraryConfig,
     urlState.tab,
     urlState.filters,
+    urlState.query ?? '',
     { page: urlState.page, pageSize: urlState.pageSize },
     urlState.sortField && urlState.sortOrder
       ? { field: urlState.sortField, order: urlState.sortOrder }
@@ -91,6 +98,13 @@ export const DataLibrary: React.FC = () => {
     setSelectedDatasetIds([])
   }
 
+  const handleSearchChange = (query: string) => {
+    updateUrlState({
+      query,
+      page: 0,
+    })
+  }
+
   const handleFiltersChange = (newFilters: typeof urlState.filters) => {
     updateUrlState({
       filters: newFilters,
@@ -106,6 +120,7 @@ export const DataLibrary: React.FC = () => {
         dac: [],
         participantCount: {},
       },
+      page: 0,
     })
   }
 
@@ -149,7 +164,7 @@ export const DataLibrary: React.FC = () => {
           description={libraryConfig.description}
         />
         <SearchBar
-          handleSearchChange={() => {}}
+          handleSearchChange={handleSearchChange}
           searchRef={searchRef}
           style={{
             paddingTop: '10px',

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -141,7 +141,7 @@ export const DataLibrary: React.FC = () => {
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100vh', pb: 5 }}>
       {/* Header */}
       <Box>
         <TableHeaderSection
@@ -188,7 +188,7 @@ export const DataLibrary: React.FC = () => {
         </Box>
 
         {/* Data Grid */}
-        <Box sx={{ flex: 1, overflow: 'hidden' }}>
+        <Box sx={{ flex: 1, height: '100%', overflow: 'hidden' }}>
           <LibraryDataGrid
             assetType={urlState.tab}
             data={data?.items || []}

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -6,8 +6,9 @@ import TableHeaderSection from 'src/components/TableHeaderSection'
 import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
 import { AssetType, AvailableFilters, LibraryVersionNew, SortOrder, TabConfig } from 'src/types/library'
 import LibraryFilters from 'src/components/data_library/LibraryFilters'
-import { useLibraryData } from 'src/hooks/useLibraryData'
+import { useLibraryData, useLibraryMetadata } from 'src/hooks/useLibraryData'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
+import { AggregationResult } from 'src/types/elastic'
 
 /**
  * DataLibrary Page Component
@@ -51,29 +52,44 @@ export const DataLibrary: React.FC = () => {
     { key: AssetType.DATASETS, label: 'Datasets' },
   ]
 
-  const availableFilters: AvailableFilters = {
-    accessManagement: [
-      { value: 'controlled', label: 'Controlled' },
-      { value: 'open', label: 'Open' },
-      { value: 'external', label: 'External' },
-    ],
-    dataUse: [
-      { value: 'HMB', label: 'Health/Medical/Biomedical' },
-      { value: 'GRU', label: 'General Research Use' },
-      { value: 'DS', label: 'Disease Specific' },
-      { value: 'NRES', label: 'No Restrictions' },
-    ],
-    dataType: [
-      { value: 'Phenotype', label: 'Phenotype' },
-      { value: 'Genomic', label: 'Genomic' },
-      { value: 'Transcriptomic', label: 'Transcriptomic' },
-    ],
-    dac: [],
-    participantCountRange: {
-      min: 0,
-      max: 100000,
-    },
-  }
+  const { data: metadata, isLoading: isMetadataLoading } = useLibraryMetadata(libraryConfig)
+
+  const availableFilters: AvailableFilters = useMemo(() => {
+    const dacAgg = (metadata?.dac as AggregationResult)?.buckets || []
+    const dataTypeAgg = (metadata?.data_type as AggregationResult)?.buckets || []
+
+    return {
+      accessManagement: [
+        { value: 'controlled', label: 'Controlled' },
+        { value: 'open', label: 'Open' },
+        { value: 'external', label: 'External' },
+      ],
+      dataUse: [
+        { value: 'HMB', label: 'Health/Medical/Biomedical' },
+        { value: 'GRU', label: 'General Research Use' },
+        { value: 'DS', label: 'Disease Specific' },
+        { value: 'NRES', label: 'No Restrictions' },
+      ],
+      dataType: dataTypeAgg
+        .map(bucket => ({
+          value: bucket.key as string,
+          label: bucket.key as string,
+          count: bucket.doc_count,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+      dac: dacAgg
+        .map(bucket => ({
+          value: bucket.key as string,
+          label: bucket.key as string,
+          count: bucket.doc_count,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+      participantCountRange: {
+        min: 0,
+        max: 100000,
+      },
+    }
+  }, [metadata])
 
   const { data, isLoading, isFetching, error } = useLibraryData(
     libraryConfig,
@@ -198,7 +214,7 @@ export const DataLibrary: React.FC = () => {
             onChange={handleFiltersChange}
             onClear={handleClearFilters}
             availableFilters={availableFilters}
-            loading={isLoading}
+            loading={isLoading || isMetadataLoading}
           />
         </Box>
 

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -1,0 +1,210 @@
+import { SortOrder } from 'src/types/library'
+import { DatasetTerm } from 'src/types/model'
+
+export interface MatchQuery {
+  match: {
+    [field: string]: string | number | boolean
+  }
+}
+
+export interface ExistsQuery {
+  exists: {
+    field: string
+  }
+}
+
+export interface TermQuery {
+  term: {
+    [field: string]: string | number | boolean
+  }
+}
+
+export interface MatchPhraseQuery {
+  match_phrase: {
+    [field: string]: string | number
+  }
+}
+
+export interface MultiMatchQuery {
+  multi_match: {
+    query: string
+    type?: string
+    fields: string[]
+  }
+}
+
+export interface RangeQuery {
+  range: {
+    [field: string]: {
+      gte?: number
+      lte?: number
+      gt?: number
+      lt?: number
+    }
+  }
+}
+
+export interface BoolQuery {
+  bool: {
+    must?: QueryClause[]
+    should?: QueryClause[]
+    must_not?: QueryClause[]
+    filter?: QueryClause[]
+  }
+}
+
+export type QueryClause
+  = MatchQuery
+    | ExistsQuery
+    | TermQuery
+    | MatchPhraseQuery
+    | MultiMatchQuery
+    | RangeQuery
+    | BoolQuery
+
+export interface ElasticsearchQuery {
+  from?: number
+  size?: number
+  query?: {
+    bool: {
+      must?: QueryClause[]
+      should?: QueryClause[]
+      must_not?: QueryClause[]
+      filter?: QueryClause[]
+    }
+  }
+  sort?: Array<{
+    [field: string]: {
+      order: SortOrder
+    }
+  }>
+  aggs?: {
+    [key: string]: AggregationDefinition
+  }
+}
+
+export interface TermsAggregation {
+  terms: {
+    field: string
+    size?: number
+  }
+}
+
+export interface CompositeAggregation {
+  composite: {
+    size: number
+    sources: Array<{
+      [key: string]: {
+        terms: {
+          field: string
+        }
+      }
+    }>
+    after?: {
+      [key: string]: string | number
+    }
+  }
+  aggs?: {
+    [key: string]: AggregationDefinition
+  }
+}
+
+export interface TopHitsAggregation {
+  top_hits: {
+    size: number
+    _source?: string[]
+  }
+}
+
+export interface ValueCountAggregation {
+  value_count: {
+    field: string
+  }
+}
+
+export interface SumAggregation {
+  sum: {
+    field: string
+  }
+}
+
+export interface CardinalityAggregation {
+  cardinality: {
+    field: string
+  }
+}
+
+export type AggregationDefinition
+  = TermsAggregation
+    | CompositeAggregation
+    | TopHitsAggregation
+    | ValueCountAggregation
+    | SumAggregation
+    | CardinalityAggregation
+
+export interface AggregationBucket {
+  key: string | number | { [key: string]: string | number }
+  doc_count: number
+  [key: string]: unknown
+}
+
+export interface AggregationResult {
+  buckets?: AggregationBucket[]
+  value?: number
+  after_key?: {
+    [key: string]: string | number
+  }
+  [key: string]: unknown
+}
+
+export interface StudyAggregationBucket {
+  key: { study_id: number }
+  doc_count: number
+  study_details?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          study?: {
+            studyId?: number
+            studyName?: string
+            description?: string
+            piName?: string
+            species?: string
+            phenotype?: string
+            dataCustodianEmail?: string[]
+          }
+        }
+      }>
+    }
+  }
+  dataset_count?: {
+    value: number
+  }
+  total_participants?: {
+    value: number
+  }
+  dataset_ids?: {
+    buckets: Array<{ key: number }>
+  }
+}
+
+export interface StudyAggregationResponse {
+  buckets: StudyAggregationBucket[]
+  after_key?: { study_id: number }
+}
+
+export interface PaginatedResponse<T> {
+  items: T[]
+  total: number
+  aggregations?: {
+    [key: string]: AggregationResult
+  }
+}
+
+export interface ElasticsearchResponse {
+  items: DatasetTerm[]
+  total: number
+  aggregations?: {
+    [key: string]: AggregationResult
+  }
+}

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -66,6 +66,7 @@ export interface LibraryUrlState {
   library: string
   tab: AssetType
   filters: FilterState
+  query?: string
   page: number
   pageSize: number
   sortField?: string


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2434
https://broadworkbench.atlassian.net/browse/DT-2459

### Summary

Wires in the Elasticsearch query logic into the data library, making it functional. This:

* Sets the default tab to Datasets
* Paginates the search queries, making them return only the minimal amount of information required for the page
* Refactors the Study queries to use Elasticsearch aggregation
* Wires in the search box into the data library
* Provides a new `useLibraryMetadata` query that can return dynamic information about the data libraries for filters or other purposes (DACs, Data Use, etc.)

<img width="1774" height="924" alt="Screenshot 2026-02-20 at 9 17 19 AM" src="https://github.com/user-attachments/assets/df4abf2a-3875-4b10-b1cf-ef402d53d289" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
