### PR TITLE
[DT-3255] Upload offline

### DIFF
--- a/cypress/component/pages/manage_dac/EditDac.spec.tsx
+++ b/cypress/component/pages/manage_dac/EditDac.spec.tsx
@@ -9,7 +9,6 @@ import chairJson from '../../DAC/chair.json'
 import daas from '../../DAC/daas.json'
 import dac from '../../DAC/dac.json'
 import { Notifications, setUserRoleStatuses } from 'src/libs/utils'
-import { Config } from 'src/libs/config'
 import type { DAAObject, DacObject, DuosUser } from 'src/types/model'
 
 const adminUser = setUserRoleStatuses({ ...(adminJson as object) } as DuosUser, Storage)
@@ -103,20 +102,9 @@ const uploadDaaFiles = (files: Array<{ fileName: string, fileContent?: string }>
   cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).should('not.be.disabled').click()
 }
 
-const stubDocumentUploadApis = (): void => {
-  cy.stub(Config, 'getApiUrl').resolves('')
-  cy.intercept('GET', '**/api/document/**', []).as('listDocuments')
-  cy.intercept('POST', '**/api/document/**', {
-    fileStorageObjectId: 101,
-    fileName: 'uploaded-daa.pdf',
-    category: 'dataAccessAgreement',
-  }).as('uploadDocument')
-}
-
 const setupCreateFlow = (user: DuosUser): void => {
   cy.stub(Storage, 'getCurrentUser').returns(user)
   cy.stub(DAA, 'getDaas').resolves(broadDaaList)
-  stubDocumentUploadApis()
   stubCommonDacApis()
   cy.mount(<BrowserRouter><EditDac /></BrowserRouter>)
 }
@@ -125,7 +113,6 @@ const setupExistingEditFlow = (daasToReturn: DAAObject[], user: DuosUser = admin
   cy.stub(Storage, 'getCurrentUser').returns(user)
   cy.stub(DAC, 'get').resolves(existingDac)
   cy.stub(DAA, 'getDaas').resolves(daasToReturn)
-  stubDocumentUploadApis()
   stubCommonDacApis()
   mountExistingEditDac(existingDac.dacId as number)
 }
@@ -218,7 +205,7 @@ describe('EditDAC Tests', () => {
     cy.get('[data-cy="btn_save"]').click()
 
     cy.wrap(createStub).should('have.been.called')
-    cy.wrap(createDaaStub).should('have.been.called')
+    cy.wrap(createDaaStub).should('have.been.calledWithMatch', Cypress.sinon.match.has('name', customFileName), 99)
   })
 
   it('Associates selected non-default DAA when editing an existing DAC', () => {
@@ -250,7 +237,7 @@ describe('EditDAC Tests', () => {
     cy.get('[data-cy="daa_option_77"]').should('be.checked')
     cy.get('[data-cy="btn_save"]').click()
 
-    cy.wrap(createDaaStub).should('have.been.called')
+    cy.wrap(createDaaStub).should('have.been.calledWithMatch', Cypress.sinon.match.has('name', 'existing-custom-daa.pdf'), existingDac.dacId)
     cy.wrap(updateStub).should('have.been.called')
     cy.wrap(addDaaToDacStub).should('not.have.been.calledWith', 77, existingDac.dacId)
   })

--- a/src/pages/manage_dac/EditDac.tsx
+++ b/src/pages/manage_dac/EditDac.tsx
@@ -504,6 +504,46 @@ export default function EditDac(): React.JSX.Element {
     return { newDaas, lastCreatedDaa }
   }
 
+  const delay = async (ms: number): Promise<void> => {
+    await new Promise(resolve => globalThis.setTimeout(resolve, ms))
+  }
+
+  const mergeDaasById = (baseDaas: DAAObject[], additionalDaas: DAAObject[]): DAAObject[] => {
+    const daaById = new Map<number, DAAObject>()
+
+    for (const daa of baseDaas) {
+      if (daa.daaId !== undefined) {
+        daaById.set(daa.daaId, daa)
+      }
+    }
+
+    for (const daa of additionalDaas) {
+      if (daa.daaId !== undefined) {
+        daaById.set(daa.daaId, daa)
+      }
+    }
+
+    return Array.from(daaById.values())
+  }
+
+  const refreshMatchingDaas = async (currentDacId: number, expectedDaaIds: number[]): Promise<DAAObject[]> => {
+    const maxAttempts = 3
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const daas = await DAA.getDaas()
+      const refreshedMatchingDaas = daas.filter(daa => daa.initialDacId === currentDacId)
+      const allExpectedPresent = expectedDaaIds.every(id => refreshedMatchingDaas.some(daa => daa.daaId === id))
+
+      if (allExpectedPresent || attempt === maxAttempts) {
+        return refreshedMatchingDaas
+      }
+
+      await delay(attempt * 250)
+    }
+
+    return []
+  }
+
   const handleExistingDacAttachment = async (attachment: File[]): Promise<void> => {
     setIsDaaOperationInProgress(true)
 
@@ -514,21 +554,38 @@ export default function EditDac(): React.JSX.Element {
       }
 
       const { newDaas, lastCreatedDaa } = await createDaasForExistingDac(attachment, dacIdToUse)
+      const expectedDaaIds = newDaas
+        .map(daa => daa.daaId)
+        .filter((id): id is number => id !== undefined)
 
-      // Add all newly created DAAs to the displayed list
-      setMatchingDaas(prev => [...prev, ...newDaas])
-      setCreatedDaa(lastCreatedDaa)
+      let displayedDaas = newDaas
+      try {
+        const refreshedMatchingDaas = await refreshMatchingDaas(dacIdToUse, expectedDaaIds)
+        displayedDaas = mergeDaasById(refreshedMatchingDaas, newDaas)
+      }
+      catch {
+        // Preserve newly uploaded DAAs in the UI if refresh fails.
+        Notifications.showError({ text: 'Unable to refresh DAA list after upload. Showing latest uploaded agreements.' })
+      }
+
+      setMatchingDaas(displayedDaas)
+
+      const selectedCreatedDaa = lastCreatedDaa?.daaId === undefined
+        ? lastCreatedDaa
+        : displayedDaas.find(daa => daa.daaId === lastCreatedDaa.daaId) ?? lastCreatedDaa
+
+      setCreatedDaa(selectedCreatedDaa ?? null)
 
       // Clear pending-upload state since DAAs are now in matchingDaas
       setUploadedDAAFile(null)
       setDaaFileData(null)
 
       // Update selected DAA based on creation success
-      if (lastCreatedDaa?.daaId === undefined) {
+      if (selectedCreatedDaa?.daaId === undefined) {
         setSelectedDaa(undefined)
       }
       else {
-        setSelectedDaa(lastCreatedDaa)
+        setSelectedDaa(selectedCreatedDaa)
         setNewDaaId(null)
       }
     }
@@ -945,7 +1002,7 @@ export default function EditDac(): React.JSX.Element {
               <UploadDaaModal
                 showModal={showUploadModal}
                 dacId={dacIdParam ?? 'new'}
-                isLiveUpload={!!dacIdParam}
+                isLiveUpload={false}
                 isReadOnly={!canUpload}
                 onCloseRequest={() => setShowUploadModal(false)}
                 onAttachmentChange={handleAttachment}


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3255](https://broadworkbench.atlassian.net/browse/DT-3255)

### Summary

At the core, this change does two things.  It:
1) Uses the legacy DAA API to upload new files for a DAC
2) Doesn't load a list of files for a case when the user has expressed to upload a new file by clicking on a button.

Why this fixes the issue:
When displaying the DAA file list, the call being made was based on the DAC ID.  This behavior was incorrect because the DAAs have DAA IDs that should be used for the entity association in the service, not the DAC.  The encapsulating page also displays the proper file list for the user.

Additional code was added to ensure the elements on the page are reloaded after a file is uploaded so that we can be sure the value was persisted properly.  During testing we identified cases where the file would appear to change to a different value after page reload.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
