### PR TITLE
[DT-2776] Use date pickers for study registration dates

### DIFF
--- a/cypress/component/DataSubmission/v2/ds_study_information.spec.tsx
+++ b/cypress/component/DataSubmission/v2/ds_study_information.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import dayjs from 'dayjs'
 import { cloneDeep } from 'src/utils/NodashUtil'
 import {
   GeneralStudyInformation, GeneralStudyInformationProps,
@@ -14,6 +15,16 @@ const props = {
 beforeEach(() => {
   propCopy = cloneDeep(props) as unknown as GeneralStudyInformationProps
 })
+
+const selectDate = (fieldClass: string, fieldId: string) => {
+  const selectedDate = dayjs().date(15).format('YYYY-MM-DD')
+  cy.get(`${fieldClass} button[aria-label*="Choose date"]`).click()
+  cy.get('[role="dialog"]').filter(':visible').last().within(() => {
+    cy.contains('button', /^15$/).click()
+    cy.contains('button', 'Select').click()
+  })
+  cy.get(`#${fieldId}`).should('have.value', selectedDate)
+}
 
 describe('GeneralStudyInformation - Tests', () => {
   it('should mount with all the fields', () => {
@@ -55,19 +66,18 @@ describe('GeneralStudyInformation - Tests', () => {
     cy.get('@setStudySpy').its('callCount').should('eq', 41)
     cy.get('#dataCustodianEmail > .css-13cymwt-control > .css-hlgwow > .css-19bb58m').type('abc@def.ghi{enter}')
     cy.get('@setStudySpy').its('callCount').should('eq', 42)
-    cy.get('#alternativeDataSharingPlanTargetDeliveryDate').type('2025-04-01')
-    cy.get('@setStudySpy').its('callCount').should('eq', 43)
-    cy.get('#alternativeDataSharingPlanTargetPublicReleaseDate').type('2025-04-01')
-    cy.get('@setStudySpy').its('callCount').should('eq', 44)
+    selectDate('.formField-alternativeDataSharingPlanTargetDeliveryDate', 'alternativeDataSharingPlanTargetDeliveryDate')
+    cy.get('@setStudySpy').its('callCount').should('be.gte', 43)
+    selectDate('.formField-alternativeDataSharingPlanTargetPublicReleaseDate', 'alternativeDataSharingPlanTargetPublicReleaseDate')
     cy.get(':nth-child(2) > [style="font-family: Montserrat; font-size: 14px;"] > label > [style="float: left;"] > span').click()
-    cy.get('@setStudySpy').its('callCount').should('eq', 45)
+    cy.get('@setStudySpy').its('callCount').should('be.gte', 44)
     cy.get(':nth-child(1) > [style="font-family: Montserrat; font-size: 14px;"] > label > [style="float: left;"] > span').click()
-    cy.get('@setStudySpy').its('callCount').should('eq', 46)
+    cy.get('@setStudySpy').its('callCount').should('be.gte', 45)
     cy.get('.formField-piEmail').type('name@anywhere.biz')
-    cy.get('@setStudySpy').its('callCount').should('eq', 63)
+    cy.get('@setStudySpy').its('callCount').should('be.gte', 62)
     cy.get('.formField-tags').type('tag1{enter}tag2{enter}')
-    cy.get('@setStudySpy').its('callCount').should('eq', 65)
+    cy.get('@setStudySpy').its('callCount').should('be.gte', 64)
     cy.get('.formField-throughBioId').type('test-bio-id')
-    cy.get('@setStudySpy').its('callCount').should('eq', 76)
+    cy.get('@setStudySpy').its('callCount').should('be.gte', 75)
   })
 })

--- a/cypress/component/StudyAssets/clinical_trial_list.spec.tsx
+++ b/cypress/component/StudyAssets/clinical_trial_list.spec.tsx
@@ -11,6 +11,14 @@ import {
 } from 'src/types/model'
 import { testDeleteViaModal } from './testUtils'
 
+const selectDate = (fieldId: string) => {
+  cy.get(`#${fieldId}`).parent().find('button[aria-label*="Choose date"]').click()
+  cy.get('[role="dialog"]').filter(':visible').last().within(() => {
+    cy.contains('button', /^15$/).click()
+    cy.contains('button', 'Select').click()
+  })
+}
+
 const sampleTrial: ClinicalTrial = {
   clinicalTrialId: 'ct1',
   studyId: 's1',
@@ -64,7 +72,7 @@ describe('ClinicalTrialList component', () => {
     cy.get('#status').click()
     cy.get('#status').type('Completed{enter}')
     cy.get('#sponsor').type('Sponsor Y')
-    cy.get('#startDate').type('2024-06-01')
+    selectDate('startDate')
     cy.get('#interventionType').click()
     cy.get('#interventionType').type('Drug{enter}')
     cy.get('#phase').click()
@@ -85,6 +93,8 @@ describe('ClinicalTrialList component', () => {
     cy.contains(sampleTrial.title).should('exist')
     cy.get('#title').should('be.disabled')
     cy.get('#registry').should('be.disabled')
+    cy.get('#startDate').should('have.value', sampleTrial.startDate)
+    cy.get('#endDate').should('have.value', sampleTrial.endDate)
     cy.get('.collaborator-form-add-save-button').should('not.exist')
     cy.get('.collaborator-form-cancel-button').contains('Close').should('exist')
   })
@@ -114,7 +124,7 @@ describe('ClinicalTrialList component', () => {
     cy.get('#status').click()
     cy.get('#status').type('Completed{enter}')
     cy.get('#sponsor').type('Org Z')
-    cy.get('#startDate').type('2024-02-02')
+    selectDate('startDate')
     cy.get('#interventionType').click()
     cy.get('#interventionType').type('Device{enter}')
     cy.get('#phase').click()

--- a/cypress/component/StudyAssets/funding_resource_list.spec.tsx
+++ b/cypress/component/StudyAssets/funding_resource_list.spec.tsx
@@ -67,6 +67,8 @@ describe('FundingResourceList component', () => {
     cy.contains(sampleFunding.funderName).should('exist')
     cy.get('#funderName').should('be.disabled')
     cy.get('#projectTitle').should('be.disabled')
+    cy.get('#startDate').should('have.value', sampleFunding.startDate)
+    cy.get('#endDate').should('have.value', sampleFunding.endDate)
     cy.get('.collaborator-form-add-save-button').should('not.exist')
     cy.get('.collaborator-form-cancel-button').contains('Close').should('exist')
   })

--- a/cypress/component/StudyAssets/intellectual_property_list.spec.tsx
+++ b/cypress/component/StudyAssets/intellectual_property_list.spec.tsx
@@ -14,6 +14,14 @@ import {
   testSummaryViewActionTrigger,
 } from './testUtils'
 
+const selectDate = (fieldId: string) => {
+  cy.get(`#${fieldId}`).parent().find('button[aria-label*="Choose date"]').click()
+  cy.get('[role="dialog"]').filter(':visible').last().within(() => {
+    cy.contains('button', /^15$/).click()
+    cy.contains('button', 'Select').click()
+  })
+}
+
 const sampleIp: IntellectualProperty = {
   ipId: 'ip-1',
   studyId: 'study-1',
@@ -68,7 +76,7 @@ function fillForm(overrides: Partial<IntellectualProperty> = {}) {
   cy.get('#title').type(overrides.title ?? 'New IP')
   cy.get('#assignee').type(overrides.assignee ?? 'Assignee Name')
   cy.get('#patentNumber').type(overrides.patentNumber ?? 'PAT123')
-  cy.get('#filingDate').type(overrides.filingDate ?? '2024-01-01')
+  selectDate('filingDate')
   cy.get('#status').type(overrides.status ?? 'Pending')
   cy.get('#url').type(overrides.url ?? 'https://example.com')
   cy.get('#contact').type(overrides.contact ?? 'contact@example.com')
@@ -107,7 +115,6 @@ describe('IntellectualPropertyAddEdit', () => {
   })
 
   const invalidInputTests = [
-    { field: '#filingDate', value: 'invalid-date', label: 'date' },
     { field: '#url', value: 'invalid-url', label: 'URL' },
   ]
 
@@ -223,6 +230,7 @@ describe('IntellectualPropertyList', () => {
 
   it('opens intellectual property in view mode when view button is clicked', () => {
     testViewModeFlow(mountListWithItem, sampleIp.title, { fieldId: '#title' })
+    cy.get('#filingDate').should('have.value', sampleIp.filingDate)
   })
 
   it('closes view mode when close button is clicked', () => {

--- a/cypress/component/StudyAssets/presentation_list.spec.tsx
+++ b/cypress/component/StudyAssets/presentation_list.spec.tsx
@@ -6,6 +6,14 @@ import PresentationSummary from 'src/components/presentations_list/PresentationS
 import { Presentation } from 'src/types/model'
 import { testDeleteViaModal } from './testUtils'
 
+const selectDate = (fieldId: string) => {
+  cy.get(`#${fieldId}`).parent().find('button[aria-label*="Choose date"]').click()
+  cy.get('[role="dialog"]').filter(':visible').last().within(() => {
+    cy.contains('button', /^15$/).click()
+    cy.contains('button', 'Select').click()
+  })
+}
+
 const samplePresentation: Presentation = {
   presentationId: 'p1',
   studyId: 's1',
@@ -52,7 +60,7 @@ describe('PresentationList component', () => {
       />,
     )
     cy.get('#title').type('New Title')
-    cy.get('#date').type('2024-07-15')
+    selectDate('date')
     cy.get('#url').type('https://example.org/new')
     cy.get('#authors').type('Author One; Author Two')
     cy.get('#datasetCitation').type('Dataset Y')
@@ -76,6 +84,7 @@ describe('PresentationList component', () => {
       cy.contains(samplePresentation.title).should('exist')
       cy.get('#title').should('be.disabled')
       cy.get('#date').should('be.disabled')
+      cy.get('#date').should('have.value', samplePresentation.date)
       cy.get('.collaborator-form-add-save-button').should('not.exist')
       cy.get('.collaborator-form-cancel-button').contains('Close').should('exist')
     })
@@ -94,7 +103,7 @@ describe('PresentationList component', () => {
     cy.get('#add-presentation-btn').click()
     cy.contains('New Presentation').should('exist')
     cy.get('#title').type('Added Talk')
-    cy.get('#date').type('2024-08-20')
+    selectDate('date')
     cy.get('#url').type('https://example.org/added')
     cy.get('#authors').type('Auth A')
     cy.get('#datasetCitation').type('Dataset Added')

--- a/cypress/component/StudyAssets/publication_list.spec.tsx
+++ b/cypress/component/StudyAssets/publication_list.spec.tsx
@@ -6,6 +6,14 @@ import PublicationSummary from 'src/components/publications_list/PublicationSumm
 import { Publication, Author } from 'src/types/model'
 import { testDeleteViaModal } from './testUtils'
 
+const selectDate = (fieldId: string) => {
+  cy.get(`#${fieldId}`).parent().find('button[aria-label*="Choose date"]').click()
+  cy.get('[role="dialog"]').filter(':visible').last().within(() => {
+    cy.contains('button', /^15$/).click()
+    cy.contains('button', 'Select').click()
+  })
+}
+
 const authorsSample: Author[] = [
   { name: 'Author One', orcId: '0000-0000-0000-0001' },
   { name: 'Author Two', orcId: '0000-0000-0000-0002' },
@@ -61,7 +69,7 @@ describe('PublicationList component', () => {
     )
 
     cy.get('#title').type('New Pub')
-    cy.get('#publishedDate').type('2024-07-15')
+    selectDate('publishedDate')
     cy.get('#pubmedId').type('99999')
     cy.get('#bibliographicCitation').type('Bib Cit X')
     cy.get('#datasetCitation').type('Dataset Cit X')
@@ -88,6 +96,7 @@ describe('PublicationList component', () => {
     cy.contains(samplePublication.title).should('exist')
     cy.get('#title').should('be.disabled')
     cy.get('#publishedDate').should('be.disabled')
+    cy.get('#publishedDate').should('have.value', samplePublication.publishedDate)
     cy.get('.collaborator-form-add-save-button').should('not.exist')
     cy.get('.collaborator-form-cancel-button').contains('Close').should('exist')
   })

--- a/src/components/DuosDatePicker.tsx
+++ b/src/components/DuosDatePicker.tsx
@@ -16,11 +16,13 @@ import dayjs, { Dayjs } from 'dayjs'
 import '@mui/x-date-pickers/themeAugmentation'
 
 interface DUOSDatePickerProps {
+  id?: string
   inputFormat: string
-  defaultValue: Dayjs | string | null
+  defaultValue: Dayjs | string | number | Date | null | undefined
   onChange: (value: Dayjs | string | undefined) => void
   onError: (error: DateValidationError | null, value: Dayjs | string | undefined) => void
   readOnly: boolean
+  disabled?: boolean
 }
 
 const WeekendFormattedDay = (props: PickerDayProps) => {
@@ -61,14 +63,18 @@ const CancelSelectActionBar = (props: PickersActionBarProps) => {
 }
 
 export const DuosDatePicker = (props: DUOSDatePickerProps) => {
-  const { inputFormat, defaultValue, onChange, onError, readOnly } = props
+  const { id, inputFormat, defaultValue, onChange, onError, readOnly, disabled } = props
   const duosColorBlue = '#216FB4'
 
   // Convert defaultValue to Dayjs object if it's a string, or use it directly if it's already Dayjs
   const defaultValueAsDayjs = useMemo(() => {
-    if (!defaultValue) return dayjs()
+    if (!defaultValue) return null
     if (typeof defaultValue === 'string') {
       const parsed = dayjs(defaultValue, inputFormat)
+      return parsed.isValid() ? parsed : null
+    }
+    if (typeof defaultValue === 'number' || defaultValue instanceof Date) {
+      const parsed = dayjs(defaultValue)
       return parsed.isValid() ? parsed : null
     }
     return defaultValue
@@ -217,7 +223,11 @@ export const DuosDatePicker = (props: DUOSDatePickerProps) => {
             onError={(error, value) => onError?.(error, value?.format(inputFormat))}
             dayOfWeekFormatter={day => (`${day.format('ddd')}`)}
             readOnly={readOnly}
+            disabled={disabled}
             slotProps={{
+              textField: {
+                id,
+              },
               actionBar: {
                 actions: ['cancel', 'accept'],
               },

--- a/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
+++ b/src/components/clinical_trial_list/ClinicalTrialAddEdit.tsx
@@ -195,8 +195,8 @@ export default function ClinicalTrialAddEdit(props: ClinicalTrialAddEditProps): 
           <FormField
             id="startDate"
             title="Start Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={clinicalTrial?.startDate}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.REQUIRED, FormValidators.DATE]}
             onChange={onChange}
             validation={validation.startDate}
@@ -205,8 +205,8 @@ export default function ClinicalTrialAddEdit(props: ClinicalTrialAddEditProps): 
           <FormField
             id="endDate"
             title="End Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={clinicalTrial?.endDate}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.DATE]}
             onChange={onChange}
             validation={validation.endDate}

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -532,8 +532,8 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                     <FormField
                       id="morText"
                       name="morDate"
+                      type={FormFieldTypes.CALENDAR}
                       validators={[FormValidators.REQUIRED, FormValidators.DATE]}
-                      placeholder="Please specify date (YYYY-MM-DD)"
                       defaultValue={morText}
                       onChange={({ key, value }: { key: string, value: string }) => {
                         onChange({ key: key, value: value })

--- a/src/components/forms/formComponents.css
+++ b/src/components/forms/formComponents.css
@@ -92,6 +92,82 @@
 }
 
 /* ----------------------------------------------------
+  formDatePicker
+------------------------------------------------------*/
+.form-calendar {
+  position: relative;
+  width: 100%;
+}
+
+.form-calendar .MuiFormControl-root,
+.form-calendar .MuiPickersTextField-root,
+.form-calendar .MuiPickersInputBase-root {
+  width: 100%;
+}
+
+.form-calendar .MuiPickersInputBase-root {
+  background-color: #fff;
+  border-color: #ccc;
+  color: #555555;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.42857143;
+  min-height: 40px;
+}
+
+.form-calendar .MuiPickersInputBase-input {
+  box-sizing: border-box;
+  color: #555555;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.42857143;
+  padding: 8px 46px 8px 15px;
+}
+
+.form-calendar .MuiInputLabel-root {
+  color: #555555;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 14px;
+}
+
+.form-calendar.disabled .MuiPickersInputBase-input,
+.form-calendar.readonly .MuiPickersInputBase-input {
+  -webkit-text-fill-color: #555555;
+  color: #555555;
+  opacity: 1;
+  padding: 16px 46px 16px 15px;
+}
+
+.form-calendar.disabled .MuiPickersInputBase-root,
+.form-calendar.readonly .MuiPickersInputBase-root {
+  background-color: #eeeeee;
+  color: #555555;
+  min-height: 52px;
+  opacity: 1;
+  padding-right: 8px;
+}
+
+.form-calendar.disabled .MuiInputLabel-root,
+.form-calendar.readonly .MuiInputLabel-root {
+  color: #555555;
+}
+
+.form-calendar.disabled,
+.form-calendar.readonly {
+  cursor: not-allowed;
+  margin-bottom: 1rem;
+}
+
+.form-calendar.disabled .MuiPickersInputBase-root,
+.form-calendar.disabled .MuiPickersInputBase-input,
+.form-calendar.disabled button,
+.form-calendar.readonly .MuiPickersInputBase-root,
+.form-calendar.readonly .MuiPickersInputBase-input,
+.form-calendar.readonly button {
+  cursor: not-allowed;
+}
+
+/* ----------------------------------------------------
   formInputFile
 ------------------------------------------------------*/
 .form-file-upload {
@@ -149,4 +225,3 @@
   justify-content: flex-end;
   background: red;
 }
-

--- a/src/components/forms/formComponents.jsx
+++ b/src/components/forms/formComponents.jsx
@@ -554,7 +554,7 @@ export const FormDatePicker = (config) => {
     readOnly ? 'readonly' : '',
   ].filter(Boolean).join(' ')
   return (
-    <div className={`form-calendar ${stateClassNames} ${!isValid(validation) ? 'errored' : ''}`}>
+    <div className={`form-calendar ${stateClassNames} ${isValid(validation) ? '' : 'errored'}`}>
       <DuosDatePicker
         id={id}
         label={label}

--- a/src/components/forms/formComponents.jsx
+++ b/src/components/forms/formComponents.jsx
@@ -548,10 +548,15 @@ export const FormInputFile = (config) => {
 }
 
 export const FormDatePicker = (config) => {
-  const { label, formValue, validation, readOnly } = config
+  const { id, label, formValue, validation, readOnly, disabled } = config
+  const stateClassNames = [
+    disabled ? 'disabled' : '',
+    readOnly ? 'readonly' : '',
+  ].filter(Boolean).join(' ')
   return (
-    <div className={`form-calendar ${!isValid(validation) ? 'errored' : ''}`}>
+    <div className={`form-calendar ${stateClassNames} ${!isValid(validation) ? 'errored' : ''}`}>
       <DuosDatePicker
+        id={id}
         label={label}
         onChange={(value) => { onFormInputChange(config, value) }}
         onError={(_error, value) => { updateValidation(config, value) }}
@@ -559,6 +564,7 @@ export const FormDatePicker = (config) => {
         inputFormat="YYYY-MM-DD"
         highlightWeekends={true}
         readOnly={readOnly}
+        disabled={disabled}
       />
       {errorMessages(validation)}
     </div>

--- a/src/components/forms/forms.jsx
+++ b/src/components/forms/forms.jsx
@@ -32,7 +32,6 @@ import {
   requiredValidator,
   urlValidator,
 } from './formValidation'
-import dayjs from 'dayjs'
 
 // ----------------------------------------------------------------------------------------------------- //
 // ======                                  MAIN FORM FIELD TYPES                                  ====== //
@@ -184,7 +183,7 @@ export const FormFieldTypes = {
     ],
   },
   CALENDAR: {
-    defaultValue: dayjs(),
+    defaultValue: null,
     component: FormDatePicker,
     requiredProps: [],
     optionalProps: ['readOnly'],

--- a/src/components/funding_resource_list/FundingResourceAddEdit.tsx
+++ b/src/components/funding_resource_list/FundingResourceAddEdit.tsx
@@ -147,8 +147,8 @@ export default function FundingResourceAddEdit(props: FundingSourceAddEditProps)
           <FormField
             id="startDate"
             title="Start Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={fundingResource?.startDate}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.DATE]}
             onChange={onChange}
             validation={validation.startDate}
@@ -157,8 +157,8 @@ export default function FundingResourceAddEdit(props: FundingSourceAddEditProps)
           <FormField
             id="endDate"
             title="End Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={fundingResource?.endDate}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.DATE]}
             onChange={onChange}
             validation={validation.endDate}

--- a/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
+++ b/src/components/intellectual_property_list/IntellectualPropertyAddEdit.tsx
@@ -166,8 +166,8 @@ export default function IntellectualPropertyAddEdit(props: IntellectualPropertyA
           <FormField
             id="filingDate"
             title="Filing Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={intellectualProperty?.filingDate}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.REQUIRED, FormValidators.DATE]}
             onChange={onChange}
             validation={validation.filingDate}

--- a/src/components/presentations_list/PresentationAddEdit.tsx
+++ b/src/components/presentations_list/PresentationAddEdit.tsx
@@ -148,8 +148,8 @@ export default function PresentationAddEdit(props: PresentationAddEditProps): Re
           <FormField
             id="date"
             title="Presentation Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={newPresentation.date}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.REQUIRED, FormValidators.DATE]}
             onChange={onChange}
             validation={(submitted || touched.date) ? validation.date : undefined}

--- a/src/components/publications_list/PublicationAddEdit.tsx
+++ b/src/components/publications_list/PublicationAddEdit.tsx
@@ -85,7 +85,7 @@ function AuthorsFieldset({
 }) {
   return (
     <div style={{ marginBottom: '1rem', width: '100%' }}>
-      <fieldset style={{ fontWeight: 600, marginTop: '1rem' }} aria-label="Authors (Name + ORCID)">
+      <fieldset style={{ fontWeight: 600, marginTop: '4rem' }} aria-label="Authors (Name + ORCID)">
         <legend style={{ fontSize: 16 }}>Authors (Name + ORCID)*</legend>
         {(submitted || touched.authors) && validation.authors && (
           <div className="error-message">
@@ -262,8 +262,8 @@ export default function PublicationAddEdit(props: PublicationAddEditProps): Reac
           <FormField
             id="publishedDate"
             title="Publication Date"
+            type={FormFieldTypes.CALENDAR}
             defaultValue={newPublication.publishedDate}
-            placeholder="YYYY-MM-DD"
             validators={[FormValidators.REQUIRED, FormValidators.DATE]}
             onChange={onChange}
             validation={(submitted || touched.publishedDate) ? validation.publishedDate : undefined}

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -113,12 +113,12 @@ export const generateStudyPropertyFormDateField = (formData: Study, setStudy: Re
     <FormField
       id={studyProperty.key}
       title={studyProperty.fieldTitle}
-      placeholder={studyProperty.fieldPlaceholderText}
+      type={FormFieldTypes.CALENDAR}
       validators={validators}
       style={style}
       defaultValue={convertDateEpochToString(getStudyPropertyValueByKey(formData, studyProperty.key))}
       onChange={(input: { key: string, value: unknown, isValid: boolean }) => {
-        studyProperty.value = input.value as Date
+        studyProperty.value = input.value as string
         setStudyPropertyByKey(formData, setStudy, input, studyProperty)
       }}
     />


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2776

### Summary

This PR does the following:
- Replaced free-text date inputs with DUOS date picker controls in V2 study registration and study asset forms.
- Updated date picker styling to match existing form fields, including disabled/read-only states.
- Added/updated component tests for date picker selection and existing value display.

**Before**
<img width="1783" height="541" alt="Before" src="https://github.com/user-attachments/assets/2656e2f4-5885-4270-94f2-e834a810dcac" />

**After**
<img width="1783" height="754" alt="After" src="https://github.com/user-attachments/assets/ad5e554e-b9b5-458b-8756-49fc8ff67d2b" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
