### PR TITLE
[DT-2977] Add action column with `export` action

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -5,6 +5,8 @@ import { DataLibrary } from 'src/pages/DataLibrary'
 import { Storage } from 'src/libs/storage'
 import { Notifications } from 'src/libs/utils'
 import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { Metrics } from 'src/libs/ajax/Metrics'
+import eventList from 'src/libs/events'
 
 const mockMetadataResponse = {
   aggregations: {
@@ -505,7 +507,7 @@ describe('DataLibrary', () => {
     })
 
     it('captures metrics for default library', () => {
-      cy.intercept('**/event').as('event')
+      cy.stub(Metrics, 'captureEvent').as('captureEvent')
       cy.mount(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/datalibrary2']}>
@@ -516,11 +518,11 @@ describe('DataLibrary', () => {
         </QueryClientProvider>,
       )
 
-      cy.wait('@event').should('exist')
+      cy.get('@captureEvent').should('have.been.calledWith', eventList.dataLibrary)
     })
 
     it('captures metrics with brand parameter for branded library', () => {
-      cy.intercept('**/event').as('event')
+      cy.stub(Metrics, 'captureEvent').as('captureEvent')
       cy.mount(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter initialEntries={['/datalibrary2/broad']}>
@@ -531,7 +533,7 @@ describe('DataLibrary', () => {
         </QueryClientProvider>,
       )
 
-      cy.wait('@event').should('exist')
+      cy.get('@captureEvent').should('have.been.calledWith', eventList.dataLibrary, { brand: 'broad' })
     })
 
     it('renders myinstitution library with user institution', () => {

--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DataLibrary } from 'src/pages/DataLibrary'
 import { Storage } from 'src/libs/storage'
 import { Notifications } from 'src/libs/utils'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
 
 const mockMetadataResponse = {
   aggregations: {
@@ -319,6 +320,143 @@ describe('DataLibrary', () => {
       cy.wait('@searchApiDelayed')
       cy.get('[class*="MuiSkeleton"]').should('not.exist')
       cy.contains('2 Studies').should('be.visible')
+    })
+  })
+
+  describe('Export functionality', () => {
+    const emptyTdrResponse = { filteredTotal: 0, total: 0, items: [], roleMap: {} }
+
+    beforeEach(() => {
+      cy.viewport(2000, 900)
+    })
+
+    it('does not show export buttons when TDR returns no snapshots', () => {
+      cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').resolves(emptyTdrResponse)
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=datasets']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('.MuiDataGrid-row').should('have.length', 1)
+      cy.contains('Export').should('not.exist')
+    })
+
+    it('shows export button when TDR returns a snapshot with reader role', () => {
+      cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').resolves({
+        filteredTotal: 1,
+        total: 1,
+        items: [{
+          id: 'snapshot-abc',
+          name: 'Snapshot ABC',
+          duosId: 'DUOS-000001',
+          cloudPlatform: 'gcp',
+          resourceLocks: {},
+        }],
+        roleMap: { 'snapshot-abc': ['reader'] },
+      })
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=datasets']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('.MuiDataGrid-row').should('have.length', 1)
+      cy.contains('Export').should('be.visible')
+    })
+
+    it('shows export button when TDR returns a snapshot with steward role', () => {
+      cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').resolves({
+        filteredTotal: 1,
+        total: 1,
+        items: [{
+          id: 'snapshot-xyz',
+          name: 'Snapshot XYZ',
+          duosId: 'DUOS-000001',
+          cloudPlatform: 'gcp',
+          resourceLocks: {},
+        }],
+        roleMap: { 'snapshot-xyz': ['steward'] },
+      })
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=datasets']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('.MuiDataGrid-row').should('have.length', 1)
+      cy.contains('Export').should('be.visible')
+    })
+
+    it('does not show export button for snapshots without reader or steward role', () => {
+      cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').resolves({
+        filteredTotal: 1,
+        total: 1,
+        items: [{
+          id: 'snapshot-abc',
+          name: 'Snapshot ABC',
+          duosId: 'DUOS-000001',
+          cloudPlatform: 'gcp',
+          resourceLocks: {},
+        }],
+        roleMap: { 'snapshot-abc': ['discoverer'] },
+      })
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=datasets']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('.MuiDataGrid-row').should('have.length', 1)
+      cy.contains('Export').should('not.exist')
+    })
+
+    it('does not show export buttons when on the Studies tab', () => {
+      const listSnapshotsSpy = cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').resolves({
+        filteredTotal: 1,
+        total: 1,
+        items: [{ id: 'snap-1', name: 'Snap', duosId: 'DUOS-000001', cloudPlatform: 'gcp', resourceLocks: {} }],
+        roleMap: { 'snap-1': ['reader'] },
+      })
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=studies']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('.MuiDataGrid-row').should('have.length.at.least', 1)
+      cy.wrap(listSnapshotsSpy).should('not.have.been.called')
+      cy.contains('Export').should('not.exist')
+    })
+
+    it('handles TDR API errors gracefully and shows no export buttons', () => {
+      cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').rejects(new Error('TDR API unavailable'))
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=datasets']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.get('.MuiDataGrid-row').should('have.length', 1)
+      cy.contains('Export').should('not.exist')
     })
   })
 

--- a/cypress/component/data_library/LibraryDataGrid.spec.tsx
+++ b/cypress/component/data_library/LibraryDataGrid.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { LibraryDataGrid } from 'src/components/data_library/LibraryDataGrid'
-import { AssetType, SortOrder, StudyAggregation } from 'src/types/library'
+import { AssetType, ExportableDatasets, SortOrder, StudyAggregation } from 'src/types/library'
 import { makeDatasetTerm } from '../test-utils'
 
 const mockPaginationModel = {
@@ -244,5 +244,158 @@ describe('LibraryDataGrid', () => {
     cy.get('@onSortChange').should('have.been.calledWith', [
       { field: 'studyName', sort: 'asc' },
     ])
+  })
+
+  describe('exportableDatasets prop', () => {
+    const exportableDataset = makeDatasetTerm({
+      datasetId: 201,
+      datasetName: 'Dataset With Snapshots',
+      datasetIdentifier: 'DUOS-000201',
+      participantCount: 75,
+      accessManagement: 'controlled',
+    })
+
+    const nonExportableDataset = makeDatasetTerm({
+      datasetId: 202,
+      datasetName: 'Dataset Without Snapshots',
+      datasetIdentifier: 'DUOS-000202',
+      participantCount: 25,
+      accessManagement: 'open',
+    })
+
+    const exportableDatasets: ExportableDatasets = {
+      'DUOS-000201': [
+        {
+          id: 'snap-001',
+          name: 'Snapshot 001',
+          duosId: 'DUOS-000201',
+          cloudPlatform: 'gcp',
+          resourceLocks: {},
+        },
+      ],
+    }
+
+    it('renders an Actions column header when exportableDatasets has entries', () => {
+      cy.mount(
+        <LibraryDataGrid
+          assetType={AssetType.DATASETS}
+          data={[exportableDataset]}
+          loading={false}
+          total={1}
+          paginationModel={mockPaginationModel}
+          onPaginationChange={cy.stub()}
+          sortModel={mockSortModel}
+          onSortChange={cy.stub()}
+          selectedDatasetIds={[]}
+          onSelectionChange={cy.stub()}
+          exportableDatasets={exportableDatasets}
+        />,
+      )
+
+      cy.contains('Actions').should('exist')
+    })
+
+    it('renders an Export link for a dataset with matching exportable snapshots', () => {
+      cy.mount(
+        <LibraryDataGrid
+          assetType={AssetType.DATASETS}
+          data={[exportableDataset]}
+          loading={false}
+          total={1}
+          paginationModel={mockPaginationModel}
+          onPaginationChange={cy.stub()}
+          sortModel={mockSortModel}
+          onSortChange={cy.stub()}
+          selectedDatasetIds={[]}
+          onSelectionChange={cy.stub()}
+          exportableDatasets={exportableDatasets}
+        />,
+      )
+
+      cy.contains('a', 'Export')
+        .should('be.visible')
+        .and('have.attr', 'title', 'Export snapshot Snapshot 001')
+    })
+
+    it('does not render an Export link for a dataset with no matching snapshots', () => {
+      cy.mount(
+        <LibraryDataGrid
+          assetType={AssetType.DATASETS}
+          data={[nonExportableDataset]}
+          loading={false}
+          total={1}
+          paginationModel={mockPaginationModel}
+          onPaginationChange={cy.stub()}
+          sortModel={mockSortModel}
+          onSortChange={cy.stub()}
+          selectedDatasetIds={[]}
+          onSelectionChange={cy.stub()}
+          exportableDatasets={exportableDatasets}
+        />,
+      )
+
+      cy.contains('Export').should('not.exist')
+    })
+
+    it('renders Export links only for datasets that have matching snapshots when multiple datasets are shown', () => {
+      cy.mount(
+        <LibraryDataGrid
+          assetType={AssetType.DATASETS}
+          data={[exportableDataset, nonExportableDataset]}
+          loading={false}
+          total={2}
+          paginationModel={mockPaginationModel}
+          onPaginationChange={cy.stub()}
+          sortModel={mockSortModel}
+          onSortChange={cy.stub()}
+          selectedDatasetIds={[]}
+          onSelectionChange={cy.stub()}
+          exportableDatasets={exportableDatasets}
+        />,
+      )
+
+      cy.contains('a', 'Export').should('have.length', 1)
+      cy.get('.MuiDataGrid-row[data-id="201"]').contains('Export').should('exist')
+      cy.get('.MuiDataGrid-row[data-id="202"]').contains('Export').should('not.exist')
+    })
+
+    it('does not render Export links when exportableDatasets is not provided (default)', () => {
+      cy.mount(
+        <LibraryDataGrid
+          assetType={AssetType.DATASETS}
+          data={[exportableDataset]}
+          loading={false}
+          total={1}
+          paginationModel={mockPaginationModel}
+          onPaginationChange={cy.stub()}
+          sortModel={mockSortModel}
+          onSortChange={cy.stub()}
+          selectedDatasetIds={[]}
+          onSelectionChange={cy.stub()}
+        />,
+      )
+
+      cy.contains('Export').should('not.exist')
+    })
+
+    it('does not render Export links for the Studies grid even if exportableDatasets is provided', () => {
+      cy.mount(
+        <LibraryDataGrid
+          assetType={AssetType.STUDIES}
+          data={studies}
+          loading={false}
+          total={2}
+          paginationModel={mockPaginationModel}
+          onPaginationChange={cy.stub()}
+          sortModel={mockSortModel}
+          onSortChange={cy.stub()}
+          selectedDatasetIds={[]}
+          onSelectionChange={cy.stub()}
+          exportableDatasets={exportableDatasets}
+        />,
+      )
+
+      cy.contains('Export').should('not.exist')
+    })
   })
 })

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -35,13 +35,14 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   onSortChange,
   selectedDatasetIds,
   onSelectionChange,
+  exportableDatasets = {},
 }) => {
   const columns = useMemo(() => {
     if (assetType === AssetType.STUDIES) {
       return makeStudyColumns() as GridColDef<DatasetTerm | StudyAggregation>[]
     }
-    return makeDatasetColumns() as GridColDef<DatasetTerm | StudyAggregation>[]
-  }, [assetType])
+    return makeDatasetColumns(exportableDatasets) as GridColDef<DatasetTerm | StudyAggregation>[]
+  }, [assetType, exportableDatasets])
 
   const getRowId = (row: DatasetTerm | StudyAggregation) => {
     if (assetType === AssetType.STUDIES) {

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
 import { DatasetTerm, getAccessManagementSummary } from 'src/types/model'
-import { AccessManagement } from 'src/types/library'
+import { AccessManagement, ExportableDatasets } from 'src/types/library'
+import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
 
 /**
  * Column definitions for dataset view
  */
-export const makeDatasetColumns = (): GridColDef<DatasetTerm>[] => [
+export const makeDatasetColumns = (exportableDatasets: ExportableDatasets = {}): GridColDef<DatasetTerm>[] => [
   {
     field: 'datasetName',
     headerName: 'Dataset Name',
@@ -103,5 +104,26 @@ export const makeDatasetColumns = (): GridColDef<DatasetTerm>[] => [
     field: 'datasetIdentifier',
     headerName: 'Identifier',
     width: 150,
+  },
+  {
+    field: 'actions',
+    headerName: 'Actions',
+    width: 120,
+    sortable: false,
+    renderCell: (params) => {
+      const exportableSnapshots = exportableDatasets[params.row.datasetIdentifier] || []
+      if (exportableSnapshots.length === 0) return null
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, alignItems: 'center' }}>
+          {exportableSnapshots.map((snapshot, i) => (
+            <DatasetExportButton
+              key={i}
+              snapshot={snapshot}
+              title={`Export snapshot ${snapshot.name}`}
+            />
+          ))}
+        </Box>
+      )
+    },
   },
 ]

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -5,7 +5,7 @@ import LibraryTabs from 'src/components/data_library/LibraryTabs'
 import SearchBar from 'src/components/SearchBar'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
-import { AssetType, AvailableFilters, LibraryVersionNew, SortOrder, StudyAggregation, TabConfig } from 'src/types/library'
+import { AssetType, AvailableFilters, ExportableDatasets, LibraryVersionNew, SortOrder, StudyAggregation, TabConfig } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 import LibraryFilters from 'src/components/data_library/LibraryFilters'
 import { useLibraryData, useLibraryMetadata } from 'src/hooks/useLibraryData'
@@ -18,6 +18,9 @@ import { Storage } from 'src/libs/storage'
 import { Notifications } from 'src/libs/utils'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import eventList from 'src/libs/events'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { chain, intersection } from 'lodash'
+import { EnumerateSnapshotModel } from 'src/types/tdrModel'
 
 /**
  * DataLibrary Page Component
@@ -42,6 +45,7 @@ export const DataLibrary: React.FC = () => {
   const [urlState, updateUrlState] = useLibraryUrlState()
 
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<number[]>([])
+  const [exportableDatasets, setExportableDatasets] = useState<ExportableDatasets>({})
 
   const user = Storage.getCurrentUser()
   const institutionId = user?.institution?.id
@@ -241,8 +245,38 @@ export const DataLibrary: React.FC = () => {
     applyForAccess(selectedDatasetIds, navigate)
   }
 
+  useEffect(() => {
+    const fetchExportable = async () => {
+      if (urlState.tab !== AssetType.DATASETS || !data?.items?.length) {
+        setExportableDatasets({})
+        return
+      }
+      const datasetIdentifiers = (data.items as DatasetTerm[]).map(d => d.datasetIdentifier).filter(Boolean)
+      if (datasetIdentifiers.length === 0) {
+        setExportableDatasets({})
+        return
+      }
+      try {
+        const result: EnumerateSnapshotModel = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers)
+        if (result.filteredTotal > 0) {
+          const mapped = chain(result.items)
+            .filter(snapshot => intersection(result.roleMap[snapshot.id], ['steward', 'reader']).length > 0)
+            .groupBy('duosId')
+            .value()
+          setExportableDatasets(mapped)
+        }
+        else {
+          setExportableDatasets({})
+        }
+      }
+      catch {
+        setExportableDatasets({})
+      }
+    }
+    fetchExportable()
+  }, [data?.items, urlState.tab])
+
   if (error) {
-    console.log(error)
     return (
       <Box sx={{ px: 3, py: 4 }}>
         <Box sx={{ textAlign: 'center', color: 'error.main' }}>
@@ -342,6 +376,7 @@ export const DataLibrary: React.FC = () => {
             onSortChange={handleSortChange}
             selectedDatasetIds={selectedDatasetIds}
             onSelectionChange={handleSelectionChange}
+            exportableDatasets={exportableDatasets}
           />
         </Box>
       </Box>

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -36,7 +36,9 @@ import { EnumerateSnapshotModel } from 'src/types/tdrModel'
  * State Management:
  * - URL state: filters, pagination, sort, search, active tab (managed by useLibraryUrlState)
  * - Server state: data fetching, caching (managed by React Query via useLibraryData)
+ * - Metadata fetching for filter options (useLibraryMetadata)
  * - Local UI state: selection tracking (useState)
+ * - Exportable datasets state for enabling export functionality (useState)
  */
 export const DataLibrary: React.FC = () => {
   const { query } = useParams()

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -1,6 +1,7 @@
 /**
  * Type definitions for the Data Library feature
  */
+import { SnapshotSummaryModel } from 'src/types/tdrModel'
 
 export enum AssetType {
   STUDIES = 'studies',
@@ -85,6 +86,8 @@ export interface LibraryTabsProps {
   tabs: TabConfig[]
 }
 
+export type ExportableDatasets = { [duosId: string]: SnapshotSummaryModel[] }
+
 export interface LibraryDataGridProps {
   assetType: AssetType
   data: unknown[]
@@ -99,6 +102,7 @@ export interface LibraryDataGridProps {
   onSortChange: (model: Array<{ field: string, sort: SortOrder | null }>) => void
   selectedDatasetIds: number[]
   onSelectionChange: (selectedIds: number[]) => void
+  exportableDatasets?: ExportableDatasets
 }
 
 export interface StudyAggregation {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2977

### Summary

Adds an action column to datasets that enables exporting to Terra.

<img width="295" height="133" alt="Screenshot 2026-02-26 at 8 48 55 AM" src="https://github.com/user-attachments/assets/bd2ea050-6c70-495f-af4b-a3e6486ddc1d" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
