### PR TITLE
[DT-2642] Convert `BackgroundSignIn.jsx` to TypeScript

### DIFF
--- a/src/pages/BackgroundSignIn.tsx
+++ b/src/pages/BackgroundSignIn.tsx
@@ -1,45 +1,65 @@
-import React from 'react'
-import { User } from '../libs/ajax/User'
-import { Storage } from '../libs/storage'
-import { Navigation, setUserRoleStatuses } from '../libs/utils'
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
+import { User } from 'src/libs/ajax/User'
+import { Storage } from 'src/libs/storage'
+import { Navigation, setUserRoleStatuses } from 'src/libs/utils'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { SpinnerComponent } from '../components/SpinnerComponent'
-import loadingImage from '../images/loading-indicator.svg'
+import { SpinnerComponent } from 'src/components/SpinnerComponent'
+import loadingImage from 'src/images/loading-indicator.svg'
+import { OidcUser as OidcUserType } from 'src/libs/auth/oidcBroker'
+import { DuosUser } from 'src/types/model'
 
-export default function BackgroundSignIn(props) {
+export interface BackgroundSignInProps {
+  onSignIn?: () => void
+  onError?: (error: { status?: number }) => void
+  bearerToken?: string
+  isLogged?: boolean
+  env?: string
+}
+
+export default function BackgroundSignIn({ onSignIn, onError, bearerToken }: Readonly<BackgroundSignInProps>) {
   const location = useLocation()
   const navigate = useNavigate()
   const queryParams = new URLSearchParams(location.search)
-  let token = queryParams.get('token')
-  const { onSignIn, onError, bearerToken } = props
-  token = bearerToken || (token || '')
-  const [loading, setLoading] = useState(token && token !== '')
+  const token = bearerToken ?? (queryParams.get('token') ?? '')
+  const [loading, setLoading] = useState(token !== '')
   const [accessToken, setAccessToken] = useState(token)
   const [formToken, setFormToken] = useState(token)
   const [invalidToken, setInvalidToken] = useState(false)
 
   useEffect(() => {
-    const getUser = async () => {
+    const getUser = async (): Promise<DuosUser> => {
       return await User.getMe()
     }
 
-    const redirect = (user) => {
+    const redirect = (user: DuosUser) => {
       Navigation.console(user, navigate)
       if (onSignIn)
         onSignIn()
     }
 
-    const performLogin = () => {
-      setLoading(true)
-      Storage.setOidcUser({ id_token: accessToken })
+    const handle409 = () => {
       getUser().then(
         (user) => {
-          user = Object.assign(user, setUserRoleStatuses(user, Storage))
+          const enriched = Object.assign(user, setUserRoleStatuses(user, Storage))
+          redirect(enriched)
           setLoading(false)
-          redirect(user)
         },
-        (error) => {
+        () => {
+          Storage.clearStorage()
+          setLoading(false)
+        })
+    }
+
+    const performLogin = () => {
+      setLoading(true)
+      Storage.setOidcUser({ id_token: accessToken } as unknown as OidcUserType)
+      getUser().then(
+        (user) => {
+          const enriched = Object.assign(user, setUserRoleStatuses(user, Storage))
+          setLoading(false)
+          redirect(enriched)
+        },
+        (error: { status?: number }) => {
           const status = error.status
           switch (status) {
             case 400:
@@ -48,22 +68,9 @@ export default function BackgroundSignIn(props) {
               setLoading(false)
               break
             case 409:
-              // If the user exists, just log them in.
-              getUser().then(
-                (user) => {
-                  user = Object.assign(user, setUserRoleStatuses(user, Storage))
-                  redirect(user)
-                  setLoading(false)
-                },
-                () => {
-                  Storage.clearStorage()
-                  setLoading(false)
-                })
+              handle409()
               break
             case 401:
-              setInvalidToken(true)
-              setLoading(false)
-              break
             default:
               setInvalidToken(true)
               setLoading(false)
@@ -74,7 +81,6 @@ export default function BackgroundSignIn(props) {
 
     if (accessToken)
       performLogin()
-    return () => { }
   }, [accessToken, navigate, onError, onSignIn])
 
   return (
@@ -106,9 +112,9 @@ export default function BackgroundSignIn(props) {
                       </div>
                     )}
                   <br />
-                  <label id="lbl_accessToken" className="common-color">
+                  <div id="lbl_accessToken" className="common-color">
                     Access Token
-                  </label>
+                  </div>
                   <div>
                     <textarea
                       name="accessToken"

--- a/test/pages/BackgroundSignIn.spec.tsx
+++ b/test/pages/BackgroundSignIn.spec.tsx
@@ -1,0 +1,172 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import BackgroundSignIn from 'src/pages/BackgroundSignIn'
+import { User } from 'src/libs/ajax/User'
+import { Storage } from 'src/libs/storage'
+import { Navigation } from 'src/libs/utils'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async (importActual) => {
+  const actual = await importActual<typeof import('react-router-dom')>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('src/libs/ajax/User', () => ({
+  User: {
+    getMe: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/storage', () => ({
+  Storage: {
+    setOidcUser: vi.fn(),
+    clearStorage: vi.fn(),
+    setCurrentUser: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/utils', async (importActual) => {
+  const actual = await importActual<typeof import('src/libs/utils')>()
+  return {
+    ...actual,
+    Navigation: { console: vi.fn() },
+    setUserRoleStatuses: vi.fn(user => user),
+  }
+})
+
+vi.mock('src/libs/auth/oidcBroker', () => ({}))
+
+vi.mock('src/components/SpinnerComponent', () => ({
+  SpinnerComponent: ({ show, name }: { show: boolean, name: string }) =>
+    React.createElement('div', { 'data-testid': 'spinner', 'data-show': String(show), 'data-name': name }),
+}))
+
+vi.mock('src/images/loading-indicator.svg', () => ({ default: 'loading.svg' }))
+
+const mockUser = {
+  userId: 1,
+  displayName: 'Test User',
+  email: 'test@example.com',
+  roles: [],
+  isChairPerson: false,
+  isMember: false,
+  isAdmin: false,
+  isResearcher: false,
+  isAlumni: false,
+  isSigningOfficial: false,
+  isDataSubmitter: false,
+}
+
+const renderComponent = (props = {}, route = '/backgroundsignin') =>
+  render(
+    <MemoryRouter initialEntries={[route]}>
+      <BackgroundSignIn {...props} />
+    </MemoryRouter>,
+  )
+
+describe('BackgroundSignIn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the access token form when no token is present', () => {
+    renderComponent()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('renders the submit button in the form', () => {
+    renderComponent()
+    expect(screen.getByDisplayValue('Submit')).toBeInTheDocument()
+  })
+
+  it('renders the Access Token label', () => {
+    renderComponent()
+    expect(screen.getByText('Access Token')).toBeInTheDocument()
+  })
+
+  it('shows the spinner when a bearerToken is provided', () => {
+    vi.mocked(User.getMe).mockReturnValue(new Promise(() => {}))
+    renderComponent({ bearerToken: 'my-token' })
+    expect(screen.getByTestId('spinner')).toBeInTheDocument()
+    expect(screen.getByTestId('spinner')).toHaveAttribute('data-show', 'true')
+  })
+
+  it('calls User.getMe and Storage.setOidcUser when bearerToken is provided', async () => {
+    vi.mocked(User.getMe).mockResolvedValue(mockUser as never)
+    await act(async () => renderComponent({ bearerToken: 'abc123' }))
+    expect(Storage.setOidcUser).toHaveBeenCalledTimes(1)
+    expect(User.getMe).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls Navigation.console and onSignIn on successful login', async () => {
+    vi.mocked(User.getMe).mockResolvedValue(mockUser as never)
+    const onSignIn = vi.fn()
+    await act(async () => renderComponent({ bearerToken: 'good-token', onSignIn }))
+    expect(Navigation.console).toHaveBeenCalledWith(expect.objectContaining({ userId: 1 }), mockNavigate)
+    expect(onSignIn).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the invalid token message on 401 error', async () => {
+    vi.mocked(User.getMe).mockRejectedValue({ status: 401 })
+    await act(async () => renderComponent({ bearerToken: 'bad-token' }))
+    expect(screen.getByText('The provided token is invalid.')).toBeInTheDocument()
+  })
+
+  it('shows the invalid token message on unknown error status', async () => {
+    vi.mocked(User.getMe).mockRejectedValue({ status: 500 })
+    await act(async () => renderComponent({ bearerToken: 'bad-token' }))
+    expect(screen.getByText('The provided token is invalid.')).toBeInTheDocument()
+  })
+
+  it('calls onError and hides spinner on 400 error', async () => {
+    vi.mocked(User.getMe).mockRejectedValue({ status: 400 })
+    const onError = vi.fn()
+    await act(async () => renderComponent({ bearerToken: 'bad-token', onError }))
+    expect(onError).toHaveBeenCalledWith({ status: 400 })
+    expect(screen.queryByTestId('spinner')).not.toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('on 409 error re-fetches user and redirects', async () => {
+    vi.mocked(User.getMe)
+      .mockRejectedValueOnce({ status: 409 })
+      .mockResolvedValue(mockUser as never)
+    await act(async () => renderComponent({ bearerToken: 'conflict-token' }))
+    expect(User.getMe).toHaveBeenCalledTimes(2)
+    expect(Navigation.console).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears storage on 409 when second getMe fails', async () => {
+    vi.mocked(User.getMe)
+      .mockRejectedValueOnce({ status: 409 })
+      .mockRejectedValue(new Error('network error'))
+    await act(async () => renderComponent({ bearerToken: 'conflict-token' }))
+    expect(Storage.clearStorage).toHaveBeenCalledTimes(1)
+  })
+
+  it('triggers login when form is submitted with a typed token', async () => {
+    vi.mocked(User.getMe).mockResolvedValue(mockUser as never)
+    await act(async () => renderComponent())
+    await act(async () => {
+      fireEvent.change(screen.getByRole('textbox'), { target: { value: 'typed-token' } })
+    })
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('form'))
+    })
+    expect(Storage.setOidcUser).toHaveBeenCalledTimes(1)
+    expect(User.getMe).toHaveBeenCalledTimes(1)
+  })
+
+  it('picks up a token from the URL query parameter', async () => {
+    vi.mocked(User.getMe).mockResolvedValue(mockUser as never)
+    await act(async () => renderComponent({}, '/backgroundsignin?token=url-token'))
+    expect(Storage.setOidcUser).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2642

### Summary

Convert `BackgroundSignIn.jsx` to TypeScript and add Vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
