### PR TITLE
[DT-2646] Convert `DatasetUpdateForm.jsx` to TypeScript

### DIFF
--- a/src/pages/DatasetUpdateForm.tsx
+++ b/src/pages/DatasetUpdateForm.tsx
@@ -1,34 +1,32 @@
-import React from 'react'
-import { useState, useEffect } from 'react'
-
-import { Notifications } from '../libs/utils'
-import { Styles } from '../libs/theme'
-import DatasetUpdate from '../components/data_update/DatasetUpdate'
-import { DataSet } from '../libs/ajax/DataSet'
+import React, { useState, useEffect } from 'react'
+import { Notifications } from 'src/libs/utils'
+import { Styles } from 'src/libs/theme'
+import DatasetUpdate from 'src/components/data_update/DatasetUpdate'
+import { DataSet } from 'src/libs/ajax/DataSet'
 import { useParams } from 'react-router-dom'
 import TableHeaderSection from 'src/components/TableHeaderSection'
+import { Dataset } from 'src/types/model'
 
-export const DatasetUpdateForm = () => {
-  const params = useParams()
-  const { datasetId } = params
+export const DatasetUpdateForm = (): React.JSX.Element | false => {
+  const { datasetId } = useParams<{ datasetId: string }>()
 
   const [failedInit, setFailedInit] = useState(true)
-  const [dataset, setDataset] = useState({})
+  const [dataset, setDataset] = useState<Dataset | null>(null)
 
   useEffect(() => {
-    const init = async () => {
+    const init = async (): Promise<void> => {
       try {
-        setDataset(await DataSet.getDataSetsByDatasetId(datasetId))
+        setDataset(await DataSet.getDataSetsByDatasetId(Number(datasetId)))
         setFailedInit(false)
       }
-      catch (_error) {
+      catch {
         Notifications.showError({ text: 'Failed to load dataset' })
       }
     }
-    init()
+    void init()
   }, [datasetId])
 
-  return !failedInit && (
+  return !failedInit && dataset !== null && (
     <div style={Styles.PAGE}>
       <div>
         <TableHeaderSection

--- a/test/pages/DatasetUpdateForm.spec.tsx
+++ b/test/pages/DatasetUpdateForm.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import { DatasetUpdateForm } from 'src/pages/DatasetUpdateForm'
+import { Dataset } from 'src/types/model'
+
+const mockDataset = { datasetId: 7, datasetName: 'Test DS', dacId: 1, dataUse: {}, properties: [] } as unknown as Dataset
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ datasetId: '7' }),
+}))
+
+vi.mock('src/libs/ajax/DataSet', () => ({
+  DataSet: { getDataSetsByDatasetId: vi.fn() },
+}))
+
+vi.mock('src/libs/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('src/libs/utils')>()
+  return { ...actual, Notifications: { showError: vi.fn(), showSuccess: vi.fn() } }
+})
+
+vi.mock('src/components/data_update/DatasetUpdate', () => ({
+  default: () => <div data-testid="dataset-update" />,
+  DatasetUpdate: () => <div data-testid="dataset-update" />,
+}))
+
+vi.mock('src/components/TableHeaderSection', () => ({
+  default: ({ title, description }: { title: string, description: string }) => (
+    <div data-testid="table-header">
+      <h1>{title}</h1>
+      <p>{description}</p>
+    </div>
+  ),
+}))
+
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { Notifications } from 'src/libs/utils'
+
+describe('DatasetUpdateForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the page with header and form after successful load', async () => {
+    vi.mocked(DataSet.getDataSetsByDatasetId).mockResolvedValue(mockDataset)
+
+    await act(async () => {
+      render(<DatasetUpdateForm />)
+    })
+
+    expect(screen.getByTestId('table-header')).toBeTruthy()
+    expect(screen.getByText('Dataset Update Form')).toBeTruthy()
+    expect(screen.getByText('This is an easy way to update a dataset in DUOS!')).toBeTruthy()
+    expect(screen.getByTestId('dataset-update')).toBeTruthy()
+  })
+
+  it('calls getDataSetsByDatasetId with the numeric datasetId from route params', async () => {
+    vi.mocked(DataSet.getDataSetsByDatasetId).mockResolvedValue(mockDataset)
+
+    await act(async () => {
+      render(<DatasetUpdateForm />)
+    })
+
+    expect(vi.mocked(DataSet.getDataSetsByDatasetId)).toHaveBeenCalledWith(7)
+  })
+
+  it('does not render the form when dataset fetch fails', async () => {
+    vi.mocked(DataSet.getDataSetsByDatasetId).mockRejectedValue(new Error('Not found'))
+
+    await act(async () => {
+      render(<DatasetUpdateForm />)
+    })
+
+    expect(screen.queryByTestId('dataset-update')).toBeNull()
+  })
+
+  it('shows an error notification when dataset fetch fails', async () => {
+    vi.mocked(DataSet.getDataSetsByDatasetId).mockRejectedValue(new Error('Not found'))
+
+    await act(async () => {
+      render(<DatasetUpdateForm />)
+    })
+
+    expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith({ text: 'Failed to load dataset' })
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2646

### Summary

Convert `DatasetUpdateForm.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
