### PR TITLE
[DT-3261] Use sudo to enable corepack.

### DIFF
--- a/scripts/setup-devcontainer.sh
+++ b/scripts/setup-devcontainer.sh
@@ -18,7 +18,7 @@ install_gcloud_cli() {
 }
 
 install_duos_cypress() {
-  corepack enable
+  sudo corepack enable
   corepack prepare pnpm@11.1.2 --activate
   pnpm install
   pnpm exec cypress install


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3261](https://broadworkbench.atlassian.net/browse/DT-3261)

### Summary

Small cleanup item to enable corepack with sudo.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
