### PR TITLE
[DT-3785]  Ensure `status` and `auth` e2e tests use a real backend    

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,13 +27,19 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm exec playwright install chromium --with-deps
       - name: Copy Configs
-        run: cp config/base_config.json public/config.json
+        run: cp config/dev.json public/config.json
       - name: Map local dev hostname
         run: echo "127.0.0.1 local.dsde-dev.broadinstitute.org" | sudo tee -a /etc/hosts
       - name: Build app
         run: CI=false pnpm run build
       - name: Run Playwright integration tests
         run: pnpm run test:e2e
+        env:
+          DUOS_AUTOMATION_ADMIN_SA: ${{ secrets.DUOS_AUTOMATION_ADMIN_SA }}
+          DUOS_AUTOMATION_CHAIR_SA: ${{ secrets.DUOS_AUTOMATION_CHAIR_SA }}
+          DUOS_AUTOMATION_MEMBER_SA: ${{ secrets.DUOS_AUTOMATION_MEMBER_SA }}
+          DUOS_AUTOMATION_RESEARCHER_SA: ${{ secrets.DUOS_AUTOMATION_RESEARCHER_SA }}
+          DUOS_AUTOMATION_SIGNING_OFFICIAL_SA: ${{ secrets.DUOS_AUTOMATION_SIGNING_OFFICIAL_SA }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: failure()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ models.json
 /coverage
 /test-results
 /playwright-report
+/test/e2e/fixtures/duos-automation*.json
 
 # production
 /build

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,0 +1,11 @@
+{
+  "env": "dev",
+  "hash": "dev",
+  "tag": "dev",
+  "bardApiUrl": "https://terra-bard-dev.appspot.com",
+  "apiUrl": "https://consent.dsde-dev.broadinstitute.org",
+  "terraUrl": "https://bvdp-saturn-dev.appspot.com",
+  "tdrApiUrl": "https://jade.datarepo-dev.broadinstitute.org",
+  "ecmApiUrl": "https://externalcreds.dsde-dev.broadinstitute.org",
+  "features": {}
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,9 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
-
-// vite.config.ts only enables HTTPS locally (certs aren't available in CI), so the
-// preview server serves plain HTTP there — match the scheme or the webServer never comes up.
-const protocol = process.env.CI ? 'http' : 'https'
-const BASE_URL = `${protocol}://local.dsde-dev.broadinstitute.org:3000`
+import { BASE_URL } from './test/e2e/support/baseUrl'
 
 export default defineConfig({
   testDir: 'test/e2e',

--- a/scripts/render-accounts.sh
+++ b/scripts/render-accounts.sh
@@ -17,6 +17,8 @@ signing-official"
 PROJECT="broad-dsde-qa"
 OUTPUT_DIR="test/e2e/fixtures"
 
+mkdir -p "$OUTPUT_DIR"
+
 for ROLE in $LIST_OF_ROLES; do
   FILE="$OUTPUT_DIR/duos-automation-$ROLE.json"
   echo "Writing $ROLE secret to $FILE"

--- a/src/components/navigation/ProfileLinks.tsx
+++ b/src/components/navigation/ProfileLinks.tsx
@@ -38,6 +38,7 @@ export const ProfileLinks: React.FC<ProfileLinksProps> = (props) => {
     }}
     >
       <Typography
+        id="sel_user"
         onClick={handleOpenUserMenu}
         sx={[
           {

--- a/src/pages/BackgroundSignIn.tsx
+++ b/src/pages/BackgroundSignIn.tsx
@@ -52,7 +52,11 @@ export default function BackgroundSignIn({ onSignIn, onError, bearerToken }: Rea
 
     const performLogin = () => {
       setLoading(true)
-      Storage.setOidcUser({ id_token: accessToken } as unknown as OidcUserType)
+      // Storage.userIsLogged() gates on profile.exp; this page accepts an opaque bearer
+      // token (not a decodable ID token), so there's no real expiry to read - assume the
+      // typical Google OAuth2 access token lifetime instead of leaving this permanently 0.
+      const oneHourFromNow = Math.floor(Date.now() / 1000) + 3600
+      Storage.setOidcUser({ id_token: accessToken, profile: { exp: oneHourFromNow } } as unknown as OidcUserType)
       getUser().then(
         (user) => {
           const enriched = Object.assign(user, setUserRoleStatuses(user, Storage))

--- a/test/e2e/auth.spec.ts
+++ b/test/e2e/auth.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, ROLES } from './support/auth'
+import type { Role } from './support/auth'
+
+// Each role's console, per headerTabsConfig in src/components/DuosHeader.tsx.
+const CONSOLE_LABEL: Record<Role, string> = {
+  ADMIN: 'Admin Console',
+  CHAIR: 'DAC Chair Console',
+  MEMBER: 'DAC Member Console',
+  RESEARCHER: 'Researcher Console',
+  SIGNING_OFFICIAL: 'SO Console',
+}
+
+for (const role of ROLES) {
+  test(`Background sign-in as ${role}`, async ({ page, signInAs }) => {
+    await signInAs(role)
+    await expect(page.getByText(CONSOLE_LABEL[role]).first()).toBeVisible()
+
+    await page.locator('#sel_user').click()
+    await page.getByText('Sign out').click()
+
+    await expect(page).toHaveURL(/\/home/)
+    await expect(page.getByText('Sign In').first()).toBeVisible()
+  })
+}

--- a/test/e2e/status.spec.ts
+++ b/test/e2e/status.spec.ts
@@ -7,22 +7,6 @@ test('Status page loads from home', async ({ page }) => {
 })
 
 test('Status page renders status indicators', async ({ page }) => {
-  // This suite has no live backend (public/config.json's apiUrl is empty), so the app's
-  // API call to /status is mocked to a known-healthy response - otherwise the fetch fails and
-  // both indicators always render unhealthy, regardless of what the app is actually doing.
-  // The page itself is also served from /status (a plain <a href> full navigation, not a
-  // client-side route), so only intercept the API fetch, not the document navigation.
-  await page.route('**/status', (route) => {
-    if (route.request().resourceType() === 'document') return route.continue()
-    return route.fulfill({
-      json: {
-        ok: true,
-        degraded: false,
-        systems: { sam: { healthy: true, details: { ok: true } } },
-      },
-    })
-  })
-
   await page.goto('/')
   await page.getByText('Status').click()
   await expect(page.locator('#consent')).toBeVisible()

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -1,0 +1,47 @@
+import { auth, JWT } from 'google-auth-library'
+import { test as base } from '@playwright/test'
+import { BASE_URL } from './baseUrl'
+
+export const ROLES = ['ADMIN', 'CHAIR', 'MEMBER', 'RESEARCHER', 'SIGNING_OFFICIAL'] as const
+export type Role = typeof ROLES[number]
+
+// Ported from the deleted cypress/support/commands.js `cy.auth()`: mints a real
+// Google-signed access token from a per-role service account key (no interactive
+// OIDC redirect needed), for submission into the app's /backgroundsignin route.
+export const getAccessToken = async (role: Role): Promise<string> => {
+  const envVar = `DUOS_AUTOMATION_${role}_SA`
+  const keysJson = process.env[envVar]
+  if (!keysJson) {
+    throw new Error(`Missing service account key env var ${envVar}`)
+  }
+
+  // fromJSON's return type covers every credential shape it supports, but a service
+  // account key (what DUOS_AUTOMATION_*_SA holds) always yields a JWT client.
+  const client = auth.fromJSON(JSON.parse(keysJson)) as JWT
+  client.scopes = ['email', 'profile']
+  await client.request({ url: BASE_URL })
+
+  const accessToken = client.credentials.access_token
+  if (!accessToken) {
+    throw new Error(`Failed to obtain access token for role ${role}`)
+  }
+  return accessToken
+}
+
+type AuthFixtures = {
+  signInAs: (role: Role) => Promise<void>
+}
+
+export const test = base.extend<AuthFixtures>({
+  signInAs: async ({ page }, use) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright's fixture callback, not a React hook
+    await use(async (role: Role) => {
+      const accessToken = await getAccessToken(role)
+      await page.goto('/backgroundsignin')
+      await page.locator('textarea[name="accessToken"]').fill(accessToken)
+      await page.locator('input[type="submit"]').click()
+    })
+  },
+})
+
+export { expect } from '@playwright/test'

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -15,9 +15,14 @@ export const getAccessToken = async (role: Role): Promise<string> => {
     throw new Error(`Missing service account key env var ${envVar}`)
   }
 
+  // DUOS_AUTOMATION_*_SA holds whatever Secret Manager returns for these accounts, which
+  // is the service account key JSON wrapped in a { key: {...} } envelope, not the bare key.
+  const parsed = JSON.parse(keysJson)
+  const serviceAccountKey = parsed.key ?? parsed
+
   // fromJSON's return type covers every credential shape it supports, but a service
   // account key (what DUOS_AUTOMATION_*_SA holds) always yields a JWT client.
-  const client = auth.fromJSON(JSON.parse(keysJson)) as JWT
+  const client = auth.fromJSON(serviceAccountKey) as JWT
   client.scopes = ['email', 'profile']
   await client.request({ url: BASE_URL })
 

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -5,7 +5,6 @@ import { BASE_URL } from './baseUrl'
 export const ROLES = ['ADMIN', 'CHAIR', 'MEMBER', 'RESEARCHER', 'SIGNING_OFFICIAL'] as const
 export type Role = typeof ROLES[number]
 
-// Ported from the deleted cypress/support/commands.js `cy.auth()`: mints a real
 // Google-signed access token from a per-role service account key (no interactive
 // OIDC redirect needed), for submission into the app's /backgroundsignin route.
 export const getAccessToken = async (role: Role): Promise<string> => {

--- a/test/e2e/support/baseUrl.ts
+++ b/test/e2e/support/baseUrl.ts
@@ -1,0 +1,4 @@
+// vite.config.ts only enables HTTPS locally (certs aren't available in CI), so the
+// preview server serves plain HTTP there — match the scheme or requests never reach it.
+const protocol = process.env.CI ? 'http' : 'https'
+export const BASE_URL = `${protocol}://local.dsde-dev.broadinstitute.org:3000`


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3785

### Summary

This PR ports the deleted Cypress `cy.auth` mechanism to Playwright and points e2e tests to a real dev backend instead of mocks, closing a gap where CI ran with an empty `apiUrl` and no live backend coverage.                                                                    
                                                                                                                                                                                                                                                                              
  - Add `config/dev.json` and point CI's e2e job at it instead of the empty `config/base_config.json`                                                                                                                                                                         
  - Port `cy.auth(roleName)` as a Playwright fixture (`test/e2e/support/auth.ts`) that mints a real Google-signed token from a service account key and signs in via `/backgroundsignin`                                                                                       
  - Add `test/e2e/auth.spec.ts`, covering background sign-in and sign-out for all five roles (Admin, Chair, Member, Researcher, Signing Official)                                                                                                                             
  - Fix `BackgroundSignIn.tsx`: it wasn't setting `profile.exp`, so `Storage.userIsLogged()` always evaluated false and silently bounced every background sign-in back to home                                                                                                
  - Update `status.spec.ts` to assert against a real `/status` response instead of a mocked one                                                                                                                                                                               
  - Restore the `#sel_user` id on the profile menu trigger (dropped in the MUI rewrite), needed to drive sign-out in tests                                                                                                                                                    
  - Wire the `DUOS_AUTOMATION_*_SA` secrets into `integration-tests.yml`, and fix `render-accounts.sh` to create its own output directory   

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
