### PR TITLE
[DT-3218]  Fix empty dataset rows in Signing Official DAR expansion

### DIFF
--- a/cypress/component/DarCollectionTable/dar_collection_table.spec.jsx
+++ b/cypress/component/DarCollectionTable/dar_collection_table.spec.jsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { DarCollectionTable } from 'src/components/dar_collection_table/DarCollectionTable'
-import { DarCollectionTableColumnOptions } from 'src/utils/DarCollectionUtils.js'
+import { DarCollectionTableColumnOptions, consoleTypes } from 'src/utils/DarCollectionUtils.js'
+import { Collections } from 'src/libs/ajax/Collections'
+import { Match } from 'src/libs/ajax/Match'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { MemoryRouter } from 'react-router-dom'
+import darCollection from './darCollection.json'
 
 const collections = [
   {
@@ -11,6 +16,10 @@ const collections = [
 ]
 
 describe('DarCollectionTable - Tests', function () {
+  beforeEach(() => {
+    cy.initApplicationConfig()
+  })
+
   it('renders a single column of the data', function () {
     const columns = [
       DarCollectionTableColumnOptions.DAR_CODE,
@@ -56,5 +65,43 @@ describe('DarCollectionTable - Tests', function () {
     )
     cy.get('.table-data').should('exist')
     cy.get('.table-loading-placeholder').should('exist')
+  })
+
+  it('shows datasets when expanded in signing official console', function () {
+    const columns = [
+      DarCollectionTableColumnOptions.DAR_CODE,
+      DarCollectionTableColumnOptions.DATASET_COUNT,
+    ]
+
+    cy.stub(Collections, 'getCollectionById').resolves(darCollection)
+    cy.stub(Match, 'findMatchBatch').resolves([])
+    cy.stub(DataSet, 'searchDatasetIndex').resolves([{
+      datasetId: 2352,
+      datasetIdentifier: 'DUOS-000850',
+      dataUse: {
+        primary: [{ code: 'GRU', description: 'General Research Use' }],
+        secondary: [{ code: 'NPU', description: 'Non-Profit Use' }],
+      },
+      dacId: 8,
+      dac: { dacId: 8, name: 'DAC 8' },
+    }])
+
+    cy.mount(
+      <MemoryRouter>
+        <DarCollectionTable
+          collections={collections}
+          columns={columns}
+          isRendered={true}
+          isLoading={false}
+          cancelCollection={null}
+          reviseCollection={null}
+          actionsDisabled={false}
+          consoleType={consoleTypes.SIGNING_OFFICIAL}
+        />
+      </MemoryRouter>,
+    )
+
+    cy.get('#211_dropdown').click()
+    cy.contains('DUOS-000850').should('exist')
   })
 })

--- a/src/components/dar_collection_table/DarCollectionTable.jsx
+++ b/src/components/dar_collection_table/DarCollectionTable.jsx
@@ -144,7 +144,9 @@ export const DarCollectionTable = function DarCollectionTable(props) {
     openCollection, goToVote, consoleType, relevantDatasets, deleteDraft,
     approveCollection,
   } = props
-  const isUnfilteredView = consoleType === consoleTypes.ADMIN || consoleType === consoleTypes.RESEARCHER
+  const isUnfilteredView = consoleType === consoleTypes.ADMIN
+    || consoleType === consoleTypes.RESEARCHER
+    || consoleType === consoleTypes.SIGNING_OFFICIAL
 
   /*
     NOTE: This component will most likely be used in muliple consoles


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3218

### Summary

This updates DAR expansion behavior for the Signing Official console so expanded dataset tables are shown in unfiltered mode (same as admin/researcher).  

Previously, expanded rows could appear empty when DAC-based filtering removed all datasets for the current SO user context. Including `SIGNING_OFFICIAL` in i`sUnfilteredView` ensures the full DAR dataset list is displayed reliably in the expanded view.

<img width="1783" height="689" alt="After" src="https://github.com/user-attachments/assets/aa4870b2-2aa1-4dc3-ade1-a3f9aa8ca235" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
