### PR TITLE
[DT-3607, DT-3792] Add single B2C OIDC client factory + PKCE helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN pnpm exec vite build && node scripts/write-vite-config-json.mjs
 
 # Build server
 COPY server/src ./server/src
-COPY server/tsconfig.json ./server/tsconfig.json
+COPY server/tsconfig.json server/tsconfig.build.json ./server/
 RUN pnpm --filter duos-server run build
 
 # Create a self-contained prod-only server bundle (no devDeps, no workspace symlinks)

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ COPY --chmod=550 --chown=node:node --from=builder /tmp/server-deploy ./server
 COPY --chmod=444 --chown=node:node --from=builder /usr/src/app/package.json ./package.json
 USER node
 EXPOSE ${PORT}
-CMD ["node", "server/dist/index.js"]
+CMD ["node", "--enable-fips", "server/dist/index.js"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       DUOS_SESSION_SECRET: ${DUOS_SESSION_SECRET:?set DUOS_SESSION_SECRET (32+ chars) in .env.local (copy .env.example)}
     volumes:
       - ./public/config.json:/usr/src/app/build/config.json
-    command: ["node", "server/dist/index.js"]
+    command: ["node", "--enable-fips", "server/dist/index.js"]
     restart: always
 
   proxy:

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
     "start": "node dist/index.js",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/server/src/auth/oidcClient.ts
+++ b/server/src/auth/oidcClient.ts
@@ -10,9 +10,10 @@ import * as oidc from 'openid-client'
  *
  * Discovery is cached for the life of the process: the B2C metadata is fixed
  * per deployment, and every /auth/* request needs it. Failed discovery is NOT
- * cached — a lookup that failed during a network blip logs and errors
- * per-request, and heals on the next call. index.ts warms this cache at
- * startup so the first login doesn't pay the discovery round-trip.
+ * cached — a lookup that failed during a network blip rejects per-request and
+ * heals on the next call (callers, e.g. index.ts's startup warm-up, decide
+ * whether/how to log). index.ts warms this cache at startup so the first
+ * login doesn't pay the discovery round-trip.
  */
 let oidcConfigPromise: Promise<oidc.Configuration> | null = null
 

--- a/server/src/auth/oidcClient.ts
+++ b/server/src/auth/oidcClient.ts
@@ -1,0 +1,62 @@
+import * as oidc from 'openid-client'
+
+/**
+ * Single Azure B2C OIDC client for the BFF OAuth flow.
+ *
+ * B2C is the only OIDC client the BFF talks to — provider selection (Google vs
+ * Microsoft) happens on the B2C-hosted login page, so there is no multi-client
+ * factory and no per-provider branching here. The sub-provider is derived from
+ * the B2C `id_token`'s `idp` claim at callback time.
+ *
+ * Discovery is cached for the life of the process: the B2C metadata is fixed
+ * per deployment, and every /auth/* request needs it. Failed discovery is NOT
+ * cached — a lookup that failed during a network blip logs and errors
+ * per-request, and heals on the next call. index.ts warms this cache at
+ * startup so the first login doesn't pay the discovery round-trip.
+ */
+let oidcConfigPromise: Promise<oidc.Configuration> | null = null
+
+export function getOidcConfig(): Promise<oidc.Configuration> {
+  oidcConfigPromise ??= discover().catch((err: unknown) => {
+    oidcConfigPromise = null
+    throw err
+  })
+  return oidcConfigPromise
+}
+
+async function discover(): Promise<oidc.Configuration> {
+  // DUOS_AZURE_ISSUER_URL is the full B2C discovery document URL — it contains
+  // `.well-known` and the `?p=<policy>` query string, which tells discovery()
+  // to fetch it as-is rather than derive a .well-known path (that would mangle
+  // the query string).
+  return oidc.discovery(
+    new URL(requireEnv('DUOS_AZURE_ISSUER_URL')),
+    requireEnv('DUOS_AZURE_CLIENT_ID'),
+    requireEnv('DUOS_AZURE_CLIENT_SECRET'),
+  )
+}
+
+/**
+ * Validated here so a misconfigured environment fails with an error naming the
+ * env var, instead of a TypeError from `new URL(undefined)` or an opaque B2C
+ * rejection at token exchange.
+ */
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} is unset but is required for the BFF OAuth flow — set it in .env.local locally, or the deployment env in k8s`)
+  }
+  return value
+}
+
+/** PKCE + state helpers for the authorization-code flow (RFC 7636 S256). */
+export const pkce = {
+  verifier: (): string => oidc.randomPKCECodeVerifier(),
+  challenge: (verifier: string): Promise<string> => oidc.calculatePKCECodeChallenge(verifier),
+  state: (): string => oidc.randomState(),
+}
+
+// Test-only: clear the process-lifetime cache between cases.
+export const resetOidcCache = (): void => {
+  oidcConfigPromise = null
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,6 +9,7 @@ import fastifyPostgres from '@fastify/postgres'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import { createPgSessionStore } from './session/pgStore.js'
+import { getOidcConfig } from './auth/oidcClient.js'
 import { configPath, readConfig } from './config.js'
 import './types/session.js'
 import FastifyVite from '@fastify/vite'
@@ -127,6 +128,15 @@ export async function buildApp(): Promise<AppInstance> {
       // would re-save the session (SELECT + UPSERT) on every session-bearing
       // request just to bump `expire`. Phase 2 adds a throttled sliding expiry
       // instead — re-save only when the session is near expiry.
+    })
+
+    // Warm the B2C OIDC discovery cache so the first login doesn't pay the
+    // discovery round-trip. Not awaited and never fatal — on failure the error
+    // is logged and getOidcConfig() retries lazily on first use; a genuinely
+    // missing env var will still fail every auth request loudly, with the
+    // error naming the variable.
+    getOidcConfig().catch((err: unknown) => {
+      fastify.log.error({ err }, '[auth] B2C OIDC discovery warm-up failed')
     })
   }
   else {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -131,13 +131,17 @@ export async function buildApp(): Promise<AppInstance> {
     })
 
     // Warm the B2C OIDC discovery cache so the first login doesn't pay the
-    // discovery round-trip. Not awaited and never fatal — on failure the error
-    // is logged and getOidcConfig() retries lazily on first use; a genuinely
-    // missing env var will still fail every auth request loudly, with the
-    // error naming the variable.
-    getOidcConfig().catch((err: unknown) => {
-      fastify.log.error({ err }, '[auth] B2C OIDC discovery warm-up failed')
-    })
+    // discovery round-trip. Gated on the Azure env vars being present: DB/
+    // session infra (this block) can be enabled ahead of B2C being configured
+    // during the phased rollout, and warming up against unset vars would log
+    // an error on every single startup for no benefit. Not awaited and never
+    // fatal either way — on failure the error is logged and getOidcConfig()
+    // retries lazily on first use.
+    if (process.env.DUOS_AZURE_ISSUER_URL && process.env.DUOS_AZURE_CLIENT_ID && process.env.DUOS_AZURE_CLIENT_SECRET) {
+      getOidcConfig().catch((err: unknown) => {
+        fastify.log.error({ err }, '[auth] B2C OIDC discovery warm-up failed')
+      })
+    }
   }
   else {
     fastify.log.info('[server] DUOS_DB_HOST is not set — starting without DB/session infrastructure (legacy client-side auth)')

--- a/server/test/config.test.ts
+++ b/server/test/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { configPath, readConfig, resetConfigCache } from '../src/config'
+import { configPath, readConfig, resetConfigCache } from '../src/config.js'
 
 describe('configPath', () => {
   afterEach(() => {

--- a/server/test/oidcClient.test.ts
+++ b/server/test/oidcClient.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createHash } from 'node:crypto'
+import type { Configuration } from 'openid-client'
+import { getOidcConfig, pkce, resetOidcCache } from '../src/auth/oidcClient.js'
+
+// Mock only discovery() — it performs a real network fetch of the B2C
+// discovery document. The PKCE helpers below are exercised for real.
+vi.mock('openid-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('openid-client')>()
+  return { ...actual, discovery: vi.fn() }
+})
+
+const AZURE_ENV = {
+  DUOS_AZURE_ISSUER_URL: 'https://duosdev.b2clogin.com/duosdev.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin',
+  DUOS_AZURE_CLIENT_ID: 'test-client-id',
+  DUOS_AZURE_CLIENT_SECRET: 'test-client-secret',
+}
+
+describe('getOidcConfig', () => {
+  const fakeConfig = {} as Configuration
+  let discovery: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    Object.assign(process.env, AZURE_ENV)
+    resetOidcCache()
+    const oidc = await import('openid-client')
+    discovery = vi.mocked(oidc.discovery)
+    discovery.mockReset()
+    discovery.mockResolvedValue(fakeConfig)
+  })
+
+  afterEach(() => {
+    for (const key of Object.keys(AZURE_ENV)) delete process.env[key]
+  })
+
+  it('discovers the B2C issuer with the configured URL, client id, and secret', async () => {
+    await getOidcConfig()
+
+    expect(discovery).toHaveBeenCalledTimes(1)
+    const [url, clientId, clientSecret] = discovery.mock.calls[0]
+    expect(url).toBeInstanceOf(URL)
+    // The full discovery-document URL must survive untouched — deriving a
+    // .well-known path from it would mangle the ?p=<policy> query string.
+    expect((url as URL).href).toBe(AZURE_ENV.DUOS_AZURE_ISSUER_URL)
+    expect(clientId).toBe('test-client-id')
+    expect(clientSecret).toBe('test-client-secret')
+  })
+
+  it('returns the cached configuration on repeated calls without re-discovering', async () => {
+    const first = await getOidcConfig()
+    const second = await getOidcConfig()
+
+    expect(first).toBe(fakeConfig)
+    expect(second).toBe(first)
+    expect(discovery).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not cache a failed discovery — the next call retries and can succeed', async () => {
+    discovery.mockRejectedValueOnce(new Error('B2C unreachable'))
+
+    await expect(getOidcConfig()).rejects.toThrow('B2C unreachable')
+    await expect(getOidcConfig()).resolves.toBe(fakeConfig)
+    expect(discovery).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(Object.keys(AZURE_ENV))('rejects with an error naming %s when it is unset', async (name) => {
+    delete process.env[name]
+
+    await expect(getOidcConfig()).rejects.toThrow(name)
+    expect(discovery).not.toHaveBeenCalled()
+  })
+})
+
+describe('pkce helpers', () => {
+  it('verifier() returns a 43-character base64url string (32 bytes of entropy per RFC 7636)', () => {
+    const verifier = pkce.verifier()
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]{43}$/)
+  })
+
+  it('verifier() returns a fresh value on every call', () => {
+    expect(pkce.verifier()).not.toBe(pkce.verifier())
+  })
+
+  it('challenge() produces the S256 challenge for the given verifier', async () => {
+    const verifier = pkce.verifier()
+    const expected = createHash('sha256').update(verifier).digest('base64url')
+    await expect(pkce.challenge(verifier)).resolves.toBe(expected)
+  })
+
+  it('state() returns a non-empty url-safe string, fresh on every call', () => {
+    const state = pkce.state()
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(pkce.state()).not.toBe(state)
+  })
+})

--- a/server/test/pgStore.test.ts
+++ b/server/test/pgStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { PostgresDb } from '@fastify/postgres'
-import { createPgSessionStore } from '../src/session/pgStore'
+import { createPgSessionStore } from '../src/session/pgStore.js'
 
 // ---------------------------------------------------------------------------
 // A minimal fake `app.pg` whose `query` is a vitest mock. createPgSessionStore

--- a/server/test/session.test.ts
+++ b/server/test/session.test.ts
@@ -3,8 +3,8 @@ import Fastify, { type FastifyInstance } from 'fastify'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import type { PostgresDb } from '@fastify/postgres'
-import { createPgSessionStore } from '../src/session/pgStore'
-import '../src/types/session'
+import { createPgSessionStore } from '../src/session/pgStore.js'
+import '../src/types/session.js'
 
 // ---------------------------------------------------------------------------
 // In-memory stand-in for the `user_sessions` table. It honours the four SQL

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/server/tsconfig.build.json
+++ b/server/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
+  // Separate from tsconfig.json because the two configs need different
+  // `include` scopes, and `include` can only be set in a config file (not
+  // overridden via the tsc CLI). tsconfig.json includes test/ so tsc --noEmit
+  // (and editors, which auto-discover tsconfig.json) typecheck it too — but
+  // building with rootDir: "src" while test/ is included fails with TS6059
+  // ("File is not under 'rootDir'"), even under noEmit. Dropping rootDir
+  // instead would infer it as the common ancestor of src/ and test/, changing
+  // dist/index.js to dist/src/index.js (breaking package.json's "main" and
+  // the Dockerfile/compose CMD) and compiling test files into the prod image.
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,12 +4,11 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
-    "outDir": "dist",
-    "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src", "test", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3607
Fully addresses https://broadworkbench.atlassian.net/browse/DT-3792

## Summary
Implements Phase 2, story 2-B of the BFF migration plan: a single Azure B2C OIDC client factory for the server-side OAuth flow, plus the PKCE helper functions the upcoming `/auth/login` and `/auth/callback` routes will use.

- `getOidcConfig()` performs B2C discovery once and caches the result for the life of the process (mirrors the existing cache pattern in `config.ts`'s `readConfig()`). A failed discovery is not cached, so a transient network blip heals on the next call instead of poisoning the process.
- `pkce.verifier()` / `pkce.challenge()` / `pkce.state()` wrap openid-client's PKCE/state primitives (RFC 7636 S256).
- `index.ts` warms the discovery cache at startup (non-fatal on failure) so the first real login doesn't pay the discovery round-trip.
- Adds `--enable-fips` when starting node

This is infrastructure only — no routes are wired up yet. `/auth/login`, `/auth/callback`, etc. land in later stories of Phase 2.

### Build/test infrastructure changes
Separate from the OIDC work above: while adding tests for the new `oidcClient.ts`, I found `server/tsconfig.json` only covered `src/`, so no test file was ever part of the TypeScript project — `tsc --noEmit` silently skipped all of `server/test/`. This was catching real errors in editors (e.g. process reported as undefined) that the CI typecheck would never see.

Fixed by splitting the config:
- `tsconfig.json` is now the type-checking config: noEmit: true, includes src + test + vitest.config.ts.
- `tsconfig.build.json` is new — extends the above, restores outDir/rootDir/noEmit: false, scoped to `src` only. This is what actually produces `dist/`.
- `package.json`: build now points at `tsconfig.build.json`; added a typecheck script (`tsc --noEmit`) for CI/local use.
- `Dockerfile`: copies `tsconfig.build.json` alongside `tsconfig.json` in the build stage.

Bringing test files into the project surfaced pre-existing issues unrelated to the OIDC work, fixed here since typecheck needs to be clean:

- Missing .js extensions on relative imports in `config.test.ts`, `pgStore.test.ts`, `session.test.ts` (required under NodeNext module resolution — tsc doesn't rewrite import paths, so a `.ts` file must already import the `.js` specifier that will exist post-compile).
- In `pgStore.test.ts`, the missing extension was silently degrading the imported `createPgSessionStore` type to any, masking two implicit-any parameter errors in a test helper.

No behavior change — `dist/` output is identical, and the full test suite (44 tests) still passes.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
