### PR TITLE
[DT-3000] Visually group rules in "Manage RADAR" page

### DIFF
--- a/cypress/component/components/dac_bot/DACBotComponent.spec.tsx
+++ b/cypress/component/components/dac_bot/DACBotComponent.spec.tsx
@@ -79,10 +79,10 @@ describe('DACBotComponent', () => {
 
   describe('rule grouping', () => {
     const allRules = [
-      { id: 1, ruleType: 'GRU_V1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
-      { id: 2, ruleType: 'HMB_V1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **Health/Medical/Biomedical Use (HMB)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
-      { id: 3, ruleType: 'GRU_DSV1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Disease Specific (DS) with one or more selected diseases** with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
-      { id: 4, ruleType: 'HMB_DSV1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **Health/Medical/Biomedical Use (HMB)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Disease Specific (DS) with one or more selected diseases** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 1, ruleType: 'GRU_V1', description: `Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.`, ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 2, ruleType: 'HMB_V1', description: `Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **Health/Medical/Biomedical Use (HMB)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.`, ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 3, ruleType: 'GRU_DSV1', description: `Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Disease Specific (DS) with one or more selected diseases** with no ethical concerns designated.`, ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 4, ruleType: 'HMB_DSV1', description: `Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **Health/Medical/Biomedical Use (HMB)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Disease Specific (DS) with one or more selected diseases** only with no ethical concerns designated.`, ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
       { id: 5, ruleType: 'AUTO_OPEN_DAR_FOR_ALL_MEMBERS', description: 'Automatically open Data Access Requests (DARs) for all DAC members upon submission, **without requiring Chair to open manually**.', ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
       { id: 6, ruleType: 'REQUIRE_SO_DAR_APPROVAL', description: 'Require approval by the Signing Official identified in the Data Access Request (DAR) prior to DAC Voting.', ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
     ]
@@ -122,7 +122,7 @@ describe('DACBotComponent', () => {
     })
 
     it('renders groups in order: Automatic approval, Automatic open, SO prior approval', () => {
-      cy.get('h6').then($headings => {
+      cy.get('h6').then(($headings) => {
         const labels = [...$headings].map(el => el.textContent)
         expect(labels).to.deep.equal(['Automatic approval', 'Automatic open', 'SO prior approval'])
       })
@@ -131,7 +131,7 @@ describe('DACBotComponent', () => {
 
   describe('rule grouping - unknown ruleType', () => {
     const rulesWithUnknown = [
-      { id: 1, ruleType: 'GRU_V1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 1, ruleType: 'GRU_V1', description: `Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.`, ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
       { id: 2, ruleType: 'FUTURE_RULE', description: 'Some future rule', ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
     ]
 

--- a/cypress/component/components/dac_bot/DACBotComponent.spec.tsx
+++ b/cypress/component/components/dac_bot/DACBotComponent.spec.tsx
@@ -106,18 +106,26 @@ describe('DACBotComponent', () => {
         cy.contains('only General Research Use (GRU)').should('exist')
         cy.contains('only Health/Medical/Biomedical Use (HMB)').should('exist')
         cy.contains('Disease Specific (DS) with one or more selected diseases').should('exist')
+        cy.contains('without requiring Chair to open manually').should('not.exist')
+        cy.contains('Require approval by the Signing Official').should('not.exist')
       })
     })
 
     it('places AUTO_OPEN_DAR_FOR_ALL_MEMBERS under Automatic open', () => {
       cy.get('[data-cy="rule-group-automatic-open"]').within(() => {
         cy.contains('without requiring Chair to open manually').should('exist')
+        cy.contains('only General Research Use (GRU)').should('not.exist')
+        cy.contains('Disease Specific (DS) with one or more selected diseases').should('not.exist')
+        cy.contains('Require approval by the Signing Official').should('not.exist')
       })
     })
 
     it('places REQUIRE_SO_DAR_APPROVAL under SO prior approval', () => {
       cy.get('[data-cy="rule-group-so-prior-approval"]').within(() => {
         cy.contains('Require approval by the Signing Official').should('exist')
+        cy.contains('only General Research Use (GRU)').should('not.exist')
+        cy.contains('Disease Specific (DS) with one or more selected diseases').should('not.exist')
+        cy.contains('without requiring Chair to open manually').should('not.exist')
       })
     })
 

--- a/cypress/component/components/dac_bot/DACBotComponent.spec.tsx
+++ b/cypress/component/components/dac_bot/DACBotComponent.spec.tsx
@@ -4,74 +4,150 @@ import { DAC } from 'src/libs/ajax/DAC'
 import { Storage } from 'src/libs/storage'
 
 describe('DACBotComponent', () => {
-  const mockRules = [
-    {
-      id: 1,
-      ruleType: 'REQUIRE_SO_DAR_APPROVAL',
-      description: 'Require SO approval for data access',
-      ruleState: 'AVAILABLE',
-      activationDate: Date.now(),
-      enabledByUserId: 1,
-      displayName: 'Test User',
-      userEmail: 'testuser@example.com',
-    },
-    {
-      id: 2,
-      ruleType: 'AUTO_OPEN_DAR_FOR_ALL_MEMBERS',
-      description: 'Auto open DAR for all members',
-      ruleState: 'AVAILABLE',
-      activationDate: 0,
-      enabledByUserId: null,
-      displayName: null,
-      userEmail: null,
-    },
-  ]
+  describe('mutual exclusivity rules', () => {
+    const mockRules = [
+      {
+        id: 1,
+        ruleType: 'REQUIRE_SO_DAR_APPROVAL',
+        description: 'Require SO approval for data access',
+        ruleState: 'AVAILABLE',
+        activationDate: Date.now(),
+        enabledByUserId: 1,
+        displayName: 'Test User',
+        userEmail: 'testuser@example.com',
+      },
+      {
+        id: 2,
+        ruleType: 'AUTO_OPEN_DAR_FOR_ALL_MEMBERS',
+        description: 'Auto open DAR for all members',
+        ruleState: 'AVAILABLE',
+        activationDate: 0,
+        enabledByUserId: null,
+        displayName: null,
+        userEmail: null,
+      },
+    ]
 
-  beforeEach(() => {
-    // Mock the user to be a chair so checkboxes are enabled
-    cy.stub(Storage, 'getCurrentUser').returns({
-      roles: [{ dacId: 1, name: 'Chairperson' }],
+    beforeEach(() => {
+      // Mock the user to be a chair so checkboxes are enabled
+      cy.stub(Storage, 'getCurrentUser').returns({
+        roles: [{ dacId: 1, name: 'Chairperson' }],
+      })
+      cy.stub(DAC, 'fetchDACbotRules').resolves(mockRules)
+      cy.stub(DAC, 'toggleDACbotRule').resolves({
+        ruleId: 1,
+        isRuleEnabled: true,
+        enabledTime: Date.now(),
+        displayName: 'Test User',
+        email: 'test@example.com',
+      })
+      cy.mount(
+        <DACBotComponent
+          dacId={1}
+          mutuallyExclusiveRules={{
+            REQUIRE_SO_DAR_APPROVAL: 'AUTO_OPEN_DAR_FOR_ALL_MEMBERS',
+            AUTO_OPEN_DAR_FOR_ALL_MEMBERS: 'REQUIRE_SO_DAR_APPROVAL',
+          }}
+        />,
+      )
     })
-    cy.stub(DAC, 'fetchDACbotRules').resolves(mockRules)
-    cy.stub(DAC, 'toggleDACbotRule').resolves({
-      ruleId: 1,
-      isRuleEnabled: true,
-      enabledTime: Date.now(),
-      displayName: 'Test User',
-      email: 'test@example.com',
+
+    it('should render component with heading and description', () => {
+      cy.contains('h4', 'Rule Automated Data Access Request (RADAR) Settings').should('be.visible')
+      cy.contains('p', 'Data Access Committees may automate Data Access Requests').should('be.visible')
     })
-    cy.mount(
-      <DACBotComponent
-        dacId={1}
-        mutuallyExclusiveRules={{
-          REQUIRE_SO_DAR_APPROVAL: 'AUTO_OPEN_DAR_FOR_ALL_MEMBERS',
-          AUTO_OPEN_DAR_FOR_ALL_MEMBERS: 'REQUIRE_SO_DAR_APPROVAL',
-        }}
-      />,
-    )
+
+    it('should display all rules from API', () => {
+      cy.get('[id="1_checkbox"]').should('exist')
+      cy.get('[id="2_checkbox"]').should('exist')
+    })
+
+    it('should disable exclusive rule checkbox when other is enabled', () => {
+      cy.get('[id="2_checkbox"]').should('be.disabled')
+    })
+
+    it('should call toggleDACbotRule API when checkbox is clicked', () => {
+      cy.get('[id="1_checkbox"]').click()
+      cy.wrap(DAC.toggleDACbotRule).should('have.been.called')
+    })
+
+    it('should display enabled rule info with user details', () => {
+      cy.contains('Enabled by:').should('be.visible')
+      cy.contains('Test User').should('be.visible')
+    })
   })
 
-  it('should render component with heading and description', () => {
-    cy.contains('h4', 'Rule Automated Data Access Request (RADAR) Settings').should('be.visible')
-    cy.contains('p', 'Data Access Committees may automate Data Access Requests').should('be.visible')
+  describe('rule grouping', () => {
+    const allRules = [
+      { id: 1, ruleType: 'GRU_V1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 2, ruleType: 'HMB_V1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **Health/Medical/Biomedical Use (HMB)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 3, ruleType: 'GRU_DSV1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Disease Specific (DS) with one or more selected diseases** with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 4, ruleType: 'HMB_DSV1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **Health/Medical/Biomedical Use (HMB)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Disease Specific (DS) with one or more selected diseases** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 5, ruleType: 'AUTO_OPEN_DAR_FOR_ALL_MEMBERS', description: 'Automatically open Data Access Requests (DARs) for all DAC members upon submission, **without requiring Chair to open manually**.', ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 6, ruleType: 'REQUIRE_SO_DAR_APPROVAL', description: 'Require approval by the Signing Official identified in the Data Access Request (DAR) prior to DAC Voting.', ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+    ]
+
+    beforeEach(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        roles: [{ dacId: 1, name: 'Chairperson' }],
+      })
+      cy.stub(DAC, 'fetchDACbotRules').resolves(allRules)
+      cy.mount(<DACBotComponent dacId={1} />)
+    })
+
+    it('renders a heading for each group', () => {
+      cy.contains('h6', 'Automatic approval').should('be.visible')
+      cy.contains('h6', 'Automatic open').should('be.visible')
+      cy.contains('h6', 'SO prior approval').should('be.visible')
+    })
+
+    it('places GRU_V1, HMB_V1, GRU_DSV1, HMB_DSV1 under Automatic approval', () => {
+      cy.get('[data-cy="rule-group-automatic-approval"]').within(() => {
+        cy.contains('only General Research Use (GRU)').should('exist')
+        cy.contains('only Health/Medical/Biomedical Use (HMB)').should('exist')
+        cy.contains('Disease Specific (DS) with one or more selected diseases').should('exist')
+      })
+    })
+
+    it('places AUTO_OPEN_DAR_FOR_ALL_MEMBERS under Automatic open', () => {
+      cy.get('[data-cy="rule-group-automatic-open"]').within(() => {
+        cy.contains('without requiring Chair to open manually').should('exist')
+      })
+    })
+
+    it('places REQUIRE_SO_DAR_APPROVAL under SO prior approval', () => {
+      cy.get('[data-cy="rule-group-so-prior-approval"]').within(() => {
+        cy.contains('Require approval by the Signing Official').should('exist')
+      })
+    })
+
+    it('renders groups in order: Automatic approval, Automatic open, SO prior approval', () => {
+      cy.get('h6').then($headings => {
+        const labels = [...$headings].map(el => el.textContent)
+        expect(labels).to.deep.equal(['Automatic approval', 'Automatic open', 'SO prior approval'])
+      })
+    })
   })
 
-  it('should display all rules from API', () => {
-    cy.get('[id="1_checkbox"]').should('exist')
-    cy.get('[id="2_checkbox"]').should('exist')
-  })
+  describe('rule grouping - unknown ruleType', () => {
+    const rulesWithUnknown = [
+      { id: 1, ruleType: 'GRU_V1', description: "Automatically approve Data Access Requests (DARs) when the requested datasets' data use term is only **General Research Use (GRU)** with no modifiers (i.e. IRB, COL, GSO, NPU etc.), and the primary purpose of the DAR's research use statement (RUS) is **Health/Medical/Biomedical Use (HMB)** only with no ethical concerns designated.", ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+      { id: 2, ruleType: 'FUTURE_RULE', description: 'Some future rule', ruleState: 'AVAILABLE', activationDate: 0, enabledByUserId: null, displayName: null, userEmail: null },
+    ]
 
-  it('should disable exclusive rule checkbox when other is enabled', () => {
-    cy.get('[id="2_checkbox"]').should('be.disabled')
-  })
+    beforeEach(() => {
+      cy.stub(Storage, 'getCurrentUser').returns({
+        roles: [{ dacId: 1, name: 'Chairperson' }],
+      })
+      cy.stub(DAC, 'fetchDACbotRules').resolves(rulesWithUnknown)
+      cy.mount(<DACBotComponent dacId={1} />)
+    })
 
-  it('should call toggleDACbotRule API when checkbox is clicked', () => {
-    cy.get('[id="1_checkbox"]').click()
-    cy.wrap(DAC.toggleDACbotRule).should('have.been.called')
-  })
-
-  it('should display enabled rule info with user details', () => {
-    cy.contains('Enabled by:').should('be.visible')
-    cy.contains('Test User').should('be.visible')
+    it('places rules with unknown ruleType in an Other group at the end', () => {
+      cy.get('h6').last().should('have.text', 'Other')
+      cy.get('[data-cy="rule-group-other"]').within(() => {
+        cy.contains('Some future rule').should('exist')
+      })
+    })
   })
 })

--- a/src/components/dac_bot/DACBotComponent.tsx
+++ b/src/components/dac_bot/DACBotComponent.tsx
@@ -44,8 +44,10 @@ export type ParsedDACbotRule = DACbotRule & {
  */
 const DEFAULT_MUTUALLY_EXCLUSIVE_RULES: { [key: string]: string } = {}
 
+type RuleGroupLabel = 'Automatic approval' | 'Automatic open' | 'SO prior approval'
+
 /** Maps each ruleType to a visual group heading */
-const RULE_GROUP_LABELS: { [key: string]: string } = {
+const RULE_GROUP_LABELS: { [key: string]: RuleGroupLabel } = {
   GRU_V1: 'Automatic approval',
   HMB_V1: 'Automatic approval',
   GRU_DSV1: 'Automatic approval',
@@ -55,14 +57,14 @@ const RULE_GROUP_LABELS: { [key: string]: string } = {
 }
 
 /** Order in which groups appear; rules with unknown types go last */
-const GROUP_ORDER = ['Automatic approval', 'Automatic open', 'SO prior approval']
+const GROUP_ORDER: RuleGroupLabel[] = ['Automatic approval', 'Automatic open', 'SO prior approval']
 
 /**
  * Groups parsed rules by their visual group label, preserving order within each group.
  * Rules with unrecognized ruleTypes are placed in an "Other" group at the end.
  */
-const groupRules = (rules: ParsedDACbotRule[]): { label: string, rules: ParsedDACbotRule[] }[] => {
-  const groups = new Map<string, ParsedDACbotRule[]>()
+const groupRules = (rules: ParsedDACbotRule[]): { label: RuleGroupLabel | 'Other', rules: ParsedDACbotRule[] }[] => {
+  const groups = new Map<RuleGroupLabel | 'Other', ParsedDACbotRule[]>()
   for (const rule of rules) {
     const label = RULE_GROUP_LABELS[rule.ruleType] ?? 'Other'
     if (!groups.has(label)) {
@@ -72,7 +74,7 @@ const groupRules = (rules: ParsedDACbotRule[]): { label: string, rules: ParsedDA
   }
   const orderedLabels = [
     ...GROUP_ORDER.filter(l => groups.has(l)),
-    ...Array.from(groups.keys()).filter(l => !GROUP_ORDER.includes(l)),
+    ...Array.from(groups.keys()).filter(l => !GROUP_ORDER.includes(l as RuleGroupLabel)),
   ]
   return orderedLabels.map(label => ({ label, rules: groups.get(label)! }))
 }

--- a/src/components/dac_bot/DACBotComponent.tsx
+++ b/src/components/dac_bot/DACBotComponent.tsx
@@ -44,6 +44,39 @@ export type ParsedDACbotRule = DACbotRule & {
  */
 const DEFAULT_MUTUALLY_EXCLUSIVE_RULES: { [key: string]: string } = {}
 
+/** Maps each ruleType to a visual group heading */
+const RULE_GROUP_LABELS: { [key: string]: string } = {
+  GRU_V1: 'Automatic approval',
+  HMB_V1: 'Automatic approval',
+  GRU_DSV1: 'Automatic approval',
+  HMB_DSV1: 'Automatic approval',
+  AUTO_OPEN_DAR_FOR_ALL_MEMBERS: 'Automatic open',
+  REQUIRE_SO_DAR_APPROVAL: 'SO prior approval',
+}
+
+/** Order in which groups appear; rules with unknown types go last */
+const GROUP_ORDER = ['Automatic approval', 'Automatic open', 'SO prior approval']
+
+/**
+ * Groups parsed rules by their visual group label, preserving order within each group.
+ * Rules with unrecognized ruleTypes are placed in an "Other" group at the end.
+ */
+const groupRules = (rules: ParsedDACbotRule[]): { label: string, rules: ParsedDACbotRule[] }[] => {
+  const groups = new Map<string, ParsedDACbotRule[]>()
+  for (const rule of rules) {
+    const label = RULE_GROUP_LABELS[rule.ruleType] ?? 'Other'
+    if (!groups.has(label)) {
+      groups.set(label, [])
+    }
+    groups.get(label)!.push(rule)
+  }
+  const orderedLabels = [
+    ...GROUP_ORDER.filter(l => groups.has(l)),
+    ...Array.from(groups.keys()).filter(l => !GROUP_ORDER.includes(l)),
+  ]
+  return orderedLabels.map(label => ({ label, rules: groups.get(label)! }))
+}
+
 export const DACBotComponent = (props: DACBotComponentProps) => {
   const { dacId, 'data-cy': dataCy, mutuallyExclusiveRules = DEFAULT_MUTUALLY_EXCLUSIVE_RULES } = props
   const [DACbotRules, setDACbotRules] = useState<Array<DACbotRule>>([])
@@ -143,17 +176,19 @@ export const DACBotComponent = (props: DACBotComponentProps) => {
       <p>
         Check the box below to opt in to this feature, and then select the data use terms for which Data Access Requests you would like automated.
       </p>
-      <h5>Rules</h5>
-      {!isLoading && parsedRules.map((rule) => {
-        return (
-          <DACBotCheckboxComponent
-            rule={rule}
-            key={rule.id}
-            disableEdit={!userIsChair || rule.isDisabled}
-            onRuleChange={handleRuleChange}
-          />
-        )
-      })}
+      {!isLoading && groupRules(parsedRules).map(({ label, rules }) => (
+        <div key={label} data-cy={`rule-group-${label.toLowerCase().replace(/\s+/g, '-')}`} style={{ marginBottom: '1.5rem' }}>
+          <h6 style={{ marginBottom: '0.5rem', color: '#333' }}>{label}</h6>
+          {rules.map(rule => (
+            <DACBotCheckboxComponent
+              rule={rule}
+              key={rule.id}
+              disableEdit={!userIsChair || rule.isDisabled}
+              onRuleChange={handleRuleChange}
+            />
+          ))}
+        </div>
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3000

### Summary
This adds headers to rules in the Manage RADAR page: “Automatic approval” for the first four, “Automatic open” for the fifth, and “SO prior approval” for the last in pages like https://duos-k8s.dsde-dev.broadinstitute.org/manage_radar/8.  This improves visual segmentation and helps orient the reader.

#### Old
<img width="1512" height="770" src="https://github.com/user-attachments/assets/b31017d9-116c-4cac-a665-24f761dfc1d2" />

#### New
<img width="1512" height="770" src="https://github.com/user-attachments/assets/d74a94d9-af70-469c-93ed-bf4a3c752bd7" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
