### PR TITLE
DT-2957: Update Dataset Statistics page to use new API and clearly show expiration

### DIFF
--- a/cypress/component/Dataset/DatasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/DatasetStatistics.spec.jsx
@@ -12,7 +12,7 @@ describe('Dataset Statistics Tests', () => {
 
   it('Renders the correct dataset from a DUOS-xxx identifier path paramter', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -31,7 +31,7 @@ describe('Dataset Statistics Tests', () => {
 
   it('Renders the correct dataset from a DUOS-Dxxx identifier path parameter', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -51,7 +51,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays Controlled Access Dataset Apply Button', () => {
     const controlled = { ...datasetTerm, accessManagement: 'controlled' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([controlled]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -73,7 +73,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays External Access Language With Location', () => {
     const external = { ...datasetTerm, accessManagement: 'external', url: 'https://duos.org' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([external]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -96,7 +96,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays External Access Language Without Location', () => {
     const external = { ...datasetTerm, accessManagement: 'external' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([external]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -119,7 +119,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays Open Access Language With Location', () => {
     const open = { ...datasetTerm, accessManagement: 'open', url: 'https://duos.org' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([open]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -142,7 +142,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays Open Access Language Without Location', () => {
     const open = { ...datasetTerm, accessManagement: 'open' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([open]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -164,7 +164,7 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays with no additional properties', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -192,7 +192,7 @@ describe('Dataset Statistics Tests', () => {
     }
 
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetWithCustodians]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -215,7 +215,7 @@ describe('Dataset Statistics Tests', () => {
   it('Does not display the Data Use field for open datasets', () => {
     const open = { ...datasetTerm, accessManagement: 'open' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([open]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -235,7 +235,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays the Data Use field for controlled datasets', () => {
     const controlled = { ...datasetTerm, accessManagement: 'controlled' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([controlled]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -255,7 +255,7 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays the Principal Investigator field', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({}))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: {
@@ -279,10 +279,11 @@ describe('Dataset Statistics Tests', () => {
       projectTitle: 'Test Project',
       updateDate: '2023-01-01',
       nonTechRus: 'Test summary',
+      expired: false,
     }]
 
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({ dars: darsData }))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve(darsData))
 
     const props = {
       match: { params: { datasetIdentifier: datasetTerm.datasetIdentifier } },
@@ -297,7 +298,7 @@ describe('Dataset Statistics Tests', () => {
 
   it('Displays message when no DARs exist', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
-    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve({ dars: [] }))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
 
     const props = {
       match: { params: { datasetIdentifier: datasetTerm.datasetIdentifier } },
@@ -306,5 +307,38 @@ describe('Dataset Statistics Tests', () => {
 
     cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
     cy.contains('No Data Access Requests have been created for this dataset').should('exist')
+  })
+
+  it('Displays DAR section with expired data', () => {
+    const year = new Date().getFullYear()
+    const expired = new Date()
+    expired.setFullYear(year - 2)
+    const dateString = expired.toISOString().split('T')[0]
+    const dateTime = expired.getTime()
+
+    const darsData = [{
+      darCode: 'DAR-123',
+      projectTitle: 'Test Project',
+      updateDate: dateTime,
+      nonTechRus: 'Test summary',
+      expired: true,
+    }]
+
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve(darsData))
+
+    const props = {
+      match: { params: { datasetIdentifier: datasetTerm.datasetIdentifier } },
+      history: { push() {} },
+    }
+
+    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    cy.contains('Data Access Requests for this dataset').should('exist')
+    cy.contains('DAR-123').should('exist')
+    cy.contains('Test Project').should('exist')
+    cy.contains('Show More').click()
+    cy.contains('Expired').should('exist')
+    cy.contains(dateString).should('exist')
+    cy.contains(darsData[0].nonTechRus).should('exist')
   })
 })

--- a/src/libs/ajax/DatasetMetrics.js
+++ b/src/libs/ajax/DatasetMetrics.js
@@ -3,7 +3,7 @@ import { fetchGet } from 'src/libs/ajax/fetchAdapter'
 
 export const DatasetMetrics = {
   getDatasetStats: async (datasetId) => {
-    const url = `${await Config.getApiUrl()}/metrics/dataset/${datasetId}`
+    const url = `${await Config.getApiUrl()}/api/metrics/dar-summaries/${datasetId}`
     const res = await fetchGet(url, Config.authOpts())
     return res.data
   },

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -8,7 +8,6 @@ import { ReadMore } from 'src/components/ReadMore'
 import { Button } from '@mui/material'
 import {
   DatasetStatisticsDar,
-  DatasetStats,
   DatasetTerm,
 } from 'src/types/model'
 import { extractError } from 'src/utils/ErrorUtils'
@@ -111,8 +110,8 @@ export default function DatasetStatistics() {
 
         if (datasetTerms.length === 1) {
           setDatasetTerm(datasetTerms[0])
-          const metrics: DatasetStats = await DatasetMetrics.getDatasetStats(datasetTerms[0].datasetId)
-          setDars(metrics.dars)
+          const dars: Array<DatasetStatisticsDar> = await DatasetMetrics.getDatasetStats(datasetTerms[0].datasetId)
+          setDars(dars)
           setIsLoading(false)
         }
         else {
@@ -181,11 +180,7 @@ export default function DatasetStatistics() {
           <div style={{ marginTop: '25px' }}>
             <div style={{ fontSize: 20, fontWeight: 600 }}>
               <div>
-                {datasetTerm.datasetIdentifier}
-                {' '}
-                -
-                {' '}
-                {datasetTerm.datasetName}
+                {datasetTerm.datasetIdentifier} - {datasetTerm.datasetName}
               </div>
             </div>
             <LabeledField label="Study">
@@ -255,7 +250,10 @@ export default function DatasetStatistics() {
                   <div key="updated" style={{ display: 'flex', backgroundColor: 'white' }}>
                     <div style={{ display: 'flex', paddingRight: '2rem' }}>
                       <div style={Styles.SMALL_BOLD}>Last Updated:</div>
-                      <div style={Styles.SMALL_BOLD}>{formatDate(dar.updateDate)}</div>
+                      <div style={{ ...Styles.SMALL_BOLD, color: `${dar.expired ? 'red' : 'rgb(31, 59, 80)'}` }}>
+                        {formatDate(dar.updateDate)}
+                        {dar.expired && ' (Expired)'}
+                      </div>
                     </div>
                   </div>,
                   <div key="summary" style={{ backgroundColor: 'white' }}>

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -559,18 +559,13 @@ export interface Acknowledgement {
   lastAcknowledged: number
 }
 
-export interface DatasetStats {
-  dataset: Dataset
-  dars: Array<DatasetStatisticsDar>
-  elections: Array<Election>
-}
-
 export interface DatasetStatisticsDar {
   updateDate: number
   projectTitle: string
   darCode: string
   nonTechRus: string
   referenceId: string
+  expired: boolean
 }
 
 /**


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2957

### Summary

* Requires back end PR here: https://github.com/DataBiosphere/consent/pull/2822
* Minor update to the page so that it pulls from the authenticated dataset metrics API
* Changes the update date to show if the DAR is expired or not

<img width="1307" height="1396" alt="Screenshot 2026-02-24 at 4 34 00 PM" src="https://github.com/user-attachments/assets/c90899d5-6092-4285-ae25-19bba729a2ed" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
