### PR TITLE
DT-400: Update dompurify library

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
     "dayjs": "1.11.21",
-    "dompurify": "3.4.10",
+    "dompurify": "3.4.11",
     "oidc-client-ts": "3.5.0",
     "query-string": "9.4.0",
     "react": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 1.11.21
         version: 1.11.21
       dompurify:
-        specifier: 3.4.10
-        version: 3.4.10
+        specifier: 3.4.11
+        version: 3.4.11
       oidc-client-ts:
         specifier: 3.5.0
         version: 3.5.0
@@ -1473,8 +1473,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -4808,7 +4808,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.10:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-400

### Summary
Fixes this audit finding:

```
pnpm audit --prod
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ DOMPurify: Permanent `ALLOWED_ATTR` pollution via      │
│                     │ `setConfig()` bypassing the hook clone-guard           │
│                     │ (incomplete fix of the 3.4.7 hook-pollution patch)     │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ dompurify                                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=3.4.10                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.4.11                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>dompurify                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-cmwh-pvxp-8882      │
└─────────────────────┴────────────────────────────────────────────────────────┘
1 vulnerabilities found
Severity: 1 moderate
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
