### PR TITLE
[DT-400] Switch to weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: cron
-      cronjob: "0 0 1,15 * *"
+      interval: weekly
     open-pull-requests-limit: 10
     target-branch: develop
     commit-message:
@@ -22,8 +21,7 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: cron
-      cronjob: "0 0 1,15 * *"
+      interval: weekly
     open-pull-requests-limit: 10
     target-branch: develop
     labels:
@@ -44,8 +42,7 @@ updates:
   - package-ecosystem: docker
     directory: "/"
     schedule:
-      interval: cron
-      cronjob: "0 0 1,15 * *"
+      interval: weekly
     open-pull-requests-limit: 10
     target-branch: develop
     labels:


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

We have a number of packages that require updates, and Dependabot has not updated them in a while. The last time grouped updates ran successfully was in #3240 in January. Temporarily switch the update cycle to weekly to see if this fixes the issue.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
