### PR TITLE
DT-2918: Get Terms of Service state from user instead of separate API call

### DIFF
--- a/cypress/component/SignIn/SignInButton.spec.tsx
+++ b/cypress/component/SignIn/SignInButton.spec.tsx
@@ -5,16 +5,19 @@ import { Auth } from 'src/libs/auth/auth'
 import { Storage } from 'src/libs/storage'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import { StackdriverReporter } from 'src/libs/stackdriverReporter'
-import { ToS } from 'src/libs/ajax/ToS'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 import { mockOidcUser } from '../Auth/mockOidcUser'
 import { BrowserRouter } from 'react-router-dom'
+import { DuosUser, UserStatusInfo } from 'src/types/model'
 
 const signInText = 'Sign In'
 
 const duosUser = {
   displayName: 'display name',
   email: 'test@user.com',
+  emailPreference: true,
+  eraCommonsId: 'eraCommonsId',
+  institutionId: 1,
   isAdmin: true,
   isAlumni: false,
   isChairPerson: false,
@@ -26,15 +29,14 @@ const duosUser = {
   roles: [{
     name: 'Admin',
   }],
-}
+} as unknown as DuosUser
 
 const userStatus = {
   adminEnabled: true,
   enabled: true,
-  inAllUsersGroup: true,
-  inGoogleProxyGroup: true,
+  userSubjectId: '1234',
   tosAccepted: true,
-}
+} as UserStatusInfo
 
 const consentStatus = {
   ok: true,
@@ -47,8 +49,6 @@ const consentStatus = {
     },
   },
 }
-
-const notAcceptedUserStatus = Object.assign({}, userStatus, { tosAccepted: false })
 
 describe('Sign In: Component Loads', function () {
   beforeEach(() => {
@@ -65,16 +65,16 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: On Success', function () {
     cy.stub(Auth, 'signIn').resolves(mockOidcUser)
-    cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: duosUser }).as('getMe')
+    const tosAcceptedUser = { ...{ userStatusInfo: userStatus }, ...duosUser }
+    cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: tosAcceptedUser }).as('getMe')
     cy.stub(StackdriverReporter, 'report').as('report')
     cy.stub(Metrics, 'identify').as('identify')
     cy.stub(Metrics, 'syncProfile').as('syncProfile')
     cy.stub(Metrics, 'captureEvent').as('captureEvent')
-    cy.stub(ToS, 'getStatus').returns(userStatus)
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').click()
     cy.wait('@getMe').then(() => {
-      expect(Storage.getCurrentUser()).to.deep.equal(duosUser)
+      expect(Storage.getCurrentUser()).to.deep.equal(tosAcceptedUser)
       assert.isNotNull(Storage.getAnonymousId(), 'Anonymous ID should not be null')
       cy.get('@report').should('not.be.called')
       cy.get('@identify').should('be.called')
@@ -85,10 +85,10 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: No Roles Error Reporter Is Called', function () {
     const bareUser = { email: 'test@user.com' }
+    const tosAcceptedUser = { ...{ userStatusInfo: userStatus }, ...bareUser }
     cy.stub(Auth, 'signIn').resolves(mockOidcUser)
-    cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: bareUser }).as('getMe')
+    cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: tosAcceptedUser }).as('getMe')
     cy.stub(StackdriverReporter, 'report').as('report')
-    cy.stub(ToS, 'getStatus').returns(userStatus)
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').click()
     cy.wait('@getMe').then(() => {
@@ -99,7 +99,7 @@ describe('Sign In: Component Loads', function () {
   it('Sign In: Redirects to ToS if not accepted', function () {
     cy.stub(Auth, 'signIn').resolves(mockOidcUser)
     cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: duosUser }).as('getMe')
-    cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus)
+    // cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus)
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').click()
     cy.wait('@getMe').then(() => {
@@ -112,7 +112,7 @@ describe('Sign In: Component Loads', function () {
     // Simulate user not found
     cy.stub(User, 'getMe').throws()
     cy.intercept({ method: 'POST', url: '**/api/user' }, { statusCode: 200, body: duosUser }).as('registerUser')
-    cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus)
+    // cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus)
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').click()
     cy.wait('@registerUser').then(() => {

--- a/cypress/component/SignIn/SignInButton.spec.tsx
+++ b/cypress/component/SignIn/SignInButton.spec.tsx
@@ -99,7 +99,6 @@ describe('Sign In: Component Loads', function () {
   it('Sign In: Redirects to ToS if not accepted', function () {
     cy.stub(Auth, 'signIn').resolves(mockOidcUser)
     cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: duosUser }).as('getMe')
-    // cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus)
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').click()
     cy.wait('@getMe').then(() => {
@@ -112,7 +111,6 @@ describe('Sign In: Component Loads', function () {
     // Simulate user not found
     cy.stub(User, 'getMe').throws()
     cy.intercept({ method: 'POST', url: '**/api/user' }, { statusCode: 200, body: duosUser }).as('registerUser')
-    // cy.stub(ToS, 'getStatus').returns(notAcceptedUserStatus)
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').click()
     cy.wait('@registerUser').then(() => {

--- a/cypress/component/SignIn/SignInButton.spec.tsx
+++ b/cypress/component/SignIn/SignInButton.spec.tsx
@@ -65,7 +65,7 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: On Success', function () {
     cy.stub(Auth, 'signIn').resolves(mockOidcUser)
-    const tosAcceptedUser = { ...{ userStatusInfo: userStatus }, ...duosUser }
+    const tosAcceptedUser = { userStatusInfo: userStatus, ...duosUser }
     cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: tosAcceptedUser }).as('getMe')
     cy.stub(StackdriverReporter, 'report').as('report')
     cy.stub(Metrics, 'identify').as('identify')
@@ -85,7 +85,7 @@ describe('Sign In: Component Loads', function () {
 
   it('Sign In: No Roles Error Reporter Is Called', function () {
     const bareUser = { email: 'test@user.com' }
-    const tosAcceptedUser = { ...{ userStatusInfo: userStatus }, ...bareUser }
+    const tosAcceptedUser = { userStatusInfo: userStatus, ...bareUser }
     cy.stub(Auth, 'signIn').resolves(mockOidcUser)
     cy.intercept({ method: 'GET', url: '**/api/user/me' }, { statusCode: 200, body: tosAcceptedUser }).as('getMe')
     cy.stub(StackdriverReporter, 'report').as('report')

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -155,8 +155,7 @@ export const SignInButton = () => {
     }
   }
 
-  // eslint-disable-next-line
-  const onFailure = (response: any) => {
+  const onFailure = (response: Error) => {
     Storage.clearStorage()
     // Known error case from oidc-client-ts PopupWindow: "new Error("Popup closed by user")"
     if (response.toString().includes('Popup closed by user')) {

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { isEmpty, isNil } from 'lodash'
 import { Alert } from 'src/components/Alert'
 import { Auth } from 'src/libs/auth/auth'
-import { ToS } from 'src/libs/ajax/ToS'
 import { User } from 'src/libs/ajax/User'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import { Storage } from 'src/libs/storage'
@@ -42,24 +41,22 @@ export const SignInButton = () => {
   // Check for ToS Acceptance - redirect user if not set.
   const checkToSAndRedirect = async (redirectPath: string | null) => {
     // Check if the user has accepted ToS yet or not:
-    const userStatus = await ToS.getStatus()
-    const { tosAccepted } = userStatus
-    if (!isEmpty(userStatus) && !tosAccepted) {
+    const tosAccepted = Storage.getCurrentUser().userStatusInfo?.tosAccepted || false
+    if (tosAccepted) {
+      if (isNil(redirectPath)) {
+        await Navigation.console(Storage.getCurrentUser(), navigate)
+      }
+      else {
+        navigate(redirectPath)
+      }
+    }
+    else {
       // User has authenticated, but has not accepted ToS
       if (isNil(redirectPath)) {
         navigate(`/tos_acceptance`)
       }
       else {
         navigate(`/tos_acceptance?redirectTo=${redirectPath}`)
-      }
-    }
-    else {
-      // User is authenticated, registered and has accepted ToS: redirect to destination.
-      if (isNil(redirectPath)) {
-        await Navigation.console(Storage.getCurrentUser(), navigate)
-      }
-      else {
-        navigate(redirectPath)
       }
     }
   }

--- a/src/libs/ajax/ToS.js
+++ b/src/libs/ajax/ToS.js
@@ -7,24 +7,6 @@ export const ToS = {
     const res = await fetchGet(url, Config.textPlain())
     return res.data
   },
-  /**
-   * Returns a json structure of various statuses for an authenticated user.
-   * See https://consent.dsde-prod.broadinstitute.org/#/Sam/get_api_sam_register_self_diagnostics
-   * for more info.
-   * {
-   *   'adminEnabled': false,
-   *   'enabled': false,
-   *   'inAllUsersGroup': true,
-   *   'inGoogleProxyGroup': false,
-   *   'tosAccepted': true
-   * }
-   * @returns {Promise<any>}
-   */
-  getStatus: async () => {
-    const url = `${await Config.getApiUrl()}/api/sam/register/self/diagnostics`
-    const res = await fetchGet(url, Config.authOpts())
-    return res.data
-  },
   acceptToS: async () => {
     const url = `${await Config.getApiUrl()}/api/sam/register/self/tos`
     const res = await fetchPost(url, {}, Config.authOpts())

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -38,10 +38,11 @@ export interface UserRole {
 }
 
 export interface UserStatusInfo {
-  adminEnabled: boolean
+  adminEnabled?: boolean
   enabled: boolean
   userEmail: string
   userSubjectId: string
+  tosAccepted?: boolean
 }
 
 export interface UserProperty {


### PR DESCRIPTION
### Addresses
Front end work related to https://broadworkbench.atlassian.net/browse/DT-2918

### Summary
~This PR requires https://github.com/DataBiosphere/consent/pull/2817~ (merged)

In the back end PR, the user status from Sam is now stored on the user object returned from the `GET /api/user/me` call which allows us to skip the API call we were making in `ToS.getStatus`

Note in this network tab that the extra diagnostics call seen in https://github.com/DataBiosphere/consent/pull/2817 is no longer made. Note also that a user who has not accepted ToS is redirected to the ToS screen instead of their original intended location.

<img width="1786" height="918" alt="Screenshot 2026-02-20 at 4 22 05 PM" src="https://github.com/user-attachments/assets/3a66a751-d031-46d6-8cfc-d45869bb8293" />

<img width="1830" height="962" alt="Screenshot 2026-02-20 at 4 23 49 PM" src="https://github.com/user-attachments/assets/22122482-1ff7-4554-82a5-d23f1b6b8962" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
