### PR TITLE
[DT-3296] Updated anvil data library query

### DIFF
--- a/cypress/component/libs/libraryVersions.spec.ts
+++ b/cypress/component/libs/libraryVersions.spec.ts
@@ -238,7 +238,7 @@ describe('Library Versions - Tests', function () {
     it('uses bool.should with match_phrase and terms for description-based libraries', function () {
       const versions = getLibraryVersions(null, null)
 
-      const descriptionLibraries = ['elwazi', 'anvil', 'hca', 'scp', 'nhlbi', 'cfde', 'schare', 'stanley', 'stanleycenter']
+      const descriptionLibraries = ['elwazi', 'hca', 'scp', 'nhlbi', 'cfde', 'schare', 'stanley', 'stanleycenter']
 
       descriptionLibraries.forEach((key) => {
         const library = versions[key]
@@ -260,7 +260,7 @@ describe('Library Versions - Tests', function () {
     it('has matching values between match_phrase description and terms tags', function () {
       const versions = getLibraryVersions(null, null)
 
-      const simpleDescriptionLibraries = ['elwazi', 'anvil', 'hca', 'nhlbi', 'cfde', 'ged']
+      const simpleDescriptionLibraries = ['elwazi', 'hca', 'nhlbi', 'cfde', 'ged']
 
       simpleDescriptionLibraries.forEach((key) => {
         const query = versions[key].query as BoolQuery
@@ -273,6 +273,18 @@ describe('Library Versions - Tests', function () {
 
         expect(tagsValue).to.include(descriptionValue, `${key} tags should include the description value`)
       })
+    })
+
+    it('anvil library uses a single terms clause with Platform: AnVIL tag', function () {
+      const versions = getLibraryVersions(null, null)
+      const query = versions['anvil'].query as { bool: { should: object[] } }
+
+      expect(query).to.have.property('bool')
+      expect(query.bool.should).to.have.length(1)
+
+      const clause = query.bool.should[0] as { terms: { 'study.data.tags.keyword': string[] } }
+      expect(clause).to.have.property('terms')
+      expect(clause.terms['study.data.tags.keyword']).to.deep.equal(['Platform: AnVIL'])
     })
 
     it('broad library uses submitter.institution.name and tags', function () {

--- a/src/libs/libraryVersions.ts
+++ b/src/libs/libraryVersions.ts
@@ -469,13 +469,8 @@ export const getLibraryVersions = (
         bool: {
           should: [
             {
-              match_phrase: {
-                'study.description': 'anvil',
-              },
-            },
-            {
               terms: {
-                'study.data.tags.keyword': ['anvil'],
+                'study.data.tags.keyword': ['Platform: AnVIL'],
               },
             },
           ],


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3296

### Summary

Some datasets from the anvil14 release are not being pulled into the AnVIL Data Library in DUOS because the tags we are using are different than those the Data Library configuration is looking for. This addresses that. 

Changes the AnVIL Data Library to explicitly look for the "Platform: AnVIL" study tag rather than the generic "anvil" term in the study description OR tags.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
