### PR TITLE
[DT-3759] Remove `isRP` and simplify unnecessary bucket checks

### DIFF
--- a/src/components/dar_dataset_table/DarDatasetTable.tsx
+++ b/src/components/dar_dataset_table/DarDatasetTable.tsx
@@ -98,9 +98,8 @@ export const DarDatasetTable = ({
       }
       const dacIds = isUnfilteredView ? [] : uniq(compact(map(user.roles, r => r.dacId))) as number[]
       const allBuckets = await binCollectionToBuckets(collection, dacIds)
-      const dataAccessBuckets = allBuckets.filter(b => b.isRP !== true)
-      setBuckets(dataAccessBuckets)
-      setTableSize(dataAccessBuckets.length)
+      setBuckets(allBuckets)
+      setTableSize(allBuckets.length)
     }
     catch {
       Notifications.showError({ text: 'Error initializing DAR Collection Dataset summary.' })

--- a/src/pages/dar_application/DucAddendum.tsx
+++ b/src/pages/dar_application/DucAddendum.tsx
@@ -106,11 +106,8 @@ export default function DucAddendum(props: Readonly<DucAddendumProps>) {
     }
     try {
       const fetchedBuckets = await binCollectionToBuckets({ datasets })
-      const dataAccessBuckets = fetchedBuckets.filter(
-        bucket => bucket.isRP !== true,
-      )
-      setBuckets(dataAccessBuckets)
-      setDacs(dataAccessBuckets.flatMap(bucket => bucket.dacs ?? []))
+      setBuckets(fetchedBuckets)
+      setDacs(fetchedBuckets.flatMap(bucket => bucket.dacs ?? []))
     }
     catch (error) {
       const errorMessage = extractError(error)

--- a/src/pages/dar_collection_review/DarCollectionReview.tsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.tsx
@@ -4,7 +4,7 @@ import TabControl from 'src/components/TabControl'
 import { type TabStyleOverride } from 'src/components/SelectableText'
 import ReviewHeader from './ReviewHeader'
 import ApplicationInformation from './ApplicationInformation'
-import { compact, filter, get, isEmpty, map, toLower, uniq } from 'src/utils/NodashUtil'
+import { compact, get, isEmpty, map, toLower, uniq } from 'src/utils/NodashUtil'
 import { updateFinalVote } from 'src/utils/DarCollectionUtils'
 import { binCollectionToBuckets, Bucket } from 'src/utils/BucketUtils'
 import { Navigation, Notifications } from 'src/libs/utils'
@@ -69,8 +69,7 @@ const tabsForUser = (user: DuosUser, buckets: Bucket[], adminPage = false): Reco
       votingHistory: 'Voting History',
     }
   }
-  const dataAccessBuckets = filter(buckets, bucket => get(bucket, 'isRP') !== true) as Bucket[]
-  const allVoteRecords = dataAccessBuckets.flatMap(b => b.votes)
+  const allVoteRecords = buckets.flatMap(b => b.votes)
   const myMemberVotes = allVoteRecords
     .map(vr => vr['dataAccess'])
     .flatMap(vg => vg.memberVotes)

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.tsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { filter, get, isNil } from 'src/utils/NodashUtil'
+import { get, isNil } from 'src/utils/NodashUtil'
 import { Alert } from 'src/components/Alert'
 import AILLMWarningBanner from 'src/components/AILLMWarningBanner'
 import MultiDatasetVoteSlab from 'src/components/collection_voting_slab/MultiDatasetVoteSlab'
@@ -103,9 +103,7 @@ export default function MultiDatasetVotingTab({
   const [dacDatasetIds, setDacDatasetIds] = useState<number[]>([])
 
   const missingLibraryCardMessage = 'The Researcher must have a Library Card before data access can be granted.\n'
-    + (adminPage ? '' : 'You can still deny this request and/or vote on the Structured Research Purpose.')
-
-  const dataBuckets = filter(buckets, bucket => get(bucket, 'isRP') !== true) as Bucket[]
+    + (adminPage ? '' : 'You can still deny this request.')
 
   useEffect(() => {
     const init = async () => {
@@ -144,7 +142,7 @@ export default function MultiDatasetVotingTab({
       <div style={styles.title}>Datasets Requested by Data Use</div>
       <div style={styles.slabs}>
         <DatasetVoteSlabs
-          dataBuckets={dataBuckets}
+          dataBuckets={buckets}
           collection={collection}
           dacDatasetIds={dacDatasetIds}
           isApprovalDisabled={dataAccessApprovalDisabled()}

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -33,7 +33,6 @@ export interface Bucket {
   votes: Record<string, VoteGroup>[]
   matchResults: MatchResult[]
   algorithmResult?: AlgorithmResult
-  isRP: boolean // In practice, this will always be false.
   dacs?: DacTerm[]
 }
 
@@ -126,7 +125,6 @@ export const binCollectionToBuckets = async (collection: Pick<DarCollection, 'da
       elections: [],
       votes: [],
       matchResults: [],
-      isRP: false,
       dacs: dacs,
     }
     buckets.push(bucket)

--- a/test/utils/BucketUtils.spec.ts
+++ b/test/utils/BucketUtils.spec.ts
@@ -275,16 +275,14 @@ describe('BucketUtils', () => {
     for (const b of buckets) {
       expect(b.key).not.toBe('')
       expect(b.votes).not.toHaveLength(0)
-      if (!b.isRP) {
-        expect(b.label).not.toBe('')
-        expect(b.datasets).not.toHaveLength(0)
-        expect(b.datasetIds).not.toHaveLength(0)
-        if (b.dataUse) {
-          expect(b.dataUse).not.toStrictEqual({})
-          expect(b.dataUses).not.toHaveLength(0)
-        }
-        expect(b.elections).not.toHaveLength(0)
+      expect(b.label).not.toBe('')
+      expect(b.datasets).not.toHaveLength(0)
+      expect(b.datasetIds).not.toHaveLength(0)
+      if (b.dataUse) {
+        expect(b.dataUse).not.toStrictEqual({})
+        expect(b.dataUses).not.toHaveLength(0)
       }
+      expect(b.elections).not.toHaveLength(0)
     }
   })
 
@@ -329,7 +327,7 @@ describe('BucketUtils', () => {
     vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue(dataset_terms)
 
     const buckets = await binCollectionToBuckets(dar_collection)
-    const missingDataUse = buckets.find(b => !b.isRP && isUndefined(b.dataUse))
+    const missingDataUse = buckets.find(b => isUndefined(b.dataUse))
 
     expect(missingDataUse).toBeDefined()
     expect(missingDataUse?.datasets).not.toHaveLength(0)
@@ -343,10 +341,9 @@ describe('BucketUtils', () => {
     vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue(dataset_terms.filter(d => d.dacId === 1))
 
     const buckets = await binCollectionToBuckets(dar_collection, [1])
-    const dataAccessBuckets = buckets.filter(b => !b.isRP)
 
-    expect(dataAccessBuckets).toHaveLength(1)
-    expect(dataAccessBuckets[0].datasetIds).toHaveLength(1)
+    expect(buckets).toHaveLength(1)
+    expect(buckets[0].datasetIds).toHaveLength(1)
     verifyBucketElectionsAndDatasets(buckets)
   })
 
@@ -355,9 +352,8 @@ describe('BucketUtils', () => {
     vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue(dataset_terms.filter(d => d.dacId === 1 || d.dacId === 5))
 
     const buckets = await binCollectionToBuckets(dar_collection, [1, 5])
-    const dataAccessBuckets = buckets.filter(b => !b.isRP)
 
-    expect(dataAccessBuckets).toHaveLength(2)
+    expect(buckets).toHaveLength(2)
     verifyBucketElectionsAndDatasets(buckets)
   })
 
@@ -398,17 +394,14 @@ describe('BucketUtils', () => {
     const buckets = await binCollectionToBuckets(similar_data_use_collection)
 
     expect(buckets).not.toHaveLength(0)
-    // Three distinct data-use patterns → three buckets (no separate RP bucket)
+    // Three distinct data-use patterns → three buckets
     expect(buckets).toHaveLength(3)
     // HMB + Other
-    expect(buckets[0].isRP).toBe(false)
     expect(buckets[0].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'HMB')).toBeDefined()
     expect(buckets[0].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'OTHER')).toBeDefined()
     // General Use
-    expect(buckets[1].isRP).toBe(false)
     expect(buckets[1].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'GRU')).toBeDefined()
     // HMB only
-    expect(buckets[2].isRP).toBe(false)
     expect(buckets[2].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'HMB')).toBeDefined()
     expect(buckets[2].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'OTHER')).toBeUndefined()
   })


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3759

### Summary
This PR continues previous work around removing outdated RP election/vote/bucket logic. Here, we remove the `isRP` flag on buckets and simplify all callers that were using it as a filter. It also includes a small message cleanup in `MultiDatasetVotingTab`

See also previous PRs:
- https://github.com/DataBiosphere/duos-ui/pull/3744
- https://github.com/DataBiosphere/duos-ui/pull/3747

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
