### PR TITLE
[DT-3759] VoteGroup refactor

### DIFF
--- a/src/pages/dar_collection_review/DarCollectionReview.tsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.tsx
@@ -223,10 +223,10 @@ export default function DarCollectionReview({ adminPage = false, readOnly = fals
     }
   }, [adminPage, navigate, collectionId])
 
-  // Remember, votes are contained within buckets, so updating final votes will update the bucket
-  // define updateFinalVote as a callback function so that its function definition can be updated alongside dataUseBucket
+  // Votes are grouped into buckets (by DataUse), so applying a final vote will update all votes in the  bucket.
+  // Define updateFinalVote as a callback function so that its function definition can be updated alongside dataUseBucket
   const updateFinalVoteFn = useCallback((key: string, votePayload: Record<string, unknown>, voteIds: number[]) => {
-    return updateFinalVote({ key, votePayload, voteIds, dataUseBuckets: dataUseBuckets as never, setDataUseBuckets: setDataUseBuckets as never })
+    return updateFinalVote({ key, votePayload, voteIds, dataUseBuckets, setDataUseBuckets })
   }, [dataUseBuckets])
 
   useEffect(() => {

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.tsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.tsx
@@ -3,7 +3,7 @@ import { get, isNil } from 'src/utils/NodashUtil'
 import { Alert } from 'src/components/Alert'
 import AILLMWarningBanner from 'src/components/AILLMWarningBanner'
 import MultiDatasetVoteSlab from 'src/components/collection_voting_slab/MultiDatasetVoteSlab'
-import ResearchProposalVoteSlab from 'src/components/collection_voting_slab/ResearchProposalSlab'
+import ResearchProposalSlab from 'src/components/collection_voting_slab/ResearchProposalSlab'
 import { User } from 'src/libs/ajax/User'
 import { Bucket } from 'src/utils/BucketUtils'
 import { DarCollection, DataAccessRequestData } from 'src/types/model'
@@ -134,9 +134,9 @@ export default function MultiDatasetVotingTab({
           id="missing_lc"
         />
       )}
-      <ResearchProposalVoteSlab
+      <ResearchProposalSlab
         darInfo={darInfo}
-        key="rp-vote"
+        key="rp-slab"
         isLoading={isLoading}
       />
       <div style={styles.title}>Datasets Requested by Data Use</div>

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -50,12 +50,10 @@ interface VoteGroup {
  *      a: Pull out the data use translations for the bucket's dataUse
  *      b: Populate translated dataUses
  * Step 2: Pull out match data based on dataset that the match data applies to.
- * Step 3: Pull all elections for those datasets into the buckets
+ * Step 3: Pull all Data Access elections for those datasets into the buckets
  * Step 4: Pull all votes up to a top level bucket field for easier iteration
  * Step 5: Set the bucket key/label from the dataUse + dataset ids
  * Step 6: Coalesce the algorithm decision per bucket
- *
- * Note that RP election votes are silently ignored as votes are no longer cast for them.
  */
 export const binCollectionToBuckets = async (collection: Pick<DarCollection, 'datasets'> & Partial<Pick<DarCollection, 'dars'>>, dacIds: number[] = []): Promise<Bucket[]> => {
   const buckets: Bucket[] = []

--- a/src/utils/DarCollectionUtils.ts
+++ b/src/utils/DarCollectionUtils.ts
@@ -2,7 +2,7 @@ import { Styles } from 'src/libs/theme'
 import { formatDate, Notifications } from 'src/libs/utils'
 import { Collections } from 'src/libs/ajax/Collections'
 import { DarCollectionSummary, Election, UserRoleName, Vote } from 'src/types/model'
-import { groupBy, isEmpty, isNil, cloneDeep } from 'src/utils/NodashUtil'
+import { groupBy, isNil, cloneDeep } from 'src/utils/NodashUtil'
 
 interface VotesByType {
   chairpersonVotes: Vote[]
@@ -16,7 +16,10 @@ interface ProcessedVotes extends Record<string, VotesByType> {
   dataAccess: VotesByType & Required<Pick<VotesByType, 'agreementVotes' | 'radarVotes'>>
 }
 
-type VoteArrayGroup = Partial<Record<'dataAccess', Partial<VotesByType>>>
+// One entry of a bucket's votes array, as produced by processVotesForBucket
+interface VoteGroup {
+  dataAccess?: Partial<VotesByType>
+}
 
 // Helper function for processDataUseBuckets, essentially organizes votes in a dar's elections by type
 export const processVotesForBucket = (darElections: Election[] = []): ProcessedVotes => {
@@ -67,7 +70,7 @@ export const processVotesForBucket = (darElections: Election[] = []): ProcessedV
 // Minimal shape of a bucket needed for vote extraction
 export interface VoteBucket {
   [key: string]: unknown
-  votes?: VoteArrayGroup[]
+  votes?: VoteGroup[]
 }
 
 // Gets data access votes from this bucket by members of this user's DAC
@@ -75,10 +78,7 @@ export interface VoteBucket {
 export const extractDacDataAccessVotesFromBucket = (bucket: VoteBucket | null | undefined, user: { userId: number }, adminPage?: boolean): Vote[] => {
   const votes = bucket?.votes ?? []
 
-  let memberVotesArrays = votes
-    .map(voteData => voteData.dataAccess)
-    .filter(dataAccessData => !isEmpty(dataAccessData))
-    .map(filteredData => filteredData?.memberVotes ?? [])
+  let memberVotesArrays = votes.map(voteData => voteData.dataAccess?.memberVotes ?? [])
 
   if (!adminPage) {
     memberVotesArrays = filterVoteArraysForUsersDac(memberVotesArrays, user)
@@ -283,7 +283,7 @@ export const approveCollectionFn = ({
 
 // helper function used in DarCollectionReview to update final vote on source of truth
 // done to trigger re-renders on parent and child components (vote summary bar, member tab, etc.)
-export const updateFinalVote = ({
+export const updateFinalVote = <T extends UpdatableVoteBucket>({
   key,
   votePayload,
   voteIds,
@@ -293,9 +293,9 @@ export const updateFinalVote = ({
   key: string
   votePayload: VotePayload | Record<string, unknown>
   voteIds: number[]
-  dataUseBuckets: UpdatableVoteBucket[]
-  setDataUseBuckets: (buckets: UpdatableVoteBucket[]) => void
-}): UpdatableVoteBucket[] | undefined => {
+  dataUseBuckets: T[]
+  setDataUseBuckets: (buckets: T[]) => void
+}): T[] | undefined => {
   if (!isVotePayload(votePayload)) {
     return undefined
   }
@@ -407,8 +407,6 @@ export const DarCollectionTableColumnOptions = {
   STATUS: 'status',
   ACTIONS: 'actions',
 } as const
-
-type VoteGroup = Record<string, VotesByType>
 
 interface VotePayload {
   vote: boolean


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3759

## Summary
This is the last of the clean up tasks for cleaning up RP votes and any references to them. 
- Updates `VoteArrayGroup` -> `VoteGroup`
- Rename `ResearchProposalVoteSlab` -> `ResearchProposalSlab`
- Minor documentation updates

See also previous PRs:
- https://github.com/DataBiosphere/duos-ui/pull/3744
- https://github.com/DataBiosphere/duos-ui/pull/3747
- https://github.com/DataBiosphere/duos-ui/pull/3754


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
