### PR TITLE
[DT-2978] Add asset count

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -216,6 +216,112 @@ describe('DataLibrary', () => {
     cy.contains('2 datasets selected from 1 study').should('be.visible')
   })
 
+  describe('asset count', () => {
+    const mountDefault = (tab = 'studies') => {
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={[`/?tab=${tab}`]}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+    }
+
+    it('shows the plural studies count after loading', () => {
+      // mockStudiesResponse has total_studies.value = 2
+      mountDefault('studies')
+      cy.wait('@searchApi')
+      cy.contains('2 Studies').should('be.visible')
+    })
+
+    it('shows singular "Study" when total is 1', () => {
+      cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
+        if (req.body.aggs?.studies) {
+          req.reply({
+            aggregations: {
+              total_studies: { value: 1 },
+              studies: {
+                buckets: [
+                  {
+                    key: { study_id: 101 },
+                    study_details: { hits: { hits: [{ _source: { study: { studyName: 'Only Study', description: '' } } }] } },
+                    dataset_count: { value: 1 },
+                    total_participants: { value: 50 },
+                    dataset_ids: { buckets: [{ key: 1 }] },
+                  },
+                ],
+              },
+            },
+          })
+        }
+        else {
+          req.reply(mockMetadataResponse)
+        }
+      }).as('searchApiSingular')
+
+      mountDefault('studies')
+      cy.wait('@searchApiSingular')
+      cy.contains('1 Study').should('be.visible')
+    })
+
+    it('shows the datasets count on the datasets tab', () => {
+      // mockDatasetsResponse has hits.total.value = 1
+      mountDefault('datasets')
+      cy.wait('@searchApi')
+      cy.contains('1 Dataset').should('be.visible')
+    })
+
+    it('shows plural "Datasets" when total is greater than 1', () => {
+      cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
+        if (req.body.aggs?.studies) {
+          req.reply(mockStudiesResponse)
+        }
+        else if (req.body.size === 0 && !req.body.queryTerm) {
+          req.reply(mockMetadataResponse)
+        }
+        else {
+          req.reply({
+            hits: {
+              total: { value: 42 },
+              hits: [],
+            },
+          })
+        }
+      }).as('searchApiMultiple')
+
+      mountDefault('datasets')
+      cy.wait('@searchApiMultiple')
+      cy.contains('42 Datasets').should('be.visible')
+    })
+
+    it('shows a loading skeleton while data is fetching', () => {
+      cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
+        req.on('response', (res) => {
+          res.setDelay(500)
+        })
+        if (req.body.aggs?.studies) {
+          req.reply(mockStudiesResponse)
+        }
+        else if (req.body.size === 0 && !req.body.queryTerm) {
+          req.reply(mockMetadataResponse)
+        }
+        else {
+          req.reply(mockDatasetsResponse)
+        }
+      }).as('searchApiDelayed')
+
+      mountDefault('studies')
+
+      // Skeleton should be visible before the response arrives
+      cy.get('[class*="MuiSkeleton"]').should('be.visible')
+
+      // After loading, skeleton should be gone and count should show
+      cy.wait('@searchApiDelayed')
+      cy.get('[class*="MuiSkeleton"]').should('not.exist')
+      cy.contains('2 Studies').should('be.visible')
+    })
+  })
+
   describe('Branded Data Libraries', () => {
     it('renders branded library based on URL parameter (broad)', () => {
       cy.mount(

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef, useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
-import { Box } from '@mui/material'
+import { Box, Skeleton, Typography } from '@mui/material'
 import LibraryTabs from 'src/components/data_library/LibraryTabs'
 import SearchBar from 'src/components/SearchBar'
 import TableHeaderSection from 'src/components/TableHeaderSection'
@@ -301,8 +301,28 @@ export const DataLibrary: React.FC = () => {
           />
         </Box>
 
-        {/* Data Grid */}
-        <Box sx={{ flex: 1, height: '100%', overflow: 'hidden' }}>
+        {/* Data Library */}
+        <Box sx={{ flex: 1, height: '100%', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {/* Asset count */}
+          {isFetching
+            ? <Skeleton variant="text" width={120} sx={{ fontSize: '1.6rem', mb: 1 }} />
+            : (
+                <Typography sx={{ fontWeight: 600, fontSize: '1.6rem', mb: 1 }}>
+                  {(data?.total ?? 0).toLocaleString()}
+                  {' '}
+                  {(() => {
+                    switch (urlState.tab) {
+                      case AssetType.STUDIES:
+                        return (data?.total === 1) ? 'Study' : 'Studies'
+                      case AssetType.DATASETS:
+                        return (data?.total === 1) ? 'Dataset' : 'Datasets'
+                      default:
+                        return 'Assets'
+                    }
+                  })()}
+                </Typography>
+              )}
+          {/* Data Grid */}
           <LibraryDataGrid
             assetType={urlState.tab}
             data={data?.items || []}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2978

### Summary

Add asset count above data library.

<img width="424" height="200" alt="Screenshot 2026-02-26 at 8 47 46 AM" src="https://github.com/user-attachments/assets/67cf1dba-247a-46dc-ac49-4966f6a03d20" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
