### PR TITLE
[DT-2552] Convert `ReviewHeader.jsx` to TypeScript

### DIFF
--- a/src/pages/dar_collection_review/ReviewHeader.tsx
+++ b/src/pages/dar_collection_review/ReviewHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const styles = {
+const styles: Record<string, React.CSSProperties> = {
   header: {
     fontWeight: 600,
     marginRight: '1rem',
@@ -43,26 +43,35 @@ const styles = {
   },
 }
 
-const appliedPrimaryHeaderStyle = Object.assign({}, styles.containerRow, styles.primaryHeaderRow)
-const appliedSecondaryHeaderStyle = Object.assign({}, styles.containerRow, styles.secondaryHeaderRow)
+const appliedPrimaryHeaderStyle: React.CSSProperties = { ...styles.containerRow, ...styles.primaryHeaderRow }
+const appliedSecondaryHeaderStyle: React.CSSProperties = { ...styles.containerRow, ...styles.secondaryHeaderRow }
 
-const getApprovedDatasetsText = (approvedDatasets) => {
+const getApprovedDatasetsText = (approvedDatasets: string[]): string => {
   if (approvedDatasets.length > 0) {
     return `${approvedDatasets.length} Dataset${approvedDatasets.length > 1 ? 's' : ''} approved: ${approvedDatasets.join(', ')}`
   }
   return 'No datasets approved'
 }
 
-export default function ReviewHeader(props) {
-  const {
-    darCode,
-    projectTitle,
-    userName,
-    institutionName,
-    approvedDatasets,
-    readOnly = false,
-    isLoading,
-  } = props
+export interface ReviewHeaderProps {
+  darCode?: string
+  projectTitle?: string
+  userName?: string
+  institutionName?: string
+  approvedDatasets: string[]
+  readOnly?: boolean
+  isLoading?: boolean
+}
+
+export default function ReviewHeader({
+  darCode,
+  projectTitle,
+  userName,
+  institutionName,
+  approvedDatasets,
+  readOnly = false,
+  isLoading,
+}: Readonly<ReviewHeaderProps>) {
   return (
     <>
       {!isLoading && (

--- a/test/pages/dar_collection_review/ReviewHeader.spec.tsx
+++ b/test/pages/dar_collection_review/ReviewHeader.spec.tsx
@@ -59,4 +59,40 @@ describe('ReviewHeader - Tests', () => {
     expect(screen.getByText('Data Access Request Review')).toBeInTheDocument()
     expect(screen.queryByText(/read-only/)).not.toBeInTheDocument()
   })
+
+  it('Renders userName and institutionName together', () => {
+    render(
+      <ReviewHeader
+        approvedDatasets={[]}
+        userName="Jane Doe"
+        institutionName="Broad Institute"
+      />,
+    )
+
+    expect(screen.getByText('Jane Doe, Broad Institute')).toBeInTheDocument()
+  })
+
+  it('Renders skeleton loader when isLoading is true', () => {
+    const { container } = render(
+      <ReviewHeader
+        approvedDatasets={[]}
+        isLoading={true}
+      />,
+    )
+
+    expect(container.querySelector('.header-skeleton-loader')).toBeInTheDocument()
+    expect(container.querySelector('.header-container')).not.toBeInTheDocument()
+  })
+
+  it('Does not render skeleton loader when isLoading is false', () => {
+    const { container } = render(
+      <ReviewHeader
+        approvedDatasets={[]}
+        isLoading={false}
+      />,
+    )
+
+    expect(container.querySelector('.header-container')).toBeInTheDocument()
+    expect(container.querySelector('.header-skeleton-loader')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2552

### Summary

Convert `ReviewHeader.jsx` to TypeScript and add Vitest tests.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
