### PR TITLE
[DT-3013] Add publications asset tab to new data library

### DIFF
--- a/cypress/component/data_library/assets/publicationAsset.spec.ts
+++ b/cypress/component/data_library/assets/publicationAsset.spec.ts
@@ -1,0 +1,428 @@
+/**
+ * Unit tests for publicationAsset — the Publications AssetDefinition.
+ *
+ * These tests are purely logic-level (no DOM mounting) so they run quickly
+ * in the Cypress component runner via plain `describe` / `it` blocks.
+ */
+import { publicationAsset } from 'src/components/data_library/assets/publicationAsset'
+import { PublicationAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  PublicationStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+/** Build a minimal PublicationStudyAggregationBucket */
+const makeBucket = (
+  studyId: number,
+  publications: Array<{
+    publicationId?: string
+    title?: string
+    journal?: string
+    doi?: string
+    pubmedId?: string
+    publishedDate?: string
+    authors?: Array<{ name: string }>
+    url?: string
+    tags?: string[]
+    citation?: boolean
+    datasetCitation?: string
+  }> = [],
+  studyName = 'Test Study',
+): PublicationStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: publications.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                publications: publications.map(p => ({
+                  publicationId: p.publicationId,
+                  title: p.title,
+                  journal: p.journal,
+                  doi: p.doi,
+                  pubmedId: p.pubmedId,
+                  publishedDate: p.publishedDate,
+                  authors: p.authors,
+                  url: p.url,
+                  tags: p.tags,
+                  citation: p.citation,
+                  datasetCitation: p.datasetCitation,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+/** Wrap buckets in a full ElasticsearchResponse */
+const makeResponse = (
+  buckets: PublicationStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+// ---------------------------------------------------------------------------
+// label
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — label', () => {
+  it('has singular "Publication" and plural "Publications"', () => {
+    expect(publicationAsset.label.singular).to.equal('Publication')
+    expect(publicationAsset.label.plural).to.equal('Publications')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortingMode
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(publicationAsset.sortingMode).to.equal('client')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// searchFields
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — searchFields', () => {
+  it('includes publication-specific fields', () => {
+    expect(publicationAsset.searchFields).to.include('study.assets.publications.title')
+    expect(publicationAsset.searchFields).to.include('study.assets.publications.journal')
+    expect(publicationAsset.searchFields).to.include('study.assets.publications.doi')
+    expect(publicationAsset.searchFields).to.include('study.assets.publications.pubmedId')
+  })
+
+  it('includes study-level fields', () => {
+    expect(publicationAsset.searchFields).to.include('study.studyName')
+    expect(publicationAsset.searchFields).to.include('study.piName')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildQuery
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).to.equal(0)
+    expect(q.from).to.equal(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).to.have.property('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).to.equal('study.studyId')
+    expect(studiesAgg.terms.size).to.equal(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).to.have.length(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).to.equal('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).to.equal(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'open' },
+    }
+    const q = publicationAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).to.have.length(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = publicationAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).to.equal(0)
+    expect(q.sort).to.equal(undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// transformResponse
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = publicationAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+
+  it('flattens publications from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ publicationId: 'p1', title: 'Alpha' }, { publicationId: 'p2', title: 'Beta' }]),
+      makeBucket(2, [{ publicationId: 'p3', title: 'Gamma' }]),
+    ])
+    const result = publicationAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(3)
+    expect(result.total).to.equal(3)
+  })
+
+  it('maps fields correctly from bucket to PublicationAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        publicationId: 'pub-xyz',
+        title: 'A Novel Method',
+        journal: 'Nature',
+        doi: '10.1038/test',
+        pubmedId: '99887766',
+        publishedDate: '2024-06-01',
+        authors: [{ name: 'Alice' }, { name: 'Bob' }],
+        url: 'https://example.com',
+        tags: ['genomics', 'GWAS'],
+        citation: true,
+        datasetCitation: 'DUOS-999',
+      }], 'NHGRI Study'),
+    ])
+    const result = publicationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PublicationAsset
+    expect(row.publicationId).to.equal('pub-xyz')
+    expect(row.studyId).to.equal(42)
+    expect(row.studyName).to.equal('NHGRI Study')
+    expect(row.title).to.equal('A Novel Method')
+    expect(row.journal).to.equal('Nature')
+    expect(row.doi).to.equal('10.1038/test')
+    expect(row.pubmedId).to.equal('99887766')
+    expect(row.publishedDate).to.equal('2024-06-01')
+    expect(row.authorNames).to.deep.equal(['Alice', 'Bob'])
+    expect(row.url).to.equal('https://example.com')
+    expect(row.tags).to.deep.equal(['genomics', 'GWAS'])
+    expect(row.citation).to.equal(true)
+    expect(row.datasetCitation).to.equal('DUOS-999')
+  })
+
+  it('falls back to composite key when publicationId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ title: 'No ID Pub' }]),
+    ])
+    const result = publicationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PublicationAsset
+    // composite fallback: `${bucket.key}-${index}`
+    expect(row.publicationId).to.equal('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const pubs = Array.from({ length: 30 }, (_, i) => ({
+      publicationId: `p${i}`,
+      title: `Publication ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, pubs)])
+
+    const page0 = publicationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).to.have.length(10)
+    expect((page0.items[0] as PublicationAsset).title).to.equal('Publication 0')
+
+    const page1 = publicationAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).to.have.length(10)
+    expect((page1.items[0] as PublicationAsset).title).to.equal('Publication 10')
+
+    const page2 = publicationAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).to.have.length(10)
+    expect((page2.items[0] as PublicationAsset).title).to.equal('Publication 20')
+  })
+
+  it('reports total as the number of all publications across all studies', () => {
+    const pubs = Array.from({ length: 30 }, (_, i) => ({ publicationId: `p${i}` }))
+    const response = makeResponse([makeBucket(1, pubs)])
+    const result = publicationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).to.equal(30)
+  })
+
+  it('builds authorNames from the authors array', () => {
+    const response = makeResponse([
+      makeBucket(1, [{
+        publicationId: 'p1',
+        authors: [{ name: 'Dr. Smith' }, { name: 'Prof. Jones' }, { name: '' }],
+      }]),
+    ])
+    const row = publicationAsset.transformResponse(response, pagination).items[0] as PublicationAsset
+    // empty-string names should be filtered out
+    expect(row.authorNames).to.deep.equal(['Dr. Smith', 'Prof. Jones'])
+  })
+
+  it('returns empty defaults for missing fields', () => {
+    const response = makeResponse([makeBucket(1, [{}])])
+    const row = publicationAsset.transformResponse(response, pagination).items[0] as PublicationAsset
+    expect(row.tags).to.deep.equal([])
+    expect(row.authors).to.deep.equal([])
+    expect(row.authorNames).to.deep.equal([])
+    expect(row.title).to.equal('')
+    expect(row.journal).to.equal('')
+    expect(row.doi).to.equal('')
+    expect(row.citation).to.equal(false)
+  })
+
+  it('handles a study bucket with no publications gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = publicationAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRowId
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — getRowId', () => {
+  it('returns the publicationId of the row', () => {
+    const row: PublicationAsset = {
+      publicationId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    expect(publicationAsset.getRowId(row)).to.equal('abc-123')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRowSelectable
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — isRowSelectable', () => {
+  it('always returns false — publications do not participate in access requests', () => {
+    const row: PublicationAsset = {
+      publicationId: 'p1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    expect(publicationAsset.isRowSelectable(row)).to.equal(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeRowSelection
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: PublicationAsset = {
+      publicationId: 'p1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    const result = publicationAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectionToDatasetIds
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = publicationAsset.selectionToDatasetIds([], ['p1', 'p2'])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStudyIdsForSelection
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: PublicationAsset = {
+      publicationId: 'p1',
+      studyId: 42,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    const result = publicationAsset.getStudyIdsForSelection([row], [1])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// makeColumns
+// ---------------------------------------------------------------------------
+
+describe('publicationAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = publicationAsset.makeColumns()
+    expect(cols).to.be.an('array')
+    expect(cols.length).to.be.greaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = publicationAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).to.include('title')
+    expect(fields).to.include('studyName')
+    expect(fields).to.include('journal')
+    expect(fields).to.include('publishedDate')
+    expect(fields).to.include('doi')
+    expect(fields).to.include('authorNames')
+    expect(fields).to.include('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = publicationAsset.makeColumns()
+    const b = publicationAsset.makeColumns({})
+    expect(a.map(c => c.field)).to.deep.equal(b.map(c => c.field))
+  })
+})

--- a/cypress/component/data_library/columns/publicationColumns.spec.tsx
+++ b/cypress/component/data_library/columns/publicationColumns.spec.tsx
@@ -1,0 +1,185 @@
+/**
+ * Component tests for makePublicationColumns — the column definitions used
+ * in the Publications tab of the Data Library.
+ *
+ * Each test mounts a minimal DataGrid with a single row and inspects the
+ * rendered HTML to verify column behaviour.
+ */
+import React from 'react'
+import { DataGrid } from '@mui/x-data-grid'
+import { makePublicationColumns } from 'src/components/data_library/columns/publicationColumns'
+import { makePublicationRow } from '../../test-utils'
+
+const renderGrid = (overrides = {}) => {
+  const row = makePublicationRow(overrides)
+  cy.mount(
+    <DataGrid
+      rows={[row]}
+      columns={makePublicationColumns()}
+      getRowId={r => r.publicationId}
+      autoHeight
+    />,
+  )
+}
+
+describe('makePublicationColumns — Title column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the publication title as a link when url is present', () => {
+    renderGrid({ title: 'A Novel Genomics Study', url: 'https://doi.org/10.1038/test' })
+    cy.get('a[href="https://doi.org/10.1038/test"]').contains('A Novel Genomics Study').should('exist')
+  })
+
+  it('renders plain text when url is absent', () => {
+    renderGrid({ title: 'No Link Title', url: '' })
+    cy.contains('No Link Title').should('exist')
+    cy.get('a').filter(':contains("No Link Title")').should('not.exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer" for the title link', () => {
+    renderGrid({ title: 'Ext Link', url: 'https://example.com/pub' })
+    cy.get('a[href="https://example.com/pub"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+
+  it('renders gracefully when title is empty', () => {
+    renderGrid({ title: '', url: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePublicationColumns — Study column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders a link with the study name', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.contains('Genome Atlas').should('exist')
+  })
+
+  it('links to /studies/:studyId', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.get('a[href="/studies/7"]').should('exist')
+  })
+})
+
+describe('makePublicationColumns — Journal column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the journal name', () => {
+    renderGrid({ journal: 'Nature Genetics' })
+    cy.contains('Nature Genetics').should('exist')
+  })
+
+  it('renders gracefully when journal is empty', () => {
+    renderGrid({ journal: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePublicationColumns — Published Date column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the published date', () => {
+    renderGrid({ publishedDate: '2024-06-15' })
+    cy.contains('2024-06-15').should('exist')
+  })
+
+  it('renders gracefully when publishedDate is empty', () => {
+    renderGrid({ publishedDate: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePublicationColumns — PubMed ID column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the PubMed ID as a link', () => {
+    renderGrid({ pubmedId: '87654321' })
+    cy.get('a[href="https://pubmed.ncbi.nlm.nih.gov/87654321"]')
+      .contains('87654321')
+      .should('exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer"', () => {
+    renderGrid({ pubmedId: '87654321' })
+    cy.get('a[href="https://pubmed.ncbi.nlm.nih.gov/87654321"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+
+  it('renders nothing when pubmedId is absent', () => {
+    renderGrid({ pubmedId: '' })
+    cy.get('a[href^="https://pubmed.ncbi.nlm.nih.gov"]').should('not.exist')
+  })
+})
+
+describe('makePublicationColumns — DOI column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the DOI as a link', () => {
+    renderGrid({ doi: '10.1038/ng.1234' })
+    cy.get('a[href="https://doi.org/10.1038/ng.1234"]')
+      .contains('10.1038/ng.1234')
+      .should('exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer"', () => {
+    renderGrid({ doi: '10.1038/ng.1234' })
+    cy.get('a[href="https://doi.org/10.1038/ng.1234"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+
+  it('renders nothing when doi is absent', () => {
+    // Clear url too so the Title column doesn't produce a doi.org link
+    renderGrid({ doi: '', url: 'https://example.com/pub' })
+    cy.get('a[href^="https://doi.org"]').should('not.exist')
+  })
+})
+
+describe('makePublicationColumns — Authors column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders comma-separated author names', () => {
+    renderGrid({ authorNames: ['Alice Smith', 'Bob Jones', 'Carol White'] })
+    cy.contains('Alice Smith, Bob Jones, Carol White').should('exist')
+  })
+
+  it('renders gracefully when authorNames is empty', () => {
+    renderGrid({ authorNames: [] })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePublicationColumns — Tags column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders nothing when tags array is empty', () => {
+    renderGrid({ tags: [] })
+    cy.get('.MuiChip-root').should('not.exist')
+  })
+
+  it('renders up to 3 chips for 3 tags', () => {
+    renderGrid({ tags: ['genomics', 'GWAS', 'cancer'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.contains('genomics').should('exist')
+    cy.contains('GWAS').should('exist')
+    cy.contains('cancer').should('exist')
+  })
+
+  it('shows "+N" overflow chip when there are more than 3 tags', () => {
+    renderGrid({ tags: ['t1', 't2', 't3', 't4', 't5'] })
+    // 3 visible tags + 1 overflow chip = 4 chips total
+    cy.get('.MuiChip-root').should('have.length', 4)
+    cy.contains('+2').should('exist')
+  })
+
+  it('does not show an overflow chip for exactly 3 tags', () => {
+    renderGrid({ tags: ['a', 'b', 'c'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.get('.MuiChip-root').each(($chip) => {
+      expect($chip.text()).to.not.match(/^\+\d+$/)
+    })
+  })
+})

--- a/cypress/component/test-utils.ts
+++ b/cypress/component/test-utils.ts
@@ -1,5 +1,5 @@
 import { BioSpecimenPreservationMethod, BioSpecimenType, ClinicalTrialInterventionType, ClinicalTrialPhase, ClinicalTrialStatus, DatasetTerm, Sex, StudyTerm, UserTerm } from 'src/types/model'
-import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PublicationAsset } from 'src/types/library'
 
 export const makeUserTerm = (overrides: Partial<UserTerm> = {}): UserTerm => ({
   userId: 0,
@@ -100,5 +100,25 @@ export const makeBiospecimenRow = (overrides: Partial<BiospecimenAsset> = {}): B
   sex: Sex.FEMALE,
   age: 45,
   organization: 'Test Biobank',
+  ...overrides,
+})
+
+export const makePublicationRow = (overrides: Partial<PublicationAsset> = {}): PublicationAsset => ({
+  publicationId: 'pub-001',
+  studyId: 42,
+  studyName: 'Test Study',
+  title: 'A Novel Approach to Genomics',
+  pubmedId: '12345678',
+  publishedDate: '2024-01-15',
+  authors: [{ name: 'Alice Smith' }, { name: 'Bob Jones' }],
+  authorNames: ['Alice Smith', 'Bob Jones'],
+  bibliographicCitation: 'Smith A, Jones B. A Novel Approach. 2024.',
+  datasetCitation: 'DUOS-123456',
+  citation: true,
+  journal: 'Nature Genetics',
+  doi: '10.1038/ng.1234',
+  url: 'https://doi.org/10.1038/ng.1234',
+  access: 'open',
+  tags: ['genomics', 'GWAS'],
   ...overrides,
 })

--- a/src/components/data_library/assets/definition.ts
+++ b/src/components/data_library/assets/definition.ts
@@ -15,13 +15,14 @@ import {
   ExportableDatasets,
   ModelAsset,
   PaginationState,
+  PublicationAsset,
   SortState,
   StudyAggregation,
 } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 /** Union of every row type that can appear in the DataGrid */
-export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset
+export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset
 
 /** Normalized result returned by every asset's `transformResponse` */
 export interface LibraryPage {

--- a/src/components/data_library/assets/index.ts
+++ b/src/components/data_library/assets/index.ts
@@ -16,6 +16,7 @@ import { datasetAsset } from 'src/components/data_library/assets/datasetAsset'
 import { modelAsset } from 'src/components/data_library/assets/modelAsset'
 import { clinicalTrialAsset } from 'src/components/data_library/assets/clinicalTrialAsset'
 import { biospecimenAsset } from 'src/components/data_library/assets/biospecimenAsset'
+import { publicationAsset } from 'src/components/data_library/assets/publicationAsset'
 
 export type {
   AssetDefinition,
@@ -30,4 +31,5 @@ export const assetRegistry: Record<AssetType, AssetDefinition> = {
   [AssetType.MODELS]: modelAsset,
   [AssetType.CLINICAL_TRIALS]: clinicalTrialAsset,
   [AssetType.BIOSPECIMENS]: biospecimenAsset,
+  [AssetType.PUBLICATIONS]: publicationAsset,
 }

--- a/src/components/data_library/assets/publicationAsset.ts
+++ b/src/components/data_library/assets/publicationAsset.ts
@@ -1,0 +1,120 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, PublicationStudyAggregationResponse, QueryClause } from 'src/types/elastic'
+import { PaginationState, PublicationAsset, SortState } from 'src/types/library'
+import { makePublicationColumns } from 'src/components/data_library/columns/publicationColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+export const publicationAsset: AssetDefinition = {
+  label: { singular: 'Publication', plural: 'Publications' },
+  sortingMode: 'client',
+  searchFields: [
+    'study.studyName',
+    'study.description',
+    'study.piName',
+    'study.assets.publications.title',
+    'study.assets.publications.journal',
+    'study.assets.publications.doi',
+    'study.assets.publications.pubmedId',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    _pagination: PaginationState,
+    _sort?: SortState,
+  ): ElasticsearchQuery {
+    // Aggregate by study to extract nested publication assets stored under
+    // study.assets.publications; client-side pagination is applied in transformResponse.
+    return {
+      size: 0,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        studies: {
+          terms: {
+            field: 'study.studyId',
+            size: 10000,
+          },
+          aggs: {
+            study_details: {
+              top_hits: {
+                size: 1,
+                _source: ['study.*'],
+              },
+            },
+          },
+        },
+      },
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
+    const studiesAgg = response.aggregations?.studies as PublicationStudyAggregationResponse | undefined
+    const buckets = studiesAgg?.buckets || []
+    const publications: PublicationAsset[] = []
+
+    for (const bucket of buckets) {
+      const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+      const studyPublications = studyData.assets?.publications || []
+      for (const [pubIndex, pub] of studyPublications.entries()) {
+        // publicationId may be absent from the indexed document; fall back to a
+        // composite key so every row in the DataGrid has a unique id.
+        publications.push({
+          publicationId: pub.publicationId || `${bucket.key}-${pubIndex}`,
+          studyId: bucket.key,
+          studyName: (studyData as { studyName?: string }).studyName || '',
+          title: pub.title || '',
+          pubmedId: pub.pubmedId || '',
+          publishedDate: pub.publishedDate || '',
+          authors: pub.authors || [],
+          authorNames: (pub.authors || []).map((a: { name?: string }) => a.name || '').filter(Boolean),
+          bibliographicCitation: pub.bibliographicCitation || '',
+          datasetCitation: pub.datasetCitation || '',
+          citation: pub.citation ?? false,
+          journal: pub.journal || '',
+          doi: pub.doi || '',
+          url: pub.url || '',
+          access: pub.access || '',
+          tags: pub.tags || [],
+        })
+      }
+    }
+
+    const total = publications.length
+    const start = pagination.page * pagination.pageSize
+    return {
+      items: publications.slice(start, start + pagination.pageSize),
+      total,
+      aggregations: response.aggregations || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as PublicationAsset).publicationId
+  },
+
+  isRowSelectable(_row: LibraryRow): boolean {
+    // Publications do not participate in dataset-level access requests
+    return false
+  },
+
+  computeRowSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): Set<string | number> {
+    return new Set()
+  },
+
+  selectionToDatasetIds(_data: LibraryRow[], _selectedRowIds: (string | number)[]): number[] {
+    return []
+  },
+
+  getStudyIdsForSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): number[] {
+    return []
+  },
+
+  makeColumns(_props?: ColumnsProps): GridColDef[] {
+    return makePublicationColumns() as GridColDef[]
+  },
+}

--- a/src/components/data_library/columns/publicationColumns.tsx
+++ b/src/components/data_library/columns/publicationColumns.tsx
@@ -1,0 +1,183 @@
+import React from 'react'
+import { GridColDef } from '@mui/x-data-grid'
+import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { PublicationAsset } from 'src/types/library'
+
+/**
+ * Column definitions for the Publications view in the Data Library.
+ */
+export const makePublicationColumns = (): GridColDef<PublicationAsset>[] => [
+  {
+    field: 'title',
+    headerName: 'Title',
+    flex: 2,
+    minWidth: 220,
+    renderCell: (params) => {
+      const text = params.value || ''
+      const url = params.row.url
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {url
+              ? (
+                  <Link href={url} target="_blank" rel="noopener noreferrer" underline="hover">
+                    {text}
+                  </Link>
+                )
+              : text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'studyName',
+    headerName: 'Study',
+    flex: 1,
+    minWidth: 150,
+    renderCell: params => (
+      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+        {params.value}
+      </Link>
+    ),
+  },
+  {
+    field: 'journal',
+    headerName: 'Journal',
+    flex: 1,
+    minWidth: 150,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'publishedDate',
+    headerName: 'Published',
+    width: 120,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Box
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </Box>
+      )
+    },
+  },
+  {
+    field: 'pubmedId',
+    headerName: 'PubMed ID',
+    width: 130,
+    renderCell: (params) => {
+      const id = params.value || ''
+      if (!id) {
+        return null
+      }
+      return (
+        <Link
+          href={`https://pubmed.ncbi.nlm.nih.gov/${id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+        >
+          {id}
+        </Link>
+      )
+    },
+  },
+  {
+    field: 'doi',
+    headerName: 'DOI',
+    width: 120,
+    renderCell: (params) => {
+      const doi = params.value || ''
+      if (!doi) {
+        return null
+      }
+      return (
+        <Link
+          href={`https://doi.org/${doi}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          underline="hover"
+        >
+          {doi}
+        </Link>
+      )
+    },
+  },
+  {
+    field: 'authorNames',
+    headerName: 'Authors',
+    flex: 1.2,
+    minWidth: 160,
+    sortable: false,
+    renderCell: (params) => {
+      const names: string[] = params.value || []
+      const text = names.join(', ')
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'tags',
+    headerName: 'Tags',
+    flex: 1,
+    minWidth: 120,
+    sortable: false,
+    renderCell: (params) => {
+      const tags: string[] = params.value || []
+      if (tags.length === 0) {
+        return null
+      }
+      const maxVisible = 3
+      const visible = tags.slice(0, maxVisible)
+      const overflow = tags.length - maxVisible
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'nowrap', overflow: 'hidden' }}>
+          {visible.map(tag => (
+            <Chip key={tag} label={tag} size="small" variant="outlined" />
+          ))}
+          {overflow > 0 && (
+            <Chip label={`+${overflow}`} size="small" variant="outlined" />
+          )}
+        </Box>
+      )
+    },
+  },
+]

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -70,6 +70,7 @@ export const DataLibrary: React.FC = () => {
     { key: AssetType.MODELS, label: 'AI Models' },
     { key: AssetType.CLINICAL_TRIALS, label: 'Clinical Trials' },
     { key: AssetType.BIOSPECIMENS, label: 'Biospecimens' },
+    { key: AssetType.PUBLICATIONS, label: 'Publications' },
   ]
 
   const searchRef = useRef<HTMLInputElement>(null)

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -1,4 +1,4 @@
-import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, SortOrder } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PublicationAsset, SortOrder } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 export interface MatchQuery {
@@ -277,6 +277,34 @@ export interface BiospecimenStudyAggregationBucket {
 
 export interface BiospecimenStudyAggregationResponse {
   buckets: BiospecimenStudyAggregationBucket[]
+}
+
+/** Raw Elasticsearch document shape for a publication asset */
+export type PartialPublicationAsset = Partial<PublicationAsset>
+
+/** Bucket shape from a terms aggregation on study.studyId, used for the Publications view */
+export interface PublicationStudyAggregationBucket {
+  key: number
+  doc_count: number
+  study_details?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          study?: {
+            studyId?: number
+            studyName?: string
+            assets?: {
+              publications?: PartialPublicationAsset[]
+            }
+          }
+        }
+      }>
+    }
+  }
+}
+
+export interface PublicationStudyAggregationResponse {
+  buckets: PublicationStudyAggregationBucket[]
 }
 
 export interface PaginatedResponse<T> {

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Data Library feature
  */
 import { SnapshotSummaryModel } from 'src/types/tdrModel'
-import { AiModel, Biospecimen, ClinicalTrial } from 'src/types/model'
+import { AiModel, Biospecimen, ClinicalTrial, Publication } from 'src/types/model'
 
 export enum AssetType {
   STUDIES = 'studies',
@@ -10,6 +10,7 @@ export enum AssetType {
   MODELS = 'models',
   CLINICAL_TRIALS = 'clinical_trials',
   BIOSPECIMENS = 'biospecimens',
+  PUBLICATIONS = 'publications',
 }
 
 export interface LibraryVersionNew {
@@ -152,4 +153,11 @@ export interface ClinicalTrialAsset extends Omit<ClinicalTrial, 'studyId'> {
 export interface BiospecimenAsset extends Omit<Biospecimen, 'studyId'> {
   studyId: number
   studyName: string
+}
+
+export interface PublicationAsset extends Omit<Publication, 'studyId'> {
+  studyId: number
+  studyName: string
+  /** Convenience flattening of the authors array for display/search */
+  authorNames: string[]
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3013

### Summary

Add publications asset tab to new data library with tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
