### PR TITLE
[DT-2756] Replace duplicated env group.

### DIFF
--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -68,7 +68,7 @@ const AppRoutes = (props: AppRoutesProps) => {
       <Route path="/tos_acceptance" element={<TermsOfServiceAcceptance />} />
       <Route path="/nih_dms_policy" element={<NIHDMSPolicyInfo />} />
       <Route path="/anvil_dms_policy" element={<AnVILDMSPolicyInfo />} />
-      <Route element={<EnvRoute env={envGroups.NON_STAGING} />}>
+      <Route element={<EnvRoute env={envGroups.DEV} />}>
         <Route path="/backgroundsignin" element={<BackgroundSignIn {...props} />} />
       </Route>
       <Route element={<Authenticated />}>

--- a/src/utils/EnvironmentUtils.ts
+++ b/src/utils/EnvironmentUtils.ts
@@ -7,14 +7,12 @@ export type AppEnvironment = 'prod' | 'staging' | 'local' | 'dev'
  * The environment hierarchy is:
  *  * prod
  *    * staging
- *      * alpha
  *      * dev
  *      * local
  */
 export const envGroups = {
   PROD_STAGING: ['prod', 'staging'],
   NON_PROD: ['local', 'dev', 'staging'],
-  NON_STAGING: ['local', 'dev'],
   DEV: ['local', 'dev'],
 } as const satisfies Record<string, readonly AppEnvironment[]>
 
@@ -24,10 +22,8 @@ export const envGroups = {
  * should be displayed or not based on current env.
  *
  * @example
- * // returns true when Storage.ENV === 'alpha' || 'dev' || 'local'
- * checkEnv(envGroups.NON_STAGING)
- * // returns false when Storage.ENV === 'staging' || 'prod'
- * checkEnv(envGroups.NON_STAGING)
+ * // returns true when Storage.ENV === 'dev' || 'local'
+ * checkEnv(envGroups.DEV)
  * @param envGroup
  * @returns {boolean}
  */

--- a/test/routing/AppRoutes.spec.tsx
+++ b/test/routing/AppRoutes.spec.tsx
@@ -78,3 +78,29 @@ describe('AppRoutes — RoleBAC routes redirect unauthenticated users', () => {
     expect(container.querySelector('[data-cy="not-found"]')).not.toBeInTheDocument()
   })
 })
+
+describe('AppRoutes — /backgroundsignin is gated to DEV environments', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders BackgroundSignIn when the current environment is dev', () => {
+    vi.spyOn(Storage, 'getEnv').mockReturnValue('dev')
+    const { container, getByText } = render(
+      <MemoryRouter initialEntries={['/backgroundsignin']}>
+        <AppRoutes isLogged={false} env="dev" />
+      </MemoryRouter>,
+    )
+    expect(getByText('Access Token')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="not-found"]')).not.toBeInTheDocument()
+  })
+
+  it('renders NotFound when the current environment is prod', () => {
+    vi.spyOn(Storage, 'getEnv').mockReturnValue('prod')
+    const { container, queryByText } = render(
+      <MemoryRouter initialEntries={['/backgroundsignin']}>
+        <AppRoutes isLogged={false} env="prod" />
+      </MemoryRouter>,
+    )
+    expect(container.querySelector('[data-cy="not-found"]')).toBeInTheDocument()
+    expect(queryByText('Access Token')).not.toBeInTheDocument()
+  })
+})

--- a/test/utils/EnvironmentUtils.spec.ts
+++ b/test/utils/EnvironmentUtils.spec.ts
@@ -10,18 +10,17 @@ describe('EnvironmentUtils', () => {
   it('exposes expected environment groups', () => {
     expect(envGroups.PROD_STAGING).toEqual(['prod', 'staging'])
     expect(envGroups.NON_PROD).toEqual(['local', 'dev', 'staging'])
-    expect(envGroups.NON_STAGING).toEqual(['local', 'dev'])
     expect(envGroups.DEV).toEqual(['local', 'dev'])
   })
 
   it('checkEnv returns true when current env is in the group', () => {
     vi.spyOn(Storage, 'getEnv').mockReturnValue('dev')
-    expect(checkEnv(envGroups.NON_STAGING)).toBe(true)
+    expect(checkEnv(envGroups.DEV)).toBe(true)
   })
 
   it('checkEnv returns false when current env is not in the group', () => {
     vi.spyOn(Storage, 'getEnv').mockReturnValue('prod')
-    expect(checkEnv(envGroups.NON_STAGING)).toBe(false)
+    expect(checkEnv(envGroups.DEV)).toBe(false)
   })
 
   it('checkEnv returns false when current env is null', () => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-2756

### Summary
* Simplify the env groups, `NON_STAGING` was the same as `DEV` so all are now migrated to `DEV`.
* Added tests to previous usage to ensure no regressions for `BackgroundSignIn`

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
