### PR TITLE
[DT-2866] Follow Up: Update DatasetSearchTable.jsx

### DIFF
--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -281,13 +281,13 @@ export const DatasetSearchTable = (props) => {
         <TableHeaderSection
           icon={{ src: icon }}
           title={title}
-          description={
-  <>
-    Search and filter datasets. For controlled access, select the dataset(s) you desire then click 'Apply for Access.' Open access data does 
-    <br />
-    not require access requests. External data requires an access request in the host repository (which is linked on the dataset page).
-  </>
-}
+          description={(
+            <>
+              Search and filter datasets. For controlled access, select the dataset(s) you desire then click &#39;Apply for Access.&#39; Open access data does
+              <br />
+              not require access requests. External data requires an access request in the host repository (which is linked on the dataset page).
+            </>
+          )}
         />
         <Box sx={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
           <SearchBar

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -281,7 +281,13 @@ export const DatasetSearchTable = (props) => {
         <TableHeaderSection
           icon={{ src: icon }}
           title={title}
-          description="Search and filter datasets. For controlled access, select the dataset(s) you desire then click ‘Apply for Access.' Open access data does not require access requests. External data requires an access request in the host repository (which is linked on the dataset page)."
+          description={
+  <>
+    Search and filter datasets. For controlled access, select the dataset(s) you desire then click 'Apply for Access.' Open access data does 
+    <br />
+    not require access requests. External data requires an access request in the host repository (which is linked on the dataset page).
+  </>
+}
         />
         <Box sx={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
           <SearchBar


### PR DESCRIPTION

### Addresses
https://broadworkbench.atlassian.net/browse/DT-2866
### Summary
Added break so all header text appears in the UI instead of being cut off on the right margin
----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
