### PR TITLE
DT-3198: Favor google auth over jwt

### DIFF
--- a/cypress/component/libs/config.spec.ts
+++ b/cypress/component/libs/config.spec.ts
@@ -196,7 +196,23 @@ describe('Config', () => {
   })
 
   describe('Token', () => {
-    it('should get token from storage when available', () => {
+    it('should prefer idp_access_token from profile when available', () => {
+      const idpToken = 'idp-access-token-123'
+      cy.stub(Storage, 'getOidcUser').returns({ profile: { idp_access_token: idpToken }, id_token: 'fallback-token' })
+
+      const token = Token.getToken()
+      expect(token).to.equal(idpToken)
+    })
+
+    it('should fall back to id_token when idp_access_token is not available', () => {
+      const mockToken = 'test-token-123'
+      cy.stub(Storage, 'getOidcUser').returns({ profile: {}, id_token: mockToken })
+
+      const token = Token.getToken()
+      expect(token).to.equal(mockToken)
+    })
+
+    it('should fall back to id_token when profile is not present', () => {
       const mockToken = 'test-token-123'
       cy.stub(Storage, 'getOidcUser').returns({ id_token: mockToken })
 
@@ -227,7 +243,18 @@ describe('Config', () => {
       })
     })
 
-    it('should create auth options with token from storage if not provided', () => {
+    it('should create auth options with idp_access_token from storage if not provided', () => {
+      const mockToken = 'idp-access-token'
+      cy.stub(Storage, 'getOidcUser').returns({ profile: { idp_access_token: mockToken }, id_token: 'fallback-token' })
+
+      const opts = authOpts()
+
+      expect(opts.headers['Authorization']).to.equal(`Bearer ${mockToken}`)
+      expect(opts.headers['Accept']).to.equal('application/json')
+      expect(opts.headers['X-App-ID']).to.equal('DUOS')
+    })
+
+    it('should create auth options with id_token from storage when idp_access_token is not present', () => {
       const mockToken = 'storage-token'
       cy.stub(Storage, 'getOidcUser').returns({ id_token: mockToken })
 
@@ -284,7 +311,18 @@ describe('Config', () => {
       })
     })
 
-    it('should create multipart options with token from storage if not provided', () => {
+    it('should create multipart options with idp_access_token from storage if not provided', () => {
+      const mockToken = 'idp-access-token'
+      cy.stub(Storage, 'getOidcUser').returns({ profile: { idp_access_token: mockToken }, id_token: 'fallback-token' })
+
+      const opts = multiPartOpts()
+
+      expect(opts.headers['Authorization']).to.equal(`Bearer ${mockToken}`)
+      expect(opts.headers['Content-Type']).to.equal('multipart/form-data')
+      expect(opts.headers['X-App-ID']).to.equal('DUOS')
+    })
+
+    it('should create multipart options with id_token from storage when idp_access_token is not present', () => {
       const mockToken = 'storage-token'
       cy.stub(Storage, 'getOidcUser').returns({ id_token: mockToken })
 

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -167,8 +167,12 @@ export const getTerraUrl = async (): Promise<string> => {
 }
 
 export const Token = {
+  // Note that there are multiple tokens available in OidcUser. There is an encoded JWT stored in id_token,
+  // access_token, and refresh_token. There is also a Google OAuth2 access token stored in profile.idp_access_token
+  // Favor the idp_access_token which bypasses all AzureB2C error cases and fall back to the regular id_token if the
+  // Google token is not present.
   getToken: () => {
-    return Storage.getOidcUser()?.id_token
+    return Storage.getOidcUser()?.profile?.idp_access_token || Storage.getOidcUser()?.id_token
   },
 }
 


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3198

## Summary
This PR looks for the Google OAuth2 bearer token as the preferred token to use for all API requests. It will only fall back to the current usage of the encoded JWT stored in `id_token` if we don't have a google one. 

This approach completely bypasses the Sam error:
```
"Cannot update azureB2cId for user 123 because user does not exist or the azureB2cId has already been set for this user"
```

## Testing
I have tested this locally with a user who hits the above Sam error through normal DUOS usage and through RAS account linking.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
