### PR TITLE
DT-3204: Scrolling fixes

### DIFF
--- a/cypress/component/dar_application/ScrollableTabs.spec.tsx
+++ b/cypress/component/dar_application/ScrollableTabs.spec.tsx
@@ -86,6 +86,29 @@ describe('ScrollableTabs Component - Integration Tests', () => {
     cy.get('.Mui-selected').contains('Research Purpose Statement', { timeout: 2000 }).should('exist')
   })
 
+  it('Case 2 - Scroll-driven tab update should NOT trigger a programmatic window.scrollTo (no feedback loop)', () => {
+    // Spy on window.scrollTo so we can count calls
+    cy.window().then((win) => {
+      cy.spy(win, 'scrollTo').as('scrollTo')
+    })
+
+    // Simulate the user scrolling to the second section - this should update the selected tab
+    // via the scroll handler (CASE 2), but must NOT cause a secondary window.scrollTo call
+    // (which was the feedback-loop bug: CASE 2 → onTabChange → formSelectedTabId change → CASE 1 → scrollTo)
+    cy.get('#data-access-request').then(($el) => {
+      cy.window().then((win) => {
+        win.scrollTo(0, $el[0].offsetTop)
+      })
+    })
+
+    // Wait for the debounced scroll handler and any React renders to settle
+    cy.get('.Mui-selected').contains('Data Access Request', { timeout: 2000 }).should('exist')
+
+    // window.scrollTo should have been called exactly once (our manual scroll above),
+    // not a second time as a reaction to the tab indicator update.
+    cy.get('@scrollTo').should('have.been.calledOnce')
+  })
+
   it('Case 3 - First tab selected by default and can click and select another tab', () => {
     cy.get('.Mui-selected').contains('Researcher Information').should('exist')
     cy.get('.Mui-selected').contains('Data Access Request').should('not.exist')

--- a/src/pages/dar_application/ScrollableTabs.tsx
+++ b/src/pages/dar_application/ScrollableTabs.tsx
@@ -114,8 +114,8 @@ export const ScrollableTabs = ({ applicationTabs, formSelectedTabId, onTabChange
         variant="scrollable"
         scrollButtons="auto"
         orientation="vertical"
-        TabIndicatorProps={{
-          style: { background: '#2BBD9B' },
+        slotProps={{
+          indicator: { style: { background: '#2BBD9B' } },
         }}
         // CASE 3 - the user selects a new tab by clicking on it
         onChange={(_event, step) => {

--- a/src/pages/dar_application/ScrollableTabs.tsx
+++ b/src/pages/dar_application/ScrollableTabs.tsx
@@ -37,10 +37,17 @@ export const ScrollableTabs = ({ applicationTabs, formSelectedTabId, onTabChange
   const scrollTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingTimeout = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  // Flag to indicate the tab change was driven by the scroll handler itself (CASE 2),
+  // so CASE 1 should not also trigger a programmatic scroll (which would cause a feedback loop).
+  const scrollHandlerUpdatedTab = useRef(false)
+
   // CASE 1 - the form scrolls to a new tab based on validation errors
   useEffect(() => {
     if (typeof formSelectedTabId === 'string') {
-      goToStep(formSelectedTabId)
+      if (!scrollHandlerUpdatedTab.current) {
+        goToStep(formSelectedTabId)
+      }
+      scrollHandlerUpdatedTab.current = false
     }
   }, [goToStep, formSelectedTabId])
 
@@ -84,6 +91,9 @@ export const ScrollableTabs = ({ applicationTabs, formSelectedTabId, onTabChange
         }
 
         if (tabId && tabId !== formSelectedTabId && onTabChange) {
+          // Mark that this tab change originated from scrolling so CASE 1
+          // does not also trigger a programmatic scroll-to, creating a loop.
+          scrollHandlerUpdatedTab.current = true
           onTabChange(tabId)
         }
       }, 80)


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3204

### Summary
Minor QOL fix for the DAR form scrolling behavior so the page doesn't jump to the top when the user is viewing content that spans form sections.

Also replaces the deprecated `TabIndicatorProps` property with `slotProps`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
