### PR TITLE
[DT-3014] Add presentations asset tab to new data library

### DIFF
--- a/cypress/component/data_library/assets/presentationAsset.spec.ts
+++ b/cypress/component/data_library/assets/presentationAsset.spec.ts
@@ -1,0 +1,408 @@
+/**
+ * Unit tests for presentationAsset — the Presentations AssetDefinition.
+ *
+ * These tests are purely logic-level (no DOM mounting) so they run quickly
+ * in the Cypress component runner via plain `describe` / `it` blocks.
+ */
+import { presentationAsset } from 'src/components/data_library/assets/presentationAsset'
+import { PresentationAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  PresentationStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+/** Build a minimal PresentationStudyAggregationBucket */
+const makeBucket = (
+  studyId: number,
+  presentations: Array<{
+    presentationId?: string
+    title?: string
+    date?: string
+    url?: string
+    authors?: string
+    event?: string
+    location?: string
+    format?: string
+    access?: string
+    tags?: string[]
+    citation?: boolean
+    datasetCitation?: string
+    presenter?: { name?: string, email?: string }
+  }> = [],
+  studyName = 'Test Study',
+): PresentationStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: presentations.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                presentations: presentations.map(p => ({
+                  presentationId: p.presentationId,
+                  title: p.title,
+                  date: p.date,
+                  url: p.url,
+                  authors: p.authors,
+                  event: p.event,
+                  location: p.location,
+                  format: p.format,
+                  access: p.access,
+                  tags: p.tags,
+                  citation: p.citation,
+                  datasetCitation: p.datasetCitation,
+                  presenter: p.presenter,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+/** Wrap buckets in a full ElasticsearchResponse */
+const makeResponse = (
+  buckets: PresentationStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+// ---------------------------------------------------------------------------
+// label
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — label', () => {
+  it('has singular "Presentation" and plural "Presentations"', () => {
+    expect(presentationAsset.label.singular).to.equal('Presentation')
+    expect(presentationAsset.label.plural).to.equal('Presentations')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortingMode
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(presentationAsset.sortingMode).to.equal('client')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// searchFields
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — searchFields', () => {
+  it('includes presentation-specific fields', () => {
+    expect(presentationAsset.searchFields).to.include('study.assets.presentations.title')
+    expect(presentationAsset.searchFields).to.include('study.assets.presentations.event')
+    expect(presentationAsset.searchFields).to.include('study.assets.presentations.location')
+    expect(presentationAsset.searchFields).to.include('study.assets.presentations.authors')
+    expect(presentationAsset.searchFields).to.include('study.assets.presentations.format')
+  })
+
+  it('includes study-level fields', () => {
+    expect(presentationAsset.searchFields).to.include('study.studyName')
+    expect(presentationAsset.searchFields).to.include('study.piName')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildQuery
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).to.equal(0)
+    expect(q.from).to.equal(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).to.have.property('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).to.equal('study.studyId')
+    expect(studiesAgg.terms.size).to.equal(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).to.have.length(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).to.equal('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).to.equal(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'open' },
+    }
+    const q = presentationAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).to.have.length(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = presentationAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).to.equal(0)
+    expect(q.sort).to.equal(undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// transformResponse
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = presentationAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+
+  it('flattens presentations from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ presentationId: 'pr1', title: 'Alpha' }, { presentationId: 'pr2', title: 'Beta' }]),
+      makeBucket(2, [{ presentationId: 'pr3', title: 'Gamma' }]),
+    ])
+    const result = presentationAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(3)
+    expect(result.total).to.equal(3)
+  })
+
+  it('maps fields correctly from bucket to PresentationAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        presentationId: 'pres-xyz',
+        title: 'Data Sharing in Practice',
+        date: '2024-10-01',
+        url: 'https://example.com/slides',
+        authors: 'Alice Smith, Bob Jones',
+        event: 'ASHG 2024',
+        location: 'Denver, CO',
+        format: 'Oral',
+        access: 'open',
+        tags: ['genomics', 'data-sharing'],
+        citation: true,
+        datasetCitation: 'DUOS-999',
+        presenter: { name: 'Alice Smith', email: 'alice@example.com' },
+      }], 'NHGRI Study'),
+    ])
+    const result = presentationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PresentationAsset
+    expect(row.presentationId).to.equal('pres-xyz')
+    expect(row.studyId).to.equal(42)
+    expect(row.studyName).to.equal('NHGRI Study')
+    expect(row.title).to.equal('Data Sharing in Practice')
+    expect(row.date).to.equal('2024-10-01')
+    expect(row.url).to.equal('https://example.com/slides')
+    expect(row.authors).to.equal('Alice Smith, Bob Jones')
+    expect(row.event).to.equal('ASHG 2024')
+    expect(row.location).to.equal('Denver, CO')
+    expect(row.format).to.equal('Oral')
+    expect(row.access).to.equal('open')
+    expect(row.tags).to.deep.equal(['genomics', 'data-sharing'])
+    expect(row.citation).to.equal(true)
+    expect(row.datasetCitation).to.equal('DUOS-999')
+    expect(row.presenter?.name).to.equal('Alice Smith')
+    expect(row.presenter?.email).to.equal('alice@example.com')
+  })
+
+  it('falls back to composite key when presentationId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ title: 'No ID Pres' }]),
+    ])
+    const result = presentationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PresentationAsset
+    // composite fallback: `${bucket.key}-${index}`
+    expect(row.presentationId).to.equal('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const preses = Array.from({ length: 30 }, (_, i) => ({
+      presentationId: `pr${i}`,
+      title: `Presentation ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, preses)])
+
+    const page0 = presentationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).to.have.length(10)
+    expect((page0.items[0] as PresentationAsset).title).to.equal('Presentation 0')
+
+    const page1 = presentationAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).to.have.length(10)
+    expect((page1.items[0] as PresentationAsset).title).to.equal('Presentation 10')
+
+    const page2 = presentationAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).to.have.length(10)
+    expect((page2.items[0] as PresentationAsset).title).to.equal('Presentation 20')
+  })
+
+  it('reports total as the number of all presentations across all studies', () => {
+    const preses = Array.from({ length: 30 }, (_, i) => ({ presentationId: `pr${i}` }))
+    const response = makeResponse([makeBucket(1, preses)])
+    const result = presentationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).to.equal(30)
+  })
+
+  it('returns empty defaults for missing fields', () => {
+    const response = makeResponse([makeBucket(1, [{}])])
+    const row = presentationAsset.transformResponse(response, pagination).items[0] as PresentationAsset
+    expect(row.tags).to.deep.equal([])
+    expect(row.title).to.equal('')
+    expect(row.date).to.equal('')
+    expect(row.authors).to.equal('')
+    expect(row.event).to.equal('')
+    expect(row.location).to.equal('')
+    expect(row.format).to.equal('')
+    expect(row.citation).to.equal(false)
+  })
+
+  it('handles a study bucket with no presentations gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = presentationAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRowId
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — getRowId', () => {
+  it('returns the presentationId of the row', () => {
+    const row: PresentationAsset = {
+      presentationId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    expect(presentationAsset.getRowId(row)).to.equal('abc-123')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRowSelectable
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — isRowSelectable', () => {
+  it('always returns false — presentations do not participate in access requests', () => {
+    const row: PresentationAsset = {
+      presentationId: 'pr1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    expect(presentationAsset.isRowSelectable(row)).to.equal(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeRowSelection
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: PresentationAsset = {
+      presentationId: 'pr1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    const result = presentationAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectionToDatasetIds
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = presentationAsset.selectionToDatasetIds([], ['pr1', 'pr2'])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStudyIdsForSelection
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: PresentationAsset = {
+      presentationId: 'pr1',
+      studyId: 42,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    const result = presentationAsset.getStudyIdsForSelection([row], [1])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// makeColumns
+// ---------------------------------------------------------------------------
+
+describe('presentationAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = presentationAsset.makeColumns()
+    expect(cols).to.be.an('array')
+    expect(cols.length).to.be.greaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = presentationAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).to.include('title')
+    expect(fields).to.include('studyName')
+    expect(fields).to.include('event')
+    expect(fields).to.include('date')
+    expect(fields).to.include('location')
+    expect(fields).to.include('presenter')
+    expect(fields).to.include('format')
+    expect(fields).to.include('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = presentationAsset.makeColumns()
+    const b = presentationAsset.makeColumns({})
+    expect(a.map(c => c.field)).to.deep.equal(b.map(c => c.field))
+  })
+})

--- a/cypress/component/data_library/columns/presentationColumns.spec.tsx
+++ b/cypress/component/data_library/columns/presentationColumns.spec.tsx
@@ -1,0 +1,171 @@
+/**
+ * Component tests for makePresentationColumns — the column definitions used
+ * in the Presentations tab of the Data Library.
+ *
+ * Each test mounts a minimal DataGrid with a single row and inspects the
+ * rendered HTML to verify column behaviour.
+ */
+import React from 'react'
+import { DataGrid } from '@mui/x-data-grid'
+import { makePresentationColumns } from 'src/components/data_library/columns/presentationColumns'
+import { makePresentationRow } from '../../test-utils'
+
+const renderGrid = (overrides = {}) => {
+  const row = makePresentationRow(overrides)
+  cy.mount(
+    <DataGrid
+      rows={[row]}
+      columns={makePresentationColumns()}
+      getRowId={r => r.presentationId}
+      autoHeight
+    />,
+  )
+}
+
+describe('makePresentationColumns — Title column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the presentation title as a link when url is present', () => {
+    renderGrid({ title: 'Genomics in Practice', url: 'https://example.com/slides' })
+    cy.get('a[href="https://example.com/slides"]').contains('Genomics in Practice').should('exist')
+  })
+
+  it('renders plain text when url is absent', () => {
+    renderGrid({ title: 'No Link Title', url: '' })
+    cy.contains('No Link Title').should('exist')
+    cy.get('a').filter(':contains("No Link Title")').should('not.exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer" for the title link', () => {
+    renderGrid({ title: 'Ext Link', url: 'https://example.com/pres' })
+    cy.get('a[href="https://example.com/pres"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+
+  it('renders gracefully when title is empty', () => {
+    renderGrid({ title: '', url: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Study column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders a link with the study name', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.contains('Genome Atlas').should('exist')
+  })
+
+  it('links to /studies/:studyId', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.get('a[href="/studies/7"]').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Event column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the event name', () => {
+    renderGrid({ event: 'ASHG 2024' })
+    cy.contains('ASHG 2024').should('exist')
+  })
+
+  it('renders gracefully when event is empty', () => {
+    renderGrid({ event: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Date column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the presentation date', () => {
+    renderGrid({ date: '2024-10-15' })
+    cy.contains('2024-10-15').should('exist')
+  })
+
+  it('renders gracefully when date is empty', () => {
+    renderGrid({ date: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Location column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the location', () => {
+    renderGrid({ location: 'Denver, CO' })
+    cy.contains('Denver, CO').should('exist')
+  })
+
+  it('renders gracefully when location is empty', () => {
+    renderGrid({ location: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Presenter column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the presenter name', () => {
+    renderGrid({ presenter: { name: 'Alice Smith', email: 'alice@example.com' } })
+    cy.contains('Alice Smith').should('exist')
+  })
+
+  it('renders gracefully when presenter is absent', () => {
+    renderGrid({ presenter: undefined })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+
+  it('renders gracefully when presenter name is absent', () => {
+    renderGrid({ presenter: { email: 'alice@example.com' } })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Format column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders the format', () => {
+    renderGrid({ format: 'Oral' })
+    cy.contains('Oral').should('exist')
+  })
+
+  it('renders gracefully when format is empty', () => {
+    renderGrid({ format: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makePresentationColumns — Tags column', () => {
+  beforeEach(() => cy.viewport(1600, 800))
+
+  it('renders nothing when tags array is empty', () => {
+    renderGrid({ tags: [] })
+    cy.get('.MuiChip-root').should('not.exist')
+  })
+
+  it('renders up to 3 chips for 3 tags', () => {
+    renderGrid({ tags: ['genomics', 'data-sharing', 'open-access'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.contains('genomics').should('exist')
+    cy.contains('data-sharing').should('exist')
+    cy.contains('open-access').should('exist')
+  })
+
+  it('shows "+N" overflow chip when there are more than 3 tags', () => {
+    renderGrid({ tags: ['t1', 't2', 't3', 't4', 't5'] })
+    // 3 visible tags + 1 overflow chip = 4 chips total
+    cy.get('.MuiChip-root').should('have.length', 4)
+    cy.contains('+2').should('exist')
+  })
+
+  it('does not show an overflow chip for exactly 3 tags', () => {
+    renderGrid({ tags: ['a', 'b', 'c'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.get('.MuiChip-root').each(($chip) => {
+      expect($chip.text()).to.not.match(/^\+\d+$/)
+    })
+  })
+})

--- a/cypress/component/test-utils.ts
+++ b/cypress/component/test-utils.ts
@@ -1,5 +1,5 @@
 import { BioSpecimenPreservationMethod, BioSpecimenType, ClinicalTrialInterventionType, ClinicalTrialPhase, ClinicalTrialStatus, DatasetTerm, Sex, StudyTerm, UserTerm } from 'src/types/model'
-import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PublicationAsset } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PresentationAsset, PublicationAsset } from 'src/types/library'
 
 export const makeUserTerm = (overrides: Partial<UserTerm> = {}): UserTerm => ({
   userId: 0,
@@ -120,5 +120,24 @@ export const makePublicationRow = (overrides: Partial<PublicationAsset> = {}): P
   url: 'https://doi.org/10.1038/ng.1234',
   access: 'open',
   tags: ['genomics', 'GWAS'],
+  ...overrides,
+})
+
+export const makePresentationRow = (overrides: Partial<PresentationAsset> = {}): PresentationAsset => ({
+  presentationId: 'pres-001',
+  studyId: 42,
+  studyName: 'Test Study',
+  title: 'Genomics Data Sharing in the Modern Era',
+  date: '2024-03-15',
+  url: 'https://example.com/presentation',
+  authors: 'Alice Smith, Bob Jones',
+  datasetCitation: 'DUOS-123456',
+  citation: true,
+  presenter: { name: 'Alice Smith', email: 'alice@example.com' },
+  event: 'ASHG 2024',
+  location: 'Denver, CO',
+  format: 'Oral',
+  access: 'open',
+  tags: ['genomics', 'data-sharing'],
   ...overrides,
 })

--- a/src/components/data_library/assets/definition.ts
+++ b/src/components/data_library/assets/definition.ts
@@ -15,6 +15,7 @@ import {
   ExportableDatasets,
   ModelAsset,
   PaginationState,
+  PresentationAsset,
   PublicationAsset,
   SortState,
   StudyAggregation,
@@ -22,7 +23,7 @@ import {
 import { DatasetTerm } from 'src/types/model'
 
 /** Union of every row type that can appear in the DataGrid */
-export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset
+export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset | PresentationAsset
 
 /** Normalized result returned by every asset's `transformResponse` */
 export interface LibraryPage {

--- a/src/components/data_library/assets/index.ts
+++ b/src/components/data_library/assets/index.ts
@@ -17,6 +17,7 @@ import { modelAsset } from 'src/components/data_library/assets/modelAsset'
 import { clinicalTrialAsset } from 'src/components/data_library/assets/clinicalTrialAsset'
 import { biospecimenAsset } from 'src/components/data_library/assets/biospecimenAsset'
 import { publicationAsset } from 'src/components/data_library/assets/publicationAsset'
+import { presentationAsset } from 'src/components/data_library/assets/presentationAsset'
 
 export type {
   AssetDefinition,
@@ -32,4 +33,5 @@ export const assetRegistry: Record<AssetType, AssetDefinition> = {
   [AssetType.CLINICAL_TRIALS]: clinicalTrialAsset,
   [AssetType.BIOSPECIMENS]: biospecimenAsset,
   [AssetType.PUBLICATIONS]: publicationAsset,
+  [AssetType.PRESENTATIONS]: presentationAsset,
 }

--- a/src/components/data_library/assets/presentationAsset.ts
+++ b/src/components/data_library/assets/presentationAsset.ts
@@ -1,0 +1,120 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, PresentationStudyAggregationResponse, QueryClause } from 'src/types/elastic'
+import { PaginationState, PresentationAsset, SortState } from 'src/types/library'
+import { makePresentationColumns } from 'src/components/data_library/columns/presentationColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+export const presentationAsset: AssetDefinition = {
+  label: { singular: 'Presentation', plural: 'Presentations' },
+  sortingMode: 'client',
+  searchFields: [
+    'study.studyName',
+    'study.description',
+    'study.piName',
+    'study.assets.presentations.title',
+    'study.assets.presentations.event',
+    'study.assets.presentations.location',
+    'study.assets.presentations.authors',
+    'study.assets.presentations.format',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    _pagination: PaginationState,
+    _sort?: SortState,
+  ): ElasticsearchQuery {
+    // Aggregate by study to extract nested presentation assets stored under
+    // study.assets.presentations; client-side pagination is applied in transformResponse.
+    return {
+      size: 0,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        studies: {
+          terms: {
+            field: 'study.studyId',
+            size: 10000,
+          },
+          aggs: {
+            study_details: {
+              top_hits: {
+                size: 1,
+                _source: ['study.*'],
+              },
+            },
+          },
+        },
+      },
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
+    const studiesAgg = response.aggregations?.studies as PresentationStudyAggregationResponse | undefined
+    const buckets = studiesAgg?.buckets || []
+    const presentations: PresentationAsset[] = []
+
+    for (const bucket of buckets) {
+      const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+      const studyPresentations = studyData.assets?.presentations || []
+      for (const [presIndex, pres] of studyPresentations.entries()) {
+        // presentationId may be absent from the indexed document; fall back to a
+        // composite key so every row in the DataGrid has a unique id.
+        presentations.push({
+          presentationId: pres.presentationId || `${bucket.key}-${presIndex}`,
+          studyId: bucket.key,
+          studyName: (studyData as { studyName?: string }).studyName || '',
+          title: pres.title || '',
+          date: pres.date || '',
+          url: pres.url || '',
+          authors: pres.authors || '',
+          datasetCitation: pres.datasetCitation || '',
+          citation: pres.citation ?? false,
+          presenter: pres.presenter || undefined,
+          event: pres.event || '',
+          location: pres.location || '',
+          format: pres.format || '',
+          access: pres.access || '',
+          tags: pres.tags || [],
+        })
+      }
+    }
+
+    const total = presentations.length
+    const start = pagination.page * pagination.pageSize
+    return {
+      items: presentations.slice(start, start + pagination.pageSize),
+      total,
+      aggregations: response.aggregations || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as PresentationAsset).presentationId
+  },
+
+  isRowSelectable(_row: LibraryRow): boolean {
+    // Presentations do not participate in dataset-level access requests
+    return false
+  },
+
+  computeRowSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): Set<string | number> {
+    return new Set()
+  },
+
+  selectionToDatasetIds(_data: LibraryRow[], _selectedRowIds: (string | number)[]): number[] {
+    return []
+  },
+
+  getStudyIdsForSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): number[] {
+    return []
+  },
+
+  makeColumns(_props?: ColumnsProps): GridColDef[] {
+    return makePresentationColumns() as GridColDef[]
+  },
+}

--- a/src/components/data_library/columns/presentationColumns.tsx
+++ b/src/components/data_library/columns/presentationColumns.tsx
@@ -1,0 +1,182 @@
+import React from 'react'
+import { GridColDef } from '@mui/x-data-grid'
+import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { PresentationAsset } from 'src/types/library'
+
+/**
+ * Column definitions for the Presentations view in the Data Library.
+ */
+export const makePresentationColumns = (): GridColDef<PresentationAsset>[] => [
+  {
+    field: 'title',
+    headerName: 'Title',
+    flex: 2,
+    minWidth: 220,
+    renderCell: (params) => {
+      const text = params.value || ''
+      const url = params.row.url
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {url
+              ? (
+                  <Link href={url} target="_blank" rel="noopener noreferrer" underline="hover">
+                    {text}
+                  </Link>
+                )
+              : text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'studyName',
+    headerName: 'Study',
+    flex: 1,
+    minWidth: 150,
+    renderCell: params => (
+      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+        {params.value}
+      </Link>
+    ),
+  },
+  {
+    field: 'event',
+    headerName: 'Event',
+    flex: 1,
+    minWidth: 150,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'date',
+    headerName: 'Date',
+    width: 120,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Box
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </Box>
+      )
+    },
+  },
+  {
+    field: 'location',
+    headerName: 'Location',
+    flex: 1,
+    minWidth: 130,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'presenter',
+    headerName: 'Presenter',
+    flex: 1,
+    minWidth: 140,
+    sortable: false,
+    valueGetter: (_value, row) => row.presenter?.name || '',
+    renderCell: (params) => {
+      const name = params.row.presenter?.name || ''
+      return (
+        <Tooltip title={name} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {name}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'format',
+    headerName: 'Format',
+    width: 120,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Box
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </Box>
+      )
+    },
+  },
+  {
+    field: 'tags',
+    headerName: 'Tags',
+    flex: 1,
+    minWidth: 120,
+    sortable: false,
+    renderCell: (params) => {
+      const tags: string[] = params.value || []
+      if (tags.length === 0) {
+        return null
+      }
+      const maxVisible = 3
+      const visible = tags.slice(0, maxVisible)
+      const overflow = tags.length - maxVisible
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'nowrap', overflow: 'hidden' }}>
+          {visible.map(tag => (
+            <Chip key={tag} label={tag} size="small" variant="outlined" />
+          ))}
+          {overflow > 0 && (
+            <Chip label={`+${overflow}`} size="small" variant="outlined" />
+          )}
+        </Box>
+      )
+    },
+  },
+]

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -71,6 +71,7 @@ export const DataLibrary: React.FC = () => {
     { key: AssetType.CLINICAL_TRIALS, label: 'Clinical Trials' },
     { key: AssetType.BIOSPECIMENS, label: 'Biospecimens' },
     { key: AssetType.PUBLICATIONS, label: 'Publications' },
+    { key: AssetType.PRESENTATIONS, label: 'Presentations' },
   ]
 
   const searchRef = useRef<HTMLInputElement>(null)

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -1,4 +1,4 @@
-import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PublicationAsset, SortOrder } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PresentationAsset, PublicationAsset, SortOrder } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 export interface MatchQuery {
@@ -305,6 +305,34 @@ export interface PublicationStudyAggregationBucket {
 
 export interface PublicationStudyAggregationResponse {
   buckets: PublicationStudyAggregationBucket[]
+}
+
+/** Raw Elasticsearch document shape for a presentation asset */
+export type PartialPresentationAsset = Partial<PresentationAsset>
+
+/** Bucket shape from a terms aggregation on study.studyId, used for the Presentations view */
+export interface PresentationStudyAggregationBucket {
+  key: number
+  doc_count: number
+  study_details?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          study?: {
+            studyId?: number
+            studyName?: string
+            assets?: {
+              presentations?: PartialPresentationAsset[]
+            }
+          }
+        }
+      }>
+    }
+  }
+}
+
+export interface PresentationStudyAggregationResponse {
+  buckets: PresentationStudyAggregationBucket[]
 }
 
 export interface PaginatedResponse<T> {

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Data Library feature
  */
 import { SnapshotSummaryModel } from 'src/types/tdrModel'
-import { AiModel, Biospecimen, ClinicalTrial, Publication } from 'src/types/model'
+import { AiModel, Biospecimen, ClinicalTrial, Presentation, Publication } from 'src/types/model'
 
 export enum AssetType {
   STUDIES = 'studies',
@@ -11,6 +11,7 @@ export enum AssetType {
   CLINICAL_TRIALS = 'clinical_trials',
   BIOSPECIMENS = 'biospecimens',
   PUBLICATIONS = 'publications',
+  PRESENTATIONS = 'presentations',
 }
 
 export interface LibraryVersionNew {
@@ -160,4 +161,9 @@ export interface PublicationAsset extends Omit<Publication, 'studyId'> {
   studyName: string
   /** Convenience flattening of the authors array for display/search */
   authorNames: string[]
+}
+
+export interface PresentationAsset extends Omit<Presentation, 'studyId'> {
+  studyId: number
+  studyName: string
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3014

### Summary

Add presentations asset tab to new data library with tests.

<img width="241" height="61" alt="Screenshot 2026-03-05 at 9 52 10 AM" src="https://github.com/user-attachments/assets/673f13c5-cc86-44d8-bbb6-65652e8c16f6" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
