### PR TITLE
[DT-3073] Ensure asset tabs are scrollable

### DIFF
--- a/cypress/component/data_library/LibraryTabs.spec.tsx
+++ b/cypress/component/data_library/LibraryTabs.spec.tsx
@@ -46,4 +46,20 @@ describe('LibraryTabs', () => {
     cy.contains('Datasets').click()
     cy.get('@onChange').should('have.been.calledWith', AssetType.DATASETS)
   })
+
+  it('shows scroll buttons when tabs overflow the container width', () => {
+    cy.viewport(300, 600)
+
+    const manyTabs = Object.values(AssetType).map(type => ({ key: type, label: type }))
+
+    cy.mount(
+      <LibraryTabs
+        value={AssetType.STUDIES}
+        onChange={() => {}}
+        tabs={manyTabs}
+      />,
+    )
+
+    cy.get('.MuiTabs-scrollButtons').should('be.visible')
+  })
 })

--- a/src/components/data_library/LibraryTabs.tsx
+++ b/src/components/data_library/LibraryTabs.tsx
@@ -20,6 +20,9 @@ export const LibraryTabs: React.FC<LibraryTabsProps> = ({
         value={value}
         onChange={(_event, newValue) => onChange(newValue)}
         aria-label="library view tabs"
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
         slotProps={{
           indicator: {
             style: { backgroundColor: '#00609f' },


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3073

### Summary

Makes the tabs scrollable left and right if there isn't enough horizontal space for them:

<img width="492" height="61" alt="Screenshot 2026-03-09 at 3 46 44 PM" src="https://github.com/user-attachments/assets/53a8fdb7-c42e-4dc9-9655-16721827faa6" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
