### PR TITLE
[DT-2315] Update Data Library result count styling

### DIFF
--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -414,9 +414,17 @@ export const DataLibrary: React.FC = () => {
         <Box sx={{ flex: 1, height: '100%', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           {/* Asset count */}
           {isFetching
-            ? <Skeleton variant="text" width={120} sx={{ fontSize: '1.6rem', mb: 1 }} />
+            ? <Skeleton variant="text" width={120} sx={{ fontSize: '15px', mb: 1 }} />
             : (
-                <Typography sx={{ fontWeight: 600, fontSize: '1.6rem', mb: 1 }}>
+                <Typography
+                  sx={{
+                    color: '#00609f',
+                    fontFamily: 'Montserrat, sans-serif',
+                    fontSize: '15px',
+                    fontWeight: 'bold',
+                    mb: 1,
+                  }}
+                >
                   {(data?.total ?? 0).toLocaleString()}
                   {' '}
                   {data?.total === 1


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2315

### Summary
This PR styles the asset count to match the active Data Library tab Typography. It also updates the loading skeleton size to align with the new count text size.

<img width="857" height="678" alt="After" src="https://github.com/user-attachments/assets/dc500cc2-3dba-41e8-82d9-13a59741d39e" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
