### PR TITLE
[DT-2641] Convert `AdminManageUsers.jsx` to TypeScript

### DIFF
--- a/src/pages/AdminManageUsers.tsx
+++ b/src/pages/AdminManageUsers.tsx
@@ -1,67 +1,49 @@
-import React from 'react'
-import { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { AddUserModal } from 'src/components/modals/AddUserModal'
 import { User } from 'src/libs/ajax/User'
-import { USER_ROLES } from 'src/libs/utils'
-import { isNil } from 'src/utils/NodashUtil'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
 import { ManageUsersTable } from 'src/components/manage_users_table/ManageUsersTable'
 import { Styles } from 'src/libs/theme'
 import SearchBar from 'src/components/SearchBar'
-import { Notification } from 'src/components/Notification'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
-import AddObjectButton from 'src/components/AddObjectButton.tsx'
+import AddObjectButton from 'src/components/AddObjectButton'
 import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined'
+import { DuosUser } from 'src/types/model'
 
-const getUserList = async () => {
-  const users = await User.list(USER_ROLES.admin)
-
-  return users.map((user) => {
-    user.researcher = false
-    if (!isNil(user.roles)) {
-      user.roles.forEach((role) => {
-        if (role.name === 'Researcher' || user.name === 'RESEARCHER') {
-          user.researcher = true
-        }
-      })
-    }
-    user.key = user.id
-    return user
-  })
-}
+const getUserList = (): Promise<DuosUser[]> => User.list(USER_ROLES.admin)
 
 export const AdminManageUsers = function AdminManageUsers() {
   usePageTitle('Manage Users')
   const [searchText, setSearchText] = useState('')
-  const [userList, setUserList] = useState([])
+  const [userList, setUserList] = useState<DuosUser[]>([])
   const [showAddUserModal, setShowAddUserModal] = useState(false)
-  const [selectedUser, setSelectedUser] = useState()
   const [isLoading, setIsLoading] = useState(false)
 
-  React.useEffect(() => {
+  useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsLoading(true)
-    getUserList().then((userList) => {
-      setIsLoading(false)
-      setUserList(userList)
-      setIsLoading(false)
-    }).catch(() => {
-      setIsLoading(false)
-      Notification.showError({ text: 'Error: Unable to retrieve user data from server' })
-    })
+    getUserList()
+      .then((users) => {
+        setUserList(users)
+        setIsLoading(false)
+      })
+      .catch(() => {
+        setIsLoading(false)
+        Notifications.showError({ text: 'Error: Unable to retrieve user data from server' })
+      })
   }, [])
 
   const addUser = () => {
-    setSelectedUser(null)
     setShowAddUserModal(true)
   }
 
   const okModal = async () => {
     setShowAddUserModal(false)
     setIsLoading(true)
-    const userList = await getUserList()
+    const users = await getUserList()
+    setUserList(users)
     setIsLoading(false)
-    setUserList(userList)
   }
 
   const closeModal = () => {
@@ -72,7 +54,7 @@ export const AdminManageUsers = function AdminManageUsers() {
     setShowAddUserModal(false)
   }
 
-  const handleSearchUser = (query) => {
+  const handleSearchUser = (query: string) => {
     setSearchText(query)
   }
 
@@ -98,12 +80,10 @@ export const AdminManageUsers = function AdminManageUsers() {
       </div>
       <ManageUsersTable userList={userList} isLoading={isLoading} searchText={searchText} />
       <AddUserModal
-        isRendered={showAddUserModal}
         showModal={showAddUserModal}
         onOKRequest={okModal}
         onCloseRequest={closeModal}
         onAfterOpen={afterModalOpen}
-        user={selectedUser}
       />
     </div>
   )

--- a/test/pages/AdminManageUsers.spec.tsx
+++ b/test/pages/AdminManageUsers.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { AdminManageUsers } from 'src/pages/AdminManageUsers'
 import { User } from 'src/libs/ajax/User'
 import { Notifications, USER_ROLES } from 'src/libs/utils'
@@ -78,24 +78,22 @@ describe('AdminManageUsers', () => {
 
   it('renders the page title and description', async () => {
     vi.mocked(User.list).mockResolvedValue([])
-    render(<AdminManageUsers />)
+    await act(async () => render(<AdminManageUsers />))
     expect(screen.getByText('Manage Users')).toBeInTheDocument()
     expect(screen.getByText('Select and manage users and their roles')).toBeInTheDocument()
   })
 
   it('fetches users with the admin role on mount', async () => {
     vi.mocked(User.list).mockResolvedValue([])
-    render(<AdminManageUsers />)
-    await waitFor(() => expect(User.list).toHaveBeenCalledWith(USER_ROLES.admin))
+    await act(async () => render(<AdminManageUsers />))
+    expect(User.list).toHaveBeenCalledWith(USER_ROLES.admin)
   })
 
   it('passes loaded users to ManageUsersTable', async () => {
     vi.mocked(User.list).mockResolvedValue(testUsers)
-    render(<AdminManageUsers />)
-    await waitFor(() => {
-      expect(screen.getByText('Alice Admin')).toBeInTheDocument()
-      expect(screen.getByText('Bob Admin')).toBeInTheDocument()
-    })
+    await act(async () => render(<AdminManageUsers />))
+    expect(screen.getByText('Alice Admin')).toBeInTheDocument()
+    expect(screen.getByText('Bob Admin')).toBeInTheDocument()
   })
 
   it('shows loading state while fetching', () => {
@@ -106,25 +104,21 @@ describe('AdminManageUsers', () => {
 
   it('clears loading state after fetch completes', async () => {
     vi.mocked(User.list).mockResolvedValue(testUsers)
-    render(<AdminManageUsers />)
-    await waitFor(() => {
-      expect(screen.getByTestId('manage-users-table')).toHaveAttribute('data-loading', 'false')
-    })
+    await act(async () => render(<AdminManageUsers />))
+    expect(screen.getByTestId('manage-users-table')).toHaveAttribute('data-loading', 'false')
   })
 
   it('shows an error notification when the fetch fails', async () => {
     vi.mocked(User.list).mockRejectedValue(new Error('network error'))
-    render(<AdminManageUsers />)
-    await waitFor(() => {
-      expect(Notifications.showError).toHaveBeenCalledWith({
-        text: 'Error: Unable to retrieve user data from server',
-      })
+    await act(async () => render(<AdminManageUsers />))
+    expect(Notifications.showError).toHaveBeenCalledWith({
+      text: 'Error: Unable to retrieve user data from server',
     })
   })
 
   it('opens the add user modal when the Add User button is clicked', async () => {
     vi.mocked(User.list).mockResolvedValue([])
-    render(<AdminManageUsers />)
+    await act(async () => render(<AdminManageUsers />))
     expect(screen.queryByTestId('add-user-modal')).not.toBeInTheDocument()
     fireEvent.click(screen.getByText('ADD USER'))
     expect(screen.getByTestId('add-user-modal')).toBeInTheDocument()
@@ -132,22 +126,20 @@ describe('AdminManageUsers', () => {
 
   it('closes the add user modal and refreshes users when OK is clicked', async () => {
     vi.mocked(User.list).mockResolvedValue(testUsers)
-    render(<AdminManageUsers />)
-    await waitFor(() => expect(User.list).toHaveBeenCalledTimes(1))
+    await act(async () => render(<AdminManageUsers />))
+    expect(User.list).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByText('ADD USER'))
     expect(screen.getByTestId('add-user-modal')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByText('OK'))
-    await waitFor(() => {
-      expect(screen.queryByTestId('add-user-modal')).not.toBeInTheDocument()
-      expect(User.list).toHaveBeenCalledTimes(2)
-    })
+    await act(async () => fireEvent.click(screen.getByText('OK')))
+    expect(screen.queryByTestId('add-user-modal')).not.toBeInTheDocument()
+    expect(User.list).toHaveBeenCalledTimes(2)
   })
 
   it('closes the add user modal when Close is clicked', async () => {
     vi.mocked(User.list).mockResolvedValue([])
-    render(<AdminManageUsers />)
+    await act(async () => render(<AdminManageUsers />))
     fireEvent.click(screen.getByText('ADD USER'))
     expect(screen.getByTestId('add-user-modal')).toBeInTheDocument()
     fireEvent.click(screen.getByText('Close'))

--- a/test/pages/AdminManageUsers.spec.tsx
+++ b/test/pages/AdminManageUsers.spec.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { AdminManageUsers } from 'src/pages/AdminManageUsers'
+import { User } from 'src/libs/ajax/User'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
+import { DuosUser } from 'src/types/model'
+
+vi.mock('src/libs/ajax/User', () => ({
+  User: { list: vi.fn() },
+}))
+
+vi.mock('src/libs/utils', async (importActual) => {
+  const actual = await importActual<typeof import('src/libs/utils')>()
+  return {
+    ...actual,
+    Notifications: { showError: vi.fn(), showSuccess: vi.fn() },
+  }
+})
+
+vi.mock('src/components/manage_users_table/ManageUsersTable', () => ({
+  ManageUsersTable: ({ userList, isLoading }: { userList: DuosUser[], isLoading: boolean }) => (
+    <div data-testid="manage-users-table" data-loading={isLoading}>
+      {userList.map(u => <span key={u.userId}>{u.displayName}</span>)}
+    </div>
+  ),
+}))
+
+vi.mock('src/components/modals/AddUserModal', () => ({
+  AddUserModal: ({ showModal, onOKRequest, onCloseRequest }: {
+    showModal: boolean
+    onOKRequest: () => void
+    onCloseRequest: () => void
+  }) => showModal
+    ? (
+        <div data-testid="add-user-modal">
+          <button onClick={onOKRequest}>OK</button>
+          <button onClick={onCloseRequest}>Close</button>
+        </div>
+      )
+    : null,
+}))
+
+vi.mock('src/components/SearchBar', () => ({
+  default: ({ handleSearchChange }: { handleSearchChange: (v: string) => void }) => (
+    <input
+      aria-label="search"
+      onChange={e => handleSearchChange(e.target.value)}
+    />
+  ),
+}))
+
+const makeUser = (overrides: Partial<DuosUser> & { userId: number, displayName: string }): DuosUser => ({
+  createDate: new Date(),
+  email: `user${overrides.userId}@test.com`,
+  emailPreference: false,
+  isAdmin: false,
+  isAlumni: false,
+  isChairPerson: false,
+  isDataSubmitter: false,
+  isMember: false,
+  isResearcher: false,
+  isSigningOfficial: false,
+  roles: [],
+  ...overrides,
+})
+
+const testUsers: DuosUser[] = [
+  makeUser({ userId: 1, displayName: 'Alice Admin' }),
+  makeUser({ userId: 2, displayName: 'Bob Admin' }),
+]
+
+describe('AdminManageUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the page title and description', async () => {
+    vi.mocked(User.list).mockResolvedValue([])
+    render(<AdminManageUsers />)
+    expect(screen.getByText('Manage Users')).toBeInTheDocument()
+    expect(screen.getByText('Select and manage users and their roles')).toBeInTheDocument()
+  })
+
+  it('fetches users with the admin role on mount', async () => {
+    vi.mocked(User.list).mockResolvedValue([])
+    render(<AdminManageUsers />)
+    await waitFor(() => expect(User.list).toHaveBeenCalledWith(USER_ROLES.admin))
+  })
+
+  it('passes loaded users to ManageUsersTable', async () => {
+    vi.mocked(User.list).mockResolvedValue(testUsers)
+    render(<AdminManageUsers />)
+    await waitFor(() => {
+      expect(screen.getByText('Alice Admin')).toBeInTheDocument()
+      expect(screen.getByText('Bob Admin')).toBeInTheDocument()
+    })
+  })
+
+  it('shows loading state while fetching', () => {
+    vi.mocked(User.list).mockReturnValue(new Promise(() => {}))
+    render(<AdminManageUsers />)
+    expect(screen.getByTestId('manage-users-table')).toHaveAttribute('data-loading', 'true')
+  })
+
+  it('clears loading state after fetch completes', async () => {
+    vi.mocked(User.list).mockResolvedValue(testUsers)
+    render(<AdminManageUsers />)
+    await waitFor(() => {
+      expect(screen.getByTestId('manage-users-table')).toHaveAttribute('data-loading', 'false')
+    })
+  })
+
+  it('shows an error notification when the fetch fails', async () => {
+    vi.mocked(User.list).mockRejectedValue(new Error('network error'))
+    render(<AdminManageUsers />)
+    await waitFor(() => {
+      expect(Notifications.showError).toHaveBeenCalledWith({
+        text: 'Error: Unable to retrieve user data from server',
+      })
+    })
+  })
+
+  it('opens the add user modal when the Add User button is clicked', async () => {
+    vi.mocked(User.list).mockResolvedValue([])
+    render(<AdminManageUsers />)
+    expect(screen.queryByTestId('add-user-modal')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('ADD USER'))
+    expect(screen.getByTestId('add-user-modal')).toBeInTheDocument()
+  })
+
+  it('closes the add user modal and refreshes users when OK is clicked', async () => {
+    vi.mocked(User.list).mockResolvedValue(testUsers)
+    render(<AdminManageUsers />)
+    await waitFor(() => expect(User.list).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByText('ADD USER'))
+    expect(screen.getByTestId('add-user-modal')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('OK'))
+    await waitFor(() => {
+      expect(screen.queryByTestId('add-user-modal')).not.toBeInTheDocument()
+      expect(User.list).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('closes the add user modal when Close is clicked', async () => {
+    vi.mocked(User.list).mockResolvedValue([])
+    render(<AdminManageUsers />)
+    fireEvent.click(screen.getByText('ADD USER'))
+    expect(screen.getByTestId('add-user-modal')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Close'))
+    expect(screen.queryByTestId('add-user-modal')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2641

### Summary

Convert `AdminManageUsers.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
