### PR TITLE
DT-3280: Add Redis to local DUOS

### DIFF
--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -87,7 +87,7 @@ colima start
 Build and run:
 
 ```shell
-docker buildx build . -t duos --platform linux/amd64
+docker buildx build . -t duos --platform linux/amd64 --load
 docker compose up -d
 ```
 

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -68,10 +68,26 @@ the `env` value to the desired environment will simulate it for local developmen
       - ./public/config.json:/usr/src/app/build/config.json
 ```
 
+Our team uses Colima as its container runtime. If you haven't already, install and start it:
+
+```shell
+brew install colima
+```
+
+On Apple Silicon, start Colima with Rosetta for reliable linux/amd64 emulation (avoids QEMU compatibility issues with Node.js):
+```shell
+colima start --arch aarch64 --vm-type=vz --vz-rosetta
+```
+
+On Intel Macs, a standard start is sufficient:
+```shell
+colima start
+```
+
 Build and run:
 
 ```shell
-docker build . -t duos --platform linux/amd64
+docker buildx build . -t duos --platform linux/amd64
 docker compose up -d
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY vite.config.ts /usr/src/app/vite.config.ts
 COPY config/base_config.json /usr/src/app/public/config.json
 RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 RUN pnpm config set update-notifier false
-RUN pnpm ci --loglevel warn
+RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm ci --loglevel warn
 RUN pnpm run build
 
 # build the server

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ COPY vite.config.ts /usr/src/app/vite.config.ts
 COPY config/base_config.json /usr/src/app/public/config.json
 RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 RUN pnpm config set update-notifier false
-RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm ci --loglevel warn
+ENV NODE_OPTIONS=--max-old-space-size=4096
+RUN pnpm ci --loglevel warn
 RUN pnpm run build
 
 # build the server

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,10 +8,10 @@
 #   * site.conf
 # Ensure that /etc/hosts contains an entry for:
 # 	127.0.0.1	local.broadinstitute.org
-# Ensure that `public/config.json` is pointing to the correct env (not local), i.e.:
+# Ensure that `public/config.json` is pointing to the correct env, e.g.:
 #   ... "env": "dev", ...
 # Build:
-#   docker build . -t duos
+#   docker buildx build . -t duos --platform linux/amd64
 # Run:
 #   docker compose up -d
 # Test
@@ -34,8 +34,9 @@ services:
     image: redis:8.6-trixie
     container_name: duos-redis
     command: ["--save", "", "--maxmemory", "96mb", "--maxmemory-policy", "allkeys-lru"]
-    ports:
-      - "6379:6379"
+#    Enable for local testing of Redis code path, but not needed for single-instance local development
+#    ports:
+#      - "6379:6379"
 
   proxy:
     image: us.gcr.io/broad-dsp-gcr-public/httpd-terra-proxy:v0.1.16

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,13 @@ services:
     command: ["node", "server/dist/index.js"]
     restart: always
 
+  redis:
+    image: redis:8.6-trixie
+    container_name: duos-redis
+    command: ["--save", "", "--maxmemory", "96mb", "--maxmemory-policy", "allkeys-lru"]
+    ports:
+      - "6379:6379"
+
   proxy:
     image: us.gcr.io/broad-dsp-gcr-public/httpd-terra-proxy:v0.1.16
     container_name: duos-proxy


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3280

### Summary
See companion PR here: https://github.com/broadinstitute/terra-helmfile/pull/6440
This PR is not gated on that one - each can proceed independently

* Adds a local Redis instance to our compose file
* Updates `Dockerfile` to handle node memory issues when building locally
* Update `DEVNOTES.md` to cover updates to local docker builds

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
