### PR TITLE
[DT-3074] Add collapsible filters

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -161,6 +161,57 @@ describe('DataLibrary', () => {
     cy.get('button').contains('Studies').should('have.css', 'font-weight', '400')
   })
 
+  it('shows filter panel by default', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/']}>
+          <DataLibrary />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+    cy.contains('Access Management').should('be.visible')
+    cy.get('[aria-label="Collapse filters"]').should('exist')
+  })
+
+  it('hides filter panel when hideFilters=true is in the URL', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/?hideFilters=true']}>
+          <DataLibrary />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+    cy.contains('Access Management').should('not.exist')
+    cy.get('[aria-label="Expand filters"]').should('exist')
+  })
+
+  it('collapses filter panel when the toggle button is clicked', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/']}>
+          <DataLibrary />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+    cy.contains('Access Management').should('be.visible')
+    cy.get('[aria-label="Collapse filters"]').click()
+    cy.contains('Access Management').should('not.exist')
+    cy.get('[aria-label="Expand filters"]').should('exist')
+  })
+
+  it('expands filter panel when expand button is clicked while collapsed', () => {
+    cy.mount(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/?hideFilters=true']}>
+          <DataLibrary />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    )
+    cy.get('[aria-label="Expand filters"]').click()
+    cy.contains('Access Management').should('be.visible')
+    cy.get('[aria-label="Collapse filters"]').should('exist')
+  })
+
   it('switches tabs and updates URL state', () => {
     cy.mount(
       <QueryClientProvider client={queryClient}>

--- a/cypress/component/data_library/LibraryFilters.spec.tsx
+++ b/cypress/component/data_library/LibraryFilters.spec.tsx
@@ -124,3 +124,71 @@ describe('LibraryFilters', () => {
     cy.contains('Access Management').should('not.exist')
   })
 })
+
+describe('LibraryFilters — collapseable panel', () => {
+  const mountWithToggle = (isOpen: boolean, onToggle = cy.stub().as('onToggle')) => {
+    cy.mount(
+      <LibraryFilters
+        filters={emptyFilters}
+        onChange={cy.stub()}
+        onClear={cy.stub()}
+        availableFilters={availableFilters}
+        isOpen={isOpen}
+        onToggle={onToggle}
+      />,
+    )
+  }
+
+  it('shows filter content and collapse button when open', () => {
+    mountWithToggle(true)
+    cy.contains('Filters').should('be.visible')
+    cy.contains('Access Management').should('be.visible')
+    cy.get('[aria-label="Collapse filters"]').should('exist')
+  })
+
+  it('hides filter content and shows expand button when closed', () => {
+    mountWithToggle(false)
+    cy.contains('Access Management').should('not.exist')
+    cy.contains('Filters').should('not.exist')
+    cy.get('[aria-label="Expand filters"]').should('exist')
+  })
+
+  it('calls onToggle when the chevron button is clicked while open', () => {
+    mountWithToggle(true)
+    cy.get('[aria-label="Collapse filters"]').click()
+    cy.get('@onToggle').should('have.been.calledOnce')
+  })
+
+  it('calls onToggle when expand button is clicked while closed', () => {
+    mountWithToggle(false)
+    cy.get('[aria-label="Expand filters"]').click()
+    cy.get('@onToggle').should('have.been.calledOnce')
+  })
+
+  it('does not render the toggle button when onToggle is not provided', () => {
+    cy.mount(
+      <LibraryFilters
+        filters={emptyFilters}
+        onChange={cy.stub()}
+        onClear={cy.stub()}
+        availableFilters={availableFilters}
+      />,
+    )
+    cy.get('[aria-label="Collapse filters"]').should('not.exist')
+    cy.get('[aria-label="Expand filters"]').should('not.exist')
+  })
+
+  it('does not show Clear button when closed even with active filters', () => {
+    cy.mount(
+      <LibraryFilters
+        filters={{ ...emptyFilters, accessManagement: ['controlled'] }}
+        onChange={cy.stub()}
+        onClear={cy.stub()}
+        availableFilters={availableFilters}
+        isOpen={false}
+        onToggle={cy.stub()}
+      />,
+    )
+    cy.contains('Clear').should('not.exist')
+  })
+})

--- a/src/components/data_library/LibraryFilters.tsx
+++ b/src/components/data_library/LibraryFilters.tsx
@@ -3,7 +3,9 @@ import {
   Box,
   Button,
   Checkbox,
+  IconButton,
   TextField,
+  Tooltip,
   Typography,
   Accordion,
   AccordionSummary,
@@ -12,6 +14,8 @@ import {
   FormControlLabel,
   Skeleton,
 } from '@mui/material'
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { LibraryFiltersProps } from 'src/types/library'
 
@@ -21,6 +25,8 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = ({
   onClear,
   availableFilters,
   loading = false,
+  isOpen = true,
+  onToggle,
 }) => {
   const handleFilterToggle = (category: keyof typeof filters, value: string) => {
     const currentValues = filters[category] as string[]
@@ -63,15 +69,24 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = ({
           mb: 2,
         }}
       >
-        <Typography variant="h6">Filters</Typography>
-        {hasActiveFilters && (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {onToggle && (
+            <Tooltip title={isOpen ? 'Collapse filters' : 'Expand filters'} placement="right">
+              <IconButton size="small" onClick={onToggle} aria-label={isOpen ? 'Collapse filters' : 'Expand filters'}>
+                {isOpen ? <ChevronLeftIcon fontSize="small" /> : <ChevronRightIcon fontSize="small" />}
+              </IconButton>
+            </Tooltip>
+          )}
+          {isOpen && <Typography variant="h6">Filters</Typography>}
+        </Box>
+        {isOpen && hasActiveFilters && (
           <Button size="small" onClick={onClear}>
             Clear
           </Button>
         )}
       </Box>
 
-      {loading
+      {isOpen && loading
         ? (
             <>
               <Skeleton height={60} />
@@ -79,165 +94,167 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = ({
               <Skeleton height={60} />
             </>
           )
-        : (
-            <>
-              {/* Access Management Filter */}
-              <Accordion defaultExpanded>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Access Management</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <FormGroup>
-                    {availableFilters.accessManagement.map(option => (
-                      <FormControlLabel
-                        key={option.value}
-                        control={(
-                          <Checkbox
-                            checked={filters.accessManagement.includes(
-                              option.value,
-                            )}
-                            onChange={() =>
-                              handleFilterToggle('accessManagement', option.value)}
-                            size="small"
-                          />
-                        )}
-                        label={(
-                          <Typography variant="body2">
-                            {option.label}
-                            {option.count !== undefined && ` (${option.count})`}
-                          </Typography>
-                        )}
-                      />
-                    ))}
-                  </FormGroup>
-                </AccordionDetails>
-              </Accordion>
+        : isOpen
+          ? (
+              <>
+                {/* Access Management Filter */}
+                <Accordion defaultExpanded>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Access Management</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <FormGroup>
+                      {availableFilters.accessManagement.map(option => (
+                        <FormControlLabel
+                          key={option.value}
+                          control={(
+                            <Checkbox
+                              checked={filters.accessManagement.includes(
+                                option.value,
+                              )}
+                              onChange={() =>
+                                handleFilterToggle('accessManagement', option.value)}
+                              size="small"
+                            />
+                          )}
+                          label={(
+                            <Typography variant="body2">
+                              {option.label}
+                              {option.count !== undefined && ` (${option.count})`}
+                            </Typography>
+                          )}
+                        />
+                      ))}
+                    </FormGroup>
+                  </AccordionDetails>
+                </Accordion>
 
-              {/* Data Use Filter */}
-              <Accordion>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Use</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <FormGroup>
-                    {availableFilters.dataUse.map(option => (
-                      <FormControlLabel
-                        key={option.value}
-                        control={(
-                          <Checkbox
-                            checked={filters.dataUse.includes(option.value)}
-                            onChange={() =>
-                              handleFilterToggle('dataUse', option.value)}
-                            size="small"
-                          />
-                        )}
-                        label={(
-                          <Typography variant="body2">
-                            {option.label}
-                            {option.count !== undefined && ` (${option.count})`}
-                          </Typography>
-                        )}
-                      />
-                    ))}
-                  </FormGroup>
-                </AccordionDetails>
-              </Accordion>
+                {/* Data Use Filter */}
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Use</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <FormGroup>
+                      {availableFilters.dataUse.map(option => (
+                        <FormControlLabel
+                          key={option.value}
+                          control={(
+                            <Checkbox
+                              checked={filters.dataUse.includes(option.value)}
+                              onChange={() =>
+                                handleFilterToggle('dataUse', option.value)}
+                              size="small"
+                            />
+                          )}
+                          label={(
+                            <Typography variant="body2">
+                              {option.label}
+                              {option.count !== undefined && ` (${option.count})`}
+                            </Typography>
+                          )}
+                        />
+                      ))}
+                    </FormGroup>
+                  </AccordionDetails>
+                </Accordion>
 
-              {/* Data Type Filter */}
-              <Accordion>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Type</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <FormGroup>
-                    {availableFilters.dataType.map(option => (
-                      <FormControlLabel
-                        key={option.value}
-                        control={(
-                          <Checkbox
-                            checked={filters.dataType.includes(option.value)}
-                            onChange={() =>
-                              handleFilterToggle('dataType', option.value)}
-                            size="small"
-                          />
-                        )}
-                        label={(
-                          <Typography variant="body2">
-                            {option.label}
-                            {option.count !== undefined && ` (${option.count})`}
-                          </Typography>
-                        )}
-                      />
-                    ))}
-                  </FormGroup>
-                </AccordionDetails>
-              </Accordion>
+                {/* Data Type Filter */}
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Type</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <FormGroup>
+                      {availableFilters.dataType.map(option => (
+                        <FormControlLabel
+                          key={option.value}
+                          control={(
+                            <Checkbox
+                              checked={filters.dataType.includes(option.value)}
+                              onChange={() =>
+                                handleFilterToggle('dataType', option.value)}
+                              size="small"
+                            />
+                          )}
+                          label={(
+                            <Typography variant="body2">
+                              {option.label}
+                              {option.count !== undefined && ` (${option.count})`}
+                            </Typography>
+                          )}
+                        />
+                      ))}
+                    </FormGroup>
+                  </AccordionDetails>
+                </Accordion>
 
-              {/* DAC Filter */}
-              <Accordion>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>DAC</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <FormGroup>
-                    {availableFilters.dac.map(option => (
-                      <FormControlLabel
-                        key={option.value}
-                        control={(
-                          <Checkbox
-                            checked={filters.dac.includes(option.value)}
-                            onChange={() => handleFilterToggle('dac', option.value)}
-                            size="small"
-                          />
-                        )}
-                        label={(
-                          <Typography variant="body2">
-                            {option.label}
-                            {option.count !== undefined && ` (${option.count})`}
-                          </Typography>
-                        )}
-                      />
-                    ))}
-                  </FormGroup>
-                </AccordionDetails>
-              </Accordion>
+                {/* DAC Filter */}
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>DAC</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <FormGroup>
+                      {availableFilters.dac.map(option => (
+                        <FormControlLabel
+                          key={option.value}
+                          control={(
+                            <Checkbox
+                              checked={filters.dac.includes(option.value)}
+                              onChange={() => handleFilterToggle('dac', option.value)}
+                              size="small"
+                            />
+                          )}
+                          label={(
+                            <Typography variant="body2">
+                              {option.label}
+                              {option.count !== undefined && ` (${option.count})`}
+                            </Typography>
+                          )}
+                        />
+                      ))}
+                    </FormGroup>
+                  </AccordionDetails>
+                </Accordion>
 
-              {/* Participant Count Filter */}
-              <Accordion>
-                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Participants</Typography>
-                </AccordionSummary>
-                <AccordionDetails>
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                    <TextField
-                      type="number"
-                      label="Minimum"
-                      size="small"
-                      value={filters.participantCount.min || ''}
-                      onChange={e =>
-                        handleParticipantChange('min', e.target.value)}
-                      inputProps={{
-                        min: availableFilters.participantCountRange.min,
-                        max: availableFilters.participantCountRange.max,
-                      }}
-                    />
-                    <TextField
-                      type="number"
-                      label="Maximum"
-                      size="small"
-                      value={filters.participantCount.max || ''}
-                      onChange={e =>
-                        handleParticipantChange('max', e.target.value)}
-                      inputProps={{
-                        min: availableFilters.participantCountRange.min,
-                        max: availableFilters.participantCountRange.max,
-                      }}
-                    />
-                  </Box>
-                </AccordionDetails>
-              </Accordion>
-            </>
-          )}
+                {/* Participant Count Filter */}
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Participants</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                      <TextField
+                        type="number"
+                        label="Minimum"
+                        size="small"
+                        value={filters.participantCount.min || ''}
+                        onChange={e =>
+                          handleParticipantChange('min', e.target.value)}
+                        inputProps={{
+                          min: availableFilters.participantCountRange.min,
+                          max: availableFilters.participantCountRange.max,
+                        }}
+                      />
+                      <TextField
+                        type="number"
+                        label="Maximum"
+                        size="small"
+                        value={filters.participantCount.max || ''}
+                        onChange={e =>
+                          handleParticipantChange('max', e.target.value)}
+                        inputProps={{
+                          min: availableFilters.participantCountRange.min,
+                          max: availableFilters.participantCountRange.max,
+                        }}
+                      />
+                    </Box>
+                  </AccordionDetails>
+                </Accordion>
+              </>
+            )
+          : null}
     </Box>
   )
 }

--- a/src/components/data_library/LibraryFilters.tsx
+++ b/src/components/data_library/LibraryFilters.tsx
@@ -86,7 +86,7 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = ({
         )}
       </Box>
 
-      {isOpen && loading
+      {isOpen && (loading
         ? (
             <>
               <Skeleton height={60} />
@@ -94,167 +94,166 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = ({
               <Skeleton height={60} />
             </>
           )
-        : isOpen
-          ? (
-              <>
-                {/* Access Management Filter */}
-                <Accordion defaultExpanded>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Access Management</Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <FormGroup>
-                      {availableFilters.accessManagement.map(option => (
-                        <FormControlLabel
-                          key={option.value}
-                          control={(
-                            <Checkbox
-                              checked={filters.accessManagement.includes(
-                                option.value,
-                              )}
-                              onChange={() =>
-                                handleFilterToggle('accessManagement', option.value)}
-                              size="small"
-                            />
-                          )}
-                          label={(
-                            <Typography variant="body2">
-                              {option.label}
-                              {option.count !== undefined && ` (${option.count})`}
-                            </Typography>
-                          )}
-                        />
-                      ))}
-                    </FormGroup>
-                  </AccordionDetails>
-                </Accordion>
-
-                {/* Data Use Filter */}
-                <Accordion>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Use</Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <FormGroup>
-                      {availableFilters.dataUse.map(option => (
-                        <FormControlLabel
-                          key={option.value}
-                          control={(
-                            <Checkbox
-                              checked={filters.dataUse.includes(option.value)}
-                              onChange={() =>
-                                handleFilterToggle('dataUse', option.value)}
-                              size="small"
-                            />
-                          )}
-                          label={(
-                            <Typography variant="body2">
-                              {option.label}
-                              {option.count !== undefined && ` (${option.count})`}
-                            </Typography>
-                          )}
-                        />
-                      ))}
-                    </FormGroup>
-                  </AccordionDetails>
-                </Accordion>
-
-                {/* Data Type Filter */}
-                <Accordion>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Type</Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <FormGroup>
-                      {availableFilters.dataType.map(option => (
-                        <FormControlLabel
-                          key={option.value}
-                          control={(
-                            <Checkbox
-                              checked={filters.dataType.includes(option.value)}
-                              onChange={() =>
-                                handleFilterToggle('dataType', option.value)}
-                              size="small"
-                            />
-                          )}
-                          label={(
-                            <Typography variant="body2">
-                              {option.label}
-                              {option.count !== undefined && ` (${option.count})`}
-                            </Typography>
-                          )}
-                        />
-                      ))}
-                    </FormGroup>
-                  </AccordionDetails>
-                </Accordion>
-
-                {/* DAC Filter */}
-                <Accordion>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>DAC</Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <FormGroup>
-                      {availableFilters.dac.map(option => (
-                        <FormControlLabel
-                          key={option.value}
-                          control={(
-                            <Checkbox
-                              checked={filters.dac.includes(option.value)}
-                              onChange={() => handleFilterToggle('dac', option.value)}
-                              size="small"
-                            />
-                          )}
-                          label={(
-                            <Typography variant="body2">
-                              {option.label}
-                              {option.count !== undefined && ` (${option.count})`}
-                            </Typography>
-                          )}
-                        />
-                      ))}
-                    </FormGroup>
-                  </AccordionDetails>
-                </Accordion>
-
-                {/* Participant Count Filter */}
-                <Accordion>
-                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-                    <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Participants</Typography>
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                      <TextField
-                        type="number"
-                        label="Minimum"
-                        size="small"
-                        value={filters.participantCount.min || ''}
-                        onChange={e =>
-                          handleParticipantChange('min', e.target.value)}
-                        inputProps={{
-                          min: availableFilters.participantCountRange.min,
-                          max: availableFilters.participantCountRange.max,
-                        }}
+        : (
+            <>
+              {/* Access Management Filter */}
+              <Accordion defaultExpanded>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Access Management</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <FormGroup>
+                    {availableFilters.accessManagement.map(option => (
+                      <FormControlLabel
+                        key={option.value}
+                        control={(
+                          <Checkbox
+                            checked={filters.accessManagement.includes(
+                              option.value,
+                            )}
+                            onChange={() =>
+                              handleFilterToggle('accessManagement', option.value)}
+                            size="small"
+                          />
+                        )}
+                        label={(
+                          <Typography variant="body2">
+                            {option.label}
+                            {option.count !== undefined && ` (${option.count})`}
+                          </Typography>
+                        )}
                       />
-                      <TextField
-                        type="number"
-                        label="Maximum"
-                        size="small"
-                        value={filters.participantCount.max || ''}
-                        onChange={e =>
-                          handleParticipantChange('max', e.target.value)}
-                        inputProps={{
-                          min: availableFilters.participantCountRange.min,
-                          max: availableFilters.participantCountRange.max,
-                        }}
+                    ))}
+                  </FormGroup>
+                </AccordionDetails>
+              </Accordion>
+
+              {/* Data Use Filter */}
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Use</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <FormGroup>
+                    {availableFilters.dataUse.map(option => (
+                      <FormControlLabel
+                        key={option.value}
+                        control={(
+                          <Checkbox
+                            checked={filters.dataUse.includes(option.value)}
+                            onChange={() =>
+                              handleFilterToggle('dataUse', option.value)}
+                            size="small"
+                          />
+                        )}
+                        label={(
+                          <Typography variant="body2">
+                            {option.label}
+                            {option.count !== undefined && ` (${option.count})`}
+                          </Typography>
+                        )}
                       />
-                    </Box>
-                  </AccordionDetails>
-                </Accordion>
-              </>
-            )
-          : null}
+                    ))}
+                  </FormGroup>
+                </AccordionDetails>
+              </Accordion>
+
+              {/* Data Type Filter */}
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Data Type</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <FormGroup>
+                    {availableFilters.dataType.map(option => (
+                      <FormControlLabel
+                        key={option.value}
+                        control={(
+                          <Checkbox
+                            checked={filters.dataType.includes(option.value)}
+                            onChange={() =>
+                              handleFilterToggle('dataType', option.value)}
+                            size="small"
+                          />
+                        )}
+                        label={(
+                          <Typography variant="body2">
+                            {option.label}
+                            {option.count !== undefined && ` (${option.count})`}
+                          </Typography>
+                        )}
+                      />
+                    ))}
+                  </FormGroup>
+                </AccordionDetails>
+              </Accordion>
+
+              {/* DAC Filter */}
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>DAC</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <FormGroup>
+                    {availableFilters.dac.map(option => (
+                      <FormControlLabel
+                        key={option.value}
+                        control={(
+                          <Checkbox
+                            checked={filters.dac.includes(option.value)}
+                            onChange={() => handleFilterToggle('dac', option.value)}
+                            size="small"
+                          />
+                        )}
+                        label={(
+                          <Typography variant="body2">
+                            {option.label}
+                            {option.count !== undefined && ` (${option.count})`}
+                          </Typography>
+                        )}
+                      />
+                    ))}
+                  </FormGroup>
+                </AccordionDetails>
+              </Accordion>
+
+              {/* Participant Count Filter */}
+              <Accordion>
+                <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                  <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>Participants</Typography>
+                </AccordionSummary>
+                <AccordionDetails>
+                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                    <TextField
+                      type="number"
+                      label="Minimum"
+                      size="small"
+                      value={filters.participantCount.min || ''}
+                      onChange={e =>
+                        handleParticipantChange('min', e.target.value)}
+                      inputProps={{
+                        min: availableFilters.participantCountRange.min,
+                        max: availableFilters.participantCountRange.max,
+                      }}
+                    />
+                    <TextField
+                      type="number"
+                      label="Maximum"
+                      size="small"
+                      value={filters.participantCount.max || ''}
+                      onChange={e =>
+                        handleParticipantChange('max', e.target.value)}
+                      inputProps={{
+                        min: availableFilters.participantCountRange.min,
+                        max: availableFilters.participantCountRange.max,
+                      }}
+                    />
+                  </Box>
+                </AccordionDetails>
+              </Accordion>
+            </>
+          )
+      )}
     </Box>
   )
 }

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -88,6 +88,7 @@ export const useLibraryUrlState = () => {
     query: searchParams.get('query') || undefined,
     sortField: searchParams.get('sort') || undefined,
     sortOrder: (searchParams.get('order') as SortOrder) || undefined,
+    hideFilters: searchParams.get('hideFilters') === 'true',
   }
 
   const updateState = (updates: Partial<LibraryUrlState>) => {
@@ -153,6 +154,15 @@ export const useLibraryUrlState = () => {
       }
       else {
         newParams.delete('order')
+      }
+    }
+
+    if ('hideFilters' in updates) {
+      if (updates.hideFilters) {
+        newParams.set('hideFilters', 'true')
+      }
+      else {
+        newParams.delete('hideFilters')
       }
     }
 

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -345,11 +345,12 @@ export const DataLibrary: React.FC = () => {
         {/* Filters Sidebar */}
         <Box
           sx={{
-            width: 280,
+            width: urlState.hideFilters ? 40 : 280,
             flexShrink: 0,
-            pr: 2,
-            overflowY: 'auto',
+            pr: urlState.hideFilters ? 0 : 2,
+            overflowY: urlState.hideFilters ? 'hidden' : 'auto',
             overflowX: 'hidden',
+            transition: 'width 0.2s ease',
           }}
         >
           <LibraryFilters
@@ -358,6 +359,8 @@ export const DataLibrary: React.FC = () => {
             onClear={handleClearFilters}
             availableFilters={availableFilters}
             loading={isLoading || isMetadataLoading}
+            isOpen={!urlState.hideFilters}
+            onToggle={() => updateUrlState({ hideFilters: !urlState.hideFilters })}
           />
         </Box>
 

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -67,6 +67,8 @@ export interface LibraryFiltersProps {
   onClear: () => void
   availableFilters: AvailableFilters
   loading?: boolean
+  isOpen?: boolean
+  onToggle?: () => void
 }
 
 export type SortOrder = 'asc' | 'desc'
@@ -80,6 +82,7 @@ export interface LibraryUrlState {
   pageSize: number
   sortField?: string
   sortOrder?: SortOrder
+  hideFilters: boolean
 }
 
 export interface TabConfig {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3074

### Summary

Makes the filters collapsible. Useful on devices with lower resolution, or to share a specific view without the filters immediately visible.

https://github.com/user-attachments/assets/a151300a-25a4-4440-9021-a77db7b74313