### PR TITLE
[DT-2680] Convert `DacMembersModal.jsx` to Typescript

### DIFF
--- a/cypress/component/pages/manage_dac/DacMembersModal.spec.tsx
+++ b/cypress/component/pages/manage_dac/DacMembersModal.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { DacMembersModal } from 'src/pages/manage_dac/DacMembersModal'
+import { DacObject } from 'src/types/model'
+
+describe('DacMembersModal Component Tests', () => {
+  const dac: DacObject = {
+    name: 'Test DAC',
+    chairpersons: [],
+    members: [],
+  }
+
+  const mountModal = (onCloseRequest = cy.stub()) => {
+    cy.mount(
+      <div id="modal-root">
+        <DacMembersModal showModal={true} onCloseRequest={onCloseRequest} dac={dac} />
+      </div>,
+    )
+  }
+
+  it('renders the modal with the correct title', () => {
+    mountModal()
+    cy.get('#dacMembersModal_title').should('contain.text', 'DAC Members associated with DAC: Test DAC')
+  })
+
+  it('renders DacUsers content in the modal body', () => {
+    mountModal()
+    cy.contains('User').should('exist')
+    cy.contains('Role').should('exist')
+  })
+
+  it('calls onCloseRequest when Close is clicked', () => {
+    const onCloseRequest = cy.stub().as('onCloseRequest')
+    mountModal(onCloseRequest)
+    cy.get('#btn_action').click()
+    cy.get('@onCloseRequest').should('have.been.calledOnce')
+  })
+})

--- a/src/pages/manage_dac/DacMembersModal.tsx
+++ b/src/pages/manage_dac/DacMembersModal.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
-import { BaseModal } from '../../components/BaseModal'
-import { DacUsers } from './DacUsers'
+import { BaseModal } from 'src/components/BaseModal'
+import { DacUsers } from 'src/pages/manage_dac/DacUsers'
+import { DacObject } from 'src/types/model'
 
-export const DacMembersModal = ({ showModal, onCloseRequest, dac }) => {
+export interface DacMembersModalProps {
+  showModal: boolean
+  onCloseRequest: () => void
+  dac: DacObject
+}
+
+export const DacMembersModal = ({ showModal, onCloseRequest, dac }: DacMembersModalProps) => {
   return (
     <BaseModal
       id="dacMembersModal"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2680

### Summary

This PR converts `DacMembersModal.jsx` to Typescript.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
