### PR TITLE
[DT-3572] Use vmThreads to improve test performance

### DIFF
--- a/test/libs/ajax/fetchAdapter.spec.ts
+++ b/test/libs/ajax/fetchAdapter.spec.ts
@@ -105,7 +105,8 @@ describe('fetchAdapter - Fetch methods', () => {
     fetchMock.mockResolvedValue(new Response(mockBlob, { status: 200 }))
 
     const result = await fetchGet<Blob>('/api/file', { responseType: 'blob' })
-    expect(result.data).toBeInstanceOf(Blob)
+    expect(result.data?.constructor?.name).toBe('Blob')
+    expect(result.data.type).toContain('text/plain')
   })
 
   it('fetchGet - should return text when content-type is text/plain', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,9 +11,10 @@ export default defineConfig({
     alias: aliases_from_tsconfig(),
   },
   test: {
-    css: true,
+    css: false,
     globals: true,
     environment: 'jsdom',
+    pool: 'vmThreads',
     include: ['test/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: ['build/**', 'cypress/**', 'node_modules/**', 'server/**'],
     coverage: {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3572

### Summary

`vmThreads` keeps a worker thread warm and reuses it across files, but runs each file inside its own lightweight V8 VM context (via Node's `node:vm`) for isolation. This gives the same per-file isolation guarantee as the default `forks` option without paying the full process-restart price each time. As a result, the thread, the compiled modules, and much of the environment setup are reused.

The same profile after the switch:

| Phase         | `forks` (before) | `vmThreads` (after) |
| ------------- | ---------------- | ------------------- |
| `import`      | ~1184s           | ~308s               |
| `environment` | ~396s            | ~11s                |
| `tests`       | ~64s             | ~50s                |
| **Duration**  | **~247s**        | **~62s**            |

`environment` decreases by ~36x and `import` by ~4x, because the warm thread no longer rebuilds everything from scratch for each file.

For comparison, here are other alternatives that were considered:

| Config                          | Duration | vs baseline |
| ------------------------------- | -------- | ----------- |
| `forks` (default baseline)      | ~247s    | 1.0x        |
| `threads` + `css: false`        | ~239s    | 1.03x       |
| `jsdom` → `happy-dom`           | ~204s    | 1.2x        |
| **`vmThreads`**                 | **~62s** | **~4x**     |

The one trade-off: cross-realm `instanceof`

Each VM context is a separate JavaScript **realm** with its own copies of the global built-ins (`Blob`, `FormData`, `ArrayBuffer`, `Error`, `Date`, …). An object created inside the VM context (i.e. produced by the code under test) does **not** pass `instanceof` against the same-named global in the test file, because the two constructors live in different realms.

This issue surfaced in one test in `test/libs/ajax/fetchAdapter.spec.ts`, which checked an assertion that a fetched blob was `toBeInstanceOf(Blob)`. The value *was* a Blob; it just wasn't an instance of the test file's `Blob`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
