### PR TITLE
DT-2845: Expressly handle AzureB2C errors

### DIFF
--- a/cypress/component/SignIn/SignInButton.spec.tsx
+++ b/cypress/component/SignIn/SignInButton.spec.tsx
@@ -129,4 +129,17 @@ describe('Sign In: Component Loads', function () {
     cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
     cy.get('button').should('exist').and('be.disabled')
   })
+
+  it('Sign In: Handles AzureB2C authentication error', function () {
+    cy.stub(Auth, 'signIn').resolves(mockOidcUser)
+    cy.stub(Auth, 'signOut').as('signOut').resolves()
+    const azureError = new Error('AzureB2C authentication error')
+    cy.stub(User, 'getMe').rejects(azureError)
+
+    cy.mount(<BrowserRouter><SignInButton /></BrowserRouter>)
+    cy.get('button').click()
+
+    cy.get('@signOut').should('have.been.called')
+    cy.contains('AzureB2C authentication error').should('exist')
+  })
 })

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -15,6 +15,7 @@ import { DuosUser } from 'src/types/model'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 import 'src/styles/tooltip.css'
 import { useNavigate } from 'react-router-dom'
+import { extractError } from 'src/utils/ErrorUtils'
 
 interface ErrorInfo {
   title?: string
@@ -79,8 +80,16 @@ export const SignInButton = () => {
         await handleRegistration(redirectTo, shouldRedirect)
       }
     }
-    catch (_error) {
-      await handleRegistration(redirectTo, shouldRedirect)
+    catch (error) {
+      // Explicitly handle AzureB2C errors from Sam
+      const errorMessage = extractError(error)
+      if (errorMessage.toLowerCase().includes('azureb2c authentication error')) {
+        await Auth.signOut()
+        setErrorDisplay({ show: true, title: 'Error', description: errorMessage })
+      }
+      else {
+        await handleRegistration(redirectTo, shouldRedirect)
+      }
     }
   }
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2845

### Summary
Requires https://github.com/DataBiosphere/consent/pull/2866

When signing in, look for a response from the back end that is a Sam Azure error and appropriately handle it by showing it to the user and directing them to support for help in resolving it.

<img width="1239" height="771" alt="Screenshot 2026-04-16 at 4 15 55 PM" src="https://github.com/user-attachments/assets/3a351c17-cb19-4477-a424-61c0c6e16b23" />

----

Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
