### PR TITLE
[DT-2974] Remove useRef and add search debounce

### DIFF
--- a/cypress/component/DataSearch/dataset_search_table.spec.jsx
+++ b/cypress/component/DataSearch/dataset_search_table.spec.jsx
@@ -37,7 +37,6 @@ describe('DatasetSearchTable (component) - basic tests', () => {
     cy.initApplicationConfig()
     cy.stub(TerraDataRepo, 'listSnapshotsByDatasetIds').returns({})
     cy.stub(DAC, 'fetchDACbotRules').resolves([])
-    cy.clock()
   })
 
   it('does not trigger an initial search on mount', () => {
@@ -70,7 +69,6 @@ describe('DatasetSearchTable (component) - basic tests', () => {
     )
 
     cy.get('[data-cy="search-bar"]').type('query')
-    cy.tick(150)
 
     cy.wait('@searchIndex').then(() => {
       expect(seen).to.include('study.publicVisibility')
@@ -93,7 +91,6 @@ describe('DatasetSearchTable (component) - basic tests', () => {
     )
 
     cy.get('[data-cy="search-bar"]').type('query')
-    cy.tick(150)
 
     cy.wait('@searchIndex').then(() => {
       expect(seen).to.not.include('study.publicVisibility')
@@ -114,17 +111,10 @@ describe('DatasetSearchTable (component) - basic tests', () => {
 
     // Trigger first search and quickly trigger a second one
     cy.get('[data-cy="search-bar"]').type('first')
-    cy.tick(50)
     cy.get('[data-cy="search-bar"]').clear()
     cy.get('[data-cy="search-bar"]').type('second')
 
-    // Advance time enough for debounced calls and the fake responses
-    cy.tick(300)
-
-    cy.wrap(null).then(() => {
-      // Debouncing may collapse rapid inputs into a single request; ensure at least one call occurred
-      expect(dsStub.callCount).to.be.at.least(1)
-    })
+    cy.wrap(dsStub).should('have.been.called')
   })
 })
 

--- a/cypress/component/SearchBar.spec.tsx
+++ b/cypress/component/SearchBar.spec.tsx
@@ -42,7 +42,7 @@ describe('SearchBar', () => {
     // With text: clear icon appears and the input shifts to accommodate it
     cy.get('[data-cy="clear-search"]').should('exist')
     cy.get('[data-cy="search-bar"]').then(($input) => {
-      const paddingRight = parseFloat(getComputedStyle($input[0]).paddingRight)
+      const paddingRight = Number.parseFloat(getComputedStyle($input[0]).paddingRight)
       expect(paddingRight).to.be.greaterThan(0)
     })
   })

--- a/cypress/component/SearchBar.spec.tsx
+++ b/cypress/component/SearchBar.spec.tsx
@@ -28,16 +28,92 @@ describe('SearchBar', () => {
     cy.get('@change').should('have.been.calledWith', '')
   })
 
-  it('maintains padding when clear icon toggles', () => {
+  it('applies wider padding to input when clear icon is visible', () => {
     const onChange = cy.stub()
     cy.mount(<SearchBar handleSearchChange={onChange} />)
+
+    // Without text: input should not have the wider right-padding class
+    cy.get('[data-cy="search-bar"]')
+      .closest('.MuiInputBase-root')
+      .should('not.have.attr', 'data-show-clear')
+
     cy.get('[data-cy="search-bar"]').type('x')
-    cy.get('[data-cy="search-bar"]')
-      .parent()
-      .invoke('css', 'padding-right')
-    cy.get('[data-cy="clear-search"]').click()
-    cy.get('[data-cy="search-bar"]')
-      .parent()
-      .invoke('css', 'padding-right')
+
+    // With text: clear icon appears and the input shifts to accommodate it
+    cy.get('[data-cy="clear-search"]').should('exist')
+    cy.get('[data-cy="search-bar"]').then(($input) => {
+      const paddingRight = parseFloat(getComputedStyle($input[0]).paddingRight)
+      expect(paddingRight).to.be.greaterThan(0)
+    })
+  })
+
+  describe('debounce', () => {
+    it('does not call handler on mount', () => {
+      const onChange = cy.stub().as('change')
+      cy.mount(<SearchBar handleSearchChange={onChange} />)
+      cy.get('[data-cy="search-bar"]').should('exist')
+      cy.get('@change').should('not.have.been.called')
+    })
+
+    it('debounces rapid keystrokes into a single call with the final value', () => {
+      const onChange = cy.stub().as('change')
+      cy.mount(<SearchBar handleSearchChange={onChange} />)
+      // type() fires one change event per character — all within a few ms
+      cy.get('[data-cy="search-bar"]').type('hello')
+      // Handler should eventually be called exactly once with the full value
+      cy.get('@change').should('have.been.calledOnce')
+      cy.get('@change').should('have.been.calledWith', 'hello')
+    })
+
+    it('calls handler with updated value after further input', () => {
+      const onChange = cy.stub().as('change')
+      cy.mount(<SearchBar handleSearchChange={onChange} />)
+      cy.get('[data-cy="search-bar"]').type('foo')
+      cy.get('@change').should('have.been.calledWith', 'foo')
+      cy.get('[data-cy="search-bar"]').type('bar')
+      cy.get('@change').should('have.been.calledWith', 'foobar')
+    })
+  })
+
+  describe('initialValue prop', () => {
+    it('pre-populates the input', () => {
+      const onChange = cy.stub()
+      cy.mount(<SearchBar handleSearchChange={onChange} initialValue="prefilled" />)
+      cy.get('[data-cy="search-bar"]').should('have.value', 'prefilled')
+    })
+
+    it('shows clear icon when initialValue is non-empty', () => {
+      const onChange = cy.stub()
+      cy.mount(<SearchBar handleSearchChange={onChange} initialValue="something" />)
+      cy.get('[data-cy="clear-search"]').should('exist')
+    })
+
+    it('does not call handler on mount even with a non-empty initialValue', () => {
+      const onChange = cy.stub().as('change')
+      cy.mount(<SearchBar handleSearchChange={onChange} initialValue="pre" />)
+      cy.get('[data-cy="search-bar"]').should('have.value', 'pre')
+      cy.get('@change').should('not.have.been.called')
+    })
+
+    it('clears the pre-populated value when clear is clicked', () => {
+      const onChange = cy.stub().as('change')
+      cy.mount(<SearchBar handleSearchChange={onChange} initialValue="preset" />)
+      cy.get('[data-cy="clear-search"]').click()
+      cy.get('[data-cy="search-bar"]').should('have.value', '')
+      cy.get('[data-cy="clear-search"]').should('not.exist')
+      cy.get('@change').should('have.been.calledWith', '')
+    })
+  })
+
+  describe('placeholder prop', () => {
+    it('renders the default placeholder when none is provided', () => {
+      cy.mount(<SearchBar handleSearchChange={cy.stub()} />)
+      cy.get('[data-cy="search-bar"]').should('have.attr', 'placeholder', 'Enter search terms')
+    })
+
+    it('renders a custom placeholder when provided', () => {
+      cy.mount(<SearchBar handleSearchChange={cy.stub()} placeholder="Search datasets..." />)
+      cy.get('[data-cy="search-bar"]').should('have.attr', 'placeholder', 'Search datasets...')
+    })
   })
 })

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,16 +1,17 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Styles } from 'src/libs/theme'
 import SearchIcon from '@mui/icons-material/Search'
 import ClearIcon from '@mui/icons-material/Clear'
 import { styled } from '@mui/material/styles'
 import InputBase from '@mui/material/InputBase'
 import IconButton from '@mui/material/IconButton'
+import { useDebouncedValue } from 'src/hooks/useDebouncedValue'
 
 interface SearchBarProps {
   readonly handleSearchChange: (value: string) => void
+  readonly initialValue?: string
   readonly placeholder?: string
   readonly style?: React.CSSProperties
-  readonly searchRef?: React.RefObject<HTMLInputElement>
 }
 
 const Search = styled('div')(({ theme }) => ({
@@ -71,35 +72,41 @@ const StyledInputBase = styled(InputBase, {
 }))
 
 export default function SearchBar(props: SearchBarProps) {
-  const { handleSearchChange, placeholder = 'Enter search terms', style, searchRef } = props
-  const searchTerms = useRef<HTMLInputElement>(null)
-  const inputRef = searchRef || searchTerms
-  const [showClear, setShowClear] = useState(false)
+  const { handleSearchChange, initialValue = '', placeholder = 'Enter search terms', style } = props
+  const [value, setValue] = useState(initialValue)
+  const debouncedValue = useDebouncedValue(value, 300)
 
-  const emitValue = () => {
-    handleSearchChange(inputRef.current?.value || '')
-  }
+  // Always hold the latest handler without adding it as a dep —
+  // the effect should only fire when the debounced value changes,
+  // not on every parent re-render that produces a new function reference.
+  const handleSearchChangeRef = useRef(handleSearchChange)
+  useEffect(() => {
+    handleSearchChangeRef.current = handleSearchChange
+  })
+
+  // Skip the initial mount; only call when the user actually changes the value.
+  const isMounted = useRef(false)
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true
+      return
+    }
+    handleSearchChangeRef.current(debouncedValue)
+  }, [debouncedValue])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (inputRef.current) {
-      inputRef.current.value = e.target.value
-      setShowClear(!!inputRef.current.value)
-      emitValue()
-    }
+    setValue(e.target.value)
   }
 
   const handleClear = () => {
-    if (inputRef.current) {
-      inputRef.current.value = ''
-      setShowClear(false)
-      emitValue()
-    }
+    setValue('')
+    handleSearchChange('')
   }
 
   return (
     <div className="right-header-section" style={{ ...Styles.RIGHT_HEADER_SECTION, ...style }}>
       <Search>
-        {showClear && (
+        {!!value && (
           <ClearIconWrapper>
             <IconButton
               size="small"
@@ -113,11 +120,11 @@ export default function SearchBar(props: SearchBarProps) {
           </ClearIconWrapper>
         )}
         <StyledInputBase
-          showClear={showClear}
+          showClear={!!value}
           placeholder={placeholder}
           inputProps={{ 'aria-label': 'search', 'data-cy': 'search-bar' }}
+          value={value}
           onChange={handleChange}
-          inputRef={inputRef}
         />
         <SearchIconWrapper>
           <SearchIcon data-cy="search-icon" />

--- a/src/components/data_search/DatasetSearchTable.jsx
+++ b/src/components/data_search/DatasetSearchTable.jsx
@@ -44,7 +44,6 @@ export const DatasetSearchTable = (props) => {
   const [selected, setSelected] = useState([])
   const [selectedTable, setSelectedTable] = useState(datasetSearchTableTabs.dataset)
   const [searchTerm, setSearchTerm] = useState('')
-  const searchRef = useRef('')
   const hasRunInitialSearch = useRef(false)
 
   const isFilteredArray = (filter, category) => (filters[category]).indexOf(filter) > -1
@@ -299,7 +298,6 @@ export const DatasetSearchTable = (props) => {
         <Box sx={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
           <SearchBar
             handleSearchChange={handleSearchChange}
-            searchRef={searchRef}
           />
         </Box>
         <Box sx={{

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -1,12 +1,11 @@
 import dayjs from 'dayjs'
-import React, { useCallback, useRef, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import ReactTooltip from 'react-tooltip'
 import {
   calcTablePageCount,
   calcVisibleWindow,
   getSearchFilterFunctions,
   Notifications,
-  searchOnFilteredList,
 } from 'src/libs/utils'
 import { cloneDeep, findIndex, isEmpty, isNaN, isNil } from 'lodash'
 import { Styles } from 'src/libs/theme'
@@ -178,7 +177,7 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   const [visibleCards, setVisibleCards] = useState<LibraryCard[]>([])
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false)
   const [currentCard, setCurrentCard] = useState<LibraryCard>({} as LibraryCard)
-  const searchRef = useRef<HTMLInputElement>(null)
+  const [searchText, setSearchText] = useState<string>('')
 
   const columnHeaderData: ColumnHeader[] = [
     columnHeaderFormat.researcher,
@@ -214,15 +213,9 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
 
   // Hook to execute on initialization and card creation/deletion, applies filter on updated collection list
   React.useEffect(() => {
-    if (searchRef.current) {
-      const searchTerms = searchRef.current.value ?? ''
-      let filteredList = libraryCards
-      if (!isEmpty(searchTerms)) {
-        filteredList = lcFilterFunction(searchTerms, libraryCards)
-      }
-      setFilteredCards(filteredList)
-    }
-  }, [props.libraryCards, libraryCards])
+    const filteredList = isEmpty(searchText) ? libraryCards : lcFilterFunction(searchText, libraryCards)
+    setFilteredCards(filteredList)
+  }, [searchText, libraryCards])
 
   // Hook that executes on prop load (initialization hook)
   React.useEffect(() => {
@@ -276,14 +269,8 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
 
   // Search function for SearchBar component
   const handleSearchChange = useCallback(
-    (searchTerms: string) =>
-      searchOnFilteredList(
-        searchTerms,
-        libraryCards,
-        lcFilterFunction,
-        setFilteredCards,
-      ),
-    [libraryCards],
+    (searchTerms: string) => setSearchText(searchTerms),
+    [],
   )
 
   // Template for render
@@ -298,7 +285,6 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
         <SearchBar
           handleSearchChange={handleSearchChange}
-          searchRef={searchRef}
         />
       </div>
       <SimpleTable

--- a/src/pages/AdminManageDarCollections.jsx
+++ b/src/pages/AdminManageDarCollections.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import SearchBar from 'src/components/SearchBar'
 import { Collections } from 'src/libs/ajax/Collections'
 import { Notifications, searchOnFilteredList, getSearchFilterFunctions, USER_ROLES } from 'src/libs/utils'
@@ -20,18 +20,16 @@ export default function AdminManageDarCollections() {
   const [collections, setCollections] = useState([])
   const [filteredList, setFilteredList] = useState([])
   const [isLoading, setIsLoading] = useState(true)
-  const searchRef = useRef('')
+  const [searchText, setSearchText] = useState('')
   const filterFn = getSearchFilterFunctions().darCollections
 
   // Get responsive columns for admin console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.ADMIN)
 
-  const handleSearchChange = useCallback(searchTerms => searchOnFilteredList(
-    searchTerms,
-    collections,
-    filterFn,
-    setFilteredList,
-  ), [collections, filterFn])
+  const handleSearchChange = useCallback((searchTerms) => {
+    setSearchText(searchTerms)
+    searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList)
+  }, [collections, filterFn])
 
   useEffect(() => {
     const init = async () => {
@@ -49,8 +47,8 @@ export default function AdminManageDarCollections() {
   }, [])
 
   const updateCollections = useCallback(
-    updatedCollection => updateCollectionFn({ collections, filterFn, searchRef, setCollections, setFilteredList })(updatedCollection),
-    [collections, filterFn, setCollections, setFilteredList],
+    updatedCollection => updateCollectionFn({ collections, filterFn, searchText, setCollections, setFilteredList })(updatedCollection),
+    [collections, filterFn, searchText, setCollections, setFilteredList],
   )
   const cancelCollection = useCallback(
     params => cancelCollectionFn({ updateCollections, role: USER_ROLES.admin })(params),
@@ -70,7 +68,7 @@ export default function AdminManageDarCollections() {
         />
       </div>
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
-        <SearchBar handleSearchChange={handleSearchChange} searchRef={searchRef} />
+        <SearchBar handleSearchChange={handleSearchChange} />
       </div>
       {responsiveColumns.length > 0 && (
         <DarCollectionTable

--- a/src/pages/AdminManageUsers.jsx
+++ b/src/pages/AdminManageUsers.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import { AddUserModal } from 'src/components/modals/AddUserModal'
 import { User } from 'src/libs/ajax/User'
 import { USER_ROLES } from 'src/libs/utils'
@@ -37,8 +37,6 @@ export const AdminManageUsers = function AdminManageUsers() {
   const [showAddUserModal, setShowAddUserModal] = useState(false)
   const [selectedUser, setSelectedUser] = useState()
   const [isLoading, setIsLoading] = useState(false)
-
-  const searchRef = useRef('')
 
   React.useEffect(() => {
     setIsLoading(true)
@@ -88,7 +86,6 @@ export const AdminManageUsers = function AdminManageUsers() {
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
         <SearchBar
           handleSearchChange={handleSearchUser}
-          searchRef={searchRef}
         />
         <AddObjectButton
           id="btn_addUser"

--- a/src/pages/ChairConsole.jsx
+++ b/src/pages/ChairConsole.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import SearchBar from 'src/components/SearchBar'
 import { User } from 'src/libs/ajax/User'
 import { Collections } from 'src/libs/ajax/Collections'
@@ -18,18 +18,16 @@ export default function ChairConsole() {
   const [filteredList, setFilteredList] = useState([])
   const [relevantDatasets, setRelevantDatasets] = useState()
   const [isLoading, setIsLoading] = useState(true)
-  const searchRef = useRef('')
+  const [searchText, setSearchText] = useState('')
   const filterFn = getSearchFilterFunctions().darCollections
 
   // Get responsive columns for chair console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.CHAIR)
 
-  const handleSearchChange = useCallback(searchTerms => searchOnFilteredList(
-    searchTerms,
-    collections,
-    filterFn,
-    setFilteredList,
-  ), [collections, filterFn])
+  const handleSearchChange = useCallback((searchTerms) => {
+    setSearchText(searchTerms)
+    searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList)
+  }, [collections, filterFn])
 
   useEffect(() => {
     const init = async () => {
@@ -51,8 +49,8 @@ export default function ChairConsole() {
   }, [])
 
   const updateCollections = useCallback(
-    updatedCollection => updateCollectionFn({ collections, filterFn, searchRef, setCollections, setFilteredList })(updatedCollection),
-    [collections, filterFn, setCollections, setFilteredList],
+    updatedCollection => updateCollectionFn({ collections, filterFn, searchText, setCollections, setFilteredList })(updatedCollection),
+    [collections, filterFn, searchText, setCollections, setFilteredList],
   )
   const cancelCollection = useCallback(
     params => cancelCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
@@ -73,7 +71,7 @@ export default function ChairConsole() {
         />
       </div>
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
-        <SearchBar handleSearchChange={handleSearchChange} searchRef={searchRef} />
+        <SearchBar handleSearchChange={handleSearchChange} />
       </div>
       {responsiveColumns.length > 0 && (
         <DarCollectionTable

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Box, Skeleton, Typography } from '@mui/material'
 import LibraryTabs from 'src/components/data_library/LibraryTabs'
@@ -76,14 +76,6 @@ export const DataLibrary: React.FC = () => {
     { key: AssetType.INTELLECTUAL_PROPERTY, label: 'Intellectual Property' },
     { key: AssetType.FUNDING_RESOURCES, label: 'Funding Resources' },
   ]
-
-  const searchRef = useRef<HTMLInputElement>(null)
-
-  useEffect(() => {
-    if (searchRef.current && urlState.query) {
-      searchRef.current.value = urlState.query
-    }
-  }, [urlState.query])
 
   useEffect(() => {
     const init = () => {
@@ -324,7 +316,7 @@ export const DataLibrary: React.FC = () => {
         />
         <SearchBar
           handleSearchChange={handleSearchChange}
-          searchRef={searchRef}
+          initialValue={urlState.query ?? ''}
           style={{
             paddingTop: '10px',
           }}

--- a/src/pages/researcher_console/DatasetSubmissions.jsx
+++ b/src/pages/researcher_console/DatasetSubmissions.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { Styles } from 'src/libs/theme'
 import { useNavigate } from 'react-router-dom'
 import AddCircleOutlineIcon from '@mui/icons-material/AddCircleOutline'
@@ -16,7 +16,6 @@ export default function DatasetSubmissions() {
   const [filteredTerms, setFilteredTerms] = useState([])
   const [isLoading, setIsLoading] = useState(true)
   const [currentUser, setCurrentUser] = useState({})
-  const searchRef = useRef('')
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -101,7 +100,6 @@ export default function DatasetSubmissions() {
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
         <SearchBar
           handleSearchChange={handleSearchChange}
-          searchRef={searchRef}
         />
         <AddObjectButton
           id="add-dataset-btn"

--- a/src/pages/researcher_console/ResearcherConsole.jsx
+++ b/src/pages/researcher_console/ResearcherConsole.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { cloneDeep, findIndex } from 'lodash'
 import { Styles } from 'src/libs/theme'
 import { DAR } from 'src/libs/ajax/DAR'
@@ -22,18 +22,18 @@ export default function ResearcherConsole() {
   const [isLoading, setIsLoading] = useState(true)
   const [researcherCollections, setResearcherCollections] = useState()
   const [filteredList, setFilteredList] = useState()
-  const searchRef = useRef('')
+  const [searchText, setSearchText] = useState('')
 
   // Get responsive columns for researcher console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.RESEARCHER)
 
   // callback function passed to search bar to perform filter
-  const handleSearchChange = useCallback(() => searchOnFilteredList(
-    searchRef.current.value,
-    researcherCollections,
-    filterFn,
-    setFilteredList,
-  ), [researcherCollections])
+  const handleSearchChange = useCallback(terms => setSearchText(terms), [])
+
+  // re-filter whenever search text or underlying data changes
+  useEffect(() => {
+    searchOnFilteredList(searchText, researcherCollections, filterFn, setFilteredList)
+  }, [searchText, researcherCollections])
 
   // sequence of init events on component load
   useEffect(() => {
@@ -45,16 +45,6 @@ export default function ResearcherConsole() {
     }
     init()
   }, [])
-
-  // sequence of events when data is updated (perform new filter based on search query)
-  useEffect(() => {
-    searchOnFilteredList(
-      searchRef.current.value,
-      researcherCollections,
-      filterFn,
-      setFilteredList,
-    )
-  }, [researcherCollections])
 
   // cancel collection function, passed to collections table to be used in buttons
   const cancelCollection = async (darCollection) => {
@@ -163,7 +153,7 @@ export default function ResearcherConsole() {
         </div>
       </div>
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
-        <SearchBar handleSearchChange={handleSearchChange} searchRef={searchRef} />
+        <SearchBar handleSearchChange={handleSearchChange} />
       </div>
       <div className="table-container">
         <DarCollectionTable

--- a/src/utils/DarCollectionUtils.js
+++ b/src/utils/DarCollectionUtils.js
@@ -224,7 +224,7 @@ const addIfUnique = (newValue, existingValues) => {
   }
 }
 
-export const updateCollectionFn = ({ collections, filterFn, searchRef, setCollections, setFilteredList }) =>
+export const updateCollectionFn = ({ collections, filterFn, searchText, setCollections, setFilteredList }) =>
   (updatedCollection) => {
     const targetIndex = findIndex(collections,
       collection =>
@@ -239,7 +239,7 @@ export const updateCollectionFn = ({ collections, filterFn, searchRef, setCollec
       const collectionsCopy = cloneDeep(collections)
       collectionsCopy[targetIndex] = updatedCollection
       const updatedFilteredList = filterFn(
-        searchRef.current.value,
+        searchText,
         collectionsCopy,
       )
       setCollections(collectionsCopy)


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2974

### Summary

Previously, the search bar had no debounce, and thus this could cause unnecessary calls and rerenders. This refactors the search bar to no longer require an external `useRef` which simplifies the code a bit, and adds a 300ms debounce to the search bar.

The UI otherwise looks identical.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
