### PR TITLE
[DT-3154] Remove switching to draft endpoints that enforce DAAs.

### DIFF
--- a/src/libs/ajax/DAR.js
+++ b/src/libs/ajax/DAR.js
@@ -18,9 +18,7 @@ export const DAR = {
   // v2, v3 Draft DAR Update
   updateDarDraft: async (dar, referenceId) => {
     Metrics.captureEvent(eventList.dar, { action: 'update' })
-    const url = DAAUtils.isEnabled()
-      ? `${await Config.getApiUrl()}/api/dar/v3/draft/${referenceId}`
-      : `${await Config.getApiUrl()}/api/dar/v2/draft/${referenceId}`
+    const url = `${await Config.getApiUrl()}/api/dar/v2/draft/${referenceId}`
     const res = await fetchPut(url, dar, Config.authOpts())
     return res.data
   },
@@ -29,9 +27,7 @@ export const DAR = {
   postDarDraft: async (dar) => {
     // noinspection ES6MissingAwait
     Metrics.captureEvent(eventList.dar, { action: 'draft' })
-    const url = DAAUtils.isEnabled()
-      ? `${await Config.getApiUrl()}/api/dar/v3/draft`
-      : `${await Config.getApiUrl()}/api/dar/v2/draft`
+    const url = `${await Config.getApiUrl()}/api/dar/v2/draft`
     const res = await fetchPost(url, dar, Config.authOpts())
     return res.data
   },


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3154](https://broadworkbench.atlassian.net/browse/DT-3154)

### Summary

Drafts should always be allowed to save.  DAA logic will be applied upon submission and does not require all Researchers to have a preassigned DAA.

Pairs with  #[https://github.com/DataBiosphere/consent/pull/2849](https://github.com/DataBiosphere/consent/pull/2849)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
