### PR TITLE
[DT-3004] Enable data library v5 in staging

### DIFF
--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -83,7 +83,7 @@ const AppRoutes = (props: AppRoutesProps) => {
       <Route element={<Authenticated />}>
         <Route path="/profile" element={<UserProfile />} />
         <Route path="/request_role" element={<RequestForm />} />
-        {checkEnv(envGroups.NON_STAGING)
+        {checkEnv(envGroups.NON_PROD)
           ? (
               <Route path="/datalibrary" element={<DataLibrary />}>
                 <Route path=":query" element={<DataLibrary />} />


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3004

### Summary

Elasticsearch v9 is enabled in staging, so the new data library can be turned on as well.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
