### PR TITLE
[DT-400] Add newline so token is always printed

### DIFF
--- a/scripts/setup-devcontainer.sh
+++ b/scripts/setup-devcontainer.sh
@@ -23,6 +23,7 @@ install_duos_cypress() {
 }
 
 install_duos_config() {
+  printf "\n"
   gcloud auth login
   gcloud config set project broad-duos-dev
   gsutil -m cp \


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

Sometimes the `gcloud` token is cut off due to how the previous steps print to the terminal. This prevents that issue by ensuring a newline is always printed after those steps but before the token.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
