### PR TITLE
[DT-3049] Convert `ChairVoteInfo.jsx` to TypeScript

### DIFF
--- a/src/components/collection_voting_slab/ChairVoteInfo.tsx
+++ b/src/components/collection_voting_slab/ChairVoteInfo.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { isNil } from 'src/utils/NodashUtil'
 import VotesPieChart from 'src/components/common/VotesPieChart'
+import { Vote } from 'src/types/model'
 
 const styles = {
   chairVoteInfo: {
@@ -10,9 +10,15 @@ const styles = {
     rowGap: '1.5rem',
     fontWeight: 'bold',
   },
+} as const
+
+interface ChairVoteInfoProps {
+  readonly dacVotes: Vote[]
+  readonly isChair?: boolean
+  readonly adminPage?: boolean
 }
 
-export const ChairVoteInfo = ({ dacVotes, isChair, adminPage = false }) => {
+export const ChairVoteInfo = ({ dacVotes, isChair, adminPage = false }: ChairVoteInfoProps) => {
   return (isChair && dacVotes.some(v => !isNil(v.vote))) && (
     <div
       style={styles.chairVoteInfo}
@@ -37,10 +43,4 @@ export const ChairVoteInfo = ({ dacVotes, isChair, adminPage = false }) => {
       </div>
     </div>
   )
-}
-
-ChairVoteInfo.propTypes = {
-  dacVotes: PropTypes.array.isRequired,
-  isChair: PropTypes.bool,
-  adminPage: PropTypes.bool,
 }

--- a/test/components/collection_voting_slab/ChairVoteInfo.spec.tsx
+++ b/test/components/collection_voting_slab/ChairVoteInfo.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ChairVoteInfo } from 'src/components/collection_voting_slab/ChairVoteInfo'
+
+vi.mock('src/components/common/VotesPieChart', () => ({
+  default: () => <div data-testid="votes-pie-chart" />,
+}))
+
+const voteBase = { voteId: 1, userId: 1, createDate: '', electionId: 1, displayName: 'A', type: 'DAC' }
+const votedYes = { ...voteBase, vote: true }
+const votedNo = { ...voteBase, voteId: 2, vote: false }
+const notYetVoted = { ...voteBase, voteId: 3, vote: undefined }
+
+describe('ChairVoteInfo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders nothing when isChair is false', () => {
+    const { container } = render(
+      <ChairVoteInfo dacVotes={[votedYes]} isChair={false} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when no votes have been cast', () => {
+    const { container } = render(
+      <ChairVoteInfo dacVotes={[notYetVoted]} isChair={true} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when dacVotes is empty', () => {
+    const { container } = render(
+      <ChairVoteInfo dacVotes={[]} isChair={true} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the vote info when isChair is true and votes have been cast', () => {
+    render(<ChairVoteInfo dacVotes={[votedYes]} isChair={true} />)
+    expect(document.querySelector('[data-cy="chair-vote-info"]')).toBeInTheDocument()
+  })
+
+  it('renders VotesPieChart with dacVotes', () => {
+    render(<ChairVoteInfo dacVotes={[votedYes, votedNo]} isChair={true} />)
+    expect(screen.getByTestId('votes-pie-chart')).toBeInTheDocument()
+  })
+
+  it('shows member label by default', () => {
+    render(<ChairVoteInfo dacVotes={[votedYes]} isChair={true} />)
+    expect(screen.getByText('My DAC\'s Votes (summary)')).toBeInTheDocument()
+  })
+
+  it('shows admin label when adminPage is true', () => {
+    render(<ChairVoteInfo dacVotes={[votedYes]} isChair={true} adminPage={true} />)
+    expect(screen.getByText('DAC Votes (summary)')).toBeInTheDocument()
+  })
+
+  it('renders when only some votes are cast', () => {
+    render(<ChairVoteInfo dacVotes={[votedYes, notYetVoted]} isChair={true} />)
+    expect(document.querySelector('[data-cy="chair-vote-info"]')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3049

### Summary

Convert `ChairVoteInfo.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
