### PR TITLE
[DT-3114] Add biospecimen help text to Study Assets section

### DIFF
--- a/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_asset_management.spec.tsx
@@ -28,7 +28,7 @@ const baseStudy: Study = {
 describe('StudyAssetManagement component', () => {
   it('renders all asset sections with titles and descriptions', () => {
     const setStudySpy = cy.spy().as('setStudySpy')
-    cy.mount(<StudyAssetManagement study={baseStudy} setStudy={setStudySpy} />)
+    cy.mount(<StudyAssetManagement study={baseStudy} setStudy={setStudySpy} onOpenContactUs={cy.stub()} />)
 
     const sections = [
       { title: 'Datasets', desc: 'Add datasets associated with this study' },
@@ -43,7 +43,8 @@ describe('StudyAssetManagement component', () => {
     ]
 
     cy.contains('Study Assets').should('exist')
-    cy.contains('Add datasets, models, workspaces, and other resources associated with this study').should('exist')
+    cy.contains('Add datasets, models, workspaces, and other resources associated with this study. To add biospecimen data,').should('exist')
+    cy.contains('contact the DUOS Team').should('exist')
 
     for (const { title, desc } of sections) {
       cy.contains('h3', title).should('exist')
@@ -61,7 +62,7 @@ describe('StudyAssetManagement component', () => {
     }
 
     const setStudySpy = cy.spy().as('setStudySpy')
-    cy.mount(<StudyAssetManagement study={baseStudyNoBiospecimens} setStudy={setStudySpy} />)
+    cy.mount(<StudyAssetManagement study={baseStudyNoBiospecimens} setStudy={setStudySpy} onOpenContactUs={cy.stub()} />)
 
     cy.contains('h3', 'Biospecimens').should('not.exist')
     cy.contains('View total biospecimens for this study').should('not.exist')

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment, useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { SupportRequestModal } from 'src/components/modals/SupportRequestModal'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { GeneralStudyInformation } from 'src/pages/data_submission/v2/GeneralStudyInformation'
 import { NihAnvilUseRelated } from 'src/pages/data_submission/v2/NihAnvilUseRelated'
@@ -31,6 +32,7 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   const [isEditing, setIsEditing] = useState(false)
   const [study, setStudy] = useState({} as Study)
   const [loadingError, setLoadingError] = useState(false)
+  const [showContactModal, setShowContactModal] = useState(false)
 
   const navigate = useNavigate()
 
@@ -123,7 +125,8 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
         <NihAnvilUseRelated study={study} setStudy={setStudy} />
         <NihAdministrativeInformation study={study} setStudy={setStudy} />
         <NihDataManagement study={study} setStudy={setStudy} />
-        <StudyAssetManagement study={study} setStudy={setStudy} isEditingExistingStudy={isEditing} />
+        <StudyAssetManagement study={study} setStudy={setStudy} isEditingExistingStudy={isEditing} onOpenContactUs={() => setShowContactModal(true)} />
+        <SupportRequestModal showModal={showContactModal} onCloseRequest={() => setShowContactModal(false)} />
         {!isEditing && (
           <AsyncSpinnerButton
             onClick={onSubmitStudy}
@@ -131,7 +134,7 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
             className="button button-white"
             data-cy="data-submission-submit-button"
             hideOnSuccess={true}
-            style={{ marginBottom: '12px' }}
+            style={{ marginTop: '1rem', marginBottom: '12px' }}
           >
             Create Study
           </AsyncSpinnerButton>

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -34,10 +34,11 @@ export interface StudyAssetManagementProps {
   study: Study
   setStudy: React.Dispatch<React.SetStateAction<Study>>
   isEditingExistingStudy?: boolean
+  onOpenContactUs: () => void
 }
 
 export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
-  const { setStudy, study, isEditingExistingStudy } = props
+  const { setStudy, study, isEditingExistingStudy, onOpenContactUs } = props
 
   const onAssetChange = <K extends keyof NonNullable<Study['assets']>>(
     assetType: K,
@@ -62,7 +63,10 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
   return (
     <div className="data-submitter-section">
       <h2>Study Assets</h2>
-      <p>Add datasets, models, workspaces, and other resources associated with this study</p>
+      <p>
+        Add datasets, models, workspaces, and other resources associated with this study. To add biospecimen data,{' '}
+        <a onClick={onOpenContactUs} style={{ cursor: 'pointer' }}>contact the DUOS Team</a>.
+      </p>
 
       <ConsentGroupList
         consentGroups={consentGroups}

--- a/src/pages/data_submission/v2/StudyAssetManagement.tsx
+++ b/src/pages/data_submission/v2/StudyAssetManagement.tsx
@@ -29,6 +29,7 @@ import ConsentGroupList from 'src/components/consent_group_list/ConsentGroupList
 import { ConsentGroup2 } from '../consent_group/consentGroupUtils'
 import BiospecimenList from 'src/components/biospecimen_list/BiospecimenList'
 import { Biotech } from '@mui/icons-material'
+import { Button } from '@mui/material'
 
 export interface StudyAssetManagementProps {
   study: Study
@@ -64,8 +65,8 @@ export const StudyAssetManagement = (props: StudyAssetManagementProps) => {
     <div className="data-submitter-section">
       <h2>Study Assets</h2>
       <p>
-        Add datasets, models, workspaces, and other resources associated with this study. To add biospecimen data,{' '}
-        <a onClick={onOpenContactUs} style={{ cursor: 'pointer' }}>contact the DUOS Team</a>.
+        Add datasets, models, workspaces, and other resources associated with this study. To add biospecimen data,
+        <Button onClick={onOpenContactUs} style={{ cursor: 'pointer' }}>contact the DUOS Team.</Button>
       </p>
 
       <ConsentGroupList


### PR DESCRIPTION
no security risk

### Addresses
https://broadworkbench.atlassian.net/browse/DT-3114

### Summary
Informs data submitters that biospecimen data is ingested via the DUOS team white-glove process, with a Contact Us modal link to initiate that. Also adds spacing above the Create Study button to match asset row gaps.

<img width="1002" height="100" alt="After" src="https://github.com/user-attachments/assets/c5bdc6d6-57f5-4d5d-a09f-c5fb26a0e243" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
