### PR TITLE
[DT-2805] Add Mixpanel metrics on logout

### DIFF
--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -629,6 +629,7 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
           expect(event).to.equal(eventList.userAutoLogout401)
           expect(details).to.have.property('expires_on', mockExpTime)
           expect(details).to.have.property('current_time').that.is.a('number')
+          expect(details).to.have.property('time_until_expires').that.is.a('number')
           expect(details).to.have.property('endpoint_url', 'https://consent.example.org/api/something')
         },
       )
@@ -694,6 +695,7 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
           expect(captureEventStub.calledOnce).to.equal(true)
           const [, details] = captureEventStub.firstCall.args
           expect(details).to.have.property('expires_on', null)
+          expect(details).to.have.property('time_until_expires', null)
         },
       )
     })

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -582,10 +582,8 @@ describe('fetchAdapter - Fetch methods', () => {
 
 describe('fetchAdapter - 401 Bard metric logging', () => {
   let fetchStub: ReturnType<typeof cy.stub>
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let captureEventStub: any
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let signOutStub: any
+  let captureEventStub: Cypress.Agent<sinon.SinonStub> | sinon.SinonStub
+  let signOutStub: Cypress.Agent<sinon.SinonStub> | sinon.SinonStub
 
   const mockExpTime = Math.floor(Date.now() / 1000) + 3600 // 1h from now
 

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -582,8 +582,8 @@ describe('fetchAdapter - Fetch methods', () => {
 
 describe('fetchAdapter - 401 Bard metric logging', () => {
   let fetchStub: ReturnType<typeof cy.stub>
-  let captureEventStub: ReturnType<typeof cy.stub>
-  let signOutStub: ReturnType<typeof cy.stub>
+  let captureEventStub: any
+  let signOutStub: any
 
   const mockExpTime = Math.floor(Date.now() / 1000) + 3600 // 1h from now
 

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -582,7 +582,9 @@ describe('fetchAdapter - Fetch methods', () => {
 
 describe('fetchAdapter - 401 Bard metric logging', () => {
   let fetchStub: ReturnType<typeof cy.stub>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let captureEventStub: any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let signOutStub: any
 
   const mockExpTime = Math.floor(Date.now() / 1000) + 3600 // 1h from now
@@ -622,7 +624,7 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
       fetchGet('https://consent.example.org/api/something').then(
         () => { throw new Error('Should have thrown') },
         () => {
-          expect(captureEventStub).to.have.been.calledOnce
+          expect(captureEventStub.calledOnce).to.equal(true)
           const [event, details] = captureEventStub.firstCall.args
           expect(event).to.equal(eventList.userAutoLogout401)
           expect(details).to.have.property('expires_on', mockExpTime)
@@ -645,8 +647,8 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
       fetchGet('https://consent.example.org/api/user/me').then(
         () => { throw new Error('Should have thrown') },
         () => {
-          expect(captureEventStub).not.to.have.been.called
-          expect(signOutStub).not.to.have.been.called
+          expect(captureEventStub.called).to.equal(false)
+          expect(signOutStub.called).to.equal(false)
         },
       )
     })
@@ -664,8 +666,8 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
       fetchGet('https://consent.example.org/api/something').then(
         () => { throw new Error('Should have thrown') },
         () => {
-          expect(captureEventStub).not.to.have.been.called
-          expect(signOutStub).not.to.have.been.called
+          expect(captureEventStub.called).to.equal(false)
+          expect(signOutStub.called).to.equal(false)
         },
       )
     })
@@ -689,7 +691,7 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
       fetchGet('https://consent.example.org/api/something').then(
         () => { throw new Error('Should have thrown') },
         () => {
-          expect(captureEventStub).to.have.been.calledOnce
+          expect(captureEventStub.calledOnce).to.equal(true)
           const [, details] = captureEventStub.firstCall.args
           expect(details).to.have.property('expires_on', null)
         },
@@ -709,8 +711,8 @@ describe('fetchAdapter - 401 Bard metric logging', () => {
       fetchGet('https://other-api.example.org/api/resource').then(
         () => { throw new Error('Should have thrown') },
         () => {
-          expect(captureEventStub).not.to.have.been.called
-          expect(signOutStub).not.to.have.been.called
+          expect(captureEventStub.called).to.equal(false)
+          expect(signOutStub.called).to.equal(false)
         },
       )
     })

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -7,6 +7,11 @@ import {
   fetchMultipart,
   type Params,
 } from 'src/libs/ajax/fetchAdapter'
+import { Metrics } from 'src/libs/ajax/Metrics'
+import { Storage } from 'src/libs/storage'
+import { Config } from 'src/libs/config'
+import { Auth } from 'src/libs/auth/auth'
+import eventList from 'src/libs/events'
 
 interface StubOptions {
   method?: string
@@ -569,6 +574,143 @@ describe('fetchAdapter - Fetch methods', () => {
             throw new Error('Expected error.response to be defined')
           }
           expect(error.response.data.message).to.equal(backendMessage)
+        },
+      )
+    })
+  })
+})
+
+describe('fetchAdapter - 401 Bard metric logging', () => {
+  let fetchStub: ReturnType<typeof cy.stub>
+  let captureEventStub: ReturnType<typeof cy.stub>
+  let signOutStub: ReturnType<typeof cy.stub>
+
+  const mockExpTime = Math.floor(Date.now() / 1000) + 3600 // 1h from now
+
+  beforeEach(() => {
+    cy.initApplicationConfig()
+    cy.stub(Config, 'getApiUrl').resolves('https://consent.example.org')
+    captureEventStub = cy.stub(Metrics, 'captureEvent').resolves()
+    signOutStub = cy.stub(Auth, 'signOut').resolves()
+    cy.stub(Storage, 'getOidcUser').returns({
+      profile: { exp: mockExpTime, sub: '', iss: '', aud: '', iat: 0 },
+    })
+
+    // Suppress navigation errors from redirectOnLogout setting window.location.href
+    cy.on('uncaught:exception', () => false)
+
+    cy.window().then((win) => {
+      fetchStub = cy.stub(win, 'fetch')
+    })
+  })
+
+  afterEach(() => {
+    cy.window().then(() => {
+      if (fetchStub) fetchStub.restore()
+    })
+  })
+
+  it('should fire Bard metric with session details on 401 from DUOS API', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchGet('https://consent.example.org/api/something').then(
+        () => { throw new Error('Should have thrown') },
+        () => {
+          expect(captureEventStub).to.have.been.calledOnce
+          const [event, details] = captureEventStub.firstCall.args
+          expect(event).to.equal(eventList.userAutoLogout401)
+          expect(details).to.have.property('expires_on', mockExpTime)
+          expect(details).to.have.property('current_time').that.is.a('number')
+          expect(details).to.have.property('endpoint_url', 'https://consent.example.org/api/something')
+        },
+      )
+    })
+  })
+
+  it('should NOT fire Bard metric on 401 for GET /api/user/me', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchGet('https://consent.example.org/api/user/me').then(
+        () => { throw new Error('Should have thrown') },
+        () => {
+          expect(captureEventStub).not.to.have.been.called
+          expect(signOutStub).not.to.have.been.called
+        },
+      )
+    })
+  })
+
+  it('should NOT fire Bard metric or redirect on non-401 errors', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify({ message: 'Server error' }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchGet('https://consent.example.org/api/something').then(
+        () => { throw new Error('Should have thrown') },
+        () => {
+          expect(captureEventStub).not.to.have.been.called
+          expect(signOutStub).not.to.have.been.called
+        },
+      )
+    })
+  })
+
+  it('should include null expires_on when OIDC user has no exp', () => {
+    // Override the Storage stub for this test
+    (Storage.getOidcUser as ReturnType<typeof cy.stub>).restore()
+    cy.stub(Storage, 'getOidcUser').returns({
+      profile: { sub: '', iss: '', aud: '', iat: 0 },
+    })
+
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchGet('https://consent.example.org/api/something').then(
+        () => { throw new Error('Should have thrown') },
+        () => {
+          expect(captureEventStub).to.have.been.calledOnce
+          const [, details] = captureEventStub.firstCall.args
+          expect(details).to.have.property('expires_on', null)
+        },
+      )
+    })
+  })
+
+  it('should NOT fire Bard metric on 401 from non-DUOS API', () => {
+    cy.window().then((win) => {
+      fetchStub.resolves(
+        new win.Response(JSON.stringify({ message: 'Unauthorized' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchGet('https://other-api.example.org/api/resource').then(
+        () => { throw new Error('Should have thrown') },
+        () => {
+          expect(captureEventStub).not.to.have.been.called
+          expect(signOutStub).not.to.have.been.called
         },
       )
     })

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -77,6 +77,10 @@ async function handleResponse<T>(
   if (!res.ok) {
     const apiUrl = await Config.getApiUrl()
     if (res.status === 401 && !shouldSkip401Redirect(url, method, apiUrl)) {
+
+      // Record relevant 401 logouts to Bard / Mixpanel.
+      // This gives systematic, empirical data to assess premature logout issues.
+      // More context: https://github.com/DataBiosphere/duos-ui/pull/3389
       const oidcUser = Storage.getOidcUser()
       const expiresOn = oidcUser?.profile?.exp ?? null
       const currentTime = Math.floor(Date.now() / 1000)
@@ -86,6 +90,7 @@ async function handleResponse<T>(
         time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
         endpoint_url: url,
       }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
+
       redirectOnLogout()
     }
     reportError(url, res.status)

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -77,7 +77,6 @@ async function handleResponse<T>(
   if (!res.ok) {
     const apiUrl = await Config.getApiUrl()
     if (res.status === 401 && !shouldSkip401Redirect(url, method, apiUrl)) {
-
       // Record relevant 401 logouts to Bard / Mixpanel.
       // This gives systematic, empirical data to assess premature logout issues.
       // More context: https://github.com/DataBiosphere/duos-ui/pull/3389
@@ -90,7 +89,6 @@ async function handleResponse<T>(
         time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
         endpoint_url: url,
       }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
-
       redirectOnLogout()
     }
     reportError(url, res.status)

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -4,7 +4,7 @@ import { Metrics } from 'src/libs/ajax/Metrics'
 import { Storage } from 'src/libs/storage'
 import { StackdriverReporter } from 'src/libs/stackdriverReporter'
 import { shouldSkip401Redirect } from 'src/utils/AuthRedirectUtils'
-import { Config } from '../config'
+import { Config } from 'src/libs/config'
 
 export type ResponseType = 'blob' | 'json' | 'text'
 export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -79,11 +79,13 @@ async function handleResponse<T>(
     if (res.status === 401 && !shouldSkip401Redirect(url, method, apiUrl)) {
       const oidcUser = Storage.getOidcUser()
       const expiresOn = oidcUser?.profile?.exp ?? null
-      Metrics.captureEvent(eventList.userAutoLogout401, {
+      const currentTime = Math.floor(Date.now() / 1000)
+      await Metrics.captureEvent(eventList.userAutoLogout401, {
         expires_on: expiresOn,
-        current_time: Math.floor(Date.now() / 1000),
+        current_time: currentTime,
+        time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
         endpoint_url: url,
-      })
+      }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
       redirectOnLogout()
     }
     reportError(url, res.status)

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -1,7 +1,10 @@
 import { redirectOnLogout } from 'src/libs/auth/auth'
+import eventList from 'src/libs/events'
+import { Metrics } from 'src/libs/ajax/Metrics'
+import { Storage } from 'src/libs/storage'
 import { StackdriverReporter } from 'src/libs/stackdriverReporter'
 import { shouldSkip401Redirect } from 'src/utils/AuthRedirectUtils'
-import { Config } from 'src/libs/config'
+import { Config } from '../config'
 
 export type ResponseType = 'blob' | 'json' | 'text'
 export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
@@ -74,6 +77,13 @@ async function handleResponse<T>(
   if (!res.ok) {
     const apiUrl = await Config.getApiUrl()
     if (res.status === 401 && !shouldSkip401Redirect(url, method, apiUrl)) {
+      const oidcUser = Storage.getOidcUser()
+      const expiresOn = oidcUser?.profile?.exp ?? null
+      Metrics.captureEvent(eventList.userAutoLogout401, {
+        expires_on: expiresOn,
+        current_time: Math.floor(Date.now() / 1000),
+        endpoint_url: url,
+      })
       redirectOnLogout()
     }
     reportError(url, res.status)

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -5,6 +5,7 @@
 const eventList = {
   userRegister: 'user:register',
   userSignIn: 'user:signin',
+  userAutoLogout401: 'user:autoLogout401',
 
   pageView: 'page:view',
   dataLibrary: 'page:view:data-library',


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2805

### Summary
Users have sometimes gotten logged out very soon after logging in.  We have not been able to reliably and realistically reproduce this premature sign-out issue.  That said, we have implemented a plausible solution in #3385.

This adds analytics to corroborate our individual observations on whether our solution indeed fixes the problem.  The new `user:autoLogout401` is logged to Bard / Mixpanel upon applicable 401 redirects.

Here's how the event looks in Mixpanel.  (You can observe it [in the "Terra Analytics Dev" Mixpanel project](https://mixpanel.com/project/2085496/view/19055/app/events#ezv5HC2FzXYV) now, and "Terra Analytics Prod" after deployment.). The most relevant property is `time_until_expires`.  If it's 0 or negative, then the user's auth session has expired.  

If the rate of these requests events increase, or these rich metrics reveal we're seeing `user:autoLogout401` where `time_until_expires > 0`, then we'll have new causal insight on the problem.  (By default, we anticipate the metrics will simply corroborate the fix.)  The new data here also provides a baseline for monitoring future premature logout issues.

<img width="1512" height="816" alt="Screenshot 2026-03-17 at 10 32 44 AM" src="https://github.com/user-attachments/assets/77fbc477-3813-40ce-9195-0db1dd8b3900" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
