### PR TITLE
[DT-2979] Fix sort issue with new data library columns

### DIFF
--- a/cypress/component/Hooks/useLibraryData.spec.tsx
+++ b/cypress/component/Hooks/useLibraryData.spec.tsx
@@ -154,6 +154,6 @@ describe('buildElasticsearchQuery', () => {
     const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, sort)
     expect(query.sort).to.have.length(1)
     const firstSort = query.sort?.[0] as Record<string, { order: string }>
-    expect(firstSort.studyName.order).to.equal('asc')
+    expect(firstSort['study.studyName.keyword'].order).to.equal('asc')
   })
 })

--- a/cypress/component/Hooks/useLibraryData.spec.tsx
+++ b/cypress/component/Hooks/useLibraryData.spec.tsx
@@ -156,4 +156,42 @@ describe('buildElasticsearchQuery', () => {
     const firstSort = query.sort?.[0] as Record<string, { order: string }>
     expect(firstSort['study.studyName.keyword'].order).to.equal('asc')
   })
+
+  it('maps each text field to its .keyword ES sort path', () => {
+    const textFieldCases: Array<[string, string]> = [
+      ['datasetName', 'datasetName.keyword'],
+      ['studyName', 'study.studyName.keyword'],
+      ['accessManagement', 'accessManagement.keyword'],
+      ['dac', 'dac.dacName.keyword'],
+      ['datasetIdentifier', 'datasetIdentifier.keyword'],
+    ]
+
+    textFieldCases.forEach(([columnField, esSortField]) => {
+      const sort: SortState = { field: columnField, order: 'asc' }
+      const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, sort)
+      expect(query.sort).to.have.length(1)
+      const firstSort = query.sort?.[0] as Record<string, { order: string }>
+      expect(firstSort[esSortField].order).to.equal('asc')
+    })
+  })
+
+  it('sorts numeric field (participantCount) without .keyword mapping', () => {
+    const sort: SortState = { field: 'participantCount', order: 'desc' }
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, sort)
+    expect(query.sort).to.have.length(1)
+    const firstSort = query.sort?.[0] as Record<string, { order: string }>
+    expect(firstSort.participantCount.order).to.equal('desc')
+  })
+
+  it('applies sort order correctly for desc', () => {
+    const sort: SortState = { field: 'datasetName', order: 'desc' }
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, sort)
+    const firstSort = query.sort?.[0] as Record<string, { order: string }>
+    expect(firstSort['datasetName.keyword'].order).to.equal('desc')
+  })
+
+  it('omits sort clause when sort is undefined', () => {
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, undefined)
+    expect(query.sort).to.equal(undefined)
+  })
 })

--- a/cypress/component/Hooks/useLibraryUrlState.spec.tsx
+++ b/cypress/component/Hooks/useLibraryUrlState.spec.tsx
@@ -116,4 +116,33 @@ describe('useLibraryUrlState', () => {
     cy.get('#page').should('have.text', '1')
     cy.get('#pageSize').should('have.text', '50')
   })
+
+  it('sets sort state via updateState', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+
+    cy.get('#update-sort').click()
+    cy.get('#sortField').should('have.text', 'studyName')
+    cy.get('#sortOrder').should('have.text', 'asc')
+  })
+
+  it('clears sort state when sortField and sortOrder are set to undefined', () => {
+    cy.mount(
+      <MemoryRouter initialEntries={['/?sort=studyName&order=asc']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+
+    // Verify sort is initially set from URL params
+    cy.get('#sortField').should('have.text', 'studyName')
+    cy.get('#sortOrder').should('have.text', 'asc')
+
+    // Clear the sort
+    cy.get('#clear-sort').click()
+    cy.get('#sortField').should('have.text', 'none')
+    cy.get('#sortOrder').should('have.text', 'none')
+  })
 })

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -163,15 +163,13 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
         onPaginationModelChange={onPaginationChange}
         // studies are sorted client-side, other assets are sorted server-side
         sortingMode={assetType === AssetType.STUDIES ? 'client' : 'server'}
-        {...(assetType !== AssetType.STUDIES && {
-          sortModel,
-          onSortModelChange: (model) => {
-            onSortChange(model.map(item => ({
-              field: item.field,
-              sort: item.sort ?? null,
-            })))
-          },
-        })}
+        sortModel={sortModel}
+        onSortModelChange={(model) => {
+          onSortChange(model.map(item => ({
+            field: item.field,
+            sort: item.sort ?? null,
+          })))
+        }}
         checkboxSelection
         disableRowSelectionOnClick
         rowSelectionModel={rowSelectionModel}

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -161,15 +161,17 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
         paginationModel={paginationModel}
         paginationMode="server"
         onPaginationModelChange={onPaginationChange}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={(model) => {
-          // Convert readonly GridSortModel to mutable array with proper type
-          onSortChange(model.map(item => ({
-            field: item.field,
-            sort: item.sort ?? null,
-          })))
-        }}
+        // studies are sorted client-side, other assets are sorted server-side
+        sortingMode={assetType === AssetType.STUDIES ? 'client' : 'server'}
+        {...(assetType !== AssetType.STUDIES && {
+          sortModel,
+          onSortModelChange: (model) => {
+            onSortChange(model.map(item => ({
+              field: item.field,
+              sort: item.sort ?? null,
+            })))
+          },
+        })}
         checkboxSelection
         disableRowSelectionOnClick
         rowSelectionModel={rowSelectionModel}

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -212,6 +212,19 @@ export const buildElasticsearchQuery = (
     }
   }
 
+  // Text fields cannot be sorted directly and must use their .keyword sub-field.
+  const DATASET_SORT_FIELD_MAP: Record<string, string> = {
+    datasetName: 'datasetName.keyword',
+    studyName: 'study.studyName.keyword',
+    accessManagement: 'accessManagement.keyword',
+    dac: 'dac.dacName.keyword',
+    datasetIdentifier: 'datasetIdentifier.keyword',
+  }
+
+  const esSortField = sort
+    ? (DATASET_SORT_FIELD_MAP[sort.field] ?? sort.field)
+    : undefined
+
   // For datasets, use standard pagination
   return {
     from: pagination.page * pagination.pageSize,
@@ -225,7 +238,7 @@ export const buildElasticsearchQuery = (
     ...(sort && {
       sort: [
         {
-          [sort.field]: {
+          [esSortField!]: {
             order: sort.order,
           },
         },

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -138,7 +138,7 @@ export const useLibraryUrlState = () => {
       }
     }
 
-    if (updates.sortField !== undefined) {
+    if ('sortField' in updates) {
       if (updates.sortField) {
         newParams.set('sort', updates.sortField)
       }
@@ -147,7 +147,7 @@ export const useLibraryUrlState = () => {
       }
     }
 
-    if (updates.sortOrder !== undefined) {
+    if ('sortOrder' in updates) {
       if (updates.sortOrder) {
         newParams.set('order', updates.sortOrder)
       }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2979

### Summary

Allows study and dataset columns to properly be sorted. Note because Study is an aggregation, it is done client side. Other data assets are sorted server side.

https://github.com/user-attachments/assets/24e63148-4145-4588-b8c7-06bdec3afaa2

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
