### PR TITLE
[DT-3181] Always show error message from API, if available

### DIFF
--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -286,7 +286,23 @@ describe('fetchAdapter - Fetch methods', () => {
     })
   })
 
-  it('should handle error response with message field', () => {
+  it('fetchMultipart - should report 502 on network-level failure', () => {
+    cy.window().then((win) => {
+      const formData = new win.FormData()
+      fetchStub.rejects(new win.TypeError('Network error'))
+
+      fetchMultipart('/api/progress_report/123', formData).then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          expect(error.message).to.include('failed with status 502')
+        },
+      )
+    })
+  })
+
+  it('fetchMultipart - should use backend error message when provided', () => {
     cy.window().then((win) => {
       const formData = new win.FormData()
       fetchStub.resolves(
@@ -296,7 +312,7 @@ describe('fetchAdapter - Fetch methods', () => {
         }),
       )
 
-      fetchMultipart('/api/upload', formData, {}, 'POST', true).then(
+      fetchMultipart('/api/upload', formData).then(
         () => {
           throw new Error('Should have thrown')
         },
@@ -307,7 +323,7 @@ describe('fetchAdapter - Fetch methods', () => {
     })
   })
 
-  it('should handle error response without message field', () => {
+  it('fetchMultipart - should fall back to help desk message when no message field in error body', () => {
     cy.window().then((win) => {
       const formData = new win.FormData()
       fetchStub.resolves(
@@ -317,18 +333,19 @@ describe('fetchAdapter - Fetch methods', () => {
         }),
       )
 
-      fetchMultipart('/api/upload', formData, {}, 'POST', true).then(
+      fetchMultipart('/api/upload', formData).then(
         () => {
           throw new Error('Should have thrown')
         },
         (error) => {
-          expect(error.message).to.include('Request failed with status 400')
+          expect(error.message).to.include('400')
+          expect(error.message).to.include('duos@duos.org')
         },
       )
     })
   })
 
-  it('should handle non-JSON error responses', () => {
+  it('fetchMultipart - should fall back to help desk message for non-JSON error responses', () => {
     cy.window().then((win) => {
       const formData = new win.FormData()
       fetchStub.resolves(
@@ -338,12 +355,34 @@ describe('fetchAdapter - Fetch methods', () => {
         }),
       )
 
-      fetchMultipart('/api/upload', formData, {}, 'POST', true).then(
+      fetchMultipart('/api/upload', formData).then(
         () => {
           throw new Error('Should have thrown')
         },
         (error) => {
-          expect(error.message).to.include('Request failed with status 500')
+          expect(error.message).to.include('500')
+          expect(error.message).to.include('duos@duos.org')
+        },
+      )
+    })
+  })
+
+  it('fetchMultipart - should always throw errors regardless of method', () => {
+    cy.window().then((win) => {
+      const formData = new win.FormData()
+      fetchStub.resolves(
+        new win.Response(JSON.stringify({ message: 'Missing library card' }), {
+          status: 400,
+          headers: { 'content-type': 'application/json' },
+        }),
+      )
+
+      fetchMultipart('/api/progress_report/123', formData, {}, 'POST').then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          expect(error.message).to.equal('Missing library card')
         },
       )
     })

--- a/cypress/component/libs/ajax/fetchAdapter.spec.ts
+++ b/cypress/component/libs/ajax/fetchAdapter.spec.ts
@@ -280,13 +280,66 @@ describe('fetchAdapter - Fetch methods', () => {
           throw new Error('Should have thrown')
         },
         (error) => {
-          expect(error.message).to.include('failed with status 502')
+          expect(error.message).to.include('Network error on request to')
+          expect(error.message).to.include('TypeError: Network error')
+          expect(error.message).to.include('duos@duos.org')
         },
       )
     })
   })
 
-  it('fetchMultipart - should report 502 on network-level failure', () => {
+  it('should handle AbortError as a DOMException network error', () => {
+    cy.window().then((win) => {
+      const abortError = new win.DOMException('The user aborted a request.', 'AbortError')
+      fetchStub.rejects(abortError)
+
+      fetchGet('/api/test').then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          expect(error.message).to.include('Network error on request to')
+          expect(error.message).to.include('AbortError: The user aborted a request.')
+          expect(error.message).to.include('duos@duos.org')
+        },
+      )
+    })
+  })
+
+  it('should handle DOMException (e.g. NotAllowedError) as a network error', () => {
+    cy.window().then((win) => {
+      const notAllowedError = new win.DOMException('The operation is not allowed.', 'NotAllowedError')
+      fetchStub.rejects(notAllowedError)
+
+      fetchGet('/api/test').then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          expect(error.message).to.include('Network error on request to')
+          expect(error.message).to.include('NotAllowedError: The operation is not allowed.')
+          expect(error.message).to.include('duos@duos.org')
+        },
+      )
+    })
+  })
+
+  it('should include help desk message for unknown thrown errors', () => {
+    cy.window().then((_win) => {
+      fetchStub.rejects({ message: 'Something unexpected', toString: () => 'Something unexpected' })
+
+      fetchGet('/api/test').then(
+        () => {
+          throw new Error('Should have thrown')
+        },
+        (error) => {
+          expect(error.message).to.include('duos@duos.org')
+        },
+      )
+    })
+  })
+
+  it('fetchMultipart - should report network error (not 502) on network-level failure', () => {
     cy.window().then((win) => {
       const formData = new win.FormData()
       fetchStub.rejects(new win.TypeError('Network error'))
@@ -296,7 +349,9 @@ describe('fetchAdapter - Fetch methods', () => {
           throw new Error('Should have thrown')
         },
         (error) => {
-          expect(error.message).to.include('failed with status 502')
+          expect(error.message).to.include('Network error on request to')
+          expect(error.message).to.include('TypeError: Network error')
+          expect(error.message).to.include('duos@duos.org')
         },
       )
     })

--- a/src/libs/ajax/DataSet.js
+++ b/src/libs/ajax/DataSet.js
@@ -17,7 +17,7 @@ export const DataSet = {
 
   registerDataset: async (registration) => {
     const url = `${await Config.getApiUrl()}/api/dataset/v3`
-    const res = await fetchMultipart(url, registration, Config.multiPartOpts(), 'POST')
+    const res = await fetchMultipart(url, registration, Config.multiPartOpts())
     return res.data
   },
 

--- a/src/libs/ajax/DataSet.js
+++ b/src/libs/ajax/DataSet.js
@@ -17,7 +17,7 @@ export const DataSet = {
 
   registerDataset: async (registration) => {
     const url = `${await Config.getApiUrl()}/api/dataset/v3`
-    const res = await fetchMultipart(url, registration, Config.multiPartOpts(), 'POST', true)
+    const res = await fetchMultipart(url, registration, Config.multiPartOpts(), 'POST')
     return res.data
   },
 
@@ -66,7 +66,7 @@ export const DataSet = {
 
   updateStudy: async (studyId, studyObject) => {
     const url = `${await Config.getApiUrl()}/api/dataset/study/${studyId}`
-    const res = await fetchMultipart(url, studyObject, Config.multiPartOpts(), 'PUT', true)
+    const res = await fetchMultipart(url, studyObject, Config.multiPartOpts(), 'PUT')
     return res.data
   },
 

--- a/src/libs/ajax/FileStorageObject.ts
+++ b/src/libs/ajax/FileStorageObject.ts
@@ -37,7 +37,7 @@ export async function uploadDocument(
   const formData = new FormData()
   formData.append('file', file)
   formData.append('category', category)
-  const res = await fetchMultipart<FileStorageObject>(url, formData, Config.multiPartOpts(), 'POST')
+  const res = await fetchMultipart<FileStorageObject>(url, formData, Config.multiPartOpts())
   return res.data
 }
 

--- a/src/libs/ajax/FileStorageObject.ts
+++ b/src/libs/ajax/FileStorageObject.ts
@@ -37,7 +37,7 @@ export async function uploadDocument(
   const formData = new FormData()
   formData.append('file', file)
   formData.append('category', category)
-  const res = await fetchMultipart<FileStorageObject>(url, formData, Config.multiPartOpts(), 'POST', true)
+  const res = await fetchMultipart<FileStorageObject>(url, formData, Config.multiPartOpts(), 'POST')
   return res.data
 }
 

--- a/src/libs/ajax/ProgressReport.ts
+++ b/src/libs/ajax/ProgressReport.ts
@@ -5,6 +5,6 @@ export const ProgressReport = {
   submitProgressReport: async (progressReport: FormData, parentReferenceId: string) => {
     const url = `${await Config.getApiUrl()}/api/dar/v2/progress_report/` + parentReferenceId
     // Assume progressReport is a FormData instance for multipart
-    return await fetchMultipart(url, progressReport, Config.multiPartOpts(), 'POST', true)
+    return await fetchMultipart(url, progressReport, Config.multiPartOpts(), 'POST')
   },
 }

--- a/src/libs/ajax/ProgressReport.ts
+++ b/src/libs/ajax/ProgressReport.ts
@@ -5,6 +5,6 @@ export const ProgressReport = {
   submitProgressReport: async (progressReport: FormData, parentReferenceId: string) => {
     const url = `${await Config.getApiUrl()}/api/dar/v2/progress_report/` + parentReferenceId
     // Assume progressReport is a FormData instance for multipart
-    return await fetchMultipart(url, progressReport, Config.multiPartOpts(), 'POST')
+    return await fetchMultipart(url, progressReport, Config.multiPartOpts())
   },
 }

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -13,7 +13,7 @@ export type ParamValue = string | number | boolean
 export type Params = Record<string, ParamValue>
 export type HeadersMap = Record<string, string>
 type FetchRequestConfig<TBody = unknown> = Omit<FetchRequestOptions<TBody>, 'url' | 'method' | 'data'>
-type FetchMultipartConfig = Omit<FetchMultipartOptions, 'url' | 'method' | 'data' | 'returnError'>
+type FetchMultipartConfig = Omit<FetchMultipartOptions, 'url' | 'method' | 'data'>
 
 interface MinimalRequestInit {
   method: Method
@@ -41,7 +41,6 @@ interface FetchRequestOptions<TBody = unknown> extends FetchOptionsBase {
 interface FetchMultipartOptions extends Omit<FetchOptionsBase, 'method'> {
   method?: Exclude<Method, 'GET' | 'DELETE'>
   data?: FormData
-  returnError?: boolean
 }
 
 export interface FetchData<T> {
@@ -203,7 +202,6 @@ async function fetchMultipartRequest<T>(
     params,
     headers = {},
     credentials,
-    returnError = false,
     signal,
   } = options
 
@@ -223,31 +221,31 @@ async function fetchMultipartRequest<T>(
     signal,
   }
 
+  const fetchFn = fetch as unknown as (input: string, init?: unknown) => Promise<Response>
+  let res: Response
   try {
-    const fetchFn = fetch as unknown as (input: string, init?: unknown) => Promise<Response>
-    const res = await fetchFn(fullUrl, fetchOptions)
-    if (!res.ok) {
-      let message = `Request failed with status ${res.status}`
-      try {
-        const errorData = await res.json() as { message?: string }
-        if (errorData?.message) message = errorData.message
-      }
-      catch {
-        // ignore parse errors
-      }
-      throw new Error(message)
-    }
-    return handleResponse<T>(res, fullUrl, 'json', method)
+    res = await fetchFn(fullUrl, fetchOptions)
   }
   catch (error) {
-    if (returnError) {
-      throw error instanceof Error ? error : new Error(String(error))
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error
     }
-    else {
-      reportError(fullUrl, 502)
-      throw new Error(`Request to ${fullUrl} failed with status 502`)
-    }
+    reportError(fullUrl, 502)
+    throw new Error(`Request to ${fullUrl} failed with status 502`)
   }
+  if (!res.ok) {
+    let message = `Request failed with status ${res.status}. Please contact the help desk at duos@duos.org.`
+    try {
+      const errorData = await res.json() as { message?: string }
+      if (errorData?.message) message = errorData.message
+    }
+    catch {
+      // ignore parse errors, use generic message
+    }
+    reportError(fullUrl, res.status)
+    throw new Error(message)
+  }
+  return handleResponse<T>(res, fullUrl, 'json', method)
 }
 
 export const fetchGet = <T>(
@@ -283,5 +281,4 @@ export const fetchMultipart = <T>(
   formData: FormData,
   config: FetchMultipartConfig = {},
   method: Exclude<Method, 'GET' | 'DELETE'> = 'POST',
-  returnError: boolean = false,
-) => fetchMultipartRequest<T>({ url, data: formData, ...config, method, returnError })
+) => fetchMultipartRequest<T>({ url, data: formData, ...config, method })

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -239,11 +239,11 @@ async function fetchMultipartRequest<T>(
       const errorData = await res.json() as { message?: string }
       if (errorData?.message) message = errorData.message
     }
-    catch {
-      // ignore parse errors, use generic message
-    }
+    finally {
     reportError(fullUrl, res.status)
     throw new Error(message)
+}
+
   }
   return handleResponse<T>(res, fullUrl, 'json', method)
 }

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -239,11 +239,11 @@ async function fetchMultipartRequest<T>(
       const errorData = await res.json() as { message?: string }
       if (errorData?.message) message = errorData.message
     }
-    finally {
+    catch {
+      // ignore parse errors, use generic message
+    }
     reportError(fullUrl, res.status)
     throw new Error(message)
-}
-
   }
   return handleResponse<T>(res, fullUrl, 'json', method)
 }

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -47,6 +47,8 @@ export interface FetchData<T> {
   data: T
 }
 
+const HELP_DESK_MESSAGE = 'Please contact the help desk at duos@duos.org.'
+
 export const reportError = (url: string, status: number): void => {
   const msg = 'Error fetching response: '
     .concat(JSON.stringify(url))
@@ -183,12 +185,15 @@ async function fetchRequest<T>(
     return handleResponse<T>(res, fullUrl, responseType, method)
   }
   catch (error) {
-    // Re-throw AbortError without reporting
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw error
+    // TypeError = network-level failure (offline, invalid URL, CORS, etc.) that never reached the server
+    // DOMException (e.g. AbortError, NotAllowedError) = aborted request or blocked by permissions policy
+    // Report with status 0 (no HTTP response) rather than 502 (bad gateway) to avoid misleading monitoring
+    if (error instanceof TypeError || error instanceof DOMException) {
+      reportError(fullUrl, 0)
+      throw new Error(`Network error on request to ${fullUrl}: ${error.toString()} ${HELP_DESK_MESSAGE}`)
     }
-    reportError(fullUrl, 502)
-    throw new Error(`Request to ${fullUrl} failed with status 502`)
+    reportError(fullUrl, 0)
+    throw new Error(`${error instanceof Error ? error.message : String(error)} ${HELP_DESK_MESSAGE}`)
   }
 }
 
@@ -227,14 +232,18 @@ async function fetchMultipartRequest<T>(
     res = await fetchFn(fullUrl, fetchOptions)
   }
   catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw error
+    // TypeError = network-level failure (offline, invalid URL, CORS, etc.) that never reached the server
+    // DOMException (e.g. AbortError, NotAllowedError) = aborted request or blocked by permissions policy
+    // Report with status 0 (no HTTP response) rather than 502 (bad gateway) to avoid misleading monitoring
+    if (error instanceof TypeError || error instanceof DOMException) {
+      reportError(fullUrl, 0)
+      throw new Error(`Network error on request to ${fullUrl}: ${error.toString()} ${HELP_DESK_MESSAGE}`)
     }
-    reportError(fullUrl, 502)
-    throw new Error(`Request to ${fullUrl} failed with status 502`)
+    reportError(fullUrl, 0)
+    throw new Error(`${error instanceof Error ? error.message : String(error)} ${HELP_DESK_MESSAGE}`)
   }
   if (!res.ok) {
-    let message = `Request failed with status ${res.status}. Please contact the help desk at duos@duos.org.`
+    let message = `Request failed with status ${res.status}. ${HELP_DESK_MESSAGE}`
     try {
       const errorData = await res.json() as { message?: string }
       if (errorData?.message) message = errorData.message


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3181

### Summary
This changes the default behavior for our fetch adapters to attempt to use the error message from the backend.  If it isn’t provided, a generic error message recommends contacting the help desk as a next step.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
