### PR TITLE
DT-3624: Change coverage reporter action

### DIFF
--- a/.github/workflows/component-tests.yml
+++ b/.github/workflows/component-tests.yml
@@ -29,26 +29,13 @@ jobs:
         run: pnpm ci
       - name: Run Vitest
         run: pnpm run test:coverage
-      - name: Upload coverage artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-report
-          path: |
-            coverage/coverage-report.xml
-          if-no-files-found: warn
       - name: Publish coverage report to PR
-        if: github.event_name == 'pull_request' && always()
-        uses: 5monkeys/cobertura-action@ee5787cc56634acddedc51f21c7947985531e6eb # v14
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@02f3c2e641286b7fa308cd3e430783103ce6103b # v2.12.0
         with:
-          path: coverage/coverage-report.xml
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          report_name: DUOS Coverage Report
-          minimum_coverage: 0
-          show_line: true
-          show_branch: true
-          show_class_names: true
-          only_changed_files: true
+          name: DUOS Coverage Report
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json
   cypress-run:
     runs-on: ubuntu-latest
     permissions:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     exclude: ['build/**', 'cypress/**', 'node_modules/**', 'server/**'],
     coverage: {
       provider: 'v8',
-      reporter: [['cobertura', { file: 'coverage-report.xml' }]],
+      reporter: ['json-summary', 'json'],
     },
   },
 })


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3624

## Summary
Swaps the `5monkeys/cobertura-action` PR coverage reporter for [davelosert/vitest-coverage-report-action](https://github.com/davelosert/vitest-coverage-report-action), which has native vitest support and is actively maintained.

### Changes:

- `vitest.config.ts`: replace cobertura reporter with json-summary + json (the formats the new action reads)
- `component-tests.yml`: remove the XML artifact upload step and replace the publish step with `davelosert/vitest-coverage-report-action@v2.12.0` (the exact hash is pinned to this version)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
