### PR TITLE
[DT-3781] Reject invalid collaboration document uploads and surface server validation errors

### DIFF
--- a/src/components/forms/formComponents.tsx
+++ b/src/components/forms/formComponents.tsx
@@ -15,6 +15,7 @@ import { isValid, validateFormValue, validationMessage } from 'src/components/fo
 export interface Validation {
   valid?: boolean
   failed?: string[]
+  messages?: string[]
 }
 
 export interface Validator {
@@ -179,7 +180,7 @@ const errorMessages = (validation: Validation | undefined): React.ReactNode => {
     <div className="error-message fadein">
       <span className="glyphicon glyphicon-play" />
       {validation?.failed?.map((err, idx) => (
-        <div key={'error_message_' + idx}>{validationMessage(err)}</div>
+        <div key={'error_message_' + idx}>{validation?.messages?.[idx] ?? validationMessage(err)}</div>
       ))}
     </div>
   )

--- a/src/components/forms/formValidation.ts
+++ b/src/components/forms/formValidation.ts
@@ -9,6 +9,7 @@ import { InstitutionInterface } from 'src/types/model'
 export interface Validation {
   valid?: boolean
   failed?: string[]
+  messages?: string[]
 }
 
 export interface Validator {
@@ -97,11 +98,11 @@ const fileExtension = (file: File): string => {
   return dotIndex === -1 ? '' : file.name.slice(dotIndex).toLowerCase()
 }
 
-export const fileTypeValidator: Validator = {
+export const fileTypeValidator = (acceptedExtensions: string[] = ACCEPTED_DOCUMENT_EXTENSIONS): Validator => ({
   id: 'fileType',
-  isValid: (val: unknown): boolean => !(val instanceof File) || ACCEPTED_DOCUMENT_EXTENSIONS.includes(fileExtension(val)),
-  msg: `Invalid file type. Please upload an accepted document format (${ACCEPTED_DOCUMENT_EXTENSIONS.join(', ')}).`,
-}
+  isValid: (val: unknown): boolean => !(val instanceof File) || acceptedExtensions.includes(fileExtension(val)),
+  msg: `Invalid file type. Please upload an accepted document format (${acceptedExtensions.join(', ')}).`,
+})
 
 const allValidators: Validator[] = [
   requiredValidator,
@@ -113,7 +114,7 @@ const allValidators: Validator[] = [
   dayJSValidator,
   uniqueValidator,
   greaterThanZeroValidator,
-  fileTypeValidator,
+  fileTypeValidator(),
 ]
 
 export const validateFormValue = (formValue: unknown, validators: Validator[] | undefined): Validation => {
@@ -125,6 +126,7 @@ export const validateFormValue = (formValue: unknown, validators: Validator[] | 
   }
 
   const failedValidators: string[] = []
+  const failedMessages: string[] = []
 
   validators?.forEach((validator) => {
     let failed: boolean
@@ -137,12 +139,14 @@ export const validateFormValue = (formValue: unknown, validators: Validator[] | 
 
     if (failed) {
       failedValidators.push(validator.id)
+      failedMessages.push(validator.msg)
     }
   })
 
   return {
     valid: failedValidators.length === 0,
     failed: failedValidators,
+    messages: failedMessages,
   }
 }
 

--- a/src/components/forms/formValidation.ts
+++ b/src/components/forms/formValidation.ts
@@ -90,6 +90,19 @@ export const greaterThanZeroValidator: Validator = {
   msg: 'Please enter a number greater than zero',
 }
 
+export const ACCEPTED_DOCUMENT_EXTENSIONS = ['.pdf', '.doc', '.docx']
+
+const fileExtension = (file: File): string => {
+  const dotIndex = file.name.lastIndexOf('.')
+  return dotIndex === -1 ? '' : file.name.slice(dotIndex).toLowerCase()
+}
+
+export const fileTypeValidator: Validator = {
+  id: 'fileType',
+  isValid: (val: unknown): boolean => !(val instanceof File) || ACCEPTED_DOCUMENT_EXTENSIONS.includes(fileExtension(val)),
+  msg: `Invalid file type. Please upload an accepted document format (${ACCEPTED_DOCUMENT_EXTENSIONS.join(', ')}).`,
+}
+
 const allValidators: Validator[] = [
   requiredValidator,
   urlValidator,
@@ -100,10 +113,14 @@ const allValidators: Validator[] = [
   dayJSValidator,
   uniqueValidator,
   greaterThanZeroValidator,
+  fileTypeValidator,
 ]
 
 export const validateFormValue = (formValue: unknown, validators: Validator[] | undefined): Validation => {
-  if (isEmpty(formValue) && !validators?.includes(requiredValidator)) {
+  // File objects have no own enumerable keys, so isEmpty() would wrongly treat a selected file as "empty"
+  // and skip validation below (e.g. fileTypeValidator would never run).
+  const isEmptyValue = !(formValue instanceof File) && isEmpty(formValue)
+  if (isEmptyValue && !validators?.includes(requiredValidator)) {
     return { valid: true }
   }
 

--- a/src/components/forms/forms.tsx
+++ b/src/components/forms/forms.tsx
@@ -26,6 +26,7 @@ import {
   dayJSValidator,
   emailDomainValidator,
   emailValidator,
+  fileTypeValidator,
   isValid,
   NotUrlValidator,
   requiredValidator,
@@ -230,6 +231,7 @@ export const FormFieldTypes: Record<string, FormFieldTypeConfig> = {
       'hideTextBar',
       'hideInput',
       'readOnly',
+      'accept',
     ],
   },
   CHECKBOX: {
@@ -304,6 +306,7 @@ export const FormValidators: Record<string, Validator> = {
   EMAILDOMAIN: emailDomainValidator as Validator,
   DATE: dateValidator,
   DATEJS: dayJSValidator,
+  FILE_TYPE: fileTypeValidator,
 }
 
 // ----------------------------------------------------------------------------------------------------- //

--- a/src/components/forms/forms.tsx
+++ b/src/components/forms/forms.tsx
@@ -26,7 +26,6 @@ import {
   dayJSValidator,
   emailDomainValidator,
   emailValidator,
-  fileTypeValidator,
   isValid,
   NotUrlValidator,
   requiredValidator,
@@ -41,6 +40,7 @@ type AnyComponent = React.ComponentType<any>
 export interface Validation {
   valid?: boolean
   failed?: string[]
+  messages?: string[]
 }
 
 export interface Validator {
@@ -306,7 +306,6 @@ export const FormValidators: Record<string, Validator> = {
   EMAILDOMAIN: emailDomainValidator as Validator,
   DATE: dateValidator,
   DATEJS: dayJSValidator,
-  FILE_TYPE: fileTypeValidator,
 }
 
 // ----------------------------------------------------------------------------------------------------- //

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -249,16 +249,22 @@ async function fetchMultipartRequest<T>(
     throw new Error(`${error instanceof Error ? error.message : String(error)} ${HELP_DESK_MESSAGE}`, { cause: error })
   }
   if (!res.ok) {
-    let message = `Request failed with status ${res.status}. ${HELP_DESK_MESSAGE}`
+    interface ErrorData {
+      message?: string
+      code?: number
+    }
+    let errorData: ErrorData = {}
     try {
-      const errorData = await res.json() as { message?: string }
-      if (errorData?.message) message = errorData.message
+      errorData = await res.json() as ErrorData
     }
     catch {
       // ignore parse errors, use generic message
     }
+    const message = errorData.message || `Request failed with status ${res.status}. ${HELP_DESK_MESSAGE}`
     reportError(fullUrl, res.status)
-    throw new Error(message)
+    const error = new Error(message) as Error & { response: { status: number, data: ErrorData } }
+    error.response = { status: res.status, data: errorData }
+    throw error
   }
   return handleResponse<T>(res, fullUrl, 'json', method)
 }

--- a/src/pages/dar_application/DataAccessRequest.tsx
+++ b/src/pages/dar_application/DataAccessRequest.tsx
@@ -405,14 +405,20 @@ export default function DataAccessRequest(props: Readonly<DataAccessRequestProps
             <FormField
               type={FormFieldTypes.FILE}
               readOnly={readOnlyMode}
+              accept=".pdf,.doc,.docx"
               defaultValue={uploadedCollaborationLetter || {
                 name: formData.collaborationLetterName,
               }}
               id="collaborationLetter"
               validation={validation.collaborationLetter}
+              validators={[FormValidators.FILE_TYPE]}
               onValidationChange={onValidationChange}
               description="One or more of the datasets you selected requires collaboration (COL) with the primary study investigators(s) for use. Please upload documentation of your collaboration here."
-              onChange={({ value }: { value: File | undefined }) => updateCollaborationLetter(value)}
+              onChange={({ value, isValid }: { value: File | undefined, isValid: boolean }) => {
+                if (isValid) {
+                  updateCollaborationLetter(value)
+                }
+              }}
             />
           )}
 

--- a/src/pages/dar_application/DataAccessRequest.tsx
+++ b/src/pages/dar_application/DataAccessRequest.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { DAR } from 'src/libs/ajax/DAR'
 import { FormField, FormFieldTitle, FormFieldTypes, FormValidators } from 'src/components/forms/forms'
 import { FORM_TEXT_AREA_MAX_LENGTH } from 'src/components/forms/formConstants'
+import { fileTypeValidator } from 'src/components/forms/formValidation'
 import {
   needsIrbApprovalDocument,
   needsCollaborationLetter,
@@ -411,7 +412,7 @@ export default function DataAccessRequest(props: Readonly<DataAccessRequestProps
               }}
               id="collaborationLetter"
               validation={validation.collaborationLetter}
-              validators={[FormValidators.FILE_TYPE]}
+              validators={[fileTypeValidator(['.pdf', '.doc', '.docx'])]}
               onValidationChange={onValidationChange}
               description="One or more of the datasets you selected requires collaboration (COL) with the primary study investigators(s) for use. Please upload documentation of your collaboration here."
               onChange={({ value, isValid }: { value: File | undefined, isValid: boolean }) => {

--- a/test/components/forms/formValidation.spec.ts
+++ b/test/components/forms/formValidation.spec.ts
@@ -176,27 +176,46 @@ describe('Form Validator tests', () => {
   describe('fileTypeValidator', () => {
     it('rejects a file with a disallowed extension', () => {
       const file = new File(['content'], 'photo.png', { type: 'image/png' })
-      expect(fileTypeValidator.isValid(file)).toBe(false)
+      expect(fileTypeValidator().isValid(file)).toBe(false)
     })
 
     it('accepts a .pdf file', () => {
       const file = new File(['content'], 'letter.pdf', { type: 'application/pdf' })
-      expect(fileTypeValidator.isValid(file)).toBe(true)
+      expect(fileTypeValidator().isValid(file)).toBe(true)
     })
 
     it('accepts a .doc or .docx file', () => {
-      expect(fileTypeValidator.isValid(new File(['content'], 'letter.doc'))).toBe(true)
-      expect(fileTypeValidator.isValid(new File(['content'], 'letter.docx'))).toBe(true)
+      expect(fileTypeValidator().isValid(new File(['content'], 'letter.doc'))).toBe(true)
+      expect(fileTypeValidator().isValid(new File(['content'], 'letter.docx'))).toBe(true)
     })
 
     it('is case-insensitive about the extension', () => {
       const file = new File(['content'], 'letter.PDF')
-      expect(fileTypeValidator.isValid(file)).toBe(true)
+      expect(fileTypeValidator().isValid(file)).toBe(true)
     })
 
     it('ignores non-File values', () => {
-      expect(fileTypeValidator.isValid('not-a-file')).toBe(true)
-      expect(fileTypeValidator.isValid(undefined)).toBe(true)
+      expect(fileTypeValidator().isValid('not-a-file')).toBe(true)
+      expect(fileTypeValidator().isValid(undefined)).toBe(true)
+    })
+
+    it('defaults to the document msg listing pdf/doc/docx', () => {
+      expect(fileTypeValidator().msg).toBe(
+        'Invalid file type. Please upload an accepted document format (.pdf, .doc, .docx).',
+      )
+    })
+
+    it('accepts a custom extension list per form', () => {
+      const validator = fileTypeValidator(['.png', '.jpg'])
+      expect(validator.isValid(new File(['content'], 'photo.png'))).toBe(true)
+      expect(validator.isValid(new File(['content'], 'letter.pdf'))).toBe(false)
+    })
+
+    it('reflects the custom extension list in its msg', () => {
+      const validator = fileTypeValidator(['.png', '.jpg'])
+      expect(validator.msg).toBe(
+        'Invalid file type. Please upload an accepted document format (.png, .jpg).',
+      )
     })
   })
 
@@ -249,20 +268,35 @@ describe('Form Validator tests', () => {
 
     it('runs a non-required validator against a File value instead of treating it as empty', () => {
       const file = new File(['content'], 'photo.png', { type: 'image/png' })
-      const result = validateFormValue(file, [fileTypeValidator])
+      const result = validateFormValue(file, [fileTypeValidator()])
       expect(result.valid).toBe(false)
       expect(result.failed).toContain('fileType')
     })
 
     it('returns valid:true for a File that passes the fileType validator', () => {
       const file = new File(['content'], 'letter.pdf', { type: 'application/pdf' })
-      const result = validateFormValue(file, [fileTypeValidator])
+      const result = validateFormValue(file, [fileTypeValidator()])
       expect(result.valid).toBe(true)
     })
 
     it('returns valid:true when no file is selected and the field is not required', () => {
-      const result = validateFormValue(undefined, [fileTypeValidator])
+      const result = validateFormValue(undefined, [fileTypeValidator()])
       expect(result.valid).toBe(true)
+    })
+
+    it('reports the failing message for each failed validator, in order', () => {
+      const result = validateFormValue('', [requiredValidator, urlValidator])
+      expect(result.failed).toEqual(['required', 'uri'])
+      expect(result.messages).toEqual([requiredValidator.msg, urlValidator.msg])
+    })
+
+    it('surfaces a per-form custom fileType message rather than the default one', () => {
+      const file = new File(['content'], 'letter.pdf', { type: 'application/pdf' })
+      const customValidator = fileTypeValidator(['.png', '.jpg'])
+      const result = validateFormValue(file, [customValidator])
+      expect(result.valid).toBe(false)
+      expect(result.messages).toEqual([customValidator.msg])
+      expect(result.messages).not.toEqual([fileTypeValidator().msg])
     })
   })
 

--- a/test/components/forms/formValidation.spec.ts
+++ b/test/components/forms/formValidation.spec.ts
@@ -9,6 +9,7 @@ import {
   dayJSValidator,
   uniqueValidator,
   emailDomainValidator,
+  fileTypeValidator,
   validateFormValue,
   validationMessage,
   isValid,
@@ -172,6 +173,33 @@ describe('Form Validator tests', () => {
     })
   })
 
+  describe('fileTypeValidator', () => {
+    it('rejects a file with a disallowed extension', () => {
+      const file = new File(['content'], 'photo.png', { type: 'image/png' })
+      expect(fileTypeValidator.isValid(file)).toBe(false)
+    })
+
+    it('accepts a .pdf file', () => {
+      const file = new File(['content'], 'letter.pdf', { type: 'application/pdf' })
+      expect(fileTypeValidator.isValid(file)).toBe(true)
+    })
+
+    it('accepts a .doc or .docx file', () => {
+      expect(fileTypeValidator.isValid(new File(['content'], 'letter.doc'))).toBe(true)
+      expect(fileTypeValidator.isValid(new File(['content'], 'letter.docx'))).toBe(true)
+    })
+
+    it('is case-insensitive about the extension', () => {
+      const file = new File(['content'], 'letter.PDF')
+      expect(fileTypeValidator.isValid(file)).toBe(true)
+    })
+
+    it('ignores non-File values', () => {
+      expect(fileTypeValidator.isValid('not-a-file')).toBe(true)
+      expect(fileTypeValidator.isValid(undefined)).toBe(true)
+    })
+  })
+
   describe('emailDomainValidator', () => {
     it('has a default msg when no institution is cached', () => {
       expect(emailDomainValidator.msg).toBe(
@@ -216,6 +244,24 @@ describe('Form Validator tests', () => {
 
     it('handles undefined validators gracefully', () => {
       const result = validateFormValue('anything', undefined)
+      expect(result.valid).toBe(true)
+    })
+
+    it('runs a non-required validator against a File value instead of treating it as empty', () => {
+      const file = new File(['content'], 'photo.png', { type: 'image/png' })
+      const result = validateFormValue(file, [fileTypeValidator])
+      expect(result.valid).toBe(false)
+      expect(result.failed).toContain('fileType')
+    })
+
+    it('returns valid:true for a File that passes the fileType validator', () => {
+      const file = new File(['content'], 'letter.pdf', { type: 'application/pdf' })
+      const result = validateFormValue(file, [fileTypeValidator])
+      expect(result.valid).toBe(true)
+    })
+
+    it('returns valid:true when no file is selected and the field is not required', () => {
+      const result = validateFormValue(undefined, [fileTypeValidator])
       expect(result.valid).toBe(true)
     })
   })

--- a/test/components/forms/forms.spec.tsx
+++ b/test/components/forms/forms.spec.tsx
@@ -152,16 +152,16 @@ describe('FormField - Tests', () => {
       fireEvent.change(input, { target: { value: 'a' } })
       expect(onValidationChange).toHaveBeenCalledWith({
         key: 'dataCustodianEmail',
-        validation: { valid: false, failed: ['email'] },
+        validation: { valid: false, failed: ['email'], messages: [FormValidators.EMAIL.msg] },
       })
 
       fireEvent.change(input, { target: { value: 'a@gmail.com' } })
-      expect(onValidationChange).toHaveBeenCalledWith({ key: 'dataCustodianEmail', validation: { valid: true, failed: [] } })
+      expect(onValidationChange).toHaveBeenCalledWith({ key: 'dataCustodianEmail', validation: { valid: true, failed: [], messages: [] } })
 
       fireEvent.change(input, { target: { value: '' } })
       expect(onValidationChange).toHaveBeenCalledWith({
         key: 'dataCustodianEmail',
-        validation: { valid: false, failed: ['email', 'required'] },
+        validation: { valid: false, failed: ['email', 'required'], messages: [FormValidators.EMAIL.msg, FormValidators.REQUIRED.msg] },
       })
     })
 

--- a/test/libs/ajax/fetchAdapter.spec.ts
+++ b/test/libs/ajax/fetchAdapter.spec.ts
@@ -324,6 +324,22 @@ describe('fetchAdapter - Fetch methods', () => {
     expect(error.message).toBe('File too large')
   })
 
+  it('fetchMultipart - should attach response.status and response.data on error, matching fetchRequest', async () => {
+    const formData = new FormData()
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ message: 'File name is invalid', code: 400 }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const error = await fetchMultipart('/api/upload', formData).catch(e => e)
+    expect(error.response).toEqual({
+      status: 400,
+      data: { message: 'File name is invalid', code: 400 },
+    })
+  })
+
   it('fetchMultipart - should fall back to help desk message when no message field in error body', async () => {
     const formData = new FormData()
     fetchMock.mockResolvedValue(

--- a/test/pages/dar_application/DataAccessRequest.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequest.spec.tsx
@@ -191,6 +191,56 @@ describe('DataAccessRequest', () => {
     expect(document.getElementById('collaborationLetter')).not.toBeNull()
   })
 
+  it('sets the accept attribute and rejects an invalid file type on the collaboration letter upload', async () => {
+    const updateCollaborationLetter = vi.fn()
+    const formValidationChange = vi.fn()
+    await renderDataAccessRequest({
+      datasets: [makeDataset({ collaboratorRequired: true })],
+      updateCollaborationLetter,
+      formValidationChange,
+    })
+
+    const input = document.getElementById('collaborationLetter') as HTMLInputElement
+    expect(input.accept).toBe('.pdf,.doc,.docx')
+
+    const invalidFile = new File(['content'], 'photo.png', { type: 'image/png' })
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [invalidFile] } })
+    })
+
+    expect(updateCollaborationLetter).not.toHaveBeenCalled()
+    expect(formValidationChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'collaborationLetter',
+        validation: expect.objectContaining({ valid: false, failed: ['fileType'] }),
+      }),
+    )
+  })
+
+  it('stages a valid file type on the collaboration letter upload', async () => {
+    const updateCollaborationLetter = vi.fn()
+    const formValidationChange = vi.fn()
+    await renderDataAccessRequest({
+      datasets: [makeDataset({ collaboratorRequired: true })],
+      updateCollaborationLetter,
+      formValidationChange,
+    })
+
+    const input = document.getElementById('collaborationLetter') as HTMLInputElement
+    const validFile = new File(['content'], 'letter.pdf', { type: 'application/pdf' })
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [validFile] } })
+    })
+
+    expect(updateCollaborationLetter).toHaveBeenCalledWith(validFile)
+    expect(formValidationChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: 'collaborationLetter',
+        validation: expect.objectContaining({ valid: true }),
+      }),
+    )
+  })
+
   it('shows a download link for an already-uploaded IRB document in read-only mode and downloads it on click', async () => {
     await renderDataAccessRequest({
       readOnlyMode: true,

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -74,6 +74,12 @@ vi.mock('src/libs/utils', async (importOriginal) => {
       ...original.Navigation,
       console: vi.fn(),
     },
+    Notifications: {
+      showError: vi.fn(),
+      showSuccess: vi.fn(),
+      showWarning: vi.fn(),
+      showInformation: vi.fn(),
+    },
   }
 })
 
@@ -86,6 +92,7 @@ import { DataSet } from 'src/libs/ajax/DataSet'
 import { Countries } from 'src/libs/ajax/Countries'
 import { NotificationService } from 'src/libs/notificationService'
 import { Metrics } from 'src/libs/ajax/Metrics'
+import { Notifications } from 'src/libs/utils'
 
 const darId = '011467b7-5544-499f-9210-3c2035810639'
 
@@ -258,6 +265,97 @@ describe('DataAccessRequestApplication', () => {
     await act(async () => {
       resolveSubmit({})
     })
+  })
+
+  const renderAndSaveDraft = async () => {
+    vi.mocked(Countries.getCountries).mockResolvedValue(['United States of America (the)', 'Canada'])
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(user as ReturnType<typeof Storage.getCurrentUser>)
+    vi.mocked(User.getMe).mockResolvedValue(user as Awaited<ReturnType<typeof User.getMe>>)
+    vi.mocked(User.getSOsForCurrentUser).mockResolvedValue(userSigningOfficials as Awaited<ReturnType<typeof User.getSOsForCurrentUser>>)
+    vi.mocked(Collections.getCollectionById).mockResolvedValue(darCollection)
+    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(datasets as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>)
+    vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(undefined)
+    vi.mocked(DAR.getPartialDarRequest).mockResolvedValue(darCollection.dars[darId])
+    vi.mocked(DAA.getDaas).mockResolvedValue([
+      {
+        daaId: 100,
+        createUserId: 1,
+        createDate: '1',
+        updateUserId: 1,
+        updateDate: '1',
+        initialDacId: 1,
+        dacs: [{ dacId: 1, dacName: 'Test DAC', email: 'dac@test.com' }],
+        file: { fileStorageObjectId: 1, entityId: '1', fileName: 'TestDAA.pdf', category: 'dataAccessAgreement', mediaType: 'application/pdf', createUserId: 1, createDate: 1 },
+      },
+    ] as Awaited<ReturnType<typeof DAA.getDaas>>)
+    vi.mocked(Metrics.captureEvent).mockResolvedValue(undefined)
+    vi.mocked(DAR.uploadDARDocument).mockResolvedValue({ data: null })
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={[`/dar_application/${darId}`]}>
+          <Routes>
+            <Route
+              path="/dar_application/:dataRequestId"
+              element={(
+                <DataAccessRequestApplication
+                  draftDar={true}
+                  isProgressReportApplication={false}
+                  existingDarsReadOnlyMode={false}
+                />
+              )}
+            />
+          </Routes>
+        </MemoryRouter>,
+      )
+    })
+
+    expect(screen.getByText('Data Access Request Application')).toBeInTheDocument()
+
+    await selectOptionByLabel('piCountryOfOperation', 'United States')
+    await selectOptionByLabel('signingOfficial', 'SO 1')
+    await typeById('itDirector', 'Some IT Director')
+    await typeById('itDirectorEmail', 'it@good.org')
+    await clickById('anvilUse_yes')
+    await typeById('projectTitle', 'Title')
+    await typeById('rus', 'asdf')
+    await typeById('nonTechRus', 'asdf asdf')
+    await fillDarDataUseCheckboxes()
+
+    await clickById('btn_saveDar')
+    expect(screen.getByText('Save changes?')).toBeInTheDocument()
+    await act(async () => {
+      fireEvent.click(document.getElementById('btn_submit')!)
+    })
+  }
+
+  it('surfaces the server validation message when saving a draft fails with a validation error', async () => {
+    const validationError = Object.assign(new Error('File name is invalid'), {
+      response: { data: { code: 400, message: 'File name is invalid' } },
+    })
+    vi.mocked(DAR.updateDarDraft).mockRejectedValue(validationError)
+
+    await renderAndSaveDraft()
+
+    await waitFor(() => {
+      expect(Notifications.showError).toHaveBeenCalled()
+    })
+
+    const call = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: React.ReactElement<{ children: string }> }
+    expect(call.text.props.children).toBe('File name is invalid')
+  })
+
+  it('falls back to the generic save-failure toast for an unexpected error', async () => {
+    vi.mocked(DAR.updateDarDraft).mockRejectedValue(new Error('network exploded'))
+
+    await renderAndSaveDraft()
+
+    await waitFor(() => {
+      expect(Notifications.showError).toHaveBeenCalled()
+    })
+
+    const call = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: string }
+    expect(call.text).toBe('Error saving Data Access Request. Please try again in a few moments.')
   })
 
   it('loads dataset/DAA snapshots in submitted read-only DAR review container', async () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3781

### Summary                                                                                                                                                                                                                                                                 
  - Validate the collaboration document file type client-side (`.pdf`/`.doc`/`.docx`) on the DAR Data Use Acknowledgements step, blocking invalid files from being staged for upload and showing a field-level error immediately.                                             
  - Fix `fetchMultipartRequest` so upload failures attach `response.data` (status/code/message) like other fetch paths, so `saveDarDraft`/`submitDARFormData` can surface the actual server validation message (e.g. "File name is invalid") instead of always falling back to the generic save-failure toast.                                                                                                                                                                                                                                             
  - Add tests covering the new validator, the `fetchMultipart` error shape, and the save-draft error-surfacing behavior.  

**Invalid FileType Prevention**
<img width="1776" height="891" alt="After-Frontend" src="https://github.com/user-attachments/assets/d11a57a9-c2b8-434b-af33-d4d5ca5d3799" />

**Error Surfacing**
<img width="1776" height="891" alt="After-Backend" src="https://github.com/user-attachments/assets/b97b322e-7eff-4f09-958b-6bdaa7a0b86c" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
