### PR TITLE
[DT-3093] Fix broken search box in Console pages

### DIFF
--- a/cypress/component/libs/utils.spec.ts
+++ b/cypress/component/libs/utils.spec.ts
@@ -1,7 +1,7 @@
 import { getSearchFilterFunctions, formatDate, processElectionStatus, sortVisibleTable, TableCell } from 'src/libs/utils'
 import { toLower } from 'lodash'
 import { VOTE_TYPES } from 'src/utils/DarUtils'
-import { DuosUser, Election, LibraryCard, Vote, DarCollection, Study } from 'src/types/model'
+import { DuosUser, Election, LibraryCard, Vote, DarCollectionSummary } from 'src/types/model'
 
 const sampleLCList: LibraryCard[] = [
   {
@@ -67,126 +67,52 @@ const sampleResearcherList: DuosUser[] = [
   },
 ]
 
-const darCollectionSummaryOne: DarCollection = {
-  id: 1,
+const darCollectionSummaryOne: DarCollectionSummary = {
   darCode: 'DAR-1',
-  createDate: 1649163460401,
-  createUserId: 1,
-  dars: {},
-  datasets: [{
-    name: 'Dataset 1',
-    datasetId: 1,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 1,
-    datasetIdentifier: 'TEST-001',
-    dataUse: {},
-  }, {
-    name: 'Dataset 2',
-    datasetId: 2,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 2,
-    datasetIdentifier: 'TEST-002',
-    dataUse: {},
-  }, {
-    name: 'Dataset 3',
-    datasetId: 3,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 3,
-    datasetIdentifier: 'TEST-003',
-    dataUse: {},
-  }, {
-    name: 'Dataset 4',
-    datasetId: 4,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 4,
-    datasetIdentifier: 'TEST-004',
-    dataUse: {},
-  }],
-} as DarCollection
+  darCollectionId: 1,
+  name: 'Test Collection 1',
+  researcherName: 'Researcher One',
+  institutionName: 'Institution One',
+  status: 'Submitted',
+  dacNames: ['Test DAC'],
+  dacCode: 'DAC-1',
+  datasetCount: 4,
+  datasetIds: [1, 2, 3, 4],
+  submissionDate: 1649163460401,
+  actions: [],
+  expired: false,
+  expiresAt: 0,
+  latestReferenceId: 'DAR-1',
+  progressReport: false,
+  referenceIds: [],
+  requiresSOApproval: false,
+}
 
-const darCollectionSummaryTwo: DarCollection = {
-  id: 2,
+const darCollectionSummaryTwo: DarCollectionSummary = {
   darCode: 'DAR-2',
-  createDate: 1629163460401,
-  createUserId: 1,
-  dars: {},
-  datasets: [{
-    name: 'Dataset 5',
-    datasetId: 5,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 5,
-    datasetIdentifier: 'TEST-005',
-    dataUse: {},
-  }, {
-    name: 'Dataset 6',
-    datasetId: 6,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 6,
-    datasetIdentifier: 'TEST-006',
-    dataUse: {},
-  }, {
-    name: 'Dataset 7',
-    datasetId: 7,
-    createUserId: 1,
-    createUser: {} as DuosUser,
-    createDate: new Date(),
-    dacId: 1,
-    translatedDataUse: 'test',
-    deletable: true,
-    properties: [],
-    study: {} as Study,
-    alias: 7,
-    datasetIdentifier: 'TEST-007',
-    dataUse: {},
-  }],
-} as DarCollection
+  darCollectionId: 2,
+  name: 'Test Collection 2',
+  researcherName: 'Researcher Two',
+  institutionName: 'Institution Two',
+  status: 'Submitted',
+  dacNames: ['Test DAC'],
+  dacCode: 'DAC-2',
+  datasetCount: 3,
+  datasetIds: [5, 6, 7],
+  submissionDate: 1629163460401,
+  actions: [],
+  expired: false,
+  expiresAt: 0,
+  latestReferenceId: 'DAR-2',
+  progressReport: false,
+  referenceIds: [],
+  requiresSOApproval: false,
+}
 
-let collectionSearchFn: (term: string, list: DarCollection[]) => DarCollection[]
+let collectionSearchFn: (term: string, list: DarCollectionSummary[]) => DarCollectionSummary[]
 let cardSearchFn: (term: string, list: LibraryCard[]) => LibraryCard[]
 let researcherSearchFn: (term: string, list: DuosUser[]) => DuosUser[]
-let summaryList: DarCollection[]
+let summaryList: DarCollectionSummary[]
 const expectResearcherMatch = (actual: DuosUser, expected: DuosUser) => {
   expect(actual.displayName).to.equal(expected.displayName)
   expect(actual.email).to.equal(expected.email)
@@ -196,7 +122,7 @@ const expectResearcherMatch = (actual: DuosUser, expected: DuosUser) => {
 
 beforeEach(() => {
   const searchFunctionsMap = getSearchFilterFunctions()
-  collectionSearchFn = searchFunctionsMap.darCollections as (term: string, list: DarCollection[]) => DarCollection[]
+  collectionSearchFn = searchFunctionsMap.darCollections
   cardSearchFn = searchFunctionsMap.libraryCard as (term: string, list: LibraryCard[]) => LibraryCard[]
   researcherSearchFn = searchFunctionsMap.signingOfficialResearchers
   summaryList = [darCollectionSummaryOne, darCollectionSummaryTwo]
@@ -219,10 +145,10 @@ describe('Dar Collection Search Filter', () => {
   })
 
   it('filters on submission date', () => {
-    const formattedSubmissionDate = formatDate(darCollectionSummaryOne.createDate)
+    const formattedSubmissionDate = formatDate(darCollectionSummaryOne.submissionDate)
     const filteredList = collectionSearchFn(formattedSubmissionDate, summaryList)
     expect(filteredList.length).to.equal(1)
-    expect(formatDate(filteredList[0].createDate)).to.equal(formattedSubmissionDate)
+    expect(formatDate(filteredList[0].submissionDate)).to.equal(formattedSubmissionDate)
     const emptyList = collectionSearchFn('invalid', summaryList)
     expect(emptyList.length).to.equal(0)
   })

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -23,6 +23,7 @@ import { ToastNotifications } from 'src/libs/ToastNotifications'
 import {
   DuosUser,
   DarCollection,
+  DarCollectionSummary,
   Election,
   Vote,
   LibraryCard,
@@ -337,7 +338,7 @@ interface SearchFilterFunctions {
   dar: (term: string, targetList: ElectionData[]) => ElectionData[]
   libraryCard: (term: string, targetList: LibraryCard[]) => LibraryCard[]
   signingOfficialResearchers: (term: string, targetList: Researcher[]) => Researcher[]
-  darCollections: (term: string, targetList: DarCollection[]) => DarCollection[]
+  darCollections: (term: string, targetList: DarCollectionSummary[]) => DarCollectionSummary[]
   users: (term: string, targetList: DuosUser[]) => DuosUser[]
   datasets: (term: string, targetList: Dataset[]) => Dataset[]
   datasetTerms: (term: string, targetList: DatasetTerm[]) => DatasetTerm[]
@@ -413,22 +414,23 @@ const filterSigningOfficialResearchers = (term: string, targetList: Researcher[]
   })
 }
 
-const filterDarCollections = (term: string, targetList: DarCollection[]): DarCollection[] => {
+const filterDarCollections = (term: string, targetList: DarCollectionSummary[]): DarCollectionSummary[] => {
   if (isEmpty(term)) return targetList
-  return filter(targetList, (collection: DarCollection) => {
-    const { darCode, createDate, updateDate } = collection
-    const datasetCount = collection.datasets?.length || 0
-    const formattedCreateDate = formatDate(createDate)
-    const formattedUpdateDate = formatDate(updateDate)
+  return filter(targetList, (collection: DarCollectionSummary) => {
+    const { darCode, name, researcherName, institutionName, status, dacNames, datasetCount, submissionDate } = collection
     const searchableValues = [
       darCode,
-      String(datasetCount),
-      formattedCreateDate,
-      formattedUpdateDate,
+      name,
+      researcherName,
+      institutionName,
+      status,
+      join(dacNames ?? [], ' '),
+      String(datasetCount ?? 0),
+      formatDate(submissionDate),
     ]
     const termArr = term.split(' ')
     return searchableValues.some(value =>
-      termArr.some(t => includes(toLower(String(value)), toLower(t))),
+      termArr.some(t => includes(toLower(String(value ?? '')), toLower(t))),
     )
   })
 }

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -562,7 +562,7 @@ type ListTypeForModel<T extends keyof SearchFilterFunctions>
   = T extends 'dar' ? ElectionData[]
     : T extends 'libraryCard' ? LibraryCard[]
       : T extends 'signingOfficialResearchers' ? Researcher[]
-        : T extends 'darCollections' ? DarCollection[]
+        : T extends 'darCollections' ? DarCollectionSummary[]
           : T extends 'users' ? DuosUser[]
             : T extends 'datasets' ? Dataset[]
               : T extends 'datasetTerms' ? DatasetTerm[]

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -657,7 +657,7 @@ export interface DarCollectionSummary {
   actions: string[]
   dacNames: string[]
   dacCode: string
-  darCode?: string
+  darCode: string
   darCollectionId: number
   datasetCount: number
   datasetIds: number[]

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -657,6 +657,7 @@ export interface DarCollectionSummary {
   actions: string[]
   dacNames: string[]
   dacCode: string
+  darCode?: string
   darCollectionId: number
   datasetCount: number
   datasetIds: number[]


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3093

### Summary
This fixes the search box on DAR tables for admin, chairs, and researchers.  Previously, entering text in the bug would never return results in the table, even when the rows had matching content.  Now, entering text returns matching rows as expected.

The cause was that `filterDarCollections` searched `DarCollection` fields, but the API returns `DarCollectionSummary` objects.  Every search term matched against [undefined, "0", "- -", "- -"] for every row, so all rows disappeared.  Fixing the subtle type error updates the filter to search the actual summary fields, and returns expected results.

Before and after:

https://github.com/user-attachments/assets/0e860af4-b859-4503-a710-224db603c404


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
