### PR TITLE
[DT-2987] Access management chip

### DIFF
--- a/cypress/component/data_library/LibraryDataGrid.spec.tsx
+++ b/cypress/component/data_library/LibraryDataGrid.spec.tsx
@@ -48,6 +48,12 @@ const datasets = [
     participantCount: 40,
     accessManagement: 'open',
   }),
+  makeDatasetTerm({
+    datasetId: 103,
+    datasetName: 'Dataset 103',
+    participantCount: 20,
+    accessManagement: 'external',
+  }),
 ]
 
 describe('LibraryDataGrid', () => {
@@ -87,7 +93,7 @@ describe('LibraryDataGrid', () => {
         assetType={AssetType.DATASETS}
         data={datasets}
         loading={false}
-        total={2}
+        total={3}
         paginationModel={mockPaginationModel}
         onPaginationChange={cy.stub().as('onPaginationChange')}
         sortModel={mockSortModel}
@@ -99,12 +105,18 @@ describe('LibraryDataGrid', () => {
 
     cy.contains('Dataset 101').should('exist')
     cy.contains('60').should('exist')
-    // Use a more specific selector to find Controlled text, maybe it's in a Chip
     cy.get('.MuiChip-label').contains('Controlled').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorPrimary').should('exist')
 
     cy.contains('Dataset 102').should('exist')
     cy.contains('40').should('exist')
     cy.get('.MuiChip-label').contains('Open').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorSuccess').should('exist')
+
+    cy.contains('Dataset 103').should('exist')
+    cy.contains('20').should('exist')
+    cy.get('.MuiChip-label').contains('External').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorSecondary').should('exist')
   })
 
   it('handles row selection for datasets', () => {

--- a/cypress/component/data_library/datasetColumns.spec.tsx
+++ b/cypress/component/data_library/datasetColumns.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { DataGrid } from '@mui/x-data-grid'
+import { makeDatasetColumns } from 'src/components/data_library/columns/datasetColumns'
+import { makeDatasetTerm } from '../test-utils'
+
+/**
+ * Tests for makeDatasetColumns — focused on the Access Management chip
+ * color and label rendering for each AccessManagement value.
+ */
+describe('datasetColumns — Access Management chip', () => {
+  beforeEach(() => {
+    cy.viewport(1200, 800)
+  })
+
+  const renderGrid = (accessManagement: string) => {
+    const row = makeDatasetTerm({ datasetId: 1, accessManagement })
+    cy.mount(
+      <DataGrid
+        rows={[row]}
+        columns={makeDatasetColumns()}
+        getRowId={r => r.datasetId}
+        autoHeight
+      />,
+    )
+  }
+
+  it('renders "Controlled" chip with primary color for controlled access', () => {
+    renderGrid('controlled')
+    cy.get('.MuiChip-label').contains('Controlled').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorPrimary').should('exist')
+  })
+
+  it('renders "Open" chip with success color for open access', () => {
+    renderGrid('open')
+    cy.get('.MuiChip-label').contains('Open').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorSuccess').should('exist')
+  })
+
+  it('renders "External" chip with secondary color for external access', () => {
+    renderGrid('external')
+    cy.get('.MuiChip-label').contains('External').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorSecondary').should('exist')
+  })
+
+  it('renders "Unknown" chip with default color for unknown access', () => {
+    renderGrid('something-unknown')
+    cy.get('.MuiChip-label').contains('Unknown').should('exist')
+    cy.get('.MuiChip-root.MuiChip-colorDefault').should('exist')
+  })
+})

--- a/cypress/component/libs/model.spec.ts
+++ b/cypress/component/libs/model.spec.ts
@@ -1,0 +1,36 @@
+import { getAccessManagementSummary } from 'src/types/model'
+
+describe('getAccessManagementSummary', () => {
+  it('returns External summary for "external"', () => {
+    const result = getAccessManagementSummary('external')
+    expect(result.name).to.equal('External')
+    expect(result.description).to.equal('External access request required')
+    expect(result.icon).to.be.a('string').and.not.equal('')
+  })
+
+  it('returns Open summary for "open"', () => {
+    const result = getAccessManagementSummary('open')
+    expect(result.name).to.equal('Open')
+    expect(result.description).to.equal('Open access')
+    expect(result.icon).to.be.a('string').and.not.equal('')
+  })
+
+  it('returns Controlled summary for "controlled"', () => {
+    const result = getAccessManagementSummary('controlled')
+    expect(result.name).to.equal('Controlled')
+    expect(result.description).to.equal('Controlled access')
+    expect(result.icon).to.be.a('string').and.not.equal('')
+  })
+
+  it('returns Unknown summary with name "Unknown" for unrecognised values', () => {
+    const result = getAccessManagementSummary('something-unknown')
+    expect(result.name).to.equal('Unknown')
+    expect(result.description).to.equal('Unknown access management')
+  })
+
+  it('returns Unknown summary for empty string', () => {
+    const result = getAccessManagementSummary('')
+    expect(result.name).to.equal('Unknown')
+    expect(result.description).to.equal('Unknown access management')
+  })
+})

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -82,7 +82,7 @@ export const makeDatasetColumns = (): GridColDef<DatasetTerm>[] => [
                   case AccessManagement.OPEN:
                     return 'success'
                   case AccessManagement.EXTERNAL:
-                    return 'default'
+                    return 'secondary'
                   default:
                     return 'default'
                 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -266,7 +266,7 @@ export const getAccessManagementSummary = (accessManagement: string): AccessMana
       }
     default:
       return {
-        name: '',
+        name: 'Unknown',
         icon: '',
         description: 'Unknown access management',
       }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2987

### Summary

Updates the colors and descriptions of the different access management chips.

<img width="132" height="227" alt="Screenshot 2026-02-26 at 9 14 29 AM" src="https://github.com/user-attachments/assets/a3be9551-6670-4e49-9890-1b744f2f85af" />
<img width="118" height="46" alt="Screenshot 2026-02-26 at 9 16 11 AM" src="https://github.com/user-attachments/assets/fdc338b7-f3fb-464d-9582-9bfb935c4f1e" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
