### PR TITLE
DT-2918: Remove awaits for sign-in related reporting calls

### DIFF
--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -72,7 +72,8 @@ export const SignInButton = () => {
         if (!duosUser.roles) {
           await StackdriverReporter.report('roles not found for user: ' + duosUser.email)
         }
-        await syncSignInOrRegistrationEvent(eventList.userSignIn)
+        // noinspection ES6MissingAwait
+        syncSignInOrRegistrationEvent(eventList.userSignIn)
         await checkToSAndRedirect(shouldRedirect ? redirectTo : null)
       }
       else {
@@ -103,7 +104,8 @@ export const SignInButton = () => {
   const registerAndRedirectNewUser = async (redirectTo: string, shouldRedirect: boolean) => {
     const registeredUser: DuosUser = await User.registerUser()
     setUserRoleStatuses(registeredUser, Storage)
-    await syncSignInOrRegistrationEvent(eventList.userRegister)
+    // noinspection ES6MissingAwait
+    syncSignInOrRegistrationEvent(eventList.userRegister)
     navigate(`/tos_acceptance${shouldRedirect ? `?redirectTo=${redirectTo}` : ''}`)
   }
 

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -72,7 +72,6 @@ export const SignInButton = () => {
         if (!duosUser.roles) {
           await StackdriverReporter.report('roles not found for user: ' + duosUser.email)
         }
-        // noinspection ES6MissingAwait
         syncSignInOrRegistrationEvent(eventList.userSignIn)
         await checkToSAndRedirect(shouldRedirect ? redirectTo : null)
       }
@@ -104,18 +103,17 @@ export const SignInButton = () => {
   const registerAndRedirectNewUser = async (redirectTo: string, shouldRedirect: boolean) => {
     const registeredUser: DuosUser = await User.registerUser()
     setUserRoleStatuses(registeredUser, Storage)
-    // noinspection ES6MissingAwait
     syncSignInOrRegistrationEvent(eventList.userRegister)
     navigate(`/tos_acceptance${shouldRedirect ? `?redirectTo=${redirectTo}` : ''}`)
   }
 
-  const syncSignInOrRegistrationEvent = async (event: MetricsEventName) => {
+  const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
     Storage.setAnonymousId()
-    // noinspection ES6MissingAwait
+    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
     Metrics.identify(`${Storage.getAnonymousId()}`)
-    // noinspection ES6MissingAwait
+    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
     Metrics.syncProfile()
-    // noinspection ES6MissingAwait
+    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
     Metrics.captureEvent(event)
   }
 

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -48,7 +48,8 @@ export const reportError = async (url: string, status: number): Promise<void> =>
     .concat(JSON.stringify(url))
     .concat('Status: ')
     .concat(String(status))
-  await StackdriverReporter.report(msg)
+  // noinspection ES6MissingAwait
+  StackdriverReporter.report(msg)
 }
 
 function buildUrlWithParams(url: string, params?: Params): string {

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -43,12 +43,12 @@ export interface FetchData<T> {
   data: T
 }
 
-export const reportError = async (url: string, status: number): Promise<void> => {
+export const reportError = (url: string, status: number): void => {
   const msg = 'Error fetching response: '
     .concat(JSON.stringify(url))
     .concat('Status: ')
     .concat(String(status))
-  // noinspection ES6MissingAwait
+  // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
   StackdriverReporter.report(msg)
 }
 
@@ -74,7 +74,7 @@ async function handleResponse<T>(
     if (res.status === 401 && !isMeCheck) {
       redirectOnLogout()
     }
-    await reportError(url, res.status)
+    reportError(url, res.status)
 
     // Parse error response and throw with axios-like structure for compatibility
     interface ErrorData {


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-2918

### Summary
This PR removes the `await` calls to Metrics and Stackdriver reporter as the results of those calls are ignored. The result is a bit more improved in that the destination path of the UI begins to paint more quickly (i.e. the spinner loads faster) given that the sign-in flow no longer blocks on the metrics calls. The overall page load is the same, however.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
