### PR TITLE
[DT-2587] Convert `CloseIconComponent.jsx` to TypeScript

### DIFF
--- a/src/components/CloseIconComponent.tsx
+++ b/src/components/CloseIconComponent.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 
-export default function CloseIconComponent(props) {
+interface CloseIconComponentProps {
+  closeFn: () => void
+}
+
+export default function CloseIconComponent(props: Readonly<CloseIconComponentProps>) {
   const { closeFn } = props
   return (
     <button type="button" className="modal-close-btn close" onClick={closeFn}>

--- a/test/components/CloseIconComponent.spec.tsx
+++ b/test/components/CloseIconComponent.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import CloseIconComponent from 'src/components/CloseIconComponent'
+
+describe('CloseIconComponent', () => {
+  it('renders a button with the correct class names', () => {
+    render(<CloseIconComponent closeFn={vi.fn()} />)
+    const button = screen.getByRole('button')
+    expect(button).toHaveClass('modal-close-btn', 'close')
+  })
+
+  it('renders a button of type "button"', () => {
+    render(<CloseIconComponent closeFn={vi.fn()} />)
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button')
+  })
+
+  it('calls closeFn when the button is clicked', async () => {
+    const closeFn = vi.fn()
+    render(<CloseIconComponent closeFn={closeFn} />)
+    await userEvent.click(screen.getByRole('button'))
+    expect(closeFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders the glyphicon span inside the button', () => {
+    const { container } = render(<CloseIconComponent closeFn={vi.fn()} />)
+    const span = container.querySelector('span.glyphicon.glyphicon-remove.default-color')
+    expect(span).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2587

### Summary

Convert `CloseIconComponent.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
