### PR TITLE
[DT-3067] Add workspaces asset tab to new data library

### DIFF
--- a/cypress/component/data_library/assets/workspaceAsset.spec.ts
+++ b/cypress/component/data_library/assets/workspaceAsset.spec.ts
@@ -1,0 +1,392 @@
+/**
+ * Unit tests for workspaceAsset — the Workspaces AssetDefinition.
+ *
+ * These tests are purely logic-level (no DOM mounting) so they run quickly
+ * in the Cypress component runner via plain `describe` / `it` blocks.
+ */
+import { workspaceAsset } from 'src/components/data_library/assets/workspaceAsset'
+import { WorkspaceAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  WorkspaceStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+/** Build a minimal WorkspaceStudyAggregationBucket */
+const makeBucket = (
+  studyId: number,
+  workspaces: Array<{
+    workspaceId?: string
+    name?: string
+    platform?: string
+    url?: string
+    description?: string
+    tools?: string[]
+    access?: string
+    tags?: string[]
+  }> = [],
+  studyName = 'Test Study',
+): WorkspaceStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: workspaces.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                workspaces: workspaces.map(w => ({
+                  workspaceId: w.workspaceId,
+                  name: w.name,
+                  platform: w.platform,
+                  url: w.url,
+                  description: w.description,
+                  tools: w.tools,
+                  access: w.access,
+                  tags: w.tags,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+/** Wrap buckets in a full ElasticsearchResponse */
+const makeResponse = (
+  buckets: WorkspaceStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+// ---------------------------------------------------------------------------
+// label
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — label', () => {
+  it('has singular "Workspace" and plural "Workspaces"', () => {
+    expect(workspaceAsset.label.singular).to.equal('Workspace')
+    expect(workspaceAsset.label.plural).to.equal('Workspaces')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sortingMode
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(workspaceAsset.sortingMode).to.equal('client')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// searchFields
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — searchFields', () => {
+  it('includes workspace-specific fields', () => {
+    expect(workspaceAsset.searchFields).to.include('study.assets.workspaces.name')
+    expect(workspaceAsset.searchFields).to.include('study.assets.workspaces.platform')
+    expect(workspaceAsset.searchFields).to.include('study.assets.workspaces.description')
+    expect(workspaceAsset.searchFields).to.include('study.assets.workspaces.tools')
+    expect(workspaceAsset.searchFields).to.include('study.assets.workspaces.tags')
+  })
+
+  it('includes study-level fields', () => {
+    expect(workspaceAsset.searchFields).to.include('study.studyName')
+    expect(workspaceAsset.searchFields).to.include('study.piName')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildQuery
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).to.equal(0)
+    expect(q.from).to.equal(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).to.have.property('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).to.equal('study.studyId')
+    expect(studiesAgg.terms.size).to.equal(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).to.have.length(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).to.equal('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).to.equal(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'controlled' },
+    }
+    const q = workspaceAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).to.have.length(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'name', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = workspaceAsset.buildQuery([existsClause], [], largePagination, sort)
+    // size should still be 0 — pagination is applied client-side in transformResponse
+    expect(q.size).to.equal(0)
+    expect(q.sort).to.equal(undefined)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// transformResponse
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = workspaceAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+
+  it('flattens workspaces from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ workspaceId: 'w1', name: 'Alpha' }, { workspaceId: 'w2', name: 'Beta' }]),
+      makeBucket(2, [{ workspaceId: 'w3', name: 'Gamma' }]),
+    ])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(3)
+    expect(result.total).to.equal(3)
+  })
+
+  it('maps fields correctly from bucket to WorkspaceAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        workspaceId: 'ws-xyz',
+        name: 'Terra Workspace',
+        platform: 'Terra',
+        url: 'https://app.terra.bio/#workspaces/test/example',
+        description: 'A test workspace',
+        tools: ['WDL', 'Jupyter'],
+        access: 'open',
+        tags: ['genomics', 'cloud'],
+      }], 'NHGRI Study'),
+    ])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    const row = result.items[0] as WorkspaceAsset
+    expect(row.workspaceId).to.equal('ws-xyz')
+    expect(row.studyId).to.equal(42)
+    expect(row.studyName).to.equal('NHGRI Study')
+    expect(row.name).to.equal('Terra Workspace')
+    expect(row.platform).to.equal('Terra')
+    expect(row.url).to.equal('https://app.terra.bio/#workspaces/test/example')
+    expect(row.description).to.equal('A test workspace')
+    expect(row.tools).to.deep.equal(['WDL', 'Jupyter'])
+    expect(row.access).to.equal('open')
+    expect(row.tags).to.deep.equal(['genomics', 'cloud'])
+  })
+
+  it('falls back to composite key when workspaceId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ name: 'No-Id Workspace' }]),
+    ])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    const row = result.items[0] as WorkspaceAsset
+    // composite fallback: `${bucket.key}-${index}`
+    expect(row.workspaceId).to.equal('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const workspaces = Array.from({ length: 30 }, (_, i) => ({
+      workspaceId: `w${i}`,
+      name: `Workspace ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, workspaces)])
+
+    const page0 = workspaceAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).to.have.length(10)
+    expect((page0.items[0] as WorkspaceAsset).name).to.equal('Workspace 0')
+
+    const page1 = workspaceAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).to.have.length(10)
+    expect((page1.items[0] as WorkspaceAsset).name).to.equal('Workspace 10')
+
+    const page2 = workspaceAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).to.have.length(10)
+    expect((page2.items[0] as WorkspaceAsset).name).to.equal('Workspace 20')
+  })
+
+  it('reports total as the number of all workspaces across all studies (not just page)', () => {
+    const workspaces = Array.from({ length: 30 }, (_, i) => ({ workspaceId: `w${i}` }))
+    const response = makeResponse([makeBucket(1, workspaces)])
+    const result = workspaceAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).to.equal(30)
+  })
+
+  it('returns empty tools / access / tags defaults for missing fields', () => {
+    const response = makeResponse([
+      makeBucket(1, [{}]),
+    ])
+    const row = workspaceAsset.transformResponse(response, pagination).items[0] as WorkspaceAsset
+    expect(row.tools).to.deep.equal([])
+    expect(row.tags).to.deep.equal([])
+    expect(row.access).to.equal('')
+    expect(row.name).to.equal('')
+    expect(row.platform).to.equal('')
+    expect(row.description).to.equal('')
+  })
+
+  it('handles a study bucket with no workspaces gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    expect(result.items).to.have.length(0)
+    expect(result.total).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getRowId
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — getRowId', () => {
+  it('returns the workspaceId of the row', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    expect(workspaceAsset.getRowId(row)).to.equal('abc-123')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isRowSelectable
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — isRowSelectable', () => {
+  it('always returns false — workspaces do not participate in access requests', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'w1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    expect(workspaceAsset.isRowSelectable(row)).to.equal(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// computeRowSelection
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'w1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    const result = workspaceAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).to.equal(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// selectionToDatasetIds
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = workspaceAsset.selectionToDatasetIds([], ['w1', 'w2'])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getStudyIdsForSelection
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'w1',
+      studyId: 42,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    const result = workspaceAsset.getStudyIdsForSelection([row], [1])
+    expect(result).to.deep.equal([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// makeColumns
+// ---------------------------------------------------------------------------
+
+describe('workspaceAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = workspaceAsset.makeColumns()
+    expect(cols).to.be.an('array')
+    expect(cols.length).to.be.greaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = workspaceAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).to.include('name')
+    expect(fields).to.include('studyName')
+    expect(fields).to.include('platform')
+    expect(fields).to.include('url')
+    expect(fields).to.include('description')
+    expect(fields).to.include('tools')
+    expect(fields).to.include('access')
+    expect(fields).to.include('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = workspaceAsset.makeColumns()
+    const b = workspaceAsset.makeColumns({})
+    expect(a.map(c => c.field)).to.deep.equal(b.map(c => c.field))
+  })
+})

--- a/cypress/component/data_library/columns/workspaceColumns.spec.tsx
+++ b/cypress/component/data_library/columns/workspaceColumns.spec.tsx
@@ -1,0 +1,210 @@
+/**
+ * Component tests for makeWorkspaceColumns — the column definitions used in the
+ * Workspaces tab of the Data Library.
+ *
+ * Each test mounts a minimal DataGrid with a single (or small set of) rows and
+ * inspects the rendered HTML to verify the column behaviour.
+ */
+import React from 'react'
+import { DataGrid } from '@mui/x-data-grid'
+import { makeWorkspaceColumns } from 'src/components/data_library/columns/workspaceColumns'
+import { makeWorkspaceRow } from '../../test-utils'
+
+const renderGrid = (overrides = {}) => {
+  const row = makeWorkspaceRow(overrides)
+  cy.mount(
+    <DataGrid
+      rows={[row]}
+      columns={makeWorkspaceColumns()}
+      getRowId={r => r.workspaceId}
+      autoHeight
+    />,
+  )
+}
+
+describe('makeWorkspaceColumns — Workspace Name column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the workspace name text', () => {
+    renderGrid({ name: 'Terra Analysis Workspace' })
+    cy.contains('Terra Analysis Workspace').should('exist')
+  })
+
+  it('renders an empty cell gracefully when name is absent', () => {
+    renderGrid({ name: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeWorkspaceColumns — Study column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders a link with the study name', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.contains('Genome Atlas').should('exist')
+  })
+
+  it('links to /studies/:studyId', () => {
+    renderGrid({ studyId: 7, studyName: 'Genome Atlas' })
+    cy.get('a[href="/studies/7"]').should('exist')
+  })
+})
+
+describe('makeWorkspaceColumns — Platform column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the platform text', () => {
+    renderGrid({ platform: 'AnVIL' })
+    cy.contains('AnVIL').should('exist')
+  })
+
+  it('renders an empty cell when platform is absent', () => {
+    renderGrid({ platform: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeWorkspaceColumns — URL column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders "Link" as a clickable anchor when url is present', () => {
+    renderGrid({ url: 'https://app.terra.bio/#workspaces/test/example' })
+    cy.get('a[href="https://app.terra.bio/#workspaces/test/example"]')
+      .contains('Link')
+      .should('exist')
+  })
+
+  it('renders nothing when url is absent', () => {
+    renderGrid({ url: '' })
+    cy.get('a').filter(':contains("Link")').should('not.exist')
+  })
+
+  it('sets target="_blank" and rel="noopener noreferrer" for external links', () => {
+    renderGrid({ url: 'https://example.com/workspace' })
+    cy.get('a[href="https://example.com/workspace"]')
+      .should('have.attr', 'target', '_blank')
+      .and('have.attr', 'rel', 'noopener noreferrer')
+  })
+})
+
+describe('makeWorkspaceColumns — Description column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the description text', () => {
+    renderGrid({ description: 'A cloud-based genomics pipeline' })
+    cy.contains('A cloud-based genomics pipeline').should('exist')
+  })
+
+  it('renders an empty cell when description is absent', () => {
+    renderGrid({ description: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeWorkspaceColumns — Tools column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders nothing when tools array is empty', () => {
+    renderGrid({ tools: [], tags: [] })
+    cy.get('.MuiChip-root').should('not.exist')
+  })
+
+  it('renders up to 3 chips for 3 tools', () => {
+    renderGrid({ tools: ['WDL', 'Jupyter', 'R'], tags: [] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.contains('WDL').should('exist')
+    cy.contains('Jupyter').should('exist')
+    cy.contains('R').should('exist')
+  })
+
+  it('shows "+N" overflow chip when there are more than 3 tools', () => {
+    renderGrid({ tools: ['WDL', 'Jupyter', 'R', 'Python', 'Nextflow'], tags: [] })
+    // 3 visible chips + 1 overflow chip = 4 chips total
+    cy.get('.MuiChip-root').should('have.length', 4)
+    cy.contains('+2').should('exist')
+  })
+
+  it('does not show an overflow chip for exactly 3 tools', () => {
+    renderGrid({ tools: ['WDL', 'Jupyter', 'R'], tags: [] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.get('.MuiChip-root').each(($chip) => {
+      expect($chip.text()).to.not.match(/^\+\d+$/)
+    })
+  })
+})
+
+describe('makeWorkspaceColumns — Access column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders the access text', () => {
+    renderGrid({ access: 'controlled' })
+    cy.contains('controlled').should('exist')
+  })
+
+  it('renders an empty cell when access is absent', () => {
+    renderGrid({ access: '' })
+    cy.get('.MuiDataGrid-root').should('exist')
+  })
+})
+
+describe('makeWorkspaceColumns — Tags column', () => {
+  beforeEach(() => cy.viewport(1400, 800))
+
+  it('renders nothing when tags array is empty', () => {
+    renderGrid({ tags: [], tools: [] })
+    cy.get('.MuiChip-root').should('not.exist')
+  })
+
+  it('renders up to 3 chips for 3 tags', () => {
+    renderGrid({ tools: [], tags: ['genomics', 'cloud', 'wgs'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.contains('genomics').should('exist')
+    cy.contains('cloud').should('exist')
+    cy.contains('wgs').should('exist')
+  })
+
+  it('shows "+N" overflow chip when there are more than 3 tags', () => {
+    renderGrid({ tools: [], tags: ['t1', 't2', 't3', 't4', 't5'] })
+    cy.get('.MuiChip-root').should('have.length', 4)
+    cy.contains('+2').should('exist')
+  })
+
+  it('does not show an overflow chip for exactly 3 tags', () => {
+    renderGrid({ tools: [], tags: ['a', 'b', 'c'] })
+    cy.get('.MuiChip-root').should('have.length', 3)
+    cy.get('.MuiChip-root').each(($chip) => {
+      expect($chip.text()).to.not.match(/^\+\d+$/)
+    })
+  })
+})
+
+describe('makeWorkspaceColumns — column structure', () => {
+  it('returns 8 column definitions', () => {
+    const cols = makeWorkspaceColumns()
+    expect(cols).to.have.length(8)
+  })
+
+  it('defines expected fields in order', () => {
+    const fields = makeWorkspaceColumns().map(c => c.field)
+    expect(fields).to.deep.equal([
+      'name',
+      'studyName',
+      'platform',
+      'url',
+      'description',
+      'tools',
+      'access',
+      'tags',
+    ])
+  })
+
+  it('marks url, tools, and tags as non-sortable', () => {
+    const cols = makeWorkspaceColumns()
+    const urlCol = cols.find(c => c.field === 'url')!
+    const toolsCol = cols.find(c => c.field === 'tools')!
+    const tagsCol = cols.find(c => c.field === 'tags')!
+    expect(urlCol.sortable).to.equal(false)
+    expect(toolsCol.sortable).to.equal(false)
+    expect(tagsCol.sortable).to.equal(false)
+  })
+})

--- a/cypress/component/test-utils.ts
+++ b/cypress/component/test-utils.ts
@@ -1,5 +1,5 @@
 import { BioSpecimenPreservationMethod, BioSpecimenType, ClinicalTrialInterventionType, ClinicalTrialPhase, ClinicalTrialStatus, DatasetTerm, Sex, StudyTerm, UserTerm } from 'src/types/model'
-import { ClinicalTrialAsset, BiospecimenAsset, IntellectualPropertyAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, IntellectualPropertyAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset, WorkspaceAsset } from 'src/types/library'
 
 export const makeUserTerm = (overrides: Partial<UserTerm> = {}): UserTerm => ({
   userId: 0,
@@ -155,6 +155,20 @@ export const makeIntellectualPropertyRow = (overrides: Partial<IntellectualPrope
   url: 'https://patents.example.com/US12345678',
   contact: 'ip@broadinstitute.org',
   tags: ['genomics', 'sequencing'],
+  ...overrides,
+})
+
+export const makeWorkspaceRow = (overrides: Partial<WorkspaceAsset> = {}): WorkspaceAsset => ({
+  workspaceId: 'ws-001',
+  studyId: 42,
+  studyName: 'Test Study',
+  name: 'My Workspace',
+  platform: 'Terra',
+  url: 'https://app.terra.bio/#workspaces/test/my-workspace',
+  description: 'A test workspace for genomics analysis',
+  tools: ['WDL', 'Jupyter'],
+  access: 'open',
+  tags: ['genomics', 'cloud'],
   ...overrides,
 })
 

--- a/src/components/data_library/assets/definition.ts
+++ b/src/components/data_library/assets/definition.ts
@@ -21,11 +21,12 @@ import {
   PublicationAsset,
   SortState,
   StudyAggregation,
+  WorkspaceAsset,
 } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 /** Union of every row type that can appear in the DataGrid */
-export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset | PresentationAsset | IntellectualPropertyAsset | FundingResourceAsset
+export type LibraryRow = DatasetTerm | StudyAggregation | ModelAsset | WorkspaceAsset | ClinicalTrialAsset | BiospecimenAsset | PublicationAsset | PresentationAsset | IntellectualPropertyAsset | FundingResourceAsset
 
 /** Normalized result returned by every asset's `transformResponse` */
 export interface LibraryPage {

--- a/src/components/data_library/assets/index.ts
+++ b/src/components/data_library/assets/index.ts
@@ -14,6 +14,7 @@ import { AssetDefinition } from 'src/components/data_library/assets/definition'
 import { studyAsset } from 'src/components/data_library/assets/studyAsset'
 import { datasetAsset } from 'src/components/data_library/assets/datasetAsset'
 import { modelAsset } from 'src/components/data_library/assets/modelAsset'
+import { workspaceAsset } from 'src/components/data_library/assets/workspaceAsset'
 import { clinicalTrialAsset } from 'src/components/data_library/assets/clinicalTrialAsset'
 import { biospecimenAsset } from 'src/components/data_library/assets/biospecimenAsset'
 import { publicationAsset } from 'src/components/data_library/assets/publicationAsset'
@@ -32,6 +33,7 @@ export const assetRegistry: Record<AssetType, AssetDefinition> = {
   [AssetType.STUDIES]: studyAsset,
   [AssetType.DATASETS]: datasetAsset,
   [AssetType.MODELS]: modelAsset,
+  [AssetType.WORKSPACES]: workspaceAsset,
   [AssetType.CLINICAL_TRIALS]: clinicalTrialAsset,
   [AssetType.BIOSPECIMENS]: biospecimenAsset,
   [AssetType.PUBLICATIONS]: publicationAsset,

--- a/src/components/data_library/assets/workspaceAsset.ts
+++ b/src/components/data_library/assets/workspaceAsset.ts
@@ -1,0 +1,115 @@
+import { GridColDef } from '@mui/x-data-grid'
+import { ElasticsearchQuery, ElasticsearchResponse, WorkspaceStudyAggregationResponse, QueryClause } from 'src/types/elastic'
+import { WorkspaceAsset, PaginationState, SortState } from 'src/types/library'
+import { makeWorkspaceColumns } from 'src/components/data_library/columns/workspaceColumns'
+import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
+
+export const workspaceAsset: AssetDefinition = {
+  label: { singular: 'Workspace', plural: 'Workspaces' },
+  sortingMode: 'client',
+  searchFields: [
+    'study.studyName',
+    'study.description',
+    'study.piName',
+    'study.assets.workspaces.name',
+    'study.assets.workspaces.platform',
+    'study.assets.workspaces.description',
+    'study.assets.workspaces.tools',
+    'study.assets.workspaces.tags',
+  ],
+
+  buildQuery(
+    queryChunks: QueryClause[],
+    filterQuery: QueryClause[],
+    _pagination: PaginationState,
+    _sort?: SortState,
+  ): ElasticsearchQuery {
+    // Aggregate by study to extract nested workspace assets stored under
+    // study.assets.workspaces; client-side pagination is applied in transformResponse.
+    return {
+      size: 0,
+      query: {
+        bool: {
+          must: queryChunks,
+          ...(filterQuery.length > 0 && { filter: filterQuery }),
+        },
+      },
+      aggs: {
+        studies: {
+          terms: {
+            field: 'study.studyId',
+            size: 10000,
+          },
+          aggs: {
+            study_details: {
+              top_hits: {
+                size: 1,
+                _source: ['study.*'],
+              },
+            },
+          },
+        },
+      },
+    }
+  },
+
+  transformResponse(response: ElasticsearchResponse, pagination: PaginationState): LibraryPage {
+    const studiesAgg = response.aggregations?.studies as WorkspaceStudyAggregationResponse | undefined
+    const buckets = studiesAgg?.buckets || []
+    const workspaces: WorkspaceAsset[] = []
+
+    for (const bucket of buckets) {
+      const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
+      const studyWorkspaces = studyData.assets?.workspaces || []
+      for (const [workspaceIndex, workspace] of studyWorkspaces.entries()) {
+        // workspaceId may be absent from the indexed document; fall back to a
+        // composite key so every row in the DataGrid has a unique id.
+        workspaces.push({
+          workspaceId: workspace.workspaceId || `${bucket.key}-${workspaceIndex}`,
+          studyId: bucket.key,
+          studyName: studyData.studyName || '',
+          name: workspace.name || '',
+          platform: workspace.platform || '',
+          url: workspace.url || '',
+          description: workspace.description || '',
+          tools: workspace.tools || [],
+          access: workspace.access || '',
+          tags: workspace.tags || [],
+        })
+      }
+    }
+
+    const total = workspaces.length
+    const start = pagination.page * pagination.pageSize
+    return {
+      items: workspaces.slice(start, start + pagination.pageSize),
+      total,
+      aggregations: response.aggregations || {},
+    }
+  },
+
+  getRowId(row: LibraryRow): string | number {
+    return (row as WorkspaceAsset).workspaceId
+  },
+
+  isRowSelectable(_row: LibraryRow): boolean {
+    // Workspaces do not participate in dataset-level access requests
+    return false
+  },
+
+  computeRowSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): Set<string | number> {
+    return new Set()
+  },
+
+  selectionToDatasetIds(_data: LibraryRow[], _selectedRowIds: (string | number)[]): number[] {
+    return []
+  },
+
+  getStudyIdsForSelection(_data: LibraryRow[], _selectedDatasetIds: number[]): number[] {
+    return []
+  },
+
+  makeColumns(_props?: ColumnsProps): GridColDef[] {
+    return makeWorkspaceColumns() as GridColDef[]
+  },
+}

--- a/src/components/data_library/columns/workspaceColumns.tsx
+++ b/src/components/data_library/columns/workspaceColumns.tsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import { GridColDef } from '@mui/x-data-grid'
+import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { WorkspaceAsset } from 'src/types/library'
+
+/**
+ * Column definitions for the Workspaces view
+ */
+export const makeWorkspaceColumns = (): GridColDef<WorkspaceAsset>[] => [
+  {
+    field: 'name',
+    headerName: 'Workspace Name',
+    flex: 1.5,
+    minWidth: 200,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'studyName',
+    headerName: 'Study',
+    flex: 1,
+    minWidth: 150,
+    renderCell: params => (
+      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+        {params.value}
+      </Link>
+    ),
+  },
+  {
+    field: 'platform',
+    headerName: 'Platform',
+    width: 150,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'url',
+    headerName: 'URL',
+    width: 80,
+    sortable: false,
+    renderCell: params =>
+      params.value
+        ? (
+            <Link
+              href={params.value}
+              underline="hover"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Link
+            </Link>
+          )
+        : null,
+  },
+  {
+    field: 'description',
+    headerName: 'Description',
+    flex: 2,
+    minWidth: 200,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'tools',
+    headerName: 'Tools',
+    flex: 1,
+    minWidth: 150,
+    sortable: false,
+    valueGetter: (_value, row) => (row.tools || []).join(', '),
+    renderCell: (params) => {
+      const tools = params.row.tools || []
+      if (tools.length === 0) return null
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {tools.slice(0, 3).map((tool, i) => (
+            <Chip key={i} label={tool} size="small" variant="outlined" />
+          ))}
+          {tools.length > 3 && (
+            <Tooltip title={tools.slice(3).join(', ')}>
+              <Chip label={`+${tools.length - 3}`} size="small" variant="outlined" />
+            </Tooltip>
+          )}
+        </Box>
+      )
+    },
+  },
+  {
+    field: 'access',
+    headerName: 'Access',
+    width: 120,
+    renderCell: (params) => {
+      const text = params.value || ''
+      return (
+        <Tooltip title={text} placement="top">
+          <Box
+            sx={{
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {text}
+          </Box>
+        </Tooltip>
+      )
+    },
+  },
+  {
+    field: 'tags',
+    headerName: 'Tags',
+    flex: 1,
+    minWidth: 150,
+    sortable: false,
+    valueGetter: (_value, row) => (row.tags || []).join(', '),
+    renderCell: (params) => {
+      const tags = params.row.tags || []
+      if (tags.length === 0) return null
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {tags.slice(0, 3).map((tag, i) => (
+            <Chip key={i} label={tag} size="small" variant="outlined" />
+          ))}
+          {tags.length > 3 && (
+            <Tooltip title={tags.slice(3).join(', ')}>
+              <Chip label={`+${tags.length - 3}`} size="small" variant="outlined" />
+            </Tooltip>
+          )}
+        </Box>
+      )
+    },
+  },
+]

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -68,6 +68,7 @@ export const DataLibrary: React.FC = () => {
     { key: AssetType.STUDIES, label: 'Studies' },
     { key: AssetType.DATASETS, label: 'Datasets' },
     { key: AssetType.MODELS, label: 'AI Models' },
+    { key: AssetType.WORKSPACES, label: 'Workspaces' },
     { key: AssetType.CLINICAL_TRIALS, label: 'Clinical Trials' },
     { key: AssetType.BIOSPECIMENS, label: 'Biospecimens' },
     { key: AssetType.PUBLICATIONS, label: 'Publications' },

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -1,4 +1,4 @@
-import { ClinicalTrialAsset, BiospecimenAsset, IntellectualPropertyAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset, SortOrder } from 'src/types/library'
+import { ClinicalTrialAsset, BiospecimenAsset, IntellectualPropertyAsset, ModelAsset, PresentationAsset, PublicationAsset, FundingResourceAsset, WorkspaceAsset, SortOrder } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 
 export interface MatchQuery {
@@ -389,6 +389,34 @@ export interface FundingResourceStudyAggregationBucket {
 
 export interface FundingResourceStudyAggregationResponse {
   buckets: FundingResourceStudyAggregationBucket[]
+}
+
+/** Raw Elasticsearch document shape for a workspace asset */
+export type PartialWorkspaceAsset = Partial<WorkspaceAsset>
+
+/** Bucket shape from a terms aggregation on study.studyId, used for the Workspaces view */
+export interface WorkspaceStudyAggregationBucket {
+  key: number
+  doc_count: number
+  study_details?: {
+    hits?: {
+      hits?: Array<{
+        _source?: {
+          study?: {
+            studyId?: number
+            studyName?: string
+            assets?: {
+              workspaces?: PartialWorkspaceAsset[]
+            }
+          }
+        }
+      }>
+    }
+  }
+}
+
+export interface WorkspaceStudyAggregationResponse {
+  buckets: WorkspaceStudyAggregationBucket[]
 }
 
 export interface PaginatedResponse<T> {

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -2,12 +2,13 @@
  * Type definitions for the Data Library feature
  */
 import { SnapshotSummaryModel } from 'src/types/tdrModel'
-import { AiModel, Biospecimen, ClinicalTrial, IntellectualProperty, Presentation, Publication, FundingResource } from 'src/types/model'
+import { AiModel, Biospecimen, ClinicalTrial, IntellectualProperty, Presentation, Publication, FundingResource, Workspace } from 'src/types/model'
 
 export enum AssetType {
   STUDIES = 'studies',
   DATASETS = 'datasets',
   MODELS = 'models',
+  WORKSPACES = 'workspaces',
   CLINICAL_TRIALS = 'clinical_trials',
   BIOSPECIMENS = 'biospecimens',
   PUBLICATIONS = 'publications',
@@ -144,6 +145,11 @@ export interface LibraryFooterProps {
 }
 
 export interface ModelAsset extends Omit<AiModel, 'studyId'> {
+  studyId: number
+  studyName: string
+}
+
+export interface WorkspaceAsset extends Omit<Workspace, 'studyId'> {
   studyId: number
   studyName: string
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3067

### Summary

Add workspaces to the new data library with tests.

<img width="412" height="200" alt="Screenshot 2026-03-05 at 1 47 32 PM" src="https://github.com/user-attachments/assets/3527c48f-4a15-49a4-961a-bd120286266c" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
