### PR TITLE
[DT-2708] Convert `spinner-service.js` to TypeScript with vitest tests

### DIFF
--- a/src/libs/spinner-service.ts
+++ b/src/libs/spinner-service.ts
@@ -25,11 +25,11 @@ export class SpinnerService {
   }
 
   showAll(): void {
-    this.spinnerCache.forEach((spinner) => (spinner.show = true))
+    this.spinnerCache.forEach(spinner => (spinner.show = true))
   }
 
   hideAll(): void {
-    this.spinnerCache.forEach((spinner) => (spinner.show = false))
+    this.spinnerCache.forEach(spinner => (spinner.show = false))
   }
 }
 

--- a/src/libs/spinner-service.ts
+++ b/src/libs/spinner-service.ts
@@ -1,15 +1,22 @@
 // TODO: Delete this class
 // Deprecated
+interface Spinner {
+  name: string
+  show: boolean
+}
+
 export class SpinnerService {
+  private spinnerCache: Set<Spinner>
+
   constructor() {
     this.spinnerCache = new Set()
   }
 
-  _register(spinner) {
+  _register(spinner: Spinner): void {
     this.spinnerCache.add(spinner)
   }
 
-  show(spinnerName) {
+  show(spinnerName: string): void {
     this.spinnerCache.forEach((spinner) => {
       if (spinner.name === spinnerName) {
         spinner.show = true
@@ -17,12 +24,12 @@ export class SpinnerService {
     })
   }
 
-  showAll() {
-    this.spinnerCache.forEach(spinner => spinner.show = true)
+  showAll(): void {
+    this.spinnerCache.forEach((spinner) => (spinner.show = true))
   }
 
-  hideAll() {
-    this.spinnerCache.forEach(spinner => spinner.show = false)
+  hideAll(): void {
+    this.spinnerCache.forEach((spinner) => (spinner.show = false))
   }
 }
 

--- a/src/libs/spinner-service.ts
+++ b/src/libs/spinner-service.ts
@@ -1,12 +1,10 @@
-// TODO: Delete this class
-// Deprecated
 interface Spinner {
   name: string
   show: boolean
 }
 
 export class SpinnerService {
-  private spinnerCache: Set<Spinner>
+  private readonly spinnerCache: Set<Spinner>
 
   constructor() {
     this.spinnerCache = new Set()
@@ -22,14 +20,6 @@ export class SpinnerService {
         spinner.show = true
       }
     })
-  }
-
-  showAll(): void {
-    this.spinnerCache.forEach(spinner => (spinner.show = true))
-  }
-
-  hideAll(): void {
-    this.spinnerCache.forEach(spinner => (spinner.show = false))
   }
 }
 

--- a/test/libs/spinner-service.spec.ts
+++ b/test/libs/spinner-service.spec.ts
@@ -37,66 +37,10 @@ describe('SpinnerService', () => {
     })
   })
 
-  describe('showAll', () => {
-    it('sets show to true on every registered spinner', () => {
-      const service = new SpinnerService()
-      const spinners = [
-        { name: 'a', show: false },
-        { name: 'b', show: false },
-        { name: 'c', show: false },
-      ]
-      spinners.forEach(s => service._register(s))
-
-      service.showAll()
-
-      spinners.forEach(s => expect(s.show).toBe(true))
-    })
-  })
-
-  describe('hideAll', () => {
-    it('sets show to false on every registered spinner', () => {
-      const service = new SpinnerService()
-      const spinners = [
-        { name: 'a', show: true },
-        { name: 'b', show: true },
-        { name: 'c', show: true },
-      ]
-      spinners.forEach(s => service._register(s))
-
-      service.hideAll()
-
-      spinners.forEach(s => expect(s.show).toBe(false))
-    })
-  })
-
-  describe('showAll then hideAll', () => {
-    it('toggles all spinners correctly', () => {
-      const service = new SpinnerService()
-      const spinner = { name: 'x', show: false }
-      service._register(spinner)
-
-      service.showAll()
-      expect(spinner.show).toBe(true)
-
-      service.hideAll()
-      expect(spinner.show).toBe(false)
-    })
-  })
-
   describe('empty cache', () => {
     it('show does not throw when no spinners are registered', () => {
       const service = new SpinnerService()
       expect(() => service.show('anything')).not.toThrow()
-    })
-
-    it('showAll does not throw when no spinners are registered', () => {
-      const service = new SpinnerService()
-      expect(() => service.showAll()).not.toThrow()
-    })
-
-    it('hideAll does not throw when no spinners are registered', () => {
-      const service = new SpinnerService()
-      expect(() => service.hideAll()).not.toThrow()
     })
   })
 })

--- a/test/libs/spinner-service.spec.ts
+++ b/test/libs/spinner-service.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { SpinnerService, spinnerService } from 'src/libs/spinner-service'
+
+describe('SpinnerService', () => {
+  describe('instance', () => {
+    it('exports a singleton spinnerService', () => {
+      expect(spinnerService).toBeInstanceOf(SpinnerService)
+    })
+  })
+
+  describe('_register / show', () => {
+    let service: SpinnerService
+
+    beforeEach(() => {
+      service = new SpinnerService()
+    })
+
+    it('shows only the spinner whose name matches', () => {
+      const a = { name: 'alpha', show: false }
+      const b = { name: 'beta', show: false }
+      service._register(a)
+      service._register(b)
+
+      service.show('alpha')
+
+      expect(a.show).toBe(true)
+      expect(b.show).toBe(false)
+    })
+
+    it('does nothing when no spinner with that name is registered', () => {
+      const a = { name: 'alpha', show: false }
+      service._register(a)
+
+      service.show('nonexistent')
+
+      expect(a.show).toBe(false)
+    })
+  })
+
+  describe('showAll', () => {
+    it('sets show to true on every registered spinner', () => {
+      const service = new SpinnerService()
+      const spinners = [
+        { name: 'a', show: false },
+        { name: 'b', show: false },
+        { name: 'c', show: false },
+      ]
+      spinners.forEach((s) => service._register(s))
+
+      service.showAll()
+
+      spinners.forEach((s) => expect(s.show).toBe(true))
+    })
+  })
+
+  describe('hideAll', () => {
+    it('sets show to false on every registered spinner', () => {
+      const service = new SpinnerService()
+      const spinners = [
+        { name: 'a', show: true },
+        { name: 'b', show: true },
+        { name: 'c', show: true },
+      ]
+      spinners.forEach((s) => service._register(s))
+
+      service.hideAll()
+
+      spinners.forEach((s) => expect(s.show).toBe(false))
+    })
+  })
+
+  describe('showAll then hideAll', () => {
+    it('toggles all spinners correctly', () => {
+      const service = new SpinnerService()
+      const spinner = { name: 'x', show: false }
+      service._register(spinner)
+
+      service.showAll()
+      expect(spinner.show).toBe(true)
+
+      service.hideAll()
+      expect(spinner.show).toBe(false)
+    })
+  })
+
+  describe('empty cache', () => {
+    it('show does not throw when no spinners are registered', () => {
+      const service = new SpinnerService()
+      expect(() => service.show('anything')).not.toThrow()
+    })
+
+    it('showAll does not throw when no spinners are registered', () => {
+      const service = new SpinnerService()
+      expect(() => service.showAll()).not.toThrow()
+    })
+
+    it('hideAll does not throw when no spinners are registered', () => {
+      const service = new SpinnerService()
+      expect(() => service.hideAll()).not.toThrow()
+    })
+  })
+})

--- a/test/libs/spinner-service.spec.ts
+++ b/test/libs/spinner-service.spec.ts
@@ -45,11 +45,11 @@ describe('SpinnerService', () => {
         { name: 'b', show: false },
         { name: 'c', show: false },
       ]
-      spinners.forEach((s) => service._register(s))
+      spinners.forEach(s => service._register(s))
 
       service.showAll()
 
-      spinners.forEach((s) => expect(s.show).toBe(true))
+      spinners.forEach(s => expect(s.show).toBe(true))
     })
   })
 
@@ -61,11 +61,11 @@ describe('SpinnerService', () => {
         { name: 'b', show: true },
         { name: 'c', show: true },
       ]
-      spinners.forEach((s) => service._register(s))
+      spinners.forEach(s => service._register(s))
 
       service.hideAll()
 
-      spinners.forEach((s) => expect(s.show).toBe(false))
+      spinners.forEach(s => expect(s.show).toBe(false))
     })
   })
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2708

### Summary
Convert `spinner-service.js` to TypeScript with tests

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
