### PR TITLE
[DT-3254] Show actual document size for listed uploaded files

### DIFF
--- a/cypress/component/components/forms/DocumentUpload.spec.tsx
+++ b/cypress/component/components/forms/DocumentUpload.spec.tsx
@@ -27,11 +27,13 @@ describe('DocumentUpload', () => {
         createDate: Date.now(),
       },
     ])
+    const getDocumentFileStub = cy.stub().resolves(new Blob([new Uint8Array(4096)], { type: 'application/pdf' }))
 
     const api = {
       uploadDocument: cy.stub().resolves({} as never),
       deleteDocument: cy.stub().resolves({} as never),
       listDocuments: listStub,
+      getDocumentFile: getDocumentFileStub,
     }
 
     cy.mount(
@@ -43,8 +45,11 @@ describe('DocumentUpload', () => {
     )
 
     cy.wrap(listStub).should('have.been.calledOnce')
+    cy.wrap(getDocumentFileStub).should('have.been.calledOnceWith', EntityType.DAR, 'dar-1', 101)
     cy.contains('existing_consent.pdf').should('exist')
     cy.get('[data-cy="document-upload-status"]').should('contain.text', 'Uploaded')
+    cy.get('[data-cy="document-upload-status"]').should('contain.text', '4.0 KB')
+    cy.get('[data-cy="document-upload-status"]').should('not.contain.text', '0 B')
     cy.get('[data-cy="document-upload-count"]').should('contain.text', '1')
   })
 

--- a/src/components/forms/DocumentUpload.tsx
+++ b/src/components/forms/DocumentUpload.tsx
@@ -53,6 +53,7 @@ export type UploadErrorType = 'permission' | 'validation' | 'unknown'
 export interface QueueEntry {
   id: string
   file: File
+  fileSizeBytes?: number
   typeId: FileCategory
   status: UploadStatus
   progress: number
@@ -128,6 +129,65 @@ const formatBytes = (bytes: number): string => {
     return `${(bytes / 1024).toFixed(1)} KB`
   }
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+const getQueueEntrySize = (doc: QueueEntry): number | undefined => {
+  if (doc.fileSizeBytes !== undefined) {
+    return doc.fileSizeBytes
+  }
+  if (doc.file.size > 0) {
+    return doc.file.size
+  }
+  if (doc.fsoId !== undefined) {
+    return undefined
+  }
+  return doc.file.size
+}
+
+const applyLoadedDocumentSize = (
+  docs: QueueEntry[],
+  docId: string,
+  fileSizeBytes: number,
+): QueueEntry[] => {
+  return docs.map(doc => doc.id === docId
+    ? {
+        ...doc,
+        fileSizeBytes,
+      }
+    : doc)
+}
+
+const populateLoadedDocumentSizes = ({
+  api,
+  entity,
+  entityId,
+  existingDocs,
+  mappedDocs,
+  setDocs,
+}: {
+  api: DocumentUploadApi
+  entity: EntityType
+  entityId: string
+  existingDocs: StoredDocument[]
+  mappedDocs: QueueEntry[]
+  setDocs: React.Dispatch<React.SetStateAction<QueueEntry[]>>
+}): void => {
+  const fetchDocumentFile = api.getDocumentFile ?? getDocumentFile
+
+  mappedDocs.forEach((mappedDoc, index) => {
+    const existingDoc = existingDocs[index]
+    if (!existingDoc || mappedDoc.fileSizeBytes !== undefined) {
+      return
+    }
+
+    runAsyncSafely(fetchDocumentFile(entity, entityId, existingDoc.fileStorageObjectId)
+      .then((blob) => {
+        setDocs(currentDocs => applyLoadedDocumentSize(currentDocs, mappedDoc.id, blob.size))
+      })
+      .catch(() => {
+        // Size is informational only; keep the document visible even if the blob fetch fails.
+      }))
+  })
 }
 
 const getDocumentTypeLabel = (typeId: FileCategory): string => {
@@ -285,6 +345,7 @@ const useInitialDocumentsLoad = ({
           deleted: Boolean(doc.deleted || doc.deleteDate),
         }))
         setDocs(mapped)
+        populateLoadedDocumentSizes({ api, entity, entityId, existingDocs, mappedDocs: mapped, setDocs })
       }
       catch (error) {
         showUploadError('Unable to load documents', error)
@@ -433,6 +494,10 @@ const DocumentQueueCard = ({
   const canRetry = !readOnly && isLiveUpload && doc.status === 'error'
   const canView = doc.status !== 'uploading' && !doc.deleted
   const canDelete = !readOnly && doc.status !== 'uploading' && !doc.deleted
+  const documentSize = getQueueEntrySize(doc)
+  const statusText = documentSize === undefined
+    ? getStatusText(doc)
+    : `${getStatusText(doc)} · ${formatBytes(documentSize)}`
 
   return (
     <Card key={doc.id} sx={{ border: '1px solid', borderColor: doc.status === 'error' ? 'error.main' : 'divider' }} data-cy="document-upload-card">
@@ -449,7 +514,7 @@ const DocumentQueueCard = ({
             {doc.deleted && <Chip label="Deleted" size="small" color="warning" variant="outlined" sx={{ ml: 1 }} data-cy="document-upload-deleted-status" />}
           </Typography>
           <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }} data-cy="document-upload-status">
-            {getStatusText(doc)} · {formatBytes(doc.file.size)}
+            {statusText}
           </Typography>
           <Select
             size="small"


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3254

### Summary

This PR fixes the document upload list so that existing uploaded files no longer display `0 B`. It derives file size from the downloaded blob when a document is loaded from the server.

**Before**
<img width="776" height="186" alt="Before" src="https://github.com/user-attachments/assets/bb0bac6a-0bba-46e5-b34b-0af9f7cbe76b" />

**After**
<img width="776" height="186" alt="After" src="https://github.com/user-attachments/assets/2b8076a9-c5f4-47c7-be3b-d8b6a91841ed" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
