### PR TITLE
[DT-2965] Fix infinite useEffect reload on Progress Report

### DIFF
--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react'
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { CombinedDataAccessRequest, Dataset, DataUse, DuosUser, SimplifiedDuosUser } from 'src/types/model'
 import {
   CLOSEOUT_KEYS,
@@ -26,6 +26,7 @@ import {
 import { FormValidationState } from 'src/pages/dar_application/FormValidationState'
 import { getApprovedElectionDatasetIds } from 'src/utils/DarUtils'
 import { useNavigate } from 'react-router-dom'
+import { isEqual } from 'lodash'
 type ProgressReportApplicationProps = {
   readonly dar: CombinedDataAccessRequest // corresponds either to the parent DAR for a new application or an existing readonly progress report
   readonly datasets: Dataset[]
@@ -196,30 +197,31 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
       )
   }
 
-  function getDatasetsInApprovedElections(datasets: Dataset[], approvedElectionDatasetIds: number[]) {
-    return datasets.filter((dataset) => {
-      return approvedElectionDatasetIds.includes(dataset.datasetId)
-    })
-  }
-
-  // required because the datasets state changes during component mount
-  useEffect(() => {
-    let approvedDatasets
+  const approvedDatasets = useMemo(() => {
     if (readOnlyMode) {
-      approvedDatasets = datasets.filter(
-        dataset => dar.datasetIds.includes(dataset.datasetId),
-      )
+      return datasets.filter(dataset => dar.datasetIds.includes(dataset.datasetId))
     }
     else {
       const approvedDatasetIds = dar.elections ? getApprovedElectionDatasetIds(Object.values(dar.elections)) : []
-      approvedDatasets = getDatasetsInApprovedElections(datasets, approvedDatasetIds)
+      return datasets.filter(dataset => approvedDatasetIds.includes(dataset.datasetId))
         .filter(ds => ds.dacApproval)
     }
+  }, [datasets, readOnlyMode, dar.datasetIds, dar.elections])
 
-    onFormChange({ datasets: approvedDatasets }, false) // Mark as non-user interaction
-    onSelectedDatasetChange(approvedDatasets)
+  const datasetIdsMatch = (a: Dataset[], b: Dataset[]) =>
+    isEqual(
+      a.map(ds => ds.datasetId).sort((a, b) => (a - b)),
+      b.map(ds => ds.datasetId).sort((a, b) => (a - b)),
+    )
+
+  // required because the datasets state changes during component mount
+  useEffect(() => {
+    if (!datasetIdsMatch(approvedDatasets, formState.selectedDatasets)) {
+      onFormChange({ datasets: approvedDatasets }, false) // Mark as non-user interaction
+      onSelectedDatasetChange(approvedDatasets)
+    }
     isMounted.current = true // Mark as mounted after initial setup
-  }, [datasets, readOnlyMode, dar.datasetIds, dar.elections, onFormChange, onSelectedDatasetChange])
+  }, [approvedDatasets, onFormChange, onSelectedDatasetChange, formState.selectedDatasets])
 
   return (
     <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2965

### Summary

This PR fixes `Maximum update depth exceeded` error caused by infinite loops of useEffect that triggers with changes from `onSelectedDatasetChange` and `onFormChange`.  This [backend PR](https://github.com/DataBiosphere/consent/pull/2821) enables showing vote information for non-privileged users which is used to determine approvedDatasets.

<img width="1492" height="1328" alt="Screenshot 2026-02-19 at 11 32 24 AM" src="https://github.com/user-attachments/assets/024299ac-bd54-4c45-8ae9-1d2f499a1e4d" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
