### PR TITLE
DT-3692: Add search filter to SO DAR pages

### DIFF
--- a/src/pages/signing_official_console/SigningOfficialDarApprovals.tsx
+++ b/src/pages/signing_official_console/SigningOfficialDarApprovals.tsx
@@ -48,9 +48,9 @@ export default function SigningOfficialDarApprovals(): React.JSX.Element {
     setCollections((prevList) => {
       const index = prevList.findIndex(c => c.darCollectionId === updatedCollection.darCollectionId)
       if (index === -1) return prevList
-      const newList = !updatedCollection.requiresSOApproval
-        ? prevList.filter((_, i) => i !== index)
-        : [...prevList.slice(0, index), updatedCollection, ...prevList.slice(index + 1)]
+      const newList = updatedCollection.requiresSOApproval
+        ? [...prevList.slice(0, index), updatedCollection, ...prevList.slice(index + 1)]
+        : prevList.filter((_, i) => i !== index)
       searchOnFilteredList(searchText, newList, filterFn, setFilteredList)
       return newList
     })

--- a/src/pages/signing_official_console/SigningOfficialDarApprovals.tsx
+++ b/src/pages/signing_official_console/SigningOfficialDarApprovals.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import { Notifications, USER_ROLES } from 'src/libs/utils'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import SearchBar from 'src/components/SearchBar'
+import { getSearchFilterFunctions, Notifications, searchOnFilteredList, USER_ROLES } from 'src/libs/utils'
 import { Styles } from 'src/libs/theme'
 import { Collections } from 'src/libs/ajax/Collections'
 import { DarCollectionTable } from 'src/components/dar_collection_table/DarCollectionTable'
@@ -11,10 +12,18 @@ import { DarCollectionSummary } from 'src/types/model'
 
 export default function SigningOfficialDarApprovals(): React.JSX.Element {
   usePageTitle('My DAR Approvals')
-  const [collectionList, setCollectionList] = useState<DarCollectionSummary[]>([])
+  const [collections, setCollections] = useState<DarCollectionSummary[]>([])
+  const [filteredList, setFilteredList] = useState<DarCollectionSummary[]>([])
+  const [searchText, setSearchText] = useState<string>('')
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const filterFn = useMemo(() => getSearchFilterFunctions().darCollections, [])
 
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.SIGNING_OFFICIAL)
+
+  const handleSearchChange = useCallback((searchTerms: string) => {
+    setSearchText(searchTerms)
+    searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList)
+  }, [collections, filterFn])
 
   useEffect(() => {
     const init = async (): Promise<void> => {
@@ -23,7 +32,8 @@ export default function SigningOfficialDarApprovals(): React.JSX.Element {
         const collectionList = (await Collections.getCollectionSummariesByRoleName(USER_ROLES.signingOfficial))
           .filter((collection: DarCollectionSummary) =>
             collection.requiresSOApproval || collection.actions.includes('Review_Progress_Report'))
-        setCollectionList(collectionList)
+        setCollections(collectionList)
+        setFilteredList(collectionList)
         setIsLoading(false)
       }
       catch {
@@ -35,17 +45,16 @@ export default function SigningOfficialDarApprovals(): React.JSX.Element {
   }, [])
 
   const updateCollections = useCallback((updatedCollection: DarCollectionSummary) => {
-    setCollectionList((prevList) => {
+    setCollections((prevList) => {
       const index = prevList.findIndex(c => c.darCollectionId === updatedCollection.darCollectionId)
       if (index === -1) return prevList
-      if (!updatedCollection.requiresSOApproval) {
-        return prevList.filter((_, i) => i !== index)
-      }
-      const newList = [...prevList]
-      newList[index] = updatedCollection
+      const newList = !updatedCollection.requiresSOApproval
+        ? prevList.filter((_, i) => i !== index)
+        : [...prevList.slice(0, index), updatedCollection, ...prevList.slice(index + 1)]
+      searchOnFilteredList(searchText, newList, filterFn, setFilteredList)
       return newList
     })
-  }, [])
+  }, [searchText, filterFn])
 
   const approveCollection = approveCollectionFn({
     updateCollections,
@@ -60,20 +69,21 @@ export default function SigningOfficialDarApprovals(): React.JSX.Element {
           description="Your Institution's Data Access Approvals: Records from all current data access approvals"
         />
       </div>
-      <div className="signing-official-tabs">
-        {responsiveColumns.length > 0 && (
-          <DarCollectionTable
-            key="so-dar-table"
-            collections={collectionList}
-            columns={responsiveColumns}
-            isLoading={isLoading}
-            cancelCollection={null}
-            reviseCollection={null}
-            approveCollection={approveCollection}
-            consoleType={consoleTypes.SIGNING_OFFICIAL}
-          />
-        )}
+      <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
+        <SearchBar handleSearchChange={handleSearchChange} />
       </div>
+      {responsiveColumns.length > 0 && (
+        <DarCollectionTable
+          key="so-dar-table"
+          collections={filteredList}
+          columns={responsiveColumns}
+          isLoading={isLoading}
+          cancelCollection={null}
+          reviseCollection={null}
+          approveCollection={approveCollection}
+          consoleType={consoleTypes.SIGNING_OFFICIAL}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/signing_official_console/SigningOfficialDarRequests.tsx
+++ b/src/pages/signing_official_console/SigningOfficialDarRequests.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect, useCallback } from 'react'
-import { Notifications, USER_ROLES } from 'src/libs/utils'
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import SearchBar from 'src/components/SearchBar'
+import { getSearchFilterFunctions, Notifications, searchOnFilteredList, USER_ROLES } from 'src/libs/utils'
 import { Styles } from 'src/libs/theme'
 import { Collections } from 'src/libs/ajax/Collections'
 import { DarCollectionTable } from 'src/components/dar_collection_table/DarCollectionTable'
-import { consoleTypes, approveCollectionFn } from 'src/utils/DarCollectionUtils'
+import { consoleTypes, approveCollectionFn, updateCollectionFn } from 'src/utils/DarCollectionUtils'
 import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCollectionColumns'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
@@ -11,18 +12,27 @@ import { DarCollectionSummary } from 'src/types/model'
 
 export default function SigningOfficialDarRequests(): React.JSX.Element {
   usePageTitle('Data Access Requests')
-  const [collectionList, setCollectionList] = useState<DarCollectionSummary[]>([])
+  const [collections, setCollections] = useState<DarCollectionSummary[]>([])
+  const [filteredList, setFilteredList] = useState<DarCollectionSummary[]>([])
+  const [searchText, setSearchText] = useState<string>('')
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const filterFn = useMemo(() => getSearchFilterFunctions().darCollections, [])
 
   // Get responsive columns for signing official console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.SIGNING_OFFICIAL)
+
+  const handleSearchChange = useCallback((searchTerms: string) => {
+    setSearchText(searchTerms)
+    searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList)
+  }, [collections, filterFn])
 
   useEffect(() => {
     const init = async (): Promise<void> => {
       try {
         setIsLoading(true)
         const collectionList = await Collections.getCollectionSummariesByRoleName(USER_ROLES.signingOfficial)
-        setCollectionList(collectionList)
+        setCollections(collectionList)
+        setFilteredList(collectionList)
         setIsLoading(false)
       }
       catch {
@@ -33,16 +43,10 @@ export default function SigningOfficialDarRequests(): React.JSX.Element {
     init()
   }, [])
 
-  const updateCollections = useCallback((updatedCollection: DarCollectionSummary) => {
-    setCollectionList((prevList) => {
-      const index = prevList.findIndex(c => c.darCollectionId === updatedCollection.darCollectionId)
-      if (index === -1) return prevList
-
-      const newList = [...prevList]
-      newList[index] = updatedCollection
-      return newList
-    })
-  }, [])
+  const updateCollections = useCallback(
+    (updatedCollection: DarCollectionSummary) => updateCollectionFn({ collections, filterFn, searchText, setCollections, setFilteredList })(updatedCollection),
+    [collections, filterFn, searchText],
+  )
 
   const approveCollection = approveCollectionFn({
     updateCollections,
@@ -57,20 +61,21 @@ export default function SigningOfficialDarRequests(): React.JSX.Element {
           description="Your Institution's Data Access Requests: Records from all current and closed data access requests"
         />
       </div>
-      <div className="signing-official-tabs">
-        {responsiveColumns.length > 0 && (
-          <DarCollectionTable
-            key="so-dar-table"
-            collections={collectionList}
-            columns={responsiveColumns}
-            isLoading={isLoading}
-            cancelCollection={null}
-            reviseCollection={null}
-            approveCollection={approveCollection}
-            consoleType={consoleTypes.SIGNING_OFFICIAL}
-          />
-        )}
+      <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
+        <SearchBar handleSearchChange={handleSearchChange} />
       </div>
+      {responsiveColumns.length > 0 && (
+        <DarCollectionTable
+          key="so-dar-table"
+          collections={filteredList}
+          columns={responsiveColumns}
+          isLoading={isLoading}
+          cancelCollection={null}
+          reviseCollection={null}
+          approveCollection={approveCollection}
+          consoleType={consoleTypes.SIGNING_OFFICIAL}
+        />
+      )}
     </div>
   )
 }

--- a/src/utils/DarCollectionUtils.ts
+++ b/src/utils/DarCollectionUtils.ts
@@ -245,7 +245,7 @@ export const updateCollectionFn = ({
   setFilteredList,
 }: {
   collections: DarCollectionSummary[]
-  filterFn: (searchText: string | undefined, collections: DarCollectionSummary[]) => DarCollectionSummary[]
+  filterFn: (searchText: string, collections: DarCollectionSummary[]) => DarCollectionSummary[]
   searchText?: string
   setCollections: (collections: DarCollectionSummary[]) => void
   setFilteredList: (collections: DarCollectionSummary[]) => void
@@ -262,7 +262,7 @@ export const updateCollectionFn = ({
     else {
       const collectionsCopy = cloneDeep(collections)
       collectionsCopy[targetIndex] = updatedCollection
-      const updatedFilteredList = filterFn(searchText, collectionsCopy)
+      const updatedFilteredList = filterFn(searchText ?? '', collectionsCopy)
       setCollections(collectionsCopy)
       setFilteredList(updatedFilteredList)
     }

--- a/test/pages/signing_official_console/SigningOfficialDarApprovals.spec.tsx
+++ b/test/pages/signing_official_console/SigningOfficialDarApprovals.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import '@testing-library/jest-dom/vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import SigningOfficialDarApprovals from 'src/pages/signing_official_console/SigningOfficialDarApprovals'
 import { Collections } from 'src/libs/ajax/Collections'
@@ -14,6 +14,16 @@ type MockDarCollectionTableProps = {
   isLoading: boolean
   consoleType: string
 }
+
+vi.mock('src/components/SearchBar', () => ({
+  default: ({ handleSearchChange }: { handleSearchChange: (value: string) => void }) => (
+    <input
+      type="text"
+      aria-label="search"
+      onChange={e => handleSearchChange(e.target.value)}
+    />
+  ),
+}))
 
 vi.mock('src/hooks/useResponsiveDarCollectionColumns', () => ({
   useResponsiveDarCollectionColumns: vi.fn(() => ['darCode', 'actions']),
@@ -125,5 +135,45 @@ describe('SigningOfficialDarApprovals', () => {
     expect(document.querySelector('#signingOfficial-approve-2')).not.toBeInTheDocument()
     expect(document.querySelector('#signingOfficial-approve-3')).toBeInTheDocument()
     expect(document.querySelector('#signingOfficial-approve-3')).toHaveTextContent('Approve')
+  })
+
+  it('renders a search bar', async () => {
+    render(<SigningOfficialDarApprovals />)
+    await screen.findByTestId('dar-collection-table')
+    expect(screen.getByRole('textbox', { name: /search/i })).toBeInTheDocument()
+  })
+
+  it('filters the approval list by search term', async () => {
+    render(<SigningOfficialDarApprovals />)
+    // DAR-1 and DAR-3 pass the requiresSOApproval filter; DAR-2 is already excluded
+    await screen.findByText('DAR-3')
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: 'DAR-1' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DAR-1')).toBeInTheDocument()
+      expect(screen.queryByText('DAR-3')).not.toBeInTheDocument()
+    })
+  })
+
+  it('restores the approval list when search is cleared', async () => {
+    render(<SigningOfficialDarApprovals />)
+    await screen.findByText('DAR-3')
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: 'DAR-1' },
+    })
+    await waitFor(() => expect(screen.queryByText('DAR-3')).not.toBeInTheDocument())
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: '' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DAR-1')).toBeInTheDocument()
+      expect(screen.getByText('DAR-3')).toBeInTheDocument()
+    })
   })
 })

--- a/test/pages/signing_official_console/SigningOfficialDarRequests.spec.tsx
+++ b/test/pages/signing_official_console/SigningOfficialDarRequests.spec.tsx
@@ -16,6 +16,16 @@ type MockDarCollectionTableProps = {
   consoleType: string
 }
 
+vi.mock('src/components/SearchBar', () => ({
+  default: ({ handleSearchChange }: { handleSearchChange: (value: string) => void }) => (
+    <input
+      type="text"
+      aria-label="search"
+      onChange={e => handleSearchChange(e.target.value)}
+    />
+  ),
+}))
+
 vi.mock('src/hooks/useResponsiveDarCollectionColumns', () => ({
   useResponsiveDarCollectionColumns: vi.fn(() => ['darCode', 'actions']),
 }))
@@ -76,10 +86,22 @@ const collection = (overrides: Partial<DarCollectionSummary> = {}): DarCollectio
   return { ...baseCollection, ...overrides }
 }
 
+const collection2 = collection({
+  darCollectionId: 2,
+  darCode: 'DAR-2',
+  name: 'Collection 2',
+  researcherName: 'Other Researcher',
+  institutionName: 'Other Institution',
+  actions: [],
+  datasetIds: [2],
+  referenceIds: ['reference-id-2'],
+  latestReferenceId: 'reference-id-2',
+})
+
 describe('SigningOfficialDarRequests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([collection()])
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([collection(), collection2])
   })
 
   it('fetches signing official DAR request summaries and renders the table', async () => {
@@ -94,7 +116,47 @@ describe('SigningOfficialDarRequests', () => {
     expect(table).toHaveAttribute('data-console-type', consoleTypes.SIGNING_OFFICIAL)
     expect(table).toHaveAttribute('data-loading', 'false')
     expect(screen.getByText('DAR-1')).toBeInTheDocument()
+    expect(screen.getByText('DAR-2')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Approve DAR-1' })).toBeInTheDocument()
+  })
+
+  it('renders a search bar', async () => {
+    render(<SigningOfficialDarRequests />)
+    await screen.findByTestId('dar-collection-table')
+    expect(screen.getByRole('textbox', { name: /search/i })).toBeInTheDocument()
+  })
+
+  it('filters collections by search term', async () => {
+    render(<SigningOfficialDarRequests />)
+    await screen.findByText('DAR-2')
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: 'DAR-1' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DAR-1')).toBeInTheDocument()
+      expect(screen.queryByText('DAR-2')).not.toBeInTheDocument()
+    })
+  })
+
+  it('restores all collections when search is cleared', async () => {
+    render(<SigningOfficialDarRequests />)
+    await screen.findByText('DAR-2')
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: 'DAR-1' },
+    })
+    await waitFor(() => expect(screen.queryByText('DAR-2')).not.toBeInTheDocument())
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: '' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DAR-1')).toBeInTheDocument()
+      expect(screen.getByText('DAR-2')).toBeInTheDocument()
+    })
   })
 
   it('approves a DAR and refreshes the updated row in place', async () => {


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-3692

## Summary
The Signing Official console's Data Access Requests and Data Access Approvals pages now have a search bar matching the one on the DAC Chair console.

- Added SearchBar to `SigningOfficialDarRequests` and `SigningOfficialDarApprovals`, wired up with `filteredList` state so the table updates as the user types
- `SigningOfficialDarRequests` delegates list updates to the existing `updateCollectionFn` utility (same as `ChairConsole`); `SigningOfficialDarApprovals` keeps its custom removal logic (strips collections once approved) and re-applies the search filter after each update
- Fixed a type mismatch in `updateCollectionFn` — `filterFn`'s parameter was typed as string | undefined but the actual filter functions only accept string; the call site now uses ?? ''
- Added search filter tests to both spec files (renders bar, filters by term, restores on clear)

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
