### PR TITLE
[DT-2614] Convert `ModalWrapper.jsx` to TypeScript

### DIFF
--- a/src/components/collaborator_list/ModalWrapper.jsx
+++ b/src/components/collaborator_list/ModalWrapper.jsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import Modal from 'react-modal'
-
-export default function ModalWrapper(props) {
-  return <Modal {...props} />
-}

--- a/src/components/collaborator_list/ModalWrapper.tsx
+++ b/src/components/collaborator_list/ModalWrapper.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import Modal, { Props } from 'react-modal'
+
+export default function ModalWrapper(props: Readonly<Props>): React.ReactElement {
+  return <Modal {...props} />
+}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2614

### Summary

This PR converts the `ModalWrapper.jsx` component to TypeScript. Test file already had comprehensive vitest coverage.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
