### PR TITLE
[DT-3613] Fix `datasetIdentifier` search

### DIFF
--- a/src/components/data_library/assets/datasetAsset.ts
+++ b/src/components/data_library/assets/datasetAsset.ts
@@ -35,6 +35,7 @@ export const datasetAsset: AssetDefinition = {
     'study.dataTypes',
     'dataUse.primary.code',
     'dataUse.secondary.code',
+    'datasetIdentifier',
   ],
 
   buildQuery(

--- a/test/hooks/useLibraryData.spec.tsx
+++ b/test/hooks/useLibraryData.spec.tsx
@@ -144,6 +144,7 @@ describe('buildElasticsearchQuery', () => {
     expect(query.query?.bool.must).toHaveLength(2)
     const secondClause = query.query?.bool.must?.[1] as MultiMatchQuery
     expect(secondClause.multi_match.query).toEqual('breast cancer')
+    expect(secondClause.multi_match.fields).toContain('datasetIdentifier')
   })
 
   it('adds access management filters', () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3613

### Summary

This PR fixes the searching of `datasetIdentifier` in the data library

<img width="1783" height="956" alt="After" src="https://github.com/user-attachments/assets/7e496376-bc10-49db-ae68-b9ce3b2e5f16" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
