### PR TITLE
[DT-3077] Remove empty date values before submitting; update types to match form requirements

### DIFF
--- a/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
@@ -15,6 +15,7 @@ import {
 } from 'src/utils/ClinicalTrialEnumUtils'
 import { SelectEntry } from 'src/components/forms/SelectOptionInterface'
 import { unset } from 'lodash'
+import { isValidDate } from 'src/pages/data_submission/v2/v2-common-functions'
 
 const defaultClinicalTrial: ClinicalTrial = {
   clinicalTrialId: '',
@@ -73,9 +74,8 @@ const calcClinicalTrialErrors = (ct: ClinicalTrial): Validation => {
   if (!ct.identifier?.trim()) v.identifier = makeError('required')
   if (isFallback(ct.status)) v.status = makeError('required')
   if (!ct.sponsor?.trim()) v.sponsor = makeError('required')
-  if (!ct.startDate?.trim()) v.startDate = makeError('required')
-  else if (!FormValidators.DATE.isValid(ct.startDate)) v.startDate = makeError('date')
-  if (ct.endDate?.trim() && !FormValidators.DATE.isValid(ct.endDate)) v.endDate = makeError('date')
+  if (!isValidDate(ct.startDate)) v.startDate = makeError('date')
+  if (ct.endDate?.trim() && !isValidDate(ct.endDate)) v.endDate = makeError('date')
   if (isFallback(ct.interventionType)) v.interventionType = makeError('required')
   if (isFallback(ct.phase)) v.phase = makeError('required')
   if (!ct.url?.trim()) v.url = makeError('required')

--- a/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
@@ -14,6 +14,7 @@ import {
   clinicalTrialInterventionSelectOptions,
 } from 'src/utils/ClinicalTrialEnumUtils'
 import { SelectEntry } from 'src/components/forms/SelectOptionInterface'
+import { unset } from 'lodash'
 
 const defaultClinicalTrial: ClinicalTrial = {
   clinicalTrialId: '',
@@ -24,7 +25,6 @@ const defaultClinicalTrial: ClinicalTrial = {
   status: ClinicalTrialStatus.UNKNOWN,
   sponsor: '',
   startDate: '',
-  endDate: '',
   interventionType: ClinicalTrialInterventionType.OTHER,
   description: '',
   phase: ClinicalTrialPhase.NA,
@@ -122,12 +122,17 @@ export default function ClinicalTrialAddEdit(props: ClinicalTrialAddEditProps): 
     const validationErrors = calcClinicalTrialErrors(newClinicalTrial)
     setValidation(validationErrors)
     if (validationFailed(validationErrors)) return
+    const clinicalTrialToSave = {
+      ...newClinicalTrial,
+      clinicalTrialId: newClinicalTrial.clinicalTrialId || crypto.randomUUID?.() || Date.now().toString(),
+    } as ClinicalTrial
+    if (clinicalTrialToSave.endDate?.trim() === '') unset(clinicalTrialToSave, 'endDate')
     if (id < 0) {
-      onClinicalTrialChange([...clinicalTrials, newClinicalTrial])
+      onClinicalTrialChange([...clinicalTrials, clinicalTrialToSave])
     }
     else {
       const copy = [...clinicalTrials]
-      copy[id] = newClinicalTrial
+      copy[id] = clinicalTrialToSave
       onClinicalTrialChange(copy)
     }
     closeAction()

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { FundingResource } from 'src/types/model'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
+import { unset } from 'lodash'
 
 interface FundingSourceAddEditProps {
   readonly id: number
@@ -81,6 +82,8 @@ export default function FundingResourceAddEdit(props: FundingSourceAddEditProps)
       ...current,
       fundingId: current.fundingId || crypto.randomUUID?.() || Date.now().toString(),
     }
+    if (toSave.endDate?.trim() === '') unset(toSave, 'endDate')
+    if (toSave.startDate?.trim() === '') unset(toSave, 'startDate')
     if (id < 0) {
       onFundingResourcesChange([...fundingResources, toSave])
     }

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -3,6 +3,7 @@ import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/
 import { FundingResource } from 'src/types/model'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
 import { unset } from 'lodash'
+import { isValidDate } from 'src/pages/data_submission/v2/v2-common-functions'
 
 interface FundingSourceAddEditProps {
   readonly id: number
@@ -30,8 +31,6 @@ const defaultFunding: FundingResource = {
   funderProgram: '',
   grantNumber: '',
   projectTitle: '',
-  startDate: '',
-  endDate: '',
   url: '',
   tags: [],
 }
@@ -44,6 +43,8 @@ const calcErrors = (f: FundingResource): Validation => {
   if (!f.funderProgram?.trim()) v.funderProgram = makeError('required')
   if (!f.grantNumber?.trim()) v.grantNumber = makeError('required')
   if (!f.projectTitle?.trim()) v.projectTitle = makeError('required')
+  if (f.startDate && !isValidDate(f.startDate)) v.startDate = makeError('date')
+  if (f.endDate && !isValidDate(f.endDate)) v.endDate = makeError('date')
   return v
 }
 

--- a/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { IntellectualProperty } from 'src/types/model'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
+import { isValidDate } from 'src/pages/data_submission/v2/v2-common-functions'
 
 interface IntellectualPropertyAddEditProps {
   readonly id: number
@@ -47,6 +48,7 @@ const calcErrors = (intellectualProperty: IntellectualProperty): Validation => {
   if (!intellectualProperty.title?.trim()) v.title = makeError('required')
   if (!intellectualProperty.assignee?.trim()) v.assignee = makeError('required')
   if (!intellectualProperty.patentNumber?.trim()) v.patentNumber = makeError('required')
+  if (!isValidDate(intellectualProperty.filingDate)) v.filingDate = makeError('date')
 
   // Date validation
   if (!intellectualProperty.filingDate?.trim()) {

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -51,6 +51,10 @@ import { NIHInstituteAndCenterAbbreviations } from 'src/components/forms/NIHInst
 import { AccessManagementType, ConsentGroup2, FileType } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 import { Dataset } from 'src/types/model'
 import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
+
+dayjs.extend(customParseFormat)
+
 export type MasterChangeHandler = ({ key, value, isValid, remove }: { key: string, value: unknown, isValid: boolean, remove?: boolean }) => void
 
 export const generateStudyPropertyYesNoField = (formData: Study, setStudy: React.Dispatch<React.SetStateAction<Study>>, studyProperty: BooleanStudyProperty) => {
@@ -339,4 +343,9 @@ export const extractThroughBioId = (input: string): string => {
     // Not a URL: return non-empty string, else ''
     return trimmed === '' ? '' : trimmed
   }
+}
+
+export const isValidDate = (dateString: string): boolean => {
+  const format = 'YYYY-MM-DD'
+  return dayjs(dateString, format, true).isValid()
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -438,8 +438,8 @@ export interface FundingResource {
   funderProgram: string
   grantNumber: string
   projectTitle: string
-  startDate: string
-  endDate: string
+  startDate?: string
+  endDate?: string
   url: string
   tags?: string[]
 }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3077](https://broadworkbench.atlassian.net/browse/DT-3077)

### Summary

Elasticsearch throws an error if we pass in a field with the name date and it doesn't have a date it can parse.  This PR updates the save logic to ensure we don't supply invalid (empty) date values to ElasticSearch, checks that the dates that are provided are valid, and updates types so they properly reflect the optional and required form elements.

The clinicalTrialId value is also now being populated in a driveby fix.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
