### PR TITLE
[DT-2975] Add "apply for access" footer and asset selection

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DataLibrary } from 'src/pages/DataLibrary'
+import { Storage } from 'src/libs/storage'
 
 const mockMetadataResponse = {
   aggregations: {
@@ -59,6 +60,12 @@ describe('DataLibrary', () => {
       },
     })
     cy.initApplicationConfig()
+    // Stub user with library card for footer functionality
+    cy.window().then(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        libraryCard: { cardNumber: '12345' },
+      })
+    })
     cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
       if (req.body.aggs?.studies) {
         req.reply(mockStudiesResponse)

--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -3,12 +3,30 @@ import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DataLibrary } from 'src/pages/DataLibrary'
 
-const queryClient = new QueryClient()
-
 const mockMetadataResponse = {
   aggregations: {
     dac: { buckets: [{ key: 'DAC-1', doc_count: 5 }] },
     data_type: { buckets: [{ key: 'Genomic', doc_count: 10 }] },
+  },
+}
+
+const mockDatasetsResponse = {
+  hits: {
+    total: { value: 1 },
+    hits: [
+      {
+        _source: {
+          datasetId: 1,
+          datasetName: 'Dataset One',
+          datasetIdentifier: 'DUOS-000001',
+          accessManagement: 'controlled',
+          study: {
+            studyId: 101,
+            studyName: 'Study One',
+          },
+        },
+      },
+    ],
   },
 }
 
@@ -30,17 +48,26 @@ const mockStudiesResponse = {
 }
 
 describe('DataLibrary', () => {
+  let queryClient: QueryClient
+
   beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
     cy.initApplicationConfig()
     cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
-      if (req.body.size === 0 && !req.body.queryTerm) {
-        req.reply(mockMetadataResponse)
-      }
-      else if (req.body.aggs?.studies) {
+      if (req.body.aggs?.studies) {
         req.reply(mockStudiesResponse)
       }
+      else if (req.body.size === 0 && !req.body.queryTerm) {
+        req.reply(mockMetadataResponse)
+      }
       else {
-        req.reply({ hits: { hits: [], total: { value: 0 } } })
+        req.reply(mockDatasetsResponse)
       }
     }).as('searchApi')
   })
@@ -142,5 +169,45 @@ describe('DataLibrary', () => {
     cy.get('button').contains('Studies').click()
     cy.get('button').contains('Studies').should('have.css', 'font-weight', '700')
     cy.get('button').contains('Datasets').should('have.css', 'font-weight', '400')
+  })
+
+  it('shows footer when a dataset is selected', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/?tab=datasets']}>
+          <DataLibrary />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    // Footer should not be visible initially
+    cy.get('[data-cy="library-footer"]').should('not.exist')
+
+    // Click on the checkbox for the first row
+    cy.get('.MuiDataGrid-row').first().find('input[type="checkbox"]').check()
+
+    // Footer should now be visible
+    cy.get('[data-cy="library-footer"]').should('be.visible')
+    cy.contains('1 dataset selected from 1 study').should('be.visible')
+  })
+
+  it('shows footer when a study is selected', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/?tab=studies']}>
+          <DataLibrary />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+
+    // Wait for the rows to appear
+    cy.get('.MuiDataGrid-row').should('have.length', 1)
+
+    // Selection on study with dataset_ids [{key: 1}, {key: 2}]
+    cy.get('.MuiDataGrid-row').first().find('input[type="checkbox"]').check()
+
+    // Footer should show 2 datasets (from mockStudiesResponse)
+    cy.get('[data-cy="library-footer"]').should('be.visible')
+    cy.contains('2 datasets selected from 1 study').should('be.visible')
   })
 })

--- a/cypress/component/LibraryFooter.spec.tsx
+++ b/cypress/component/LibraryFooter.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
+import { Storage } from 'src/libs/storage'
 
 describe('LibraryFooter', () => {
   it('should not be visible when no datasets are selected', () => {
@@ -39,14 +40,76 @@ describe('LibraryFooter', () => {
 
   it('should call onApplyForAccess when button is clicked', () => {
     const onApplyForAccess = cy.spy().as('onApplyForAccess')
-    cy.mount(
-      <LibraryFooter
-        selectedDatasetIds={[1]}
-        selectedStudyIds={[101]}
-        onApplyForAccess={onApplyForAccess}
-      />,
-    )
+    cy.window().then(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        libraryCard: { cardNumber: '12345' },
+      })
+      cy.mount(
+        <LibraryFooter
+          selectedDatasetIds={[1]}
+          selectedStudyIds={[101]}
+          onApplyForAccess={onApplyForAccess}
+        />,
+      )
+    })
     cy.get('[data-cy="library-footer"]').find('button').contains('Apply for Access').click()
     cy.get('@onApplyForAccess').should('have.been.calledOnce')
+  })
+
+  it('should disable Apply for Access button when user has no library card', () => {
+    cy.window().then(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        libraryCard: null,
+      })
+      cy.mount(
+        <LibraryFooter
+          selectedDatasetIds={[1]}
+          selectedStudyIds={[101]}
+          onApplyForAccess={cy.spy()}
+        />,
+      )
+      cy.get('[data-cy="library-footer"]').find('button').contains('Apply for Access').should('be.disabled')
+    })
+  })
+
+  it('should show tooltip when hovering over disabled button', () => {
+    cy.window().then(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        libraryCard: null,
+      })
+      cy.mount(
+        <LibraryFooter
+          selectedDatasetIds={[1]}
+          selectedStudyIds={[101]}
+          onApplyForAccess={cy.spy()}
+        />,
+      )
+
+      cy.get('[data-cy="library-footer"]')
+        .find('button')
+        .contains('Apply for Access')
+        .parent('span')
+        .trigger('mouseover')
+
+      cy.get('[role="tooltip"]')
+        .should('be.visible')
+        .and('contain', 'A Library Card is required to apply for data access')
+    })
+  })
+
+  it('should enable button when user has a library card', () => {
+    cy.window().then(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        libraryCard: { cardNumber: '12345' },
+      })
+      cy.mount(
+        <LibraryFooter
+          selectedDatasetIds={[1]}
+          selectedStudyIds={[101]}
+          onApplyForAccess={cy.spy()}
+        />,
+      )
+      cy.get('[data-cy="library-footer"]').find('button').contains('Apply for Access').should('not.be.disabled')
+    })
   })
 })

--- a/cypress/component/LibraryFooter.spec.tsx
+++ b/cypress/component/LibraryFooter.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import LibraryFooter from 'src/components/data_library/LibraryFooter'
+
+describe('LibraryFooter', () => {
+  it('should not be visible when no datasets are selected', () => {
+    cy.mount(
+      <LibraryFooter
+        selectedDatasetIds={[]}
+        selectedStudyIds={[]}
+        onApplyForAccess={cy.spy()}
+      />,
+    )
+    cy.get('[data-cy="library-footer"]').should('not.exist')
+  })
+
+  it('should be visible when datasets are selected', () => {
+    cy.mount(
+      <LibraryFooter
+        selectedDatasetIds={[1]}
+        selectedStudyIds={[101]}
+        onApplyForAccess={cy.spy()}
+      />,
+    )
+    cy.get('[data-cy="library-footer"]').should('be.visible')
+    cy.contains('1 dataset selected from 1 study').should('be.visible')
+  })
+
+  it('should show correct counts for multiple selections', () => {
+    cy.mount(
+      <LibraryFooter
+        selectedDatasetIds={[1, 2, 3]}
+        selectedStudyIds={[101, 102]}
+        onApplyForAccess={cy.spy()}
+      />,
+    )
+    cy.get('[data-cy="library-footer"]').should('be.visible')
+    cy.contains('3 datasets selected from 2 studies').should('be.visible')
+  })
+
+  it('should call onApplyForAccess when button is clicked', () => {
+    const onApplyForAccess = cy.spy().as('onApplyForAccess')
+    cy.mount(
+      <LibraryFooter
+        selectedDatasetIds={[1]}
+        selectedStudyIds={[101]}
+        onApplyForAccess={onApplyForAccess}
+      />,
+    )
+    cy.get('[data-cy="library-footer"]').find('button').contains('Apply for Access').click()
+    cy.get('@onApplyForAccess').should('have.been.calledOnce')
+  })
+})

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -3,7 +3,6 @@ import {
   DataGrid,
   GridRowSelectionModel,
   GridColDef,
-  useGridApiRef,
 } from '@mui/x-data-grid'
 import { Box, Typography, CircularProgress } from '@mui/material'
 import { isEmpty } from 'lodash'
@@ -37,62 +36,6 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   selectedDatasetIds,
   onSelectionChange,
 }) => {
-  // API ref for manual selection workaround (MUI DataGrid checkbox click doesn't fire onChange)
-  const apiRef = useGridApiRef()
-
-  // Manual selection handler - workaround for MUI DataGrid checkbox click issue
-  const handleCheckboxCellClick = (rowId: number | string) => {
-    const api = apiRef.current
-    if (!api) return
-
-    const targetId = typeof rowId === 'string' && !isNaN(Number(rowId)) ? Number(rowId) : rowId
-    const selectedRowsSet = api.getSelectedRows()
-    const newSelectedIds = new Set(selectedRowsSet.keys())
-
-    if (newSelectedIds.has(targetId)) {
-      newSelectedIds.delete(targetId)
-    }
-    else {
-      newSelectedIds.add(targetId)
-    }
-
-    api.setRowSelectionModel({
-      type: 'include',
-      ids: newSelectedIds,
-    })
-  }
-
-  // Manual selection handler for "select all" in the header - workaround for checkbox issues
-  const handleHeaderCheckboxClick = () => {
-    const api = apiRef.current
-    if (!api) return
-
-    const allRowIds = api.getAllRowIds()
-    const selectableRowIds = allRowIds.filter((id) => {
-      const row = api.getRow(id)
-      return row && isRowSelectable({ row })
-    })
-
-    if (selectableRowIds.length === 0) return
-
-    const selectedRowsSet = api.getSelectedRows()
-    const allSelectableAreSelected = selectableRowIds.every(id => selectedRowsSet.has(id))
-
-    const newSelectedIds = new Set(selectedRowsSet.keys())
-
-    if (allSelectableAreSelected) {
-      selectableRowIds.forEach(id => newSelectedIds.delete(id))
-    }
-    else {
-      selectableRowIds.forEach(id => newSelectedIds.add(id))
-    }
-
-    api.setRowSelectionModel({
-      type: 'include',
-      ids: newSelectedIds,
-    })
-  }
-
   const columns = useMemo(() => {
     if (assetType === AssetType.STUDIES) {
       return makeStudyColumns() as GridColDef<DatasetTerm | StudyAggregation>[]
@@ -210,20 +153,6 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   return (
     <Box sx={{ width: '100%', height: '100%' }}>
       <DataGrid
-        apiRef={apiRef}
-        onCellClick={(params) => {
-          // Manual workaround for MUI DataGrid checkbox click issue
-          // The checkbox's internal onChange doesn't fire, so we use onCellClick + API
-          if (params.field === '__check__') {
-            handleCheckboxCellClick(params.id)
-          }
-        }}
-        onColumnHeaderClick={(params) => {
-          // Manual workaround for MUI DataGrid "select all" checkbox click issue
-          if (params.field === '__check__') {
-            handleHeaderCheckboxClick()
-          }
-        }}
         rows={data as (StudyAggregation | DatasetTerm)[]}
         columns={columns}
         rowCount={total}

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -3,6 +3,7 @@ import {
   DataGrid,
   GridRowSelectionModel,
   GridColDef,
+  useGridApiRef,
 } from '@mui/x-data-grid'
 import { Box, Typography, CircularProgress } from '@mui/material'
 import { isEmpty } from 'lodash'
@@ -36,6 +37,62 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   selectedDatasetIds,
   onSelectionChange,
 }) => {
+  // API ref for manual selection workaround (MUI DataGrid checkbox click doesn't fire onChange)
+  const apiRef = useGridApiRef()
+
+  // Manual selection handler - workaround for MUI DataGrid checkbox click issue
+  const handleCheckboxCellClick = (rowId: number | string) => {
+    const api = apiRef.current
+    if (!api) return
+
+    const targetId = typeof rowId === 'string' && !isNaN(Number(rowId)) ? Number(rowId) : rowId
+    const selectedRowsSet = api.getSelectedRows()
+    const newSelectedIds = new Set(selectedRowsSet.keys())
+
+    if (newSelectedIds.has(targetId)) {
+      newSelectedIds.delete(targetId)
+    }
+    else {
+      newSelectedIds.add(targetId)
+    }
+
+    api.setRowSelectionModel({
+      type: 'include',
+      ids: newSelectedIds,
+    })
+  }
+
+  // Manual selection handler for "select all" in the header - workaround for checkbox issues
+  const handleHeaderCheckboxClick = () => {
+    const api = apiRef.current
+    if (!api) return
+
+    const allRowIds = api.getAllRowIds()
+    const selectableRowIds = allRowIds.filter((id) => {
+      const row = api.getRow(id)
+      return row && isRowSelectable({ row })
+    })
+
+    if (selectableRowIds.length === 0) return
+
+    const selectedRowsSet = api.getSelectedRows()
+    const allSelectableAreSelected = selectableRowIds.every(id => selectedRowsSet.has(id))
+
+    const newSelectedIds = new Set(selectedRowsSet.keys())
+
+    if (allSelectableAreSelected) {
+      selectableRowIds.forEach(id => newSelectedIds.delete(id))
+    }
+    else {
+      selectableRowIds.forEach(id => newSelectedIds.add(id))
+    }
+
+    api.setRowSelectionModel({
+      type: 'include',
+      ids: newSelectedIds,
+    })
+  }
+
   const columns = useMemo(() => {
     if (assetType === AssetType.STUDIES) {
       return makeStudyColumns() as GridColDef<DatasetTerm | StudyAggregation>[]
@@ -153,6 +210,20 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   return (
     <Box sx={{ width: '100%', height: '100%' }}>
       <DataGrid
+        apiRef={apiRef}
+        onCellClick={(params) => {
+          // Manual workaround for MUI DataGrid checkbox click issue
+          // The checkbox's internal onChange doesn't fire, so we use onCellClick + API
+          if (params.field === '__check__') {
+            handleCheckboxCellClick(params.id)
+          }
+        }}
+        onColumnHeaderClick={(params) => {
+          // Manual workaround for MUI DataGrid "select all" checkbox click issue
+          if (params.field === '__check__') {
+            handleHeaderCheckboxClick()
+          }
+        }}
         rows={data as (StudyAggregation | DatasetTerm)[]}
         columns={columns}
         rowCount={total}

--- a/src/components/data_library/LibraryFooter.tsx
+++ b/src/components/data_library/LibraryFooter.tsx
@@ -14,6 +14,7 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
   return (
     <Slide direction="up" in={hasSelection} mountOnEnter unmountOnExit>
       <Paper
+        data-cy="library-footer"
         elevation={8}
         sx={{
           position: 'fixed',

--- a/src/components/data_library/LibraryFooter.tsx
+++ b/src/components/data_library/LibraryFooter.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Paper, Slide, Button, Typography } from '@mui/material'
+import { LibraryFooterProps } from 'src/types/library'
+
+export const LibraryFooter: React.FC<LibraryFooterProps> = ({
+  selectedDatasetIds,
+  selectedStudyIds,
+  onApplyForAccess,
+}) => {
+  const hasSelection = selectedDatasetIds.length > 0
+  const datasetText = selectedDatasetIds.length === 1 ? 'dataset' : 'datasets'
+  const studyText = selectedStudyIds.length === 1 ? 'study' : 'studies'
+
+  return (
+    <Slide direction="up" in={hasSelection} mountOnEnter unmountOnExit>
+      <Paper
+        elevation={8}
+        sx={{
+          position: 'fixed',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          p: 2,
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          gap: 2,
+          zIndex: 1200,
+          backgroundColor: 'white',
+          borderTop: '1px solid #DEDEDE',
+        }}
+      >
+        <Typography variant="body1">
+          {selectedDatasetIds.length} {datasetText} selected from{' '}
+          {selectedStudyIds.length} {studyText}
+        </Typography>
+        <Button
+          variant="contained"
+          size="large"
+          onClick={onApplyForAccess}
+          sx={{ fontWeight: 600 }}
+        >
+          Apply for Access
+        </Button>
+      </Paper>
+    </Slide>
+  )
+}
+
+export default LibraryFooter

--- a/src/components/data_library/LibraryFooter.tsx
+++ b/src/components/data_library/LibraryFooter.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { Paper, Slide, Button, Typography } from '@mui/material'
+import { Paper, Slide, Button, Typography, Tooltip } from '@mui/material'
+import { isNil } from 'lodash'
 import { LibraryFooterProps } from 'src/types/library'
+import { Storage } from 'src/libs/storage'
 
 export const LibraryFooter: React.FC<LibraryFooterProps> = ({
   selectedDatasetIds,
@@ -10,6 +12,7 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
   const hasSelection = selectedDatasetIds.length > 0
   const datasetText = selectedDatasetIds.length === 1 ? 'dataset' : 'datasets'
   const studyText = selectedStudyIds.length === 1 ? 'study' : 'studies'
+  const hasLibraryCard = !isNil(Storage.getCurrentUser().libraryCard)
 
   return (
     <Slide direction="up" in={hasSelection} mountOnEnter unmountOnExit>
@@ -35,14 +38,29 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
           {selectedDatasetIds.length} {datasetText} selected from{' '}
           {selectedStudyIds.length} {studyText}
         </Typography>
-        <Button
-          variant="contained"
-          size="large"
-          onClick={onApplyForAccess}
-          sx={{ fontWeight: 600 }}
+        <Tooltip
+          title={hasLibraryCard ? '' : 'A Library Card is required to apply for data access'}
+          slotProps={{
+            tooltip: {
+              sx: {
+                backgroundColor: 'red',
+                color: 'white',
+              },
+            },
+          }}
         >
-          Apply for Access
-        </Button>
+          <span>
+            <Button
+              variant="contained"
+              size="large"
+              onClick={onApplyForAccess}
+              sx={{ fontWeight: 600 }}
+              disabled={!hasLibraryCard}
+            >
+              Apply for Access
+            </Button>
+          </span>
+        </Tooltip>
       </Paper>
     </Slide>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -828,11 +828,13 @@ a[disabled], .cell-button[disabled], [disabled] .cell-button, [disabled] button,
   text-overflow: ellipsis;
 }
 
-input[type=checkbox] {
+.checkbox input[type=checkbox],
+.checkbox-inline input[type=checkbox] {
   display: none;
 }
 
-input[type=checkbox]:checked+label:before {
+.checkbox input[type=checkbox]:checked+label:before,
+.checkbox-inline input[type=checkbox]:checked+label:before {
   content: "\2713";
   text-shadow: 1px 1px 1px rgba(0, 0, 0, .2);
   color: #ffffff;

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -5,7 +5,8 @@ import LibraryTabs from 'src/components/data_library/LibraryTabs'
 import SearchBar from 'src/components/SearchBar'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
-import { AssetType, AvailableFilters, LibraryVersionNew, SortOrder, TabConfig } from 'src/types/library'
+import { AssetType, AvailableFilters, LibraryVersionNew, SortOrder, StudyAggregation, TabConfig } from 'src/types/library'
+import { DatasetTerm } from 'src/types/model'
 import LibraryFilters from 'src/components/data_library/LibraryFilters'
 import { useLibraryData, useLibraryMetadata } from 'src/hooks/useLibraryData'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
@@ -110,13 +111,28 @@ export const DataLibrary: React.FC = () => {
   const selectedStudyIds = useMemo(() => {
     if (!data?.items) return []
     const studyIds = new Set<number>()
-    data.items.forEach((item: { datasetId: number, study: { studyId: number } }) => {
-      if (selectedDatasetIds.includes(item.datasetId)) {
-        studyIds.add(item.study.studyId)
+    data.items.forEach((item: StudyAggregation | DatasetTerm) => {
+      switch (urlState.tab) {
+        case AssetType.STUDIES: {
+          const study = item as StudyAggregation
+          if (study.datasetIds?.some((id: number) => selectedDatasetIds.includes(id))) {
+            studyIds.add(study.studyId)
+          }
+          break
+        }
+        case AssetType.DATASETS: {
+          const dataset = item as DatasetTerm
+          if (selectedDatasetIds.includes(dataset.datasetId)) {
+            studyIds.add(dataset.study.studyId)
+          }
+          break
+        }
+        default:
+          throw new Error('Unknown asset type')
       }
     })
     return Array.from(studyIds)
-  }, [data, selectedDatasetIds])
+  }, [data, selectedDatasetIds, urlState.tab])
 
   const sortModel = useMemo(() => {
     if (urlState.sortField && urlState.sortOrder) {

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -12,6 +12,7 @@ import { useLibraryData, useLibraryMetadata } from 'src/hooks/useLibraryData'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
 import { AggregationResult } from 'src/types/elastic'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
+import { applyForAccess } from 'src/utils/accessUtils'
 
 /**
  * DataLibrary Page Component
@@ -192,8 +193,7 @@ export const DataLibrary: React.FC = () => {
   }
 
   const handleApplyForAccess = () => {
-    const datasetIdsParam = selectedDatasetIds.join(',')
-    navigate(`/dar_application?datasetIds=${datasetIdsParam}`)
+    applyForAccess(selectedDatasetIds, navigate)
   }
 
   if (error) {

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Box } from '@mui/material'
 import LibraryTabs from 'src/components/data_library/LibraryTabs'
 import SearchBar from 'src/components/SearchBar'
@@ -9,6 +10,7 @@ import LibraryFilters from 'src/components/data_library/LibraryFilters'
 import { useLibraryData, useLibraryMetadata } from 'src/hooks/useLibraryData'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
 import { AggregationResult } from 'src/types/elastic'
+import LibraryFooter from 'src/components/data_library/LibraryFooter'
 
 /**
  * DataLibrary Page Component
@@ -27,6 +29,8 @@ import { AggregationResult } from 'src/types/elastic'
  * - Local UI state: selection tracking (useState)
  */
 export const DataLibrary: React.FC = () => {
+  const navigate = useNavigate()
+
   const [urlState, updateUrlState] = useLibraryUrlState()
 
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<number[]>([])
@@ -103,6 +107,17 @@ export const DataLibrary: React.FC = () => {
       : undefined,
   )
 
+  const selectedStudyIds = useMemo(() => {
+    if (!data?.items) return []
+    const studyIds = new Set<number>()
+    data.items.forEach((item: { datasetId: number, study: { studyId: number } }) => {
+      if (selectedDatasetIds.includes(item.datasetId)) {
+        studyIds.add(item.study.studyId)
+      }
+    })
+    return Array.from(studyIds)
+  }, [data, selectedDatasetIds])
+
   const sortModel = useMemo(() => {
     if (urlState.sortField && urlState.sortOrder) {
       return [{ field: urlState.sortField, sort: urlState.sortOrder }]
@@ -158,6 +173,11 @@ export const DataLibrary: React.FC = () => {
 
   const handleSelectionChange = (datasetIds: number[]) => {
     setSelectedDatasetIds(datasetIds)
+  }
+
+  const handleApplyForAccess = () => {
+    const datasetIdsParam = selectedDatasetIds.join(',')
+    navigate(`/dar_application?datasetIds=${datasetIdsParam}`)
   }
 
   if (error) {
@@ -243,6 +263,13 @@ export const DataLibrary: React.FC = () => {
           />
         </Box>
       </Box>
+
+      {/* Footer (shown when assets are selected) */}
+      <LibraryFooter
+        selectedDatasetIds={selectedDatasetIds}
+        selectedStudyIds={selectedStudyIds}
+        onApplyForAccess={handleApplyForAccess}
+      />
     </Box>
   )
 }

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -124,3 +124,9 @@ export interface SortState {
   field: string
   order: SortOrder
 }
+
+export interface LibraryFooterProps {
+  selectedDatasetIds: number[]
+  selectedStudyIds: number[]
+  onApplyForAccess: () => void
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2975

### Summary

Adds the "apply for access" library footer with tests.

<img width="476" height="55" alt="Screenshot 2026-02-24 at 10 30 16 AM" src="https://github.com/user-attachments/assets/6504e065-9737-44ee-ab20-dbabcdf21fe5" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
