### PR TITLE
[DT-400] Move scripts section above dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "duos-ui",
   "version": "1.0.0",
   "private": true,
+  "scripts": {
+    "analyze": "VISUALIZER_PLUGIN=true vite build",
+    "start": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "lint:staged": "eslint $(git diff --name-only --cached | xargs)",
+    "cypress:open": "CYPRESS_ADMIN=$(cat cypress/fixtures/duos-automation-admin.json) CYPRESS_CHAIR=$(cat cypress/fixtures/duos-automation-chair.json) CYPRESS_MEMBER=$(cat cypress/fixtures/duos-automation-member.json) CYPRESS_RESEARCHER=$(cat cypress/fixtures/duos-automation-researcher.json) CYPRESS_SIGNING_OFFICIAL=$(cat cypress/fixtures/duos-automation-signing-official.json) cypress open",
+    "cypress:open:component": "cypress open --component",
+    "cypress:run": "CYPRESS_ADMIN=$(cat cypress/fixtures/duos-automation-admin.json) CYPRESS_CHAIR=$(cat cypress/fixtures/duos-automation-chair.json) CYPRESS_MEMBER=$(cat cypress/fixtures/duos-automation-member.json) CYPRESS_RESEARCHER=$(cat cypress/fixtures/duos-automation-researcher.json) CYPRESS_SIGNING_OFFICIAL=$(cat cypress/fixtures/duos-automation-signing-official.json) cypress run",
+    "cypress:run:component": "cypress run --component",
+    "cypress:verify": "cypress verify"
+  },
   "dependencies": {
     "@databiosphere/bard-client": "0.1.0",
     "@mui/icons-material": "7.3.6",
@@ -29,20 +43,6 @@
     "stackdriver-errors-js": "0.12.0",
     "tss-react": "4.9.20",
     "uuid": "13.0.0"
-  },
-  "scripts": {
-    "analyze": "VISUALIZER_PLUGIN=true vite build",
-    "start": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "lint:staged": "eslint $(git diff --name-only --cached | xargs)",
-    "cypress:open": "CYPRESS_ADMIN=$(cat cypress/fixtures/duos-automation-admin.json) CYPRESS_CHAIR=$(cat cypress/fixtures/duos-automation-chair.json) CYPRESS_MEMBER=$(cat cypress/fixtures/duos-automation-member.json) CYPRESS_RESEARCHER=$(cat cypress/fixtures/duos-automation-researcher.json) CYPRESS_SIGNING_OFFICIAL=$(cat cypress/fixtures/duos-automation-signing-official.json) cypress open",
-    "cypress:open:component": "cypress open --component",
-    "cypress:run": "CYPRESS_ADMIN=$(cat cypress/fixtures/duos-automation-admin.json) CYPRESS_CHAIR=$(cat cypress/fixtures/duos-automation-chair.json) CYPRESS_MEMBER=$(cat cypress/fixtures/duos-automation-member.json) CYPRESS_RESEARCHER=$(cat cypress/fixtures/duos-automation-researcher.json) CYPRESS_SIGNING_OFFICIAL=$(cat cypress/fixtures/duos-automation-signing-official.json) cypress run",
-    "cypress:run:component": "cypress run --component",
-    "cypress:verify": "cypress verify"
   },
   "devDependencies": {
     "@emotion/styled": "11.14.1",


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

Moves scripts above the dev dependencies, so that the dev dependencies and dependencies are grouped together visually.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
