### PR TITLE
[DT-3607] Add POST /auth/login endpoint (BFF Phase 2, 2-C)

### DIFF
--- a/server/src/auth/login.ts
+++ b/server/src/auth/login.ts
@@ -1,0 +1,55 @@
+import * as oidc from 'openid-client'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { getOidcConfig, pkce, requireEnv } from './oidcClient.js'
+
+/**
+ * Open-redirect guard for the post-login redirect target: accept only
+ * same-origin absolute paths, falling back to '/'. Requiring a leading '/'
+ * and then parsing against a fixed base catches every classic bypass in one
+ * origin comparison — 'https://evil.com' (absolute URL), '//evil.com'
+ * (protocol-relative), '/\evil.com' (WHATWG URL parsing treats '\' as '/'),
+ * and encoded or control-character variants — because the parser normalizes
+ * them all before the check. Returning the parsed path also re-serializes
+ * any '../' segments.
+ */
+const RETURN_TO_BASE = 'https://returnto.invalid'
+export function safeReturnTo(value: unknown): string {
+  if (typeof value !== 'string' || !value.startsWith('/')) return '/'
+  try {
+    const url = new URL(value, RETURN_TO_BASE)
+    if (url.origin !== RETURN_TO_BASE) return '/'
+    return url.pathname + url.search + url.hash
+  }
+  catch {
+    return '/'
+  }
+}
+
+/**
+ * Generates PKCE parameters, stores them in the session, and returns the B2C
+ * authorization URL. The browser never sees the verifier — only the redirect
+ * URL, which the client navigates to directly.
+ */
+export async function handleLogin(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const config = await getOidcConfig()
+  const verifier = pkce.verifier()
+  const state = pkce.state()
+
+  request.session.pkceVerifier = verifier
+  request.session.pkceState = state
+  request.session.returnTo = safeReturnTo((request.query as Record<string, unknown>).returnTo)
+
+  // v6: redirect_uri is a per-call parameter (Configuration does not hold
+  // redirect_uris), and the PKCE challenge calculation is async.
+  const redirectUrl = oidc.buildAuthorizationUrl(config, {
+    redirect_uri: requireEnv('DUOS_OAUTH_REDIRECT_URI'),
+    // See oidcClient.ts's B2C scope quirk note: DUOS_AZURE_CLIENT_ID must be
+    // in the scope string, or B2C returns an id_token with no access_token.
+    scope: `openid email profile offline_access ${requireEnv('DUOS_AZURE_CLIENT_ID')}`,
+    code_challenge: await pkce.challenge(verifier),
+    code_challenge_method: 'S256',
+    state,
+  })
+
+  reply.send({ redirectUrl: redirectUrl.href }) // buildAuthorizationUrl returns a URL
+}

--- a/server/src/auth/oidcClient.ts
+++ b/server/src/auth/oidcClient.ts
@@ -40,9 +40,10 @@ async function discover(): Promise<oidc.Configuration> {
 /**
  * Validated here so a misconfigured environment fails with an error naming the
  * env var, instead of a TypeError from `new URL(undefined)` or an opaque B2C
- * rejection at token exchange.
+ * rejection at token exchange. Exported so other `/auth/*` handlers (e.g.
+ * `login.ts`'s `DUOS_OAUTH_REDIRECT_URI`) fail the same way.
  */
-function requireEnv(name: string): string {
+export function requireEnv(name: string): string {
   const value = process.env[name]
   if (!value) {
     throw new Error(`${name} is unset but is required for the BFF OAuth flow — set it in .env.local locally, or the deployment env in k8s`)

--- a/server/test/login.test.ts
+++ b/server/test/login.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import type { Configuration } from 'openid-client'
+import { handleLogin, safeReturnTo } from '../src/auth/login.js'
+
+// Mock getOidcConfig()/pkce (network + randomness) but keep the real
+// requireEnv() so its env-var validation is exercised for real.
+vi.mock('../src/auth/oidcClient.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/auth/oidcClient.js')>()
+  return {
+    ...actual,
+    getOidcConfig: vi.fn(),
+    pkce: { verifier: vi.fn(), challenge: vi.fn(), state: vi.fn() },
+  }
+})
+
+vi.mock('openid-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('openid-client')>()
+  return { ...actual, buildAuthorizationUrl: vi.fn() }
+})
+
+describe('safeReturnTo', () => {
+  it('returns a legitimate same-origin path unchanged, including query and hash', () => {
+    expect(safeReturnTo('/datalibrary?filter=x#top')).toBe('/datalibrary?filter=x#top')
+  })
+
+  it('re-serializes ../ segments through URL parsing', () => {
+    expect(safeReturnTo('/a/../b')).toBe('/b')
+  })
+
+  it.each([
+    ['https://evil.com', 'absolute URL'],
+    ['//evil.com', 'protocol-relative'],
+    ['/\\evil.com', 'backslash treated as slash by WHATWG URL parsing'],
+    ['relative/path', 'missing leading slash'],
+    [undefined, 'not a string'],
+    [42, 'not a string'],
+  ])('falls back to / for %s (%s)', (value, _description) => {
+    expect(safeReturnTo(value)).toBe('/')
+  })
+})
+
+describe('handleLogin', () => {
+  const fakeConfig = {} as Configuration
+  const AZURE_ENV = {
+    DUOS_OAUTH_REDIRECT_URI: 'https://local.dsde-dev.broadinstitute.org:3000/auth/callback',
+    DUOS_AZURE_CLIENT_ID: 'test-client-id',
+  }
+
+  function makeRequest(query: Record<string, unknown> = {}): FastifyRequest {
+    return { session: {}, query } as unknown as FastifyRequest
+  }
+
+  function makeReply(): FastifyReply & { send: ReturnType<typeof vi.fn> } {
+    return { send: vi.fn() } as unknown as FastifyReply & { send: ReturnType<typeof vi.fn> }
+  }
+
+  beforeEach(async () => {
+    Object.assign(process.env, AZURE_ENV)
+
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    vi.mocked(oidcClient.getOidcConfig).mockReset().mockResolvedValue(fakeConfig)
+    vi.mocked(oidcClient.pkce.verifier).mockReset().mockReturnValue('test-verifier')
+    vi.mocked(oidcClient.pkce.challenge).mockReset().mockResolvedValue('test-challenge')
+    vi.mocked(oidcClient.pkce.state).mockReset().mockReturnValue('test-state')
+
+    const oidc = await import('openid-client')
+    vi.mocked(oidc.buildAuthorizationUrl).mockReset()
+      .mockReturnValue(new URL('https://duosdev.b2clogin.com/authorize?foo=bar'))
+  })
+
+  afterEach(() => {
+    for (const key of Object.keys(AZURE_ENV)) delete process.env[key]
+  })
+
+  it('stores the PKCE verifier, state, and sanitized returnTo in the session', async () => {
+    const request = makeRequest({ returnTo: '/datalibrary' })
+
+    await handleLogin(request, makeReply())
+
+    expect(request.session.pkceVerifier).toBe('test-verifier')
+    expect(request.session.pkceState).toBe('test-state')
+    expect(request.session.returnTo).toBe('/datalibrary')
+  })
+
+  it('defaults returnTo to / when the query param is an open-redirect attempt', async () => {
+    const request = makeRequest({ returnTo: 'https://evil.com' })
+
+    await handleLogin(request, makeReply())
+
+    expect(request.session.returnTo).toBe('/')
+  })
+
+  it('builds the authorization URL with the configured redirect_uri, B2C scope quirk, and S256 PKCE params', async () => {
+    await handleLogin(makeRequest(), makeReply())
+
+    const oidc = await import('openid-client')
+    expect(oidc.buildAuthorizationUrl).toHaveBeenCalledWith(fakeConfig, {
+      redirect_uri: AZURE_ENV.DUOS_OAUTH_REDIRECT_URI,
+      scope: `openid email profile offline_access ${AZURE_ENV.DUOS_AZURE_CLIENT_ID}`,
+      code_challenge: 'test-challenge',
+      code_challenge_method: 'S256',
+      state: 'test-state',
+    })
+
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    expect(oidcClient.pkce.challenge).toHaveBeenCalledWith('test-verifier')
+  })
+
+  it('sends the authorization URL as { redirectUrl }', async () => {
+    const reply = makeReply()
+
+    await handleLogin(makeRequest(), reply)
+
+    expect(reply.send).toHaveBeenCalledWith({ redirectUrl: 'https://duosdev.b2clogin.com/authorize?foo=bar' })
+  })
+
+  it.each(['DUOS_OAUTH_REDIRECT_URI', 'DUOS_AZURE_CLIENT_ID'])(
+    'rejects with an error naming %s when it is unset',
+    async (name) => {
+      delete process.env[name]
+
+      await expect(handleLogin(makeRequest(), makeReply())).rejects.toThrow(name)
+    },
+  )
+})


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3607

### Summary
- Implements `POST /auth/login` per BFF Migration Plan v2 epic-2, section 2-C: generates PKCE parameters, stashes them in the session, and returns the B2C authorization URL for the client to redirect to.
- Adds `safeReturnTo()`, an open-redirect guard for the `returnTo` query param — accepts only same-origin absolute paths (leading /, parsed against a fixed base) and falls back to /, catching absolute URLs, protocol-relative URLs, backslash tricks, and ../ traversal in one origin check. The validated value is saved to session.returnTo to restore the user's destination after callback.
- Exports `requireEnv` from `oidcClient.ts` so `login.ts` fails the same way (named env var in the error) when `DUOS_OAUTH_REDIRECT_URI` is unset.
- Scope string includes `DUOS_AZURE_CLIENT_ID` alongside the standard OIDC scopes, per the B2C quirk noted in `oidcClient.ts` — B2C omits the `access_token` from the response if the client ID isn't in the scope.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
