### PR TITLE
DT-3150: Fix readonly console error after DAC deletion

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -691,7 +691,7 @@ export const setStyle = (
   targetColorAttribute: string,
 ): Record<string, unknown> => {
   const appliedStyle = disabled ? { [targetColorAttribute]: Theme.palette.disabled } : {}
-  return Object.assign(baseStyle, appliedStyle)
+  return { ...baseStyle, ...appliedStyle }
 }
 
 interface DivAttributes {


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3150

### Summary
Fix a minor bug discovered when testing DAC deletion in the UI. After deletion, the page loads with a console error:

```
Uncaught TypeError: Cannot assign to read only property 'color' of object '#<Object>'
    at Object.assign (<anonymous>)
    at setStyle (utils.ts:694:17)
    at TableIconButton (TableIconButton.jsx:39:24)
...

The above error occurred in the <TableIconButton> component:

    at TableIconButton (https://local.dsde-dev.broadinstitute.org:3000/src/components/TableIconButton.jsx?t=1777044755345:26:5)
    at div
    at div
    at div
    at DataRows (https://local.dsde-dev.broadinstitute.org:3000/src/components/SimpleTable.jsx:135:21)
```

Note that I can only reproduce this problem locally, it does not happen in dev.

Claude Sonnet 4.6 was able to find the bug quickly:

> The issue is clear. Object.assign(baseStyle, appliedStyle) mutates baseStyle in place, but baseStyle is the Styles.TABLE.TABLE_ICON_BUTTON constant object which is frozen/read-only. The fix is to spread into a new object instead of mutating the original.
> 
> The fix changes Object.assign(baseStyle, appliedStyle) to Object.assign({}, baseStyle, appliedStyle).
> 
> The original code was trying to mutate baseStyle directly (the Styles.TABLE.TABLE_ICON_BUTTON object), which is a frozen/read-only constant. By passing an empty {} as the first argument, we create a new object and merge into it instead of mutating the original — resolving the Cannot assign to read only property 'color' error.

Sonarqube correctly suggested using a spread operator instead of using `Object.assign`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
