### PR TITLE
[DT-2976] Ensure dataset columns are in correct order

### DIFF
--- a/cypress/component/data_library/columns/datasetColumns.spec.tsx
+++ b/cypress/component/data_library/columns/datasetColumns.spec.tsx
@@ -7,6 +7,23 @@ import { makeDatasetTerm } from '../../test-utils'
  * Tests for makeDatasetColumns — focused on the Access Management chip
  * color and label rendering for each AccessManagement value.
  */
+describe('datasetColumns — column order', () => {
+  it('returns columns in the expected order', () => {
+    const columns = makeDatasetColumns()
+    const fields = columns.map(c => c.field)
+    expect(fields).to.deep.equal([
+      'datasetName',
+      'studyName',
+      'datasetIdentifier',
+      'accessManagement',
+      'participantCount',
+      'dataUse',
+      'dac',
+      'actions',
+    ])
+  })
+})
+
 describe('datasetColumns — Access Management chip', () => {
   beforeEach(() => {
     cy.viewport(1200, 800)

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -37,36 +37,9 @@ export const makeDatasetColumns = (
     ),
   },
   {
-    field: 'participantCount',
-    headerName: 'Participants',
-    width: 120,
-    type: 'number',
-    align: 'right',
-    headerAlign: 'right',
-  },
-  {
-    field: 'dataUse',
-    headerName: 'Data Use',
+    field: 'datasetIdentifier',
+    headerName: 'Identifier',
     width: 150,
-    valueGetter: (_value, row) => row.dataUse?.primary?.[0]?.code || '',
-    renderCell: (params) => {
-      const codes = params.row.dataUse?.primary?.map(du => du.code).filter(Boolean) || []
-      if (codes.length === 0) return null
-
-      return (
-        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
-          {codes.slice(0, 2).map((code, idx) => (
-            <Chip key={idx} label={code} size="small" variant="outlined" />
-          ))}
-          {codes.length > 2 && (
-            <Tooltip title={codes.slice(2).join(', ')}>
-              <Chip label={`+${codes.length - 2}`} size="small" variant="outlined" />
-            </Tooltip>
-          )}
-        </Box>
-      )
-    },
-    sortable: false,
   },
   {
     field: 'accessManagement',
@@ -111,15 +84,42 @@ export const makeDatasetColumns = (
     },
   },
   {
+    field: 'participantCount',
+    headerName: 'Participants',
+    width: 120,
+    type: 'number',
+    align: 'right',
+    headerAlign: 'right',
+  },
+  {
+    field: 'dataUse',
+    headerName: 'Data Use',
+    width: 150,
+    valueGetter: (_value, row) => row.dataUse?.primary?.[0]?.code || '',
+    renderCell: (params) => {
+      const codes = params.row.dataUse?.primary?.map(du => du.code).filter(Boolean) || []
+      if (codes.length === 0) return null
+
+      return (
+        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap' }}>
+          {codes.slice(0, 2).map((code, idx) => (
+            <Chip key={idx} label={code} size="small" variant="outlined" />
+          ))}
+          {codes.length > 2 && (
+            <Tooltip title={codes.slice(2).join(', ')}>
+              <Chip label={`+${codes.length - 2}`} size="small" variant="outlined" />
+            </Tooltip>
+          )}
+        </Box>
+      )
+    },
+    sortable: false,
+  },
+  {
     field: 'dac',
     headerName: 'DAC',
     width: 150,
     valueGetter: (_value, row) => row.dac?.dacName || '',
-  },
-  {
-    field: 'datasetIdentifier',
-    headerName: 'Identifier',
-    width: 150,
   },
   {
     field: 'actions',


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2976

### Summary

Reorders the columns to match the old data library, and adds a test.

<img width="942" height="124" alt="Screenshot 2026-03-09 at 8 12 12 AM" src="https://github.com/user-attachments/assets/fbb72084-438e-428b-b589-2c6487864899" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
