### PR TITLE
[DT-3174] Do not include DAAs on closeouts.

### DIFF
--- a/cypress/component/utils/dar_utils.spec.ts
+++ b/cypress/component/utils/dar_utils.spec.ts
@@ -278,7 +278,36 @@ describe('DarUtils', () => {
       expect(result.irbProtocolExpiration).to.equal(formState.irbProtocolExpiration)
       expect(result.collaborationLetterLocation).to.equal(formState.collaborationLetterLocation)
       expect(result.collaborationLetterName).to.equal(formState.collaborationLetterName)
+      // closeoutYesNo is true in this formState, so daaIds should be absent
+      expect(result.daaIds).to.equal(undefined)
+    })
+
+    it('should include daaIds when closeoutYesNo is false', () => {
+      const formState = {
+        progressReportSummary: 'Test summary',
+        datasetIds: [1],
+        daaIds: [101, 102, 101] as number[],
+        closeoutYesNo: false,
+        labCollaborators: [],
+        internalCollaborators: [],
+        externalCollaborators: [],
+      } as unknown as FormState
+      const result = convertFormStateToDAR(formState)
       expect(result.daaIds).to.deep.equal([101, 102])
+    })
+
+    it('should omit daaIds when closeoutYesNo is true', () => {
+      const formState = {
+        progressReportSummary: 'Test summary',
+        datasetIds: [1],
+        daaIds: [101, 102] as number[],
+        closeoutYesNo: true,
+        labCollaborators: [],
+        internalCollaborators: [],
+        externalCollaborators: [],
+      } as unknown as FormState
+      const result = convertFormStateToDAR(formState)
+      expect(result.daaIds).to.equal(undefined)
     })
   })
 

--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -252,7 +252,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
           />
         </div>
       </div>
-      {DAAUtils.isEnabled() && (
+      {DAAUtils.isEnabled() && !formState.closeoutYesNo && (
         <div className={readOnlyMode ? 'accordion-step-container' : 'step-container'}>
           <ProgressReportDataAccessAgreements
             datasets={formState.selectedDatasets}

--- a/src/utils/DarUtils.ts
+++ b/src/utils/DarUtils.ts
@@ -46,9 +46,11 @@ export function convertFormStateToDAR(formState: FormState): Partial<CombinedDat
     expectedForm.intellectualProperties = formState.intellectualProperties
   }
   expectedForm.datasetIds = formState.datasetIds ?? []
-  expectedForm.daaIds = [...new Set((formState.daaIds ?? [])
-    .map(Number)
-    .filter(id => Number.isInteger(id) && id > 0))]
+  if (!formState.closeoutYesNo) {
+    expectedForm.daaIds = [...new Set((formState.daaIds ?? [])
+      .map(Number)
+      .filter(id => Number.isInteger(id) && id > 0))]
+  }
   if (formState.publicationsYesNo) {
     expectedForm.publications = getPublicationList(formState)
   }


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3174](https://broadworkbench.atlassian.net/browse/DT-3174)

### Summary

When submitting a closeout progress report, the current DAAs should not be submitted as the access was covered by agreement with the prior progress report or the original DAR.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
