### PR TITLE
[DT-3012] Data models tab

### DIFF
--- a/cypress/component/Hooks/useLibraryData.spec.tsx
+++ b/cypress/component/Hooks/useLibraryData.spec.tsx
@@ -194,4 +194,26 @@ describe('buildElasticsearchQuery', () => {
     const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, '', pagination, undefined)
     expect(query.sort).to.equal(undefined)
   })
+
+  it('builds an aggregation query for models (size: 0, studies terms agg)', () => {
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.MODELS, filters, '', pagination)
+    // Models use an aggregation-only query
+    expect(query.size).to.equal(0)
+    expect(query.from).to.equal(undefined)
+    expect(query.aggs).to.have.property('studies')
+    const studiesAgg = query.aggs!.studies as { terms: { field: string, size: number } }
+    expect(studiesAgg.terms.field).to.equal('study.studyId')
+    expect(studiesAgg.terms.size).to.equal(10000)
+  })
+
+  it('adds model-specific search fields for the models asset type', () => {
+    const query = buildElasticsearchQuery(libraryConfig, AssetType.MODELS, filters, 'pytorch', pagination)
+    expect(query.query?.bool.must).to.have.length(2)
+    const searchClause = query.query?.bool.must?.[1] as {
+      multi_match: { fields: string[], query: string }
+    }
+    expect(searchClause.multi_match.fields).to.include('study.assets.models.name')
+    expect(searchClause.multi_match.fields).to.include('study.assets.models.format')
+    expect(searchClause.multi_match.query).to.equal('pytorch')
+  })
 })

--- a/cypress/component/data_library/modelAsset.spec.ts
+++ b/cypress/component/data_library/modelAsset.spec.ts
@@ -1,0 +1,398 @@
+/**
+ * Unit tests for modelAsset — the AI Models AssetDefinition.
+ *
+ * These tests are purely logic-level (no DOM mounting) so they run quickly
+ * in the Cypress component runner via plain `describe` / `it` blocks.
+ */
+import { modelAsset } from 'src/components/data_library/assets/modelAsset'
+import { ModelRow, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  ModelStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+/** Build a minimal ModelStudyAggregationBucket */
+const makeBucket = (
+  studyId: number,
+  models: Array<{
+    modelId?: string
+    name?: string
+    format?: string
+    license?: string
+    tags?: string[]
+    url?: string
+    maintainer?: { name: string, email: string }
+  }> = [],
+  studyName = 'Test Study',
+): ModelStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: models.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                models: models.map(m => ({
+                  modelId: m.modelId,
+                  name: m.name,
+                  format: m.format,
+                  license: m.license,
+                  tags: m.tags,
+                  url: m.url,
+                  maintainer: m.maintainer,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+/** Wrap buckets in a full ElasticsearchResponse */
+const makeResponse = (
+  buckets: ModelStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+// ---------------------------------------------------------------------------
+// label
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — label', () => {
+  it('has singular "AI Model" and plural "AI Models"', () => {
+    expect(modelAsset.label.singular).to.equal('AI Model')
+    expect(modelAsset.label.plural).to.equal('AI Models')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortingMode
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(modelAsset.sortingMode).to.equal('client')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// searchFields
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — searchFields', () => {
+  it('includes model-specific fields', () => {
+    expect(modelAsset.searchFields).to.include('study.assets.models.name')
+    expect(modelAsset.searchFields).to.include('study.assets.models.format')
+    expect(modelAsset.searchFields).to.include('study.assets.models.license')
+    expect(modelAsset.searchFields).to.include('study.assets.models.tags')
+  })
+
+  it('includes study-level fields', () => {
+    expect(modelAsset.searchFields).to.include('study.studyName')
+    expect(modelAsset.searchFields).to.include('study.piName')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildQuery
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).to.equal(0)
+    expect(q.from).to.equal(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).to.have.property('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).to.equal('study.studyId')
+    expect(studiesAgg.terms.size).to.equal(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).to.have.length(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).to.equal('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).to.equal(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'controlled' },
+    }
+    const q = modelAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).to.have.length(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'name', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = modelAsset.buildQuery([existsClause], [], largePagination, sort)
+    // size should still be 0 — pagination is applied client-side in transformResponse
+    expect(q.size).to.equal(0)
+    expect(q.sort).to.equal(undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// transformResponse
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = modelAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+
+  it('flattens models from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ modelId: 'm1', name: 'Alpha' }, { modelId: 'm2', name: 'Beta' }]),
+      makeBucket(2, [{ modelId: 'm3', name: 'Gamma' }]),
+    ])
+    const result = modelAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(3)
+    expect(result.total).to.equal(3)
+  })
+
+  it('maps fields correctly from bucket to ModelRow', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        modelId: 'model-xyz',
+        name: 'ResNet',
+        format: 'ONNX',
+        license: 'Apache-2.0',
+        tags: ['vision', 'classification'],
+        url: 'https://example.com',
+        maintainer: { name: 'Alice', email: 'alice@example.com' },
+      }], 'NHGRI Study'),
+    ])
+    const result = modelAsset.transformResponse(response, pagination)
+    const row = result.items[0] as ModelRow
+    expect(row.modelId).to.equal('model-xyz')
+    expect(row.studyId).to.equal(42)
+    expect(row.studyName).to.equal('NHGRI Study')
+    expect(row.name).to.equal('ResNet')
+    expect(row.format).to.equal('ONNX')
+    expect(row.license).to.equal('Apache-2.0')
+    expect(row.url).to.equal('https://example.com')
+    expect(row.tags).to.deep.equal(['vision', 'classification'])
+    expect(row.maintainer.name).to.equal('Alice')
+    expect(row.maintainer.email).to.equal('alice@example.com')
+  })
+
+  it('falls back to composite key when modelId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ name: 'NoId Model' }]),
+    ])
+    const result = modelAsset.transformResponse(response, pagination)
+    const row = result.items[0] as ModelRow
+    // composite fallback: `${bucket.key}-${index}`
+    expect(row.modelId).to.equal('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const models = Array.from({ length: 30 }, (_, i) => ({
+      modelId: `m${i}`,
+      name: `Model ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, models)])
+
+    const page0 = modelAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).to.have.length(10)
+    expect((page0.items[0] as ModelRow).name).to.equal('Model 0')
+
+    const page1 = modelAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).to.have.length(10)
+    expect((page1.items[0] as ModelRow).name).to.equal('Model 10')
+
+    const page2 = modelAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).to.have.length(10)
+    expect((page2.items[0] as ModelRow).name).to.equal('Model 20')
+  })
+
+  it('reports total as the number of all models across all studies (not just page)', () => {
+    const models = Array.from({ length: 30 }, (_, i) => ({ modelId: `m${i}` }))
+    const response = makeResponse([makeBucket(1, models)])
+    const result = modelAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).to.equal(30)
+  })
+
+  it('returns empty tags / maintainer defaults for missing fields', () => {
+    const response = makeResponse([
+      makeBucket(1, [{}]),
+    ])
+    const row = modelAsset.transformResponse(response, pagination).items[0] as ModelRow
+    expect(row.tags).to.deep.equal([])
+    expect(row.maintainer.name).to.equal('')
+    expect(row.maintainer.email).to.equal('')
+    expect(row.name).to.equal('')
+    expect(row.format).to.equal('')
+  })
+
+  it('handles a study bucket with no models gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = modelAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRowId
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — getRowId', () => {
+  it('returns the modelId of the row', () => {
+    const row: ModelRow = {
+      modelId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    expect(modelAsset.getRowId(row)).to.equal('abc-123')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRowSelectable
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — isRowSelectable', () => {
+  it('always returns false — models do not participate in access requests', () => {
+    const row: ModelRow = {
+      modelId: 'm1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    expect(modelAsset.isRowSelectable(row)).to.equal(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeRowSelection
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: ModelRow = {
+      modelId: 'm1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    const result = modelAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectionToDatasetIds
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = modelAsset.selectionToDatasetIds([], ['m1', 'm2'])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStudyIdsForSelection
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: ModelRow = {
+      modelId: 'm1',
+      studyId: 42,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    const result = modelAsset.getStudyIdsForSelection([row], [1])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// makeColumns
+// ---------------------------------------------------------------------------
+
+describe('modelAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = modelAsset.makeColumns()
+    expect(cols).to.be.an('array')
+    expect(cols.length).to.be.greaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = modelAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).to.include('name')
+    expect(fields).to.include('studyName')
+    expect(fields).to.include('format')
+    expect(fields).to.include('license')
+    expect(fields).to.include('maintainer')
+    expect(fields).to.include('url')
+    expect(fields).to.include('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = modelAsset.makeColumns()
+    const b = modelAsset.makeColumns({})
+    expect(a.map(c => c.field)).to.deep.equal(b.map(c => c.field))
+  })
+})

--- a/cypress/component/data_library/modelAsset.spec.ts
+++ b/cypress/component/data_library/modelAsset.spec.ts
@@ -5,7 +5,7 @@
  * in the Cypress component runner via plain `describe` / `it` blocks.
  */
 import { modelAsset } from 'src/components/data_library/assets/modelAsset'
-import { ModelRow, PaginationState, SortState } from 'src/types/library'
+import { ModelAsset, PaginationState, SortState } from 'src/types/library'
 import {
   ElasticsearchResponse,
   ModelStudyAggregationBucket,
@@ -183,7 +183,7 @@ describe('modelAsset — transformResponse', () => {
     expect(result.total).to.equal(3)
   })
 
-  it('maps fields correctly from bucket to ModelRow', () => {
+  it('maps fields correctly from bucket to ModelAsset', () => {
     const response = makeResponse([
       makeBucket(42, [{
         modelId: 'model-xyz',
@@ -196,7 +196,7 @@ describe('modelAsset — transformResponse', () => {
       }], 'NHGRI Study'),
     ])
     const result = modelAsset.transformResponse(response, pagination)
-    const row = result.items[0] as ModelRow
+    const row = result.items[0] as ModelAsset
     expect(row.modelId).to.equal('model-xyz')
     expect(row.studyId).to.equal(42)
     expect(row.studyName).to.equal('NHGRI Study')
@@ -214,7 +214,7 @@ describe('modelAsset — transformResponse', () => {
       makeBucket(99, [{ name: 'NoId Model' }]),
     ])
     const result = modelAsset.transformResponse(response, pagination)
-    const row = result.items[0] as ModelRow
+    const row = result.items[0] as ModelAsset
     // composite fallback: `${bucket.key}-${index}`
     expect(row.modelId).to.equal('99-0')
   })
@@ -228,15 +228,15 @@ describe('modelAsset — transformResponse', () => {
 
     const page0 = modelAsset.transformResponse(response, { page: 0, pageSize: 10 })
     expect(page0.items).to.have.length(10)
-    expect((page0.items[0] as ModelRow).name).to.equal('Model 0')
+    expect((page0.items[0] as ModelAsset).name).to.equal('Model 0')
 
     const page1 = modelAsset.transformResponse(response, { page: 1, pageSize: 10 })
     expect(page1.items).to.have.length(10)
-    expect((page1.items[0] as ModelRow).name).to.equal('Model 10')
+    expect((page1.items[0] as ModelAsset).name).to.equal('Model 10')
 
     const page2 = modelAsset.transformResponse(response, { page: 2, pageSize: 10 })
     expect(page2.items).to.have.length(10)
-    expect((page2.items[0] as ModelRow).name).to.equal('Model 20')
+    expect((page2.items[0] as ModelAsset).name).to.equal('Model 20')
   })
 
   it('reports total as the number of all models across all studies (not just page)', () => {
@@ -250,7 +250,7 @@ describe('modelAsset — transformResponse', () => {
     const response = makeResponse([
       makeBucket(1, [{}]),
     ])
-    const row = modelAsset.transformResponse(response, pagination).items[0] as ModelRow
+    const row = modelAsset.transformResponse(response, pagination).items[0] as ModelAsset
     expect(row.tags).to.deep.equal([])
     expect(row.maintainer.name).to.equal('')
     expect(row.maintainer.email).to.equal('')
@@ -272,7 +272,7 @@ describe('modelAsset — transformResponse', () => {
 
 describe('modelAsset — getRowId', () => {
   it('returns the modelId of the row', () => {
-    const row: ModelRow = {
+    const row: ModelAsset = {
       modelId: 'abc-123',
       studyId: 1,
       studyName: '',
@@ -294,7 +294,7 @@ describe('modelAsset — getRowId', () => {
 
 describe('modelAsset — isRowSelectable', () => {
   it('always returns false — models do not participate in access requests', () => {
-    const row: ModelRow = {
+    const row: ModelAsset = {
       modelId: 'm1',
       studyId: 1,
       studyName: '',
@@ -316,7 +316,7 @@ describe('modelAsset — isRowSelectable', () => {
 
 describe('modelAsset — computeRowSelection', () => {
   it('always returns an empty Set regardless of inputs', () => {
-    const row: ModelRow = {
+    const row: ModelAsset = {
       modelId: 'm1',
       studyId: 1,
       studyName: '',
@@ -350,7 +350,7 @@ describe('modelAsset — selectionToDatasetIds', () => {
 
 describe('modelAsset — getStudyIdsForSelection', () => {
   it('always returns an empty array', () => {
-    const row: ModelRow = {
+    const row: ModelAsset = {
       modelId: 'm1',
       studyId: 42,
       studyName: '',

--- a/cypress/component/data_library/modelColumns.spec.tsx
+++ b/cypress/component/data_library/modelColumns.spec.tsx
@@ -1,0 +1,178 @@
+/**
+ * Component tests for makeModelColumns — the column definitions used in the
+ * AI Models tab of the Data Library.
+ *
+ * Each test mounts a minimal DataGrid with a single (or small set of) rows and
+ * inspects the rendered HTML to verify the column behaviour.
+ */
+import React from 'react'
+import { DataGrid } from '@mui/x-data-grid'
+import { makeModelColumns } from 'src/components/data_library/columns/modelColumns'
+import { makeModelRow } from '../test-utils'
+
+const renderGrid = (overrides = {}) => {
+  const row = makeModelRow(overrides)
+  cy.mount(
+    <DataGrid
+      rows={[row]}
+      columns={makeModelColumns()}
+      getRowId={r => r.modelId}
+      autoHeight
+    />,
+  )
+}
+
+describe('makeModelColumns — Model Name column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the model name text', () => {
+    renderGrid({ name: 'ResNet-50' })
+    cy.contains('ResNet-50').should('exist')
+  })
+
+  it('renders an empty cell gracefully when name is absent', () => {
+    renderGrid({ name: '' })
+    // No error thrown, grid should still render
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeModelColumns — Study column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders a link with the study name', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.contains('Genome Atlas').should('exist')
+  })
+
+  it('links to /studies/:studyId', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.get('a[href="/studies/7"]').should('exist')
+  })
+})
+
+describe('makeModelColumns — Format column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the format text', () => {
+    renderGrid({ format: 'ONNX' })
+    cy.contains('ONNX').should('exist')
+  })
+
+  it('renders an empty cell when format is absent', () => {
+    renderGrid({ format: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeModelColumns — License column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the license text', () => {
+    renderGrid({ license: 'Apache-2.0' })
+    cy.contains('Apache-2.0').should('exist')
+  })
+
+  it('renders an empty cell when license is absent', () => {
+    renderGrid({ license: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeModelColumns — Maintainer column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the maintainer name', () => {
+    renderGrid({ maintainer: { name: 'Alice Smith', email: 'alice@example.com' } })
+    cy.contains('Alice Smith').should('exist')
+  })
+
+  it('renders an empty cell when maintainer name is absent', () => {
+    renderGrid({ maintainer: { name: '', email: '' } })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeModelColumns — URL column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders "Link" as a clickable anchor when url is present', () => {
+    renderGrid({ url: 'https://huggingface.co/my-model' })
+    cy.get('a[href="https://huggingface.co/my-model"]')
+      .contains('Link')
+      .should('exist')
+  })
+
+  it('renders nothing when url is absent', () => {
+    renderGrid({ url: '' })
+    // No "Link" anchor should exist
+    cy.get('a').filter(':contains("Link")').should('not.exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer" for external links', () => {
+    renderGrid({ url: 'https://example.com' })
+    cy.get('a[href="https://example.com"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+})
+
+describe('makeModelColumns — Tags column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders nothing when tags array is empty', () => {
+    renderGrid({ tags: [] })
+    cy.get('.MuiChip-root').should('not.exist')
+  })
+
+  it('renders up to 3 chips for 3 tags', () => {
+    renderGrid({ tags: ['genomics', 'classification', 'vision'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.contains('genomics').should('exist')
+    cy.contains('classification').should('exist')
+    cy.contains('vision').should('exist')
+  })
+
+  it('shows "+N" overflow chip when there are more than 3 tags', () => {
+    renderGrid({ tags: ['t1', 't2', 't3', 't4', 't5'] })
+    // 3 visible tags + 1 overflow chip = 4 chips total
+    cy.get('.MuiChip-root').should('have.length', 4)
+    cy.contains('+2').should('exist')
+  })
+
+  it('does not show an overflow chip for exactly 3 tags', () => {
+    renderGrid({ tags: ['a', 'b', 'c'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.get('.MuiChip-root').each(($chip) => {
+      expect($chip.text()).to.not.match(/^\+\d+$/)
+    })
+  })
+})
+
+describe('makeModelColumns — column structure', () => {
+  it('returns 7 column definitions', () => {
+    const cols = makeModelColumns()
+    expect(cols).to.have.length(7)
+  })
+
+  it('defines expected fields', () => {
+    const fields = makeModelColumns().map(c => c.field)
+    expect(fields).to.deep.equal([
+      'name',
+      'studyName',
+      'format',
+      'license',
+      'maintainer',
+      'url',
+      'tags',
+    ])
+  })
+
+  it('marks url and tags as non-sortable', () => {
+    const cols = makeModelColumns()
+    const urlCol = cols.find(c => c.field === 'url')!
+    const tagsCol = cols.find(c => c.field === 'tags')!
+    expect(urlCol.sortable).to.equal(false)
+    expect(tagsCol.sortable).to.equal(false)
+  })
+})

--- a/cypress/component/test-utils.ts
+++ b/cypress/component/test-utils.ts
@@ -1,5 +1,5 @@
 import { DatasetTerm, StudyTerm, UserTerm } from 'src/types/model'
-import { ModelRow } from 'src/types/library'
+import { ModelAsset } from 'src/types/library'
 
 export const makeUserTerm = (overrides: Partial<UserTerm> = {}): UserTerm => ({
   userId: 0,
@@ -57,7 +57,7 @@ export const makeDatasetTerm = (overrides: Partial<DatasetTerm> = {}): DatasetTe
   ...overrides,
 })
 
-export const makeModelRow = (overrides: Partial<ModelRow> = {}): ModelRow => ({
+export const makeModelRow = (overrides: Partial<ModelAsset> = {}): ModelAsset => ({
   modelId: 'model-1',
   studyId: 42,
   studyName: 'Test Study',

--- a/cypress/component/test-utils.ts
+++ b/cypress/component/test-utils.ts
@@ -1,4 +1,5 @@
 import { DatasetTerm, StudyTerm, UserTerm } from 'src/types/model'
+import { ModelRow } from 'src/types/library'
 
 export const makeUserTerm = (overrides: Partial<UserTerm> = {}): UserTerm => ({
   userId: 0,
@@ -53,5 +54,20 @@ export const makeDatasetTerm = (overrides: Partial<DatasetTerm> = {}): DatasetTe
     dacEmail: 'some email',
   },
   piName: 'pi name',
+  ...overrides,
+})
+
+export const makeModelRow = (overrides: Partial<ModelRow> = {}): ModelRow => ({
+  modelId: 'model-1',
+  studyId: 42,
+  studyName: 'Test Study',
+  name: 'My Model',
+  description: 'A test model',
+  url: 'https://example.com/model',
+  format: 'ONNX',
+  license: 'MIT',
+  trainedOnDatasets: [],
+  maintainer: { name: 'Jane Doe', email: 'jane@example.com' },
+  tags: ['genomics', 'classification'],
   ...overrides,
 })

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -2,14 +2,11 @@ import React, { useMemo } from 'react'
 import {
   DataGrid,
   GridRowSelectionModel,
-  GridColDef,
 } from '@mui/x-data-grid'
 import { Box, Typography, CircularProgress } from '@mui/material'
 import { isEmpty } from 'lodash'
-import { LibraryDataGridProps, AssetType, StudyAggregation } from 'src/types/library'
-import { DatasetTerm } from 'src/types/model'
-import { makeDatasetColumns } from 'src/components/data_library/columns/datasetColumns'
-import { makeStudyColumns } from 'src/components/data_library/columns/studyColumns'
+import { LibraryDataGridProps } from 'src/types/library'
+import { assetRegistry, LibraryRow } from 'src/components/data_library/assets'
 
 const LoadingOverlay = () => (
   <Box
@@ -38,83 +35,35 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   exportableDatasets = {},
   radarEnabledDatasetIds = new Set(),
 }) => {
-  const columns = useMemo(() => {
-    if (assetType === AssetType.STUDIES) {
-      return makeStudyColumns() as GridColDef<DatasetTerm | StudyAggregation>[]
-    }
-    return makeDatasetColumns(exportableDatasets, radarEnabledDatasetIds) as GridColDef<DatasetTerm | StudyAggregation>[]
-  }, [assetType, exportableDatasets, radarEnabledDatasetIds])
+  const asset = assetRegistry[assetType]
 
-  const getRowId = (row: DatasetTerm | StudyAggregation) => {
-    if (assetType === AssetType.STUDIES) {
-      return (row as StudyAggregation).studyId
-    }
-    return (row as DatasetTerm).datasetId
-  }
+  const columns = useMemo(
+    () => asset.makeColumns({ exportableDatasets, radarEnabledDatasetIds }),
+    [asset, exportableDatasets, radarEnabledDatasetIds],
+  )
 
-  // For studies, we need to map study selection to dataset IDs
-  const rowSelectionModel: GridRowSelectionModel = useMemo(() => {
-    if (!Array.isArray(data)) {
-      return {
-        type: 'include',
-        ids: new Set([]),
-      }
-    }
-    if (assetType === AssetType.STUDIES) {
-      const selectedStudyIds = data
-        .filter((study) => {
-          const studyDatasetIds = (study as StudyAggregation).datasetIds || []
-          return studyDatasetIds.some(id => selectedDatasetIds.includes(id))
-        })
-        .map(study => (study as StudyAggregation).studyId)
-      return {
-        type: 'include',
-        ids: new Set(selectedStudyIds),
-      }
-    }
-    return {
-      type: 'include',
-      ids: new Set(selectedDatasetIds),
-    }
-  }, [assetType, data, selectedDatasetIds])
+  const getRowId = (row: LibraryRow) => asset.getRowId(row)
+
+  // Derive which DataGrid rows should appear checked from the set of selected dataset IDs
+  const rowSelectionModel: GridRowSelectionModel = useMemo(() => ({
+    type: 'include',
+    ids: asset.computeRowSelection(
+      Array.isArray(data) ? data as LibraryRow[] : [],
+      selectedDatasetIds,
+    ),
+  }), [asset, data, selectedDatasetIds])
 
   const handleSelectionChange = (newSelection: GridRowSelectionModel) => {
-    const selectedIds = Array.from(newSelection.ids) as number[]
-
-    if (assetType === AssetType.STUDIES) {
-      // Convert study selection to dataset IDs
-      const newDatasetIds: number[] = []
-
-      if (Array.isArray(data)) {
-        data.forEach((study) => {
-          if (selectedIds.includes((study as StudyAggregation).studyId)) {
-            newDatasetIds.push(...((study as StudyAggregation).datasetIds || []))
-          }
-        })
-      }
-
-      onSelectionChange(newDatasetIds)
-    }
-    else {
-      onSelectionChange(selectedIds)
-    }
+    onSelectionChange(
+      asset.selectionToDatasetIds(
+        Array.isArray(data) ? data as LibraryRow[] : [],
+        Array.from(newSelection.ids) as (string | number)[],
+      ),
+    )
   }
 
-  const isRowSelectable = (params: { row: DatasetTerm | StudyAggregation }) => {
-    if (!params.row) {
-      return false
-    }
-
-    if (assetType === AssetType.DATASETS) {
-      const dataset = params.row as DatasetTerm
-      return (
-        dataset.accessManagement !== 'open'
-        && dataset.accessManagement !== 'external'
-      )
-    }
-    // For studies, check if any dataset in the study is selectable
-    return true
-  }
+  const isRowSelectable = (params: { row: LibraryRow }) =>
+    params.row ? asset.isRowSelectable(params.row) : false
 
   if (isEmpty(data)) {
     // Show loading state when data is empty and loading
@@ -145,7 +94,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
           }}
         >
           <Typography variant="h6" color="text.secondary">
-            No {assetType} found matching your criteria
+            No {asset.label.plural.toLowerCase()} found matching your criteria
           </Typography>
         </Box>
       )
@@ -155,7 +104,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
   return (
     <Box sx={{ width: '100%', height: '100%' }}>
       <DataGrid
-        rows={data as (StudyAggregation | DatasetTerm)[]}
+        rows={data as LibraryRow[]}
         columns={columns}
         rowCount={total}
         loading={loading}
@@ -163,8 +112,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
         paginationModel={paginationModel}
         paginationMode="server"
         onPaginationModelChange={onPaginationChange}
-        // studies are sorted client-side, other assets are sorted server-side
-        sortingMode={assetType === AssetType.STUDIES ? 'client' : 'server'}
+        sortingMode={asset.sortingMode}
         sortModel={sortModel}
         onSortModelChange={(model) => {
           onSortChange(model.map(item => ({

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -57,7 +57,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridProps> = ({
     onSelectionChange(
       asset.selectionToDatasetIds(
         Array.isArray(data) ? data as LibraryRow[] : [],
-        Array.from(newSelection.ids) as (string | number)[],
+        Array.from(newSelection.ids),
       ),
     )
   }

--- a/src/components/data_library/assets/datasetAsset.ts
+++ b/src/components/data_library/assets/datasetAsset.ts
@@ -1,0 +1,112 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, QueryClause } from 'src/types/elastic'
+import { PaginationState, SortState } from 'src/types/library'
+import { DatasetTerm } from 'src/types/model'
+import { makeDatasetColumns } from 'src/components/data_library/columns/datasetColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+// Text fields cannot be sorted directly and must use their .keyword sub-field.
+const SORT_FIELD_MAP: Record<string, string> = {
+  datasetName: 'datasetName.keyword',
+  studyName: 'study.studyName.keyword',
+  accessManagement: 'accessManagement.keyword',
+  dac: 'dac.dacName.keyword',
+  datasetIdentifier: 'datasetIdentifier.keyword',
+}
+
+const FILTER_AGGS = {
+  access_management: { terms: { field: 'accessManagement.keyword' } },
+  data_use: { terms: { field: 'dataUse.primary.code.keyword' } },
+  data_type: { terms: { field: 'study.dataTypes.keyword' } },
+  dac: { terms: { field: 'dac.dacName.keyword' } },
+}
+
+export const datasetAsset: AssetDefinition = {
+  label: { singular: 'Dataset', plural: 'Datasets' },
+  sortingMode: 'server',
+  searchFields: [
+    'datasetName',
+    'dataLocation',
+    'study.description',
+    'study.studyName',
+    'study.species',
+    'study.piName',
+    'study.dataCustodianEmail',
+    'study.dataTypes',
+    'dataUse.primary.code',
+    'dataUse.secondary.code',
+    'dac.dacName',
+    'datasetIdentifier',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    pagination: PaginationState,
+    sort?: SortState,
+  ): ElasticsearchQuery {
+    const esSortField = sort ? (SORT_FIELD_MAP[sort.field] ?? sort.field) : undefined
+    return {
+      from: pagination.page * pagination.pageSize,
+      size: pagination.pageSize,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      ...(sort && {
+        sort: [
+          {
+            [esSortField!]: { order: sort.order },
+          },
+        ],
+      }),
+      aggs: FILTER_AGGS,
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, _pagination: PaginationState): LibraryPage {
+    // The API may return an array directly, a DUOS-shaped object, or a raw
+    // Elasticsearch response with a `hits` wrapper.
+    const raw = response as unknown as Record<string, unknown>
+    const items = Array.isArray(raw)
+      ? (raw as DatasetTerm[])
+      : ((raw.hits as { hits?: Array<{ _source?: DatasetTerm }> })?.hits?.map(h => h._source as DatasetTerm) || [])
+    return {
+      items,
+      total: Array.isArray(raw)
+        ? (raw as DatasetTerm[]).length
+        : ((raw.hits as { total?: { value?: number } })?.total?.value || 0),
+      aggregations: (raw.aggregations as Record<string, unknown>) || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as DatasetTerm).datasetId
+  },
+
+  isRowSelectable(row: LibraryRow): boolean {
+    const dataset = row as DatasetTerm
+    return dataset.accessManagement !== 'open' && dataset.accessManagement !== 'external'
+  },
+
+  computeRowSelection(_data: LibraryRow[], selectedDatasetIds: number[]): Set<string | number> {
+    return new Set(selectedDatasetIds)
+  },
+
+  selectionToDatasetIds(_data: LibraryRow[], selectedRowIds: (string | number)[]): number[] {
+    return selectedRowIds as number[]
+  },
+
+  getStudyIdsForSelection(data: LibraryRow[], selectedDatasetIds: number[]): number[] {
+    return data
+      .filter(d => selectedDatasetIds.includes((d as DatasetTerm).datasetId))
+      .map(d => (d as DatasetTerm).study?.studyId)
+      .filter((id): id is number => id !== undefined)
+  },
+
+  makeColumns(props?: ColumnsProps): GridColDef[] {
+    return makeDatasetColumns(props?.exportableDatasets, props?.radarEnabledDatasetIds) as GridColDef[]
+  },
+}

--- a/src/components/data_library/assets/definition.ts
+++ b/src/components/data_library/assets/definition.ts
@@ -1,0 +1,86 @@
+/**
+ * Asset definition interface for the Data Library.
+ *
+ * Each data asset type (Studies, Datasets, AI Models, …) that can appear as a
+ * tab in the Data Library implements this interface.  Adding a new asset type
+ * is therefore a matter of creating one new file in this folder and registering
+ * it in `index.ts` — no changes are needed in the generic Data Library
+ * components or hook.
+ */
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, QueryClause } from 'src/types/elastic'
+import { ExportableDatasets, ModelRow, PaginationState, SortState, StudyAggregation } from 'src/types/library'
+import { DatasetTerm } from 'src/types/model'
+
+/** Union of every row type that can appear in the DataGrid */
+export type LibraryRow = DatasetTerm | StudyAggregation | ModelRow
+
+/** Normalized result returned by every asset's `transformResponse` */
+export interface LibraryPage {
+  items: LibraryRow[]
+  total: number
+  aggregations: Record<string, unknown>
+}
+
+/** Props forwarded to `makeColumns` that only certain assets use */
+export interface ColumnsProps {
+  exportableDatasets?: ExportableDatasets
+  radarEnabledDatasetIds?: Set<number>
+}
+
+export interface AssetDefinition {
+  /** Singular / plural display names used for count labels and empty states */
+  readonly label: { readonly singular: string, readonly plural: string }
+
+  /** Whether the DataGrid sorts rows client-side (`'client'`) or relies on the
+   *  server to return pre-sorted results (`'server'`). */
+  readonly sortingMode: 'client' | 'server'
+
+  /** Elasticsearch fields to search when a free-text query term is present */
+  readonly searchFields: string[]
+
+  /**
+   * Build the full Elasticsearch query body.
+   *
+   * The common code in `buildElasticsearchQuery` assembles the shared
+   * `queryChunks` (library filter + search term) and `filterQuery` (filter
+   * panel selections) and then delegates the overall query shape—aggregations,
+   * pagination, sort—to the asset.
+   */
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    pagination: PaginationState,
+    sort?: SortState,
+  ): ElasticsearchQuery
+
+  /** Turn a raw Elasticsearch response into a typed, paginated page */
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage
+
+  /** Unique DataGrid row identifier */
+  getRowId(row: LibraryRow): string | number
+
+  /** Whether a row can be selected for an access request */
+  isRowSelectable(row: LibraryRow): boolean
+
+  /**
+   * Given the current page of data and the global set of selected dataset IDs,
+   * compute which DataGrid row IDs should appear checked.
+   */
+  computeRowSelection(data: LibraryRow[], selectedDatasetIds: number[]): Set<string | number>
+
+  /**
+   * Given a new DataGrid row selection, convert it back to the dataset IDs
+   * that drive the Apply for Access flow.
+   */
+  selectionToDatasetIds(data: LibraryRow[], selectedRowIds: (string | number)[]): number[]
+
+  /**
+   * Given the current page of data and the global set of selected dataset IDs,
+   * return the study IDs that contain those selections.  Used by LibraryFooter.
+   */
+  getStudyIdsForSelection(data: LibraryRow[], selectedDatasetIds: number[]): number[]
+
+  /** Column definitions for the DataGrid */
+  makeColumns(props?: ColumnsProps): GridColDef[]
+}

--- a/src/components/data_library/assets/definition.ts
+++ b/src/components/data_library/assets/definition.ts
@@ -9,11 +9,11 @@
  */
 import { GridColDef } from '@mui/x-data-grid'
 import { ElasticsearchQuery, ElasticsearchResponse, QueryClause } from 'src/types/elastic'
-import { ExportableDatasets, ModelRow, PaginationState, SortState, StudyAggregation } from 'src/types/library'
+import { ExportableDatasets, ModelAsset, PaginationState, SortState, StudyAggregation } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 /** Union of every row type that can appear in the DataGrid */
-export type LibraryRow = DatasetTerm | StudyAggregation | ModelRow
+export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset
 
 /** Normalized result returned by every asset's `transformResponse` */
 export interface LibraryPage {

--- a/src/components/data_library/assets/index.ts
+++ b/src/components/data_library/assets/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Asset registry for the Data Library.
+ *
+ * To add a new asset type:
+ *   1. Add its value to the `AssetType` enum in `src/types/library.ts`
+ *   2. Create `<newAsset>Asset.ts` in this folder implementing `AssetDefinition`
+ *   3. Import it below and add it to `assetRegistry`
+ *
+ * No changes are needed in `useLibraryData`, `LibraryDataGrid`, or
+ * `DataLibrary` — they all delegate to the registry.
+ */
+import { AssetType } from 'src/types/library'
+import { AssetDefinition } from 'src/components/data_library/assets/definition'
+import { studyAsset } from 'src/components/data_library/assets/studyAsset'
+import { datasetAsset } from 'src/components/data_library/assets/datasetAsset'
+import { modelAsset } from 'src/components/data_library/assets/modelAsset'
+
+export type {
+  AssetDefinition,
+  LibraryRow,
+  LibraryPage,
+  ColumnsProps,
+} from 'src/components/data_library/assets/definition'
+
+export const assetRegistry: Record<AssetType, AssetDefinition> = {
+  [AssetType.STUDIES]: studyAsset,
+  [AssetType.DATASETS]: datasetAsset,
+  [AssetType.MODELS]: modelAsset,
+}

--- a/src/components/data_library/assets/modelAsset.ts
+++ b/src/components/data_library/assets/modelAsset.ts
@@ -1,0 +1,118 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, ModelStudyAggregationResponse, QueryClause } from 'src/types/elastic'
+import { ModelRow, PaginationState, SortState } from 'src/types/library'
+import { makeModelColumns } from 'src/components/data_library/columns/modelColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+export const modelAsset: AssetDefinition = {
+  label: { singular: 'AI Model', plural: 'AI Models' },
+  sortingMode: 'client',
+  searchFields: [
+    'study.studyName',
+    'study.description',
+    'study.piName',
+    'study.assets.models.name',
+    'study.assets.models.format',
+    'study.assets.models.license',
+    'study.assets.models.tags',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    _pagination: PaginationState,
+    _sort?: SortState,
+  ): ElasticsearchQuery {
+    // Aggregate by study to extract nested model assets stored under
+    // study.assets.models; client-side pagination is applied in transformResponse.
+    return {
+      size: 0,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        studies: {
+          terms: {
+            field: 'study.studyId',
+            size: 10000,
+          },
+          aggs: {
+            study_details: {
+              top_hits: {
+                size: 1,
+                _source: ['study.*'],
+              },
+            },
+          },
+        },
+      },
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
+    const studiesAgg = response.aggregations?.studies as ModelStudyAggregationResponse | undefined
+    const buckets = studiesAgg?.buckets || []
+    const models: ModelRow[] = []
+
+    for (const bucket of buckets) {
+      const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+      const studyModels = studyData.assets?.models || []
+      for (const [modelIndex, model] of studyModels.entries()) {
+        // modelId may be absent from the indexed document; fall back to a
+        // composite key so every row in the DataGrid has a unique id.
+        models.push({
+          modelId: model.modelId || `${bucket.key}-${modelIndex}`,
+          studyId: bucket.key,
+          studyName: studyData.studyName || '',
+          name: model.name || '',
+          description: model.description || '',
+          url: model.url || '',
+          format: model.format || '',
+          license: model.license || '',
+          trainedOnDatasets: model.trainedOnDatasets || [],
+          maintainer: {
+            name: model.maintainer?.name || '',
+            email: model.maintainer?.email || '',
+          },
+          tags: model.tags || [],
+        })
+      }
+    }
+
+    const total = models.length
+    const start = pagination.page * pagination.pageSize
+    return {
+      items: models.slice(start, start + pagination.pageSize),
+      total,
+      aggregations: response.aggregations || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as ModelRow).modelId
+  },
+
+  isRowSelectable(_row: LibraryRow): boolean {
+    // Models do not participate in dataset-level access requests
+    return false
+  },
+
+  computeRowSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): Set<string | number> {
+    return new Set()
+  },
+
+  selectionToDatasetIds(_data: LibraryRow[], _selectedRowIds: (string | number)[]): number[] {
+    return []
+  },
+
+  getStudyIdsForSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): number[] {
+    return []
+  },
+
+  makeColumns(_props?: ColumnsProps): GridColDef[] {
+    return makeModelColumns() as GridColDef[]
+  },
+}

--- a/src/components/data_library/assets/modelAsset.ts
+++ b/src/components/data_library/assets/modelAsset.ts
@@ -1,6 +1,6 @@
 import { GridColDef } from '@mui/x-data-grid'
 import { ElasticsearchQuery, ElasticsearchResponse, ModelStudyAggregationResponse, QueryClause } from 'src/types/elastic'
-import { ModelRow, PaginationState, SortState } from 'src/types/library'
+import { ModelAsset, PaginationState, SortState } from 'src/types/library'
 import { makeModelColumns } from 'src/components/data_library/columns/modelColumns'
 import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
 
@@ -55,7 +55,7 @@ export const modelAsset: AssetDefinition = {
   transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
     const studiesAgg = response.aggregations?.studies as ModelStudyAggregationResponse | undefined
     const buckets = studiesAgg?.buckets || []
-    const models: ModelRow[] = []
+    const models: ModelAsset[] = []
 
     for (const bucket of buckets) {
       const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
@@ -92,7 +92,7 @@ export const modelAsset: AssetDefinition = {
   },
 
   getRowId(row: LibraryRow): string | number {
-    return (row as ModelRow).modelId
+    return (row as ModelAsset).modelId
   },
 
   isRowSelectable(_row: LibraryRow): boolean {

--- a/src/components/data_library/assets/studyAsset.ts
+++ b/src/components/data_library/assets/studyAsset.ts
@@ -1,0 +1,147 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, QueryClause, StudyAggregationResponse } from 'src/types/elastic'
+import { PaginationState, SortState, StudyAggregation } from 'src/types/library'
+import { makeStudyColumns } from 'src/components/data_library/columns/studyColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+export const studyAsset: AssetDefinition = {
+  label: { singular: 'Study', plural: 'Studies' },
+  sortingMode: 'client',
+  searchFields: [
+    'datasetName',
+    'dataLocation',
+    'study.description',
+    'study.studyName',
+    'study.species',
+    'study.piName',
+    'study.dataCustodianEmail',
+    'study.dataTypes',
+    'dataUse.primary.code',
+    'dataUse.secondary.code',
+    'dac.dacName',
+    'datasetIdentifier',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    pagination: PaginationState,
+    _sort?: SortState,
+  ): ElasticsearchQuery {
+    return {
+      size: 0,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        total_studies: {
+          cardinality: { field: 'study.studyId' },
+        },
+        studies: {
+          composite: {
+            size: (pagination.page + 1) * pagination.pageSize,
+            sources: [
+              {
+                study_id: {
+                  terms: { field: 'study.studyId' },
+                },
+              },
+            ],
+          },
+          aggs: {
+            study_details: {
+              top_hits: { size: 1, _source: ['study.*'] },
+            },
+            dataset_count: {
+              value_count: { field: 'datasetId' },
+            },
+            total_participants: {
+              sum: { field: 'participantCount' },
+            },
+            dataset_ids: {
+              terms: { field: 'datasetId', size: 10000 },
+            },
+          },
+        },
+        access_management: { terms: { field: 'accessManagement.keyword' } },
+        data_use: { terms: { field: 'dataUse.primary.code.keyword' } },
+        data_type: { terms: { field: 'study.dataTypes.keyword' } },
+        dac: { terms: { field: 'dac.dacName.keyword' } },
+      },
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
+    const studiesAgg = response.aggregations?.studies as StudyAggregationResponse | undefined
+    const buckets = studiesAgg?.buckets || []
+
+    const allStudies: StudyAggregation[] = buckets.map((bucket) => {
+      const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+      return {
+        studyId: bucket.key.study_id,
+        studyName: studyData.studyName || '',
+        studyDescription: studyData.description || '',
+        piName: studyData.piName || '',
+        species: studyData.species || '',
+        phenotype: studyData.phenotype || '',
+        dataCustodianEmail: studyData.dataCustodianEmail || [],
+        datasetCount: bucket.dataset_count?.value || 0,
+        totalParticipants: bucket.total_participants?.value || 0,
+        datasetIds: bucket.dataset_ids?.buckets?.map(b => b.key) || [],
+      }
+    })
+
+    const totalResult = response.aggregations?.total_studies as { value: number } | undefined
+    const total = totalResult?.value || allStudies.length
+    const start = pagination.page * pagination.pageSize
+    return {
+      items: allStudies.slice(start, start + pagination.pageSize),
+      total,
+      aggregations: response.aggregations || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as StudyAggregation).studyId
+  },
+
+  isRowSelectable(_row: LibraryRow): boolean {
+    return true
+  },
+
+  computeRowSelection(data: LibraryRow[], selectedDatasetIds: number[]): Set<string | number> {
+    const selectedStudyIds = data
+      .filter((study) => {
+        const studyDatasetIds = (study as StudyAggregation).datasetIds || []
+        return studyDatasetIds.some(id => selectedDatasetIds.includes(id))
+      })
+      .map(study => (study as StudyAggregation).studyId)
+    return new Set(selectedStudyIds)
+  },
+
+  selectionToDatasetIds(data: LibraryRow[], selectedRowIds: (string | number)[]): number[] {
+    const datasetIds: number[] = []
+    data.forEach((study) => {
+      if (selectedRowIds.includes((study as StudyAggregation).studyId)) {
+        datasetIds.push(...((study as StudyAggregation).datasetIds || []))
+      }
+    })
+    return datasetIds
+  },
+
+  getStudyIdsForSelection(data: LibraryRow[], selectedDatasetIds: number[]): number[] {
+    return data
+      .filter((study) => {
+        const studyDatasetIds = (study as StudyAggregation).datasetIds || []
+        return studyDatasetIds.some(id => selectedDatasetIds.includes(id))
+      })
+      .map(study => (study as StudyAggregation).studyId)
+  },
+
+  makeColumns(_props?: ColumnsProps): GridColDef[] {
+    return makeStudyColumns() as GridColDef[]
+  },
+}

--- a/src/components/data_library/columns/modelColumns.tsx
+++ b/src/components/data_library/columns/modelColumns.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import { GridColDef } from '@mui/x-data-grid'
+import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { ModelRow } from 'src/types/library'
+
+/**
+ * Column definitions for AI model view
+ */
+export const makeModelColumns = (): GridColDef<ModelRow>[] => [
+  {
+    field: 'name',
+    headerName: 'Model Name',
+    flex: 1.5,
+    minWidth: 200,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'studyName',
+    headerName: 'Study',
+    flex: 1,
+    minWidth: 150,
+    renderCell: params => (
+      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+        {params.value}
+      </Link>
+    ),
+  },
+  {
+    field: 'format',
+    headerName: 'Format',
+    width: 150,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'license',
+    headerName: 'License',
+    width: 120,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'maintainer',
+    headerName: 'Maintainer',
+    flex: 1,
+    minWidth: 150,
+    valueGetter: (_value, row) => row.maintainer?.name || '',
+    renderCell: (params) => {
+      const name = params.row.maintainer?.name || ''
+      const email = params.row.maintainer?.email || ''
+      return (
+        <Tooltip title={email || name} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {name}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'url',
+    headerName: 'URL',
+    width: 80,
+    sortable: false,
+    renderCell: params =>
+      params.value
+        ? (
+            <Link
+              href={params.value}
+              underline="hover"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Link
+            </Link>
+          )
+        : null,
+  },
+  {
+    field: 'tags',
+    headerName: 'Tags',
+    flex: 1,
+    minWidth: 150,
+    sortable: false,
+    valueGetter: (_value, row) => (row.tags || []).join(', '),
+    renderCell: (params) => {
+      const tags = params.row.tags || []
+      if (tags.length === 0) return null
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {tags.slice(0, 3).map((tag, i) => (
+            <Chip key={i} label={tag} size="small" variant="outlined" />
+          ))}
+          {tags.length > 3 && (
+            <Tooltip title={tags.slice(3).join(', ')}>
+              <Chip label={`+${tags.length - 3}`} size="small" variant="outlined" />
+            </Tooltip>
+          )}
+        </Box>
+      )
+    },
+  },
+]

--- a/src/components/data_library/columns/modelColumns.tsx
+++ b/src/components/data_library/columns/modelColumns.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
-import { ModelRow } from 'src/types/library'
+import { ModelAsset } from 'src/types/library'
 
 /**
  * Column definitions for AI model view
  */
-export const makeModelColumns = (): GridColDef<ModelRow>[] => [
+export const makeModelColumns = (): GridColDef<ModelAsset>[] => [
   {
     field: 'name',
     headerName: 'Model Name',

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -1,78 +1,48 @@
 import { useQuery } from '@tanstack/react-query'
 import { DataSet } from 'src/libs/ajax/DataSet'
-import {
-  ElasticsearchQuery,
-  ElasticsearchResponse,
-  QueryClause,
-  StudyAggregationResponse,
-} from 'src/types/elastic'
-import {
-  AssetType,
-  FilterState,
-  LibraryVersionNew,
-  PaginationState,
-  SortState,
-  StudyAggregation,
-} from 'src/types/library'
+import { ElasticsearchQuery, QueryClause } from 'src/types/elastic'
+import { AssetType, FilterState, LibraryVersionNew, PaginationState, SortState } from 'src/types/library'
+import { assetRegistry } from 'src/components/data_library/assets'
 
 /**
- * Build ElasticSearch query for datasets or studies
+ * Build the common Elasticsearch query clauses shared by every asset type:
+ * the base `must` clauses (study-exists check + library filter + search term)
+ * and the `filter` clauses derived from the filter panel.
+ *
+ * Asset-specific code (aggregations, pagination, sort) is handled by each
+ * asset's own `buildQuery` method.
  */
-export const buildElasticsearchQuery = (
+const buildCommonQueryClauses = (
   libraryConfig: LibraryVersionNew,
-  assetType: AssetType,
   filters: FilterState,
   queryTerm: string,
-  pagination: PaginationState,
-  sort?: SortState,
-): ElasticsearchQuery => {
+  searchFields: string[],
+): { queryChunks: QueryClause[], filterQuery: QueryClause[] } => {
   const queryChunks: QueryClause[] = [
-    {
-      exists: {
-        field: 'study',
-      },
-    },
+    { exists: { field: 'study' } },
   ]
 
-  // Add library-specific query
   if (libraryConfig.query) {
     queryChunks.push(libraryConfig.query as QueryClause)
   }
 
-  // Add search modifier if search term exists
   if (queryTerm.length > 0) {
     queryChunks.push({
       multi_match: {
         query: queryTerm,
         type: 'phrase_prefix',
-        fields: [
-          'datasetName',
-          'dataLocation',
-          'study.description',
-          'study.studyName',
-          'study.species',
-          'study.piName',
-          'study.dataCustodianEmail',
-          'study.dataTypes',
-          'dataUse.primary.code',
-          'dataUse.secondary.code',
-          'dac.dacName',
-          'datasetIdentifier',
-        ],
+        fields: searchFields,
       },
     })
   }
 
-  // Build filter query
   const filterQuery: QueryClause[] = []
 
   if (filters.accessManagement.length > 0) {
     filterQuery.push({
       bool: {
         should: filters.accessManagement.map(term => ({
-          term: {
-            'accessManagement.keyword': term,
-          },
+          term: { 'accessManagement.keyword': term },
         })),
       },
     })
@@ -82,9 +52,7 @@ export const buildElasticsearchQuery = (
     filterQuery.push({
       bool: {
         should: filters.dataUse.map(term => ({
-          match: {
-            'dataUse.primary.code': term,
-          },
+          match: { 'dataUse.primary.code': term },
         })),
       },
     })
@@ -94,9 +62,7 @@ export const buildElasticsearchQuery = (
     filterQuery.push({
       bool: {
         should: filters.dataType.map(term => ({
-          match: {
-            'study.dataTypes': term,
-          },
+          match: { 'study.dataTypes': term },
         })),
       },
     })
@@ -106,9 +72,7 @@ export const buildElasticsearchQuery = (
     filterQuery.push({
       bool: {
         should: filters.dac.map(term => ({
-          match_phrase: {
-            'dac.dacName': term,
-          },
+          match_phrase: { 'dac.dacName': term },
         })),
       },
     })
@@ -121,179 +85,39 @@ export const buildElasticsearchQuery = (
     filterQuery.push({
       range: {
         participantCount: {
-          ...(filters.participantCount.min !== undefined && {
-            gte: filters.participantCount.min,
-          }),
-          ...(filters.participantCount.max !== undefined && {
-            lte: filters.participantCount.max,
-          }),
+          ...(filters.participantCount.min !== undefined && { gte: filters.participantCount.min }),
+          ...(filters.participantCount.max !== undefined && { lte: filters.participantCount.max }),
         },
       },
     })
   }
 
-  // Build different query structure for studies vs datasets
-  if (assetType === AssetType.STUDIES) {
-    // For studies, use aggregations
-    return {
-      size: 0, // Don't return documents
-      query: {
-        bool: {
-          must: queryChunks,
-          ...(filterQuery.length > 0 && { filter: filterQuery }),
-        },
-      },
-      aggs: {
-        total_studies: {
-          cardinality: {
-            field: 'study.studyId',
-          },
-        },
-        studies: {
-          composite: {
-            size: (pagination.page + 1) * pagination.pageSize,
-            sources: [
-              {
-                study_id: {
-                  terms: {
-                    field: 'study.studyId',
-                  },
-                },
-              },
-            ],
-          },
-          aggs: {
-            study_details: {
-              top_hits: {
-                size: 1,
-                _source: ['study.*'],
-              },
-            },
-            dataset_count: {
-              value_count: {
-                field: 'datasetId',
-              },
-            },
-            total_participants: {
-              sum: {
-                field: 'participantCount',
-              },
-            },
-            dataset_ids: {
-              terms: {
-                field: 'datasetId',
-                size: 10000,
-              },
-            },
-          },
-        },
-        // Add filter aggregations
-        access_management: {
-          terms: {
-            field: 'accessManagement.keyword',
-          },
-        },
-        data_use: {
-          terms: {
-            field: 'dataUse.primary.code.keyword',
-          },
-        },
-        data_type: {
-          terms: {
-            field: 'study.dataTypes.keyword',
-          },
-        },
-        dac: {
-          terms: {
-            field: 'dac.dacName.keyword',
-          },
-        },
-      },
-    }
-  }
-
-  // Text fields cannot be sorted directly and must use their .keyword sub-field.
-  const DATASET_SORT_FIELD_MAP: Record<string, string> = {
-    datasetName: 'datasetName.keyword',
-    studyName: 'study.studyName.keyword',
-    accessManagement: 'accessManagement.keyword',
-    dac: 'dac.dacName.keyword',
-    datasetIdentifier: 'datasetIdentifier.keyword',
-  }
-
-  const esSortField = sort
-    ? (DATASET_SORT_FIELD_MAP[sort.field] ?? sort.field)
-    : undefined
-
-  // For datasets, use standard pagination
-  return {
-    from: pagination.page * pagination.pageSize,
-    size: pagination.pageSize,
-    query: {
-      bool: {
-        must: queryChunks,
-        ...(filterQuery.length > 0 && { filter: filterQuery }),
-      },
-    },
-    ...(sort && {
-      sort: [
-        {
-          [esSortField!]: {
-            order: sort.order,
-          },
-        },
-      ],
-    }),
-    // Add filter aggregations
-    aggs: {
-      access_management: {
-        terms: {
-          field: 'accessManagement.keyword',
-        },
-      },
-      data_use: {
-        terms: {
-          field: 'dataUse.primary.code.keyword',
-        },
-      },
-      data_type: {
-        terms: {
-          field: 'study.dataTypes.keyword',
-        },
-      },
-      dac: {
-        terms: {
-          field: 'dac.dacName.keyword',
-        },
-      },
-    },
-  }
+  return { queryChunks, filterQuery }
 }
 
 /**
- * Transform aggregation response to study rows
+ * Build the full Elasticsearch query for the given asset type.
+ *
+ * Assembles the common query clauses and then delegates the asset-type-specific
+ * query shape (aggregations, pagination, sort) to the asset registry.
+ * The public signature is preserved so existing tests continue to pass.
  */
-export const transformStudyAggregations = (
-  response: ElasticsearchResponse,
-): StudyAggregation[] => {
-  const studiesAgg = response.aggregations?.studies as StudyAggregationResponse | undefined
-  const buckets = studiesAgg?.buckets || []
-
-  return buckets.map((bucket) => {
-    const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
-    return {
-      studyId: bucket.key.study_id,
-      studyName: studyData.studyName || '',
-      studyDescription: studyData.description || '',
-      piName: studyData.piName || '',
-      species: studyData.species || '',
-      phenotype: studyData.phenotype || '',
-      dataCustodianEmail: studyData.dataCustodianEmail || [],
-      datasetCount: bucket.dataset_count?.value || 0,
-      totalParticipants: bucket.total_participants?.value || 0,
-      datasetIds: bucket.dataset_ids?.buckets?.map(b => b.key) || [],
-    }
-  })
+export const buildElasticsearchQuery = (
+  libraryConfig: LibraryVersionNew,
+  assetType: AssetType,
+  filters: FilterState,
+  queryTerm: string,
+  pagination: PaginationState,
+  sort?: SortState,
+): ElasticsearchQuery => {
+  const asset = assetRegistry[assetType]
+  const { queryChunks, filterQuery } = buildCommonQueryClauses(
+    libraryConfig,
+    filters,
+    queryTerm,
+    asset.searchFields,
+  )
+  return asset.buildQuery(queryChunks, filterQuery, pagination, sort)
 }
 
 /**
@@ -328,31 +152,8 @@ export const useLibraryData = (
       )
 
       const response = await DataSet.searchDatasetIndexV2(query)
-
       const actualData = response.data || response
-
-      if (assetType === AssetType.STUDIES && actualData.aggregations) {
-        const studies = transformStudyAggregations(actualData)
-        const totalResult = actualData.aggregations.total_studies as { value: number } | undefined
-        const total = totalResult?.value || studies.length
-        const start = pagination.page * pagination.pageSize
-        const slice = studies.slice(start, start + pagination.pageSize)
-
-        return {
-          items: slice,
-          total,
-          aggregations: actualData.aggregations,
-        }
-      }
-
-      const items = Array.isArray(actualData)
-        ? actualData
-        : (actualData.hits?.hits?.map((h: Record<string, unknown>) => h._source) || [])
-      return {
-        items,
-        total: Array.isArray(actualData) ? actualData.length : (actualData.hits?.total?.value || 0),
-        aggregations: actualData.aggregations || {},
-      }
+      return assetRegistry[assetType].transformResponse(actualData, pagination)
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     retry: 1,

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -197,7 +197,7 @@ export const DataLibrary: React.FC = () => {
   }, [urlState.sortField, urlState.sortOrder])
 
   const handleTabChange = (newAssetType: AssetType) => {
-    updateUrlState({ tab: newAssetType })
+    updateUrlState({ tab: newAssetType, page: 0 })
     setSelectedDatasetIds([])
   }
 

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -5,8 +5,9 @@ import LibraryTabs from 'src/components/data_library/LibraryTabs'
 import SearchBar from 'src/components/SearchBar'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
-import { AssetType, AvailableFilters, ExportableDatasets, LibraryVersionNew, SortOrder, StudyAggregation, TabConfig } from 'src/types/library'
+import { AssetType, AvailableFilters, ExportableDatasets, LibraryVersionNew, SortOrder, TabConfig } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
+import { assetRegistry } from 'src/components/data_library/assets'
 import LibraryFilters from 'src/components/data_library/LibraryFilters'
 import { useLibraryData, useLibraryMetadata } from 'src/hooks/useLibraryData'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
@@ -59,6 +60,7 @@ export const DataLibrary: React.FC = () => {
   const tabs: TabConfig[] = [
     { key: AssetType.STUDIES, label: 'Studies' },
     { key: AssetType.DATASETS, label: 'Datasets' },
+    { key: AssetType.MODELS, label: 'AI Models' },
   ]
 
   const searchRef = useRef<HTMLInputElement>(null)
@@ -163,31 +165,15 @@ export const DataLibrary: React.FC = () => {
       : undefined,
   )
 
+  const currentAsset = useMemo(() => assetRegistry[urlState.tab], [urlState.tab])
+
   const selectedStudyIds = useMemo(() => {
     if (!data?.items) return []
-    const studyIds = new Set<number>()
-    data.items.forEach((item: StudyAggregation | DatasetTerm) => {
-      switch (urlState.tab) {
-        case AssetType.STUDIES: {
-          const study = item as StudyAggregation
-          if (study.datasetIds?.some((id: number) => selectedDatasetIds.includes(id))) {
-            studyIds.add(study.studyId)
-          }
-          break
-        }
-        case AssetType.DATASETS: {
-          const dataset = item as DatasetTerm
-          if (selectedDatasetIds.includes(dataset.datasetId)) {
-            studyIds.add(dataset.study.studyId)
-          }
-          break
-        }
-        default:
-          throw new Error('Unknown asset type')
-      }
-    })
-    return Array.from(studyIds)
-  }, [data, selectedDatasetIds, urlState.tab])
+    return currentAsset.getStudyIdsForSelection(
+      data.items,
+      selectedDatasetIds,
+    )
+  }, [data, selectedDatasetIds, currentAsset])
 
   const sortModel = useMemo(() => {
     if (urlState.sortField && urlState.sortOrder) {
@@ -290,7 +276,7 @@ export const DataLibrary: React.FC = () => {
         return
       }
       try {
-        const radarEnabledIds = await getRadarEnabledDatasetsWithRules(data.items)
+        const radarEnabledIds = await getRadarEnabledDatasetsWithRules(data.items as DatasetTerm[])
         setRadarEnabledDatasetIds(new Set(radarEnabledIds))
       }
       catch {
@@ -369,16 +355,9 @@ export const DataLibrary: React.FC = () => {
                 <Typography sx={{ fontWeight: 600, fontSize: '1.6rem', mb: 1 }}>
                   {(data?.total ?? 0).toLocaleString()}
                   {' '}
-                  {(() => {
-                    switch (urlState.tab) {
-                      case AssetType.STUDIES:
-                        return (data?.total === 1) ? 'Study' : 'Studies'
-                      case AssetType.DATASETS:
-                        return (data?.total === 1) ? 'Dataset' : 'Datasets'
-                      default:
-                        return 'Assets'
-                    }
-                  })()}
+                  {data?.total === 1
+                    ? currentAsset.label.singular
+                    : currentAsset.label.plural}
                 </Typography>
               )}
           {/* Data Library */}

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -1,4 +1,4 @@
-import { SortOrder } from 'src/types/library'
+import { ModelAsset, SortOrder } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 export interface MatchQuery {
@@ -193,23 +193,8 @@ export interface StudyAggregationResponse {
   after_key?: { study_id: number }
 }
 
-export interface Maintainer {
-  name?: string
-  email?: string
-}
-
-export interface AiModelAsset {
-  modelId?: string
-  studyId?: string
-  name?: string
-  description?: string
-  url?: string
-  format?: string
-  license?: string
-  trainedOnDatasets?: string[]
-  maintainer?: Maintainer
-  tags?: string[]
-}
+/** Raw Elasticsearch document shape for a model asset; derived from ModelAsset so both stay in sync. */
+export type PartialModelAsset = Partial<ModelAsset>
 
 /** Bucket shape from a terms aggregation on study.studyId, used for the Models view */
 export interface ModelStudyAggregationBucket {
@@ -225,7 +210,7 @@ export interface ModelStudyAggregationBucket {
             description?: string
             piName?: string
             assets?: {
-              models?: AiModelAsset[]
+              models?: PartialModelAsset[]
             }
           }
         }

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -193,6 +193,51 @@ export interface StudyAggregationResponse {
   after_key?: { study_id: number }
 }
 
+export interface Maintainer {
+  name?: string
+  email?: string
+}
+
+export interface AiModelAsset {
+  modelId?: string
+  studyId?: string
+  name?: string
+  description?: string
+  url?: string
+  format?: string
+  license?: string
+  trainedOnDatasets?: string[]
+  maintainer?: Maintainer
+  tags?: string[]
+}
+
+/** Bucket shape from a terms aggregation on study.studyId, used for the Models view */
+export interface ModelStudyAggregationBucket {
+  key: number
+  doc_count: number
+  study_details?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          study?: {
+            studyId?: number
+            studyName?: string
+            description?: string
+            piName?: string
+            assets?: {
+              models?: AiModelAsset[]
+            }
+          }
+        }
+      }>
+    }
+  }
+}
+
+export interface ModelStudyAggregationResponse {
+  buckets: ModelStudyAggregationBucket[]
+}
+
 export interface PaginatedResponse<T> {
   items: T[]
   total: number

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -135,3 +135,22 @@ export interface LibraryFooterProps {
   selectedStudyIds: number[]
   onApplyForAccess: () => void
 }
+
+export interface Maintainer {
+  name: string
+  email: string
+}
+
+export interface ModelRow {
+  modelId: string
+  studyId: number
+  studyName: string
+  name: string
+  description: string
+  url: string
+  format: string
+  license: string
+  trainedOnDatasets: string[]
+  maintainer: Maintainer
+  tags?: string[]
+}

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -141,7 +141,7 @@ export interface Maintainer {
   email: string
 }
 
-export interface ModelRow {
+export interface ModelAsset {
   modelId: string
   studyId: number
   studyName: string


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3012

### Summary

Refactors the asset code to make adding new assets more scalable, and adds the AI models tab:

<img width="385" height="270" alt="Screenshot 2026-03-02 at 9 57 19 AM" src="https://github.com/user-attachments/assets/84cac8e3-c929-4f3a-ad51-27219f359b55" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
