### PR TITLE
[DT-3774] Filter Manage DAC table dataset count by dacApproval  

### DIFF
--- a/src/components/manage_dac_table/ManageDacTableCellData.tsx
+++ b/src/components/manage_dac_table/ManageDacTableCellData.tsx
@@ -74,7 +74,7 @@ export function descriptionCellData({ description = '- -', dacId, label = 'dac-d
 }
 
 export function datasetsCellData({ dac, viewDatasets, label = 'dac-datasets' }: DatasetsCellDataParams): CellData {
-  const datasetCount = (dac.datasets ?? []).length
+  const datasetCount = (dac.datasets ?? []).filter(dataset => dataset.dacApproval).length
   return {
     isComponent: true,
     id: dac.dacId,

--- a/test/components/manage_dac_table/ManageDacTableCellData.spec.tsx
+++ b/test/components/manage_dac_table/ManageDacTableCellData.spec.tsx
@@ -64,11 +64,32 @@ describe('ManageDacTableCellData', () => {
   })
 
   describe('datasetsCellData', () => {
-    it('shows the dataset count', () => {
-      const dac: DacObject = { ...baseDac, datasets: [{ datasetId: 1 } as Dataset, { datasetId: 2 } as Dataset] }
+    it('shows the count of approved datasets', () => {
+      const dac: DacObject = {
+        ...baseDac,
+        datasets: [
+          { datasetId: 1, dacApproval: true } as Dataset,
+          { datasetId: 2, dacApproval: true } as Dataset,
+          { datasetId: 3, dacApproval: false } as Dataset,
+        ],
+      }
       const cell = datasetsCellData({ dac, viewDatasets: vi.fn() })
       renderNode(cell.data)
       expect(screen.getByRole('button')).toHaveTextContent('2')
+    })
+
+    it('excludes datasets that are not approved', () => {
+      const dac: DacObject = {
+        ...baseDac,
+        datasets: [
+          { datasetId: 1, dacApproval: true } as Dataset,
+          { datasetId: 2, dacApproval: false } as Dataset,
+          { datasetId: 3 } as Dataset,
+        ],
+      }
+      const cell = datasetsCellData({ dac, viewDatasets: vi.fn() })
+      renderNode(cell.data)
+      expect(screen.getByRole('button')).toHaveTextContent('1')
     })
 
     it('shows 0 when dac has no datasets', () => {

--- a/test/components/manage_dac_table/ManageDacTableCellData.spec.tsx
+++ b/test/components/manage_dac_table/ManageDacTableCellData.spec.tsx
@@ -64,11 +64,31 @@ describe('ManageDacTableCellData', () => {
   })
 
   describe('datasetsCellData', () => {
-    it('shows the dataset count', () => {
-      const dac: DacObject = { ...baseDac, datasets: [{ datasetId: 1 } as Dataset, { datasetId: 2 } as Dataset] }
+    it('shows the count of approved datasets', () => {
+      const dac: DacObject = {
+        ...baseDac,
+        datasets: [
+          { datasetId: 1, dacApproval: true } as Dataset,
+          { datasetId: 2, dacApproval: true } as Dataset,
+        ],
+      }
       const cell = datasetsCellData({ dac, viewDatasets: vi.fn() })
       renderNode(cell.data)
       expect(screen.getByRole('button')).toHaveTextContent('2')
+    })
+
+    it('excludes datasets that are not approved', () => {
+      const dac: DacObject = {
+        ...baseDac,
+        datasets: [
+          { datasetId: 1, dacApproval: true } as Dataset,
+          { datasetId: 2, dacApproval: false } as Dataset,
+          { datasetId: 3 } as Dataset,
+        ],
+      }
+      const cell = datasetsCellData({ dac, viewDatasets: vi.fn() })
+      renderNode(cell.data)
+      expect(screen.getByRole('button')).toHaveTextContent('1')
     })
 
     it('shows 0 when dac has no datasets', () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3774

### Summary

The Manage DAC table's dataset count included all datasets regardless of approval status, while the DAC profile/EditDac page only counts approved ones. Filtered `datasetsCellData` to `dacApproval === true` so both views agree. Depends on the companion `consent` fix that populates `dacApproval` on `GET /api/dac`. 

Backend PR: https://github.com/DataBiosphere/consent/pull/2962

**Before**
<img width="1782" height="535" alt="Before-Table" src="https://github.com/user-attachments/assets/4109d929-666d-422d-adfa-105cb5693cda" />

**After**
<img width="1782" height="533" alt="After-Table" src="https://github.com/user-attachments/assets/e5112e72-b64f-43af-925e-8a57086730b4" />

**Approved Datasets**
<img width="1755" height="419" alt="Approved-Datasets" src="https://github.com/user-attachments/assets/401b7558-8044-4947-a91f-26da1fc36bef" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
