### PR TITLE
[DT-2840] consolidate SO closeout/approver fields.

### DIFF
--- a/src/pages/dar_application/ProgressReportApplication.tsx
+++ b/src/pages/dar_application/ProgressReportApplication.tsx
@@ -198,7 +198,7 @@ export const ProgressReportApplication = ({ dar, datasets, readOnlyMode = true, 
   const isCloseoutReview = () => {
     const user = Storage.getCurrentUser()
     const isSameUserId = user.userId === dar.closeoutSupplement?.signingOfficialId
-    const isCloseoutApproved = dar.closeoutSigningOfficialApprovedDate !== undefined
+    const isCloseoutApproved = dar.approvingSigningOfficialApprovedDate !== undefined
     return readOnlyMode
       && (
         (user.isSigningOfficial && isSameUserId && !isCloseoutApproved)

--- a/src/pages/progress_reports/CloseoutReview.tsx
+++ b/src/pages/progress_reports/CloseoutReview.tsx
@@ -20,7 +20,7 @@ export const CloseoutReview: React.FC<CloseoutReviewProps> = ({
 
   const onApprove = async (): Promise<void> => {
     const user = Storage.getCurrentUser()
-    const isCloseoutApproved = dar.closeoutSigningOfficialApprovedDate !== undefined
+    const isCloseoutApproved = dar.approvingSigningOfficialApprovedDate !== undefined
 
     if (user.isSigningOfficial && !isCloseoutApproved) {
       await DAR.approveCloseout(dar.referenceId)

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -708,6 +708,8 @@ export interface DarCollectionSummary {
   referenceIds: string[]
   requiresSOApproval: boolean
   researcherName: string
+  soApproverId?: number
+  soApproverTimestamp?: number
   status: string
   submissionDate: number
 }
@@ -729,8 +731,8 @@ export interface DataAccessRequest {
   datasetIds: number[]
   elections: Record<number, Election>
   eraCommonsId: string
-  closeoutSigningOfficialApprovedDate?: number
-  closeoutSigningOfficialApprovedUserId?: number
+  approvingSigningOfficialApprovedDate?: number
+  approvingSigningOfficialUserId?: number
 }
 
 export interface DataAccessRequestData {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-2840](https://broadworkbench.atlassian.net/browse/DT-2840)

### Summary

model.ts (DataAccessRequest): renamed closeoutSigningOfficialApprovedDate → approvingSigningOfficialApprovedDate and closeoutSigningOfficialApprovedUserId → approvingSigningOfficialUserId.
model.ts (DarCollectionSummary): added soApproverId and soApproverTimestamp fields.
CloseoutReview.tsx, ProgressReportApplication.tsx: updated to check dar.approvingSigningOfficialApprovedDate.

#### Note
Requires backend changes in the PR here: [https://github.com/DataBiosphere/consent/pull/2942](https://github.com/DataBiosphere/consent/pull/2942)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
