### PR TITLE
[DT-3136] Fix Data Library tag queries, wide title layout

### DIFF
--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -294,7 +294,7 @@ describe('Library Versions - Tests', function () {
       Object.entries(versions).forEach(([key, library]) => {
         if (library.query === null || !('bool' in library.query)) return
 
-        const query = library.query as BoolQuery
+        const query = library.query
         query.bool.should.forEach((clause) => {
           if ('terms' in clause) {
             expect(clause.terms).to.not.have.property(

--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -269,7 +269,7 @@ describe('Library Versions - Tests', function () {
         const termsClause = query.bool.should.find(c => 'terms' in c)
 
         const descriptionValue = matchPhraseClause!.match_phrase['study.description'] as string
-        const tagsValue = termsClause!.terms['study.data.tags']
+        const tagsValue = termsClause!.terms['study.data.tags.keyword']
 
         expect(tagsValue).to.include(descriptionValue, `${key} tags should include the description value`)
       })
@@ -285,7 +285,26 @@ describe('Library Versions - Tests', function () {
       expect(matchPhraseClause).to.not.equal(undefined)
       expect(termsClause).to.not.equal(undefined)
       expect(matchPhraseClause!.match_phrase).to.have.property('submitter.institution.name')
-      expect(termsClause!.terms['study.data.tags']).to.include('The Broad Institute of MIT and Harvard')
+      expect(termsClause!.terms['study.data.tags.keyword']).to.include('The Broad Institute of MIT and Harvard')
+    })
+
+    it('all terms clauses use study.data.tags.keyword (not study.data.tags) for case-sensitive matching', function () {
+      const versions = getLibraryVersions(null, null)
+
+      Object.entries(versions).forEach(([key, library]) => {
+        if (library.query === null || !('bool' in library.query)) return
+
+        const query = library.query as BoolQuery
+        query.bool.should.forEach((clause) => {
+          if ('terms' in clause) {
+            expect(clause.terms).to.not.have.property(
+              'study.data.tags',
+              `${key} should use study.data.tags.keyword, not study.data.tags`
+            )
+            expect(clause.terms).to.have.property('study.data.tags.keyword')
+          }
+        })
+      })
     })
   })
 })

--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -299,7 +299,7 @@ describe('Library Versions - Tests', function () {
           if ('terms' in clause) {
             expect(clause.terms).to.not.have.property(
               'study.data.tags',
-              `${key} should use study.data.tags.keyword, not study.data.tags`
+              `${key} should use study.data.tags.keyword, not study.data.tags`,
             )
             expect(clause.terms).to.have.property('study.data.tags.keyword')
           }

--- a/src/components/TableHeaderSection.tsx
+++ b/src/components/TableHeaderSection.tsx
@@ -43,6 +43,7 @@ export const TableHeaderSection: React.FC<TableHeaderSectionProps> = ({
               fontFamily: 'Montserrat',
               fontWeight: 600,
               fontSize: '2.8rem',
+              width: '150%',
             }}
           >
             {title}

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -95,7 +95,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['The Broad Institute of MIT and Harvard'],
+                'study.data.tags.keyword': ['The Broad Institute of MIT and Harvard'],
               },
             },
           ],
@@ -132,7 +132,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['mgb', 'Massachusetts General Hospital', 'Brigham and Women\'s Hospital', 'Faulkner Hospital', 'Spaulding Hospital'],
+                'study.data.tags.keyword': ['mgb', 'Massachusetts General Hospital', 'Brigham and Women\'s Hospital', 'Faulkner Hospital', 'Spaulding Hospital'],
               },
             },
           ],
@@ -154,7 +154,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['elwazi'],
+                'study.data.tags.keyword': ['elwazi'],
               },
             },
           ],
@@ -187,7 +187,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['anvil'],
+                'study.data.tags.keyword': ['anvil'],
               },
             },
           ],
@@ -209,7 +209,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI'],
+                'study.data.tags.keyword': ['NHLBI'],
               },
             },
           ],
@@ -231,7 +231,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['Platform: Single Cell Portal'],
+                'study.data.tags.keyword': ['(Platform: Single Cell Portal)'],
               },
             },
           ],
@@ -253,7 +253,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Blood Disorders and Blood Safety'],
+                'study.data.tags.keyword': ['NHLBI Blood Disorders and Blood Safety'],
               },
             },
           ],
@@ -275,7 +275,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Health Disparities'],
+                'study.data.tags.keyword': ['NHLBI Health Disparities'],
               },
             },
           ],
@@ -297,7 +297,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Heart and Vascular Diseases'],
+                'study.data.tags.keyword': ['NHLBI Heart and Vascular Diseases'],
               },
             },
           ],
@@ -319,7 +319,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Lung Diseases'],
+                'study.data.tags.keyword': ['NHLBI Lung Diseases'],
               },
             },
           ],
@@ -341,7 +341,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Obesity, Nutrition, and Physical Activity'],
+                'study.data.tags.keyword': ['NHLBI Obesity, Nutrition, and Physical Activity'],
               },
             },
           ],
@@ -363,7 +363,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Population and Epidemiology Studies'],
+                'study.data.tags.keyword': ['NHLBI Population and Epidemiology Studies'],
               },
             },
           ],
@@ -385,7 +385,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Precision Medicine Activities'],
+                'study.data.tags.keyword': ['NHLBI Precision Medicine Activities'],
               },
             },
           ],
@@ -407,7 +407,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Research Spectrum'],
+                'study.data.tags.keyword': ['NHLBI Research Spectrum'],
               },
             },
           ],
@@ -429,7 +429,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Sleep Science and Sleep Disorders'],
+                'study.data.tags.keyword': ['NHLBI Sleep Science and Sleep Disorders'],
               },
             },
           ],
@@ -451,7 +451,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NHLBI Women\'s Health'],
+                'study.data.tags.keyword': ['NHLBI Women\'s Health'],
               },
             },
           ],
@@ -473,7 +473,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['anvil'],
+                'study.data.tags.keyword': ['anvil'],
               },
             },
           ],
@@ -495,7 +495,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['hca dcp'],
+                'study.data.tags.keyword': ['hca dcp'],
               },
             },
           ],
@@ -517,7 +517,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['zoonomics'],
+                'study.data.tags.keyword': ['zoonomics'],
               },
             },
           ],
@@ -546,7 +546,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['cfde'],
+                'study.data.tags.keyword': ['cfde'],
               },
             },
           ],
@@ -568,7 +568,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['FireCloud'],
+                'study.data.tags.keyword': ['FireCloud'],
               },
             },
           ],
@@ -590,7 +590,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['All of Us'],
+                'study.data.tags.keyword': ['All of Us'],
               },
             },
           ],
@@ -629,7 +629,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['International Fetal Genomics Consortium'],
+                'study.data.tags.keyword': ['International Fetal Genomics Consortium'],
               },
             },
           ],
@@ -651,7 +651,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['SCHARE'],
+                'study.data.tags.keyword': ['SCHARE'],
               },
             },
           ],
@@ -673,7 +673,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['Stanley Center'],
+                'study.data.tags.keyword': ['Stanley Center'],
               },
             },
           ],
@@ -695,7 +695,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['Stanley Center'],
+                'study.data.tags.keyword': ['Stanley Center'],
               },
             },
           ],
@@ -717,7 +717,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['Getz Lab'],
+                'study.data.tags.keyword': ['Getz Lab'],
               },
             },
           ],
@@ -739,7 +739,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['ASAP'],
+                'study.data.tags.keyword': ['ASAP'],
               },
             },
           ],
@@ -761,7 +761,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['GP2'],
+                'study.data.tags.keyword': ['GP2'],
               },
             },
           ],
@@ -783,7 +783,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['ASD'],
+                'study.data.tags.keyword': ['ASD'],
               },
             },
           ],
@@ -805,7 +805,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['PBN'],
+                'study.data.tags.keyword': ['PBN'],
               },
             },
           ],
@@ -827,7 +827,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['PGC'],
+                'study.data.tags.keyword': ['PGC'],
               },
             },
           ],
@@ -849,7 +849,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['SCZ'],
+                'study.data.tags.keyword': ['Broad: SCZ_BD'],
               },
             },
           ],
@@ -871,7 +871,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['ESP'],
+                'study.data.tags.keyword': ['ESP'],
               },
             },
           ],
@@ -893,7 +893,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['IBD'],
+                'study.data.tags.keyword': ['IBD'],
               },
             },
           ],
@@ -915,7 +915,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['Helmsley'],
+                'study.data.tags.keyword': ['Helmsley'],
               },
             },
           ],
@@ -937,7 +937,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['Eating Disorder Sequencing Program'],
+                'study.data.tags.keyword': ['Eating Disorder Sequencing Program'],
               },
             },
           ],
@@ -959,7 +959,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['CCXDP'],
+                'study.data.tags.keyword': ['CCXDP'],
               },
             },
           ],
@@ -981,7 +981,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['NCPI DUO'],
+                'study.data.tags.keyword': ['NCPI DUO'],
               },
             },
           ],
@@ -1003,7 +1003,7 @@ export const getLibraryVersions = (
             },
             {
               terms: {
-                'study.data.tags': ['ga4gh'],
+                'study.data.tags.keyword': ['ga4gh'],
               },
             },
           ],

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -843,11 +843,6 @@ export const getLibraryVersions = (
         bool: {
           should: [
             {
-              match_phrase: {
-                'study.description': 'SCZ',
-              },
-            },
-            {
               terms: {
                 'study.data.tags.keyword': ['Broad: SCZ_BD'],
               },


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3136
https://broadworkbench.atlassian.net/browse/DT-3207

### Summary
* Fixes the `tags` clause of ElasticSearch queries for data libraries, ahead of populating some data for an event on Thursday 2026-04-06
* Removes overly-broad study description for match phrase for "Broad Institute Schizophrenia & Bipolar Disorder Data Library", and refines the query tag.  Also incidentally cleaned up SCP tag query.  Others aren't necessarily in scope.
* Fixes an odd line break in long Data Library titles.

#### Before

<img width="1512" height="498" alt="Screenshot 2026-05-01 at 4 33 31 PM" src="https://github.com/user-attachments/assets/82e61787-36ef-4c22-8005-b891439f7615" />


#### After

<img width="1512" height="500" alt="Screenshot 2026-05-01 at 4 33 48 PM" src="https://github.com/user-attachments/assets/a28b126d-2b4b-4f50-8fe7-508db4557434" />


More context: https://broadinstitute.slack.com/archives/C07T2DLHD24/p1777560353157859

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
