### PR TITLE
[DT-3002] Add new DAC usage menu item in support modal

### DIFF
--- a/cypress/component/Support/SupportRequestModal.spec.tsx
+++ b/cypress/component/Support/SupportRequestModal.spec.tsx
@@ -243,6 +243,83 @@ describe('Support Request Modal Tests', () => {
     })
   })
 
+  describe('"Using DUOS for my DAC" support type option', () => {
+    beforeEach(() => {
+      cy.stub(Storage, 'userIsLogged').returns(true)
+      cy.stub(Storage, 'getCurrentUser').returns(mockUser)
+    })
+
+    it('Renders "Using DUOS for my DAC" as an option in the type dropdown', () => {
+      cy.mount(
+        <BrowserRouter>
+          <SupportRequestModal
+            onCloseRequest={handler}
+            url="url"
+            showModal={true}
+          />
+        </BrowserRouter>,
+      )
+      cy.get('[data-cy="supportFormType"]').click()
+      cy.contains('Using DUOS for my DAC').should('exist')
+    })
+
+    it('Allows selecting "Using DUOS for my DAC" from the type dropdown', () => {
+      cy.mount(
+        <BrowserRouter>
+          <SupportRequestModal
+            onCloseRequest={handler}
+            url="url"
+            showModal={true}
+          />
+        </BrowserRouter>,
+      )
+      cy.get('[data-cy="supportFormType"]').click()
+      cy.contains('Using DUOS for my DAC').click()
+      cy.get('[data-cy="supportFormType"]').should('contain', 'Using DUOS for my DAC')
+    })
+
+    it('Enables submit button when "Using DUOS for my DAC" is selected and required fields are filled', () => {
+      cy.mount(
+        <BrowserRouter>
+          <SupportRequestModal
+            onCloseRequest={handler}
+            url="url"
+            showModal={true}
+          />
+        </BrowserRouter>,
+      )
+      cy.get('[data-cy="supportFormType"]').click()
+      cy.contains('Using DUOS for my DAC').click()
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled')
+      cy.get('[data-cy="supportFormSubject"]').type('DAC Setup Question')
+      cy.get('[data-cy="supportFormSubmit"]').should('be.disabled')
+      cy.get('[data-cy="supportFormDescription"]').type('I need help setting up my DAC in DUOS.')
+      cy.get('[data-cy="supportFormSubmit"]').should('not.be.disabled')
+    })
+
+    it('Submits with dac_usage type and correct payload', () => {
+      cy.mount(
+        <BrowserRouter>
+          <SupportRequestModal
+            onCloseRequest={handler}
+            url="url"
+            showModal={true}
+          />
+        </BrowserRouter>,
+      )
+      cy.get('[data-cy="supportFormType"]').click()
+      cy.contains('Using DUOS for my DAC').click()
+      cy.get('[data-cy="supportFormSubject"]').type('DAC Setup Question')
+      cy.get('[data-cy="supportFormDescription"]').type('I need help setting up my DAC in DUOS.')
+      cy.intercept({ method: 'POST', url: '**/support/request' }, (req) => {
+        expect(req.body.type).to.equal('DAC_USAGE')
+        req.reply({ statusCode: 201 })
+      }).as('request')
+      cy.get('[data-cy="supportFormSubmit"]').click()
+      cy.wait('@request')
+    })
+  })
+
   describe('RedirectLink functionality', () => {
     describe('When user is logged in:', () => {
       beforeEach(() => {

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -255,6 +255,7 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
               <MenuItem value="question">Question</MenuItem>
               <MenuItem value="bug">Bug</MenuItem>
               <MenuItem value="feature_request">Feature Request</MenuItem>
+              <MenuItem value="dac_usage">Using DUOS for my DAC</MenuItem>
             </Select>
           </FormControl>
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3002

See also https://github.com/DataBiosphere/consent/pull/2829

### Summary

Adds a new "Using DUOS for my DAC" menu option with tests.

<img width="868" height="237" alt="Screenshot 2026-03-10 at 9 22 39 AM" src="https://github.com/user-attachments/assets/8f2a59ea-e4d6-48f6-a5b5-e585dd303dec" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
