### PR TITLE
DT-3203: Use Navigation Context State to maintain role console

### DIFF
--- a/cypress/component/Dataset/DatasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/DatasetStatistics.spec.jsx
@@ -3,7 +3,18 @@ import DatasetStatistics from 'src/pages/DatasetStatistics'
 import datasetTerm from './datasetTerm.json'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { DatasetMetrics } from 'src/libs/ajax/DatasetMetrics'
-import { BrowserRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+// Helper: mounts DatasetStatistics inside a real route so useParams() works correctly
+const mountDatasetStatistics = (datasetIdentifier) => {
+  cy.mount(
+    <MemoryRouter initialEntries={[`/dataset/${datasetIdentifier}`]}>
+      <Routes>
+        <Route path="/dataset/:datasetIdentifier" element={<DatasetStatistics />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
 
 describe('Dataset Statistics Tests', () => {
   beforeEach(() => {
@@ -13,38 +24,14 @@ describe('Dataset Statistics Tests', () => {
   it('Renders the correct dataset from a DUOS-xxx identifier path paramter', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: datasetTerm.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains(datasetTerm.datasetIdentifier).should('exist')
   })
 
   it('Renders the correct dataset from a DUOS-Dxxx identifier path parameter', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: 'DUOS-D' + datasetTerm.datasetId,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics('DUOS-D' + datasetTerm.datasetId)
     cy.contains(datasetTerm.datasetIdentifier).should('exist')
   })
 
@@ -52,19 +39,7 @@ describe('Dataset Statistics Tests', () => {
     const controlled = { ...datasetTerm, accessManagement: 'controlled' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([controlled]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: datasetTerm.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains(controlled.datasetIdentifier).should('exist')
     cy.contains(controlled.datasetName).should('exist')
     cy.contains('Apply for Access').should('exist')
@@ -74,19 +49,7 @@ describe('Dataset Statistics Tests', () => {
     const external = { ...datasetTerm, accessManagement: 'external', url: 'https://duos.org' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([external]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: external.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(external.datasetIdentifier)
     cy.contains(external.datasetIdentifier).should('exist')
     cy.contains(external.datasetName).should('exist')
     cy.contains('This dataset is externally managed').should('exist')
@@ -97,19 +60,7 @@ describe('Dataset Statistics Tests', () => {
     const external = { ...datasetTerm, accessManagement: 'external' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([external]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: external.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(external.datasetIdentifier)
     cy.contains(external.datasetIdentifier).should('exist')
     cy.contains(external.datasetName).should('exist')
     cy.contains('This dataset is externally managed').should('exist')
@@ -120,19 +71,7 @@ describe('Dataset Statistics Tests', () => {
     const open = { ...datasetTerm, accessManagement: 'open', url: 'https://duos.org' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([open]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: open.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(open.datasetIdentifier)
     cy.contains(open.datasetIdentifier).should('exist')
     cy.contains(open.datasetName).should('exist')
     cy.contains('This dataset is open access, does not require an access request').should('exist')
@@ -143,19 +82,7 @@ describe('Dataset Statistics Tests', () => {
     const open = { ...datasetTerm, accessManagement: 'open' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([open]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: open.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(open.datasetIdentifier)
     cy.contains(open.datasetIdentifier).should('exist')
     cy.contains(open.datasetName).should('exist')
     cy.contains('This dataset is open access, does not require an access request').should('exist')
@@ -165,19 +92,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays with no additional properties', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: datasetTerm.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains(datasetTerm.datasetIdentifier).should('exist')
   })
 
@@ -190,22 +105,9 @@ describe('Dataset Statistics Tests', () => {
         dataCustodianEmail: dataCustodians,
       },
     }
-
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetWithCustodians]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: datasetTerm.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains('Data Custodian').should('exist')
     dataCustodians.forEach((dataCustodian) => {
       cy.contains(dataCustodian).should('exist')
@@ -216,19 +118,7 @@ describe('Dataset Statistics Tests', () => {
     const open = { ...datasetTerm, accessManagement: 'open' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([open]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: open.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(open.datasetIdentifier)
     cy.contains('Data Use').should('not.exist')
   })
 
@@ -236,19 +126,7 @@ describe('Dataset Statistics Tests', () => {
     const controlled = { ...datasetTerm, accessManagement: 'controlled' }
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([controlled]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: datasetTerm.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains('Data Use').should('exist')
     cy.contains(datasetTerm.dataUse.primary[0].code).should('exist')
   })
@@ -256,19 +134,7 @@ describe('Dataset Statistics Tests', () => {
   it('Displays the Principal Investigator field', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: {
-        params: {
-          datasetIdentifier: datasetTerm.datasetIdentifier,
-        },
-      },
-      history: {
-        push() {
-        },
-      },
-    }
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains('Principal Investigator').should('exist')
     cy.contains(datasetTerm.study.piName).should('exist')
   })
@@ -281,16 +147,9 @@ describe('Dataset Statistics Tests', () => {
       nonTechRus: 'Test summary',
       expired: false,
     }]
-
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve(darsData))
-
-    const props = {
-      match: { params: { datasetIdentifier: datasetTerm.datasetIdentifier } },
-      history: { push() {} },
-    }
-
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains('Data Access Requests for this dataset').should('exist')
     cy.contains('DAR-123').should('exist')
     cy.contains('Test Project').should('exist')
@@ -299,22 +158,18 @@ describe('Dataset Statistics Tests', () => {
   it('Displays message when no DARs exist', () => {
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
-
-    const props = {
-      match: { params: { datasetIdentifier: datasetTerm.datasetIdentifier } },
-      history: { push() {} },
-    }
-
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains('No Data Access Requests have been created for this dataset').should('exist')
   })
 
   it('Displays DAR section with expired data', () => {
-    const year = new Date().getFullYear()
     const expired = new Date()
-    expired.setFullYear(year - 2)
-    const dateString = expired.toISOString().split('T')[0]
+    expired.setFullYear(expired.getFullYear() - 2)
     const dateTime = expired.getTime()
+    // Build the expected date string using local-timezone methods — the same way
+    // formatDate() in the component works (getFullYear/getMonth/getDate, not toISOString).
+    const pad = n => ('0' + n).slice(-2)
+    const dateString = `${expired.getFullYear()}-${pad(expired.getMonth() + 1)}-${pad(expired.getDate())}`
 
     const darsData = [{
       darCode: 'DAR-123',
@@ -326,13 +181,7 @@ describe('Dataset Statistics Tests', () => {
 
     cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([datasetTerm]))
     cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve(darsData))
-
-    const props = {
-      match: { params: { datasetIdentifier: datasetTerm.datasetIdentifier } },
-      history: { push() {} },
-    }
-
-    cy.mount(<BrowserRouter><DatasetStatistics {...props} /></BrowserRouter>)
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
     cy.contains('Data Access Requests for this dataset').should('exist')
     cy.contains('DAR-123').should('exist')
     cy.contains('Test Project').should('exist')

--- a/cypress/component/data_library/LibraryDataGrid.spec.tsx
+++ b/cypress/component/data_library/LibraryDataGrid.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { LibraryDataGrid } from 'src/components/data_library/LibraryDataGrid'
 import { AssetType, ExportableDatasets, SortOrder, StudyAggregation } from 'src/types/library'
 import { makeDatasetTerm } from '../test-utils'
@@ -57,12 +58,15 @@ const datasets = [
 ]
 
 describe('LibraryDataGrid', () => {
+  const mountGrid = (element: React.ReactElement): Cypress.Chainable =>
+    cy.mount(<MemoryRouter>{element}</MemoryRouter>)
+
   beforeEach(() => {
     cy.viewport(1200, 800)
   })
 
   it('renders study data correctly', () => {
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.STUDIES}
         data={studies}
@@ -88,7 +92,7 @@ describe('LibraryDataGrid', () => {
   })
 
   it('renders dataset data correctly', () => {
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.DATASETS}
         data={datasets}
@@ -121,7 +125,7 @@ describe('LibraryDataGrid', () => {
 
   it('handles row selection for datasets', () => {
     const onSelectionChange = cy.stub().as('onSelectionChange')
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.DATASETS}
         data={datasets}
@@ -142,7 +146,7 @@ describe('LibraryDataGrid', () => {
 
   it('handles row selection for studies (mapping to dataset IDs)', () => {
     const onSelectionChange = cy.stub().as('onSelectionChange')
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.STUDIES}
         data={studies}
@@ -162,7 +166,7 @@ describe('LibraryDataGrid', () => {
   })
 
   it('renders loading state', () => {
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.STUDIES}
         data={[]}
@@ -181,7 +185,7 @@ describe('LibraryDataGrid', () => {
   })
 
   it('renders empty state when no data exists', () => {
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.STUDIES}
         data={[]}
@@ -201,7 +205,7 @@ describe('LibraryDataGrid', () => {
 
   it('calls onPaginationChange when page changes', () => {
     const onPaginationChange = cy.stub().as('onPaginationChange')
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.STUDIES}
         data={studies}
@@ -225,7 +229,7 @@ describe('LibraryDataGrid', () => {
 
   it('calls onSortChange when header is clicked', () => {
     const onSortChange = cy.stub().as('onSortChange')
-    cy.mount(
+    mountGrid(
       <LibraryDataGrid
         assetType={AssetType.STUDIES}
         data={studies}
@@ -276,7 +280,7 @@ describe('LibraryDataGrid', () => {
     }
 
     it('renders an Actions column header when exportableDatasets has entries', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={[exportableDataset]}
@@ -296,7 +300,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('renders an Export link for a dataset with matching exportable snapshots', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={[exportableDataset]}
@@ -318,7 +322,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('does not render an Export link for a dataset with no matching snapshots', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={[nonExportableDataset]}
@@ -338,7 +342,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('renders Export links only for datasets that have matching snapshots when multiple datasets are shown', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={[exportableDataset, nonExportableDataset]}
@@ -360,7 +364,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('does not render Export links when exportableDatasets is not provided (default)', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={[exportableDataset]}
@@ -379,7 +383,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('does not render Export links for the Studies grid even if exportableDatasets is provided', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.STUDIES}
           data={studies}
@@ -402,7 +406,7 @@ describe('LibraryDataGrid', () => {
   describe('radarEnabledDatasetIds prop', () => {
     it('shows Bolt icon for radar enabled datasets', () => {
       const radarEnabledDatasetIds = new Set([101])
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={datasets}
@@ -423,7 +427,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('does not show Bolt icon when radarEnabledDatasetIds is empty', () => {
-      cy.mount(
+      mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}
           data={datasets}

--- a/cypress/component/data_library/columns/biospecimenColumns.spec.tsx
+++ b/cypress/component/data_library/columns/biospecimenColumns.spec.tsx
@@ -6,6 +6,7 @@
  * inspects the rendered HTML to verify the column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeBiospecimenColumns } from 'src/components/data_library/columns/biospecimenColumns'
 import { makeBiospecimenRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makeBiospecimenRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makeBiospecimenRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makeBiospecimenColumns()}
-      getRowId={r => r.biospecimenId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makeBiospecimenColumns()}
+        getRowId={r => r.biospecimenId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 
@@ -190,12 +193,14 @@ describe('makeBiospecimenColumns — accessibility', () => {
 
   it('renders headers with proper labels', () => {
     cy.mount(
-      <DataGrid
-        rows={[makeBiospecimenRow()]}
-        columns={makeBiospecimenColumns()}
-        getRowId={r => r.biospecimenId}
-        autoHeight
-      />,
+      <MemoryRouter>
+        <DataGrid
+          rows={[makeBiospecimenRow()]}
+          columns={makeBiospecimenColumns()}
+          getRowId={r => r.biospecimenId}
+          autoHeight
+        />,
+      </MemoryRouter>,
     )
     cy.contains('Study Name').should('exist')
     cy.contains('Biospecimen ID').should('exist')

--- a/cypress/component/data_library/columns/clinicalTrialColumns.spec.tsx
+++ b/cypress/component/data_library/columns/clinicalTrialColumns.spec.tsx
@@ -6,6 +6,7 @@
  * inspects the rendered HTML to verify the column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeClinicalTrialColumns } from 'src/components/data_library/columns/clinicalTrialColumns'
 import { makeClinicalTrialRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makeClinicalTrialRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makeClinicalTrialRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makeClinicalTrialColumns()}
-      getRowId={r => r.clinicalTrialId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makeClinicalTrialColumns()}
+        getRowId={r => r.clinicalTrialId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 

--- a/cypress/component/data_library/columns/datasetColumns.spec.tsx
+++ b/cypress/component/data_library/columns/datasetColumns.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeDatasetColumns } from 'src/components/data_library/columns/datasetColumns'
 import { makeDatasetTerm } from '../../test-utils'
@@ -32,12 +33,14 @@ describe('datasetColumns — Access Management chip', () => {
   const renderGrid = (accessManagement: string) => {
     const row = makeDatasetTerm({ datasetId: 1, accessManagement })
     cy.mount(
-      <DataGrid
-        rows={[row]}
-        columns={makeDatasetColumns()}
-        getRowId={r => r.datasetId}
-        autoHeight
-      />,
+      <MemoryRouter>
+        <DataGrid
+          rows={[row]}
+          columns={makeDatasetColumns()}
+          getRowId={r => r.datasetId}
+          autoHeight
+        />,
+      </MemoryRouter>,
     )
   }
 
@@ -73,12 +76,14 @@ describe('datasetColumns — Access Management chip', () => {
     const radarEnabledDatasetIds = new Set([1])
     const row = makeDatasetTerm({ datasetId: 1, accessManagement: 'controlled' })
     cy.mount(
-      <DataGrid
-        rows={[row]}
-        columns={makeDatasetColumns({}, radarEnabledDatasetIds)}
-        getRowId={r => r.datasetId}
-        autoHeight
-      />,
+      <MemoryRouter>
+        <DataGrid
+          rows={[row]}
+          columns={makeDatasetColumns({}, radarEnabledDatasetIds)}
+          getRowId={r => r.datasetId}
+          autoHeight
+        />,
+      </MemoryRouter>,
     )
     cy.get('svg[data-testid="BoltIcon"]').should('exist')
   })

--- a/cypress/component/data_library/columns/fundingResourceColumns.spec.tsx
+++ b/cypress/component/data_library/columns/fundingResourceColumns.spec.tsx
@@ -6,6 +6,7 @@
  * inspects the rendered HTML to verify the column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeFundingResourceColumns } from 'src/components/data_library/columns/fundingResourceColumns'
 import { makeFundingResourceRow } from '../../test-utils'
@@ -13,13 +14,15 @@ import { makeFundingResourceRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makeFundingResourceRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makeFundingResourceColumns()}
-      getRowId={r => r.fundingId}
-      autoHeight
-      sx={{ width: 1200 }} // Ensures grid is wide enough for all columns
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makeFundingResourceColumns()}
+        getRowId={r => r.fundingId}
+        autoHeight
+        sx={{ width: 1200 }} // Ensures grid is wide enough for all columns
+      />,
+    </MemoryRouter>,
   )
 }
 
@@ -179,13 +182,15 @@ describe('makeFundingResourceColumns — column structure', () => {
 describe('makeFundingResourceColumns — accessibility', () => {
   it('renders headers with proper labels', () => {
     cy.mount(
-      <DataGrid
-        rows={[makeFundingResourceRow()]}
-        columns={makeFundingResourceColumns()}
-        getRowId={r => r.fundingId}
-        autoHeight
-        sx={{ width: 1200 }} // Ensures grid is wide enough for all columns
-      />,
+      <MemoryRouter>
+        <DataGrid
+          rows={[makeFundingResourceRow()]}
+          columns={makeFundingResourceColumns()}
+          getRowId={r => r.fundingId}
+          autoHeight
+          sx={{ width: 1200 }} // Ensures grid is wide enough for all columns
+        />,
+      </MemoryRouter>,
     )
     cy.contains('Study Name').should('exist')
     cy.contains('Funding Resource ID').should('exist')

--- a/cypress/component/data_library/columns/intellectualPropertyColumns.spec.tsx
+++ b/cypress/component/data_library/columns/intellectualPropertyColumns.spec.tsx
@@ -6,6 +6,7 @@
  * rendered HTML to verify column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeIntellectualPropertyColumns } from 'src/components/data_library/columns/intellectualPropertyColumns'
 import { makeIntellectualPropertyRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makeIntellectualPropertyRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makeIntellectualPropertyRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makeIntellectualPropertyColumns()}
-      getRowId={r => r.ipId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makeIntellectualPropertyColumns()}
+        getRowId={r => r.ipId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 

--- a/cypress/component/data_library/columns/modelColumns.spec.tsx
+++ b/cypress/component/data_library/columns/modelColumns.spec.tsx
@@ -6,6 +6,7 @@
  * inspects the rendered HTML to verify the column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeModelColumns } from 'src/components/data_library/columns/modelColumns'
 import { makeModelRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makeModelRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makeModelRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makeModelColumns()}
-      getRowId={r => r.modelId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makeModelColumns()}
+        getRowId={r => r.modelId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 

--- a/cypress/component/data_library/columns/presentationColumns.spec.tsx
+++ b/cypress/component/data_library/columns/presentationColumns.spec.tsx
@@ -6,6 +6,7 @@
  * rendered HTML to verify column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makePresentationColumns } from 'src/components/data_library/columns/presentationColumns'
 import { makePresentationRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makePresentationRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makePresentationRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makePresentationColumns()}
-      getRowId={r => r.presentationId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makePresentationColumns()}
+        getRowId={r => r.presentationId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 

--- a/cypress/component/data_library/columns/publicationColumns.spec.tsx
+++ b/cypress/component/data_library/columns/publicationColumns.spec.tsx
@@ -6,6 +6,7 @@
  * rendered HTML to verify column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makePublicationColumns } from 'src/components/data_library/columns/publicationColumns'
 import { makePublicationRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makePublicationRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makePublicationRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makePublicationColumns()}
-      getRowId={r => r.publicationId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makePublicationColumns()}
+        getRowId={r => r.publicationId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 

--- a/cypress/component/data_library/columns/workspaceColumns.spec.tsx
+++ b/cypress/component/data_library/columns/workspaceColumns.spec.tsx
@@ -6,6 +6,7 @@
  * inspects the rendered HTML to verify the column behaviour.
  */
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { DataGrid } from '@mui/x-data-grid'
 import { makeWorkspaceColumns } from 'src/components/data_library/columns/workspaceColumns'
 import { makeWorkspaceRow } from '../../test-utils'
@@ -13,12 +14,14 @@ import { makeWorkspaceRow } from '../../test-utils'
 const renderGrid = (overrides = {}) => {
   const row = makeWorkspaceRow(overrides)
   cy.mount(
-    <DataGrid
-      rows={[row]}
-      columns={makeWorkspaceColumns()}
-      getRowId={r => r.workspaceId}
-      autoHeight
-    />,
+    <MemoryRouter>
+      <DataGrid
+        rows={[row]}
+        columns={makeWorkspaceColumns()}
+        getRowId={r => r.workspaceId}
+        autoHeight
+      />,
+    </MemoryRouter>,
   )
 }
 

--- a/cypress/component/navigation/DuosHeader.spec.tsx
+++ b/cypress/component/navigation/DuosHeader.spec.tsx
@@ -23,7 +23,7 @@ const mockUser: DuosUser = {
 
 const mountHeader = (path: string, user?: DuosUser) => {
   cy.viewport(1280, 720)
-  cy.intercept('GET', '**/api/notifications/banners', []).as('getBanners')
+  cy.intercept('GET', '**/api/notifications/banners', [])
 
   // Stub Storage module BEFORE mount - don't use cy.wrap
   if (user) {
@@ -135,11 +135,36 @@ describe('DuosHeader', () => {
   })
 
   describe('Tab Highlighting', () => {
-    it('highlights active tab based on current route', () => {
+    it('highlights Researcher Console on /datalibrary for researcher-only user', () => {
       mountHeader('/datalibrary', mockUser)
       cy.contains('Researcher Console')
         .should('be.visible')
         .should('have.class', 'Mui-selected')
+    })
+
+    it('highlights Researcher Console on /datalibrary for admin+researcher (direct link wins over child match)', () => {
+      const adminResearcher = { ...mockUser, isAdmin: true, isResearcher: true }
+      mountHeader('/datalibrary', adminResearcher)
+      cy.contains('Researcher Console')
+        .should('be.visible')
+        .should('have.class', 'Mui-selected')
+    })
+
+    it('highlights Admin Console on /admin_manage_dar_collections for admin+researcher', () => {
+      const adminResearcher = { ...mockUser, isAdmin: true, isResearcher: true }
+      mountHeader('/admin_manage_dar_collections', adminResearcher)
+      cy.contains('Admin Console')
+        .should('be.visible')
+        .should('have.class', 'Mui-selected')
+    })
+
+    it('preserves Researcher Console tab on a detail page with no URL match (context fallback)', () => {
+      // Mount on a known-tab URL first to seed context, then navigate to a detail URL.
+      // MemoryRouter is re-created each mount, so we simulate context by providing
+      // a path that has no tab match — the tab falls back to index 0 (first tab).
+      // The important thing is that no crash occurs and a tab is still selected.
+      mountHeader('/dar_application_review/999', mockUser)
+      cy.get('.Mui-selected').should('exist')
     })
   })
 })

--- a/cypress/component/navigation/DuosHeader.spec.tsx
+++ b/cypress/component/navigation/DuosHeader.spec.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import DuosHeader from 'src/components/DuosHeader'
 import { DuosUser } from 'src/types/model'
 import * as StorageModule from 'src/libs/storage'
+import { NavigationStateProvider } from 'src/contexts/NavigationStateContext'
 
 const mockUser: DuosUser = {
   createDate: new Date(),
@@ -36,9 +37,11 @@ const mountHeader = (path: string, user?: DuosUser) => {
 
   cy.mount(
     <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="*" element={<DuosHeader classes={{ drawerPaper: '' }} />} />
-      </Routes>
+      <NavigationStateProvider>
+        <Routes>
+          <Route path="*" element={<DuosHeader classes={{ drawerPaper: '' }} />} />
+        </Routes>
+      </NavigationStateProvider>
     </MemoryRouter>,
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,10 +59,10 @@ function App() {
   })
 
   /**
-   * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect
-   * information and user linkage information. With that, we can sync the users account linkage and then redirect the
-   * user to the original page they authenticated from.
-   */
+     * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect
+     * information and user linkage information. With that, we can sync the users account linkage and then redirect the
+     * user to the original page they authenticated from.
+     */
   useEffect(() => {
     const checkRASAuthentication = async () => {
       const queryParams = new URLSearchParams(location.search)
@@ -106,16 +106,16 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={muiThemeFix}>
         <NavigationStateProvider>
-        <div className="body">
-          <div className="wrap">
-            <div className="main">
-              <DuosHeader />
-              {isLoading && <div style={loadingSyle}><Spinner /></div>}
-              {!isLoading && <AppRoutes isLogged={isLoggedIn} env={env} />}
+          <div className="body">
+            <div className="wrap">
+              <div className="main">
+                <DuosHeader />
+                {isLoading && <div style={loadingSyle}><Spinner /></div>}
+                {!isLoading && <AppRoutes isLogged={isLoggedIn} env={env} />}
+              </div>
             </div>
+            <DuosFooter />
           </div>
-          <DuosFooter />
-        </div>
         </NavigationStateProvider>
       </ThemeProvider>
     </QueryClientProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { ThemeProvider } from '@mui/material/styles'
+import { NavigationStateProvider } from 'src/contexts/NavigationStateContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import 'src/App.css'
 import { muiThemeFix } from 'src/libs/muiThemeFix'
@@ -104,6 +105,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={muiThemeFix}>
+        <NavigationStateProvider>
         <div className="body">
           <div className="wrap">
             <div className="main">
@@ -114,6 +116,7 @@ function App() {
           </div>
           <DuosFooter />
         </div>
+        </NavigationStateProvider>
       </ThemeProvider>
     </QueryClientProvider>
   )

--- a/src/components/DuosHeader.tsx
+++ b/src/components/DuosHeader.tsx
@@ -293,19 +293,18 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
   // Prefer a direct top-level match over a child-only match.
   // This prevents e.g. Admin Console (which has /datalibrary as a child) from winning
   // over Researcher Console (whose own link IS /datalibrary).
-  const urlDerivedTab = (() => {
-    const direct = tabs.findIndex(isDirectTabMatch)
-    return direct !== -1 ? direct : tabs.findIndex(isChildTabMatch)
-  })()
+  const directTabMatch = tabs.findIndex(isDirectTabMatch)
+  const urlDerivedTab = directTabMatch >= 0 ? directTabMatch : tabs.findIndex(isChildTabMatch)
 
   // NavigationTabsComponent always sets location.state.selectedMenuTab when a tab is clicked.
   // Honour that so clicking e.g. "Researcher Console" always wins, even when the destination
   // URL is also reachable via another tab's children.
   const stateTab: number | undefined = location?.state?.selectedMenuTab
 
-  const urlMatchedTab = (stateTab != null && tabs.length > stateTab && (isDirectTabMatch(tabs[stateTab]) || isChildTabMatch(tabs[stateTab])))
-    ? stateTab
-    : urlDerivedTab
+  let urlMatchedTab = urlDerivedTab
+  if (stateTab != null && tabs.length > stateTab && (isDirectTabMatch(tabs[stateTab]) || isChildTabMatch(tabs[stateTab]))) {
+    urlMatchedTab = stateTab
+  }
 
   useEffect(() => {
     if (urlMatchedTab !== -1) {

--- a/src/components/DuosHeader.tsx
+++ b/src/components/DuosHeader.tsx
@@ -17,6 +17,7 @@ import './DuosHeader.css'
 import { Notification } from './Notification'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { DuosUser } from 'src/types/model'
+import { useNavigationState } from 'src/contexts/NavigationStateContext'
 
 interface SubTab {
   label: string
@@ -164,6 +165,8 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
     showProfileLinks: false,
   })
 
+  const { activeTab, setActiveTab } = useNavigationState()
+
   useEffect(() => {
     const fetchNotificationData = async (): Promise<void> => {
       const notificationData = await NotificationService.getActiveBanners()
@@ -277,31 +280,48 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
 
   const tabs = headerTabsConfig.filter(data => data.isRendered(currentUser))
 
-  // returns true if the current page the app is on is a part of this tab
-  const isValidTab = (tab: Tab): boolean => {
-    if (tab.link === location.pathname || location.pathname.includes(tab.search || '')) {
-      return true
+  // returns true if the tab's own link/search matches the current URL (not via children)
+  const isDirectTabMatch = (tab: Tab): boolean =>
+    tab.link === location.pathname || !!(tab.search && location.pathname.includes(tab.search))
+
+  // returns true if any child of this tab matches the current URL
+  const isChildTabMatch = (tab: Tab): boolean =>
+    tab.children?.some(subtab =>
+      subtab.link === location.pathname || !!(subtab.search && location.pathname.includes(subtab.search)),
+    ) ?? false
+
+  // Prefer a direct top-level match over a child-only match.
+  // This prevents e.g. Admin Console (which has /datalibrary as a child) from winning
+  // over Researcher Console (whose own link IS /datalibrary).
+  const urlDerivedTab = (() => {
+    const direct = tabs.findIndex(isDirectTabMatch)
+    return direct !== -1 ? direct : tabs.findIndex(isChildTabMatch)
+  })()
+
+  // NavigationTabsComponent always sets location.state.selectedMenuTab when a tab is clicked.
+  // Honour that so clicking e.g. "Researcher Console" always wins, even when the destination
+  // URL is also reachable via another tab's children.
+  const stateTab: number | undefined = location?.state?.selectedMenuTab
+
+  const urlMatchedTab = (stateTab != null && tabs.length > stateTab && (isDirectTabMatch(tabs[stateTab]) || isChildTabMatch(tabs[stateTab])))
+    ? stateTab
+    : urlDerivedTab
+
+  useEffect(() => {
+    if (urlMatchedTab !== -1) {
+      setActiveTab(urlMatchedTab)
     }
-    if (tab.children) {
-      return tab.children.some((subtab: SubTab) => {
-        return subtab.link === location.pathname || location.pathname.includes(subtab.search || '')
-      })
-    }
-    return false
-  }
+  }, [urlMatchedTab, setActiveTab])
 
   let initialSubTab: number = -1
-  let initialTab: number
 
-  // note: location.state.selectedMenuTab will be populated if the user navigated
-  // to the current page by clicking on a tab from the nav bar.
-
-  // populate initialTab based on state (if valid) or by manually searching through all tabs.
-  if (location?.state?.selectedMenuTab && tabs.length > location.state.selectedMenuTab && isValidTab(tabs[location.state.selectedMenuTab])) {
-    initialTab = location.state.selectedMenuTab
-  }
-  else {
-    initialTab = tabs.findIndex(isValidTab)
+  // populate initialTab:
+  //   1. URL match (with state from tab click taking priority over findIndex)
+  //   2. Context fallback for detail pages whose URL doesn't appear in any tab config
+  //   3. First available tab as last resort
+  let initialTab = urlMatchedTab
+  if (initialTab === -1 && activeTab != null && tabs.length > activeTab) {
+    initialTab = activeTab
   }
 
   // populate initialSubTab
@@ -316,7 +336,7 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
     )
   }
 
-  if (initialTab === -1) {
+  if (initialTab === -1 && tabs.length > 0) {
     initialTab = 0
   }
 

--- a/src/components/data_library/columns/biospecimenColumns.tsx
+++ b/src/components/data_library/columns/biospecimenColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Box, Link } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import Tooltip from '@mui/material/Tooltip'
 import { BiospecimenAsset } from 'src/types/library'
 
@@ -11,7 +12,7 @@ export const makeBiospecimenColumns = (): GridColDef<BiospecimenAsset>[] => [
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/clinicalTrialColumns.tsx
+++ b/src/components/data_library/columns/clinicalTrialColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { ClinicalTrialAsset } from 'src/types/library'
 
 /**
@@ -42,7 +43,7 @@ export const makeClinicalTrialColumns = (): GridColDef<ClinicalTrialAsset>[] => 
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { DatasetTerm, getAccessManagementSummary } from 'src/types/model'
 import { AccessManagement, ExportableDatasets } from 'src/types/library'
 import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
@@ -19,7 +20,7 @@ export const makeDatasetColumns = (
     flex: 1.5,
     minWidth: 200,
     renderCell: params => (
-      <Link href={`/dataset/${params.row.datasetIdentifier}`} underline="hover">
+      <Link component={RouterLink} to={`/dataset/${params.row.datasetIdentifier}`} underline="hover">
         {params.value}
       </Link>
     ),
@@ -31,7 +32,7 @@ export const makeDatasetColumns = (
     minWidth: 150,
     valueGetter: (_value, row) => row.study?.studyName || '',
     renderCell: params => (
-      <Link href={`/studies/${params.row.study?.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.study?.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/fundingResourceColumns.tsx
+++ b/src/components/data_library/columns/fundingResourceColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Box, Chip, Link } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import Tooltip from '@mui/material/Tooltip'
 import { FundingResourceAsset } from 'src/types/library'
 
@@ -11,7 +12,7 @@ export const makeFundingResourceColumns = (): GridColDef<FundingResourceAsset>[]
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/intellectualPropertyColumns.tsx
+++ b/src/components/data_library/columns/intellectualPropertyColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { IntellectualPropertyAsset } from 'src/types/library'
 
 /**
@@ -42,7 +43,7 @@ export const makeIntellectualPropertyColumns = (): GridColDef<IntellectualProper
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/modelColumns.tsx
+++ b/src/components/data_library/columns/modelColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { ModelAsset } from 'src/types/library'
 
 /**
@@ -35,7 +36,7 @@ export const makeModelColumns = (): GridColDef<ModelAsset>[] => [
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/presentationColumns.tsx
+++ b/src/components/data_library/columns/presentationColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { PresentationAsset } from 'src/types/library'
 
 /**
@@ -42,7 +43,7 @@ export const makePresentationColumns = (): GridColDef<PresentationAsset>[] => [
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/publicationColumns.tsx
+++ b/src/components/data_library/columns/publicationColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { PublicationAsset } from 'src/types/library'
 
 /**
@@ -42,7 +43,7 @@ export const makePublicationColumns = (): GridColDef<PublicationAsset>[] => [
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/studyColumns.tsx
+++ b/src/components/data_library/columns/studyColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Tooltip, Box } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { StudyAggregation } from 'src/types/library'
 
 /**
@@ -13,7 +14,7 @@ export const makeStudyColumns = (): GridColDef<StudyAggregation>[] => [
     flex: 1.5,
     minWidth: 200,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_library/columns/workspaceColumns.tsx
+++ b/src/components/data_library/columns/workspaceColumns.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { GridColDef } from '@mui/x-data-grid'
 import { Link, Chip, Box, Tooltip } from '@mui/material'
+import { Link as RouterLink } from 'react-router-dom'
 import { WorkspaceAsset } from 'src/types/library'
 
 /**
@@ -35,7 +36,7 @@ export const makeWorkspaceColumns = (): GridColDef<WorkspaceAsset>[] => [
     flex: 1,
     minWidth: 150,
     renderCell: params => (
-      <Link href={`/studies/${params.row.studyId}`} underline="hover">
+      <Link component={RouterLink} to={`/studies/${params.row.studyId}`} underline="hover">
         {params.value}
       </Link>
     ),

--- a/src/components/data_search/DatasetSearchTableConstants.tsx
+++ b/src/components/data_search/DatasetSearchTableConstants.tsx
@@ -2,6 +2,7 @@ import { DatasetTerm, getAccessManagementSummary } from 'src/types/model'
 import { groupBy, intersection, without, xor } from 'lodash'
 import { Checkbox, Link } from '@mui/material'
 import * as React from 'react'
+import { Link as RouterLink } from 'react-router-dom'
 import { OverflowTooltip } from 'src/components/Tooltips'
 import { SnapshotSummaryModel } from 'src/types/tdrModel'
 import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
@@ -131,7 +132,7 @@ export const makeStudyTableHeaders = (datasets: DatasetTerm[], selected: number[
       cellStyle: makeHeaderStyle(studyCellWidths.studyName),
       cellDataFn: datasets => ({
         data: (
-          <Link key={datasets[0].study.studyId} id="link_study" href={`/studies/${datasets[0].study.studyId}`}>
+          <Link key={datasets[0].study.studyId} id="link_study" component={RouterLink} to={`/studies/${datasets[0].study.studyId}`}>
             {trimNewlineCharacters(datasets[0].study.studyName)}
           </Link>
         ),
@@ -328,7 +329,8 @@ export const makeDatasetTableHeader = (
             <Link
               key={dataset.datasetId}
               id={`${dataset.datasetId}-link-dataset-name`}
-              href={`/dataset/${dataset.datasetIdentifier}`}
+              component={RouterLink}
+              to={`/dataset/${dataset.datasetIdentifier}`}
             >
               {trimNewlineCharacters(dataset.datasetName)}
             </Link>
@@ -353,7 +355,8 @@ export const makeDatasetTableHeader = (
             <Link
               key={dataset.study.studyId}
               id={`${dataset.datasetId}-link-study-name`}
-              href={`/studies/${dataset.study.studyId}`}
+              component={RouterLink}
+              to={`/studies/${dataset.study.studyId}`}
             >
               {trimNewlineCharacters(dataset.study.studyName)}
             </Link>
@@ -373,7 +376,8 @@ export const makeDatasetTableHeader = (
         data: (
           <Link
             key={dataset.datasetId}
-            href={`/dataset/${dataset.datasetIdentifier}`}
+            component={RouterLink}
+            to={`/dataset/${dataset.datasetIdentifier}`}
           >
             {dataset.datasetIdentifier}
           </Link>

--- a/src/contexts/NavigationStateContext.tsx
+++ b/src/contexts/NavigationStateContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react'
+
+interface NavigationStateContextType {
+  activeTab: number | undefined
+  setActiveTab: (tab: number) => void
+}
+
+const NavigationStateContext = createContext<NavigationStateContextType>({
+  activeTab: undefined,
+  setActiveTab: () => {},
+})
+
+export const NavigationStateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [activeTab, setActiveTab] = useState<number | undefined>(undefined)
+  return (
+    <NavigationStateContext.Provider value={{ activeTab, setActiveTab }}>
+      {children}
+    </NavigationStateContext.Provider>
+  )
+}
+
+export const useNavigationState = () => useContext(NavigationStateContext)
+

--- a/src/contexts/NavigationStateContext.tsx
+++ b/src/contexts/NavigationStateContext.tsx
@@ -1,4 +1,6 @@
-import React, { createContext, useContext, useState } from 'react'
+/* eslint-disable react-refresh/only-export-components */
+/* this is the standard pattern for context files that export both a provider component and a hook. */
+import React, { createContext, useContext, useMemo, useState } from 'react'
 
 interface NavigationStateContextType {
   activeTab: number | undefined
@@ -12,12 +14,12 @@ const NavigationStateContext = createContext<NavigationStateContextType>({
 
 export const NavigationStateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [activeTab, setActiveTab] = useState<number | undefined>(undefined)
+  const value = useMemo(() => ({ activeTab, setActiveTab }), [activeTab])
   return (
-    <NavigationStateContext.Provider value={{ activeTab, setActiveTab }}>
+    <NavigationStateContext.Provider value={value}>
       {children}
     </NavigationStateContext.Provider>
   )
 }
 
 export const useNavigationState = () => useContext(NavigationStateContext)
-

--- a/src/pages/researcher_console/DatasetSubmissionsTable.jsx
+++ b/src/pages/researcher_console/DatasetSubmissionsTable.jsx
@@ -114,7 +114,8 @@ export default function DatasetSubmissionsTable(props) {
         : (
             <div>
               <Button
-                href={editLink}
+                component={Link}
+                to={editLink}
                 sx={{
                   fontSize: '1.25rem',
                   border: '1px solid #0948B7',


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3203

## Summary
Significant refactor of navigation state. Previous logic was challenging to maintain and buggy for users with multiple roles. This PR takes a slightly different approach by using a context pattern that maintains the navigation tab as state. In addition to that, we also need to update a significant number of internal links to go through the Router so that state can be maintained.

### NavigationStateContext
This is a lightweight [context](https://react.dev/learn/passing-data-deeply-with-context) component that maintains the last url-matched tab across internal navigation

### Updated Tab Resolution Logic

```
Priority   Signal                         When present
────────── ────────────────────────────── ────────────────────────────────────────
1 (high)   location.state.selectedMenuTab NavigationTabsComponent sets this on
                                          every tab / sub-tab click
2          Direct URL match               tab.link === pathname  OR
           (top-level link/search only)   tab.search in pathname
3          Child URL match                a child tab's link/search matches
4          Context fallback               activeTab from NavigationStateContext
           (last known tab)               — used on detail pages with no match
5 (low)    First available tab            Last resort when context is also empty
```

### SPA Navigation Fixes (`href` → React Router `Link`)

Several components used `href` on MUI `<Button>` and `<Link>`, which triggers a **full-page navigation** and discards all Router state. These were converted to use React Router's `<Link component={RouterLink} to={...}>` pattern.

| File | Change |
|---|---|
| `data_library/columns/datasetColumns.tsx` | `Link href` → `RouterLink` for `/dataset/` and `/studies/` |
| `data_library/columns/studyColumns.tsx` | `Link href` → `RouterLink` for `/studies/` |
| `data_library/columns/biospecimenColumns.tsx` | Same |
| `data_library/columns/clinicalTrialColumns.tsx` | Same |
| `data_library/columns/fundingResourceColumns.tsx` | Same |
| `data_library/columns/intellectualPropertyColumns.tsx` | Same |
| `data_library/columns/modelColumns.tsx` | Same |
| `data_library/columns/presentationColumns.tsx` | Same |
| `data_library/columns/publicationColumns.tsx` | Same |
| `data_library/columns/workspaceColumns.tsx` | Same |
| `data_search/DatasetSearchTableConstants.tsx` | `Link href` → `RouterLink` for `/dataset/` and `/studies/` |
| `researcher_console/DatasetSubmissionsTable.jsx` | `Button href={editLink}` → `Button component={Link} to={editLink}` |

> External links (`target="_blank"`), `mailto:` links, and footer informational pages (`/privacy`, `/tos`, etc.) retain plain `href` — only internal SPA navigation links are changed.

---


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
