### PR TITLE
[DT-2799] Add Help Text to Data Custodian Filed in Study Registration

### DIFF
--- a/src/pages/data_submission/v2/GeneralStudyInformation.tsx
+++ b/src/pages/data_submission/v2/GeneralStudyInformation.tsx
@@ -115,8 +115,8 @@ export const GeneralStudyInformation = (props: GeneralStudyInformationProps) => 
       {generateStudyInputFormTextField(setStudy, 'piEmail', study?.piEmail, 'Principal Investigator Email Address', 'Enter the Principal Investigator\'s email address', [FormValidators.EMAIL])}
       <FormField
         id={DataCustodianEmail.key}
-        title="Data Custodian Email"
-        description="Insert the email for any individual with the authority to add/remove users access to this study&apos;s datasets."
+        title="Data Custodian Email" 
+        description="Data Custodian contacts will be displayed publicly in DUOS and may be contacted regarding data access questions or data quality issues. Please provide the appropriate institutional contact(s)."
         type={FormFieldTypes.SELECT}
         validators={[FormValidators.EMAIL]}
         selectOptions={[]}

--- a/src/pages/data_submission/v2/GeneralStudyInformation.tsx
+++ b/src/pages/data_submission/v2/GeneralStudyInformation.tsx
@@ -115,7 +115,7 @@ export const GeneralStudyInformation = (props: GeneralStudyInformationProps) => 
       {generateStudyInputFormTextField(setStudy, 'piEmail', study?.piEmail, 'Principal Investigator Email Address', 'Enter the Principal Investigator\'s email address', [FormValidators.EMAIL])}
       <FormField
         id={DataCustodianEmail.key}
-        title="Data Custodian Email" 
+        title="Data Custodian Email"
         description="Data Custodian contacts will be displayed publicly in DUOS and may be contacted regarding data access questions or data quality issues. Please provide the appropriate institutional contact(s)."
         type={FormFieldTypes.SELECT}
         validators={[FormValidators.EMAIL]}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2799

### Summary
Updated help text

Insert the email for any individual with the authority to add/remove users access to this study&apos;s datasets.  **-->** 
Data Custodian contacts will be displayed publicly in DUOS and may be contacted regarding data access questions or data quality issues. Please provide the appropriate institutional contact(s).
----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
