### PR TITLE
[DT-3086] Add `Office of the Director (OD)` to Institutes and Centers list

### DIFF
--- a/src/components/forms/NIHInstitutesAndCenters.ts
+++ b/src/components/forms/NIHInstitutesAndCenters.ts
@@ -158,6 +158,12 @@ export class NIHInstitutesAndCenters {
     abbreviation: 'NCCIH',
   }
 
+  static readonly OD: SelectOptionWithKeyNameAndAbbreviation = {
+    key: 'OD',
+    name: 'NIH Office of the Director',
+    abbreviation: 'OD',
+  }
+
   static readonly VALUES: SelectOptionWithKeyNameAndAbbreviation[] = [
     NIHInstitutesAndCenters.NCI,
     NIHInstitutesAndCenters.NEI,
@@ -185,7 +191,9 @@ export class NIHInstitutesAndCenters {
     NIHInstitutesAndCenters.CSR,
     NIHInstitutesAndCenters.FIC,
     NIHInstitutesAndCenters.NCATS,
-    NIHInstitutesAndCenters.NCCIH]
+    NIHInstitutesAndCenters.NCCIH,
+    NIHInstitutesAndCenters.OD,
+  ]
 
   static readonly ABBREVIATIONS: string[] = NIHInstitutesAndCenters.VALUES.map(val => val.abbreviation || '')
 }

--- a/src/pages/NIHicWebform.jsx
+++ b/src/pages/NIHicWebform.jsx
@@ -80,7 +80,7 @@ export default function NIHICWebform() {
     'National Institute of Neurological Disorders and Stroke (NINDS)',
     'National Institute of Nursing Research (NINR)',
     'National Library of Medicine (NLM)',
-    'NIH Office of the Director',
+    'NIH Office of the Director (OD)',
   ]
 
   const nihCenterOptions = nihCenterList.map(function (item) {

--- a/src/pages/NIHicWebform.jsx
+++ b/src/pages/NIHicWebform.jsx
@@ -58,7 +58,8 @@ export default function NIHICWebform() {
     display: 'inline-block',
   }
 
-  const nihCenterList = ['National Cancer Institute (NCI)',
+  const nihCenterList = [
+    'National Cancer Institute (NCI)',
     'National Eye Institute (NEI)',
     'National Heart, Lung, and Blood Institute (NHLBI)',
     'National Human Genome Research Institute (NHGRI)',
@@ -78,7 +79,9 @@ export default function NIHICWebform() {
     'National Institute on Minority Health and Health Disparities (NIMHD)',
     'National Institute of Neurological Disorders and Stroke (NINDS)',
     'National Institute of Nursing Research (NINR)',
-    'National Library of Medicine (NLM)']
+    'National Library of Medicine (NLM)',
+    'NIH Office of the Director',
+  ]
 
   const nihCenterOptions = nihCenterList.map(function (item) {
     return {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3086

### Summary

The NIH Institutes and Centers list now includes `Office of the Director (OD)`. This value is already present in dbGaP and should be available in DUOS when selecting an Institute or Center.

<img width="2092" height="1004" alt="After" src="https://github.com/user-attachments/assets/9746c574-d222-4877-a3d5-a6f337b26742" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
