### PR TITLE
[DT-2996] Use new data library in non-staging

### DIFF
--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -83,12 +83,17 @@ const AppRoutes = (props: AppRoutesProps) => {
       <Route element={<Authenticated />}>
         <Route path="/profile" element={<UserProfile />} />
         <Route path="/request_role" element={<RequestForm />} />
-        <Route path="/datalibrary" element={<DatasetSearch {...props} />}>
-          <Route path=":query" element={<DatasetSearch {...props} />} />
-        </Route>
-        <Route path="/datalibrary2" element={<DataLibrary />}>
-          <Route path=":query" element={<DataLibrary />} />
-        </Route>
+        {checkEnv(envGroups.NON_STAGING)
+          ? (
+              <Route path="/datalibrary" element={<DataLibrary />}>
+                <Route path=":query" element={<DataLibrary />} />
+              </Route>
+            )
+          : (
+              <Route path="/datalibrary" element={<DatasetSearch {...props} />}>
+                <Route path=":query" element={<DatasetSearch {...props} />} />
+              </Route>
+            )}
         <Route path="/studies/:studyId" element={<StudyDetails />} />
         <Route path="/dataset/:datasetIdentifier" element={<DatasetStatistics />} />
         <Route element={<RoleBAC rolesAllowed={[USER_ROLES.researcher]} />}>


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2996

### Summary

Sets the new data library to the default in local and dev.


https://github.com/user-attachments/assets/e4a7815b-e0c8-428d-b66a-597a8b93f99a

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
