### PR TITLE
[DT-3408][DT-3391][DT-3389][DT-3393][DT-3390][DT-3394][DT-3395][DT-3396][DT-3404] Migrate over asset tests

### DIFF
--- a/test/components/data_library/assets/biospecimenAsset.spec.ts
+++ b/test/components/data_library/assets/biospecimenAsset.spec.ts
@@ -1,0 +1,380 @@
+/**
+ * Unit tests for biospecimenAsset — the Biospecimens AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { biospecimenAsset } from 'src/components/data_library/assets/biospecimenAsset'
+import { BiospecimenAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  BiospecimenStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+import { BioSpecimenType, BioSpecimenPreservationMethod, Sex } from 'src/types/model'
+import { EMPTY_FILTERS } from 'src/components/data_library/filterRegistry'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  biospecimens: Array<{
+    biospecimenId?: string
+    donorId?: string
+    specimenType?: BioSpecimenType
+    preservationMethod?: BioSpecimenPreservationMethod
+    dateOfCollection?: string
+    sex?: Sex
+    age?: number
+    race?: string
+    organization?: string
+  }> = [],
+  studyName = 'Test Study',
+): BiospecimenStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: biospecimens.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                biospecimens: biospecimens.map(b => ({
+                  biospecimenId: b.biospecimenId,
+                  donorId: b.donorId,
+                  specimenType: b.specimenType,
+                  preservationMethod: b.preservationMethod,
+                  dateOfCollection: b.dateOfCollection,
+                  sex: b.sex,
+                  age: b.age,
+                  race: b.race,
+                  organization: b.organization,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: BiospecimenStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('biospecimenAsset — label', () => {
+  it('has singular "Biospecimen" and plural "Biospecimens"', () => {
+    expect(biospecimenAsset.label.singular).toBe('Biospecimen')
+    expect(biospecimenAsset.label.plural).toBe('Biospecimens')
+  })
+})
+
+describe('biospecimenAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(biospecimenAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('biospecimenAsset — searchFields', () => {
+  it('includes biospecimen-specific fields', () => {
+    expect(biospecimenAsset.searchFields).toContain('study.assets.biospecimens.biospecimenId')
+    expect(biospecimenAsset.searchFields).toContain('study.assets.biospecimens.donorId')
+    expect(biospecimenAsset.searchFields).toContain('study.assets.biospecimens.specimenType')
+  })
+
+  it('excludes dateOfCollection from searchFields (date field)', () => {
+    expect(biospecimenAsset.searchFields).not.toContain(
+      'study.assets.biospecimens.dateOfCollection',
+    )
+  })
+
+  it('includes study-level fields', () => {
+    expect(biospecimenAsset.searchFields).toContain('study.studyName')
+    expect(biospecimenAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('biospecimenAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study.assets.biospecimens' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = biospecimenAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = biospecimenAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = biospecimenAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe(
+      'study.assets.biospecimens',
+    )
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = biospecimenAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'controlled' },
+    }
+    const q = biospecimenAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'biospecimenId', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = biospecimenAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('biospecimenAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = biospecimenAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens biospecimens from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        { biospecimenId: 'BS-001', donorId: 'D-001' },
+        { biospecimenId: 'BS-002', donorId: 'D-002' },
+      ]),
+      makeBucket(2, [{ biospecimenId: 'BS-003', donorId: 'D-003' }]),
+    ])
+    const result = biospecimenAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to BiospecimenAsset', () => {
+    const response = makeResponse([
+      makeBucket(
+        42,
+        [
+          {
+            biospecimenId: 'BS-12345',
+            donorId: 'DONOR-ABC',
+            specimenType: BioSpecimenType.BLOOD,
+            preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+            dateOfCollection: '2023-01-15',
+            sex: Sex.FEMALE,
+            age: 45,
+            race: 'African American',
+            organization: 'Test Biobank',
+          },
+        ],
+        'NHGRI Study',
+      ),
+    ])
+    const result = biospecimenAsset.transformResponse(response, pagination)
+    const row = result.items[0] as BiospecimenAsset
+    expect(row.biospecimenId).toBe('BS-12345')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.donorId).toBe('DONOR-ABC')
+    expect(row.specimenType).toBe(BioSpecimenType.BLOOD)
+    expect(row.preservationMethod).toBe(BioSpecimenPreservationMethod.FRESH_FROZEN)
+    expect(row.dateOfCollection).toBe('2023-01-15')
+    expect(row.sex).toBe(Sex.FEMALE)
+    expect(row.age).toBe(45)
+    expect(row.race).toBe('African American')
+    expect(row.organization).toBe('Test Biobank')
+  })
+
+  it('falls back to composite key when biospecimenId is absent', () => {
+    const response = makeResponse([makeBucket(99, [{ donorId: 'D-001' }])])
+    const result = biospecimenAsset.transformResponse(response, pagination)
+    const row = result.items[0] as BiospecimenAsset
+    expect(row.biospecimenId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const biospecimens = Array.from({ length: 30 }, (_, i) => ({
+      biospecimenId: `BS-${String(i).padStart(3, '0')}`,
+      donorId: `DONOR-${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, biospecimens)])
+
+    const page0 = biospecimenAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as BiospecimenAsset).biospecimenId).toBe('BS-000')
+
+    const page1 = biospecimenAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as BiospecimenAsset).biospecimenId).toBe('BS-010')
+
+    const page2 = biospecimenAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as BiospecimenAsset).biospecimenId).toBe('BS-020')
+  })
+
+  it('reports total as the number of all biospecimens across all studies (not just page)', () => {
+    const biospecimens = Array.from({ length: 30 }, (_, i) => ({
+      biospecimenId: `BS-${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, biospecimens)])
+    const result = biospecimenAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('returns empty/default values for missing fields', () => {
+    const response = makeResponse([makeBucket(1, [{}])])
+    const row = biospecimenAsset.transformResponse(response, pagination).items[0] as BiospecimenAsset
+    expect(row.biospecimenId).toBe('1-0')
+    expect(row.donorId).toBe('')
+    expect(row.organization).toBe('')
+    expect(row.dateOfCollection).toBe('')
+    expect(row.age).toBe(0)
+  })
+
+  it('handles a study bucket with no biospecimens gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = biospecimenAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('returns only matching biospecimens when filtered within a shared study', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        {
+          biospecimenId: 'BS-HOURS',
+          specimenType: BioSpecimenType.BLOOD,
+          dateOfCollection: '2024-01-01',
+          organization: 'Org',
+        },
+        {
+          biospecimenId: 'BS-DAYS',
+          specimenType: BioSpecimenType.TISSUE,
+          dateOfCollection: '2024-02-01',
+          organization: 'Org',
+        },
+      ]),
+    ])
+
+    const result = biospecimenAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      biospecimenType: [BioSpecimenType.BLOOD],
+    })
+
+    expect(result.items).toHaveLength(1)
+    expect((result.items[0] as BiospecimenAsset).biospecimenId).toBe('BS-HOURS')
+  })
+})
+
+describe('biospecimenAsset — getRowId', () => {
+  it('returns the biospecimenId of the row', () => {
+    const row: BiospecimenAsset = {
+      biospecimenId: 'BS-xyz-789',
+      studyId: 1,
+      studyName: '',
+      donorId: 'D-001',
+      specimenType: BioSpecimenType.BLOOD,
+      preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+      organization: 'Biobank',
+    }
+    expect(biospecimenAsset.getRowId(row)).toBe('BS-xyz-789')
+  })
+})
+
+describe('biospecimenAsset — isRowSelectable', () => {
+  it('always returns false — biospecimens do not participate in access requests', () => {
+    const row: BiospecimenAsset = {
+      biospecimenId: 'BS-001',
+      studyId: 1,
+      studyName: 'Test',
+      donorId: 'D-001',
+      specimenType: BioSpecimenType.BLOOD,
+      preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+      organization: 'Biobank',
+    }
+    expect(biospecimenAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('biospecimenAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: BiospecimenAsset = {
+      biospecimenId: 'BS-001',
+      studyId: 1,
+      studyName: 'Test',
+      donorId: 'D-001',
+      specimenType: BioSpecimenType.BLOOD,
+      preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+      organization: 'Biobank',
+    }
+    const result = biospecimenAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('biospecimenAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = biospecimenAsset.selectionToDatasetIds([], ['BS-001', 'BS-002'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('biospecimenAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: BiospecimenAsset = {
+      biospecimenId: 'BS-001',
+      studyId: 42,
+      studyName: 'Test',
+      donorId: 'D-001',
+      specimenType: BioSpecimenType.BLOOD,
+      preservationMethod: BioSpecimenPreservationMethod.FRESH_FROZEN,
+      organization: 'Biobank',
+    }
+    const result = biospecimenAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('biospecimenAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = biospecimenAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = biospecimenAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('biospecimenId')
+    expect(fields).toContain('specimenType')
+    expect(fields).toContain('donorId')
+    expect(fields).toContain('dateOfCollection')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = biospecimenAsset.makeColumns()
+    const b = biospecimenAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/assets/clinicalTrialAsset.spec.ts
+++ b/test/components/data_library/assets/clinicalTrialAsset.spec.ts
@@ -1,0 +1,438 @@
+/**
+ * Unit tests for clinicalTrialAsset — the Clinical Trials AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { clinicalTrialAsset } from 'src/components/data_library/assets/clinicalTrialAsset'
+import { ClinicalTrialAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ClinicalTrialStudyAggregationBucket,
+  ElasticsearchResponse,
+  QueryClause,
+} from 'src/types/elastic'
+import { ClinicalTrialInterventionType, ClinicalTrialPhase, ClinicalTrialStatus } from 'src/types/model'
+import { EMPTY_FILTERS } from 'src/components/data_library/filterRegistry'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  trials: Array<{
+    clinicalTrialId?: string
+    title?: string
+    registry?: string
+    identifier?: string
+    status?: ClinicalTrialStatus
+    sponsor?: string
+    startDate?: string
+    endDate?: string
+    interventionType?: ClinicalTrialInterventionType
+    description?: string
+    phase?: ClinicalTrialPhase
+    url?: string
+    tags?: string[]
+  }> = [],
+  studyName = 'Test Study',
+): ClinicalTrialStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: trials.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                clinicalTrials: trials.map(t => ({
+                  clinicalTrialId: t.clinicalTrialId,
+                  title: t.title,
+                  registry: t.registry,
+                  identifier: t.identifier,
+                  status: t.status,
+                  sponsor: t.sponsor,
+                  startDate: t.startDate,
+                  endDate: t.endDate,
+                  interventionType: t.interventionType,
+                  description: t.description,
+                  phase: t.phase,
+                  url: t.url,
+                  tags: t.tags,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: ClinicalTrialStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('clinicalTrialAsset — label', () => {
+  it('has singular "Clinical Trial" and plural "Clinical Trials"', () => {
+    expect(clinicalTrialAsset.label.singular).toBe('Clinical Trial')
+    expect(clinicalTrialAsset.label.plural).toBe('Clinical Trials')
+  })
+})
+
+describe('clinicalTrialAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(clinicalTrialAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('clinicalTrialAsset — searchFields', () => {
+  it('includes trial-specific fields', () => {
+    expect(clinicalTrialAsset.searchFields).toContain('study.assets.clinicalTrials.title')
+    expect(clinicalTrialAsset.searchFields).toContain('study.assets.clinicalTrials.sponsor')
+    expect(clinicalTrialAsset.searchFields).toContain('study.assets.clinicalTrials.identifier')
+    expect(clinicalTrialAsset.searchFields).toContain('study.assets.clinicalTrials.registry')
+    expect(clinicalTrialAsset.searchFields).toContain('study.assets.clinicalTrials.tags')
+  })
+
+  it('includes study-level fields', () => {
+    expect(clinicalTrialAsset.searchFields).toContain('study.studyName')
+    expect(clinicalTrialAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('clinicalTrialAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = clinicalTrialAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = clinicalTrialAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = clinicalTrialAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = clinicalTrialAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'controlled' },
+    }
+    const q = clinicalTrialAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = clinicalTrialAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('clinicalTrialAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = clinicalTrialAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens trials from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        { clinicalTrialId: 'ct1', title: 'Trial Alpha' },
+        { clinicalTrialId: 'ct2', title: 'Trial Beta' },
+      ]),
+      makeBucket(2, [{ clinicalTrialId: 'ct3', title: 'Trial Gamma' }]),
+    ])
+    const result = clinicalTrialAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to ClinicalTrialAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        clinicalTrialId: 'NCT00000042',
+        title: 'Phase II Immunotherapy Study',
+        registry: 'ClinicalTrials.gov',
+        identifier: 'NCT00000042',
+        status: ClinicalTrialStatus.RECRUITING,
+        sponsor: 'NHGRI',
+        startDate: '2024-01-01',
+        endDate: '2026-12-31',
+        interventionType: ClinicalTrialInterventionType.BIOLOGICAL,
+        description: 'A phase II study',
+        phase: ClinicalTrialPhase.PHASE2,
+        url: 'https://clinicaltrials.gov/study/NCT00000042',
+        tags: ['immunotherapy', 'cancer'],
+      }], 'NHGRI Study'),
+    ])
+    const result = clinicalTrialAsset.transformResponse(response, pagination)
+    const row = result.items[0] as ClinicalTrialAsset
+    expect(row.clinicalTrialId).toBe('NCT00000042')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.title).toBe('Phase II Immunotherapy Study')
+    expect(row.registry).toBe('ClinicalTrials.gov')
+    expect(row.identifier).toBe('NCT00000042')
+    expect(row.status).toBe(ClinicalTrialStatus.RECRUITING)
+    expect(row.sponsor).toBe('NHGRI')
+    expect(row.startDate).toBe('2024-01-01')
+    expect(row.endDate).toBe('2026-12-31')
+    expect(row.interventionType).toBe(ClinicalTrialInterventionType.BIOLOGICAL)
+    expect(row.phase).toBe(ClinicalTrialPhase.PHASE2)
+    expect(row.url).toBe('https://clinicaltrials.gov/study/NCT00000042')
+    expect(row.tags).toEqual(['immunotherapy', 'cancer'])
+  })
+
+  it('falls back to composite key when clinicalTrialId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ title: 'No ID Trial' }]),
+    ])
+    const result = clinicalTrialAsset.transformResponse(response, pagination)
+    const row = result.items[0] as ClinicalTrialAsset
+    expect(row.clinicalTrialId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const trials = Array.from({ length: 30 }, (_, i) => ({
+      clinicalTrialId: `ct${i}`,
+      title: `Trial ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, trials)])
+
+    const page0 = clinicalTrialAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as ClinicalTrialAsset).title).toBe('Trial 0')
+
+    const page1 = clinicalTrialAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as ClinicalTrialAsset).title).toBe('Trial 10')
+
+    const page2 = clinicalTrialAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as ClinicalTrialAsset).title).toBe('Trial 20')
+  })
+
+  it('reports total as the number of all trials across all studies (not just page)', () => {
+    const trials = Array.from({ length: 30 }, (_, i) => ({ clinicalTrialId: `ct${i}` }))
+    const response = makeResponse([makeBucket(1, trials)])
+    const result = clinicalTrialAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('returns empty defaults for missing fields', () => {
+    const response = makeResponse([makeBucket(1, [{}])])
+    const row = clinicalTrialAsset.transformResponse(response, pagination).items[0] as ClinicalTrialAsset
+    expect(row.tags).toEqual([])
+    expect(row.title).toBe('')
+    expect(row.sponsor).toBe('')
+    expect(row.status).toBe('')
+    expect(row.phase).toBe('')
+    expect(row.interventionType).toBe('')
+    expect(row.identifier).toBe('')
+    expect(row.registry).toBe('')
+  })
+
+  it('handles a study bucket with no clinical trials gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = clinicalTrialAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('returns only matching clinical trials when filtered within a shared study', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        {
+          clinicalTrialId: 'CT-RECRUITING',
+          status: ClinicalTrialStatus.RECRUITING,
+          phase: ClinicalTrialPhase.PHASE1,
+        },
+        {
+          clinicalTrialId: 'CT-COMPLETED',
+          status: ClinicalTrialStatus.COMPLETED,
+          phase: ClinicalTrialPhase.PHASE2,
+        },
+      ]),
+    ])
+
+    const result = clinicalTrialAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      clinicalTrialStatus: [ClinicalTrialStatus.RECRUITING],
+    })
+
+    expect(result.items).toHaveLength(1)
+    expect((result.items[0] as ClinicalTrialAsset).clinicalTrialId).toBe('CT-RECRUITING')
+  })
+
+  it('applies row-level date filtering to nested clinical trial rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        {
+          clinicalTrialId: 'CT-INSIDE',
+          startDate: '2024-02-01',
+          endDate: '2024-06-01',
+        },
+        {
+          clinicalTrialId: 'CT-OUTSIDE',
+          startDate: '2023-01-01',
+          endDate: '2024-12-31',
+        },
+      ]),
+    ])
+
+    const result = clinicalTrialAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      clinicalTrialDates: {
+        startDate: '2024-01-01',
+        endDate: '2024-07-01',
+      },
+    })
+
+    expect(result.items).toHaveLength(1)
+    expect((result.items[0] as ClinicalTrialAsset).clinicalTrialId).toBe('CT-INSIDE')
+  })
+})
+
+describe('clinicalTrialAsset — getRowId', () => {
+  it('returns the clinicalTrialId of the row', () => {
+    const row: ClinicalTrialAsset = {
+      clinicalTrialId: 'NCT-abc-123',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      registry: '',
+      identifier: '',
+      status: '' as ClinicalTrialStatus,
+      sponsor: '',
+      startDate: '',
+      interventionType: '' as ClinicalTrialInterventionType,
+      description: '',
+      phase: '' as ClinicalTrialPhase,
+      url: '',
+    }
+    expect(clinicalTrialAsset.getRowId(row)).toBe('NCT-abc-123')
+  })
+})
+
+describe('clinicalTrialAsset — isRowSelectable', () => {
+  it('always returns false — clinical trials do not participate in access requests', () => {
+    const row: ClinicalTrialAsset = {
+      clinicalTrialId: 'ct1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      registry: '',
+      identifier: '',
+      status: '' as ClinicalTrialStatus,
+      sponsor: '',
+      startDate: '',
+      interventionType: '' as ClinicalTrialInterventionType,
+      description: '',
+      phase: '' as ClinicalTrialPhase,
+      url: '',
+    }
+    expect(clinicalTrialAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('clinicalTrialAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: ClinicalTrialAsset = {
+      clinicalTrialId: 'ct1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      registry: '',
+      identifier: '',
+      status: '' as ClinicalTrialStatus,
+      sponsor: '',
+      startDate: '',
+      interventionType: '' as ClinicalTrialInterventionType,
+      description: '',
+      phase: '' as ClinicalTrialPhase,
+      url: '',
+    }
+    const result = clinicalTrialAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('clinicalTrialAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = clinicalTrialAsset.selectionToDatasetIds([], ['ct1', 'ct2'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('clinicalTrialAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: ClinicalTrialAsset = {
+      clinicalTrialId: 'ct1',
+      studyId: 42,
+      studyName: '',
+      title: '',
+      registry: '',
+      identifier: '',
+      status: '' as ClinicalTrialStatus,
+      sponsor: '',
+      startDate: '',
+      interventionType: '' as ClinicalTrialInterventionType,
+      description: '',
+      phase: '' as ClinicalTrialPhase,
+      url: '',
+    }
+    const result = clinicalTrialAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('clinicalTrialAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = clinicalTrialAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = clinicalTrialAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('title')
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('status')
+    expect(fields).toContain('phase')
+    expect(fields).toContain('sponsor')
+    expect(fields).toContain('identifier')
+    expect(fields).toContain('interventionType')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = clinicalTrialAsset.makeColumns()
+    const b = clinicalTrialAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/assets/fundingResourceAsset.spec.ts
+++ b/test/components/data_library/assets/fundingResourceAsset.spec.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect } from 'vitest'
+import { FundingResourceAsset as FundingResourceRow, PaginationState, SortState } from 'src/types/library'
+import { ElasticsearchResponse, QueryClause } from 'src/types/elastic'
+import { fundingResourceAsset } from 'src/components/data_library/assets/fundingResourceAsset'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: string,
+  funding: Array<{
+    fundingId?: string
+    funderName?: string
+    funderProgram?: string
+    grantNumber?: string
+    projectTitle?: string
+    startDate?: string
+    endDate?: string
+    url?: string
+    tags?: string[]
+  }> = [],
+  studyName = 'Test Study',
+) => ({
+  key: studyId,
+  doc_count: funding.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                funding: funding.map(f => ({
+                  fundingId: f.fundingId,
+                  funderName: f.funderName,
+                  funderProgram: f.funderProgram,
+                  grantNumber: f.grantNumber,
+                  projectTitle: f.projectTitle,
+                  startDate: f.startDate,
+                  endDate: f.endDate,
+                  url: f.url,
+                  tags: f.tags,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (buckets: ReturnType<typeof makeBucket>[]): ElasticsearchResponse =>
+  ({
+    items: [],
+    total: 0,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    aggregations: { studies: { buckets } as any },
+  }) as ElasticsearchResponse
+
+describe('fundingResourceAsset — label', () => {
+  it('has singular "FundingResource" and plural "FundingResources"', () => {
+    expect(fundingResourceAsset.label.singular).toBe('FundingResource')
+    expect(fundingResourceAsset.label.plural).toBe('FundingResources')
+  })
+})
+
+describe('fundingResourceAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(fundingResourceAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('fundingResourceAsset — searchFields', () => {
+  it('includes funding-specific fields', () => {
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.fundingId')
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.funderName')
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.funderProgram')
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.grantNumber')
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.projectTitle')
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.url')
+    expect(fundingResourceAsset.searchFields).toContain('study.assets.funding.tags')
+  })
+
+  it('includes study-level fields', () => {
+    expect(fundingResourceAsset.searchFields).toContain('study.studyName')
+    expect(fundingResourceAsset.searchFields).toContain('study.description')
+    expect(fundingResourceAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('fundingResourceAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study.assets.funding' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = fundingResourceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = fundingResourceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as { terms: { field: string, size: number } }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = fundingResourceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe(
+      'study.assets.funding',
+    )
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = fundingResourceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = { term: { 'accessManagement.keyword': 'controlled' } }
+    const q = fundingResourceAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'fundingId', order: 'asc' }
+    const largePagination: PaginationState = { page: 5, pageSize: 100 }
+    const q = fundingResourceAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('fundingResourceAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = fundingResourceAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens funding resources from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket('1', [
+        { fundingId: 'FR-001', funderName: 'NIH' },
+        { fundingId: 'FR-002', funderName: 'NSF' },
+      ]),
+      makeBucket('2', [{ fundingId: 'FR-003', funderName: 'DoD' }]),
+    ])
+    const result = fundingResourceAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to FundingResourceAsset', () => {
+    const response = makeResponse([
+      makeBucket(
+        '42',
+        [
+          {
+            fundingId: 'FR-12345',
+            funderName: 'NIH',
+            funderProgram: 'R01',
+            grantNumber: 'R01-ABC',
+            projectTitle: 'Project Atlas',
+            startDate: '2023-01-15',
+            endDate: '2024-01-14',
+            url: 'https://example.org/grant',
+            tags: ['genomics', 'rare-disease'],
+          },
+        ],
+        'NHGRI Study',
+      ),
+    ])
+    const result = fundingResourceAsset.transformResponse(response, pagination)
+    const row = result.items[0] as FundingResourceRow
+    expect(row.fundingId).toBe('FR-12345')
+    expect(row.studyId).toBe('42')
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.funderName).toBe('NIH')
+    expect(row.funderProgram).toBe('R01')
+    expect(row.grantNumber).toBe('R01-ABC')
+    expect(row.projectTitle).toBe('Project Atlas')
+    expect(row.startDate).toBe('2023-01-15')
+    expect(row.endDate).toBe('2024-01-14')
+    expect(row.url).toBe('https://example.org/grant')
+    expect(row.tags).toEqual(['genomics', 'rare-disease'])
+  })
+
+  it('falls back to composite key when fundingId is absent', () => {
+    const response = makeResponse([makeBucket('99', [{ funderName: 'NSF' }])])
+    const result = fundingResourceAsset.transformResponse(response, pagination)
+    const row = result.items[0] as FundingResourceRow
+    expect(row.fundingId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const funding = Array.from({ length: 30 }, (_, i) => ({
+      fundingId: `FR-${String(i).padStart(3, '0')}`,
+      funderName: `Funder-${i}`,
+    }))
+    const response = makeResponse([makeBucket('1', funding)])
+
+    const page0 = fundingResourceAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as FundingResourceRow).fundingId).toBe('FR-000')
+
+    const page1 = fundingResourceAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as FundingResourceRow).fundingId).toBe('FR-010')
+
+    const page2 = fundingResourceAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as FundingResourceRow).fundingId).toBe('FR-020')
+  })
+
+  it('reports total as all funding resources across all studies', () => {
+    const funding = Array.from({ length: 30 }, (_, i) => ({ fundingId: `FR-${i}` }))
+    const response = makeResponse([makeBucket('1', funding)])
+    const result = fundingResourceAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('returns empty/default values for missing fields', () => {
+    const response = makeResponse([makeBucket('1', [{}])])
+    const row = fundingResourceAsset.transformResponse(response, pagination).items[0] as FundingResourceRow
+    expect(row.fundingId).toBe('1-0')
+    expect(row.studyName).toBe('Test Study')
+    expect(row.funderName).toBe('')
+    expect(row.funderProgram).toBe('')
+    expect(row.grantNumber).toBe('')
+    expect(row.projectTitle).toBe('')
+    expect(row.startDate).toBe('')
+    expect(row.endDate).toBe('')
+    expect(row.url).toBe('')
+    expect(row.tags).toEqual([])
+  })
+
+  it('handles a study bucket with no funding resources gracefully', () => {
+    const response = makeResponse([makeBucket('1', [])])
+    const result = fundingResourceAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+})
+
+describe('fundingResourceAsset — getRowId', () => {
+  it('returns the fundingId of the row', () => {
+    const row: FundingResourceRow = {
+      fundingId: 'FR-xyz-789',
+      studyId: 1,
+      studyName: '',
+      funderName: '',
+      funderProgram: '',
+      grantNumber: '',
+      projectTitle: '',
+      startDate: '',
+      endDate: '',
+      url: '',
+      tags: [],
+    }
+    expect(fundingResourceAsset.getRowId(row)).toBe('FR-xyz-789')
+  })
+})
+
+describe('fundingResourceAsset — isRowSelectable', () => {
+  it('always returns false — funding resources do not participate in access requests', () => {
+    const row: FundingResourceRow = {
+      fundingId: 'FR-001',
+      studyId: 1,
+      studyName: 'Test',
+      funderName: 'NIH',
+      funderProgram: 'R01',
+      grantNumber: 'R01-XYZ',
+      projectTitle: 'Project',
+      startDate: '',
+      endDate: '',
+      url: '',
+      tags: [],
+    }
+    expect(fundingResourceAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('fundingResourceAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: FundingResourceRow = {
+      fundingId: 'FR-001',
+      studyId: 1,
+      studyName: 'Test',
+      funderName: '',
+      funderProgram: '',
+      grantNumber: '',
+      projectTitle: '',
+      startDate: '',
+      endDate: '',
+      url: '',
+      tags: [],
+    }
+    const result = fundingResourceAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('fundingResourceAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = fundingResourceAsset.selectionToDatasetIds([], ['FR-001', 'FR-002'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('fundingResourceAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: FundingResourceRow = {
+      fundingId: 'FR-001',
+      studyId: 42,
+      studyName: 'Test',
+      funderName: '',
+      funderProgram: '',
+      grantNumber: '',
+      projectTitle: '',
+      startDate: '',
+      endDate: '',
+      url: '',
+      tags: [],
+    }
+    const result = fundingResourceAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('fundingResourceAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = fundingResourceAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = fundingResourceAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('fundingId')
+    expect(fields).toContain('funderName')
+    expect(fields).toContain('projectTitle')
+    expect(fields).toContain('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = fundingResourceAsset.makeColumns()
+    const b = fundingResourceAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/assets/intellectualPropertyAsset.spec.ts
+++ b/test/components/data_library/assets/intellectualPropertyAsset.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * Unit tests for intellectualPropertyAsset — the Intellectual Property AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { intellectualPropertyAsset } from 'src/components/data_library/assets/intellectualPropertyAsset'
+import { IntellectualPropertyAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  IntellectualPropertyStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  ips: Array<{
+    ipId?: string
+    type?: string
+    title?: string
+    assignee?: string
+    patentNumber?: string
+    filingDate?: string
+    status?: string
+    url?: string
+    contact?: string
+    tags?: string[]
+  }> = [],
+  studyName = 'Test Study',
+): IntellectualPropertyStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: ips.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                intellectualProperties: ips.map(ip => ({
+                  ipId: ip.ipId,
+                  type: ip.type,
+                  title: ip.title,
+                  assignee: ip.assignee,
+                  patentNumber: ip.patentNumber,
+                  filingDate: ip.filingDate,
+                  status: ip.status,
+                  url: ip.url,
+                  contact: ip.contact,
+                  tags: ip.tags,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: IntellectualPropertyStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('intellectualPropertyAsset — label', () => {
+  it('has singular "Intellectual Property" and plural "Intellectual Properties"', () => {
+    expect(intellectualPropertyAsset.label.singular).toBe('Intellectual Property')
+    expect(intellectualPropertyAsset.label.plural).toBe('Intellectual Properties')
+  })
+})
+
+describe('intellectualPropertyAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(intellectualPropertyAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('intellectualPropertyAsset — searchFields', () => {
+  it('includes IP-specific fields', () => {
+    expect(intellectualPropertyAsset.searchFields).toContain('study.assets.intellectualProperties.title')
+    expect(intellectualPropertyAsset.searchFields).toContain('study.assets.intellectualProperties.type')
+    expect(intellectualPropertyAsset.searchFields).toContain('study.assets.intellectualProperties.assignee')
+    expect(intellectualPropertyAsset.searchFields).toContain('study.assets.intellectualProperties.patentNumber')
+    expect(intellectualPropertyAsset.searchFields).toContain('study.assets.intellectualProperties.status')
+  })
+
+  it('includes study-level fields', () => {
+    expect(intellectualPropertyAsset.searchFields).toContain('study.studyName')
+    expect(intellectualPropertyAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('intellectualPropertyAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'open' },
+    }
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = intellectualPropertyAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('intellectualPropertyAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = intellectualPropertyAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens IPs from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ ipId: 'ip1', title: 'Alpha' }, { ipId: 'ip2', title: 'Beta' }]),
+      makeBucket(2, [{ ipId: 'ip3', title: 'Gamma' }]),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to IntellectualPropertyAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        ipId: 'ip-abc',
+        type: 'Patent',
+        title: 'Novel Method',
+        assignee: 'Broad Institute',
+        patentNumber: 'US12345678',
+        filingDate: '2023-06-15',
+        status: 'Granted',
+        url: 'https://patents.example.com/US12345678',
+        contact: 'ip@broadinstitute.org',
+        tags: ['genomics'],
+      }], 'My Study'),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    const row = result.items[0] as IntellectualPropertyAsset
+    expect(row.ipId).toBe('ip-abc')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('My Study')
+    expect(row.type).toBe('Patent')
+    expect(row.title).toBe('Novel Method')
+    expect(row.assignee).toBe('Broad Institute')
+    expect(row.patentNumber).toBe('US12345678')
+    expect(row.filingDate).toBe('2023-06-15')
+    expect(row.status).toBe('Granted')
+    expect(row.url).toBe('https://patents.example.com/US12345678')
+    expect(row.contact).toBe('ip@broadinstitute.org')
+    expect(row.tags).toEqual(['genomics'])
+  })
+
+  it('falls back to composite key when ipId is absent', () => {
+    const response = makeResponse([
+      makeBucket(10, [{ title: 'No ID' }]),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    const row = result.items[0] as IntellectualPropertyAsset
+    expect(row.ipId).toBe('10-0')
+  })
+
+  it('defaults missing string fields to empty string', () => {
+    const response = makeResponse([
+      makeBucket(5, [{ ipId: 'ip-x' }]),
+    ])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    const row = result.items[0] as IntellectualPropertyAsset
+    expect(row.type).toBe('')
+    expect(row.title).toBe('')
+    expect(row.assignee).toBe('')
+    expect(row.patentNumber).toBe('')
+    expect(row.filingDate).toBe('')
+    expect(row.status).toBe('')
+    expect(row.url).toBe('')
+    expect(row.contact).toBe('')
+    expect(row.tags).toEqual([])
+  })
+
+  it('applies client-side pagination correctly', () => {
+    const ips = Array.from({ length: 30 }, (_, i) => ({ ipId: `ip-${i}`, title: `IP ${i}` }))
+    const response = makeResponse([makeBucket(1, ips)])
+    const page1 = intellectualPropertyAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    const page2 = intellectualPropertyAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect(page1.total).toBe(30)
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as IntellectualPropertyAsset).ipId).toBe('ip-10')
+  })
+
+  it('handles studies with no intellectualProperties assets', () => {
+    const response = makeResponse([makeBucket(7, [])])
+    const result = intellectualPropertyAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+})
+
+describe('intellectualPropertyAsset — getRowId', () => {
+  it('returns the ipId', () => {
+    const row: IntellectualPropertyAsset = {
+      ipId: 'ip-xyz',
+      studyId: 1,
+      studyName: 'Study',
+      type: 'Patent',
+      title: 'Title',
+      assignee: 'Org',
+      patentNumber: 'US000',
+      filingDate: '2024-01-01',
+      status: 'Pending',
+      url: '',
+      contact: '',
+    }
+    expect(intellectualPropertyAsset.getRowId(row)).toBe('ip-xyz')
+  })
+})
+
+describe('intellectualPropertyAsset — isRowSelectable', () => {
+  it('returns false (IPs do not participate in access requests)', () => {
+    const row: IntellectualPropertyAsset = {
+      ipId: 'ip-1',
+      studyId: 1,
+      studyName: 'Study',
+      type: 'Patent',
+      title: 'Title',
+      assignee: 'Org',
+      patentNumber: 'US000',
+      filingDate: '2024-01-01',
+      status: 'Granted',
+      url: '',
+      contact: '',
+    }
+    expect(intellectualPropertyAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('intellectualPropertyAsset — selection helpers', () => {
+  it('computeRowSelection always returns an empty Set', () => {
+    const set = intellectualPropertyAsset.computeRowSelection([], [1, 2, 3])
+    expect(set.size).toBe(0)
+  })
+
+  it('selectionToDatasetIds always returns an empty array', () => {
+    const ids = intellectualPropertyAsset.selectionToDatasetIds([], ['ip-1', 'ip-2'])
+    expect(ids).toEqual([])
+  })
+
+  it('getStudyIdsForSelection always returns an empty array', () => {
+    const ids = intellectualPropertyAsset.getStudyIdsForSelection([], [1, 2])
+    expect(ids).toEqual([])
+  })
+})
+
+describe('intellectualPropertyAsset — makeColumns', () => {
+  it('returns an array of column definitions', () => {
+    const cols = intellectualPropertyAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes expected field names', () => {
+    const fields = intellectualPropertyAsset.makeColumns().map(c => c.field)
+    expect(fields).toContain('title')
+    expect(fields).toContain('type')
+    expect(fields).toContain('patentNumber')
+    expect(fields).toContain('assignee')
+    expect(fields).toContain('status')
+    expect(fields).toContain('filingDate')
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('contact')
+    expect(fields).toContain('tags')
+  })
+})

--- a/test/components/data_library/assets/modelAsset.spec.ts
+++ b/test/components/data_library/assets/modelAsset.spec.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit tests for modelAsset — the AI Models AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { modelAsset } from 'src/components/data_library/assets/modelAsset'
+import { ModelAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  ModelStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  models: Array<{
+    modelId?: string
+    name?: string
+    format?: string
+    license?: string
+    tags?: string[]
+    url?: string
+    maintainer?: { name: string, email: string }
+  }> = [],
+  studyName = 'Test Study',
+): ModelStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: models.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                models: models.map(m => ({
+                  modelId: m.modelId,
+                  name: m.name,
+                  format: m.format,
+                  license: m.license,
+                  tags: m.tags,
+                  url: m.url,
+                  maintainer: m.maintainer,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: ModelStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('modelAsset — label', () => {
+  it('has singular "AI Model" and plural "AI Models"', () => {
+    expect(modelAsset.label.singular).toBe('AI Model')
+    expect(modelAsset.label.plural).toBe('AI Models')
+  })
+})
+
+describe('modelAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(modelAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('modelAsset — searchFields', () => {
+  it('includes model-specific fields', () => {
+    expect(modelAsset.searchFields).toContain('study.assets.models.name')
+    expect(modelAsset.searchFields).toContain('study.assets.models.format')
+    expect(modelAsset.searchFields).toContain('study.assets.models.license')
+    expect(modelAsset.searchFields).toContain('study.assets.models.tags')
+  })
+
+  it('includes study-level fields', () => {
+    expect(modelAsset.searchFields).toContain('study.studyName')
+    expect(modelAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('modelAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = modelAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'controlled' },
+    }
+    const q = modelAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'name', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = modelAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('modelAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = modelAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens models from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ modelId: 'm1', name: 'Alpha' }, { modelId: 'm2', name: 'Beta' }]),
+      makeBucket(2, [{ modelId: 'm3', name: 'Gamma' }]),
+    ])
+    const result = modelAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to ModelAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        modelId: 'model-xyz',
+        name: 'ResNet',
+        format: 'ONNX',
+        license: 'Apache-2.0',
+        tags: ['vision', 'classification'],
+        url: 'https://example.com',
+        maintainer: { name: 'Alice', email: 'alice@example.com' },
+      }], 'NHGRI Study'),
+    ])
+    const result = modelAsset.transformResponse(response, pagination)
+    const row = result.items[0] as ModelAsset
+    expect(row.modelId).toBe('model-xyz')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.name).toBe('ResNet')
+    expect(row.format).toBe('ONNX')
+    expect(row.license).toBe('Apache-2.0')
+    expect(row.url).toBe('https://example.com')
+    expect(row.tags).toEqual(['vision', 'classification'])
+    expect(row.maintainer.name).toBe('Alice')
+    expect(row.maintainer.email).toBe('alice@example.com')
+  })
+
+  it('falls back to composite key when modelId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ name: 'NoId Model' }]),
+    ])
+    const result = modelAsset.transformResponse(response, pagination)
+    const row = result.items[0] as ModelAsset
+    expect(row.modelId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const models = Array.from({ length: 30 }, (_, i) => ({
+      modelId: `m${i}`,
+      name: `Model ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, models)])
+
+    const page0 = modelAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as ModelAsset).name).toBe('Model 0')
+
+    const page1 = modelAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as ModelAsset).name).toBe('Model 10')
+
+    const page2 = modelAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as ModelAsset).name).toBe('Model 20')
+  })
+
+  it('reports total as the number of all models across all studies (not just page)', () => {
+    const models = Array.from({ length: 30 }, (_, i) => ({ modelId: `m${i}` }))
+    const response = makeResponse([makeBucket(1, models)])
+    const result = modelAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('returns empty tags / maintainer defaults for missing fields', () => {
+    const response = makeResponse([
+      makeBucket(1, [{}]),
+    ])
+    const row = modelAsset.transformResponse(response, pagination).items[0] as ModelAsset
+    expect(row.tags).toEqual([])
+    expect(row.maintainer.name).toBe('')
+    expect(row.maintainer.email).toBe('')
+    expect(row.name).toBe('')
+    expect(row.format).toBe('')
+  })
+
+  it('handles a study bucket with no models gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = modelAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+})
+
+describe('modelAsset — getRowId', () => {
+  it('returns the modelId of the row', () => {
+    const row: ModelAsset = {
+      modelId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    expect(modelAsset.getRowId(row)).toBe('abc-123')
+  })
+})
+
+describe('modelAsset — isRowSelectable', () => {
+  it('always returns false — models do not participate in access requests', () => {
+    const row: ModelAsset = {
+      modelId: 'm1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    expect(modelAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('modelAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: ModelAsset = {
+      modelId: 'm1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    const result = modelAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('modelAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = modelAsset.selectionToDatasetIds([], ['m1', 'm2'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('modelAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: ModelAsset = {
+      modelId: 'm1',
+      studyId: 42,
+      studyName: '',
+      name: '',
+      description: '',
+      url: '',
+      format: '',
+      license: '',
+      trainedOnDatasets: [],
+      maintainer: { name: '', email: '' },
+    }
+    const result = modelAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('modelAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = modelAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = modelAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('name')
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('format')
+    expect(fields).toContain('license')
+    expect(fields).toContain('maintainer')
+    expect(fields).toContain('url')
+    expect(fields).toContain('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = modelAsset.makeColumns()
+    const b = modelAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/assets/presentationAsset.spec.ts
+++ b/test/components/data_library/assets/presentationAsset.spec.ts
@@ -1,0 +1,381 @@
+/**
+ * Unit tests for presentationAsset — the Presentations AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { presentationAsset } from 'src/components/data_library/assets/presentationAsset'
+import { PresentationAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  PresentationStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+import { EMPTY_FILTERS } from 'src/components/data_library/filterRegistry'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  presentations: Array<{
+    presentationId?: string
+    title?: string
+    date?: string
+    url?: string
+    authors?: string
+    event?: string
+    location?: string
+    format?: string
+    access?: string
+    tags?: string[]
+    citation?: boolean
+    datasetCitation?: string
+    presenter?: { name?: string, email?: string }
+  }> = [],
+  studyName = 'Test Study',
+): PresentationStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: presentations.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                presentations: presentations.map(p => ({
+                  presentationId: p.presentationId,
+                  title: p.title,
+                  date: p.date,
+                  url: p.url,
+                  authors: p.authors,
+                  event: p.event,
+                  location: p.location,
+                  format: p.format,
+                  access: p.access,
+                  tags: p.tags,
+                  citation: p.citation,
+                  datasetCitation: p.datasetCitation,
+                  presenter: p.presenter,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: PresentationStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('presentationAsset — label', () => {
+  it('has singular "Presentation" and plural "Presentations"', () => {
+    expect(presentationAsset.label.singular).toBe('Presentation')
+    expect(presentationAsset.label.plural).toBe('Presentations')
+  })
+})
+
+describe('presentationAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(presentationAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('presentationAsset — searchFields', () => {
+  it('includes presentation-specific fields', () => {
+    expect(presentationAsset.searchFields).toContain('study.assets.presentations.title')
+    expect(presentationAsset.searchFields).toContain('study.assets.presentations.event')
+    expect(presentationAsset.searchFields).toContain('study.assets.presentations.location')
+    expect(presentationAsset.searchFields).toContain('study.assets.presentations.authors')
+    expect(presentationAsset.searchFields).toContain('study.assets.presentations.format')
+  })
+
+  it('includes study-level fields', () => {
+    expect(presentationAsset.searchFields).toContain('study.studyName')
+    expect(presentationAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('presentationAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = presentationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'open' },
+    }
+    const q = presentationAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = presentationAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('presentationAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = presentationAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens presentations from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ presentationId: 'pr1', title: 'Alpha' }, { presentationId: 'pr2', title: 'Beta' }]),
+      makeBucket(2, [{ presentationId: 'pr3', title: 'Gamma' }]),
+    ])
+    const result = presentationAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to PresentationAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        presentationId: 'pres-xyz',
+        title: 'Data Sharing in Practice',
+        date: '2024-10-01',
+        url: 'https://example.com/slides',
+        authors: 'Alice Smith, Bob Jones',
+        event: 'ASHG 2024',
+        location: 'Denver, CO',
+        format: 'Oral',
+        access: 'open',
+        tags: ['genomics', 'data-sharing'],
+        citation: true,
+        datasetCitation: 'DUOS-999',
+        presenter: { name: 'Alice Smith', email: 'alice@example.com' },
+      }], 'NHGRI Study'),
+    ])
+    const result = presentationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PresentationAsset
+    expect(row.presentationId).toBe('pres-xyz')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.title).toBe('Data Sharing in Practice')
+    expect(row.date).toBe('2024-10-01')
+    expect(row.url).toBe('https://example.com/slides')
+    expect(row.authors).toBe('Alice Smith, Bob Jones')
+    expect(row.event).toBe('ASHG 2024')
+    expect(row.location).toBe('Denver, CO')
+    expect(row.format).toBe('Oral')
+    expect(row.access).toBe('open')
+    expect(row.tags).toEqual(['genomics', 'data-sharing'])
+    expect(row.citation).toBe(true)
+    expect(row.datasetCitation).toBe('DUOS-999')
+    expect(row.presenter?.name).toBe('Alice Smith')
+    expect(row.presenter?.email).toBe('alice@example.com')
+  })
+
+  it('falls back to composite key when presentationId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ title: 'No ID Pres' }]),
+    ])
+    const result = presentationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PresentationAsset
+    expect(row.presentationId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const preses = Array.from({ length: 30 }, (_, i) => ({
+      presentationId: `pr${i}`,
+      title: `Presentation ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, preses)])
+
+    const page0 = presentationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as PresentationAsset).title).toBe('Presentation 0')
+
+    const page1 = presentationAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as PresentationAsset).title).toBe('Presentation 10')
+
+    const page2 = presentationAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as PresentationAsset).title).toBe('Presentation 20')
+  })
+
+  it('reports total as the number of all presentations across all studies', () => {
+    const preses = Array.from({ length: 30 }, (_, i) => ({ presentationId: `pr${i}` }))
+    const response = makeResponse([makeBucket(1, preses)])
+    const result = presentationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('returns empty defaults for missing fields', () => {
+    const response = makeResponse([makeBucket(1, [{}])])
+    const row = presentationAsset.transformResponse(response, pagination).items[0] as PresentationAsset
+    expect(row.tags).toEqual([])
+    expect(row.title).toBe('')
+    expect(row.date).toBe('')
+    expect(row.authors).toBe('')
+    expect(row.event).toBe('')
+    expect(row.location).toBe('')
+    expect(row.format).toBe('')
+    expect(row.citation).toBe(false)
+  })
+
+  it('handles a study bucket with no presentations gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = presentationAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('returns only matching presentations when filtered within a shared study', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        {
+          presentationId: 'PRES-CITED',
+          title: 'Cited',
+          citation: true,
+        },
+        {
+          presentationId: 'PRES-NOT-CITED',
+          title: 'Not Cited',
+          citation: false,
+        },
+      ]),
+    ])
+
+    const result = presentationAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      datasetsCited: true,
+    })
+
+    expect(result.items).toHaveLength(1)
+    expect((result.items[0] as PresentationAsset).presentationId).toBe('PRES-CITED')
+  })
+})
+
+describe('presentationAsset — getRowId', () => {
+  it('returns the presentationId of the row', () => {
+    const row: PresentationAsset = {
+      presentationId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    expect(presentationAsset.getRowId(row)).toBe('abc-123')
+  })
+})
+
+describe('presentationAsset — isRowSelectable', () => {
+  it('always returns false — presentations do not participate in access requests', () => {
+    const row: PresentationAsset = {
+      presentationId: 'pr1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    expect(presentationAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('presentationAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: PresentationAsset = {
+      presentationId: 'pr1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    const result = presentationAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('presentationAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = presentationAsset.selectionToDatasetIds([], ['pr1', 'pr2'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('presentationAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: PresentationAsset = {
+      presentationId: 'pr1',
+      studyId: 42,
+      studyName: '',
+      title: '',
+      date: '',
+      citation: false,
+    }
+    const result = presentationAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('presentationAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = presentationAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = presentationAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('title')
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('event')
+    expect(fields).toContain('date')
+    expect(fields).toContain('location')
+    expect(fields).toContain('presenter')
+    expect(fields).toContain('format')
+    expect(fields).toContain('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = presentationAsset.makeColumns()
+    const b = presentationAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/assets/publicationAsset.spec.ts
+++ b/test/components/data_library/assets/publicationAsset.spec.ts
@@ -1,0 +1,400 @@
+/**
+ * Unit tests for publicationAsset — the Publications AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { publicationAsset } from 'src/components/data_library/assets/publicationAsset'
+import { PublicationAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  PublicationStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+import { EMPTY_FILTERS } from 'src/components/data_library/filterRegistry'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  publications: Array<{
+    publicationId?: string
+    title?: string
+    journal?: string
+    doi?: string
+    pubmedId?: string
+    publishedDate?: string
+    authors?: Array<{ name: string }>
+    url?: string
+    tags?: string[]
+    citation?: boolean
+    datasetCitation?: string
+  }> = [],
+  studyName = 'Test Study',
+): PublicationStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: publications.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                publications: publications.map(p => ({
+                  publicationId: p.publicationId,
+                  title: p.title,
+                  journal: p.journal,
+                  doi: p.doi,
+                  pubmedId: p.pubmedId,
+                  publishedDate: p.publishedDate,
+                  authors: p.authors,
+                  url: p.url,
+                  tags: p.tags,
+                  citation: p.citation,
+                  datasetCitation: p.datasetCitation,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: PublicationStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('publicationAsset — label', () => {
+  it('has singular "Publication" and plural "Publications"', () => {
+    expect(publicationAsset.label.singular).toBe('Publication')
+    expect(publicationAsset.label.plural).toBe('Publications')
+  })
+})
+
+describe('publicationAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(publicationAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('publicationAsset — searchFields', () => {
+  it('includes publication-specific fields', () => {
+    expect(publicationAsset.searchFields).toContain('study.assets.publications.title')
+    expect(publicationAsset.searchFields).toContain('study.assets.publications.journal')
+    expect(publicationAsset.searchFields).toContain('study.assets.publications.doi')
+    expect(publicationAsset.searchFields).toContain('study.assets.publications.pubmedId')
+  })
+
+  it('includes study-level fields', () => {
+    expect(publicationAsset.searchFields).toContain('study.studyName')
+    expect(publicationAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('publicationAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = publicationAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'open' },
+    }
+    const q = publicationAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'title', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = publicationAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('publicationAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = publicationAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens publications from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ publicationId: 'p1', title: 'Alpha' }, { publicationId: 'p2', title: 'Beta' }]),
+      makeBucket(2, [{ publicationId: 'p3', title: 'Gamma' }]),
+    ])
+    const result = publicationAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to PublicationAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        publicationId: 'pub-xyz',
+        title: 'A Novel Method',
+        journal: 'Nature',
+        doi: '10.1038/test',
+        pubmedId: '99887766',
+        publishedDate: '2024-06-01',
+        authors: [{ name: 'Alice' }, { name: 'Bob' }],
+        url: 'https://example.com',
+        tags: ['genomics', 'GWAS'],
+        citation: true,
+        datasetCitation: 'DUOS-999',
+      }], 'NHGRI Study'),
+    ])
+    const result = publicationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PublicationAsset
+    expect(row.publicationId).toBe('pub-xyz')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.title).toBe('A Novel Method')
+    expect(row.journal).toBe('Nature')
+    expect(row.doi).toBe('10.1038/test')
+    expect(row.pubmedId).toBe('99887766')
+    expect(row.publishedDate).toBe('2024-06-01')
+    expect(row.authorNames).toEqual(['Alice', 'Bob'])
+    expect(row.url).toBe('https://example.com')
+    expect(row.tags).toEqual(['genomics', 'GWAS'])
+    expect(row.citation).toBe(true)
+    expect(row.datasetCitation).toBe('DUOS-999')
+  })
+
+  it('falls back to composite key when publicationId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ title: 'No ID Pub' }]),
+    ])
+    const result = publicationAsset.transformResponse(response, pagination)
+    const row = result.items[0] as PublicationAsset
+    expect(row.publicationId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const pubs = Array.from({ length: 30 }, (_, i) => ({
+      publicationId: `p${i}`,
+      title: `Publication ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, pubs)])
+
+    const page0 = publicationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as PublicationAsset).title).toBe('Publication 0')
+
+    const page1 = publicationAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as PublicationAsset).title).toBe('Publication 10')
+
+    const page2 = publicationAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as PublicationAsset).title).toBe('Publication 20')
+  })
+
+  it('reports total as the number of all publications across all studies', () => {
+    const pubs = Array.from({ length: 30 }, (_, i) => ({ publicationId: `p${i}` }))
+    const response = makeResponse([makeBucket(1, pubs)])
+    const result = publicationAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('builds authorNames from the authors array', () => {
+    const response = makeResponse([
+      makeBucket(1, [{
+        publicationId: 'p1',
+        authors: [{ name: 'Dr. Smith' }, { name: 'Prof. Jones' }, { name: '' }],
+      }]),
+    ])
+    const row = publicationAsset.transformResponse(response, pagination).items[0] as PublicationAsset
+    expect(row.authorNames).toEqual(['Dr. Smith', 'Prof. Jones'])
+  })
+
+  it('returns empty defaults for missing fields', () => {
+    const response = makeResponse([makeBucket(1, [{}])])
+    const row = publicationAsset.transformResponse(response, pagination).items[0] as PublicationAsset
+    expect(row.tags).toEqual([])
+    expect(row.authors).toEqual([])
+    expect(row.authorNames).toEqual([])
+    expect(row.title).toBe('')
+    expect(row.journal).toBe('')
+    expect(row.doi).toBe('')
+    expect(row.citation).toBe(false)
+  })
+
+  it('handles a study bucket with no publications gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = publicationAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('returns only matching publications when a citation filter is present', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        {
+          publicationId: 'PUB-CITED',
+          title: 'Cited Publication',
+          citation: true,
+        },
+        {
+          publicationId: 'PUB-NOT-CITED',
+          title: 'Not Cited Publication',
+          citation: false,
+        },
+      ]),
+    ])
+
+    const result = publicationAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      datasetsCited: true,
+    })
+
+    expect(result.items).toHaveLength(1)
+    expect((result.items[0] as PublicationAsset).publicationId).toBe('PUB-CITED')
+  })
+})
+
+describe('publicationAsset — getRowId', () => {
+  it('returns the publicationId of the row', () => {
+    const row: PublicationAsset = {
+      publicationId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    expect(publicationAsset.getRowId(row)).toBe('abc-123')
+  })
+})
+
+describe('publicationAsset — isRowSelectable', () => {
+  it('always returns false — publications do not participate in access requests', () => {
+    const row: PublicationAsset = {
+      publicationId: 'p1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    expect(publicationAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('publicationAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: PublicationAsset = {
+      publicationId: 'p1',
+      studyId: 1,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    const result = publicationAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('publicationAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = publicationAsset.selectionToDatasetIds([], ['p1', 'p2'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('publicationAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: PublicationAsset = {
+      publicationId: 'p1',
+      studyId: 42,
+      studyName: '',
+      title: '',
+      publishedDate: '',
+      authors: [],
+      authorNames: [],
+      datasetCitation: '',
+      citation: false,
+      journal: '',
+      doi: '',
+    }
+    const result = publicationAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('publicationAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = publicationAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = publicationAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('title')
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('journal')
+    expect(fields).toContain('publishedDate')
+    expect(fields).toContain('doi')
+    expect(fields).toContain('authorNames')
+    expect(fields).toContain('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = publicationAsset.makeColumns()
+    const b = publicationAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/assets/workspaceAsset.spec.ts
+++ b/test/components/data_library/assets/workspaceAsset.spec.ts
@@ -1,0 +1,338 @@
+/**
+ * Unit tests for workspaceAsset — the Workspaces AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { workspaceAsset } from 'src/components/data_library/assets/workspaceAsset'
+import { WorkspaceAsset, PaginationState, SortState } from 'src/types/library'
+import {
+  ElasticsearchResponse,
+  WorkspaceStudyAggregationBucket,
+  QueryClause,
+} from 'src/types/elastic'
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+const makeBucket = (
+  studyId: number,
+  workspaces: Array<{
+    workspaceId?: string
+    name?: string
+    platform?: string
+    url?: string
+    description?: string
+    tools?: string[]
+    access?: string
+    tags?: string[]
+  }> = [],
+  studyName = 'Test Study',
+): WorkspaceStudyAggregationBucket => ({
+  key: studyId,
+  doc_count: workspaces.length,
+  study_details: {
+    hits: {
+      hits: [
+        {
+          _source: {
+            study: {
+              studyId,
+              studyName,
+              assets: {
+                workspaces: workspaces.map(w => ({
+                  workspaceId: w.workspaceId,
+                  name: w.name,
+                  platform: w.platform,
+                  url: w.url,
+                  description: w.description,
+                  tools: w.tools,
+                  access: w.access,
+                  tags: w.tags,
+                })),
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+})
+
+const makeResponse = (
+  buckets: WorkspaceStudyAggregationBucket[],
+): ElasticsearchResponse => ({
+  items: [],
+  total: 0,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregations: { studies: { buckets } as any },
+})
+
+describe('workspaceAsset — label', () => {
+  it('has singular "Workspace" and plural "Workspaces"', () => {
+    expect(workspaceAsset.label.singular).toBe('Workspace')
+    expect(workspaceAsset.label.plural).toBe('Workspaces')
+  })
+})
+
+describe('workspaceAsset — sortingMode', () => {
+  it('is "client"', () => {
+    expect(workspaceAsset.sortingMode).toBe('client')
+  })
+})
+
+describe('workspaceAsset — searchFields', () => {
+  it('includes workspace-specific fields', () => {
+    expect(workspaceAsset.searchFields).toContain('study.assets.workspaces.name')
+    expect(workspaceAsset.searchFields).toContain('study.assets.workspaces.platform')
+    expect(workspaceAsset.searchFields).toContain('study.assets.workspaces.description')
+    expect(workspaceAsset.searchFields).toContain('study.assets.workspaces.tools')
+    expect(workspaceAsset.searchFields).toContain('study.assets.workspaces.tags')
+  })
+
+  it('includes study-level fields', () => {
+    expect(workspaceAsset.searchFields).toContain('study.studyName')
+    expect(workspaceAsset.searchFields).toContain('study.piName')
+  })
+})
+
+describe('workspaceAsset — buildQuery', () => {
+  const existsClause: QueryClause = { exists: { field: 'study' } }
+
+  it('returns size: 0 (aggregation-only query)', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.size).toBe(0)
+    expect(q.from).toBe(undefined)
+  })
+
+  it('has a studies terms aggregation on study.studyId', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.aggs).toHaveProperty('studies')
+    const studiesAgg = q.aggs!.studies as {
+      terms: { field: string, size: number }
+    }
+    expect(studiesAgg.terms.field).toBe('study.studyId')
+    expect(studiesAgg.terms.size).toBe(10000)
+  })
+
+  it('includes queryChunks in the must array', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.must).toHaveLength(1)
+    expect((q.query!.bool.must![0] as { exists: { field: string } }).exists.field).toBe('study')
+  })
+
+  it('omits filter when filterQuery is empty', () => {
+    const q = workspaceAsset.buildQuery([existsClause], [], pagination)
+    expect(q.query?.bool.filter).toBe(undefined)
+  })
+
+  it('adds filter when filterQuery has clauses', () => {
+    const filterClause: QueryClause = {
+      term: { 'accessManagement.keyword': 'controlled' },
+    }
+    const q = workspaceAsset.buildQuery([existsClause], [filterClause], pagination)
+    expect(q.query?.bool.filter).toHaveLength(1)
+  })
+
+  it('ignores pagination and sort (all data fetched at once)', () => {
+    const sort: SortState = { field: 'name', order: 'asc' }
+    const largePagination = { page: 5, pageSize: 100 }
+    const q = workspaceAsset.buildQuery([existsClause], [], largePagination, sort)
+    expect(q.size).toBe(0)
+    expect(q.sort).toBe(undefined)
+  })
+})
+
+describe('workspaceAsset — transformResponse', () => {
+  it('returns empty items for an empty response', () => {
+    const result = workspaceAsset.transformResponse(makeResponse([]), pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+
+  it('flattens workspaces from multiple studies into rows', () => {
+    const response = makeResponse([
+      makeBucket(1, [{ workspaceId: 'w1', name: 'Alpha' }, { workspaceId: 'w2', name: 'Beta' }]),
+      makeBucket(2, [{ workspaceId: 'w3', name: 'Gamma' }]),
+    ])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(3)
+    expect(result.total).toBe(3)
+  })
+
+  it('maps fields correctly from bucket to WorkspaceAsset', () => {
+    const response = makeResponse([
+      makeBucket(42, [{
+        workspaceId: 'ws-xyz',
+        name: 'Terra Workspace',
+        platform: 'Terra',
+        url: 'https://app.terra.bio/#workspaces/test/example',
+        description: 'A test workspace',
+        tools: ['WDL', 'Jupyter'],
+        access: 'open',
+        tags: ['genomics', 'cloud'],
+      }], 'NHGRI Study'),
+    ])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    const row = result.items[0] as WorkspaceAsset
+    expect(row.workspaceId).toBe('ws-xyz')
+    expect(row.studyId).toBe(42)
+    expect(row.studyName).toBe('NHGRI Study')
+    expect(row.name).toBe('Terra Workspace')
+    expect(row.platform).toBe('Terra')
+    expect(row.url).toBe('https://app.terra.bio/#workspaces/test/example')
+    expect(row.description).toBe('A test workspace')
+    expect(row.tools).toEqual(['WDL', 'Jupyter'])
+    expect(row.access).toBe('open')
+    expect(row.tags).toEqual(['genomics', 'cloud'])
+  })
+
+  it('falls back to composite key when workspaceId is absent', () => {
+    const response = makeResponse([
+      makeBucket(99, [{ name: 'No-Id Workspace' }]),
+    ])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    const row = result.items[0] as WorkspaceAsset
+    expect(row.workspaceId).toBe('99-0')
+  })
+
+  it('applies client-side pagination', () => {
+    const workspaces = Array.from({ length: 30 }, (_, i) => ({
+      workspaceId: `w${i}`,
+      name: `Workspace ${i}`,
+    }))
+    const response = makeResponse([makeBucket(1, workspaces)])
+
+    const page0 = workspaceAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(page0.items).toHaveLength(10)
+    expect((page0.items[0] as WorkspaceAsset).name).toBe('Workspace 0')
+
+    const page1 = workspaceAsset.transformResponse(response, { page: 1, pageSize: 10 })
+    expect(page1.items).toHaveLength(10)
+    expect((page1.items[0] as WorkspaceAsset).name).toBe('Workspace 10')
+
+    const page2 = workspaceAsset.transformResponse(response, { page: 2, pageSize: 10 })
+    expect(page2.items).toHaveLength(10)
+    expect((page2.items[0] as WorkspaceAsset).name).toBe('Workspace 20')
+  })
+
+  it('reports total as the number of all workspaces across all studies (not just page)', () => {
+    const workspaces = Array.from({ length: 30 }, (_, i) => ({ workspaceId: `w${i}` }))
+    const response = makeResponse([makeBucket(1, workspaces)])
+    const result = workspaceAsset.transformResponse(response, { page: 0, pageSize: 10 })
+    expect(result.total).toBe(30)
+  })
+
+  it('returns empty tools / access / tags defaults for missing fields', () => {
+    const response = makeResponse([
+      makeBucket(1, [{}]),
+    ])
+    const row = workspaceAsset.transformResponse(response, pagination).items[0] as WorkspaceAsset
+    expect(row.tools).toEqual([])
+    expect(row.tags).toEqual([])
+    expect(row.access).toBe('')
+    expect(row.name).toBe('')
+    expect(row.platform).toBe('')
+    expect(row.description).toBe('')
+  })
+
+  it('handles a study bucket with no workspaces gracefully', () => {
+    const response = makeResponse([makeBucket(1, [])])
+    const result = workspaceAsset.transformResponse(response, pagination)
+    expect(result.items).toHaveLength(0)
+    expect(result.total).toBe(0)
+  })
+})
+
+describe('workspaceAsset — getRowId', () => {
+  it('returns the workspaceId of the row', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'abc-123',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    expect(workspaceAsset.getRowId(row)).toBe('abc-123')
+  })
+})
+
+describe('workspaceAsset — isRowSelectable', () => {
+  it('always returns false — workspaces do not participate in access requests', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'w1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    expect(workspaceAsset.isRowSelectable(row)).toBe(false)
+  })
+})
+
+describe('workspaceAsset — computeRowSelection', () => {
+  it('always returns an empty Set regardless of inputs', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'w1',
+      studyId: 1,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    const result = workspaceAsset.computeRowSelection([row], [1, 2, 3])
+    expect(result.size).toBe(0)
+  })
+})
+
+describe('workspaceAsset — selectionToDatasetIds', () => {
+  it('always returns an empty array', () => {
+    const result = workspaceAsset.selectionToDatasetIds([], ['w1', 'w2'])
+    expect(result).toEqual([])
+  })
+})
+
+describe('workspaceAsset — getStudyIdsForSelection', () => {
+  it('always returns an empty array', () => {
+    const row: WorkspaceAsset = {
+      workspaceId: 'w1',
+      studyId: 42,
+      studyName: '',
+      name: '',
+      platform: '',
+      url: '',
+      description: '',
+    }
+    const result = workspaceAsset.getStudyIdsForSelection([row], [1])
+    expect(result).toEqual([])
+  })
+})
+
+describe('workspaceAsset — makeColumns', () => {
+  it('returns a non-empty array of column definitions', () => {
+    const cols = workspaceAsset.makeColumns()
+    expect(Array.isArray(cols)).toBe(true)
+    expect(cols.length).toBeGreaterThan(0)
+  })
+
+  it('includes required field names', () => {
+    const cols = workspaceAsset.makeColumns()
+    const fields = cols.map(c => c.field)
+    expect(fields).toContain('name')
+    expect(fields).toContain('studyName')
+    expect(fields).toContain('platform')
+    expect(fields).toContain('url')
+    expect(fields).toContain('description')
+    expect(fields).toContain('tools')
+    expect(fields).toContain('access')
+    expect(fields).toContain('tags')
+  })
+
+  it('produces the same result when called with or without props', () => {
+    const a = workspaceAsset.makeColumns()
+    const b = workspaceAsset.makeColumns({})
+    expect(a.map(c => c.field)).toEqual(b.map(c => c.field))
+  })
+})

--- a/test/components/data_library/filterRegistry.spec.ts
+++ b/test/components/data_library/filterRegistry.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildFilterClausesForAsset,
+  EMPTY_FILTERS,
+  getFilterSectionsForAsset,
+  sanitizeFiltersForAsset,
+} from 'src/components/data_library/filterRegistry'
+import { AssetType, AvailableFilters, FilterState } from 'src/types/library'
+
+const availableFilters: AvailableFilters = {
+  accessManagement: [],
+  dataUse: [],
+  dataType: [],
+  dac: [],
+  workspaceTools: [],
+  workspacePlatform: [],
+  clinicalTrialStatus: [],
+  clinicalTrialPhase: [],
+  clinicalTrialInterventionType: [],
+  clinicalTrialRegistry: [],
+  biospecimenType: [],
+  biospecimenDataUse: [],
+  biospecimenPostMortemIntervalUnit: [],
+  datasetsCited: [],
+  biospecimenPostMortemIntervalRange: { min: 0, max: 10 },
+  participantCountRange: { min: 0, max: 10 },
+}
+
+describe('filterRegistry', () => {
+  const filters: FilterState = {
+    ...EMPTY_FILTERS,
+    accessManagement: ['controlled'],
+    dataType: ['Genomic'],
+    participantCount: { min: 10, max: 100 },
+    datasetsCited: true,
+  }
+
+  it('returns asset-specific visible filters', () => {
+    const publicationFilters = getFilterSectionsForAsset(AssetType.PUBLICATIONS, availableFilters)
+    expect(publicationFilters.map(section => section.key)).toEqual([])
+  })
+
+  it('returns presentation-specific datasets cited filter', () => {
+    const presentationFilters = getFilterSectionsForAsset(AssetType.PRESENTATIONS, availableFilters)
+    expect(presentationFilters.map(section => section.key)).toEqual(['datasetsCited'])
+  })
+
+  it('sanitizes incompatible filters for target asset type', () => {
+    const sanitized = sanitizeFiltersForAsset(AssetType.PRESENTATIONS, filters)
+
+    expect(sanitized.datasetsCited).toBe(true)
+    expect(sanitized.accessManagement).toEqual([])
+    expect(sanitized.dataType).toEqual([])
+    expect(sanitized.participantCount).toEqual({})
+  })
+
+  it('preserves all current filters for datasets', () => {
+    const sanitized = sanitizeFiltersForAsset(AssetType.DATASETS, filters)
+    expect(sanitized.accessManagement).toEqual(['controlled'])
+    expect(sanitized.dataType).toEqual(['Genomic'])
+    expect(sanitized.participantCount).toEqual({ min: 10, max: 100 })
+    expect(sanitized.datasetsCited).toBe(undefined)
+  })
+
+  it('builds query clauses only for filters visible on the selected asset', () => {
+    const clauses = buildFilterClausesForAsset(AssetType.PRESENTATIONS, filters)
+    expect(clauses).toHaveLength(1)
+    const serialized = JSON.stringify(clauses)
+
+    expect(serialized).toContain('study.assets.presentations.citation')
+    expect(serialized).not.toContain('accessManagement.keyword')
+    expect(serialized).not.toContain('participantCount')
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3408
https://broadworkbench.atlassian.net/browse/DT-3391
https://broadworkbench.atlassian.net/browse/DT-3389
https://broadworkbench.atlassian.net/browse/DT-3393
https://broadworkbench.atlassian.net/browse/DT-3390
https://broadworkbench.atlassian.net/browse/DT-3394
https://broadworkbench.atlassian.net/browse/DT-3395
https://broadworkbench.atlassian.net/browse/DT-3396
https://broadworkbench.atlassian.net/browse/DT-3404

### Summary

These data library asset tests were migrated from Cypress using Claude Code. I had one agent migrate over the tests, and another agent verify that the migrations were accurate and successful. I also manually verified that these tests were accurate migrations of the original Cypress tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
