### PR TITLE
[DT-400] Update Dependabot Directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,9 +21,7 @@ updates:
           - "minor"
           - "patch"
   - package-ecosystem: npm
-    directories:
-      - "/"
-      - "/server/"
+    directory: "/"
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-400

## Summary

### Problem
Dependabot's grouped npm PRs (e.g. [DT-400-pnpm](https://github.com/DataBiosphere/duos-ui/pull/3742)): Bump the pnpm-other-updates group across 2 directories with 12 updates) fail CI with:

```
[ERR_PNPM_OUTDATED_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with package.json
```

The failure listed 10 mismatched specifiers — all of them root-only dependencies (`@mui/*`, `vite`, `react-router-dom`, etc.), while the three packages also bumped in `/server` (`fastify`, `@fastify/vite`, `server @types/node`) were consistent.

### Root cause
The npm ecosystem entry in dependabot.yml listed two directories:

```
directories:
  - "/"
  - "/server/"
```

But this repo is a pnpm workspace (`pnpm-workspace.yaml` declares `server` as a member) with a single root `pnpm-lock.yaml` — there is no `server/pnpm-lock.yaml`. With a multi-directory grouped config, dependabot runs one update pass per directory, and each pass regenerates the same shared lockfile. The `/server` pass ran last and overwrote the lockfile with one that only reflects the server manifest bumps, leaving the root `package.json` bumps unlocked. This is a known dependabot-core defect with grouped multi-directory configs over a shared lockfile.

### Fix
Point dependabot at the workspace root only:

```
directory: "/"
```

Dependabot discovers workspace members from `pnpm-workspace.yaml`, so it still bumps `server/package.json` — but now regenerates the lockfile in a single pass covering the whole workspace.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
