### PR TITLE
[DT-2617] Convert `MemberVoteSummary.jsx` to TypeScript

### DIFF
--- a/src/components/collection_voting_slab/MemberVoteSummary.tsx
+++ b/src/components/collection_voting_slab/MemberVoteSummary.tsx
@@ -4,8 +4,6 @@ import VoteSummaryTable from 'src/components/vote_summary_table/VoteSummaryTable
 import { ExpandLess, ExpandMore } from '@mui/icons-material'
 import { Vote } from 'src/types/model'
 
-import './member_vote_summary.css'
-
 interface MemberVoteSummaryProps {
   readonly dacVotes: Vote[]
   readonly isLoading?: boolean
@@ -33,7 +31,7 @@ export const MemberVoteSummary = ({
     >
       <button
         type="button"
-        className={`sort-icon dac-member-vote-dropdown-arrow ${showMemberVotes ? 'sort-icon-up' : 'sort-icon-down'}`}
+        className={`sort-icon ${showMemberVotes ? 'sort-icon-up' : 'sort-icon-down'}`}
         style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', background: 'none', border: 'none', cursor: 'pointer', padding: 0, width: '100%' }}
         onClick={() => setShowMemberVotes(!showMemberVotes)}
         id="show-member-vote-dropdown"

--- a/src/components/collection_voting_slab/MemberVoteSummary.tsx
+++ b/src/components/collection_voting_slab/MemberVoteSummary.tsx
@@ -1,21 +1,26 @@
-import { React, useState } from 'react'
-import {
-  collapseVotesByUser,
-} from '../../utils/DarCollectionUtils'
-import VoteSummaryTable from '../vote_summary_table/VoteSummaryTable'
+import React, { useState } from 'react'
+import { collapseVotesByUser } from 'src/utils/DarCollectionUtils'
+import VoteSummaryTable from 'src/components/vote_summary_table/VoteSummaryTable'
 import { ExpandLess, ExpandMore } from '@mui/icons-material'
+import { Vote } from 'src/types/model'
 
 import './member_vote_summary.css'
 
-export const MemberVoteSummary = (props) => {
-  const {
-    isLoading = false,
-    title = 'DAC Member Votes (detail)',
-    adminPage = false,
-    isChair = false,
-    dacVotes,
-  } = props
+interface MemberVoteSummaryProps {
+  readonly dacVotes: Vote[]
+  readonly isLoading?: boolean
+  readonly title?: string
+  readonly adminPage?: boolean
+  readonly isChair?: boolean
+}
 
+export const MemberVoteSummary = ({
+  isLoading = false,
+  title = 'DAC Member Votes (detail)',
+  adminPage = false,
+  isChair = false,
+  dacVotes,
+}: MemberVoteSummaryProps) => {
   const [showMemberVotes, setShowMemberVotes] = useState(false)
 
   return (
@@ -26,15 +31,17 @@ export const MemberVoteSummary = (props) => {
       padding: '20px 20px 20px 20px',
     }}
     >
-      <div
+      <button
+        type="button"
         className={`sort-icon dac-member-vote-dropdown-arrow ${showMemberVotes ? 'sort-icon-up' : 'sort-icon-down'}`}
-        style={{ display: 'flex', flexDirection: 'row', alignItems: 'center' }}
-        onClick={() => { setShowMemberVotes(!showMemberVotes) }}
+        style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', background: 'none', border: 'none', cursor: 'pointer', padding: 0, width: '100%' }}
+        onClick={() => setShowMemberVotes(!showMemberVotes)}
         id="show-member-vote-dropdown"
+        aria-expanded={showMemberVotes}
       >
         <span style={{ display: 'flex' }}>{showMemberVotes ? <ExpandLess /> : <ExpandMore />}</span>
         <span>{title}</span>
-      </div>
+      </button>
       {showMemberVotes && (
         <VoteSummaryTable
           dacVotes={collapseVotesByUser(dacVotes)}

--- a/src/components/collection_voting_slab/member_vote_summary.css
+++ b/src/components/collection_voting_slab/member_vote_summary.css
@@ -1,7 +1,0 @@
-.dac-member-vote-dropdown-arrow {
-  margin-left: 0px;
-}
-
-.dac-member-vote-dropdown-arrow:hover {
-  cursor: pointer;
-}

--- a/test/components/collection_voting_slab/MemberVoteSummary.spec.tsx
+++ b/test/components/collection_voting_slab/MemberVoteSummary.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemberVoteSummary } from 'src/components/collection_voting_slab/MemberVoteSummary'
+import { Vote } from 'src/types/model'
+
+vi.mock('src/components/vote_summary_table/VoteSummaryTable', () => ({
+  default: () => <div data-testid="vote-summary-table" />,
+}))
+
+vi.mock('src/utils/DarCollectionUtils', () => ({
+  collapseVotesByUser: vi.fn(votes => votes),
+}))
+
+const voteBase = { userId: 1, createDate: '', electionId: 1, displayName: 'A', type: 'DAC' }
+const dacVotes: Vote[] = [
+  { ...voteBase, voteId: 1, vote: true },
+  { ...voteBase, voteId: 2, vote: false },
+]
+
+describe('MemberVoteSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the default title', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    expect(screen.getByText('DAC Member Votes (detail)')).toBeInTheDocument()
+  })
+
+  it('renders a custom title', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} title="Custom Title" />)
+    expect(screen.getByText('Custom Title')).toBeInTheDocument()
+  })
+
+  it('does not show the vote table when collapsed', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    expect(screen.queryByTestId('vote-summary-table')).not.toBeInTheDocument()
+  })
+
+  it('shows the vote table after clicking the toggle', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    fireEvent.click(screen.getByRole('button', { name: /DAC Member Votes/i }))
+    expect(screen.getByTestId('vote-summary-table')).toBeInTheDocument()
+  })
+
+  it('hides the vote table after clicking the toggle twice', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    const toggle = screen.getByRole('button', { name: /DAC Member Votes/i })
+    fireEvent.click(toggle)
+    fireEvent.click(toggle)
+    expect(screen.queryByTestId('vote-summary-table')).not.toBeInTheDocument()
+  })
+
+  it('has aria-expanded=false when collapsed', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    expect(screen.getByRole('button', { name: /DAC Member Votes/i })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('has aria-expanded=true when expanded', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    const toggle = screen.getByRole('button', { name: /DAC Member Votes/i })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('applies sort-icon-down class when collapsed', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    expect(screen.getByRole('button', { name: /DAC Member Votes/i })).toHaveClass('sort-icon-down')
+  })
+
+  it('applies sort-icon-up class when expanded', () => {
+    render(<MemberVoteSummary dacVotes={dacVotes} />)
+    const toggle = screen.getByRole('button', { name: /DAC Member Votes/i })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveClass('sort-icon-up')
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2617

### Summary

Convert `MemberVoteSummary.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
