### PR TITLE
[DT-3087] Missing study prop needs setting

### DIFF
--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -53,6 +53,10 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
     }
     return NihAnvilUsePreSelectOptions.NO
   })
+  const didApplyDefaultNoRef = React.useRef(false)
+  const lastStudyNihAnvilUseValueRef = React.useRef<string | undefined>(
+    getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined,
+  )
 
   const cleanDownstreamProperties = (newVal: Study) => {
     removeStudyPropertiesByKeys(newVal,
@@ -104,24 +108,29 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
 
   React.useEffect(() => {
     const nihAnvilUseStudyValue = getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined
-    if (!nihAnvilUseStudyValue && preSelectorValue === NihAnvilUsePreSelectOptions.NO) {
+    if (!nihAnvilUseStudyValue) {
+      if (!didApplyDefaultNoRef.current && preSelectorValue === NihAnvilUsePreSelectOptions.NO) {
+        didApplyDefaultNoRef.current = true
+        handlePreSelectorChange(NihAnvilUsePreSelectOptions.NO)
+      }
+      lastStudyNihAnvilUseValueRef.current = nihAnvilUseStudyValue
+      return
+    }
+
+    didApplyDefaultNoRef.current = true
+    if (lastStudyNihAnvilUseValueRef.current === nihAnvilUseStudyValue) {
+      return
+    }
+    lastStudyNihAnvilUseValueRef.current = nihAnvilUseStudyValue
+
+    const derivedPreSelectorValue = nihAnvilUseStudyValue === NihAnvilUse.NO_NHGRI_NO_ANVIL
+      ? NihAnvilUsePreSelectOptions.NO
+      : NihAnvilUsePreSelectOptions.YES
+    if (preSelectorValue !== derivedPreSelectorValue) {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      handlePreSelectorChange(NihAnvilUsePreSelectOptions.NO)
+      setPreSelectorValue(derivedPreSelectorValue)
     }
   }, [handlePreSelectorChange, preSelectorValue, study])
-
-  React.useEffect(() => {
-    const nihAnvilUseStudyValue = getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined
-    if (nihAnvilUseStudyValue) {
-      if (nihAnvilUseStudyValue === NihAnvilUse.NO_NHGRI_NO_ANVIL) {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setPreSelectorValue(NihAnvilUsePreSelectOptions.NO)
-      }
-      else {
-        setPreSelectorValue(NihAnvilUsePreSelectOptions.YES)
-      }
-    }
-  }, [study, setPreSelectorValue])
 
   return (
     <div className="data-submitter-section">

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -55,7 +55,7 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
   })
   const didApplyDefaultNoRef = React.useRef(false)
   const lastStudyNihAnvilUseValueRef = React.useRef(
-    getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined,
+    getStudyPropertyValueByKey(study, 'nihAnvilUse'),
   )
 
   const cleanDownstreamProperties = (newVal: Study) => {

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -54,7 +54,7 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
     return NihAnvilUsePreSelectOptions.NO
   })
   const didApplyDefaultNoRef = React.useRef(false)
-  const lastStudyNihAnvilUseValueRef = React.useRef<string | undefined>(
+  const lastStudyNihAnvilUseValueRef = React.useRef(
     getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined,
   )
 

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -46,7 +46,13 @@ export interface NihAnvilUseVisibleOptions {
 
 export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
   const [{ setStudy, study }] = [props]
-  const [preSelectorValue, setPreSelectorValue] = React.useState<string | undefined>(NihAnvilUsePreSelectOptions.NO)
+  const [preSelectorValue, setPreSelectorValue] = React.useState<string | undefined>(() => {
+    const nihAnvilUseStudyValue = getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined
+    if (nihAnvilUseStudyValue && nihAnvilUseStudyValue !== NihAnvilUse.NO_NHGRI_NO_ANVIL) {
+      return NihAnvilUsePreSelectOptions.YES
+    }
+    return NihAnvilUsePreSelectOptions.NO
+  })
 
   const cleanDownstreamProperties = (newVal: Study) => {
     removeStudyPropertiesByKeys(newVal,
@@ -95,6 +101,14 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
     },
     [setStudy, study],
   )
+
+  React.useEffect(() => {
+    const nihAnvilUseStudyValue = getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined
+    if (!nihAnvilUseStudyValue && preSelectorValue === NihAnvilUsePreSelectOptions.NO) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      handlePreSelectorChange(NihAnvilUsePreSelectOptions.NO)
+    }
+  }, [handlePreSelectorChange, preSelectorValue, study])
 
   React.useEffect(() => {
     const nihAnvilUseStudyValue = getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -45,7 +45,7 @@ export interface NihAnvilUseVisibleOptions {
 }
 
 export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
-  const [{ setStudy, study }] = [props]
+  const { setStudy, study } = props
   const [preSelectorValue, setPreSelectorValue] = React.useState<string | undefined>(() => {
     const nihAnvilUseStudyValue = getStudyPropertyValueByKey(study, 'nihAnvilUse') as string | undefined
     if (nihAnvilUseStudyValue && nihAnvilUseStudyValue !== NihAnvilUse.NO_NHGRI_NO_ANVIL) {
@@ -158,9 +158,11 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
           defaultValue={getStudyPropertyValueByKey(study, 'nihAnvilUse')}
           validators={[FormValidators.REQUIRED]}
           onChange={(input: { key: string, value: string | undefined, isValid: boolean }) => {
-            const newVal = structuredClone(study)
-            cleanDownstreamProperties(newVal)
-            setStudyPropertyByKey(newVal, setStudy, input, new NihAnvilUse(input.value as string))
+            if (input.value) {
+              const newVal = structuredClone(study)
+              cleanDownstreamProperties(newVal)
+              setStudyPropertyByKey(newVal, setStudy, input, new NihAnvilUse(input.value))
+            }
           }}
         />
       )}

--- a/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
+++ b/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
@@ -21,6 +21,14 @@ const buildProps = (properties: StudyProperty[] = []): NihAnvilUseRelatedProps =
   study: { properties } as Study,
 })
 
+const getNextStudyFromSetStudyCall = (setStudyMock: ReturnType<typeof vi.fn>, baseStudy: Study): Study => {
+  const firstCallArg = setStudyMock.mock.calls[0]?.[0]
+  if (typeof firstCallArg === 'function') {
+    return firstCallArg(baseStudy)
+  }
+  return firstCallArg
+}
+
 const renderComponent = (nihAnvilUseValue?: string) => {
   const properties = nihAnvilUseValue ? [new NihAnvilUse(nihAnvilUseValue)] : []
   render(<NihAnvilUseRelated {...buildProps(properties)} />)
@@ -40,6 +48,18 @@ describe('NihAnvilUseRelated', () => {
 
     clickPreSelector(NihAnvilUsePreSelectOptions.YES)
     expect(queryById(NIH_ANVIL_FIELD_ID)).not.toBeNull()
+  })
+
+  it('applies NO initialization logic on mount for a new study', () => {
+    const setStudy = vi.fn()
+    const baseStudy = { properties: [] } as Study
+
+    render(<NihAnvilUseRelated study={baseStudy} setStudy={setStudy} />)
+
+    expect(setStudy).toHaveBeenCalled()
+    const nextStudy = getNextStudyFromSetStudyCall(setStudy, baseStudy)
+    const nihAnvilUseProperty = nextStudy.properties?.find((prop) => prop.key === NihAnvilUse.key)
+    expect(nihAnvilUseProperty?.value).toBe(NihAnvilUse.NO_NHGRI_NO_ANVIL)
   })
 
   it('shows nihAnvilUse field after selecting YES in pre-selector', () => {

--- a/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
+++ b/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
@@ -58,7 +58,7 @@ describe('NihAnvilUseRelated', () => {
 
     expect(setStudy).toHaveBeenCalled()
     const nextStudy = getNextStudyFromSetStudyCall(setStudy, baseStudy)
-    const nihAnvilUseProperty = nextStudy.properties?.find((prop) => prop.key === NihAnvilUse.key)
+    const nihAnvilUseProperty = nextStudy.properties?.find(prop => prop.key === NihAnvilUse.key)
     expect(nihAnvilUseProperty?.value).toBe(NihAnvilUse.NO_NHGRI_NO_ANVIL)
   })
 

--- a/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
+++ b/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
@@ -51,13 +51,13 @@ describe('NihAnvilUseRelated', () => {
   })
 
   it('applies NO initialization logic on mount for a new study', () => {
-    const setStudy = vi.fn()
-    const baseStudy = { properties: [] } as Study
+    const setStudyMock = vi.fn()
+    const baseStudy = buildProps([]).study
 
-    render(<NihAnvilUseRelated study={baseStudy} setStudy={setStudy} />)
+    render(<NihAnvilUseRelated study={baseStudy} setStudy={setStudyMock} />)
 
-    expect(setStudy).toHaveBeenCalled()
-    const nextStudy = getNextStudyFromSetStudyCall(setStudy, baseStudy)
+    expect(setStudyMock).toHaveBeenCalled()
+    const nextStudy = getNextStudyFromSetStudyCall(setStudyMock, baseStudy)
     const nihAnvilUseProperty = nextStudy.properties?.find(prop => prop.key === NihAnvilUse.key)
     expect(nihAnvilUseProperty?.value).toBe(NihAnvilUse.NO_NHGRI_NO_ANVIL)
   })


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3087](https://broadworkbench.atlassian.net/browse/DT-3087)

### Summary

Missed a study prop that needs setting on the study option when initializing to false.  Adds:
- Study property setting
- Test to confirm property is set.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
