### PR TITLE
[DT-2633] Convert `MemberConsole.jsx` to TypeScript

### DIFF
--- a/src/pages/MemberConsole.tsx
+++ b/src/pages/MemberConsole.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import SearchBar from 'src/components/SearchBar'
 import { User } from 'src/libs/ajax/User'
 import { Collections } from 'src/libs/ajax/Collections'
@@ -10,22 +10,21 @@ import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCol
 import { useNavigate } from 'react-router-dom'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
+import { DarCollectionSummary, Dataset } from 'src/types/model'
 
 export default function MemberConsole() {
   usePageTitle('Data Access Requests')
   const navigate = useNavigate()
-  const [collections, setCollections] = useState([])
-  const [filteredList, setFilteredList] = useState([])
-  const [relevantDatasets, setRelevantDatasets] = useState()
+  const [collections, setCollections] = useState<DarCollectionSummary[]>([])
+  const [filteredList, setFilteredList] = useState<DarCollectionSummary[]>([])
+  const [relevantDatasets, setRelevantDatasets] = useState<Dataset[]>()
   const [isLoading, setIsLoading] = useState(true)
-  const searchRef = useRef('')
   const filterFn = getSearchFilterFunctions().darCollections
 
-  // Get responsive columns for member console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.MEMBER)
 
   const handleSearchChange = useCallback(
-    searchTerms =>
+    (searchTerms: string) =>
       searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList),
     [collections, filterFn],
   )
@@ -35,14 +34,14 @@ export default function MemberConsole() {
       try {
         const [collections, datasets] = await Promise.all([
           Collections.getCollectionSummariesByRoleName(USER_ROLES.member),
-          User.getUserRelevantDatasets(), // still need this on this console for status cell
+          User.getUserRelevantDatasets(),
         ])
         setCollections(collections)
         setRelevantDatasets(datasets)
         setFilteredList(collections)
         setIsLoading(false)
       }
-      catch (_error) {
+      catch {
         Notifications.showError({
           text: 'Error initializing Collections table',
         })
@@ -51,7 +50,7 @@ export default function MemberConsole() {
     init()
   }, [])
 
-  const goToVote = useCallback(collectionId => navigate(`/dar_collection/${collectionId}`), [navigate])
+  const goToVote = useCallback((collectionId: number) => navigate(`/dar_collection/${collectionId}`), [navigate])
 
   return (
     <div style={Styles.PAGE}>
@@ -62,7 +61,7 @@ export default function MemberConsole() {
         />
       </div>
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
-        <SearchBar handleSearchChange={handleSearchChange} searchRef={searchRef} />
+        <SearchBar handleSearchChange={handleSearchChange} />
       </div>
       {responsiveColumns.length > 0 && (
         <DarCollectionTable

--- a/test/pages/MemberConsole.spec.tsx
+++ b/test/pages/MemberConsole.spec.tsx
@@ -1,0 +1,179 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import MemberConsole from 'src/pages/MemberConsole'
+import { Collections } from 'src/libs/ajax/Collections'
+import { User } from 'src/libs/ajax/User'
+import { USER_ROLES } from 'src/libs/utils'
+import { consoleTypes } from 'src/utils/DarCollectionUtils'
+import { DarCollectionSummary } from 'src/types/model'
+import { renderWithRouter } from '../test-utils'
+
+type MockDarCollectionTableProps = {
+  collections: DarCollectionSummary[]
+  columns: string[]
+  isLoading: boolean
+  consoleType: string
+  goToVote: (collectionId: number) => void
+}
+
+vi.mock('src/components/SearchBar', () => ({
+  default: ({ handleSearchChange }: { handleSearchChange: (value: string) => void }) => (
+    <input
+      type="text"
+      aria-label="search"
+      onChange={e => handleSearchChange(e.target.value)}
+    />
+  ),
+}))
+
+vi.mock('src/hooks/useResponsiveDarCollectionColumns', () => ({
+  useResponsiveDarCollectionColumns: vi.fn(() => ['darCode', 'actions']),
+}))
+
+vi.mock('src/components/dar_collection_table/DarCollectionTable', () => ({
+  DarCollectionTable: ({ collections, columns, isLoading, consoleType, goToVote }: MockDarCollectionTableProps) => (
+    <div
+      data-testid="dar-collection-table"
+      data-columns={columns.join(',')}
+      data-console-type={consoleType}
+      data-loading={isLoading}
+    >
+      {collections.map(c => (
+        <div key={c.darCollectionId}>
+          <span>{c.darCode}</span>
+          <button type="button" onClick={() => goToVote(c.darCollectionId)}>
+            Vote {c.darCode}
+          </button>
+        </div>
+      ))}
+    </div>
+  ),
+}))
+
+vi.mock('src/libs/ajax/Collections', () => ({
+  Collections: {
+    getCollectionSummariesByRoleName: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/ajax/User', () => ({
+  User: {
+    getUserRelevantDatasets: vi.fn(),
+  },
+}))
+
+vi.mock('src/components/TableHeaderSection', () => ({
+  default: ({ title, description }: { title: string, description: string }) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{description}</p>
+    </div>
+  ),
+}))
+
+const makeCollection = (overrides: Partial<DarCollectionSummary> = {}): DarCollectionSummary => ({
+  darCollectionId: 1,
+  darCode: 'DAR-1',
+  requiresSOApproval: false,
+  actions: [],
+  name: 'Collection 1',
+  datasetCount: 1,
+  status: 'Open',
+  submissionDate: 1640995200000,
+  researcherName: 'Researcher',
+  institutionName: 'Institution',
+  dacNames: ['DAC1'],
+  dacCode: 'DAC1',
+  datasetIds: [1],
+  expired: false,
+  expiresAt: 1672531200000,
+  latestReferenceId: 'reference-id-1',
+  progressReport: false,
+  referenceIds: ['reference-id-1'],
+  ...overrides,
+})
+
+const collection1 = makeCollection()
+const collection2 = makeCollection({
+  darCollectionId: 2,
+  darCode: 'DAR-2',
+  name: 'Collection 2',
+  researcherName: 'Other Researcher',
+  datasetIds: [2],
+  referenceIds: ['reference-id-2'],
+  latestReferenceId: 'reference-id-2',
+})
+
+describe('MemberConsole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([collection1, collection2])
+    vi.mocked(User.getUserRelevantDatasets).mockResolvedValue([])
+  })
+
+  it('renders the page title and description', async () => {
+    renderWithRouter(<MemberConsole />)
+    await screen.findByTestId('dar-collection-table')
+    expect(screen.getByText('My DAC\'s Data Access Requests')).toBeInTheDocument()
+    expect(screen.getByText('Vote on Data Access Request for DAC Review')).toBeInTheDocument()
+  })
+
+  it('fetches member collections and renders the table', async () => {
+    renderWithRouter(<MemberConsole />)
+
+    await waitFor(() => {
+      expect(Collections.getCollectionSummariesByRoleName).toHaveBeenCalledWith(USER_ROLES.member)
+    })
+
+    const table = await screen.findByTestId('dar-collection-table')
+    expect(table).toHaveAttribute('data-columns', 'darCode,actions')
+    expect(table).toHaveAttribute('data-console-type', consoleTypes.MEMBER)
+    expect(table).toHaveAttribute('data-loading', 'false')
+    expect(screen.getByText('DAR-1')).toBeInTheDocument()
+    expect(screen.getByText('DAR-2')).toBeInTheDocument()
+  })
+
+  it('fetches relevant datasets alongside collections', async () => {
+    renderWithRouter(<MemberConsole />)
+
+    await waitFor(() => {
+      expect(User.getUserRelevantDatasets).toHaveBeenCalled()
+    })
+  })
+
+  it('renders a search bar', async () => {
+    renderWithRouter(<MemberConsole />)
+    await screen.findByTestId('dar-collection-table')
+    expect(screen.getByRole('textbox', { name: /search/i })).toBeInTheDocument()
+  })
+
+  it('filters collections by search term', async () => {
+    renderWithRouter(<MemberConsole />)
+    await screen.findByText('DAR-2')
+
+    fireEvent.change(screen.getByRole('textbox', { name: /search/i }), {
+      target: { value: 'DAR-1' },
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('DAR-1')).toBeInTheDocument()
+      expect(screen.queryByText('DAR-2')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows an error notification when fetching fails', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockRejectedValue(new Error('Network error'))
+    const { Notifications } = await import('src/libs/utils')
+    vi.spyOn(Notifications, 'showError')
+
+    renderWithRouter(<MemberConsole />)
+
+    await waitFor(() => {
+      expect(Notifications.showError).toHaveBeenCalledWith({
+        text: 'Error initializing Collections table',
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2685

### Summary

Convert `MemberConsole.jsx` to TypeScript and add Vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
