### PR TITLE
DT-2640: Convert DAAs.jsx to typescript

### DIFF
--- a/cypress/component/UserProfile/DAAs.spec.tsx
+++ b/cypress/component/UserProfile/DAAs.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import DAAs from 'src/pages/user_profile/DAAs'
+import { DAA } from 'src/libs/ajax/DAA'
+import { DAAObject, FileStorageObject } from 'src/types/model'
+
+describe('DAAs', () => {
+  const fso: FileStorageObject = {
+    fileStorageObjectId: 1,
+    entityId: 'entity-1',
+    fileName: 'test-agreement.pdf',
+    category: 'irbCollaborationLetter',
+    mediaType: 'application/pdf',
+    createUserId: 3,
+    createDate: new Date().getDate(),
+  }
+
+  const daa: DAAObject = {
+    broadDaa: false,
+    daaId: 1,
+    createUserId: 3,
+    createDate: new Date().toISOString(),
+    updateUserId: 3,
+    updateDate: new Date().toISOString(),
+    initialDacId: 1,
+    file: fso,
+    dacs: [],
+  }
+
+  const issuedBy = 'Test Signing Official'
+  const issuedOn = '2024-06-15T00:00:00.000Z'
+
+  beforeEach(() => {
+    cy.viewport(800, 600)
+    cy.initApplicationConfig()
+    cy.stub(DAA, 'getDaaFileById').resolves(undefined)
+  })
+
+  it('renders a download link for each DAA', () => {
+    cy.mount(<DAAs issuedOn={issuedOn} issuedBy={issuedBy} daas={[daa]} />)
+
+    cy.contains('test-agreement').should('exist')
+  })
+
+  it('renders the issued-by name and formatted date', () => {
+    const expectedDate = new Date(issuedOn).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
+
+    cy.mount(<DAAs issuedOn={issuedOn} issuedBy={issuedBy} daas={[daa]} />)
+
+    cy.contains('Issued by').should('exist')
+    cy.contains(issuedBy).should('exist')
+    cy.contains(expectedDate).should('exist')
+  })
+
+  it('renders multiple DAAs', () => {
+    const daa2: DAAObject = {
+      ...daa,
+      daaId: 2,
+      file: { ...fso, fileStorageObjectId: 2, fileName: 'second-agreement.pdf' },
+    }
+
+    cy.mount(<DAAs issuedOn={issuedOn} issuedBy={issuedBy} daas={[daa, daa2]} />)
+
+    cy.contains('test-agreement').should('exist')
+    cy.contains('second-agreement').should('exist')
+  })
+
+  it('renders nothing when daas array is empty', () => {
+    cy.mount(<DAAs issuedOn={issuedOn} issuedBy={issuedBy} daas={[]} />)
+
+    cy.get('a').should('not.exist')
+  })
+
+  it('strips the file extension from the displayed file name', () => {
+    cy.mount(<DAAs issuedOn={issuedOn} issuedBy={issuedBy} daas={[daa]} />)
+
+    cy.contains('test-agreement').should('exist')
+    cy.contains('test-agreement.pdf').should('not.exist')
+  })
+
+  it('calls DAA.getDaaFileById with the correct id and name when download is clicked', () => {
+    cy.mount(<DAAs issuedOn={issuedOn} issuedBy={issuedBy} daas={[daa]} />)
+
+    cy.contains('test-agreement').click()
+    cy.wrap(DAA.getDaaFileById).should('have.been.calledWith', daa.daaId, 'test-agreement')
+  })
+})

--- a/src/pages/user_profile/DAAs.tsx
+++ b/src/pages/user_profile/DAAs.tsx
@@ -1,22 +1,34 @@
 import React from 'react'
-import { DAA } from '../../libs/ajax/DAA'
+import { DAA } from 'src/libs/ajax/DAA'
+import { DAAObject } from 'src/types/model'
 
-export default function DAAs(props) {
+interface DAAsProps {
+  readonly issuedOn: string
+  readonly issuedBy: string
+  readonly daas: DAAObject[]
+}
+
+export default function DAAs(props: DAAsProps) {
   const {
     issuedOn,
     issuedBy,
     daas,
   } = props
 
-  const DAADownload = (id, fileName) => {
+  const DAADownload = (id: number, fileName: string) => {
     return (
       <div className="flex flex-row" style={{ justifyContent: 'flex-start', marginBottom: '30px' }}>
         <div>
-          <a target="_blank" rel="noreferrer" onClick={() => DAA.getDaaFileById(id, fileName)} className="button button-white" style={{ marginRight: '2rem', display: 'flex', alignItems: 'center' }}>
-            <span style={{ paddingRight: '1rem' }}className="glyphicon glyphicon-download"></span>
+          <button
+            type="button"
+            onClick={() => DAA.getDaaFileById(id, fileName)}
+            className="button button-white"
+            style={{ marginRight: '2rem', display: 'flex', alignItems: 'center' }}
+          >
+            <span style={{ paddingRight: '1rem' }} className="glyphicon glyphicon-download"></span>
             {' '}
             {fileName}
-          </a>
+          </button>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <p style={{ margin: '0px 0px 0px 10px' }}>Issued by</p>
@@ -31,7 +43,7 @@ export default function DAAs(props) {
     )
   }
 
-  const daaDivs = daas.map((daa) => {
+  const daaDivs = daas.map((daa: DAAObject) => {
     const id = daa.daaId
     const fileName = daa.file.fileName.split('.')[0]
     return (


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2640

### Summary
Migrate component to Typescript. When DAAs are enabled, this part of the User Profile page is updated with a user's pre-authorizations:

<img width="1082" height="444" alt="Screenshot 2026-04-27 at 12 58 10 PM" src="https://github.com/user-attachments/assets/dee0c4ac-8c3a-428f-ae2e-25ba6afbcda2" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
