### PR TITLE
[DT-2176] Add optional Cloud field to Study Registration assets

### DIFF
--- a/cypress/component/StudyAssets/ai_model_list.spec.tsx
+++ b/cypress/component/StudyAssets/ai_model_list.spec.tsx
@@ -60,11 +60,11 @@ describe('AiModelList component', () => {
       expect(onChangeSpy.length).to.eq(1)
       expect(onChangeSpy[0].name).to.eq('My Model')
       expect(onChangeSpy[0].maintainer.email).to.eq('bob@example.com')
-      expect(onChangeSpy[0].cloud).to.eq('')
+      expect(onChangeSpy[0].cloud).to.deep.eq([])
     })
   })
 
-  it('saves a selected cloud value', () => {
+  it('saves selected cloud values', () => {
     const onChangeSpy: AiModel[] = []
     cy.mount(
       <AiModelAddEdit
@@ -78,7 +78,7 @@ describe('AiModelList component', () => {
     cy.contains('label', 'Cloud').should('exist')
     cy.get('#name').type('Cloud Model')
     cy.get('#url').type('https://cloud-model.com')
-    cy.get('#cloud').type('AWS{enter}')
+    cy.get('#cloud').type('AWS{enter}Azure{enter}')
     cy.get('#format').type('ONNX')
     cy.get('#license').type('Apache-2.0')
     cy.get('#maintainerName').type('Bob')
@@ -86,7 +86,7 @@ describe('AiModelList component', () => {
     cy.get('.collaborator-form-add-save-button').click()
     cy.wrap(null).then(() => {
       expect(onChangeSpy.length).to.eq(1)
-      expect(onChangeSpy[0].cloud).to.eq('AWS')
+      expect(onChangeSpy[0].cloud).to.deep.eq(['AWS', 'Azure'])
     })
   })
 

--- a/cypress/component/StudyAssets/ai_model_list.spec.tsx
+++ b/cypress/component/StudyAssets/ai_model_list.spec.tsx
@@ -60,6 +60,33 @@ describe('AiModelList component', () => {
       expect(onChangeSpy.length).to.eq(1)
       expect(onChangeSpy[0].name).to.eq('My Model')
       expect(onChangeSpy[0].maintainer.email).to.eq('bob@example.com')
+      expect(onChangeSpy[0].cloud).to.eq('')
+    })
+  })
+
+  it('saves a selected cloud value', () => {
+    const onChangeSpy: AiModel[] = []
+    cy.mount(
+      <AiModelAddEdit
+        id={-1}
+        aiModel={undefined}
+        aiModels={[]}
+        closeAction={cy.stub().as('close')}
+        onAiModelsChange={(models) => { onChangeSpy.push(...models) }}
+      />,
+    )
+    cy.contains('label', 'Cloud').should('exist')
+    cy.get('#name').type('Cloud Model')
+    cy.get('#url').type('https://cloud-model.com')
+    cy.get('#cloud').type('AWS{enter}')
+    cy.get('#format').type('ONNX')
+    cy.get('#license').type('Apache-2.0')
+    cy.get('#maintainerName').type('Bob')
+    cy.get('#maintainerEmail').type('bob@example.com')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.wrap(null).then(() => {
+      expect(onChangeSpy.length).to.eq(1)
+      expect(onChangeSpy[0].cloud).to.eq('AWS')
     })
   })
 

--- a/cypress/component/StudyAssets/consent_group_list.spec.tsx
+++ b/cypress/component/StudyAssets/consent_group_list.spec.tsx
@@ -169,6 +169,29 @@ describe('ConsentGroupList component', () => {
     cy.wrap(null).then(() => {
       expect(collected.length).to.eq(1)
       expect(collected[0].consentGroupName).to.eq('New Consent Group')
+      expect(collected[0].data?.cloud).to.eq(undefined)
+    })
+  })
+
+  it('saves a selected cloud value', () => {
+    const collected: ConsentGroup2[] = []
+    cy.mount(
+      <ConsentGroupList
+        consentGroups={[]}
+        columnsToShow={['consentGroupName']}
+        onConsentGroupChange={(items) => { collected.splice(0, collected.length, ...items) }}
+        disabled={false}
+      />,
+    )
+    cy.get('#add-consent-group-btn').click()
+    cy.contains('label', 'Cloud').should('exist')
+    fillConsentGroupForm()
+    cy.get('#cloud').type('Azure{enter}')
+    clickSaveButton()
+
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].data?.cloud).to.eq('Azure')
     })
   })
 

--- a/cypress/component/StudyAssets/consent_group_list.spec.tsx
+++ b/cypress/component/StudyAssets/consent_group_list.spec.tsx
@@ -173,7 +173,7 @@ describe('ConsentGroupList component', () => {
     })
   })
 
-  it('saves a selected cloud value', () => {
+  it('saves selected cloud values', () => {
     const collected: ConsentGroup2[] = []
     cy.mount(
       <ConsentGroupList
@@ -186,12 +186,12 @@ describe('ConsentGroupList component', () => {
     cy.get('#add-consent-group-btn').click()
     cy.contains('label', 'Cloud').should('exist')
     fillConsentGroupForm()
-    cy.get('#cloud').type('Azure{enter}')
+    cy.get('#cloud').type('Azure{enter}AWS{enter}')
     clickSaveButton()
 
     cy.wrap(null).then(() => {
       expect(collected.length).to.eq(1)
-      expect(collected[0].data?.cloud).to.eq('Azure')
+      expect(collected[0].data?.cloud).to.deep.eq(['Azure', 'AWS'])
     })
   })
 

--- a/cypress/component/StudyAssets/workspace_list.spec.tsx
+++ b/cypress/component/StudyAssets/workspace_list.spec.tsx
@@ -58,11 +58,11 @@ describe('WorkspaceList component', () => {
       expect(collected.length).to.eq(1)
       expect(collected[0].name).to.eq('New Workspace')
       expect(collected[0].platform).to.eq('New Platform')
-      expect(collected[0].cloud).to.eq('')
+      expect(collected[0].cloud).to.deep.eq([])
     })
   })
 
-  it('saves a selected cloud value', () => {
+  it('saves selected cloud values', () => {
     const collected: Workspace[] = []
     cy.mount(
       <WorkspaceAddEdit
@@ -77,13 +77,13 @@ describe('WorkspaceList component', () => {
     cy.get('#name').type('Cloud Workspace')
     cy.get('#platform').type('Terra')
     cy.get('#url').type('https://workspace.example.com')
-    cy.get('#cloud').type('Oracle{enter}')
+    cy.get('#cloud').type('Oracle{enter}AWS{enter}')
     cy.get('#description').type('Cloud workspace description')
     cy.get('#access').type('open')
     cy.get('.collaborator-form-add-save-button').click()
     cy.wrap(null).then(() => {
       expect(collected.length).to.eq(1)
-      expect(collected[0].cloud).to.eq('Oracle')
+      expect(collected[0].cloud).to.deep.eq(['Oracle', 'AWS'])
     })
   })
 

--- a/cypress/component/StudyAssets/workspace_list.spec.tsx
+++ b/cypress/component/StudyAssets/workspace_list.spec.tsx
@@ -58,6 +58,32 @@ describe('WorkspaceList component', () => {
       expect(collected.length).to.eq(1)
       expect(collected[0].name).to.eq('New Workspace')
       expect(collected[0].platform).to.eq('New Platform')
+      expect(collected[0].cloud).to.eq('')
+    })
+  })
+
+  it('saves a selected cloud value', () => {
+    const collected: Workspace[] = []
+    cy.mount(
+      <WorkspaceAddEdit
+        id={-1}
+        workspace={undefined}
+        workspaces={[]}
+        closeAction={cy.stub().as('close')}
+        onWorkspaceChange={(items) => { collected.splice(0, collected.length, ...items) }}
+      />,
+    )
+    cy.contains('label', 'Cloud').should('exist')
+    cy.get('#name').type('Cloud Workspace')
+    cy.get('#platform').type('Terra')
+    cy.get('#url').type('https://workspace.example.com')
+    cy.get('#cloud').type('Oracle{enter}')
+    cy.get('#description').type('Cloud workspace description')
+    cy.get('#access').type('open')
+    cy.get('.collaborator-form-add-save-button').click()
+    cy.wrap(null).then(() => {
+      expect(collected.length).to.eq(1)
+      expect(collected[0].cloud).to.eq('Oracle')
     })
   })
 

--- a/src/components/ai_models_list/AiModelAddEdit.tsx
+++ b/src/components/ai_models_list/AiModelAddEdit.tsx
@@ -15,7 +15,7 @@ const defaultAiModel: AiModel = {
   name: '',
   description: '',
   url: '',
-  cloud: '',
+  cloud: [],
   format: '',
   license: '',
   trainedOnDatasets: [],
@@ -25,7 +25,7 @@ const defaultAiModel: AiModel = {
 
 interface FormFieldChange {
   key: string
-  value: string
+  value: string | string[]
 }
 
 interface AiModelAddEditProps {
@@ -80,15 +80,16 @@ export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.El
 
   const onChange = ({ key, value }: FormFieldChange) => {
     let updated: AiModel = { ...newAiModel }
+    const valueAsString = Array.isArray(value) ? value.join(',') : value
 
     if (key === 'trainedOnDatasets') {
-      updated.trainedOnDatasets = value.split(',').map((s: string) => s.trim()).filter(Boolean)
+      updated.trainedOnDatasets = valueAsString.split(',').map((s: string) => s.trim()).filter(Boolean)
     }
     else if (key === 'maintainerName') {
-      updated.maintainer = { ...updated.maintainer, name: value }
+      updated.maintainer = { ...updated.maintainer, name: valueAsString }
     }
     else if (key === 'maintainerEmail') {
-      updated.maintainer = { ...updated.maintainer, email: value }
+      updated.maintainer = { ...updated.maintainer, email: valueAsString }
     }
     else {
       // generic assignment
@@ -157,6 +158,7 @@ export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.El
             placeholder="Select or enter cloud environment"
             type={FormFieldTypes.SELECT}
             isCreatable={true}
+            isMulti={true}
             optionsAreString={true}
             selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
             defaultValue={aiModel?.cloud}

--- a/src/components/ai_models_list/AiModelAddEdit.tsx
+++ b/src/components/ai_models_list/AiModelAddEdit.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { CloudProviders } from 'src/components/forms/CloudProviders'
 import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
 import { AiModel, Maintainer } from 'src/types/model'
@@ -14,6 +15,7 @@ const defaultAiModel: AiModel = {
   name: '',
   description: '',
   url: '',
+  cloud: '',
   format: '',
   license: '',
   trainedOnDatasets: [],
@@ -147,6 +149,18 @@ export default function AiModelAddEdit(props: AiModelAddEditProps): React.JSX.El
             validators={[FormValidators.REQUIRED, FormValidators.URL]}
             onChange={onChange}
             validation={validation.url}
+            disabled={readOnly}
+          />
+          <FormField
+            id="cloud"
+            title="Cloud"
+            placeholder="Select or enter cloud environment"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            optionsAreString={true}
+            selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
+            defaultValue={aiModel?.cloud}
+            onChange={onChange}
             disabled={readOnly}
           />
           <FormField

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -1,6 +1,7 @@
 import { isNil, isEmpty, set, unset } from 'src/utils/NodashUtil'
 import React, { useState, useEffect } from 'react'
 import { FormField, FormFieldTitle, FormFieldTypes, FormTable, FormValidators } from 'src/components/forms/forms'
+import { CloudProviders } from 'src/components/forms/CloudProviders'
 import { findOntologyTerms, searchOntologyTerm } from 'src/libs/utils'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
 import { AccessManagementType, ConsentGroup, ConsentGroup2, selectedPrimaryGroup } from 'src/pages/data_submission/consent_group/consentGroupUtils'
@@ -185,7 +186,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
     setValidation(calcErrors(next))
   }
 
-  const onTagsChange = ({ key, value }: { key: string, value: unknown }) => {
+  const onDatasetDataChange = ({ key, value }: { key: string, value: unknown }) => {
     const next = structuredClone(current)
     next.data ??= {}
     set(next.data, key, value)
@@ -236,7 +237,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             isCreatable={true}
             isMulti={true}
             optionsAreString={true}
-            onChange={onTagsChange}
+            onChange={onDatasetDataChange}
             disabled={readOnly}
             defaultValue={current?.data?.tags || []}
             selectOptions={(current?.data?.tags as string[]) || []}
@@ -246,6 +247,19 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                 Menu: () => null,
               },
             }}
+          />
+          <FormField
+            id="cloud"
+            name="cloud"
+            title="Cloud"
+            placeholder="Select or enter cloud environment"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            optionsAreString={true}
+            selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
+            defaultValue={current?.data?.cloud as string | undefined}
+            onChange={onDatasetDataChange}
+            disabled={readOnly}
           />
 
           {/* controlled, open and external access */}

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -248,20 +248,6 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               },
             }}
           />
-          <FormField
-            id="cloud"
-            name="cloud"
-            title="Cloud"
-            placeholder="Select or enter cloud environment"
-            type={FormFieldTypes.SELECT}
-            isCreatable={true}
-            isMulti={true}
-            optionsAreString={true}
-            selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
-            defaultValue={current?.data?.cloud as string[] | undefined}
-            onChange={onDatasetDataChange}
-            disabled={readOnly}
-          />
 
           {/* controlled, open and external access */}
           <div>
@@ -673,6 +659,22 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
               onChange={onChange}
             />
           </div>
+
+          <FormField
+            id="cloud"
+            name="cloud"
+            title="Cloud"
+            placeholder="Select or enter cloud environment"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            isMulti={true}
+            optionsAreString={true}
+            selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
+            defaultValue={current?.data?.cloud as string[] | undefined}
+            onChange={onDatasetDataChange}
+            disabled={readOnly}
+          />
+
           <FormField
             id="requestLocation"
             name="requestLocation"

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -255,9 +255,10 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
             placeholder="Select or enter cloud environment"
             type={FormFieldTypes.SELECT}
             isCreatable={true}
+            isMulti={true}
             optionsAreString={true}
             selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
-            defaultValue={current?.data?.cloud as string | undefined}
+            defaultValue={current?.data?.cloud as string[] | undefined}
             onChange={onDatasetDataChange}
             disabled={readOnly}
           />

--- a/src/components/forms/CloudProviders.ts
+++ b/src/components/forms/CloudProviders.ts
@@ -4,9 +4,11 @@ export class CloudProviders {
   static GCP: SelectOptionWithKeyNameAndAbbreviation = { key: 'GCP', name: 'GCP' }
   static AWS: SelectOptionWithKeyNameAndAbbreviation = { key: 'AWS', name: 'AWS' }
   static AZURE: SelectOptionWithKeyNameAndAbbreviation = { key: 'Azure', name: 'Azure' }
+  static ORACLE: SelectOptionWithKeyNameAndAbbreviation = { key: 'Oracle', name: 'Oracle' }
   static VALUES: SelectOptionWithKeyNameAndAbbreviation[] = [
     CloudProviders.GCP,
     CloudProviders.AWS,
     CloudProviders.AZURE,
+    CloudProviders.ORACLE,
   ]
 }

--- a/src/components/forms/CloudProviders.ts
+++ b/src/components/forms/CloudProviders.ts
@@ -1,11 +1,11 @@
 import { SelectOptionWithKeyNameAndAbbreviation } from './SelectOptionInterface'
 
 export class CloudProviders {
-  static GCP: SelectOptionWithKeyNameAndAbbreviation = { key: 'GCP', name: 'GCP' }
-  static AWS: SelectOptionWithKeyNameAndAbbreviation = { key: 'AWS', name: 'AWS' }
-  static AZURE: SelectOptionWithKeyNameAndAbbreviation = { key: 'Azure', name: 'Azure' }
-  static ORACLE: SelectOptionWithKeyNameAndAbbreviation = { key: 'Oracle', name: 'Oracle' }
-  static VALUES: SelectOptionWithKeyNameAndAbbreviation[] = [
+  static readonly GCP: SelectOptionWithKeyNameAndAbbreviation = { key: 'GCP', name: 'GCP' }
+  static readonly AWS: SelectOptionWithKeyNameAndAbbreviation = { key: 'AWS', name: 'AWS' }
+  static readonly AZURE: SelectOptionWithKeyNameAndAbbreviation = { key: 'Azure', name: 'Azure' }
+  static readonly ORACLE: SelectOptionWithKeyNameAndAbbreviation = { key: 'Oracle', name: 'Oracle' }
+  static readonly VALUES: SelectOptionWithKeyNameAndAbbreviation[] = [
     CloudProviders.GCP,
     CloudProviders.AWS,
     CloudProviders.AZURE,

--- a/src/components/workspaces_list/WorkspaceAddEdit.tsx
+++ b/src/components/workspaces_list/WorkspaceAddEdit.tsx
@@ -26,7 +26,7 @@ const defaultWorkspace: Workspace = {
   name: '',
   platform: '',
   url: '',
-  cloud: '',
+  cloud: [],
   description: '',
   tools: [],
   access: '',
@@ -139,6 +139,7 @@ export default function WorkspaceAddEdit(props: WorkspaceAddEditProps): React.JS
             placeholder="Select or enter cloud environment"
             type={FormFieldTypes.SELECT}
             isCreatable={true}
+            isMulti={true}
             optionsAreString={true}
             selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
             defaultValue={workspace?.cloud}

--- a/src/components/workspaces_list/WorkspaceAddEdit.tsx
+++ b/src/components/workspaces_list/WorkspaceAddEdit.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { CloudProviders } from 'src/components/forms/CloudProviders'
 import { FormField, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { Workspace } from 'src/types/model'
 import { ValidationError } from 'src/pages/dar_application/FormValidationState'
@@ -25,6 +26,7 @@ const defaultWorkspace: Workspace = {
   name: '',
   platform: '',
   url: '',
+  cloud: '',
   description: '',
   tools: [],
   access: '',
@@ -129,6 +131,18 @@ export default function WorkspaceAddEdit(props: WorkspaceAddEditProps): React.JS
             validators={[FormValidators.REQUIRED, FormValidators.URL]}
             onChange={onChange}
             validation={validation.url}
+            disabled={readOnly}
+          />
+          <FormField
+            id="cloud"
+            title="Cloud"
+            placeholder="Select or enter cloud environment"
+            type={FormFieldTypes.SELECT}
+            isCreatable={true}
+            optionsAreString={true}
+            selectOptions={CloudProviders.VALUES.map(provider => provider.name)}
+            defaultValue={workspace?.cloud}
+            onChange={onChange}
             disabled={readOnly}
           />
           <FormField

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -379,6 +379,7 @@ export interface AiModel {
   name: string
   description: string
   url: string
+  cloud?: string
   format: string
   license: string
   trainedOnDatasets: string[]
@@ -392,6 +393,7 @@ export interface Workspace {
   name: string
   platform: string
   url: string
+  cloud?: string
   description: string
   tools?: string[]
   access?: string

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -379,7 +379,7 @@ export interface AiModel {
   name: string
   description: string
   url: string
-  cloud?: string
+  cloud?: string[]
   format: string
   license: string
   trainedOnDatasets: string[]
@@ -393,7 +393,7 @@ export interface Workspace {
   name: string
   platform: string
   url: string
-  cloud?: string
+  cloud?: string[]
   description: string
   tools?: string[]
   access?: string


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2176

### Summary

This PR adds an optional Cloud field for `Dataset`, `AI Model`, and `Featured Workspace` assets in the Study Registration workflow. The field uses existing creatable select behavior with predefined cloud options and persists submitted values with the asset record.

<img width="1568" height="949" alt="After" src="https://github.com/user-attachments/assets/c2c01bed-180a-48d9-bf30-6b4bf630b4f7" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
