### PR TITLE
[DT-2984] Use correct dataset identifier in New Data Library

### DIFF
--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -14,7 +14,7 @@ export const makeDatasetColumns = (): GridColDef<DatasetTerm>[] => [
     flex: 1.5,
     minWidth: 200,
     renderCell: params => (
-      <Link href={`/dataset/${params.row.datasetId}`} underline="hover">
+      <Link href={`/dataset/${params.row.datasetIdentifier}`} underline="hover">
         {params.value}
       </Link>
     ),


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2984

### Summary

This PR updates the new DataLibrary to dataset routes to use the correct identifier to view dataset statistics.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
