### PR TITLE
[DT-2988] Ensure all asset types support searching appropriate tags.

### DIFF
--- a/src/components/data_library/assets/datasetAsset.ts
+++ b/src/components/data_library/assets/datasetAsset.ts
@@ -37,6 +37,7 @@ export const datasetAsset: AssetDefinition = {
     'dataUse.secondary.code',
     'dac.dacName',
     'datasetIdentifier',
+    'data.tags',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/intellectualPropertyAsset.ts
+++ b/src/components/data_library/assets/intellectualPropertyAsset.ts
@@ -16,6 +16,7 @@ export const intellectualPropertyAsset: AssetDefinition = {
     'study.assets.intellectualProperties.assignee',
     'study.assets.intellectualProperties.patentNumber',
     'study.assets.intellectualProperties.status',
+    'study.assets.intellectualProperties.tags',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/presentationAsset.ts
+++ b/src/components/data_library/assets/presentationAsset.ts
@@ -16,6 +16,7 @@ export const presentationAsset: AssetDefinition = {
     'study.assets.presentations.location',
     'study.assets.presentations.authors',
     'study.assets.presentations.format',
+    'study.assets.presentations.tags',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/publicationAsset.ts
+++ b/src/components/data_library/assets/publicationAsset.ts
@@ -15,6 +15,7 @@ export const publicationAsset: AssetDefinition = {
     'study.assets.publications.journal',
     'study.assets.publications.doi',
     'study.assets.publications.pubmedId',
+    'study.assets.publications.tags',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/studyAsset.ts
+++ b/src/components/data_library/assets/studyAsset.ts
@@ -20,6 +20,7 @@ export const studyAsset: AssetDefinition = {
     'dataUse.secondary.code',
     'dac.dacName',
     'datasetIdentifier',
+    'study.data.tags',
   ],
 
   buildQuery(


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2988](https://broadworkbench.atlassian.net/browse/DT-2988)

### Summary

Updates asset definition for Study, Dataset, IP, Presentations, Publications, and IP to search the appropriate tag object for each asset type.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
