### PR TITLE
[DT-2735] Convert `useResponsiveDarCollectionColumns.js` to TypeScript

### DIFF
--- a/cypress/component/Hooks/useResponsiveDarCollectionColumns.spec.tsx
+++ b/cypress/component/Hooks/useResponsiveDarCollectionColumns.spec.tsx
@@ -1,0 +1,53 @@
+import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCollectionColumns'
+import { DarCollectionTableColumnOptions, consoleTypes } from 'src/utils/DarCollectionUtils'
+import React from 'react'
+
+interface HookTestComponentProps {
+  consoleType: string
+}
+
+const HookTestComponent = ({ consoleType }: HookTestComponentProps) => {
+  const columns = useResponsiveDarCollectionColumns(consoleType)
+
+  return (
+    <div>
+      <div data-testid="column-count">{columns.length}</div>
+      <div data-testid="columns">{columns.join(',')}</div>
+    </div>
+  )
+}
+
+describe('useResponsiveDarCollectionColumns', () => {
+  it('returns admin columns including DAC on wide viewports', () => {
+    cy.viewport(1600, 900)
+    cy.mount(<HookTestComponent consoleType={consoleTypes.ADMIN} />)
+
+    cy.get('[data-testid="columns"]').should('contain', DarCollectionTableColumnOptions.DAC)
+    cy.get('[data-testid="columns"]').should('contain', DarCollectionTableColumnOptions.DATASET_COUNT)
+    cy.get('[data-testid="columns"]').should('contain', DarCollectionTableColumnOptions.EXPIRES_AT)
+  })
+
+  it('returns researcher columns without DAC and respects narrow viewport defaults', () => {
+    cy.viewport(900, 900)
+    cy.mount(<HookTestComponent consoleType={consoleTypes.RESEARCHER} />)
+
+    cy.get('[data-testid="columns"]').should('not.contain', DarCollectionTableColumnOptions.DAC)
+    cy.get('[data-testid="columns"]').should('not.contain', DarCollectionTableColumnOptions.DATASET_COUNT)
+    cy.get('[data-testid="columns"]').should('not.contain', DarCollectionTableColumnOptions.EXPIRES_AT)
+  })
+
+  it('updates returned columns when crossing researcher breakpoints on resize', () => {
+    cy.viewport(1600, 900)
+    cy.mount(<HookTestComponent consoleType={consoleTypes.RESEARCHER} />)
+
+    cy.get('[data-testid="columns"]').should('contain', DarCollectionTableColumnOptions.DATASET_COUNT)
+    cy.get('[data-testid="columns"]').should('contain', DarCollectionTableColumnOptions.EXPIRES_AT)
+
+    cy.viewport(1100, 900)
+    cy.get('[data-testid="columns"]').should('not.contain', DarCollectionTableColumnOptions.DATASET_COUNT)
+    cy.get('[data-testid="columns"]').should('contain', DarCollectionTableColumnOptions.EXPIRES_AT)
+
+    cy.viewport(900, 900)
+    cy.get('[data-testid="columns"]').should('not.contain', DarCollectionTableColumnOptions.EXPIRES_AT)
+  })
+})

--- a/src/hooks/useResponsiveDarCollectionColumns.ts
+++ b/src/hooks/useResponsiveDarCollectionColumns.ts
@@ -1,20 +1,20 @@
-import { useState, useEffect } from 'react'
-import { getDarCollectionColumns } from '../utils/darCollectionColumns'
+import { useEffect, useState } from 'react'
+import { getDarCollectionColumns } from 'src/utils/darCollectionColumns'
 
 /**
  * Custom hook for responsive DAR collection columns
  * Handles window resize events and returns appropriate columns for the console type
  *
- * @param {string} consoleType - The type of console (ADMIN, CHAIR, MEMBER, etc.)
- * @returns {Array} responsiveColumns - Array of column options based on current window width
+ * @param consoleType - The type of console (ADMIN, CHAIR, MEMBER, etc.)
+ * @returns Array of column options based on current window width
  */
-export function useResponsiveDarCollectionColumns(consoleType) {
-  const [responsiveColumns, setResponsiveColumns] = useState(() =>
+export function useResponsiveDarCollectionColumns(consoleType: string): string[] {
+  const [responsiveColumns, setResponsiveColumns] = useState<string[]>(() =>
     getDarCollectionColumns(consoleType, window.innerWidth),
   )
 
   useEffect(() => {
-    const handleResize = () => {
+    const handleResize = (): void => {
       const newWidth = window.innerWidth
       setResponsiveColumns(getDarCollectionColumns(consoleType, newWidth))
     }


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2735

### Summary

This PR converts `useResponsiveDarCollectionColumns.js` to Typescript. 

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
