### PR TITLE
[DT-3015] Add intellectual property asset tab to new data library

### DIFF
--- a/cypress/component/data_library/assets/intellectualPropertyAsset.spec.ts
+++ b/cypress/component/data_library/assets/intellectualPropertyAsset.spec.ts
@@ -1,0 +1,358 @@
+/**
+ * Unit tests for intellectualPropertyAsset — the Intellectual Property AssetDefinition.
+ *
+ * These tests are purely logic-level (no DOM mounting) so they run quickly
+ * in the Cypress component runner via plain `describe` / `it` blocks.
+ */
+import { intellectualPropertyAsset } from 'src/components/data_library/assets/intellectualPropertyAsset'
+import { IntellectualPropertyAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  IntellectualPropertyStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+/** Build a minimal IntellectualPropertyStudyAggregationBucket */
+const makeBucket = (
+  studyId: number,
+  ips: Array<{
+    ipId?: string
+    type?: string
+    title?: string
+    assignee?: string
+    patentNumber?: string
+    filingDate?: string
+    status?: string
+    url?: string
+    contact?: string
+    tags?: string[]
+  }> = [],
+  studyName = 'Test Study',
+): IntellectualPropertyStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: ips.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                intellectualProperties: ips.map(ip => ({
+                  ipId: ip.ipId,
+                  type: ip.type,
+                  title: ip.title,
+                  assignee: ip.assignee,
+                  patentNumber: ip.patentNumber,
+                  filingDate: ip.filingDate,
+                  status: ip.status,
+                  url: ip.url,
+                  contact: ip.contact,
+                  tags: ip.tags,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+/** Wrap buckets in a full ElasticsearchResponse */
+const makeResponse = (
+  buckets: IntellectualPropertyStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+// ---------------------------------------------------------------------------
+// label
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — label', () => {
+  it('has singular "Intellectual Property" and plural "Intellectual Properties"', () => {
+    expect(intellectualPropertyAsset.label.singular).to.equal('Intellectual Property')
+    expect(intellectualPropertyAsset.label.plural).to.equal('Intellectual Properties')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortingMode
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(intellectualPropertyAsset.sortingMode).to.equal('client')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// searchFields
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — searchFields', () => {
+  it('includes IP-specific fields', () => {
+    expect(intellectualPropertyAsset.searchFields).to.include('study.assets.intellectualProperties.title')
+    expect(intellectualPropertyAsset.searchFields).to.include('study.assets.intellectualProperties.type')
+    expect(intellectualPropertyAsset.searchFields).to.include('study.assets.intellectualProperties.assignee')
+    expect(intellectualPropertyAsset.searchFields).to.include('study.assets.intellectualProperties.patentNumber')
+    expect(intellectualPropertyAsset.searchFields).to.include('study.assets.intellectualProperties.status')
+  })
+
+  it('includes study-level fields', () => {
+    expect(intellectualPropertyAsset.searchFields).to.include('study.studyName')
+    expect(intellectualPropertyAsset.searchFields).to.include('study.piName')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildQuery
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).to.equal(0)
+    expect(q.from).to.equal(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).to.have.property('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).to.equal('study.studyId')
+    expect(studiesAgg.terms.size).to.equal(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).to.have.length(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).to.equal('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).to.equal(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'open' },
+    }
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).to.have.length(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).to.equal(0)
+    expect(q.sort).to.equal(undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// transformResponse
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = intellectualPropertyAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+
+  it('flattens IPs from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ ipId: 'ip1', title: 'Alpha' }, { ipId: 'ip2', title: 'Beta' }]),
+      makeBucket(2, [{ ipId: 'ip3', title: 'Gamma' }]),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(3)
+    expect(result.total).to.equal(3)
+  })
+
+  it('maps fields correctly from bucket to IntellectualPropertyAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        ipId: 'ip-abc',
+        type: 'Patent',
+        title: 'Novel Method',
+        assignee: 'Broad Institute',
+        patentNumber: 'US12345678',
+        filingDate: '2023-06-15',
+        status: 'Granted',
+        url: 'https://patents.example.com/US12345678',
+        contact: 'ip@broadinstitute.org',
+        tags: ['genomics'],
+      }], 'My Study'),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    const row = result.items[0] as IntellectualPropertyAsset
+    expect(row.ipId).to.equal('ip-abc')
+    expect(row.studyId).to.equal(42)
+    expect(row.studyName).to.equal('My Study')
+    expect(row.type).to.equal('Patent')
+    expect(row.title).to.equal('Novel Method')
+    expect(row.assignee).to.equal('Broad Institute')
+    expect(row.patentNumber).to.equal('US12345678')
+    expect(row.filingDate).to.equal('2023-06-15')
+    expect(row.status).to.equal('Granted')
+    expect(row.url).to.equal('https://patents.example.com/US12345678')
+    expect(row.contact).to.equal('ip@broadinstitute.org')
+    expect(row.tags).to.deep.equal(['genomics'])
+  })
+
+  it('falls back to composite key when ipId is absent', () => {
+    const response = makeResponse([
+      makeBucket(10, [{ title: 'No ID' }]),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    const row = result.items[0] as IntellectualPropertyAsset
+    expect(row.ipId).to.equal('10-0')
+  })
+
+  it('defaults missing string fields to empty string', () => {
+    const response = makeResponse([
+      makeBucket(5, [{ ipId: 'ip-x' }]),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    const row = result.items[0] as IntellectualPropertyAsset
+    expect(row.type).to.equal('')
+    expect(row.title).to.equal('')
+    expect(row.assignee).to.equal('')
+    expect(row.patentNumber).to.equal('')
+    expect(row.filingDate).to.equal('')
+    expect(row.status).to.equal('')
+    expect(row.url).to.equal('')
+    expect(row.contact).to.equal('')
+    expect(row.tags).to.deep.equal([])
+  })
+
+  it('applies client-side pagination correctly', () => {
+    const ips = Array.from({ length: 30 }, (_, i) => ({ ipId: `ip-${i}`, title: `IP ${i}` }))
+    const response = makeResponse([makeBucket(1, ips)])
+    const page1 = intellectualPropertyAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    const page2 = intellectualPropertyAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).to.have.length(10)
+    expect(page1.total).to.equal(30)
+    expect(page2.items).to.have.length(10)
+    expect((page2.items[0] as IntellectualPropertyAsset).ipId).to.equal('ip-10')
+  })
+
+  it('handles studies with no intellectualProperties assets', () => {
+    const response = makeResponse([makeBucket(7, [])])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRowId
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — getRowId', () => {
+  it('returns the ipId', () => {
+    const row: IntellectualPropertyAsset = {
+      ipId: 'ip-xyz',
+      studyId: 1,
+      studyName: 'Study',
+      type: 'Patent',
+      title: 'Title',
+      assignee: 'Org',
+      patentNumber: 'US000',
+      filingDate: '2024-01-01',
+      status: 'Pending',
+      url: '',
+      contact: '',
+    }
+    expect(intellectualPropertyAsset.getRowId(row)).to.equal('ip-xyz')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRowSelectable
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — isRowSelectable', () => {
+  it('returns false (IPs do not participate in access requests)', () => {
+    const row: IntellectualPropertyAsset = {
+      ipId: 'ip-1',
+      studyId: 1,
+      studyName: 'Study',
+      type: 'Patent',
+      title: 'Title',
+      assignee: 'Org',
+      patentNumber: 'US000',
+      filingDate: '2024-01-01',
+      status: 'Granted',
+      url: '',
+      contact: '',
+    }
+    expect(intellectualPropertyAsset.isRowSelectable(row)).to.equal(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeRowSelection / selectionToDatasetIds / getStudyIdsForSelection
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — selection helpers', () => {
+  it('computeRowSelection always returns an empty Set', () => {
+    const set = intellectualPropertyAsset.computeRowSelection([], [1, 2, 3])
+    expect(set.size).to.equal(0)
+  })
+
+  it('selectionToDatasetIds always returns an empty array', () => {
+    const ids = intellectualPropertyAsset.selectionToDatasetIds([], ['ip-1', 'ip-2'])
+    expect(ids).to.deep.equal([])
+  })
+
+  it('getStudyIdsForSelection always returns an empty array', () => {
+    const ids = intellectualPropertyAsset.getStudyIdsForSelection([], [1, 2])
+    expect(ids).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// makeColumns
+// ---------------------------------------------------------------------------
+
+describe('intellectualPropertyAsset — makeColumns', () => {
+  it('returns an array of column definitions', () => {
+    const cols = intellectualPropertyAsset.makeColumns()
+    expect(cols).to.be.an('array')
+    expect(cols.length).to.be.greaterThan(0)
+  })
+
+  it('includes expected field names', () => {
+    const fields = intellectualPropertyAsset.makeColumns().map(c => c.field)
+    expect(fields).to.include('title')
+    expect(fields).to.include('type')
+    expect(fields).to.include('patentNumber')
+    expect(fields).to.include('assignee')
+    expect(fields).to.include('status')
+    expect(fields).to.include('filingDate')
+    expect(fields).to.include('studyName')
+    expect(fields).to.include('contact')
+    expect(fields).to.include('tags')
+  })
+})

--- a/cypress/component/data_library/columns/intellectualPropertyColumns.spec.tsx
+++ b/cypress/component/data_library/columns/intellectualPropertyColumns.spec.tsx
@@ -1,0 +1,169 @@
+/**
+ * Component tests for makeIntellectualPropertyColumns — the column definitions
+ * used in the Intellectual Property tab of the Data Library.
+ *
+ * Each test mounts a minimal DataGrid with a single row and inspects the
+ * rendered HTML to verify column behaviour.
+ */
+import React from 'react'
+import { DataGrid } from '@mui/x-data-grid'
+import { makeIntellectualPropertyColumns } from 'src/components/data_library/columns/intellectualPropertyColumns'
+import { makeIntellectualPropertyRow } from '../../test-utils'
+
+const renderGrid = (overrides = {}) => {
+  const row = makeIntellectualPropertyRow(overrides)
+  cy.mount(
+    <DataGrid
+      rows={[row]}
+      columns={makeIntellectualPropertyColumns()}
+      getRowId={r => r.ipId}
+      autoHeight
+    />,
+  )
+}
+
+describe('makeIntellectualPropertyColumns — Title column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the IP title as a link when url is present', () => {
+    renderGrid({ title: 'Novel Sequencing Method', url: 'https://patents.example.com/US00001' })
+    cy.get('a[href="https://patents.example.com/US00001"]').contains('Novel Sequencing Method').should('exist')
+  })
+
+  it('renders plain text when url is absent', () => {
+    renderGrid({ title: 'No Link Title', url: '' })
+    cy.contains('No Link Title').should('exist')
+    cy.get('a').filter(':contains("No Link Title")').should('not.exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer" for the title link', () => {
+    renderGrid({ title: 'Ext Link', url: 'https://patents.example.com/US99999' })
+    cy.get('a[href="https://patents.example.com/US99999"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+
+  it('renders gracefully when title is empty', () => {
+    renderGrid({ title: '', url: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Study column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders a link with the study name', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.contains('Genome Atlas').should('exist')
+  })
+
+  it('links to /studies/:studyId', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.get('a[href="/studies/7"]').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Type column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the IP type', () => {
+    renderGrid({ type: 'Patent' })
+    cy.contains('Patent').should('exist')
+  })
+
+  it('renders gracefully when type is empty', () => {
+    renderGrid({ type: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Patent Number column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the patent number', () => {
+    renderGrid({ patentNumber: 'US12345678' })
+    cy.contains('US12345678').should('exist')
+  })
+
+  it('renders gracefully when patent number is empty', () => {
+    renderGrid({ patentNumber: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Assignee column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the assignee', () => {
+    renderGrid({ assignee: 'Broad Institute' })
+    cy.contains('Broad Institute').should('exist')
+  })
+
+  it('renders gracefully when assignee is empty', () => {
+    renderGrid({ assignee: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Status column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the status', () => {
+    renderGrid({ status: 'Granted' })
+    cy.contains('Granted').should('exist')
+  })
+
+  it('renders gracefully when status is empty', () => {
+    renderGrid({ status: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Filing Date column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the filing date', () => {
+    renderGrid({ filingDate: '2023-06-15' })
+    cy.contains('2023-06-15').should('exist')
+  })
+
+  it('renders gracefully when filing date is empty', () => {
+    renderGrid({ filingDate: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Contact column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders the contact', () => {
+    renderGrid({ contact: 'ip@broadinstitute.org' })
+    cy.contains('ip@broadinstitute.org').should('exist')
+  })
+
+  it('renders gracefully when contact is empty', () => {
+    renderGrid({ contact: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeIntellectualPropertyColumns — Tags column', () => {
+  beforeEach(() => cy.viewport(1800, 800))
+
+  it('renders chips for each tag', () => {
+    renderGrid({ tags: ['genomics', 'sequencing', 'IP'] })
+    cy.contains('genomics').should('exist')
+    cy.contains('sequencing').should('exist')
+    cy.contains('IP').should('exist')
+  })
+
+  it('shows overflow chip when more than 3 tags are present', () => {
+    renderGrid({ tags: ['a', 'b', 'c', 'd', 'e'] })
+    cy.contains('+2').should('exist')
+  })
+
+  it('renders gracefully when tags array is empty', () => {
+    renderGrid({ tags: [] })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})

--- a/cypress/component/test-utils.ts
+++ b/cypress/component/test-utils.ts
@@ -1,5 +1,5 @@
 import { BioSpecimenPreservationMethod, BioSpecimenType, ClinicalTrialInterventionType, ClinicalTrialPhase, ClinicalTrialStatus, DatasetTerm, Sex, StudyTerm, UserTerm } from 'src/types/model'
-import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, IntellectualPropertyAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset } from 'src/types/library'
 
 export const makeUserTerm = (overrides: Partial<UserTerm> = {}): UserTerm => ({
   userId: 0,
@@ -139,6 +139,22 @@ export const makePresentationRow = (overrides: Partial<PresentationAsset> = {}):
   format: 'Oral',
   access: 'open',
   tags: ['genomics', 'data-sharing'],
+  ...overrides,
+})
+
+export const makeIntellectualPropertyRow = (overrides: Partial<IntellectualPropertyAsset> = {}): IntellectualPropertyAsset => ({
+  ipId: 'ip-001',
+  studyId: 42,
+  studyName: 'Test Study',
+  type: 'Patent',
+  title: 'Novel Genomic Sequencing Method',
+  assignee: 'Broad Institute',
+  patentNumber: 'US12345678',
+  filingDate: '2023-06-15',
+  status: 'Granted',
+  url: 'https://patents.example.com/US12345678',
+  contact: 'ip@broadinstitute.org',
+  tags: ['genomics', 'sequencing'],
   ...overrides,
 })
 

--- a/src/components/data_library/assets/definition.ts
+++ b/src/components/data_library/assets/definition.ts
@@ -13,6 +13,7 @@ import {
   ClinicalTrialAsset,
   BiospecimenAsset,
   ExportableDatasets,
+  IntellectualPropertyAsset,
   FundingResourceAsset,
   ModelAsset,
   PaginationState,
@@ -24,7 +25,7 @@ import {
 import { DatasetTerm } from 'src/types/model'
 
 /** Union of every row type that can appear in the DataGrid */
-export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset | PresentationAsset | FundingResourceAsset
+export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset | PresentationAsset | IntellectualPropertyAsset | FundingResourceAsset
 
 /** Normalized result returned by every asset's `transformResponse` */
 export interface LibraryPage {

--- a/src/components/data_library/assets/index.ts
+++ b/src/components/data_library/assets/index.ts
@@ -18,6 +18,7 @@ import { clinicalTrialAsset } from 'src/components/data_library/assets/clinicalT
 import { biospecimenAsset } from 'src/components/data_library/assets/biospecimenAsset'
 import { publicationAsset } from 'src/components/data_library/assets/publicationAsset'
 import { presentationAsset } from 'src/components/data_library/assets/presentationAsset'
+import { intellectualPropertyAsset } from 'src/components/data_library/assets/intellectualPropertyAsset'
 import { fundingResourceAsset } from 'src/components/data_library/assets/fundingResourceAsset'
 
 export type {
@@ -35,5 +36,6 @@ export const assetRegistry: Record<AssetType, AssetDefinition> = {
   [AssetType.BIOSPECIMENS]: biospecimenAsset,
   [AssetType.PUBLICATIONS]: publicationAsset,
   [AssetType.PRESENTATIONS]: presentationAsset,
+  [AssetType.INTELLECTUAL_PROPERTY]: intellectualPropertyAsset,
   [AssetType.FUNDING_RESOURCES]: fundingResourceAsset,
 }

--- a/src/components/data_library/assets/intellectualPropertyAsset.ts
+++ b/src/components/data_library/assets/intellectualPropertyAsset.ts
@@ -1,0 +1,118 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, IntellectualPropertyStudyAggregationResponse, QueryClause } from 'src/types/elastic'
+import { IntellectualPropertyAsset, PaginationState, SortState } from 'src/types/library'
+import { makeIntellectualPropertyColumns } from 'src/components/data_library/columns/intellectualPropertyColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+export const intellectualPropertyAsset: AssetDefinition = {
+  label: { singular: 'Intellectual Property', plural: 'Intellectual Properties' },
+  sortingMode: 'client',
+  searchFields: [
+    'study.studyName',
+    'study.description',
+    'study.piName',
+    'study.assets.intellectualProperties.title',
+    'study.assets.intellectualProperties.type',
+    'study.assets.intellectualProperties.assignee',
+    'study.assets.intellectualProperties.patentNumber',
+    'study.assets.intellectualProperties.status',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    _pagination: PaginationState,
+    _sort?: SortState,
+  ): ElasticsearchQuery {
+    // Aggregate by study to extract nested intellectual property assets stored
+    // under study.assets.intellectualProperties; client-side pagination is
+    // applied in transformResponse.
+    return {
+      size: 0,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        studies: {
+          terms: {
+            field: 'study.studyId',
+            size: 10000,
+          },
+          aggs: {
+            study_details: {
+              top_hits: {
+                size: 1,
+                _source: ['study.*'],
+              },
+            },
+          },
+        },
+      },
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
+    const studiesAgg = response.aggregations?.studies as IntellectualPropertyStudyAggregationResponse | undefined
+    const buckets = studiesAgg?.buckets || []
+    const items: IntellectualPropertyAsset[] = []
+
+    for (const bucket of buckets) {
+      const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+      const studyIPs = studyData.assets?.intellectualProperties || []
+      for (const [ipIndex, ip] of studyIPs.entries()) {
+        // ipId may be absent from the indexed document; fall back to a
+        // composite key so every row in the DataGrid has a unique id.
+        items.push({
+          ipId: ip.ipId || `${bucket.key}-${ipIndex}`,
+          studyId: bucket.key,
+          studyName: (studyData as { studyName?: string }).studyName || '',
+          type: ip.type || '',
+          title: ip.title || '',
+          assignee: ip.assignee || '',
+          patentNumber: ip.patentNumber || '',
+          filingDate: ip.filingDate || '',
+          status: ip.status || '',
+          url: ip.url || '',
+          contact: ip.contact || '',
+          tags: ip.tags || [],
+        })
+      }
+    }
+
+    const total = items.length
+    const start = pagination.page * pagination.pageSize
+    return {
+      items: items.slice(start, start + pagination.pageSize),
+      total,
+      aggregations: response.aggregations || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as IntellectualPropertyAsset).ipId
+  },
+
+  isRowSelectable(_row: LibraryRow): boolean {
+    // Intellectual properties do not participate in dataset-level access requests
+    return false
+  },
+
+  computeRowSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): Set<string | number> {
+    return new Set()
+  },
+
+  selectionToDatasetIds(_data: LibraryRow[], _selectedRowIds: (string | number)[]): number[] {
+    return []
+  },
+
+  getStudyIdsForSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): number[] {
+    return []
+  },
+
+  makeColumns(_props?: ColumnsProps): GridColDef[] {
+    return makeIntellectualPropertyColumns() as GridColDef[]
+  },
+}

--- a/src/components/data_library/columns/intellectualPropertyColumns.tsx
+++ b/src/components/data_library/columns/intellectualPropertyColumns.tsx
@@ -1,0 +1,200 @@
+import React from 'react'
+import { GridColDef } from '@mui/x-data-grid'
+import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { IntellectualPropertyAsset } from 'src/types/library'
+
+/**
+ * Column definitions for the Intellectual Property view in the Data Library.
+ */
+export const makeIntellectualPropertyColumns = (): GridColDef<IntellectualPropertyAsset>[] => [
+  {
+    field: 'title',
+    headerName: 'Title',
+    flex: 2,
+    minWidth: 220,
+    renderCell: (params) => {
+      const text = params.value || ''
+      const url = params.row.url
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {url
+              ? (
+                  <Link href={url} target="_blank" rel="noopener noreferrer" underline="hover">
+                    {text}
+                  </Link>
+                )
+              : text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'studyName',
+    headerName: 'Study',
+    flex: 1,
+    minWidth: 150,
+    renderCell: params => (
+      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+        {params.value}
+      </Link>
+    ),
+  },
+  {
+    field: 'type',
+    headerName: 'Type',
+    width: 140,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'patentNumber',
+    headerName: 'Patent Number',
+    width: 160,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'assignee',
+    headerName: 'Assignee',
+    flex: 1,
+    minWidth: 140,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'status',
+    headerName: 'Status',
+    width: 130,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Box
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </Box>
+      )
+    },
+  },
+  {
+    field: 'filingDate',
+    headerName: 'Filing Date',
+    width: 130,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Box
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </Box>
+      )
+    },
+  },
+  {
+    field: 'contact',
+    headerName: 'Contact',
+    flex: 1,
+    minWidth: 140,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'tags',
+    headerName: 'Tags',
+    flex: 1,
+    minWidth: 120,
+    sortable: false,
+    renderCell: (params) => {
+      const tags: string[] = params.value || []
+      if (tags.length === 0) {
+        return null
+      }
+      const maxVisible = 3
+      const visible = tags.slice(0, maxVisible)
+      const overflow = tags.length - maxVisible
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'nowrap', overflow: 'hidden' }}>
+          {visible.map(tag => (
+            <Chip key={tag} label={tag} size="small" variant="outlined" />
+          ))}
+          {overflow > 0 && (
+            <Chip label={`+${overflow}`} size="small" variant="outlined" />
+          )}
+        </Box>
+      )
+    },
+  },
+]

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -72,6 +72,7 @@ export const DataLibrary: React.FC = () => {
     { key: AssetType.BIOSPECIMENS, label: 'Biospecimens' },
     { key: AssetType.PUBLICATIONS, label: 'Publications' },
     { key: AssetType.PRESENTATIONS, label: 'Presentations' },
+    { key: AssetType.INTELLECTUAL_PROPERTY, label: 'Intellectual Property' },
     { key: AssetType.FUNDING_RESOURCES, label: 'Funding Resources' },
   ]
 

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -1,4 +1,4 @@
-import { ClinicalTrialAsset, BiospecimenAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset, SortOrder } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, IntellectualPropertyAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset, SortOrder } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 export interface MatchQuery {
@@ -333,6 +333,34 @@ export interface PresentationStudyAggregationBucket {
 
 export interface PresentationStudyAggregationResponse {
   buckets: PresentationStudyAggregationBucket[]
+}
+
+/** Raw Elasticsearch document shape for an intellectual property asset */
+export type PartialIntellectualPropertyAsset = Partial<IntellectualPropertyAsset>
+
+/** Bucket shape from a terms aggregation on study.studyId, used for the Intellectual Property view */
+export interface IntellectualPropertyStudyAggregationBucket {
+  key: number
+  doc_count: number
+  study_details?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          study?: {
+            studyId?: number
+            studyName?: string
+            assets?: {
+              intellectualProperties?: PartialIntellectualPropertyAsset[]
+            }
+          }
+        }
+      }>
+    }
+  }
+}
+
+export interface IntellectualPropertyStudyAggregationResponse {
+  buckets: IntellectualPropertyStudyAggregationBucket[]
 }
 
 /** Raw Elasticsearch document shape for a funding resource asset */

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -2,7 +2,7 @@
  * Type definitions for the Data Library feature
  */
 import { SnapshotSummaryModel } from 'src/types/tdrModel'
-import { AiModel, Biospecimen, ClinicalTrial, Presentation, Publication, FundingResource } from 'src/types/model'
+import { AiModel, Biospecimen, ClinicalTrial, IntellectualProperty, Presentation, Publication, FundingResource } from 'src/types/model'
 
 export enum AssetType {
   STUDIES = 'studies',
@@ -12,6 +12,7 @@ export enum AssetType {
   BIOSPECIMENS = 'biospecimens',
   PUBLICATIONS = 'publications',
   PRESENTATIONS = 'presentations',
+  INTELLECTUAL_PROPERTY = 'intellectual_properties',
   FUNDING_RESOURCES = 'funding_resources',
 }
 
@@ -165,6 +166,11 @@ export interface PublicationAsset extends Omit<Publication, 'studyId'> {
 }
 
 export interface PresentationAsset extends Omit<Presentation, 'studyId'> {
+  studyId: number
+  studyName: string
+}
+
+export interface IntellectualPropertyAsset extends Omit<IntellectualProperty, 'studyId'> {
   studyId: number
   studyName: string
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3015

### Summary

Add IP asset tab to new data library with tests.

<img width="532" height="61" alt="Screenshot 2026-03-05 at 9 51 00 AM" src="https://github.com/user-attachments/assets/36d392d3-eebd-46f8-b6c8-68d050a79f5b" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
