### PR TITLE
[DT-2973] Add branded data libraries

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DataLibrary } from 'src/pages/DataLibrary'
 import { Storage } from 'src/libs/storage'
+import { Notifications } from 'src/libs/utils'
 
 const mockMetadataResponse = {
   aggregations: {
@@ -216,5 +217,183 @@ describe('DataLibrary', () => {
     // Footer should show 2 datasets (from mockStudiesResponse)
     cy.get('[data-cy="library-footer"]').should('be.visible')
     cy.contains('2 datasets selected from 1 study').should('be.visible')
+  })
+
+  describe('Branded Data Libraries', () => {
+    it('renders branded library based on URL parameter (broad)', () => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/broad']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('Broad Data Library').should('be.visible')
+      cy.contains('Search, filter, and select datasets').should('be.visible')
+    })
+
+    it('renders branded library based on URL parameter (anvil)', () => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/anvil']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('AnVIL Data Library').should('be.visible')
+    })
+
+    it('handles case-insensitive branded library query params', () => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/BROAD']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('Broad Data Library').should('be.visible')
+    })
+
+    it('captures metrics for default library', () => {
+      cy.intercept('**/event').as('event')
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2']}>
+            <Routes>
+              <Route path="/datalibrary2" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.wait('@event').should('exist')
+    })
+
+    it('captures metrics with brand parameter for branded library', () => {
+      cy.intercept('**/event').as('event')
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/broad']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.wait('@event').should('exist')
+    })
+
+    it('renders myinstitution library with user institution', () => {
+      const mockUser = {
+        userId: 123,
+        institution: {
+          id: 456,
+          name: 'Test Institution',
+        },
+      }
+      cy.stub(Storage, 'getCurrentUser').returns(mockUser)
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/myinstitution']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('Test Institution Data Library').should('be.visible')
+    })
+
+    it('redirects to profile when accessing myinstitution without institution', () => {
+      const mockUser = {
+        userId: 123,
+        institution: null,
+      }
+      cy.stub(Storage, 'getCurrentUser').returns(mockUser)
+      cy.stub(Notifications, 'showError').as('showError')
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/myinstitution']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('@showError').should('have.been.calledOnce')
+    })
+
+    it('redirects to profile when accessing myinstitution without user', () => {
+      cy.stub(Storage, 'getCurrentUser').returns(null)
+      cy.stub(Notifications, 'showError').as('showError')
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/myinstitution']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('@showError').should('have.been.calledOnce')
+    })
+
+    it('falls back to default library for unknown brand', () => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/unknownbrand']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('DUOS Data Library').should('be.visible')
+    })
+
+    it('renders terra library without query filter', () => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/terra']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('Terra Data Library').should('be.visible')
+    })
+
+    it('renders elwazi library with data type filter', () => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/datalibrary2/elwazi']}>
+            <Routes>
+              <Route path="/datalibrary2/:query" element={<DataLibrary />} />
+            </Routes>
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.contains('eLwazi Data Library').should('be.visible')
+    })
   })
 })

--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -61,11 +61,8 @@ describe('DataLibrary', () => {
       },
     })
     cy.initApplicationConfig()
-    // Stub user with library card for footer functionality
-    cy.window().then(() => {
-      cy.stub(Storage, 'getCurrentUser').returns({
-        libraryCard: { cardNumber: '12345' },
-      })
+    cy.stub(Storage, 'getCurrentUser').as('getCurrentUserStub').returns({
+      libraryCard: { cardNumber: '12345' },
     })
     cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
       if (req.body.aggs?.studies) {
@@ -301,7 +298,7 @@ describe('DataLibrary', () => {
           name: 'Test Institution',
         },
       }
-      cy.stub(Storage, 'getCurrentUser').returns(mockUser)
+      cy.get('@getCurrentUserStub').invoke('returns', mockUser)
 
       cy.mount(
         <QueryClientProvider client={queryClient}>
@@ -321,7 +318,7 @@ describe('DataLibrary', () => {
         userId: 123,
         institution: null,
       }
-      cy.stub(Storage, 'getCurrentUser').returns(mockUser)
+      cy.get('@getCurrentUserStub').invoke('returns', mockUser)
       cy.stub(Notifications, 'showError').as('showError')
 
       cy.mount(
@@ -338,7 +335,7 @@ describe('DataLibrary', () => {
     })
 
     it('redirects to profile when accessing myinstitution without user', () => {
-      cy.stub(Storage, 'getCurrentUser').returns(null)
+      cy.get('@getCurrentUserStub').invoke('returns', null)
       cy.stub(Notifications, 'showError').as('showError')
 
       cy.mount(

--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -1,4 +1,4 @@
-import { getLibraryVersions } from 'src/libs/libraryVersions'
+import { getLibraryVersions, getBrandedLibrary } from 'src/libs/libraryVersions'
 
 describe('Library Versions - Tests', function () {
   describe('getLibraryVersions function', function () {
@@ -139,6 +139,98 @@ describe('Library Versions - Tests', function () {
         expect(library).to.have.property('order')
         expect(library.featured).to.equal(true)
       })
+    })
+  })
+
+  describe('getBrandedLibrary function', function () {
+    it('returns the default library when queryParam is undefined', function () {
+      const library = getBrandedLibrary(undefined, undefined, undefined)
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('DUOS Data Library')
+      expect(library.featured).to.equal(true)
+      expect(library.query).to.equal(null)
+    })
+
+    it('returns the default library when queryParam is /datalibrary', function () {
+      const library = getBrandedLibrary(undefined, undefined, '/datalibrary')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('DUOS Data Library')
+      expect(library.featured).to.equal(true)
+    })
+
+    it('returns correct library for branded query param (broad)', function () {
+      const library = getBrandedLibrary(undefined, undefined, 'broad')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('Broad Data Library')
+      expect(library.featured).to.equal(true)
+      expect(library.icon).to.not.equal(undefined)
+    })
+
+    it('returns correct library for branded query param (anvil)', function () {
+      const library = getBrandedLibrary(undefined, undefined, 'anvil')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('AnVIL Data Library')
+      expect(library.featured).to.equal(true)
+      expect(library.query).to.not.equal(null)
+    })
+
+    it('handles case-insensitive query param', function () {
+      const library1 = getBrandedLibrary(undefined, undefined, 'BROAD')
+      const library2 = getBrandedLibrary(undefined, undefined, 'Broad')
+      const library3 = getBrandedLibrary(undefined, undefined, 'broad')
+
+      expect(library1).to.deep.equal(library2)
+      expect(library2).to.deep.equal(library3)
+      expect(library1.title).to.equal('Broad Data Library')
+    })
+
+    it('returns myinstitution library with dynamic institution data', function () {
+      const institutionId = 456
+      const institutionName = 'Research Institute'
+      const library = getBrandedLibrary(institutionId, institutionName, 'myinstitution')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('Research Institute Data Library')
+      if (library.query && 'match_phrase' in library.query) {
+        expect(library.query.match_phrase['submitter.institution.id']).to.equal(456)
+      }
+      expect(library.featured).to.equal(false)
+    })
+
+    it('handles unknown query param by returning undefined', function () {
+      const library = getBrandedLibrary(undefined, undefined, 'unknownbrand')
+
+      expect(library).to.equal(undefined)
+    })
+
+    it('handles terra library correctly', function () {
+      const library = getBrandedLibrary(undefined, undefined, 'terra')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('Terra Data Library')
+      expect(library.featured).to.equal(false)
+      expect(library.query).to.equal(null)
+    })
+
+    it('handles mgb library correctly', function () {
+      const library = getBrandedLibrary(undefined, undefined, 'mgb')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('Mass General Brigham Data Library')
+      expect(library.featured).to.equal(false)
+    })
+
+    it('returns library with query for data type restricted libraries', function () {
+      const library = getBrandedLibrary(undefined, undefined, 'elwazi')
+
+      expect(library).to.not.equal(undefined)
+      expect(library.title).to.equal('eLwazi Data Library')
+      expect(library.query).to.not.equal(null)
+      expect(library.featured).to.equal(true)
     })
   })
 })

--- a/src/components/data_library/LibraryFooter.tsx
+++ b/src/components/data_library/LibraryFooter.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Paper, Slide, Button, Typography, Tooltip } from '@mui/material'
-import { isNil } from 'lodash'
 import { LibraryFooterProps } from 'src/types/library'
 import { Storage } from 'src/libs/storage'
 
@@ -12,7 +11,7 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
   const hasSelection = selectedDatasetIds.length > 0
   const datasetText = selectedDatasetIds.length === 1 ? 'dataset' : 'datasets'
   const studyText = selectedStudyIds.length === 1 ? 'study' : 'studies'
-  const hasLibraryCard = !isNil(Storage.getCurrentUser().libraryCard)
+  const hasLibraryCard = Storage.getCurrentUser()?.libraryCard != null
 
   return (
     <Slide direction="up" in={hasSelection} mountOnEnter unmountOnExit>

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -575,3 +575,9 @@ export const getLibraryVersions = (
     },
   }
 }
+
+export const getBrandedLibrary = (institutionId: number | undefined, institutionName: string | undefined, queryParam: string | undefined) => {
+  const key = queryParam === undefined ? '/datalibrary' : queryParam.toLowerCase()
+  const versions = getLibraryVersions(institutionId ?? null, institutionName ?? null)
+  return versions[key]
+}

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useMemo, useRef, useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
 import { Box } from '@mui/material'
 import LibraryTabs from 'src/components/data_library/LibraryTabs'
 import SearchBar from 'src/components/SearchBar'
@@ -13,6 +13,11 @@ import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
 import { AggregationResult } from 'src/types/elastic'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
 import { applyForAccess } from 'src/utils/accessUtils'
+import { getBrandedLibrary } from 'src/libs/libraryVersions'
+import { Storage } from 'src/libs/storage'
+import { Notifications } from 'src/libs/utils'
+import { Metrics } from 'src/libs/ajax/Metrics'
+import eventList from 'src/libs/events'
 
 /**
  * DataLibrary Page Component
@@ -31,32 +36,72 @@ import { applyForAccess } from 'src/utils/accessUtils'
  * - Local UI state: selection tracking (useState)
  */
 export const DataLibrary: React.FC = () => {
+  const { query } = useParams()
   const navigate = useNavigate()
 
   const [urlState, updateUrlState] = useLibraryUrlState()
 
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<number[]>([])
 
-  const searchRef = useRef<HTMLInputElement>(null)
-
-  React.useEffect(() => {
-    if (searchRef.current && urlState.query) {
-      searchRef.current.value = urlState.query
-    }
-  }, [urlState.query])
-
-  const libraryConfig: LibraryVersionNew = {
-    key: 'duos',
-    title: 'DUOS Data Library',
-    description: 'Search, filter, and select datasets, then click \'Apply for Access\' to request access',
-    featured: true,
-    order: 0,
-  }
+  const user = Storage.getCurrentUser()
+  const institutionId = user?.institution?.id
+  const institutionName = user?.institution?.name
 
   const tabs: TabConfig[] = [
     { key: AssetType.STUDIES, label: 'Studies' },
     { key: AssetType.DATASETS, label: 'Datasets' },
   ]
+
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (searchRef.current && urlState.query) {
+      searchRef.current.value = urlState.query
+    }
+  }, [urlState.query])
+
+  useEffect(() => {
+    const init = () => {
+      const key = query === undefined ? '/datalibrary' : query.toLowerCase()
+      if (key === 'myinstitution' && !institutionId) {
+        Notifications.showError({ text: 'You must set an institution in your profile to view the `myinstitution` data library' })
+        navigate('/profile')
+      }
+      if (key === '/datalibrary') {
+        Metrics.captureEvent(eventList.dataLibrary)
+      }
+      else {
+        const brand = key.replaceAll('/', '').toLowerCase()
+        Metrics.captureEvent(eventList.dataLibrary, { brand })
+      }
+    }
+    init()
+  }, [query, institutionId, navigate])
+
+  const libraryConfig: LibraryVersionNew = useMemo(() => {
+    const brand = getBrandedLibrary(institutionId, institutionName, query)
+    const description = 'Search, filter, and select datasets, then click \'Apply for Access\' to request access'
+
+    if (brand) {
+      return {
+        key: query || 'default',
+        query: brand.query,
+        icon: brand.icon || undefined,
+        title: brand.title,
+        description,
+        featured: brand.featured,
+        order: brand.order,
+      }
+    }
+
+    return {
+      key: 'duos',
+      title: 'DUOS Data Library',
+      description,
+      featured: true,
+      order: 0,
+    }
+  }, [query, institutionId, institutionName])
 
   const { data: metadata, isLoading: isMetadataLoading } = useLibraryMetadata(libraryConfig)
 
@@ -213,6 +258,7 @@ export const DataLibrary: React.FC = () => {
       {/* Header */}
       <Box>
         <TableHeaderSection
+          icon={libraryConfig.icon ? { src: libraryConfig.icon } : undefined}
           title={libraryConfig.title}
           description={libraryConfig.description}
         />


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2973

### Summary

Adds branded data libraries to the new data library.

<img width="870" height="138" alt="Screenshot 2026-02-25 at 9 28 04 AM" src="https://github.com/user-attachments/assets/50079a76-ecf2-438a-9fcc-f6576dd696be" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
