### PR TITLE
[DT-3149] Include External Profile in Read Only mode on AdminEditUser.jsx

### DIFF
--- a/cypress/component/ExternalProfile/external_profile.spec.tsx
+++ b/cypress/component/ExternalProfile/external_profile.spec.tsx
@@ -50,7 +50,6 @@ describe('ExternalProfile', () => {
   it('Renders read-only table with two columns', () => {
     cy.mount(<ExternalProfile {...mockExternalProfilePropsForReadOnly} />)
     cy.wait('@getUser')
-    cy.get('table thead tr th').should('have.length', 2)
     cy.get('btn-secondary').should('not.exist')
     cy.get('btn-primary').should('not.exist')
     cy.get('input').should('not.exist')

--- a/src/pages/AdminEditUser.jsx
+++ b/src/pages/AdminEditUser.jsx
@@ -7,6 +7,7 @@ import editUserIcon from 'src/images/icon_edit_user.png'
 import { PageHeading } from 'src/components/PageHeading'
 import { extractError } from 'src/utils/ErrorUtils.js'
 import { useNavigate, useParams } from 'react-router-dom'
+import ExternalProfile from 'src/pages/user_profile/ExternalProfile'
 
 const adminRole = { roleId: 4, name: USER_ROLES.admin }
 const researcherRole = { roleId: 5, name: USER_ROLES.researcher }
@@ -332,8 +333,11 @@ export const AdminEditUser = () => {
         </div>
         {
           !isEmpty(state.user) && (
-            <div style={{ margin: 50, padding: 80 }}>
+            <div style={{ marginTop: '50px' }} className="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12 no-padding">
               <ResearcherReview user={state.user} />
+              <div style={{ marginTop: '20px' }}>
+                <ExternalProfile userId={userId} readonly={true} />
+              </div>
             </div>
           )
         }

--- a/src/pages/user_profile/ExternalProfile.css
+++ b/src/pages/user_profile/ExternalProfile.css
@@ -13,6 +13,15 @@
     font-weight: 600;
 }
 
+.external-profile .header-container-readonly h1 {
+    margin: 0px;
+    padding-right: 20px;
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 1.1;
+    color: inherit;
+}
+
 .external-profile .header-container button:hover {
     background-color: #2FA4E7;
 }

--- a/src/pages/user_profile/ExternalProfile.tsx
+++ b/src/pages/user_profile/ExternalProfile.tsx
@@ -167,152 +167,178 @@ export default function ExternalProfile(props: ExternalProfileProps) {
     init()
   }, [readonly, props.userId])
 
-  return (
-    <div className="external-profile">
-      <div className="header-container">
-        <h1> External Profile
-        </h1>
-      </div>
-      <div style={{ marginTop: '20px' }} />
-      <table>
-        <thead>
-          <tr>
-            <th>Site</th>
-            { !readonly && <th>ID</th> }
-            <th>Link</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>
-              <label htmlFor="linkedIn">LinkedIn</label>
-            </td>
-            {!readonly && (
-              <td>
-                <input
-                  type="text"
-                  id="linkedIn"
-                  name="linkedIn"
-                  placeholder="LinkedIn Profile User ID (e.g. https://www.linkedin.com/in/username)"
-                  value={linkedIn}
-                  onChange={onLinkedInChange}
-                  minLength={2}
-                  disabled={readonly}
-                />
-              </td>
-            )}
-            <td>
-              <a href={formattedLinkedIn(linkedIn)} target="_blank" rel="noopener noreferrer">
-                {formattedLinkedIn(linkedIn)}
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <label htmlFor="ORCID">ORCID iD</label>
-            </td>
-            {!readonly && (
-              <td>
-                <input
-                  type="text"
-                  id="ORCID"
-                  name="ORCID"
-                  style={{ padding: '25px 15px', borderRadius: '4px', border: '1px solid #ccc', width: '400px', height: '34px', color: '#555555', backgroundColor: '#fff', transition: 'border-color ease-in-out .15s, box-shadow ease-in-out .15s' }}
-                  placeholder="ORCID iD (e.g. https://orcid.org/0000-0000-0000-0000)"
-                  value={orcid}
-                  minLength={2}
-                  onChange={onOrcidChange}
-                  disabled={readonly}
-                />
-              </td>
-            )}
-            <td>
-              <a href={formattedOrcid(orcid)} target="_blank" rel="noopener noreferrer">
-                {formattedOrcid(orcid)}
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <label htmlFor="throughBio">Through.bio</label>
-            </td>
-            {!readonly && (
-              <td>
-                <input
-                  type="text"
-                  id="throughBio"
-                  name="throughBio"
-                  placeholder="Through.bio profile id (e.g. https://through.bio/<profile-id>)"
-                  value={throughBio}
-                  minLength={2}
-                  onChange={onThroughBioChange}
-                  disabled={readonly}
-                />
-              </td>
-            )}
-            <td>
-              <a href={formattedThroughBio(throughBio)} target="_blank" rel="noopener noreferrer">
-                {formattedThroughBio(throughBio)}
-              </a>
-            </td>
-          </tr>
-          <tr>
-            <td>
-              <label htmlFor="institutionalWebsite">Institutional Website</label>
-            </td>
-            {!readonly && (
-              <td>
-                <input
-                  type="url"
-                  id="institutionalWebsite"
-                  name="Institutional Website"
-                  placeholder="Institutional Website (e.g. https://www.institution.edu/~username)"
-                  value={institutionalWebsite}
-                  onChange={onInstitutionalWebsiteChange}
-                  disabled={readonly}
-                />
-              </td>
-            )}
-            <td>
-              <a href={institutionalWebsite} target="_blank" rel="noopener noreferrer">
-                {institutionalWebsite}
-              </a>
-            </td>
-          </tr>
-          {otherUrls && otherUrls.length > 0 && otherUrls.map((url, index) => (
-            <tr key={index}>
-              <td>
-                <label htmlFor={`otherUrl${index}`}>Other URL {index + 1}</label>
-              </td>
-              {!readonly && (
+  const getLinkedInLink = () => {
+    return (
+      getUrlLink(formattedLinkedIn(linkedIn))
+    )
+  }
+
+  const getOrcidLink = () => {
+    return (
+      getUrlLink(formattedOrcid(orcid))
+    )
+  }
+
+  const getThroughBioLink = () => {
+    return (
+      getUrlLink(formattedThroughBio(throughBio))
+    )
+  }
+
+  const getInstitutionalWebsiteLink = () => {
+    return (
+      getUrlLink(institutionalWebsite)
+    )
+  }
+
+  const getUrlLink = (url: string) => {
+    return (
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        {url}
+      </a>
+    )
+  }
+
+  return readonly
+    ? (
+        <div>
+          <h4>External Profile</h4>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+            <div style={{ fontWeight: 'bold' }}>Linked In</div><div>{getLinkedInLink()}</div>
+            <div style={{ fontWeight: 'bold' }}>ORCID iD</div><div>{getOrcidLink()}</div>
+            <div style={{ fontWeight: 'bold' }}>Through.bio</div><div>{getThroughBioLink()}</div>
+            <div style={{ fontWeight: 'bold' }}>Institutional Website</div><div>{getInstitutionalWebsiteLink()}</div>
+            {otherUrls && otherUrls.length > 0 && otherUrls.map((url, index) => (
+              <React.Fragment key={index}>
+                <div>Other URL {index + 1}</div><div>{getUrlLink(url)}</div>
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+      )
+    : (
+        <div className="external-profile">
+          <div className="header-container">
+            <h1> External Profile
+            </h1>
+          </div>
+          <div style={{ marginTop: '20px' }} />
+          <table>
+            <thead>
+              <tr>
+                <th>Site</th>
+                <th>ID</th>
+                <th>Link</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <label htmlFor="linkedIn">LinkedIn</label>
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    id="linkedIn"
+                    name="linkedIn"
+                    placeholder="LinkedIn Profile User ID (e.g. https://www.linkedin.com/in/username)"
+                    value={linkedIn}
+                    onChange={onLinkedInChange}
+                    minLength={2}
+                  />
+                </td>
+                <td>
+                  { getLinkedInLink() }
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <label htmlFor="ORCID">ORCID iD</label>
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    id="ORCID"
+                    name="ORCID"
+                    style={{ padding: '25px 15px', borderRadius: '4px', border: '1px solid #ccc', width: '400px', height: '34px', color: '#555555', backgroundColor: '#fff', transition: 'border-color ease-in-out .15s, box-shadow ease-in-out .15s' }}
+                    placeholder="ORCID iD (e.g. https://orcid.org/0000-0000-0000-0000)"
+                    value={orcid}
+                    minLength={2}
+                    onChange={onOrcidChange}
+                  />
+                </td>
+                <td>
+                  { getOrcidLink() }
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <label htmlFor="throughBio">Through.bio</label>
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    id="throughBio"
+                    name="throughBio"
+                    placeholder="Through.bio profile id (e.g. https://through.bio/<profile-id>)"
+                    value={throughBio}
+                    minLength={2}
+                    onChange={onThroughBioChange}
+                  />
+                </td>
+                <td>
+                  { getThroughBioLink() }
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <label htmlFor="institutionalWebsite">Institutional Website</label>
+                </td>
                 <td>
                   <input
                     type="url"
-                    id={`otherUrl${index}`}
-                    name={`Other URL ${index + 1}`}
-                    placeholder="Other URL"
-                    value={url}
-                    onChange={(event) => {
-                      onOtherUrlChange(event, index)
-                    }}
-                    onBlur={(event) => { event.target.reportValidity() }}
-                    disabled={readonly}
+                    id="institutionalWebsite"
+                    name="Institutional Website"
+                    placeholder="Institutional Website (e.g. https://www.institution.edu/~username)"
+                    value={institutionalWebsite}
+                    onChange={onInstitutionalWebsiteChange}
                   />
                 </td>
-              )}
-              <td>
-                {!readonly
-                  && <IconButton aria-label="remove entry" onClick={() => { removeEntry(index) }}><RemoveCircleOutlineIcon /></IconButton>}
-                <a href={url} target="_blank" rel="noopener noreferrer">
-                  {url}
-                </a>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <button hidden={readonly} onClick={addNewOtherUrl} className="btn-secondary">Add URL</button>
-      <button style={{ marginLeft: '30px' }} hidden={readonly} disabled={invalidUrls.length > 0} onClick={onSaveClick} className="btn-primary">Save</button>
-    </div>
-  )
+                <td>
+                  { getInstitutionalWebsiteLink() }
+                </td>
+              </tr>
+              {otherUrls && otherUrls.length > 0 && otherUrls.map((url, index) => (
+                <tr key={index}>
+                  <td>
+                    <label htmlFor={`otherUrl${index}`}>Other URL {index + 1}</label>
+                  </td>
+                  <td>
+                    <input
+                      type="url"
+                      id={`otherUrl${index}`}
+                      name={`Other URL ${index + 1}`}
+                      placeholder="Other URL"
+                      value={url}
+                      onChange={(event) => {
+                        onOtherUrlChange(event, index)
+                      }}
+                      onBlur={(event) => { event.target.reportValidity() }}
+                      disabled={readonly}
+                    />
+                  </td>
+                  <td>
+                    && <IconButton aria-label="remove entry" onClick={() => { removeEntry(index) }}><RemoveCircleOutlineIcon /></IconButton>
+                    <a href={url} target="_blank" rel="noopener noreferrer">
+                      {url}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <button onClick={addNewOtherUrl} className="btn-secondary">Add URL</button>
+          <button style={{ marginLeft: '30px' }}disabled={invalidUrls.length > 0} onClick={onSaveClick} className="btn-primary">Save</button>
+        </div>
+      )
 }

--- a/src/pages/user_profile/ExternalProfile.tsx
+++ b/src/pages/user_profile/ExternalProfile.tsx
@@ -168,26 +168,24 @@ export default function ExternalProfile(props: ExternalProfileProps) {
   }, [readonly, props.userId])
 
   const getLinkedInLink = () => {
-    return (
-      getUrlLink(formattedLinkedIn(linkedIn))
-    )
+    return readonly && !linkedIn ? <span>No LinkedIn profile provided</span> : getUrlLink(formattedLinkedIn(linkedIn))
   }
 
   const getOrcidLink = () => {
     return (
-      getUrlLink(formattedOrcid(orcid))
+      readonly && !orcid ? <span>No ORCID iD provided</span> : getUrlLink(formattedOrcid(orcid))
     )
   }
 
   const getThroughBioLink = () => {
     return (
-      getUrlLink(formattedThroughBio(throughBio))
+      readonly && !throughBio ? <span>No Through.bio profile provided</span> : getUrlLink(formattedThroughBio(throughBio))
     )
   }
 
   const getInstitutionalWebsiteLink = () => {
     return (
-      getUrlLink(institutionalWebsite)
+      readonly && !institutionalWebsite ? <span>No institutional website provided</span> : getUrlLink(institutionalWebsite)
     )
   }
 

--- a/src/pages/user_profile/ExternalProfile.tsx
+++ b/src/pages/user_profile/ExternalProfile.tsx
@@ -329,9 +329,7 @@ export default function ExternalProfile(props: ExternalProfileProps) {
                   </td>
                   <td>
                     && <IconButton aria-label="remove entry" onClick={() => { removeEntry(index) }}><RemoveCircleOutlineIcon /></IconButton>
-                    <a href={url} target="_blank" rel="noopener noreferrer">
-                      {url}
-                    </a>
+                    { getUrlLink(url) }
                   </td>
                 </tr>
               ))}

--- a/src/pages/user_profile/ExternalProfile.tsx
+++ b/src/pages/user_profile/ExternalProfile.tsx
@@ -324,7 +324,6 @@ export default function ExternalProfile(props: ExternalProfileProps) {
                         onOtherUrlChange(event, index)
                       }}
                       onBlur={(event) => { event.target.reportValidity() }}
-                      disabled={readonly}
                     />
                   </td>
                   <td>

--- a/src/pages/user_profile/ExternalProfile.tsx
+++ b/src/pages/user_profile/ExternalProfile.tsx
@@ -202,7 +202,7 @@ export default function ExternalProfile(props: ExternalProfileProps) {
         <div>
           <h4>External Profile</h4>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
-            <div style={{ fontWeight: 'bold' }}>Linked In</div><div>{getLinkedInLink()}</div>
+            <div style={{ fontWeight: 'bold' }}>LinkedIn</div><div>{getLinkedInLink()}</div>
             <div style={{ fontWeight: 'bold' }}>ORCID iD</div><div>{getOrcidLink()}</div>
             <div style={{ fontWeight: 'bold' }}>Through.bio</div><div>{getThroughBioLink()}</div>
             <div style={{ fontWeight: 'bold' }}>Institutional Website</div><div>{getInstitutionalWebsiteLink()}</div>
@@ -278,7 +278,7 @@ export default function ExternalProfile(props: ExternalProfileProps) {
                     type="text"
                     id="throughBio"
                     name="throughBio"
-                    placeholder="Through.bio profile id (e.g. https://through.bio/<profile-id>)"
+                    placeholder="Through.bio profile ID (e.g. https://through.bio/<profile-id>)"
                     value={throughBio}
                     minLength={2}
                     onChange={onThroughBioChange}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3149](https://broadworkbench.atlassian.net/browse/DT-3149)

### Summary

- Updates the ExternalProfile component in read only mode to build a grid instead of a table for alignment with elements of the ResearcherInfo component
- Minor refactoring in ExternalProfile to make this easier to maintain going forward.
- Includes the ExternalProfile component on the AdminEditUser.jsx component
 
<img width="1351" height="1088" alt="image" src="https://github.com/user-attachments/assets/7fb6692f-10fc-4b31-9344-51b186335ebb" />

Read only mode on AdminEditUser.jsx when user does not have information entered:
<img width="700" height="163" alt="image" src="https://github.com/user-attachments/assets/969b1c35-45f1-49bb-9adc-02865cb00573" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
