### PR TITLE
[DT-3263] Adds Request Location to S4R, DatasetStatistics, and Library.

### DIFF
--- a/cypress/component/Dataset/DatasetStatistics.spec.jsx
+++ b/cypress/component/Dataset/DatasetStatistics.spec.jsx
@@ -139,6 +139,25 @@ describe('Dataset Statistics Tests', () => {
     cy.contains(datasetTerm.study.piName).should('exist')
   })
 
+  it('Displays the Request Location field as a link when present', () => {
+    const requestLocationUrl = 'https://request.example.org/apply'
+    const withRequestLocation = { ...datasetTerm, requestLocation: requestLocationUrl }
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([withRequestLocation]))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
+    cy.contains('Request Location').should('exist')
+    cy.get(`a[href="${requestLocationUrl}"]`).should('exist')
+  })
+
+  it('Does not display the Request Location field when absent', () => {
+    const withoutRequestLocation = { ...datasetTerm }
+    delete withoutRequestLocation.requestLocation
+    cy.stub(DataSet, 'searchDatasetIndex').returns(Promise.resolve([withoutRequestLocation]))
+    cy.stub(DatasetMetrics, 'getDatasetStats').returns(Promise.resolve([]))
+    mountDatasetStatistics(datasetTerm.datasetIdentifier)
+    cy.contains('Request Location').should('not.exist')
+  })
+
   it('Displays DAR section with data', () => {
     const darsData = [{
       darCode: 'DAR-123',

--- a/cypress/component/StudyAssets/consent_group_list.spec.tsx
+++ b/cypress/component/StudyAssets/consent_group_list.spec.tsx
@@ -233,3 +233,61 @@ describe('ConsentGroupRow', () => {
     testViewActionTrigger<React.ComponentProps<typeof ConsentGroupRow>>(mountRow)
   })
 })
+
+describe('ConsentGroupAddEdit requestLocation', () => {
+  it('renders the Request Location field', () => {
+    mountAddEdit()
+    cy.get('#requestLocation').should('exist')
+  })
+
+  it('pre-fills Request Location when editing an existing consent group', () => {
+    const existingGroup: ConsentGroup2 = {
+      ...sampleConsentGroup,
+      requestLocation: 'https://request.example.org/apply',
+    }
+    mountAddEdit({ consentGroup: existingGroup, consentGroups: [existingGroup], id: 0 })
+    cy.get('#requestLocation').should('have.value', 'https://request.example.org/apply')
+  })
+
+  it('saves a new consent group with a requestLocation value', () => {
+    const collected: ConsentGroup2[] = []
+    cy.mount(
+      <ConsentGroupList
+        consentGroups={[]}
+        columnsToShow={['consentGroupName']}
+        onConsentGroupChange={(items) => { collected.splice(0, collected.length, ...items) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-consent-group-btn').click()
+    fillConsentGroupForm()
+    cy.get('#requestLocation').type('https://request.example.org/apply')
+    clickSaveButton()
+
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].requestLocation).to.eq('https://request.example.org/apply')
+    })
+  })
+
+  it('saves a consent group without requestLocation when field is left empty', () => {
+    const collected: ConsentGroup2[] = []
+    cy.mount(
+      <ConsentGroupList
+        consentGroups={[]}
+        columnsToShow={['consentGroupName']}
+        onConsentGroupChange={(items) => { collected.splice(0, collected.length, ...items) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-consent-group-btn').click()
+    fillConsentGroupForm()
+    // Leave requestLocation blank
+    clickSaveButton()
+
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].requestLocation).to.eq(undefined)
+    })
+  })
+})

--- a/cypress/component/data_library/LibraryDataGrid.spec.tsx
+++ b/cypress/component/data_library/LibraryDataGrid.spec.tsx
@@ -300,6 +300,7 @@ describe('LibraryDataGrid', () => {
     })
 
     it('renders an Export link for a dataset with matching exportable snapshots', () => {
+      cy.viewport(1600, 800)
       mountGrid(
         <LibraryDataGrid
           assetType={AssetType.DATASETS}

--- a/cypress/component/data_library/columns/datasetColumns.spec.tsx
+++ b/cypress/component/data_library/columns/datasetColumns.spec.tsx
@@ -20,6 +20,7 @@ describe('datasetColumns — column order', () => {
       'participantCount',
       'dataUse',
       'dac',
+      'requestLocation',
       'actions',
     ])
   })

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -658,6 +658,17 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               onChange={onChange}
             />
           </div>
+          <FormField
+            id="requestLocation"
+            name="requestLocation"
+            title="Request Location"
+            description="URL of an external location where data access requests should be submitted (e.g. a DAC website or data access request form)"
+            placeholder="https://..."
+            validators={[FormValidators.URL]}
+            defaultValue={consentGroup?.requestLocation}
+            onChange={onChange}
+            disabled={readOnly}
+          />
 
           <FormTable
             id="fileTypes"

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -6,6 +6,7 @@ import { DatasetTerm, getAccessManagementSummary } from 'src/types/model'
 import { AccessManagement, ExportableDatasets } from 'src/types/library'
 import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
 import BoltIcon from '@mui/icons-material/Bolt'
+import { validateHttpUrl } from 'src/utils/UrlUtils'
 
 /**
  * Column definitions for dataset view
@@ -130,7 +131,7 @@ export const makeDatasetColumns = (
     renderCell: params =>
       params.value
         ? (
-            <Link href={params.value} target="_blank" rel="noopener noreferrer" underline="hover">
+            <Link href={validateHttpUrl(params.value) ? params.value : undefined} target="_blank" rel="noopener noreferrer" underline="hover">
               {params.value}
             </Link>
           )

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -123,6 +123,20 @@ export const makeDatasetColumns = (
     valueGetter: (_value, row) => row.dac?.dacName || '',
   },
   {
+    field: 'requestLocation',
+    headerName: 'Request Location',
+    width: 180,
+    sortable: false,
+    renderCell: params =>
+      params.value
+        ? (
+            <Link href={params.value} target="_blank" rel="noopener noreferrer" underline="hover">
+              {params.value}
+            </Link>
+          )
+        : null,
+  },
+  {
     field: 'actions',
     headerName: 'Actions',
     width: 120,

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -244,7 +244,7 @@ export default function DatasetStatistics() {
             </LabeledField>
             {datasetTerm.requestLocation && (
               <LabeledField label="Request Location">
-                <a href={datasetTerm.requestLocation} target="_blank" rel="noopener noreferrer">
+                <a href={validateHttpUrl(datasetTerm.requestLocation) ? datasetTerm.requestLocation : undefined} target="_blank" rel="noopener noreferrer">
                   {datasetTerm.requestLocation}
                 </a>
               </LabeledField>

--- a/src/pages/DatasetStatistics.tsx
+++ b/src/pages/DatasetStatistics.tsx
@@ -242,6 +242,13 @@ export default function DatasetStatistics() {
                 <DatasetExportButton snapshots={exportableSnapshots} />
               </div>
             </LabeledField>
+            {datasetTerm.requestLocation && (
+              <LabeledField label="Request Location">
+                <a href={datasetTerm.requestLocation} target="_blank" rel="noopener noreferrer">
+                  {datasetTerm.requestLocation}
+                </a>
+              </LabeledField>
+            )}
             <LabeledField label="Phenotype">
               {datasetTerm.study?.phenotype ?? 'N/A'}
             </LabeledField>

--- a/src/pages/data_submission/consent_group/consentGroupUtils.ts
+++ b/src/pages/data_submission/consent_group/consentGroupUtils.ts
@@ -38,6 +38,7 @@ export interface ConsentGroup2 {
   otherSecondary?: string
   dataLocation?: DataLocationType
   url?: string
+  requestLocation?: string
   fileTypes?: Array<FileType>
 };
 

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -39,6 +39,7 @@ import {
   DataLocation,
   DataLocationType,
   DataURL,
+  RequestLocation,
   FileTypes,
   NumberOfParticipants, StudyData,
   DatasetData,
@@ -287,6 +288,7 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
     consentGroup.nihInstitutionalCertificationFile = dataset.nihInstitutionalCertificationFile
     consentGroup.dataLocation = getDatasetPropertyValueByKey(DataLocation.propertyName, dataset) as DataLocationType
     consentGroup.url = getDatasetPropertyValueByKey(DataURL.propertyName, dataset) as string
+    consentGroup.requestLocation = getDatasetPropertyValueByKey(RequestLocation.propertyName, dataset) as string
     consentGroup.fileTypes = fileTypeAdjustment(getDatasetPropertyValueByKey(FileTypes.propertyName, dataset) as Array<FileType>)
     consentGroup.numberOfParticipants = getDatasetPropertyValueByKey(NumberOfParticipants.propertyName, dataset) as number || 0
     consentGroup.data = getDatasetPropertyValueByKey(DatasetData.propertyName, dataset) as Record<string, unknown> || {}

--- a/src/pages/data_submission/v2/v2-models.tsx
+++ b/src/pages/data_submission/v2/v2-models.tsx
@@ -604,6 +604,14 @@ export class DataURL extends StringDatasetProperty {
   }
 }
 
+export class RequestLocation extends StringDatasetProperty {
+  static readonly schemaProperty = 'requestLocation'
+  static readonly propertyName = 'Request Location'
+  constructor(value?: string, datasetId?: number, propertyId?: number) {
+    super('Request Location', '', RequestLocation.propertyName, RequestLocation.schemaProperty, value, datasetId, propertyId)
+  }
+}
+
 export class FileTypes extends DatasetProperty {
   static readonly schemaProperty = 'fileTypes'
   static readonly propertyName = 'File Types'

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -251,6 +251,7 @@ export interface DatasetTerm {
   dataUse: DataUseSummary
   dataLocation: string
   url: string
+  requestLocation?: string
   dacId: number
   dacApproval: boolean
   accessManagement: string


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3263](https://broadworkbench.atlassian.net/browse/DT-3263)

### Summary

Adds a new field called 'Request Location' to S4R (ConsentGroupAddEdit), Dataset Display (DatasetStatistics), and the Data Library's dataset tab.  The intent is to allow data custodians to provide a location where users should visit to understand more about requirements for the dataset.

After:

S4R (ConsentGroupAddEdit)
<img width="1581" height="483" alt="image" src="https://github.com/user-attachments/assets/1177a97f-d21c-4b17-83f4-c705735dfb5b" />


Dataset Display:
<img width="501" height="473" alt="image" src="https://github.com/user-attachments/assets/d3cf0472-3040-44ea-b59a-1b9c6a1459cc" />


Library:

<img width="1815" height="336" alt="image" src="https://github.com/user-attachments/assets/444f3df9-3784-4ecb-a154-cc7cebdb6c91" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
