### PR TITLE
[DT-3085] Ensure displayed columns are included in search when they don't rely on aggregation filtering.

### DIFF
--- a/cypress/component/data_library/columns/fundingResourceColumns.spec.tsx
+++ b/cypress/component/data_library/columns/fundingResourceColumns.spec.tsx
@@ -188,7 +188,7 @@ describe('makeFundingResourceColumns — accessibility', () => {
       />,
     )
     cy.contains('Study Name').should('exist')
-    cy.contains('FundingResource ID').should('exist')
+    cy.contains('Funding Resource ID').should('exist')
     cy.contains('Funder Name').should('exist')
     cy.contains('Funder Program').should('exist')
     cy.contains('Grant Number').should('exist')

--- a/src/components/data_library/assets/clinicalTrialAsset.ts
+++ b/src/components/data_library/assets/clinicalTrialAsset.ts
@@ -22,6 +22,9 @@ export const clinicalTrialAsset: AssetDefinition = {
     'study.assets.clinicalTrials.identifier',
     'study.assets.clinicalTrials.registry',
     'study.assets.clinicalTrials.tags',
+    'study.assets.clinicalTrials.interventionTypes',
+    'study.assets.clinicalTrials.phase',
+    'study.assets.clinicalTrials.status',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/intellectualPropertyAsset.ts
+++ b/src/components/data_library/assets/intellectualPropertyAsset.ts
@@ -16,6 +16,7 @@ export const intellectualPropertyAsset: AssetDefinition = {
     'study.assets.intellectualProperties.assignee',
     'study.assets.intellectualProperties.patentNumber',
     'study.assets.intellectualProperties.status',
+    'study.assets.intellectualProperties.contact',
     'study.assets.intellectualProperties.tags',
   ],
 

--- a/src/components/data_library/assets/modelAsset.ts
+++ b/src/components/data_library/assets/modelAsset.ts
@@ -15,6 +15,11 @@ export const modelAsset: AssetDefinition = {
     'study.assets.models.format',
     'study.assets.models.license',
     'study.assets.models.tags',
+    'study.assets.models.description',
+    'study.assets.models.url',
+    'study.assets.models.trainedOnDatasets',
+    'study.assets.models.maintainer.name',
+    'study.assets.models.maintainer.email',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/presentationAsset.ts
+++ b/src/components/data_library/assets/presentationAsset.ts
@@ -15,6 +15,7 @@ export const presentationAsset: AssetDefinition = {
     'study.assets.presentations.event',
     'study.assets.presentations.location',
     'study.assets.presentations.authors',
+    'study.assets.presentations.presenter.name',
     'study.assets.presentations.format',
     'study.assets.presentations.tags',
   ],

--- a/src/components/data_library/assets/publicationAsset.ts
+++ b/src/components/data_library/assets/publicationAsset.ts
@@ -15,6 +15,8 @@ export const publicationAsset: AssetDefinition = {
     'study.assets.publications.journal',
     'study.assets.publications.doi',
     'study.assets.publications.pubmedId',
+    'study.assets.publications.doi',
+    'study.assets.publications.authors.name',
     'study.assets.publications.tags',
   ],
 

--- a/src/components/data_library/assets/studyAsset.ts
+++ b/src/components/data_library/assets/studyAsset.ts
@@ -21,6 +21,7 @@ export const studyAsset: AssetDefinition = {
     'dac.dacName',
     'datasetIdentifier',
     'study.data.tags',
+    'study.phenotype',
   ],
 
   buildQuery(

--- a/src/components/data_library/assets/workspaceAsset.ts
+++ b/src/components/data_library/assets/workspaceAsset.ts
@@ -16,6 +16,8 @@ export const workspaceAsset: AssetDefinition = {
     'study.assets.workspaces.description',
     'study.assets.workspaces.tools',
     'study.assets.workspaces.tags',
+    'study.assets.workspaces.access',
+    'study.assets.workspaces.url',
   ],
 
   buildQuery(

--- a/src/components/data_library/columns/fundingResourceColumns.tsx
+++ b/src/components/data_library/columns/fundingResourceColumns.tsx
@@ -18,7 +18,7 @@ export const makeFundingResourceColumns = (): GridColDef<FundingResourceAsset>[]
   },
   {
     field: 'fundingId',
-    headerName: 'FundingResource ID',
+    headerName: 'Funding Resource ID',
     flex: 1,
     minWidth: 150,
     renderCell: (params) => {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3085](https://broadworkbench.atlassian.net/browse/DT-3085)

### Summary

Adds missing columns to searching for different assets.
Drive by fix for a column heading name that was missing a space in it.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
