### PR TITLE
[DT-2841] Include Closeout DARs in SO Approval List

### DIFF
--- a/src/pages/progress_reports/CloseoutReview.tsx
+++ b/src/pages/progress_reports/CloseoutReview.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react'
 import InfoIcon from '@mui/icons-material/Info'
 import { User } from 'src/libs/ajax/User'
 import { Notifications } from 'src/libs/utils'
-import { extractConsentError, extractError } from 'src/utils/ErrorUtils'
+import { extractError } from 'src/utils/ErrorUtils'
 import { Storage } from 'src/libs/storage'
 import { DAR } from 'src/libs/ajax/DAR'
-import { DataAccessRequest } from 'src/types/model'
+import { DataAccessRequest, ResponseError } from 'src/types/model'
 import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton'
 
 interface CloseoutReviewProps {
@@ -50,8 +50,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
         }
       }
       catch (error) {
-        const consentError = extractConsentError(error)
-        if (consentError?.code === 404) {
+        if ((error as ResponseError)?.response?.status === 404) {
           // 404 indicates no acknowledgement found, which is not an error
         }
         else {

--- a/src/pages/progress_reports/CloseoutReview.tsx
+++ b/src/pages/progress_reports/CloseoutReview.tsx
@@ -51,7 +51,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
       }
       catch (error) {
         const consentError = extractConsentError(error)
-        if (consentError && consentError.code === 404) {
+        if (consentError?.code === 404) {
           // 404 indicates no acknowledgement found, which is not an error
         }
         else {

--- a/src/pages/progress_reports/DarCloseout.tsx
+++ b/src/pages/progress_reports/DarCloseout.tsx
@@ -15,7 +15,7 @@ interface DarCloseoutProps {
   validation?: DarErrors
 }
 
-export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element {
+export default function DarCloseout(props: Readonly<DarCloseoutProps>): React.JSX.Element {
   const { readOnly, datasets, formState, onFormChange, onValidationChange, validation } = props
 
   const [allSigningOfficials, setAllSigningOfficials] = useState<SimplifiedDuosUser[]>([])
@@ -93,17 +93,17 @@ export default function DarCloseout(props: DarCloseoutProps): React.JSX.Element 
               <p>
                 A close out submission will immediately revoke access to all datasets accessed through the
                 original Data Access Request:
-                <ul>
-                  {datasets.map(dataset => (
-                    <li key={dataset.datasetId}>
-                      {dataset.datasetIdentifier}
-                      :
-                      {' '}
-                      {dataset.name}
-                    </li>
-                  ))}
-                </ul>
               </p>
+              <ul>
+                {datasets.map(dataset => (
+                  <li key={dataset.datasetId}>
+                    {dataset.datasetIdentifier}
+                    :
+                    {' '}
+                    {dataset.name}
+                  </li>
+                ))}
+              </ul>
               <p>
                 By completing this page, upon project close-out, the PI and all approved users acknowledge
                 they have destroyed all copies, versions, and derivations of the dataset(s) retrieved from

--- a/src/pages/signing_official_console/SigningOfficialDarApprovals.tsx
+++ b/src/pages/signing_official_console/SigningOfficialDarApprovals.tsx
@@ -26,7 +26,8 @@ export default function SigningOfficialDarApprovals(): React.JSX.Element {
       try {
         setIsLoading(true)
         const collectionList = (await Collections.getCollectionSummariesByRoleName(USER_ROLES.signingOfficial))
-          .filter((collection: DarCollectionSummary) => collection.requiresSOApproval === true)
+          .filter((collection: DarCollectionSummary) =>
+            collection.requiresSOApproval || collection.actions.includes('Review_Progress_Report'))
         setCollectionList(collectionList)
         setIsLoading(false)
       }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,6 +2,13 @@ import externalAccessIcon from 'src/images/external_access.svg'
 import openAccessIcon from 'src/images/open_access.svg'
 import controlledAccessIcon from 'src/images/controlled_access.svg'
 
+export interface ResponseError {
+  readonly response?: {
+    readonly data?: ConsentError
+    readonly status?: number
+  }
+}
+
 export interface ConsentError {
   readonly message?: string
   readonly code?: number

--- a/src/utils/ErrorUtils.ts
+++ b/src/utils/ErrorUtils.ts
@@ -1,4 +1,4 @@
-import { ConsentError, ResponseError } from 'src/types/model'
+import { ConsentError } from 'src/types/model'
 
 export function extractError(error: unknown): string {
   const consentError = extractConsentError(error)
@@ -14,7 +14,7 @@ export function extractError(error: unknown): string {
 export function extractConsentError(error: unknown): ConsentError | undefined {
   // If error is a fetch-based error with a ConsentError shape
   if (typeof error === 'object' && error !== null && 'message' in error) {
-    return (error as ResponseError)?.response?.data as ConsentError
+    return error as ConsentError
   }
   return undefined
 }

--- a/src/utils/ErrorUtils.ts
+++ b/src/utils/ErrorUtils.ts
@@ -1,4 +1,4 @@
-import { ConsentError } from 'src/types/model'
+import { ConsentError, ResponseError } from 'src/types/model'
 
 export function extractError(error: unknown): string {
   const consentError = extractConsentError(error)
@@ -14,7 +14,7 @@ export function extractError(error: unknown): string {
 export function extractConsentError(error: unknown): ConsentError | undefined {
   // If error is a fetch-based error with a ConsentError shape
   if (typeof error === 'object' && error !== null && 'message' in error) {
-    return error as ConsentError
+    return (error as ResponseError)?.response?.data as ConsentError
   }
   return undefined
 }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2841

### Summary

This PR updates the SO approval page to include DAR Closeout Progress Reports in addition to standard DARs.

We use the existing `Review_Progress_Report` backend action to identify these Progress Reports and surface them in the UI so that SOs can see and act on all approvals in one place.

**Approval Table**
<img width="1782" height="707" alt="Table" src="https://github.com/user-attachments/assets/0568d5bd-28eb-404c-8040-c61f22886b4d" />

**Approval Button**
<img width="1782" height="798" alt="Approval" src="https://github.com/user-attachments/assets/b89f58b8-f128-4556-936b-69d903c28b6e" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
