### PR TITLE
[DT-2643] Convert `ChairConsole.jsx` to TypeScript

### DIFF
--- a/src/pages/ChairConsole.tsx
+++ b/src/pages/ChairConsole.tsx
@@ -10,21 +10,21 @@ import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCol
 import { useNavigate } from 'react-router-dom'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
+import { DarCollectionSummary, Dataset } from 'src/types/model'
 
 export default function ChairConsole() {
   usePageTitle('Data Access Requests')
   const navigate = useNavigate()
-  const [collections, setCollections] = useState([])
-  const [filteredList, setFilteredList] = useState([])
-  const [relevantDatasets, setRelevantDatasets] = useState()
+  const [collections, setCollections] = useState<DarCollectionSummary[]>([])
+  const [filteredList, setFilteredList] = useState<DarCollectionSummary[]>([])
+  const [relevantDatasets, setRelevantDatasets] = useState<Dataset[] | undefined>()
   const [isLoading, setIsLoading] = useState(true)
   const [searchText, setSearchText] = useState('')
   const filterFn = getSearchFilterFunctions().darCollections
 
-  // Get responsive columns for chair console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.CHAIR)
 
-  const handleSearchChange = useCallback((searchTerms) => {
+  const handleSearchChange = useCallback((searchTerms: string) => {
     setSearchText(searchTerms)
     searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList)
   }, [collections, filterFn])
@@ -32,16 +32,16 @@ export default function ChairConsole() {
   useEffect(() => {
     const init = async () => {
       try {
-        const [collections, datasets] = await Promise.all([
+        const [cols, datasets] = await Promise.all([
           Collections.getCollectionSummariesByRoleName(USER_ROLES.chairperson),
           User.getUserRelevantDatasets(),
         ])
-        setCollections(collections)
+        setCollections(cols)
         setRelevantDatasets(datasets)
-        setFilteredList(collections)
+        setFilteredList(cols)
         setIsLoading(false)
       }
-      catch (_error) {
+      catch {
         Notifications.showError({ text: 'Error initializing Collections table' })
       }
     }
@@ -49,18 +49,18 @@ export default function ChairConsole() {
   }, [])
 
   const updateCollections = useCallback(
-    updatedCollection => updateCollectionFn({ collections, filterFn, searchText, setCollections, setFilteredList })(updatedCollection),
+    (updatedCollection: DarCollectionSummary) => updateCollectionFn({ collections, filterFn, searchText, setCollections, setFilteredList })(updatedCollection),
     [collections, filterFn, searchText, setCollections, setFilteredList],
   )
   const cancelCollection = useCallback(
-    params => cancelCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
+    (params: { darCode: string, darCollectionId: number }) => cancelCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
     [updateCollections],
   )
   const openCollection = useCallback(
-    params => openCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
+    (params: { darCode: string, darCollectionId: number }) => openCollectionFn({ updateCollections, role: USER_ROLES.chairperson })(params),
     [updateCollections],
   )
-  const goToVote = useCallback(collectionId => navigate(`/dar_collection/${collectionId}`), [navigate])
+  const goToVote = useCallback((collectionId: number) => navigate(`/dar_collection/${collectionId}`), [navigate])
 
   return (
     <div style={Styles.PAGE}>

--- a/test/pages/ChairConsole.spec.tsx
+++ b/test/pages/ChairConsole.spec.tsx
@@ -1,0 +1,193 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import ChairConsole from 'src/pages/ChairConsole'
+import { Collections } from 'src/libs/ajax/Collections'
+import { User } from 'src/libs/ajax/User'
+import { Notifications } from 'src/libs/utils'
+import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCollectionColumns'
+import { DarCollectionSummary } from 'src/types/model'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('src/libs/ajax/Collections', () => ({
+  Collections: {
+    getCollectionSummariesByRoleName: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/ajax/User', () => ({
+  User: {
+    getUserRelevantDatasets: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/utils', async (importActual) => {
+  const actual = await importActual<typeof import('src/libs/utils')>()
+  return {
+    ...actual,
+    Notifications: { showError: vi.fn(), showSuccess: vi.fn() },
+    getSearchFilterFunctions: () => ({
+      darCollections: (term: string, list: DarCollectionSummary[]) =>
+        list.filter(c => c.darCode.toLowerCase().includes(term.toLowerCase())),
+    }),
+  }
+})
+
+vi.mock('src/libs/theme', () => ({
+  Styles: {
+    PAGE: {},
+    SEARCH_ACTION_HEADER_SECTION: {},
+  },
+}))
+
+vi.mock('src/hooks/usePageTitle', () => ({
+  usePageTitle: vi.fn(),
+}))
+
+vi.mock('src/hooks/useResponsiveDarCollectionColumns', () => ({
+  useResponsiveDarCollectionColumns: vi.fn().mockReturnValue(['col1', 'col2']),
+}))
+
+vi.mock('src/components/TableHeaderSection', () => ({
+  default: ({ title, description }: { title: string, description: string }) =>
+    React.createElement('div', null,
+      React.createElement('h1', null, title),
+      React.createElement('p', null, description)),
+}))
+
+vi.mock('src/components/SearchBar', () => ({
+  default: ({ handleSearchChange }: { handleSearchChange: (v: string) => void }) =>
+    React.createElement('input', {
+      'aria-label': 'search',
+      'onChange': (e: React.ChangeEvent<HTMLInputElement>) => handleSearchChange(e.target.value),
+    }),
+}))
+
+vi.mock('src/components/dar_collection_table/DarCollectionTable', () => ({
+  DarCollectionTable: ({ collections, isLoading }: { collections: DarCollectionSummary[], isLoading: boolean }) =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'dar-collection-table', 'data-loading': String(isLoading) },
+      (collections ?? []).map(c =>
+        React.createElement('span', { key: c.darCollectionId }, c.darCode),
+      ),
+    ),
+}))
+
+vi.mock('src/utils/DarCollectionUtils', () => ({
+  cancelCollectionFn: vi.fn(() => vi.fn()),
+  openCollectionFn: vi.fn(() => vi.fn()),
+  updateCollectionFn: vi.fn(() => vi.fn()),
+  consoleTypes: { CHAIR: 'CHAIR', MEMBER: 'MEMBER', RESEARCHER: 'RESEARCHER' },
+}))
+
+const makeCollection = (id: number, darCode: string): DarCollectionSummary => ({
+  darCollectionId: id,
+  darCode,
+  actions: [],
+  dacNames: [],
+  dacCode: 'DAC-1',
+  datasetCount: 0,
+  datasetIds: [],
+  expired: false,
+  expiresAt: 0,
+  institutionName: 'Test Institution',
+  latestReferenceId: `ref-${id}`,
+  name: `Collection ${id}`,
+  progressReport: false,
+  referenceIds: [],
+  requiresSOApproval: false,
+  researcherName: 'Test Researcher',
+  status: 'In Progress',
+  submissionDate: 0,
+})
+
+const testCollections = [
+  makeCollection(1, 'DAR-001'),
+  makeCollection(2, 'DAR-002'),
+]
+
+describe('ChairConsole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useResponsiveDarCollectionColumns).mockReturnValue(['col1', 'col2'])
+    vi.mocked(User.getUserRelevantDatasets).mockResolvedValue([])
+  })
+
+  it('renders the page title', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ChairConsole />))
+    expect(screen.getByText('My DAC\'s Data Access Requests')).toBeInTheDocument()
+  })
+
+  it('renders the description', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ChairConsole />))
+    expect(screen.getByText('Select and manage Data Access Requests for DAC Review')).toBeInTheDocument()
+  })
+
+  it('fetches collections and relevant datasets on mount', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ChairConsole />))
+    expect(Collections.getCollectionSummariesByRoleName).toHaveBeenCalledTimes(1)
+    expect(User.getUserRelevantDatasets).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes loaded collections to the table', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue(testCollections)
+    await act(async () => render(<ChairConsole />))
+    expect(screen.getByText('DAR-001')).toBeInTheDocument()
+    expect(screen.getByText('DAR-002')).toBeInTheDocument()
+  })
+
+  it('shows loading state while fetching', () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockReturnValue(new Promise(() => {}))
+    render(<ChairConsole />)
+    expect(screen.getByTestId('dar-collection-table')).toHaveAttribute('data-loading', 'true')
+  })
+
+  it('clears loading state after fetch completes', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ChairConsole />))
+    expect(screen.getByTestId('dar-collection-table')).toHaveAttribute('data-loading', 'false')
+  })
+
+  it('shows an error notification when fetch fails', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockRejectedValue(new Error('network error'))
+    await act(async () => render(<ChairConsole />))
+    expect(Notifications.showError).toHaveBeenCalledWith({
+      text: 'Error initializing Collections table',
+    })
+  })
+
+  it('does not render the table when no responsive columns are available', async () => {
+    vi.mocked(useResponsiveDarCollectionColumns).mockReturnValue([])
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue(testCollections)
+    await act(async () => render(<ChairConsole />))
+    expect(screen.queryByTestId('dar-collection-table')).not.toBeInTheDocument()
+  })
+
+  it('renders the search bar', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ChairConsole />))
+    expect(screen.getByRole('textbox', { name: 'search' })).toBeInTheDocument()
+  })
+
+  it('filters collections when the search input changes', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue(testCollections)
+    await act(async () => render(<ChairConsole />))
+    expect(screen.getByText('DAR-001')).toBeInTheDocument()
+    expect(screen.getByText('DAR-002')).toBeInTheDocument()
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox', { name: 'search' }), { target: { value: 'DAR-001' } })
+    })
+    expect(screen.getByText('DAR-001')).toBeInTheDocument()
+    expect(screen.queryByText('DAR-002')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2643

### Summary

Convert `ChairConsole.jsx` to TypeScript and add Vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
