### PR TITLE
[DT-2636] Convert `ResearcherConsole.jsx` to TypeScript

### DIFF
--- a/src/pages/researcher_console/ResearcherConsole.tsx
+++ b/src/pages/researcher_console/ResearcherConsole.tsx
@@ -3,9 +3,7 @@ import { cloneDeep, findIndex } from 'src/utils/NodashUtil'
 import { Styles } from 'src/libs/theme'
 import { DAR } from 'src/libs/ajax/DAR'
 import { Collections } from 'src/libs/ajax/Collections'
-import {
-  DarCollectionTable,
-} from 'src/components/dar_collection_table/DarCollectionTable'
+import { DarCollectionTable } from 'src/components/dar_collection_table/DarCollectionTable'
 import { getSearchFilterFunctions, Notifications, searchOnFilteredList, USER_ROLES } from 'src/libs/utils'
 import { consoleTypes } from 'src/utils/DarCollectionUtils'
 import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCollectionColumns'
@@ -14,106 +12,94 @@ import BroadLibraryCardAgreementLink from 'src/assets/Library_Card_Agreement_202
 import NihLibraryCardAgreementLink from 'src/assets/NIHLibraryCardAgreement06252025.pdf'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
+import { DarCollectionSummary } from 'src/types/model'
 
 const filterFn = getSearchFilterFunctions().darCollections
 
 export default function ResearcherConsole() {
   usePageTitle('Data Acccess Requests')
   const [isLoading, setIsLoading] = useState(true)
-  const [researcherCollections, setResearcherCollections] = useState()
-  const [filteredList, setFilteredList] = useState()
+  const [researcherCollections, setResearcherCollections] = useState<DarCollectionSummary[]>([])
+  const [filteredList, setFilteredList] = useState<DarCollectionSummary[]>([])
   const [searchText, setSearchText] = useState('')
 
-  // Get responsive columns for researcher console
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.RESEARCHER)
 
-  // callback function passed to search bar to perform filter
-  const handleSearchChange = useCallback(terms => setSearchText(terms), [])
+  const handleSearchChange = useCallback((terms: string) => setSearchText(terms), [])
 
-  // re-filter whenever search text or underlying data changes
   useEffect(() => {
     searchOnFilteredList(searchText, researcherCollections, filterFn, setFilteredList)
   }, [searchText, researcherCollections])
 
-  // sequence of init events on component load
   useEffect(() => {
     const init = async () => {
-      const collections = await Collections.getCollectionSummariesByRoleName(USER_ROLES.researcher)
-      setResearcherCollections(collections)
-      setFilteredList(collections)
-      setIsLoading(false)
+      try {
+        const collections = await Collections.getCollectionSummariesByRoleName(USER_ROLES.researcher)
+        setResearcherCollections(collections)
+        setFilteredList(collections)
+        setIsLoading(false)
+      }
+      catch {
+        Notifications.showError({ text: 'Error: Failed to load Data Access Requests' })
+        setIsLoading(false)
+      }
     }
-    init()
+    void init()
   }, [])
 
-  // cancel collection function, passed to collections table to be used in buttons
-  const cancelCollection = async (darCollection) => {
+  const fetchAndUpdateCollection = async (darCollectionId: number) => {
+    const updatedCollection = await Collections.getCollectionSummaryByRoleNameAndId({
+      roleName: USER_ROLES.researcher,
+      id: darCollectionId,
+    })
+    const targetIndex = researcherCollections.findIndex(collection =>
+      collection.darCollectionId === darCollectionId)
+    if (targetIndex < 0) {
+      throw new Error('Error: Could not find target Data Access Request')
+    }
+    const clonedCollections = cloneDeep(researcherCollections)
+    clonedCollections[targetIndex] = updatedCollection
+    setResearcherCollections(clonedCollections)
+  }
+
+  const cancelCollection = async (darCollection: DarCollectionSummary) => {
     try {
       const { darCollectionId, darCode } = darCollection
       await Collections.cancelCollection(darCollectionId, USER_ROLES.researcher)
-      const updatedCollection = await Collections.getCollectionSummaryByRoleNameAndId({
-        roleName: USER_ROLES.researcher,
-        id: darCollectionId,
-      })
-      const targetIndex = researcherCollections.findIndex(collection =>
-        collection.darCollectionId === darCollectionId)
-      if (targetIndex < 0) {
-        throw new Error('Error: Could not find target Data Access Request')
-      }
-      const clonedCollections = cloneDeep(researcherCollections)
-      clonedCollections[targetIndex] = updatedCollection
-      setResearcherCollections(clonedCollections)
+      await fetchAndUpdateCollection(darCollectionId)
       Notifications.showSuccess({ text: `Deleted Data Access Request ${darCode}` })
     }
-    catch (_error) {
-      Notifications.showError({
-        text: 'Error: Cannot cancel target Data Access Request',
-      })
+    catch {
+      Notifications.showError({ text: 'Error: Cannot cancel target Data Access Request' })
     }
   }
 
-  // revise collection function, passed to collections table to be used in buttons
-  const reviseCollection = async (darCollection) => {
+  const reviseCollection = async (darCollection: DarCollectionSummary) => {
     try {
       const { darCollectionId, darCode } = darCollection
-      const draftCollection = await Collections.reviseCollection(darCollectionId)
-      const targetIndex = researcherCollections.findIndex(collection =>
-        collection.darCollectionId === darCollectionId)
-      if (targetIndex < 0) {
-        throw new Error('Error: Could not find target Data Access Request')
-      }
-      // remove resubmitted collection from DAR Collection table
-      const clonedCollections = cloneDeep(researcherCollections)
-      clonedCollections[targetIndex] = draftCollection
-      setResearcherCollections(clonedCollections)
+      await Collections.reviseCollection(darCollectionId)
+      await fetchAndUpdateCollection(darCollectionId)
       Notifications.showSuccess({ text: `Revising Data Access Request ${darCode}` })
     }
-    catch (_error) {
-      Notifications.showError({
-        text: 'Error: Cannot revise target Data Access Request',
-      })
+    catch {
+      Notifications.showError({ text: 'Error: Cannot revise target Data Access Request' })
     }
   }
 
-  // Draft delete, by referenceIds
-  const deleteDraftById = async ({ referenceId }) => {
+  const deleteDraftById = async ({ referenceId }: { referenceId: string }): Promise<number> => {
     const collectionsClone = cloneDeep(researcherCollections)
     await DAR.deleteDar(referenceId)
     const targetIndex = findIndex(collectionsClone, (draft) => {
       return draft.referenceIds[0] === referenceId
     })
-
-    // if deleted index, remove it from the collections array
     collectionsClone.splice(targetIndex, 1)
     setResearcherCollections(collectionsClone)
-
     return targetIndex
   }
 
-  // Draft delete, passed down to draft table to be used with delete button
-  const deleteDraft = async ({ referenceIds, darCode }) => {
+  const deleteDraft = async ({ referenceIds, darCode }: Pick<DarCollectionSummary, 'referenceIds' | 'darCode'>) => {
     try {
-      const targetIndex = deleteDraftById({ referenceId: referenceIds[0] })
+      const targetIndex = await deleteDraftById({ referenceId: referenceIds[0] })
       if (targetIndex === -1) {
         Notifications.showError({ text: 'Error processing delete request' })
       }
@@ -121,7 +107,7 @@ export default function ResearcherConsole() {
         Notifications.showSuccess({ text: `Deleted Data Access Request Draft ${darCode}` })
       }
     }
-    catch (_error) {
+    catch {
       Notifications.showError({
         text: `Failed to delete Data Access Request Draft ${darCode}`,
       })

--- a/test/pages/researcher_console/ResearcherConsole.spec.tsx
+++ b/test/pages/researcher_console/ResearcherConsole.spec.tsx
@@ -1,0 +1,269 @@
+import React from 'react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import ResearcherConsole from 'src/pages/researcher_console/ResearcherConsole'
+import { Collections } from 'src/libs/ajax/Collections'
+import { DAR } from 'src/libs/ajax/DAR'
+import { Notifications } from 'src/libs/utils'
+import { DarCollectionSummary } from 'src/types/model'
+
+vi.mock('src/libs/ajax/Collections', () => ({
+  Collections: {
+    getCollectionSummariesByRoleName: vi.fn(),
+    cancelCollection: vi.fn(),
+    reviseCollection: vi.fn(),
+    getCollectionSummaryByRoleNameAndId: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/ajax/DAR', () => ({
+  DAR: {
+    deleteDar: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/utils', async (importActual) => {
+  const actual = await importActual<typeof import('src/libs/utils')>()
+  return {
+    ...actual,
+    Notifications: { showError: vi.fn(), showSuccess: vi.fn() },
+    searchOnFilteredList: vi.fn(),
+    getSearchFilterFunctions: () => ({ darCollections: (_term: string, list: DarCollectionSummary[]) => list }),
+  }
+})
+
+vi.mock('src/hooks/usePageTitle', () => ({
+  usePageTitle: vi.fn(),
+}))
+
+vi.mock('src/hooks/useResponsiveDarCollectionColumns', () => ({
+  useResponsiveDarCollectionColumns: vi.fn(),
+}))
+
+vi.mock('src/utils/DarCollectionUtils', () => ({
+  consoleTypes: { RESEARCHER: 'researcher', ADMIN: 'admin', SIGNING_OFFICIAL: 'signingOfficial' },
+  styles: {},
+  DarCollectionTableColumnOptions: {},
+}))
+
+let capturedCancelCollection: ((c: DarCollectionSummary) => Promise<void>) | null = null
+let capturedReviseCollection: ((c: DarCollectionSummary) => Promise<void>) | null = null
+let capturedDeleteDraft: ((c: Pick<DarCollectionSummary, 'referenceIds' | 'darCode'>) => Promise<void>) | null = null
+let capturedCollections: DarCollectionSummary[] | undefined = undefined
+
+vi.mock('src/components/dar_collection_table/DarCollectionTable', () => ({
+  DarCollectionTable: ({
+    collections,
+    isLoading,
+    cancelCollection,
+    reviseCollection,
+    deleteDraft,
+  }: {
+    collections: DarCollectionSummary[]
+    isLoading: boolean
+    cancelCollection: (c: DarCollectionSummary) => Promise<void>
+    reviseCollection: (c: DarCollectionSummary) => Promise<void>
+    deleteDraft: (c: Pick<DarCollectionSummary, 'referenceIds' | 'darCode'>) => Promise<void>
+  }) => {
+    capturedCollections = collections
+    capturedCancelCollection = cancelCollection
+    capturedReviseCollection = reviseCollection
+    capturedDeleteDraft = deleteDraft
+    return React.createElement('div', { 'data-testid': 'dar-collection-table', 'data-loading': String(isLoading) })
+  },
+}))
+
+vi.mock('src/components/SearchBar', () => ({
+  default: ({ handleSearchChange }: { handleSearchChange: (v: string) => void }) =>
+    React.createElement('input', { 'data-testid': 'search-bar', 'onChange': (e: React.ChangeEvent<HTMLInputElement>) => handleSearchChange(e.target.value) }),
+}))
+
+vi.mock('src/components/TableHeaderSection', () => ({
+  default: ({ title, description }: { title: string, description: string }) =>
+    React.createElement('div', null,
+      React.createElement('h1', null, title),
+      React.createElement('p', null, description)),
+}))
+
+vi.mock('src/assets/Library_Card_Agreement_2023_ApplicationVersion.pdf', () => ({ default: 'broad-lca.pdf' }))
+vi.mock('src/assets/NIHLibraryCardAgreement06252025.pdf', () => ({ default: 'nih-lca.pdf' }))
+
+const { useResponsiveDarCollectionColumns } = await import('src/hooks/useResponsiveDarCollectionColumns')
+const { searchOnFilteredList } = await import('src/libs/utils')
+
+const makeCollection = (overrides: Partial<DarCollectionSummary> = {}): DarCollectionSummary => ({
+  actions: [],
+  dacNames: [],
+  dacCode: 'DAC-001',
+  darCode: 'DAR-001',
+  darCollectionId: 1,
+  datasetCount: 1,
+  datasetIds: [1],
+  expired: false,
+  expiresAt: 0,
+  institutionName: 'Broad Institute',
+  latestReferenceId: 'ref-001',
+  name: 'Test Collection',
+  progressReport: false,
+  referenceIds: ['ref-001'],
+  requiresSOApproval: false,
+  researcherName: 'Jane Doe',
+  status: 'In Progress',
+  submissionDate: 1700000000,
+  ...overrides,
+})
+
+describe('ResearcherConsole', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedCancelCollection = null
+    capturedReviseCollection = null
+    capturedDeleteDraft = null
+    capturedCollections = undefined
+    vi.mocked(useResponsiveDarCollectionColumns).mockReturnValue(['col1', 'col2'] as never)
+    vi.mocked(searchOnFilteredList).mockImplementation((_term, list, _fn, setter) => {
+      setter(list ?? [])
+    })
+  })
+
+  it('renders the page title and description', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ResearcherConsole />))
+    expect(screen.getByText('My Data Access Requests')).toBeInTheDocument()
+    expect(screen.getByText('Select and manage Data Access Requests and Drafts below')).toBeInTheDocument()
+  })
+
+  it('renders links to Broad and NIH Library Card Agreements', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ResearcherConsole />))
+    expect(screen.getByText('Broad')).toBeInTheDocument()
+    expect(screen.getByText('NIH')).toBeInTheDocument()
+  })
+
+  it('renders the SearchBar', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ResearcherConsole />))
+    expect(screen.getByTestId('search-bar')).toBeInTheDocument()
+  })
+
+  it('renders the DarCollectionTable', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ResearcherConsole />))
+    expect(screen.getByTestId('dar-collection-table')).toBeInTheDocument()
+  })
+
+  it('fetches collections on mount and passes them to the table', async () => {
+    const collections = [makeCollection()]
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue(collections)
+    await act(async () => render(<ResearcherConsole />))
+    expect(Collections.getCollectionSummariesByRoleName).toHaveBeenCalledWith('Researcher')
+    expect(capturedCollections).toEqual(collections)
+  })
+
+  it('shows loading state initially and clears it after fetch', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    const { getByTestId } = render(<ResearcherConsole />)
+    expect(getByTestId('dar-collection-table').getAttribute('data-loading')).toBe('true')
+    await act(async () => {})
+    expect(getByTestId('dar-collection-table').getAttribute('data-loading')).toBe('false')
+  })
+
+  it('shows error notification when fetch fails', async () => {
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockRejectedValue(new Error('network'))
+    await act(async () => render(<ResearcherConsole />))
+    await waitFor(() =>
+      expect(Notifications.showError).toHaveBeenCalledWith({ text: 'Error: Failed to load Data Access Requests' }),
+    )
+  })
+
+  it('does not render table when no responsive columns are returned', async () => {
+    vi.mocked(useResponsiveDarCollectionColumns).mockReturnValue([] as never)
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
+    await act(async () => render(<ResearcherConsole />))
+    // table still renders but columns prop is empty
+    expect(screen.getByTestId('dar-collection-table')).toBeInTheDocument()
+  })
+
+  it('cancelCollection updates collection in state and shows success', async () => {
+    const original = makeCollection({ darCollectionId: 1, darCode: 'DAR-001' })
+    const updated = makeCollection({ darCollectionId: 1, darCode: 'DAR-001', status: 'Canceled' })
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([original])
+    vi.mocked(Collections.cancelCollection).mockResolvedValue(updated as never)
+    vi.mocked(Collections.getCollectionSummaryByRoleNameAndId).mockResolvedValue(updated)
+    await act(async () => render(<ResearcherConsole />))
+    await act(async () => {
+      await capturedCancelCollection!(original)
+    })
+    await waitFor(() =>
+      expect(Notifications.showSuccess).toHaveBeenCalledWith({ text: 'Deleted Data Access Request DAR-001' }),
+    )
+  })
+
+  it('cancelCollection shows error notification on failure', async () => {
+    const collection = makeCollection()
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([collection])
+    vi.mocked(Collections.cancelCollection).mockRejectedValue(new Error('fail'))
+    await act(async () => render(<ResearcherConsole />))
+    await act(async () => {
+      await capturedCancelCollection!(collection)
+    })
+    await waitFor(() =>
+      expect(Notifications.showError).toHaveBeenCalledWith({ text: 'Error: Cannot cancel target Data Access Request' }),
+    )
+  })
+
+  it('reviseCollection shows success notification after revising', async () => {
+    const collection = makeCollection({ darCollectionId: 1, darCode: 'DAR-001' })
+    const revised = makeCollection({ darCollectionId: 1, darCode: 'DAR-001', status: 'Draft' })
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([collection])
+    vi.mocked(Collections.reviseCollection).mockResolvedValue(revised as never)
+    vi.mocked(Collections.getCollectionSummaryByRoleNameAndId).mockResolvedValue(revised)
+    await act(async () => render(<ResearcherConsole />))
+    await act(async () => {
+      await capturedReviseCollection!(collection)
+    })
+    await waitFor(() =>
+      expect(Notifications.showSuccess).toHaveBeenCalledWith({ text: 'Revising Data Access Request DAR-001' }),
+    )
+  })
+
+  it('reviseCollection shows error notification on failure', async () => {
+    const collection = makeCollection()
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([collection])
+    vi.mocked(Collections.reviseCollection).mockRejectedValue(new Error('fail'))
+    await act(async () => render(<ResearcherConsole />))
+    await act(async () => {
+      await capturedReviseCollection!(collection)
+    })
+    await waitFor(() =>
+      expect(Notifications.showError).toHaveBeenCalledWith({ text: 'Error: Cannot revise target Data Access Request' }),
+    )
+  })
+
+  it('deleteDraft removes draft from collections and shows success', async () => {
+    const draft = makeCollection({ referenceIds: ['ref-001'], darCode: 'DAR-DRAFT' })
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([draft])
+    vi.mocked(DAR.deleteDar).mockResolvedValue({ status: 200 })
+    await act(async () => render(<ResearcherConsole />))
+    await act(async () => {
+      await capturedDeleteDraft!({ referenceIds: ['ref-001'], darCode: 'DAR-DRAFT' })
+    })
+    await waitFor(() =>
+      expect(Notifications.showSuccess).toHaveBeenCalledWith({ text: 'Deleted Data Access Request Draft DAR-DRAFT' }),
+    )
+  })
+
+  it('deleteDraft shows error notification on failure', async () => {
+    const draft = makeCollection({ referenceIds: ['ref-001'], darCode: 'DAR-DRAFT' })
+    vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([draft])
+    vi.mocked(DAR.deleteDar).mockRejectedValue(new Error('fail'))
+    await act(async () => render(<ResearcherConsole />))
+    await act(async () => {
+      await capturedDeleteDraft!({ referenceIds: ['ref-001'], darCode: 'DAR-DRAFT' })
+    })
+    await waitFor(() =>
+      expect(Notifications.showError).toHaveBeenCalledWith({ text: 'Failed to delete Data Access Request Draft DAR-DRAFT' }),
+    )
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2636

### Summary

Convert `ResearcherConsole.jsx` to TypeScript and add Vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
