### PR TITLE
[DT-2972] Remove custom data libraries

### DIFF
--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -68,7 +68,6 @@ describe('Library Versions - Tests', function () {
       expect(keys).to.include('terra')
       expect(keys).to.include('mgb')
       expect(keys).to.include('myinstitution')
-      expect(keys).to.include('/custom')
     })
 
     it('handles myinstitution library with dynamic parameters', function () {

--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -3,14 +3,14 @@ import { getLibraryVersions } from 'src/libs/libraryVersions'
 describe('Library Versions - Tests', function () {
   describe('getLibraryVersions function', function () {
     it('returns an object with library configurations', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       expect(versions).to.be.an('object')
       expect(Object.keys(versions).length).to.be.greaterThan(0)
     })
 
     it('includes required properties for each library', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       Object.entries(versions).forEach(([_key, library]) => {
         expect(library).to.have.property('title')
@@ -24,7 +24,7 @@ describe('Library Versions - Tests', function () {
     })
 
     it('marks exactly the correct libraries as featured', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       const featuredLibraries = Object.entries(versions)
         .filter(([, library]) => library.featured)
@@ -43,7 +43,7 @@ describe('Library Versions - Tests', function () {
     })
 
     it('marks non-featured libraries correctly', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       const nonFeaturedLibraries = Object.entries(versions)
         .filter(([, library]) => !library.featured)
@@ -56,7 +56,7 @@ describe('Library Versions - Tests', function () {
     })
 
     it('includes all expected library keys', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
       const keys = Object.keys(versions)
 
       // Check for some expected keys
@@ -74,7 +74,7 @@ describe('Library Versions - Tests', function () {
     it('handles myinstitution library with dynamic parameters', function () {
       const institutionId = 123
       const institutionName = 'Test Institution'
-      const versions = getLibraryVersions(institutionId, institutionName, null)
+      const versions = getLibraryVersions(institutionId, institutionName)
 
       const myInstitution = versions.myinstitution
 
@@ -86,23 +86,8 @@ describe('Library Versions - Tests', function () {
       expect(myInstitution.featured).to.equal(false)
     })
 
-    it('handles custom library with dynamic query', function () {
-      const customQuery = 'custom search term'
-      const versions = getLibraryVersions(null, null, customQuery)
-
-      const customLibrary = versions['/custom']
-
-      expect(customLibrary).to.not.equal(undefined)
-      expect(customLibrary.title).to.equal('custom search term Data Library')
-      if (customLibrary.query && 'bool' in customLibrary.query) {
-        expect(customLibrary.query.bool.should).to.be.an('array')
-        expect(customLibrary.query.bool.should.length).to.equal(2)
-      }
-      expect(customLibrary.featured).to.equal(false)
-    })
-
     it('includes Elasticsearch query for most libraries', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       Object.entries(versions).forEach(([_key, library]) => {
         // Some libraries have null query (/datalibrary, terra)
@@ -119,7 +104,7 @@ describe('Library Versions - Tests', function () {
     })
 
     it('maintains consistent title format', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       Object.entries(versions).forEach(([key, library]) => {
         if (key !== '/datalibrary') {
@@ -131,7 +116,7 @@ describe('Library Versions - Tests', function () {
 
   describe('Featured libraries integration', function () {
     it('provides correct data for Home page rendering', function () {
-      const versions = getLibraryVersions(null, null, null)
+      const versions = getLibraryVersions(null, null)
 
       const featuredLibraries = Object.entries(versions)
         .filter(([, library]) => library.featured)

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -20,7 +20,6 @@ import gp2Icon from 'src/images/gp2-logo.png'
 import asapIcon from 'src/images/asap-logo.png'
 import gedIcon from 'src/images/GED_logo.png'
 import ncpiIcon from 'src/images/ncpi-logo.png'
-import homeIcon from 'src/images/icon_dataset_.png'
 import epi25Icon from 'src/images/Epi25_logo.png'
 import PGCIcon from 'src/images/PGC_logo.jpg'
 import PBNIcon from 'src/images/PBN_logo.jpg'
@@ -69,7 +68,6 @@ export interface LibraryVersions {
 export const getLibraryVersions = (
   institutionId: number | null,
   institutionName: string | null,
-  customQuery: string | null,
 ): LibraryVersions => {
   return {
     '/datalibrary': {
@@ -572,28 +570,6 @@ export const getLibraryVersions = (
       },
       icon: ncpiIcon,
       title: 'NCPI DUO Data Library',
-      featured: false,
-      order: 999,
-    },
-    '/custom': {
-      query: {
-        bool: {
-          should: [
-            {
-              match_phrase: {
-                'study.description': customQuery ?? '',
-              },
-            },
-            {
-              match_phrase: {
-                'submitter.institution.name': customQuery ?? '',
-              },
-            },
-          ],
-        },
-      },
-      icon: homeIcon,
-      title: (customQuery ?? '') + ' Data Library',
       featured: false,
       order: 999,
     },

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -107,7 +107,7 @@ export const DatasetSearch = (props) => {
     [institutionId, institutionName],
   )
 
-  const version = versions[key] === undefined ? versions['/custom'] : versions[key]
+  const version = versions[key]
   const isInstitutionQuery = key === 'myinstitution'
 
   // Memoize fullQuery to prevent recreation on every render

--- a/src/pages/DatasetSearch.jsx
+++ b/src/pages/DatasetSearch.jsx
@@ -103,8 +103,8 @@ export const DatasetSearch = (props) => {
 
   // Memoize versions to prevent recreation on every render
   const versions = useMemo(
-    () => getLibraryVersions(institutionId, institutionName, query),
-    [institutionId, institutionName, query],
+    () => getLibraryVersions(institutionId, institutionName),
+    [institutionId, institutionName],
   )
 
   const version = versions[key] === undefined ? versions['/custom'] : versions[key]

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -13,7 +13,7 @@ const Home = (props) => {
 
   // Get all library versions and filter for featured ones
   const featuredLibraries = useMemo(() => {
-    const allLibraries = getLibraryVersions(null, null, null)
+    const allLibraries = getLibraryVersions(null, null)
     return Object.entries(allLibraries)
       .filter(([_key, library]) => library.featured)
       .map(([key, library]) => ({ key, ...library }))


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2972

### Summary

Removes custom data libraries to make support of branded data libraries in the new system easier.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
