### PR TITLE
[DT-3216] Add constraint to dataset query.

### DIFF
--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -8,6 +8,29 @@ import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import eventList from 'src/libs/events'
 
+type DatasetApprovalTerm = {
+  term?: {
+    accessManagement?: string
+    dacApproval?: boolean
+  }
+}
+
+type DatasetApprovalBranch = {
+  bool?: {
+    should?: DatasetApprovalBranch[]
+    must_not?: DatasetApprovalTerm[]
+    must?: DatasetApprovalTerm[]
+  }
+}
+
+type DatasetSearchBody = {
+  query?: {
+    bool?: {
+      must?: DatasetApprovalBranch[]
+    }
+  }
+}
+
 const mockMetadataResponse = {
   aggregations: {
     dac: { buckets: [{ key: 'DAC-1', doc_count: 5 }] },
@@ -798,9 +821,9 @@ describe('DataLibrary', () => {
     })
 
     it('sends correct query for controlled/open dataset approval logic', () => {
-      let capturedBody = undefined
+      let capturedBody: DatasetSearchBody | undefined
       cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
-        capturedBody = req.body
+        capturedBody = req.body as DatasetSearchBody
         req.reply(mockDatasetsResponse)
       }).as('searchApi')
 
@@ -817,23 +840,39 @@ describe('DataLibrary', () => {
         cy.then(() => {
           // Find the top-level must array
           const must = capturedBody?.query?.bool?.must
-          expect(must).to.exist
-          // Find the should clause
+          assert.exists(must)
+          if (!must) {
+            throw new Error('Expected top-level bool.must clause in dataset search query')
+          }
+
+          // Find the should clause using optional chaining
           const should = must.find(
-            (clause) => clause.bool && Array.isArray(clause.bool.should)
+            clause => clause.bool?.should && Array.isArray(clause.bool.should),
           )?.bool?.should
-          expect(should).to.exist
+          assert.exists(should)
+          if (!should) {
+            throw new Error('Expected bool.should clause for approval filtering')
+          }
+
           // Should have two branches
-          expect(should.length).to.equal(2)
+          assert.lengthOf(should, 2)
+
           // First branch: must_not accessManagement: controlled
           const mustNot = should[0]?.bool?.must_not
-          expect(mustNot).to.exist
-          expect(mustNot[0]?.term).to.deep.equal({ accessManagement: 'controlled' })
+          assert.exists(mustNot)
+          if (!mustNot) {
+            throw new Error('Expected must_not branch excluding controlled datasets')
+          }
+          assert.deepEqual(mustNot[0]?.term, { accessManagement: 'controlled' })
+
           // Second branch: must accessManagement: controlled AND dacApproval: true
           const mustArr = should[1]?.bool?.must
-          expect(mustArr).to.exist
-          expect(mustArr.some(q => q.term && q.term.accessManagement === 'controlled')).to.be.true
-          expect(mustArr.some(q => q.term && q.term.dacApproval === true)).to.be.true
+          assert.exists(mustArr)
+          if (!mustArr) {
+            throw new Error('Expected must branch for controlled approved datasets')
+          }
+          assert.isTrue(mustArr.some((q: DatasetApprovalTerm) => q.term?.accessManagement === 'controlled'))
+          assert.isTrue(mustArr.some((q: DatasetApprovalTerm) => q.term?.dacApproval === true))
         })
       })
     })

--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -26,7 +26,10 @@ type DatasetApprovalBranch = {
 type DatasetSearchBody = {
   query?: {
     bool?: {
+      should?: DatasetApprovalBranch[]
+      minimum_should_match?: number
       must?: DatasetApprovalBranch[]
+      filter?: DatasetApprovalBranch[]
     }
   }
 }
@@ -838,23 +841,20 @@ describe('DataLibrary', () => {
       cy.wait('@searchApi').then(() => {
         cy.wrap(capturedBody).should('exist')
         cy.then(() => {
-          // Find the top-level must array
-          const must = capturedBody?.query?.bool?.must
-          assert.exists(must)
-          if (!must) {
-            throw new Error('Expected top-level bool.must clause in dataset search query')
+          // ES 9: top-level bool.should + minimum_should_match drives approval logic
+          const topBool = capturedBody?.query?.bool
+          assert.exists(topBool)
+          if (!topBool) {
+            throw new Error('Expected top-level bool clause in dataset search query')
           }
 
-          // Find the should clause using optional chaining
-          const should = must.find(
-            clause => clause.bool?.should && Array.isArray(clause.bool.should),
-          )?.bool?.should
+          assert.equal(topBool.minimum_should_match, 1)
+
+          const should = topBool.should
           assert.exists(should)
           if (!should) {
             throw new Error('Expected bool.should clause for approval filtering')
           }
-
-          // Should have two branches
           assert.lengthOf(should, 2)
 
           // First branch: must_not accessManagement: controlled

--- a/cypress/component/DataLibrary.spec.tsx
+++ b/cypress/component/DataLibrary.spec.tsx
@@ -796,5 +796,46 @@ describe('DataLibrary', () => {
 
       cy.contains('eLwazi Data Library').should('be.visible')
     })
+
+    it('sends correct query for controlled/open dataset approval logic', () => {
+      let capturedBody = undefined
+      cy.intercept('POST', '**/api/dataset/search/index/v2', (req) => {
+        capturedBody = req.body
+        req.reply(mockDatasetsResponse)
+      }).as('searchApi')
+
+      cy.mount(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/?tab=datasets']}>
+            <DataLibrary />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      )
+
+      cy.wait('@searchApi').then(() => {
+        cy.wrap(capturedBody).should('exist')
+        cy.then(() => {
+          // Find the top-level must array
+          const must = capturedBody?.query?.bool?.must
+          expect(must).to.exist
+          // Find the should clause
+          const should = must.find(
+            (clause) => clause.bool && Array.isArray(clause.bool.should)
+          )?.bool?.should
+          expect(should).to.exist
+          // Should have two branches
+          expect(should.length).to.equal(2)
+          // First branch: must_not accessManagement: controlled
+          const mustNot = should[0]?.bool?.must_not
+          expect(mustNot).to.exist
+          expect(mustNot[0]?.term).to.deep.equal({ accessManagement: 'controlled' })
+          // Second branch: must accessManagement: controlled AND dacApproval: true
+          const mustArr = should[1]?.bool?.must
+          expect(mustArr).to.exist
+          expect(mustArr.some(q => q.term && q.term.accessManagement === 'controlled')).to.be.true
+          expect(mustArr.some(q => q.term && q.term.dacApproval === true)).to.be.true
+        })
+      })
+    })
   })
 })

--- a/src/components/data_library/assets/datasetAsset.ts
+++ b/src/components/data_library/assets/datasetAsset.ts
@@ -40,6 +40,7 @@ export const datasetAsset: AssetDefinition = {
     'data.tags',
   ],
 
+  // Always filter for DAC-approved datasets
   buildQuery(
     queryChunks: QueryClause[],
     filterQuery: QueryClause[],
@@ -47,12 +48,27 @@ export const datasetAsset: AssetDefinition = {
     sort?: SortState,
   ): ElasticsearchQuery {
     const esSortField = sort ? (SORT_FIELD_MAP[sort.field] ?? sort.field) : undefined
+    // Only require dacApproval: true for controlled access datasets
+    const must: QueryClause[] = [
+      {
+        bool: {
+          should: [
+            // Non-controlled datasets (open/external/etc) are always included
+            { bool: { must_not: [{ term: { accessManagement: 'controlled' } }] } },
+            // Controlled datasets must be approved
+            { bool: { must: [{ term: { accessManagement: 'controlled' } }, { term: { dacApproval: true } }] } },
+          ],
+          minimum_should_match: 1,
+        },
+      },
+      ...queryChunks,
+    ]
     return {
       from: pagination.page * pagination.pageSize,
       size: pagination.pageSize,
       query: {
         bool: {
-          must: queryChunks,
+          must,
           ...(filterQuery.length > 0 && { filter: filterQuery }),
         },
       },

--- a/src/components/data_library/assets/datasetAsset.ts
+++ b/src/components/data_library/assets/datasetAsset.ts
@@ -35,12 +35,8 @@ export const datasetAsset: AssetDefinition = {
     'study.dataTypes',
     'dataUse.primary.code',
     'dataUse.secondary.code',
-    'dac.dacName',
-    'datasetIdentifier',
-    'data.tags',
   ],
 
-  // Always filter for DAC-approved datasets
   buildQuery(
     queryChunks: QueryClause[],
     filterQuery: QueryClause[],
@@ -48,27 +44,23 @@ export const datasetAsset: AssetDefinition = {
     sort?: SortState,
   ): ElasticsearchQuery {
     const esSortField = sort ? (SORT_FIELD_MAP[sort.field] ?? sort.field) : undefined
-    // Only require dacApproval: true for controlled access datasets
-    const must: QueryClause[] = [
-      {
-        bool: {
-          should: [
-            // Non-controlled datasets (open/external/etc) are always included
-            { bool: { must_not: [{ term: { accessManagement: 'controlled' } }] } },
-            // Controlled datasets must be approved
-            { bool: { must: [{ term: { accessManagement: 'controlled' } }, { term: { dacApproval: true } }] } },
-          ],
-          minimum_should_match: 1,
-        },
-      },
-      ...queryChunks,
-    ]
+    // ES 9: top-level bool should/minimum_should_match, must/filter for additional clauses
     return {
       from: pagination.page * pagination.pageSize,
       size: pagination.pageSize,
       query: {
         bool: {
-          must,
+          should: [
+            // Non-controlled datasets (open/external/etc) are always included
+            { bool: { must_not: [{ term: { accessManagement: 'controlled' } }] } },
+            // Controlled datasets must be approved
+            { bool: { must: [
+              { term: { accessManagement: 'controlled' } },
+              { term: { dacApproval: true } },
+            ] } },
+          ],
+          minimum_should_match: 1,
+          ...(queryChunks.length > 0 && { must: queryChunks }),
           ...(filterQuery.length > 0 && { filter: filterQuery }),
         },
       },

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -50,6 +50,7 @@ export interface BoolQuery {
     should?: QueryClause[]
     must_not?: QueryClause[]
     filter?: QueryClause[]
+    minimum_should_match?: number
   }
 }
 

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -72,6 +72,7 @@ export interface ElasticsearchQuery {
       should?: QueryClause[]
       must_not?: QueryClause[]
       filter?: QueryClause[]
+      minimum_should_match?: number
     }
   }
   sort?: Array<{


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3216](https://broadworkbench.atlassian.net/browse/DT-3216)

### Summary

Adds a constraint to dataset queries that adds filtering to include only the datasets that are controlled access with DAC approval.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
