### PR TITLE
[DT-2698] Convert `EnvironmentUtils.jsx` to TypeScript

### DIFF
--- a/cypress/component/utils/EnvironmentUtils.spec.ts
+++ b/cypress/component/utils/EnvironmentUtils.spec.ts
@@ -1,0 +1,45 @@
+import { Storage } from 'src/libs/storage'
+import { checkEnv, envGroups, isDevEnv } from 'src/utils/EnvironmentUtils'
+
+describe('EnvironmentUtils', () => {
+  it('exposes expected environment groups', () => {
+    expect(envGroups.PROD_STAGING).to.deep.equal(['prod', 'staging'])
+    expect(envGroups.NON_PROD).to.deep.equal(['local', 'dev', 'staging'])
+    expect(envGroups.NON_STAGING).to.deep.equal(['local', 'dev'])
+    expect(envGroups.DEV).to.deep.equal(['local', 'dev'])
+  })
+
+  it('checkEnv returns true when current env is in the group', () => {
+    const getEnvStub = Cypress.sinon.stub(Storage, 'getEnv').returns('dev')
+
+    expect(checkEnv(envGroups.NON_STAGING)).to.equal(true)
+
+    getEnvStub.restore()
+  })
+
+  it('checkEnv returns false when current env is not in the group', () => {
+    const getEnvStub = Cypress.sinon.stub(Storage, 'getEnv').returns('prod')
+
+    expect(checkEnv(envGroups.NON_STAGING)).to.equal(false)
+
+    getEnvStub.restore()
+  })
+
+  it('checkEnv returns false when current env is null', () => {
+    const getEnvStub = Cypress.sinon.stub(Storage, 'getEnv').returns(null)
+
+    expect(checkEnv(envGroups.NON_PROD)).to.equal(false)
+
+    getEnvStub.restore()
+  })
+
+  it('isDevEnv returns true for local/dev and false for prod', () => {
+    const getEnvStub = Cypress.sinon.stub(Storage, 'getEnv').returns('local')
+    expect(isDevEnv()).to.equal(true)
+
+    getEnvStub.returns('prod')
+    expect(isDevEnv()).to.equal(false)
+
+    getEnvStub.restore()
+  })
+})

--- a/src/routing/EnvRoute.tsx
+++ b/src/routing/EnvRoute.tsx
@@ -4,7 +4,7 @@ import { checkEnv } from 'src/utils/EnvironmentUtils'
 import NotFound from 'src/pages/NotFound'
 
 interface EnvRouteProps {
-  readonly env: Array<string>
+  readonly env: readonly string[]
 }
 
 const EnvRoute = ({ env }: EnvRouteProps) => {

--- a/src/utils/EnvironmentUtils.ts
+++ b/src/utils/EnvironmentUtils.ts
@@ -1,5 +1,6 @@
 import { Storage } from 'src/libs/storage'
-import { includes } from 'lodash'
+
+export type AppEnvironment = 'prod' | 'staging' | 'local' | 'dev'
 
 /**
  * Predefined groups of environments for which certain features might be valid for.
@@ -9,14 +10,13 @@ import { includes } from 'lodash'
  *      * alpha
  *      * dev
  *      * local
- * @type {{PROD_STAGING: string[], NON_STAGING: string[], NON_PROD: string[]}}
  */
 export const envGroups = {
   PROD_STAGING: ['prod', 'staging'],
   NON_PROD: ['local', 'dev', 'staging'],
   NON_STAGING: ['local', 'dev'],
   DEV: ['local', 'dev'],
-}
+} as const satisfies Record<string, readonly AppEnvironment[]>
 
 /**
  * Returns true if the current application `Storage.ENV` variable exists as an element
@@ -31,9 +31,9 @@ export const envGroups = {
  * @param envGroup
  * @returns {boolean}
  */
-export const checkEnv = (envGroup) => {
+export const checkEnv = (envGroup: readonly string[]): boolean => {
   const env = Storage.getEnv()
-  return env ? includes(envGroup, env) : false
+  return env === null ? false : envGroup.includes(env)
 }
 
 /**
@@ -44,7 +44,7 @@ export const checkEnv = (envGroup) => {
  * isDevEnv()
  * @returns {boolean}
  */
-export const isDevEnv = () => checkEnv(envGroups.DEV)
+export const isDevEnv = (): boolean => checkEnv(envGroups.DEV)
 
 export default {
   checkEnv,


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2698

### Summary

This PR converts `EnvironmentUtils.jsx` to Typescript.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
