### PR TITLE
[DT-2613] Convert `UsgOmbText.jsx` to TypeScript

### DIFF
--- a/src/components/UsgOmbText.tsx
+++ b/src/components/UsgOmbText.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 
 export default function UsgOmbText() {
   return (

--- a/test/components/UsgOmbText.spec.tsx
+++ b/test/components/UsgOmbText.spec.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import UsgOmbText from 'src/components/UsgOmbText'
+
+describe('UsgOmbText', () => {
+  it('renders the OMB number', () => {
+    render(<UsgOmbText />)
+    expect(screen.getByText(/OMB No\.: 0925-7775/)).toBeInTheDocument()
+  })
+
+  it('renders the expiration date', () => {
+    render(<UsgOmbText />)
+    expect(screen.getByText(/Expiration Date:/)).toBeInTheDocument()
+  })
+
+  it('renders the public reporting burden text', () => {
+    render(<UsgOmbText />)
+    expect(screen.getByText(/Public reporting burden/)).toBeInTheDocument()
+  })
+
+  it('renders within a styled container', () => {
+    const { container } = render(<UsgOmbText />)
+    const div = container.firstChild as HTMLElement
+    expect(div.style.background).toBe('rgb(238, 238, 238)')
+    expect(div.style.padding).toBe('20px')
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2613

### Summary

Convert `UsgOmbText.jsx` to TypeScript with vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
