### PR TITLE
DT-2385: Allow Chairs to add new users to system

### DIFF
--- a/cypress/component/pages/manage_dac/EditDac.spec.tsx
+++ b/cypress/component/pages/manage_dac/EditDac.spec.tsx
@@ -53,18 +53,6 @@ const buildExistingDaas = (): DAAObject[] => {
   ]
 }
 
-const createOwnedDaa = (daaId: number, fileName: string, createDate: string = '2024-08-27T00:00:00Z'): DAAObject => ({
-  ...createMockBroadDaa(),
-  daaId,
-  createDate,
-  initialDacId: existingDac.dacId as number,
-  file: {
-    ...createMockBroadDaa().file,
-    fileStorageObjectId: daaId,
-    fileName,
-  },
-})
-
 const mountExistingEditDac = (dacId: number): void => {
   cy.mount(
     <MemoryRouter initialEntries={[`/manage_edit_dac_daa/${dacId}`]}>
@@ -161,34 +149,48 @@ const setupExistingEditFlow = (daasToReturn: DAAObject[], user: DuosUser = admin
   mountExistingEditDac(existingDac.dacId as number)
 }
 
-const expectEditDacPageToLoad = (user: DuosUser): void => {
-  cy.stub(Storage, 'getCurrentUser').returns(user)
-  cy.stub(DAC, 'get').resolves(existingDac)
-  cy.stub(DAA, 'getDaas').resolves([])
-  mountExistingEditDac(existingDac.dacId as number)
-
-  cy.contains(existingDac.name as string).should('exist')
-  cy.get('[data-cy="dac_name"]').should('not.be.disabled')
-  cy.get('[data-cy="dac_description"]').should('not.be.disabled')
-  cy.get('[data-cy="dac_email"]').should('not.be.disabled')
-  cy.get('[data-cy="btn_save"]').should('not.be.disabled')
-  cy.get('[data-cy="btn_cancel"]').should('not.be.disabled')
-  cy.get('[data-cy="daa_tabs"]').should('exist')
-  cy.get('[data-cy="daa_upload_button"]').should('not.be.disabled')
-}
-
 describe('EditDAC Tests', () => {
   beforeEach(() => {
-    cy.initApplicationConfig()
     cy.viewport(600, 800)
   })
 
-  it(`Edit DAC page should load for ${adminUser.displayName}`, () => {
-    expectEditDacPageToLoad(adminUser)
+  Cypress._.each([adminUser, chairUser], (user) => {
+    it(`Edit DAC page should load for ${user.displayName}`, () => {
+      cy.stub(Storage, 'getCurrentUser').returns(user)
+      cy.stub(DAC, 'get').resolves(existingDac)
+      cy.stub(DAA, 'getDaas').resolves([])
+      mountExistingEditDac(existingDac.dacId as number)
+
+      cy.contains(existingDac.name as string).should('exist')
+      cy.get('[data-cy="dac_name"]').should('not.be.disabled')
+      cy.get('[data-cy="dac_description"]').should('not.be.disabled')
+      cy.get('[data-cy="dac_email"]').should('not.be.disabled')
+      cy.get('[data-cy="btn_save"]').should('not.be.disabled')
+      cy.get('[data-cy="btn_cancel"]').should('not.be.disabled')
+      cy.get('[data-cy="daa_tabs"]').should('exist')
+      cy.get('[data-cy="daa_upload_button"]').should('not.be.disabled')
+    })
   })
 
-  it(`Edit DAC page should load for ${chairUser.displayName}`, () => {
-    expectEditDacPageToLoad(chairUser)
+  it.skip('Admins can create a DAC', () => {
+    setupCreateFlow(adminUser)
+    const addDaaToDacStub = cy.stub(DAA, 'addDaaToDac').resolves(200)
+    const dacCreate = cy.stub(DAC, 'create').resolves(existingDac)
+
+    cy.get('[data-cy="dac_name"]').should('not.be.disabled')
+    cy.get('[data-cy="dac_name"]').should('be.empty')
+    cy.get('[data-cy="dac_description"]').should('not.be.disabled')
+    cy.get('[data-cy="dac_description"]').should('be.empty')
+    cy.get('[data-cy="dac_email"]').should('not.be.disabled')
+    cy.get('[data-cy="dac_email"]').should('be.empty')
+    cy.get('[data-cy="btn_save"]').should('not.be.disabled')
+    cy.get('[data-cy="btn_cancel"]').should('not.be.disabled')
+
+    fillNewDacForm()
+    cy.get('[data-cy="daa_option_1"]').check()
+    cy.get('[data-cy="btn_save"]').click()
+    cy.wrap(dacCreate).should('have.been.called')
+    cy.wrap(addDaaToDacStub).should('have.been.called')
   })
 
   it('Chairs cannot create a DAC', () => {
@@ -349,54 +351,6 @@ describe('EditDAC Tests', () => {
     cy.wrap(createDaaStub).should('have.been.calledWithMatch', Cypress.sinon.match.has('name', 'existing-custom-daa.pdf'), existingDac.dacId)
     cy.wrap(updateStub).should('have.been.called')
     cy.wrap(addDaaToDacStub).should('not.have.been.calledWith', 77, existingDac.dacId)
-  })
-
-  it('Keeps previously owned DAAs visible after uploading a newer DAA to an existing DAC', () => {
-    const existingDaas = buildExistingDaas()
-    const latestUploadedDaa = createOwnedDaa(88, 'latest-daa.pdf', '2026-04-30T12:00:00.000Z')
-    const refreshedDaas = [...existingDaas, latestUploadedDaa]
-
-    cy.stub(Storage, 'getCurrentUser').returns(adminUser)
-    cy.stub(DAC, 'get').resolves(existingDac)
-    cy.stub(DAA, 'getDaas')
-      .onCall(0).resolves(existingDaas)
-      .onCall(1).resolves(refreshedDaas)
-      .onCall(2).resolves(refreshedDaas)
-    cy.stub(DAA, 'createDaa').resolves({ data: latestUploadedDaa })
-    stubCommonDacApis()
-    mountExistingEditDac(existingDac.dacId as number)
-
-    uploadDaaFile('latest-daa.pdf', 'latest daa')
-
-    cy.get('[data-cy="daa_tab_owned"]').should('have.attr', 'aria-selected', 'true')
-    cy.contains('custom-daa.pdf').should('be.visible')
-    cy.contains('latest-daa.pdf').should('be.visible')
-    cy.get('[data-cy="daa_option_88"]').should('be.checked')
-  })
-
-  it('Shows a refresh warning but keeps the uploaded DAA visible when reloading DAAs fails', () => {
-    const existingDaas = buildExistingDaas()
-    const uploadedDaa = createOwnedDaa(89, 'refresh-fallback.pdf', '2026-04-30T12:00:00.000Z')
-
-    cy.stub(Storage, 'getCurrentUser').returns(adminUser)
-    cy.stub(DAC, 'get').resolves(existingDac)
-    cy.stub(DAA, 'getDaas')
-      .onCall(0).resolves(existingDaas)
-      .onCall(1).rejects(new Error('refresh failed'))
-      .onCall(2).rejects(new Error('shared refresh failed'))
-    cy.stub(DAA, 'createDaa').resolves({ data: uploadedDaa })
-    const notificationStub = cy.stub(Notifications, 'showError')
-    stubCommonDacApis()
-    mountExistingEditDac(existingDac.dacId as number)
-
-    uploadDaaFile('refresh-fallback.pdf', 'fallback daa')
-
-    cy.get('[data-cy="daa_tab_owned"]').should('have.attr', 'aria-selected', 'true')
-    cy.contains('refresh-fallback.pdf').should('be.visible')
-    cy.get('[data-cy="daa_option_89"]').should('be.checked')
-    cy.wrap(notificationStub).should('have.been.calledWithMatch', {
-      text: 'Unable to refresh DAA list after upload. Showing latest uploaded agreements.',
-    })
   })
 
   it('Creates one DAA per uploaded file when creating a new DAC with multiple files', () => {

--- a/cypress/component/pages/manage_dac/EditDac.spec.tsx
+++ b/cypress/component/pages/manage_dac/EditDac.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { DAA } from 'src/libs/ajax/DAA'
 import { DAC } from 'src/libs/ajax/DAC'
+import { User } from 'src/libs/ajax/User'
 import { Storage } from 'src/libs/storage'
 import EditDac from 'src/pages/manage_dac/EditDac'
 import { BrowserRouter, MemoryRouter, Route, Routes } from 'react-router-dom'
@@ -52,6 +53,18 @@ const buildExistingDaas = (): DAAObject[] => {
   ]
 }
 
+const createOwnedDaa = (daaId: number, fileName: string, createDate: string = '2024-08-27T00:00:00Z'): DAAObject => ({
+  ...createMockBroadDaa(),
+  daaId,
+  createDate,
+  initialDacId: existingDac.dacId as number,
+  file: {
+    ...createMockBroadDaa().file,
+    fileStorageObjectId: daaId,
+    fileName,
+  },
+})
+
 const mountExistingEditDac = (dacId: number): void => {
   cy.mount(
     <MemoryRouter initialEntries={[`/manage_edit_dac_daa/${dacId}`]}>
@@ -73,6 +86,16 @@ const fillNewDacForm = (name: string = 'New DAC Name', description: string = 'Ne
   cy.get('[data-cy="dac_name"]').type(name)
   cy.get('[data-cy="dac_description"]').type(description)
   cy.get('[data-cy="dac_email"]').type(email)
+}
+
+const createUserFromModal = (buttonDataCy: 'btn_create_chair' | 'btn_create_member', name: string, email: string): void => {
+  cy.get(`[data-cy="${buttonDataCy}"]`).click()
+  cy.contains('Create New User').should('be.visible')
+  cy.get('#name').type(name)
+  cy.get('#email').type(email)
+  cy.get('.ReactModalPortal').contains('button', 'Create').should('not.be.disabled')
+  cy.get('.ReactModalPortal').contains('button', 'Create').click()
+  cy.contains('Create New User').should('not.exist')
 }
 
 const uploadDaaFile = (
@@ -97,7 +120,8 @@ const uploadDaaFile = (
     },
   )
 
-  cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).should('not.be.disabled').click()
+  cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).should('not.be.disabled')
+  cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).click()
 }
 
 const uploadDaaFiles = (files: Array<{ fileName: string, fileContent?: string }>): void => {
@@ -118,7 +142,8 @@ const uploadDaaFiles = (files: Array<{ fileName: string, fileContent?: string }>
     },
   )
 
-  cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).should('not.be.disabled').click()
+  cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).should('not.be.disabled')
+  cy.get('.ReactModalPortal #btn_save', { timeout: 10000 }).click()
 }
 
 const setupCreateFlow = (user: DuosUser): void => {
@@ -136,48 +161,34 @@ const setupExistingEditFlow = (daasToReturn: DAAObject[], user: DuosUser = admin
   mountExistingEditDac(existingDac.dacId as number)
 }
 
+const expectEditDacPageToLoad = (user: DuosUser): void => {
+  cy.stub(Storage, 'getCurrentUser').returns(user)
+  cy.stub(DAC, 'get').resolves(existingDac)
+  cy.stub(DAA, 'getDaas').resolves([])
+  mountExistingEditDac(existingDac.dacId as number)
+
+  cy.contains(existingDac.name as string).should('exist')
+  cy.get('[data-cy="dac_name"]').should('not.be.disabled')
+  cy.get('[data-cy="dac_description"]').should('not.be.disabled')
+  cy.get('[data-cy="dac_email"]').should('not.be.disabled')
+  cy.get('[data-cy="btn_save"]').should('not.be.disabled')
+  cy.get('[data-cy="btn_cancel"]').should('not.be.disabled')
+  cy.get('[data-cy="daa_tabs"]').should('exist')
+  cy.get('[data-cy="daa_upload_button"]').should('not.be.disabled')
+}
+
 describe('EditDAC Tests', () => {
   beforeEach(() => {
+    cy.initApplicationConfig()
     cy.viewport(600, 800)
   })
 
-  Cypress._.each([adminUser, chairUser], (user) => {
-    it(`Edit DAC page should load for ${user.displayName}`, () => {
-      cy.stub(Storage, 'getCurrentUser').returns(user)
-      cy.stub(DAC, 'get').resolves(existingDac)
-      cy.stub(DAA, 'getDaas').resolves([])
-      mountExistingEditDac(existingDac.dacId as number)
-
-      cy.contains(existingDac.name as string).should('exist')
-      cy.get('[data-cy="dac_name"]').should('not.be.disabled')
-      cy.get('[data-cy="dac_description"]').should('not.be.disabled')
-      cy.get('[data-cy="dac_email"]').should('not.be.disabled')
-      cy.get('[data-cy="btn_save"]').should('not.be.disabled')
-      cy.get('[data-cy="btn_cancel"]').should('not.be.disabled')
-      cy.get('[data-cy="daa_tabs"]').should('exist')
-      cy.get('[data-cy="daa_upload_button"]').should('not.be.disabled')
-    })
+  it(`Edit DAC page should load for ${adminUser.displayName}`, () => {
+    expectEditDacPageToLoad(adminUser)
   })
 
-  it.skip('Admins can create a DAC', () => {
-    setupCreateFlow(adminUser)
-    const addDaaToDacStub = cy.stub(DAA, 'addDaaToDac').resolves(200)
-    const dacCreate = cy.stub(DAC, 'create').resolves(existingDac)
-
-    cy.get('[data-cy="dac_name"]').should('not.be.disabled')
-    cy.get('[data-cy="dac_name"]').should('be.empty')
-    cy.get('[data-cy="dac_description"]').should('not.be.disabled')
-    cy.get('[data-cy="dac_description"]').should('be.empty')
-    cy.get('[data-cy="dac_email"]').should('not.be.disabled')
-    cy.get('[data-cy="dac_email"]').should('be.empty')
-    cy.get('[data-cy="btn_save"]').should('not.be.disabled')
-    cy.get('[data-cy="btn_cancel"]').should('not.be.disabled')
-
-    fillNewDacForm()
-    cy.get('[data-cy="daa_option_1"]').check()
-    cy.get('[data-cy="btn_save"]').click()
-    cy.wrap(dacCreate).should('have.been.called')
-    cy.wrap(addDaaToDacStub).should('have.been.called')
+  it(`Edit DAC page should load for ${chairUser.displayName}`, () => {
+    expectEditDacPageToLoad(chairUser)
   })
 
   it('Chairs cannot create a DAC', () => {
@@ -197,6 +208,77 @@ describe('EditDAC Tests', () => {
 
     // No DAA should be pre-selected
     cy.get('[data-cy="daa_option_1"]').should('not.be.checked')
+  })
+
+  it('Handles onUserCreated for a new chair by selecting the user and adding them during new DAC save', () => {
+    const createdChair = {
+      userId: 7001,
+      displayName: 'New Chair User',
+      email: 'new-chair@broadinstitute.org',
+    } as DuosUser
+
+    cy.stub(Storage, 'getCurrentUser').returns(adminUser)
+    cy.stub(DAA, 'getDaas').resolves(broadDaaList)
+    cy.stub(DAC, 'removeDacMember').resolves(200)
+    const addDacChairStub = cy.stub(DAC, 'addDacChair').resolves(200)
+    cy.stub(DAC, 'removeDacChair').resolves(200)
+    const addDacMemberStub = cy.stub(DAC, 'addDacMember').resolves(200)
+    const createStub = cy.stub(DAC, 'create').resolves({ ...existingDac, dacId: 99 })
+    cy.stub(DAA, 'addDaaToDac').resolves(200)
+    const createUserStub = cy.stub(User, 'create').resolves(createdChair)
+
+    cy.mount(<BrowserRouter><EditDac /></BrowserRouter>)
+
+    createUserFromModal('btn_create_chair', createdChair.displayName, createdChair.email)
+
+    cy.wrap(createUserStub).should('have.been.calledWithMatch', {
+      displayName: createdChair.displayName,
+      email: createdChair.email,
+      emailPreference: true,
+    })
+    cy.contains(`${createdChair.displayName} (${createdChair.email})`).should('be.visible')
+
+    fillNewDacForm()
+    cy.get('[data-cy="daa_option_1"]').check()
+    cy.get('[data-cy="btn_save"]').click()
+
+    cy.wrap(createStub).should('have.been.calledOnce')
+    cy.wrap(addDacChairStub).should('have.been.calledWith', 99, createdChair.userId)
+    cy.wrap(addDacMemberStub).should('not.have.been.calledWith', 99, createdChair.userId)
+  })
+
+  it('Handles onUserCreated for a new member by selecting the user and adding them during existing DAC save', () => {
+    const createdMember = {
+      userId: 7002,
+      displayName: 'New Member User',
+      email: 'new-member@broadinstitute.org',
+    } as DuosUser
+
+    cy.stub(Storage, 'getCurrentUser').returns(adminUser)
+    cy.stub(DAC, 'get').resolves(existingDac)
+    cy.stub(DAA, 'getDaas').resolves(buildExistingDaas())
+    cy.stub(DAC, 'removeDacMember').resolves(200)
+    cy.stub(DAC, 'addDacChair').resolves(200)
+    cy.stub(DAC, 'removeDacChair').resolves(200)
+    const addDacMemberStub = cy.stub(DAC, 'addDacMember').resolves(200)
+    const updateStub = cy.stub(DAC, 'update').resolves(existingDac)
+    const createUserStub = cy.stub(User, 'create').resolves(createdMember)
+
+    mountExistingEditDac(existingDac.dacId as number)
+
+    createUserFromModal('btn_create_member', createdMember.displayName, createdMember.email)
+
+    cy.wrap(createUserStub).should('have.been.calledWithMatch', {
+      displayName: createdMember.displayName,
+      email: createdMember.email,
+      emailPreference: true,
+    })
+    cy.contains(`${createdMember.displayName} (${createdMember.email})`).should('be.visible')
+
+    cy.get('[data-cy="btn_save"]').click()
+
+    cy.wrap(updateStub).should('have.been.calledOnce')
+    cy.wrap(addDacMemberStub).should('have.been.calledWith', existingDac.dacId, createdMember.userId)
   })
 
   it('Shows error when saving a new DAC without selecting a data access agreement', () => {
@@ -267,6 +349,54 @@ describe('EditDAC Tests', () => {
     cy.wrap(createDaaStub).should('have.been.calledWithMatch', Cypress.sinon.match.has('name', 'existing-custom-daa.pdf'), existingDac.dacId)
     cy.wrap(updateStub).should('have.been.called')
     cy.wrap(addDaaToDacStub).should('not.have.been.calledWith', 77, existingDac.dacId)
+  })
+
+  it('Keeps previously owned DAAs visible after uploading a newer DAA to an existing DAC', () => {
+    const existingDaas = buildExistingDaas()
+    const latestUploadedDaa = createOwnedDaa(88, 'latest-daa.pdf', '2026-04-30T12:00:00.000Z')
+    const refreshedDaas = [...existingDaas, latestUploadedDaa]
+
+    cy.stub(Storage, 'getCurrentUser').returns(adminUser)
+    cy.stub(DAC, 'get').resolves(existingDac)
+    cy.stub(DAA, 'getDaas')
+      .onCall(0).resolves(existingDaas)
+      .onCall(1).resolves(refreshedDaas)
+      .onCall(2).resolves(refreshedDaas)
+    cy.stub(DAA, 'createDaa').resolves({ data: latestUploadedDaa })
+    stubCommonDacApis()
+    mountExistingEditDac(existingDac.dacId as number)
+
+    uploadDaaFile('latest-daa.pdf', 'latest daa')
+
+    cy.get('[data-cy="daa_tab_owned"]').should('have.attr', 'aria-selected', 'true')
+    cy.contains('custom-daa.pdf').should('be.visible')
+    cy.contains('latest-daa.pdf').should('be.visible')
+    cy.get('[data-cy="daa_option_88"]').should('be.checked')
+  })
+
+  it('Shows a refresh warning but keeps the uploaded DAA visible when reloading DAAs fails', () => {
+    const existingDaas = buildExistingDaas()
+    const uploadedDaa = createOwnedDaa(89, 'refresh-fallback.pdf', '2026-04-30T12:00:00.000Z')
+
+    cy.stub(Storage, 'getCurrentUser').returns(adminUser)
+    cy.stub(DAC, 'get').resolves(existingDac)
+    cy.stub(DAA, 'getDaas')
+      .onCall(0).resolves(existingDaas)
+      .onCall(1).rejects(new Error('refresh failed'))
+      .onCall(2).rejects(new Error('shared refresh failed'))
+    cy.stub(DAA, 'createDaa').resolves({ data: uploadedDaa })
+    const notificationStub = cy.stub(Notifications, 'showError')
+    stubCommonDacApis()
+    mountExistingEditDac(existingDac.dacId as number)
+
+    uploadDaaFile('refresh-fallback.pdf', 'fallback daa')
+
+    cy.get('[data-cy="daa_tab_owned"]').should('have.attr', 'aria-selected', 'true')
+    cy.contains('refresh-fallback.pdf').should('be.visible')
+    cy.get('[data-cy="daa_option_89"]').should('be.checked')
+    cy.wrap(notificationStub).should('have.been.calledWithMatch', {
+      text: 'Unable to refresh DAA list after upload. Showing latest uploaded agreements.',
+    })
   })
 
   it('Creates one DAA per uploaded file when creating a new DAC with multiple files', () => {
@@ -433,7 +563,8 @@ describe('EditDAC Tests', () => {
       const addDaaToDacStub = cy.stub(DAA, 'addDaaToDac').resolves(200)
 
       cy.get('[data-cy="daa_tab_owned"]').click()
-      cy.get('[data-cy="daa_option_2"]').should('be.visible').check()
+      cy.get('[data-cy="daa_option_2"]').should('be.visible')
+      cy.get('[data-cy="daa_option_2"]').check()
       cy.get('[data-cy="btn_save"]').click()
 
       cy.wrap(updateStub).should('have.been.called')
@@ -458,7 +589,8 @@ describe('EditDAC Tests', () => {
       const addDaaToDacStub = cy.stub(DAA, 'addDaaToDac').resolves(200)
 
       cy.get('[data-cy="daa_tab_shared"]').click()
-      cy.get('[data-cy="daa_option_5"]').should('be.visible').check()
+      cy.get('[data-cy="daa_option_5"]').should('be.visible')
+      cy.get('[data-cy="daa_option_5"]').check()
       cy.get('[data-cy="btn_save"]').click()
 
       cy.wrap(updateStub).should('have.been.called')
@@ -566,6 +698,10 @@ describe('EditDAC Tests', () => {
 })
 
 describe('EditDAC Tests - No DAAs Configured', () => {
+  beforeEach(() => {
+    cy.initApplicationConfig()
+  })
+
   it('should display tabs when no DAAs are configured', () => {
     cy.stub(Storage, 'getCurrentUser').returns(adminUser)
     cy.stub(DAC, 'get').resolves(existingDac)

--- a/cypress/component/pages/manage_dac/EditDac.spec.tsx
+++ b/cypress/component/pages/manage_dac/EditDac.spec.tsx
@@ -652,10 +652,6 @@ describe('EditDAC Tests', () => {
 })
 
 describe('EditDAC Tests - No DAAs Configured', () => {
-  beforeEach(() => {
-    cy.initApplicationConfig()
-  })
-
   it('should display tabs when no DAAs are configured', () => {
     cy.stub(Storage, 'getCurrentUser').returns(adminUser)
     cy.stub(DAC, 'get').resolves(existingDac)

--- a/src/components/modals/CreateDacUserModal.tsx
+++ b/src/components/modals/CreateDacUserModal.tsx
@@ -9,6 +9,7 @@ import { Alert } from 'src/components/Alert'
 import { Spinner } from 'src/components/Spinner'
 import { User } from 'src/libs/ajax/User'
 import type { DuosUser, UserRole } from 'src/types/model'
+import { extractError } from 'src/utils/ErrorUtils'
 
 const researcherRole = { roleId: 5, name: 'Researcher' as const } as UserRole
 
@@ -39,7 +40,7 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
   const [validation, setValidation] = useState<Validation>({})
   const [hasValidated, setHasValidated] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const [duplicateEmail, setDuplicateEmail] = useState(false)
+  const [serverError, setServerError] = useState<string | null>(null)
   const [domainError, setDomainError] = useState(false)
 
   const isEmailDomainAllowed = (emailValue: string): boolean => {
@@ -70,7 +71,7 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
     if (key === 'name') setName(value)
     if (key === 'email') {
       setEmail(value)
-      setDuplicateEmail(false)
+      setServerError(null)
       setDomainError(false)
     }
     if (hasValidated) {
@@ -80,7 +81,7 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
 
   const submitHandler = async (): Promise<void> => {
     setHasValidated(true)
-    setDuplicateEmail(false)
+    setServerError(null)
     setDomainError(false)
 
     const errors = calcErrors(name, email)
@@ -102,11 +103,14 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
       })
 
       if (!createdUser) {
-        setDuplicateEmail(true)
+        setServerError('User could not be created. Please try again.')
         return
       }
 
       onUserCreated(createdUser, targetRole)
+    }
+    catch (error) {
+      setServerError(extractError(error))
     }
     finally {
       setIsLoading(false)
@@ -127,7 +131,7 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
       onRequestClose={onCloseRequest}
       shouldCloseOnOverlayClick={true}
       style={{
-        content: { ...Styles.MODAL.CONTENT, maxHeight: '550px' },
+        content: { ...Styles.MODAL.CONTENT, maxHeight: '600px' },
         overlay: { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
       }}
     >
@@ -188,12 +192,12 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
             description={`Email must belong to one of your institution's domains: ${(allowedDomains ?? []).join(', ') || 'none configured'}`}
           />
         )}
-        {duplicateEmail && (
+        {serverError !== null && (
           <Alert
-            id="duplicateEmail"
+            id="serverError"
             type="danger"
-            title="Conflicts to resolve!"
-            description="There is a user already registered with this email account."
+            title="Error creating user"
+            description={serverError}
           />
         )}
       </div>

--- a/src/components/modals/CreateDacUserModal.tsx
+++ b/src/components/modals/CreateDacUserModal.tsx
@@ -1,0 +1,202 @@
+import React, { useState } from 'react'
+import { Styles, Theme } from 'src/libs/theme'
+import CloseIconComponent from 'src/components/CloseIconComponent'
+import ModalWrapper from 'src/components/collaborator_list/ModalWrapper'
+import SimpleButton from 'src/components/SimpleButton'
+import { FormField, FormValidators } from 'src/components/forms/forms'
+import { ValidationError } from 'src/pages/dar_application/FormValidationState'
+import { Alert } from 'src/components/Alert'
+import { Spinner } from 'src/components/Spinner'
+import { User } from 'src/libs/ajax/User'
+import type { DuosUser, UserRole } from 'src/types/model'
+
+const researcherRole = { roleId: 5, name: 'Researcher' as const } as UserRole
+
+interface Validation {
+  name?: ValidationError
+  email?: ValidationError
+}
+
+interface FieldChange {
+  key: string
+  value: string
+}
+
+interface CreateDacUserModalProps {
+  showModal: boolean
+  targetRole: 'chair' | 'member'
+  // null = Admin (no domain restriction); string[] = allowed domains for Chair
+  allowedDomains: string[] | null
+  onUserCreated: (user: DuosUser, role: 'chair' | 'member') => void
+  onCloseRequest: () => void
+}
+
+export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => {
+  const { showModal, targetRole, allowedDomains, onUserCreated, onCloseRequest } = props
+
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [validation, setValidation] = useState<Validation>({})
+  const [hasValidated, setHasValidated] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [duplicateEmail, setDuplicateEmail] = useState(false)
+  const [domainError, setDomainError] = useState(false)
+
+  const isEmailDomainAllowed = (emailValue: string): boolean => {
+    if (allowedDomains === null) return true
+    const domain = emailValue.split('@')[1]?.toLowerCase() ?? ''
+    return allowedDomains.some(d => d.toLowerCase() === domain)
+  }
+
+  const makeError = (id: string): ValidationError => ({ valid: false, failed: [id] })
+
+  const calcErrors = (n: string, e: string): Validation => {
+    const v: Validation = {}
+    if (!n.trim()) v.name = makeError('required')
+    if (!e.trim()) {
+      v.email = makeError('required')
+    }
+    else if (!FormValidators.EMAIL.isValid(e)) {
+      v.email = makeError('email')
+    }
+    return v
+  }
+
+  const hasErrors = (v: Validation): boolean => Object.values(v).some(err => !!err)
+
+  const handleChange = ({ key, value }: FieldChange): void => {
+    const updatedName = key === 'name' ? value : name
+    const updatedEmail = key === 'email' ? value : email
+    if (key === 'name') setName(value)
+    if (key === 'email') {
+      setEmail(value)
+      setDuplicateEmail(false)
+      setDomainError(false)
+    }
+    if (hasValidated) {
+      setValidation(calcErrors(updatedName, updatedEmail))
+    }
+  }
+
+  const submitHandler = async (): Promise<void> => {
+    setHasValidated(true)
+    setDuplicateEmail(false)
+    setDomainError(false)
+
+    const errors = calcErrors(name, email)
+    setValidation(errors)
+    if (hasErrors(errors)) return
+
+    if (!isEmailDomainAllowed(email)) {
+      setDomainError(true)
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const createdUser = await User.create({
+        displayName: name,
+        email,
+        emailPreference: true,
+        roles: [researcherRole],
+      })
+
+      if (!createdUser) {
+        setDuplicateEmail(true)
+        return
+      }
+
+      onUserCreated(createdUser, targetRole)
+    }
+    finally {
+      setIsLoading(false)
+    }
+  }
+
+  const isConfirmDisabled = (): boolean => {
+    if (isLoading) return true
+    if (!hasValidated) return !name.trim() || !email.trim()
+    return hasErrors(validation)
+  }
+
+  const roleLabel = targetRole === 'chair' ? 'Chairperson' : 'Member'
+
+  return (
+    <ModalWrapper
+      isOpen={showModal}
+      onRequestClose={onCloseRequest}
+      shouldCloseOnOverlayClick={true}
+      style={{
+        content: { ...Styles.MODAL.CONTENT, maxHeight: '550px' },
+        overlay: { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
+      }}
+    >
+      <div style={Styles.MODAL.CONTENT}>
+        <CloseIconComponent closeFn={onCloseRequest} />
+        <div style={Styles.MODAL.TITLE_HEADER}>
+          Create New User
+        </div>
+        <div style={{ borderBottom: '1px solid #E8ECEF', marginBottom: '1rem' }} />
+        <p style={{ marginBottom: '1rem' }}>
+          Create a new DUOS user and add them as a <strong>{roleLabel}</strong>.
+        </p>
+        <div>
+          <FormField
+            id="name"
+            title="Name"
+            defaultValue={name}
+            placeholder="User name"
+            validators={[FormValidators.REQUIRED]}
+            onChange={handleChange}
+            validation={validation.name}
+          />
+        </div>
+        <div>
+          <FormField
+            id="email"
+            title="Email Address"
+            defaultValue={email}
+            placeholder={allowedDomains?.[0] ? `e.g. username@${allowedDomains[0]}` : 'e.g. username@broadinstitute.org'}
+            validators={[FormValidators.REQUIRED, FormValidators.EMAIL]}
+            onChange={handleChange}
+            validation={validation.email}
+          />
+        </div>
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginTop: '2rem' }}>
+          {isLoading && <Spinner />}
+          <SimpleButton
+            onClick={() => { void submitHandler() }}
+            additionalStyle={{ margin: '0', width: '80px', height: '15px', padding: '20px' }}
+            baseColor={Theme.palette.secondary}
+            disabled={isConfirmDisabled()}
+            label="Create"
+          />
+          <SimpleButton
+            onClick={onCloseRequest}
+            additionalStyle={{ marginLeft: '1%', width: '80px', height: '15px', padding: '20px' }}
+            baseColor={Theme.palette.secondary}
+            label="Cancel"
+          />
+        </div>
+
+        {domainError && (
+          <Alert
+            id="domainError"
+            type="danger"
+            title="Invalid email domain"
+            description={`Email must belong to one of your institution's domains: ${(allowedDomains ?? []).join(', ') || 'none configured'}`}
+          />
+        )}
+        {duplicateEmail && (
+          <Alert
+            id="duplicateEmail"
+            type="danger"
+            title="Conflicts to resolve!"
+            description="There is a user already registered with this Google account."
+          />
+        )}
+      </div>
+    </ModalWrapper>
+  )
+}

--- a/src/components/modals/CreateDacUserModal.tsx
+++ b/src/components/modals/CreateDacUserModal.tsx
@@ -193,7 +193,7 @@ export const CreateDacUserModal: React.FC<CreateDacUserModalProps> = (props) => 
             id="duplicateEmail"
             type="danger"
             title="Conflicts to resolve!"
-            description="There is a user already registered with this Google account."
+            description="There is a user already registered with this email account."
           />
         )}
       </div>

--- a/src/pages/manage_dac/EditDac.tsx
+++ b/src/pages/manage_dac/EditDac.tsx
@@ -3,6 +3,7 @@ import AsyncSelect from 'react-select/async'
 import type { MultiValue } from 'react-select'
 import { DAC } from 'src/libs/ajax/DAC'
 import { DAA } from 'src/libs/ajax/DAA'
+import { Institution } from 'src/libs/ajax/Institution'
 import { Notifications, PromiseSerial } from 'src/libs/utils'
 import { Alert } from 'src/components/Alert'
 import { Link, useNavigate, useParams } from 'react-router-dom'
@@ -13,6 +14,7 @@ import { Spinner } from 'src/components/Spinner'
 import { Styles } from 'src/libs/theme'
 import PublishIcon from '@mui/icons-material/Publish'
 import { UploadDaaModal } from 'src/components/modals/UploadDaaModal'
+import { CreateDacUserModal } from 'src/components/modals/CreateDacUserModal'
 import { Storage } from 'src/libs/storage'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import type { DAAObject, DacObject, DuosUser, SimplifiedDuosUser } from 'src/types/model'
@@ -95,6 +97,9 @@ export default function EditDac(): React.JSX.Element {
   const [selectedUploadedFileName, setSelectedUploadedFileName] = useState<string | null>(null)
   const [daaFileData, setDaaFileData] = useState<File[] | null>(null)
   const [showUploadModal, setShowUploadModal] = useState<boolean>(false)
+  const [showCreateUserModal, setShowCreateUserModal] = useState<boolean>(false)
+  const [createUserTargetRole, setCreateUserTargetRole] = useState<'chair' | 'member'>('chair')
+  const [allowedDomains, setAllowedDomains] = useState<string[] | null>(null)
   const [fetchedDac, setFetchedDac] = useState<DacObject | null>(null)
   const [ownedDaas, setOwnedDaas] = useState<DAAObject[]>([])
   const [sharedDaas, setSharedDaas] = useState<DAAObject[]>([])
@@ -159,6 +164,28 @@ export default function EditDac(): React.JSX.Element {
 
     void fetchData()
   }, [dacId, dacIdParam])
+
+  useEffect(() => {
+    const loadAllowedDomains = async (): Promise<void> => {
+      if (user?.isAdmin) {
+        setAllowedDomains(null)
+        return
+      }
+      if (user?.institutionId) {
+        try {
+          const institution = await Institution.getById(user.institutionId)
+          setAllowedDomains(institution?.domains ?? [])
+        }
+        catch {
+          setAllowedDomains([])
+        }
+      }
+      else {
+        setAllowedDomains([])
+      }
+    }
+    void loadAllowedDomains()
+  }, [user?.isAdmin, user?.institutionId])
 
   const saveErrorMessage = 'There was an error saving DAC information. Please verify that the DAC is correct by viewing the current information.'
 
@@ -411,6 +438,36 @@ export default function EditDac(): React.JSX.Element {
       membersSelectedOptions: [...data],
       dirtyFlag: true,
     }))
+  }
+
+  const onUserCreated = (newUser: DuosUser, role: 'chair' | 'member'): void => {
+    const newOption: UserSelectOption = {
+      key: newUser.userId,
+      value: newUser.userId,
+      label: `${newUser.displayName} (${newUser.email})`,
+      item: {
+        userId: newUser.userId,
+        displayName: newUser.displayName,
+        email: newUser.email,
+      },
+    }
+    if (role === CHAIR) {
+      setState(prev => ({
+        ...prev,
+        chairIdsToAdd: [...prev.chairIdsToAdd, newUser.userId],
+        chairsSelectedOptions: [...prev.chairsSelectedOptions, newOption],
+        dirtyFlag: true,
+      }))
+    }
+    else {
+      setState(prev => ({
+        ...prev,
+        memberIdsToAdd: [...prev.memberIdsToAdd, newUser.userId],
+        membersSelectedOptions: [...prev.membersSelectedOptions, newOption],
+        dirtyFlag: true,
+      }))
+    }
+    setShowCreateUserModal(false)
   }
 
   const onSearchInputChanged = (): void => {
@@ -806,6 +863,18 @@ export default function EditDac(): React.JSX.Element {
                           placeholder="Select a DUOS User..."
                           className="select-autocomplete"
                         />
+                        <button
+                          className="btn btn-link"
+                          style={{ paddingLeft: 0, fontSize: '0.9em' }}
+                          data-cy="btn_create_chair"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            setCreateUserTargetRole('chair')
+                            setShowCreateUserModal(true)
+                          }}
+                        >
+                          + Create new user as Chairperson
+                        </button>
                       </div>
                     </div>
                     <div style={{ display: 'flex', marginBottom: '15px' }}>
@@ -838,6 +907,18 @@ export default function EditDac(): React.JSX.Element {
                           placeholder="Select a DUOS User..."
                           className="select-autocomplete"
                         />
+                        <button
+                          className="btn btn-link"
+                          style={{ paddingLeft: 0, fontSize: '0.9em' }}
+                          data-cy="btn_create_member"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            setCreateUserTargetRole('member')
+                            setShowCreateUserModal(true)
+                          }}
+                        >
+                          + Create new user as Member
+                        </button>
                       </div>
                     </div>
                     <div style={{ paddingBottom: '20px', float: 'right' }}>
@@ -953,6 +1034,15 @@ export default function EditDac(): React.JSX.Element {
                 </div>
               </div>
             </div>
+            {showCreateUserModal && (
+              <CreateDacUserModal
+                showModal={showCreateUserModal}
+                targetRole={createUserTargetRole}
+                allowedDomains={allowedDomains}
+                onUserCreated={onUserCreated}
+                onCloseRequest={() => setShowCreateUserModal(false)}
+              />
+            )}
             {showUploadModal && (
               <UploadDaaModal
                 showModal={showUploadModal}

--- a/test/components/modals/CreateDacUserModal.spec.tsx
+++ b/test/components/modals/CreateDacUserModal.spec.tsx
@@ -1,0 +1,250 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CreateDacUserModal } from 'src/components/modals/CreateDacUserModal'
+import { User } from 'src/libs/ajax/User'
+import type { DuosUser } from 'src/types/model'
+
+vi.mock('src/components/collaborator_list/ModalWrapper', () => ({
+  default: ({ children, isOpen }: { children: React.ReactNode, isOpen: boolean }) =>
+    isOpen ? <>{children}</> : null,
+}))
+
+vi.mock('src/libs/ajax/User', () => ({
+  User: {
+    create: vi.fn(),
+  },
+}))
+
+const mockCreatedUser: DuosUser = {
+  userId: 42,
+  displayName: 'New User',
+  email: 'newuser@broad.org',
+  emailPreference: true,
+  isAdmin: false,
+  isAlumni: false,
+  isChairPerson: false,
+  isDataSubmitter: false,
+  isMember: false,
+  isResearcher: true,
+  isSigningOfficial: false,
+  roles: [],
+  createDate: new Date(),
+}
+
+const defaultProps = {
+  showModal: true,
+  targetRole: 'chair' as const,
+  allowedDomains: ['broad.org'],
+  onUserCreated: vi.fn(),
+  onCloseRequest: vi.fn(),
+}
+
+describe('CreateDacUserModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Rendering ────────────────────────────────────────────────────────────
+
+  it('renders the modal title', () => {
+    render(<CreateDacUserModal {...defaultProps} />)
+    expect(screen.getByText('Create New User')).toBeTruthy()
+  })
+
+  it('does not render when showModal is false', () => {
+    render(<CreateDacUserModal {...defaultProps} showModal={false} />)
+    expect(screen.queryByText('Create New User')).toBeNull()
+  })
+
+  it('shows Chairperson in the description for chair role', () => {
+    render(<CreateDacUserModal {...defaultProps} targetRole="chair" />)
+    expect(screen.getByText(/Chairperson/)).toBeTruthy()
+  })
+
+  it('shows Member in the description for member role', () => {
+    render(<CreateDacUserModal {...defaultProps} targetRole="member" />)
+    expect(screen.getByText(/Member/)).toBeTruthy()
+  })
+
+  it('uses the first allowed domain in the email placeholder', () => {
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org', 'other.org']} />)
+    expect(screen.getByPlaceholderText('e.g. username@broad.org')).toBeTruthy()
+  })
+
+  it('falls back to generic placeholder when allowedDomains is null', () => {
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={null} />)
+    expect(screen.getByPlaceholderText('e.g. username@broadinstitute.org')).toBeTruthy()
+  })
+
+  it('falls back to generic placeholder when allowedDomains is empty', () => {
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={[]} />)
+    expect(screen.getByPlaceholderText('e.g. username@broadinstitute.org')).toBeTruthy()
+  })
+
+  // ── Close / cancel ───────────────────────────────────────────────────────
+
+  it('calls onCloseRequest when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const onCloseRequest = vi.fn()
+    render(<CreateDacUserModal {...defaultProps} onCloseRequest={onCloseRequest} />)
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCloseRequest).toHaveBeenCalledOnce()
+  })
+
+  it('calls onCloseRequest when the close icon is clicked', async () => {
+    const user = userEvent.setup()
+    const onCloseRequest = vi.fn()
+    render(<CreateDacUserModal {...defaultProps} onCloseRequest={onCloseRequest} />)
+
+    await user.click(document.querySelector('.modal-close-btn')!)
+    expect(onCloseRequest).toHaveBeenCalledOnce()
+  })
+
+  // ── Validation ───────────────────────────────────────────────────────────
+
+  it('shows email format error when email is malformed', async () => {
+    const user = userEvent.setup()
+    render(<CreateDacUserModal {...defaultProps} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'Test User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'notanemail')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    expect(screen.getByText('Please enter a valid email address (e.g., person@example.com)')).toBeTruthy()
+    expect(User.create).not.toHaveBeenCalled()
+  })
+
+  it('shows domain error when email domain does not match allowedDomains', async () => {
+    const user = userEvent.setup()
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'Test User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'user@other.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    expect(screen.getByText('Invalid email domain')).toBeTruthy()
+    expect(screen.getByText(/broad\.org/)).toBeTruthy()
+    expect(User.create).not.toHaveBeenCalled()
+  })
+
+  it('domain error message lists all allowed domains', async () => {
+    const user = userEvent.setup()
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org', 'mit.edu']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'Test User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'user@other.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    expect(screen.getByText(/broad\.org.*mit\.edu|mit\.edu.*broad\.org/)).toBeTruthy()
+  })
+
+  it('clears domain error when email field is changed', async () => {
+    const user = userEvent.setup()
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'Test User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'user@other.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+    expect(screen.getByText('Invalid email domain')).toBeTruthy()
+
+    await user.clear(screen.getByPlaceholderText('e.g. username@broad.org'))
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'n')
+    expect(screen.queryByText('Invalid email domain')).toBeNull()
+  })
+
+  // ── Domain bypass for admins ──────────────────────────────────────────────
+
+  it('bypasses domain check when allowedDomains is null (Admin)', async () => {
+    const user = userEvent.setup()
+    vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={null} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'Test User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broadinstitute.org'), 'test@anyDomain.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => expect(User.create).toHaveBeenCalledOnce())
+    expect(screen.queryByText('Invalid email domain')).toBeNull()
+  })
+
+  // ── Successful creation ───────────────────────────────────────────────────
+
+  it('calls User.create with the correct payload', async () => {
+    const user = userEvent.setup()
+    vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'New User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => {
+      expect(User.create).toHaveBeenCalledWith({
+        displayName: 'New User',
+        email: 'newuser@broad.org',
+        emailPreference: true,
+        roles: [{ roleId: 5, name: 'Researcher' }],
+      })
+    })
+  })
+
+  it('calls onUserCreated with the new user and chair role on success', async () => {
+    const user = userEvent.setup()
+    const onUserCreated = vi.fn()
+    vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
+    render(<CreateDacUserModal {...defaultProps} targetRole="chair" onUserCreated={onUserCreated} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'New User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => expect(onUserCreated).toHaveBeenCalledWith(mockCreatedUser, 'chair'))
+  })
+
+  it('calls onUserCreated with the new user and member role on success', async () => {
+    const user = userEvent.setup()
+    const onUserCreated = vi.fn()
+    vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
+    render(<CreateDacUserModal {...defaultProps} targetRole="member" onUserCreated={onUserCreated} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'New User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => expect(onUserCreated).toHaveBeenCalledWith(mockCreatedUser, 'member'))
+  })
+
+  // ── Server errors ─────────────────────────────────────────────────────────
+
+  it('shows a server error alert when User.create throws', async () => {
+    const user = userEvent.setup()
+    vi.mocked(User.create).mockRejectedValue(new Error('User exists with this email address: newuser@broad.org'))
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'New User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+
+    await waitFor(() => expect(screen.getByText('Error creating user')).toBeTruthy())
+    expect(screen.getByText('User exists with this email address: newuser@broad.org')).toBeTruthy()
+    expect(defaultProps.onUserCreated).not.toHaveBeenCalled()
+  })
+
+  it('clears the server error when email is changed after a failure', async () => {
+    const user = userEvent.setup()
+    vi.mocked(User.create).mockRejectedValue(new Error('User exists with this email address: newuser@broad.org'))
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+
+    await user.type(screen.getByPlaceholderText('User name'), 'New User')
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.click(screen.getByRole('button', { name: /create/i }))
+    await waitFor(() => expect(screen.getByText('Error creating user')).toBeTruthy())
+
+    await user.clear(screen.getByPlaceholderText('e.g. username@broad.org'))
+    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'o')
+    expect(screen.queryByText('Error creating user')).toBeNull()
+  })
+})

--- a/test/components/modals/CreateDacUserModal.spec.tsx
+++ b/test/components/modals/CreateDacUserModal.spec.tsx
@@ -97,9 +97,12 @@ describe('CreateDacUserModal', () => {
   it('calls onCloseRequest when the close icon is clicked', async () => {
     const user = userEvent.setup()
     const onCloseRequest = vi.fn()
-    render(<CreateDacUserModal {...defaultProps} onCloseRequest={onCloseRequest} />)
-
-    await user.click(document.querySelector('.modal-close-btn')!)
+    const { container } = render(
+      <CreateDacUserModal {...defaultProps} onCloseRequest={onCloseRequest} />,
+    )
+    const closeBtn = container.querySelector('.modal-close-btn')
+    if (!closeBtn) throw new Error('Expected .modal-close-btn to be present')
+    await user.click(closeBtn)
     expect(onCloseRequest).toHaveBeenCalledOnce()
   })
 

--- a/test/components/modals/CreateDacUserModal.spec.tsx
+++ b/test/components/modals/CreateDacUserModal.spec.tsx
@@ -20,7 +20,7 @@ vi.mock('src/libs/ajax/User', () => ({
 const mockCreatedUser: DuosUser = {
   userId: 42,
   displayName: 'New User',
-  email: 'newuser@broad.org',
+  email: 'newuser@example.org',
   emailPreference: true,
   isAdmin: false,
   isAlumni: false,
@@ -36,7 +36,7 @@ const mockCreatedUser: DuosUser = {
 const defaultProps = {
   showModal: true,
   targetRole: 'chair' as const,
-  allowedDomains: ['broad.org'],
+  allowedDomains: ['example.org'],
   onUserCreated: vi.fn(),
   onCloseRequest: vi.fn(),
 }
@@ -69,8 +69,8 @@ describe('CreateDacUserModal', () => {
   })
 
   it('uses the first allowed domain in the email placeholder', () => {
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org', 'other.org']} />)
-    expect(screen.getByPlaceholderText('e.g. username@broad.org')).toBeTruthy()
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org', 'other.org']} />)
+    expect(screen.getByPlaceholderText('e.g. username@example.org')).toBeTruthy()
   })
 
   it('falls back to generic placeholder when allowedDomains is null', () => {
@@ -110,7 +110,7 @@ describe('CreateDacUserModal', () => {
     render(<CreateDacUserModal {...defaultProps} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'Test User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'notanemail')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'notanemail')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     expect(screen.getByText('Please enter a valid email address (e.g., person@example.com)')).toBeTruthy()
@@ -119,39 +119,39 @@ describe('CreateDacUserModal', () => {
 
   it('shows domain error when email domain does not match allowedDomains', async () => {
     const user = userEvent.setup()
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'Test User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'user@other.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'user@other.example')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     expect(screen.getByText('Invalid email domain')).toBeTruthy()
-    expect(screen.getByText(/broad\.org/)).toBeTruthy()
+    expect(screen.getByText(/example\.org/)).toBeTruthy()
     expect(User.create).not.toHaveBeenCalled()
   })
 
   it('domain error message lists all allowed domains', async () => {
     const user = userEvent.setup()
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org', 'mit.edu']} />)
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org', 'example.edu']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'Test User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'user@other.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'user@other.example')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
-    expect(screen.getByText(/broad\.org.*mit\.edu|mit\.edu.*broad\.org/)).toBeTruthy()
+    expect(screen.getByText(/example\.org.*example\.edu|example\.edu.*example\.org/)).toBeTruthy()
   })
 
   it('clears domain error when email field is changed', async () => {
     const user = userEvent.setup()
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'Test User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'user@other.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'user@other.example')
     await user.click(screen.getByRole('button', { name: /create/i }))
     expect(screen.getByText('Invalid email domain')).toBeTruthy()
 
-    await user.clear(screen.getByPlaceholderText('e.g. username@broad.org'))
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'n')
+    await user.clear(screen.getByPlaceholderText('e.g. username@example.org'))
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'n')
     expect(screen.queryByText('Invalid email domain')).toBeNull()
   })
 
@@ -163,7 +163,7 @@ describe('CreateDacUserModal', () => {
     render(<CreateDacUserModal {...defaultProps} allowedDomains={null} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'Test User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broadinstitute.org'), 'test@anyDomain.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@broadinstitute.org'), 'test@anydomain.example')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     await waitFor(() => expect(User.create).toHaveBeenCalledOnce())
@@ -175,16 +175,16 @@ describe('CreateDacUserModal', () => {
   it('calls User.create with the correct payload', async () => {
     const user = userEvent.setup()
     vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'New User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'newuser@example.org')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     await waitFor(() => {
       expect(User.create).toHaveBeenCalledWith({
         displayName: 'New User',
-        email: 'newuser@broad.org',
+        email: 'newuser@example.org',
         emailPreference: true,
         roles: [{ roleId: 5, name: 'Researcher' }],
       })
@@ -195,10 +195,10 @@ describe('CreateDacUserModal', () => {
     const user = userEvent.setup()
     const onUserCreated = vi.fn()
     vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
-    render(<CreateDacUserModal {...defaultProps} targetRole="chair" onUserCreated={onUserCreated} allowedDomains={['broad.org']} />)
+    render(<CreateDacUserModal {...defaultProps} targetRole="chair" onUserCreated={onUserCreated} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'New User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'newuser@example.org')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     await waitFor(() => expect(onUserCreated).toHaveBeenCalledWith(mockCreatedUser, 'chair'))
@@ -208,10 +208,10 @@ describe('CreateDacUserModal', () => {
     const user = userEvent.setup()
     const onUserCreated = vi.fn()
     vi.mocked(User.create).mockResolvedValue(mockCreatedUser)
-    render(<CreateDacUserModal {...defaultProps} targetRole="member" onUserCreated={onUserCreated} allowedDomains={['broad.org']} />)
+    render(<CreateDacUserModal {...defaultProps} targetRole="member" onUserCreated={onUserCreated} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'New User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'newuser@example.org')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     await waitFor(() => expect(onUserCreated).toHaveBeenCalledWith(mockCreatedUser, 'member'))
@@ -221,30 +221,30 @@ describe('CreateDacUserModal', () => {
 
   it('shows a server error alert when User.create throws', async () => {
     const user = userEvent.setup()
-    vi.mocked(User.create).mockRejectedValue(new Error('User exists with this email address: newuser@broad.org'))
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+    vi.mocked(User.create).mockRejectedValue(new Error('User exists with this email address: newuser@example.org'))
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'New User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'newuser@example.org')
     await user.click(screen.getByRole('button', { name: /create/i }))
 
     await waitFor(() => expect(screen.getByText('Error creating user')).toBeTruthy())
-    expect(screen.getByText('User exists with this email address: newuser@broad.org')).toBeTruthy()
+    expect(screen.getByText('User exists with this email address: newuser@example.org')).toBeTruthy()
     expect(defaultProps.onUserCreated).not.toHaveBeenCalled()
   })
 
   it('clears the server error when email is changed after a failure', async () => {
     const user = userEvent.setup()
-    vi.mocked(User.create).mockRejectedValue(new Error('User exists with this email address: newuser@broad.org'))
-    render(<CreateDacUserModal {...defaultProps} allowedDomains={['broad.org']} />)
+    vi.mocked(User.create).mockRejectedValue(new Error('User exists with this email address: newuser@example.org'))
+    render(<CreateDacUserModal {...defaultProps} allowedDomains={['example.org']} />)
 
     await user.type(screen.getByPlaceholderText('User name'), 'New User')
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'newuser@broad.org')
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'newuser@example.org')
     await user.click(screen.getByRole('button', { name: /create/i }))
     await waitFor(() => expect(screen.getByText('Error creating user')).toBeTruthy())
 
-    await user.clear(screen.getByPlaceholderText('e.g. username@broad.org'))
-    await user.type(screen.getByPlaceholderText('e.g. username@broad.org'), 'o')
+    await user.clear(screen.getByPlaceholderText('e.g. username@example.org'))
+    await user.type(screen.getByPlaceholderText('e.g. username@example.org'), 'o')
     expect(screen.queryByText('Error creating user')).toBeNull()
   })
 })


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-2385

## Summary
Adds a new modal option for DAC Chairs and Admins on the Manage DAC screen. The modal allows for creating a new user that doesn't exist in the system. Once created, they can then be added as a Chairperson or a Member. Admins can add a user with any email domain. Chairpersons can only add users with an email domain that matches one of their institutional domains.

### Testing Notes
1. There is a new vite test for the new component
2. I added new tests for `EditDac.tsx` to the existing `EditDac.spec.tsx` rather than convert it to vite tests. I'm open to expanding this PR to tackle that. Claude reported some gaps in vite test handling the file upload aspects of the component that cypress seems to handle better and wasn't able to convert them all cleanly so it will take some additional investigation to port that pattern over to vite.

### Adding a new user
<img width="1542" height="967" alt="Screenshot 2026-05-29 at 7 59 03 PM" src="https://github.com/user-attachments/assets/32736ddb-5696-4a87-b469-9de21c518b63" />

<img width="1542" height="967" alt="Screenshot 2026-05-29 at 7 59 12 PM" src="https://github.com/user-attachments/assets/a2a810a6-fc3e-4708-a6f0-52d9d6d6a41b" />

<img width="1542" height="967" alt="Screenshot 2026-05-29 at 7 59 59 PM" src="https://github.com/user-attachments/assets/2b448b84-64fb-467c-bfba-0df5ef9819bb" />

### Error cases
<img width="1542" height="967" alt="Screenshot 2026-05-29 at 7 59 43 PM" src="https://github.com/user-attachments/assets/49d975fc-c717-4abe-889a-7eb336bc9476" />

<img width="1542" height="967" alt="Screenshot 2026-05-29 at 8 00 26 PM" src="https://github.com/user-attachments/assets/0f54a275-9d37-4e1d-985c-38984ad9c2aa" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
