### PR TITLE
[DT-2616] Convert `DataUsePill.jsx` to TypeScript

### DIFF
--- a/src/components/collection_voting_slab/DataUsePill.tsx
+++ b/src/components/collection_voting_slab/DataUsePill.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { isNil } from 'src/utils/NodashUtil'
-import { ControlledAccessType } from '../../libs/dataUseTranslation'
+import { ControlledAccessType, TranslationEntry } from 'src/libs/dataUseTranslation'
 
 const styles = {
   baseStyle: {
@@ -29,20 +29,23 @@ const styles = {
     color: '#333F52',
     fontWeight: '500',
   },
+} as const
+
+interface DataUsePillProps {
+  readonly dataUse: TranslationEntry
+  readonly index: number
 }
 
-export const DataUsePill = (props) => {
-  const { dataUse, index } = props
-
+export const DataUsePill = ({ dataUse, index }: DataUsePillProps) => {
   return (
     <div key={`data_use_pill_${dataUse.type}_${dataUse.code}_${index}`} style={styles.baseStyle}>
-      <span style={styles.code}>{!isNil(dataUse) ? [dataUse.code] : []}</span>
-      <span style={styles.description}>{!isNil(dataUse) ? [dataUse.description] : []}</span>
+      <span style={styles.code}>{isNil(dataUse) ? [] : [dataUse.code]}</span>
+      <span style={styles.description}>{isNil(dataUse) ? [] : [dataUse.description]}</span>
     </div>
   )
 }
 
-export const DataUsePills = (dataUses, twoColumn = false) => {
+export const DataUsePills = (dataUses: TranslationEntry[], twoColumn = false) => {
   const permissionsUses = dataUses.filter(dataUse => dataUse.type === ControlledAccessType.permissions)
   const modifierUses = dataUses.filter(dataUse => dataUse.type === ControlledAccessType.modifiers)
 

--- a/test/components/collection_voting_slab/DataUsePill.spec.tsx
+++ b/test/components/collection_voting_slab/DataUsePill.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DataUsePill, DataUsePills } from 'src/components/collection_voting_slab/DataUsePill'
+import { TranslationEntry } from 'src/libs/dataUseTranslation'
+
+const permissionEntry: TranslationEntry = {
+  code: 'HMB',
+  description: 'Health/Medical/Biomedical research',
+  type: 'Permissions',
+}
+
+const modifierEntry: TranslationEntry = {
+  code: 'MDS',
+  description: 'Methods development study',
+  type: 'Modifiers',
+}
+
+const permissionEntry2: TranslationEntry = {
+  code: 'DS',
+  description: 'Disease-specific research',
+  type: 'Permissions',
+}
+
+describe('DataUsePill', () => {
+  it('renders the code', () => {
+    render(<DataUsePill dataUse={permissionEntry} index={0} />)
+    expect(screen.getByText('HMB')).toBeInTheDocument()
+  })
+
+  it('renders the description', () => {
+    render(<DataUsePill dataUse={permissionEntry} index={0} />)
+    expect(screen.getByText('Health/Medical/Biomedical research')).toBeInTheDocument()
+  })
+})
+
+describe('DataUsePills', () => {
+  it('renders permission entries', () => {
+    render(<>{DataUsePills([permissionEntry])}</>)
+    expect(screen.getByText('HMB')).toBeInTheDocument()
+    expect(screen.getByText('Health/Medical/Biomedical research')).toBeInTheDocument()
+  })
+
+  it('renders modifier entries under a Modifiers heading', () => {
+    render(<>{DataUsePills([permissionEntry, modifierEntry])}</>)
+    expect(screen.getByText('Modifiers')).toBeInTheDocument()
+    expect(screen.getByText('MDS')).toBeInTheDocument()
+  })
+
+  it('does not render the Modifiers heading when there are no modifier entries', () => {
+    render(<>{DataUsePills([permissionEntry])}</>)
+    expect(screen.queryByText('Modifiers')).not.toBeInTheDocument()
+  })
+
+  it('renders two-column layout with Permissions heading when twoColumn=true', () => {
+    const { container } = render(<>{DataUsePills([permissionEntry], true)}</>)
+    expect(screen.getByText('Permissions')).toBeInTheDocument()
+    expect(container.querySelector('.permissions-uses')).toBeInTheDocument()
+    expect(container.querySelector('.modifier-uses')).toBeInTheDocument()
+  })
+
+  it('renders modifier entries in twoColumn layout', () => {
+    render(<>{DataUsePills([permissionEntry, modifierEntry], true)}</>)
+    expect(screen.getByText('Modifiers')).toBeInTheDocument()
+    expect(screen.getByText('MDS')).toBeInTheDocument()
+  })
+
+  it('does not render the Modifiers heading in twoColumn layout when there are no modifier entries', () => {
+    render(<>{DataUsePills([permissionEntry], true)}</>)
+    expect(screen.queryByText('Modifiers')).not.toBeInTheDocument()
+  })
+
+  it('renders multiple entries of the same type', () => {
+    render(<>{DataUsePills([permissionEntry, permissionEntry2])}</>)
+    expect(screen.getByText('HMB')).toBeInTheDocument()
+    expect(screen.getByText('DS')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2616

### Summary

Convert `DataUsePill.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
