### PR TITLE
[DT-2978] Ensure data library is not cut off due to asset count

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -180,6 +180,7 @@ describe('DataLibrary', () => {
   })
 
   it('shows footer when a dataset is selected', () => {
+    cy.viewport(800, 600)
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={['/?tab=datasets']}>
@@ -200,6 +201,7 @@ describe('DataLibrary', () => {
   })
 
   it('shows footer when a study is selected', () => {
+    cy.viewport(800, 600)
     cy.mount(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter initialEntries={['/?tab=studies']}>
@@ -295,6 +297,16 @@ describe('DataLibrary', () => {
       mountDefault('datasets')
       cy.wait('@searchApiMultiple')
       cy.contains('42 Datasets').should('be.visible')
+    })
+
+    it('does not clip the data grid when the asset count header is visible', () => {
+      cy.viewport(1200, 900)
+      mountDefault('datasets')
+      cy.wait('@searchApi')
+
+      cy.contains('1 Dataset').should('be.visible')
+
+      cy.get('.MuiDataGrid-footerContainer').should('be.visible')
     })
 
     it('shows a loading skeleton while data is fetching', () => {

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -337,7 +337,6 @@ export const DataLibrary: React.FC = () => {
           />
         </Box>
 
-        {/* Data Library */}
         <Box sx={{ flex: 1, height: '100%', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           {/* Asset count */}
           {isFetching
@@ -358,28 +357,30 @@ export const DataLibrary: React.FC = () => {
                   })()}
                 </Typography>
               )}
-          {/* Data Grid */}
-          <LibraryDataGrid
-            assetType={urlState.tab}
-            data={data?.items || []}
-            loading={isFetching}
-            total={data?.total || 0}
-            paginationModel={{
-              page: urlState.page,
-              pageSize: urlState.pageSize,
-            }}
-            onPaginationChange={(model) => {
-              updateUrlState({
-                page: model.page,
-                pageSize: model.pageSize,
-              })
-            }}
-            sortModel={sortModel}
-            onSortChange={handleSortChange}
-            selectedDatasetIds={selectedDatasetIds}
-            onSelectionChange={handleSelectionChange}
-            exportableDatasets={exportableDatasets}
-          />
+          {/* Data Library */}
+          <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+            <LibraryDataGrid
+              assetType={urlState.tab}
+              data={data?.items || []}
+              loading={isFetching}
+              total={data?.total || 0}
+              paginationModel={{
+                page: urlState.page,
+                pageSize: urlState.pageSize,
+              }}
+              onPaginationChange={(model) => {
+                updateUrlState({
+                  page: model.page,
+                  pageSize: model.pageSize,
+                })
+              }}
+              sortModel={sortModel}
+              onSortChange={handleSortChange}
+              selectedDatasetIds={selectedDatasetIds}
+              onSelectionChange={handleSelectionChange}
+              exportableDatasets={exportableDatasets}
+            />
+          </Box>
         </Box>
       </Box>
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2978

### Summary

Fix for a visual regression introduced in #3351 where the data grid pagination footer would be cut off due to the additional height of the asset count.

| Before | After |
| ------- | ----- |
| <img width="270" height="94" alt="Screenshot 2026-02-26 at 12 51 10 PM" src="https://github.com/user-attachments/assets/ff40da89-f980-4c3b-921d-1247d59b360f" /> | <img width="273" height="125" alt="Screenshot 2026-02-26 at 12 52 20 PM" src="https://github.com/user-attachments/assets/8ed48fe8-1736-49dc-b188-82d243dc177f" /> |

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
