### PR TITLE
[DT-3078] Use React managed value instead of defaultValue

### DIFF
--- a/src/components/forms/formComponents.jsx
+++ b/src/components/forms/formComponents.jsx
@@ -82,7 +82,7 @@ export const FormInputGeneric = (config) => {
         type={type?.inputType || 'text'}
         className={`form-control ${!isValid(validation) ? 'errored' : ''}`}
         placeholder={placeholder || title}
-        defaultValue={formValue?.toString()}
+        value={formValue?.toString()}
         readOnly={readOnly}
         style={{ ...styles.inputStyle, ...inputStyle }}
         disabled={disabled}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3078](https://broadworkbench.atlassian.net/browse/DT-3078)

### Summary

Switches the generic text input form control from unmanaged to managed.  Fields configured with FormValidation functions were expecting managed elements and would not properly fire onChange events.  Using the managed input restores the desired behavior.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
