### PR TITLE
DT-2861: Fix incorrect usage of navigate

### DIFF
--- a/src/pages/manage_dac/ManageDac.jsx
+++ b/src/pages/manage_dac/ManageDac.jsx
@@ -63,8 +63,7 @@ export const ManageDac = function ManageDac() {
 
   useEffect(() => {
     if (showDatasetsPage && selectedDatasets.length > 0) {
-      navigate({
-        pathname: '/manage_dac_datasets',
+      navigate('/manage_dac_datasets', {
         state: { dac: selectedDac, datasets: selectedDatasets },
       })
     }


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2861

### Summary
The bug stems from the incorrect usage of the navigate function. This was introduced in the migration from react router 5 -> 6: https://github.com/DataBiosphere/duos-ui/pull/3126 and looks like the only incorrect usage in the codebase.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
