### PR TITLE
[DT-400][DT-3795] React set-state-in-effect II

### DIFF
--- a/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
+++ b/src/components/collection_vote_box/CollectionSubmitVoteBox.tsx
@@ -125,12 +125,16 @@ const allMatch = (values: (boolean | string | null | undefined)[]) => {
   })
 }
 
+const matchedVote = (votes: Vote[]): boolean | undefined =>
+  !isEmpty(votes) && allMatch(votes.map(v => v.vote)) ? (votes[0].vote ?? undefined) : undefined
+
+const votesSubmitted = (votes: Vote[]): boolean =>
+  !isEmpty(votes) && allMatch(votes.map(v => v.vote))
+
+const matchedRationale = (votes: Vote[]): string =>
+  !isEmpty(votes) && allMatch(votes.map(v => v.rationale)) ? (votes[0].rationale ?? '') : ''
+
 const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) => {
-  const [vote, setVote] = useState<boolean | undefined>()
-  const [rationale, setRationale] = useState<string>('')
-  const [submitted, setSubmitted] = useState<boolean>(false)
-  const [isRadar, setIsRadar] = useState<boolean>(false)
-  const [voteInProgress, setVoteInProgress] = useState<boolean>(false)
   const {
     question,
     votes,
@@ -143,6 +147,27 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
     reloadFn = () => {},
   } = props
 
+  const [vote, setVote] = useState<boolean | undefined>(() => matchedVote(votes))
+  const [rationale, setRationale] = useState<string>(() => matchedRationale(votes))
+  const [submitted, setSubmitted] = useState<boolean>(() => votesSubmitted(votes))
+  const [voteInProgress, setVoteInProgress] = useState<boolean>(false)
+
+  const isRadar = !isEmpty(votes) && votes.some(v => v.type === VOTE_TYPES.RADAR_APPROVE)
+
+  const [prevVotes, setPrevVotes] = useState(votes)
+  if (votes !== prevVotes) {
+    setPrevVotes(votes)
+    if (!isEmpty(votes)) {
+      if (allMatch(votes.map(v => v.vote))) {
+        setVote(votes[0].vote ?? undefined)
+        setSubmitted(true)
+      }
+      if (allMatch(votes.map(v => v.rationale))) {
+        setRationale(votes[0].rationale ?? '')
+      }
+    }
+  }
+
   const isElectionClosed = useMemo(() => {
     return votes.filter(v => v.electionStatus?.toLowerCase() === 'open').length === 0
   }, [votes])
@@ -150,27 +175,6 @@ const CollectionSubmitVoteBox: React.FC<CollectionSubmitVoteBoxProps> = (props) 
   const isVotingDisabled = useMemo(() => {
     return props.isDisabled || (isFinal && submitted) || adminPage
   }, [props.isDisabled, isFinal, submitted, adminPage])
-
-  React.useEffect(() => {
-    if (!isEmpty(votes)) {
-      const prevVote = votes[0]
-
-      const voteValues = votes.map(vote => vote.vote)
-      if (allMatch(voteValues)) {
-        // oxlint-disable-next-line react/react-compiler
-        setVote(prevVote.vote ?? undefined)
-        setSubmitted(true)
-      }
-
-      const rationaleValues = votes.map(vote => vote.rationale)
-      if (allMatch(rationaleValues)) {
-        setRationale(prevVote.rationale ?? '')
-      }
-
-      const radar = votes.some(vote => vote.type === VOTE_TYPES.RADAR_APPROVE)
-      setIsRadar(radar)
-    }
-  }, [votes])
 
   const updateVote = async (newVote: boolean, isChair: boolean) => {
     setVoteInProgress(true)

--- a/src/components/collection_voting_slab/MultiDatasetVoteSlab.tsx
+++ b/src/components/collection_voting_slab/MultiDatasetVoteSlab.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo } from 'react'
 import { get, isEmpty, isNil } from 'src/utils/NodashUtil'
 import { Storage } from 'src/libs/storage'
 import { convertLabelToKey } from 'src/libs/utils'
@@ -166,10 +166,25 @@ export default function MultiDatasetVoteSlab({
   updateFinalVote,
   reloadFn,
 }: MultiDatasetVoteSlabProps) {
-  const [memberVotes, setMemberVotes] = useState<Vote[]>([])
-  const [chairVotes, setChairVotes] = useState<Vote[]>([])
-  const [dacVotes, setDacVotes] = useState<Vote[]>([])
-  const [isDMI, setIsDMI] = useState(false)
+  const dacVotes = useMemo(
+    () => extractDacDataAccessVotesFromBucket(bucket, Storage.getCurrentUser(), adminPage),
+    [bucket, adminPage],
+  )
+  const memberVotes = useMemo(
+    () => extractUserDataAccessVotesFromBucket(bucket, Storage.getCurrentUser(), false, adminPage),
+    [bucket, adminPage],
+  )
+  const chairVotes = useMemo(
+    () => extractUserDataAccessVotesFromBucket(bucket, Storage.getCurrentUser(), true, adminPage),
+    [bucket, adminPage],
+  )
+  const isDMI = useMemo(() => {
+    const sorted = Object.values(collection.dars).sort(
+      (a, b) => new Date(b.submissionDate).getTime() - new Date(a.submissionDate).getTime(),
+    )
+    const darData = sorted.at(0)?.data
+    return !!(darData && Object.keys(darData).includes('dmi'))
+  }, [collection.dars])
   const { algorithmResult } = bucket
   // Role labels are only shown when the user has both member and chair votes so the vote blocks can be quickly
   // distinguished from each other. If the user only has one type of vote, the label is not shown to reduce visual
@@ -181,24 +196,6 @@ export default function MultiDatasetVoteSlab({
     if (!isEmpty(chairVotes)) return 'My DAC Member\'s Votes (detail)'
     return 'Other DAC Member\'s Votes'
   }
-
-  React.useEffect(() => {
-    const sorted = Object.values(collection.dars).sort(
-      (a, b) => new Date(b.submissionDate).getTime() - new Date(a.submissionDate).getTime(),
-    )
-    const mostRecentDar = sorted.at(0)
-    const darData = mostRecentDar?.data
-
-    if (darData && Object.keys(darData).includes('dmi')) {
-      // oxlint-disable-next-line react/react-compiler
-      setIsDMI(true)
-    }
-
-    const user = Storage.getCurrentUser()
-    setDacVotes(extractDacDataAccessVotesFromBucket(bucket, user, adminPage))
-    setMemberVotes(extractUserDataAccessVotesFromBucket(bucket, user, false, adminPage))
-    setChairVotes(extractUserDataAccessVotesFromBucket(bucket, user, true, adminPage))
-  }, [bucket, adminPage, collection.dars])
 
   return (
     <div style={styles.baseStyle} data-cy="dataset-vote-slab">

--- a/src/components/library_card_table/LibraryCardTable.tsx
+++ b/src/components/library_card_table/LibraryCardTable.tsx
@@ -172,11 +172,20 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
   const [tableSize, setTableSize] = useState<number>(10)
   const [currentPage, setCurrentPage] = useState<number>(1)
   const [pageCount, setPageCount] = useState<number>(1)
-  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [isLoading, setIsLoading] = useState<boolean>(isNil(props.libraryCards))
   const [visibleCards, setVisibleCards] = useState<LibraryCard[]>([])
   const [showConfirmation, setShowConfirmation] = useState<boolean>(false)
   const [currentCard, setCurrentCard] = useState<LibraryCard>({} as LibraryCard)
   const [searchText, setSearchText] = useState<string>('')
+
+  const [prevPropsLibraryCards, setPrevPropsLibraryCards] = useState(props.libraryCards)
+  if (props.libraryCards !== prevPropsLibraryCards) {
+    setPrevPropsLibraryCards(props.libraryCards)
+    setLibraryCards(props.libraryCards ?? [])
+    if (!isNil(props.libraryCards)) {
+      setIsLoading(false)
+    }
+  }
 
   const filteredCards = useMemo(
     () => isEmpty(searchText) ? libraryCards : lcFilterFunction(searchText, libraryCards),
@@ -214,15 +223,6 @@ const LibraryCardTable: React.FC<LibraryCardTableProps> = (props) => {
     }
     init()
   }, [filteredCards, tableSize, currentPage, pageCount])
-
-  // Hook that executes on prop load (initialization hook)
-  React.useEffect(() => {
-    // oxlint-disable-next-line react/react-compiler
-    setLibraryCards(props.libraryCards ?? [])
-    if (!isNil(props.libraryCards)) {
-      setIsLoading(false)
-    }
-  }, [props.libraryCards])
 
   // Formats institution data to be used by SimpleTable component
   const processLCData = (cards: LibraryCard[] = []): TableCell[][] => {

--- a/src/pages/dar_application/DataAccessRequestApplication.tsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ResearcherInfo from 'src/pages/dar_application/ResearcherInfo'
 import { DataAccessAgreements } from 'src/pages/dar_application/DataAccessAgreements'
 import DataAccessRequest, { OntologyOption } from 'src/pages/dar_application/DataAccessRequest'
@@ -202,7 +202,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
   const [isLoading, setIsLoading] = useState(true)
   const [isAttested, setIsAttested] = useState(false)
 
-  const [applicationTabs, setApplicationTabs] = useState<AppTab[]>([])
+  const [showAddendum, setShowAddendum] = useState(false)
 
   const [countriesOfOperation, setCountriesOfOperation] = useState<string[]>([])
 
@@ -310,12 +310,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
       setDatasets(datasets)
       setSelectedDatasets(datasets)
     })
-    if (!existingDarsReadOnlyMode) {
-      const updatedTabs = [...ApplicationTabs, { name: 'Data Access Agreements (DAA)', id: DATA_ACCESS_AGREEMENTS_TAB_ID }]
-      // oxlint-disable-next-line react/react-compiler
-      setApplicationTabs(updatedTabs)
-    }
-  }, [formData.datasetIds, existingDarsReadOnlyMode])
+  }, [formData.datasetIds])
 
   useEffect(() => {
     translateDataUseRestrictionsFromDataUseArray(datasets.map(ds => ds.dataUse)).then((translations) => {
@@ -402,15 +397,14 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
     setIsLoading(false)
   }, [researcher, existingDarsReadOnlyMode, resolveInitialFormData, batchFormFieldChange])
 
-  React.useEffect(() => {
+  const baseApplicationTabs = useMemo<AppTab[]>(() => {
     if (existingDarsReadOnlyMode) {
       let appTabs: AppTab[] = []
       if (isProgressReportApplication) {
         // if we are creating a new progress report, we need to add another tab for the application
         appTabs = [{ name: 'Progress Report ' + reverseOrderedDARs.length, id: PROGRESS_REPORT_APPLICATION_TAB_ID, showStep: false }]
       }
-      // oxlint-disable-next-line react/react-compiler
-      setApplicationTabs([...appTabs,
+      return [...appTabs,
         ...reverseOrderedDARs.map((_dar, index) => {
           const whichPRIsThis = reverseOrderedDARs.length - index - 1
           const isLast = index === reverseOrderedDARs.length - 1
@@ -418,9 +412,17 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
           return { name: itemLabel ?? '', id: `${PROGRESS_REPORT_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false }
         }),
         { name: 'Voting History', id: VOTING_HISTORY_TAB_ID, showStep: false },
-      ])
+      ]
     }
+    return [...ApplicationTabs, { name: 'Data Access Agreements (DAA)', id: DATA_ACCESS_AGREEMENTS_TAB_ID }]
   }, [formData.darCode, isProgressReportApplication, existingDarsReadOnlyMode, reverseOrderedDARs])
+
+  const applicationTabs = useMemo<AppTab[]>(
+    () => showAddendum
+      ? [...baseApplicationTabs, { name: 'Addendum', id: ADDENDUM_TAB_ID, showStep: false }]
+      : baseApplicationTabs,
+    [baseApplicationTabs, showAddendum],
+  )
 
   React.useEffect(() => {
     // oxlint-disable-next-line react/react-compiler
@@ -468,22 +470,11 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
   }
 
   const addDucAddendumTab = () => {
-    const hasAddendumTab = applicationTabs.some(tab => tab.id === ADDENDUM_TAB_ID)
-    if (!hasAddendumTab) {
-      const tabs = [
-        ...applicationTabs,
-        { name: 'Addendum', id: ADDENDUM_TAB_ID, showStep: false },
-      ]
-      setApplicationTabs(tabs)
-    }
+    setShowAddendum(true)
   }
 
   const removeAddendumTab = () => {
-    const hasAddendumTab = applicationTabs.some(tab => tab.id === ADDENDUM_TAB_ID)
-    if (hasAddendumTab) {
-      const tabs = applicationTabs.filter(tab => tab.id !== ADDENDUM_TAB_ID)
-      setApplicationTabs(tabs)
-    }
+    setShowAddendum(false)
   }
 
   const attemptSubmit = async (): Promise<boolean> => {

--- a/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
+++ b/src/pages/data_submission/v2/NihAnvilUseRelated.tsx
@@ -44,6 +44,33 @@ export interface NihAnvilUseVisibleOptions {
   name: string
 }
 
+const cleanDownstreamProperties = (newVal: Study) => {
+  removeStudyPropertiesByKeys(newVal,
+    new Set(
+      [
+        PiInstitution.key,
+        NihGrantContractNumber.key,
+        NihICsSupportingStudy.key,
+        NihProgramOfficerName.key,
+        NihInstitutionCenterSubmission.key,
+        NihGenomicProgramAdministratorName.key,
+        MultiCenterStudy.key,
+        CollaboratingSites.key,
+        ControlledAccessRequiredForGenomicSummaryResultsGSR.key,
+        ControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation.key,
+        AlternativeDataSharingPlan.key,
+        AlternativeDataSharingPlanReasons.key,
+        AlternativeDataSharingPlanExplanation.key,
+        AlternativeDataSharingPlanDataSubmitted.key,
+        AlternativeDataSharingPlanDataReleased.key,
+        DbGaPPhsID.key,
+        DbGaPStudyRegistrationName.key,
+        EmbargoReleaseDate.key,
+        SequencingCenter.key,
+      ]))
+  unset(newVal, ALTERNATIVE_DATA_SHARING_PLAN_FILE)
+}
+
 export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
   const { setStudy, study } = props
   const [preSelectorValue, setPreSelectorValue] = React.useState<string | undefined>(() => {
@@ -58,39 +85,11 @@ export const NihAnvilUseRelated = (props: NihAnvilUseRelatedProps) => {
     getStudyPropertyValueByKey(study, 'nihAnvilUse'),
   )
 
-  const cleanDownstreamProperties = (newVal: Study) => {
-    removeStudyPropertiesByKeys(newVal,
-      new Set(
-        [
-          PiInstitution.key,
-          NihGrantContractNumber.key,
-          NihICsSupportingStudy.key,
-          NihProgramOfficerName.key,
-          NihInstitutionCenterSubmission.key,
-          NihGenomicProgramAdministratorName.key,
-          MultiCenterStudy.key,
-          CollaboratingSites.key,
-          ControlledAccessRequiredForGenomicSummaryResultsGSR.key,
-          ControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation.key,
-          AlternativeDataSharingPlan.key,
-          AlternativeDataSharingPlanReasons.key,
-          AlternativeDataSharingPlanExplanation.key,
-          AlternativeDataSharingPlanDataSubmitted.key,
-          AlternativeDataSharingPlanDataReleased.key,
-          DbGaPPhsID.key,
-          DbGaPStudyRegistrationName.key,
-          EmbargoReleaseDate.key,
-          SequencingCenter.key,
-        ]))
-    unset(newVal, ALTERNATIVE_DATA_SHARING_PLAN_FILE)
-  }
-
   const handlePreSelectorChange = React.useCallback(
     (input: string) => {
       if (input === NihAnvilUsePreSelectOptions.NO) {
         const translatedNoOption = { key: NihAnvilUse.key, value: NihAnvilUse.NO_NHGRI_NO_ANVIL, isValid: true }
         const newVal = structuredClone(study)
-        // oxlint-disable-next-line react/react-compiler
         cleanDownstreamProperties(newVal)
         setStudyPropertyByKey(newVal, setStudy, translatedNoOption, new NihAnvilUse(translatedNoOption.value))
       }

--- a/test/components/collection_vote_box/CollectionSubmitVoteBox.spec.tsx
+++ b/test/components/collection_vote_box/CollectionSubmitVoteBox.spec.tsx
@@ -310,4 +310,18 @@ describe('CollectionSubmitVoteBox - Tests', () => {
     await user.click(noBtn)
     expect(updateFinalVote).not.toHaveBeenCalled()
   })
+
+  it('re-syncs the vote and rationale when the votes prop changes', () => {
+    const { container, rerender } = render(
+      <CollectionSubmitVoteBox {...defaultProps} votes={votesMixed} isFinal={false} />,
+    )
+    // Mixed votes -> nothing selected, empty rationale.
+    expect(container.querySelector('[data-cy="yes-collection-vote-button"]')).toHaveStyle({ backgroundColor: votingColors.default })
+    expect(screen.getByRole('textbox')).toHaveValue('')
+
+    // All-matching "true" votes with a shared rationale -> re-derive selection + rationale.
+    rerender(<CollectionSubmitVoteBox {...defaultProps} votes={votesMatch} isFinal={false} />)
+    expect(container.querySelector('[data-cy="yes-collection-vote-button"]')).toHaveStyle({ backgroundColor: votingColors.yes })
+    expect(screen.getByRole('textbox')).toHaveValue('test')
+  })
 })

--- a/test/components/collection_voting_slab/MultiDatasetVoteSlab.spec.tsx
+++ b/test/components/collection_voting_slab/MultiDatasetVoteSlab.spec.tsx
@@ -546,4 +546,62 @@ describe('MultiDatasetVoteSlab', () => {
       expect(screen.queryByTestId('collection-algorithm-decision')).not.toBeInTheDocument()
     })
   })
+
+  it('re-derives algorithm decision visibility when the collection prop changes', () => {
+    mockUser(100)
+    const element = (collectionProp: DarCollection) => (
+      <MultiDatasetVoteSlab
+        title="GROUP 1"
+        bucket={{
+          key: 'group-1',
+          datasets: [],
+          elections: [openElection2],
+          votes: [votesForOpenElection2],
+          algorithmResult: { createDate: new Date(), id: 1, result: 'Yes', rationales: [] },
+        } as never}
+        collection={collectionProp}
+        dacDatasetIds={[]}
+        isApprovalDisabled={false}
+        isLoading={false}
+        readOnly={false}
+        adminPage={false}
+        updateFinalVote={vi.fn()}
+        reloadFn={vi.fn()}
+      />
+    )
+
+    const { rerender } = render(element(collectionWithoutDMI))
+    expect(screen.getByTestId('collection-algorithm-decision')).toBeInTheDocument()
+
+    // Latest DAR now has a DMI -> algorithm decision should hide.
+    rerender(element(collection))
+    expect(screen.queryByTestId('collection-algorithm-decision')).not.toBeInTheDocument()
+  })
+
+  it('re-derives the vote section when the bucket prop changes', async () => {
+    mockUser(400)
+    const element = (bucket: unknown) => (
+      <MultiDatasetVoteSlab
+        title="GROUP 1"
+        bucket={bucket as never}
+        collection={collection}
+        dacDatasetIds={[]}
+        isApprovalDisabled={false}
+        isLoading={false}
+        readOnly={false}
+        adminPage={false}
+        updateFinalVote={vi.fn()}
+        reloadFn={vi.fn()}
+      />
+    )
+
+    const { rerender } = render(element({
+      key: 'group-1', datasets: [], elections: [openElection2], votes: [votesForOpenElection2],
+    }))
+    await waitFor(() => expect(screen.getByTestId('no-collection-vote-button')).toBeInTheDocument())
+
+    // A bucket where this user has no votes -> the vote section should disappear.
+    rerender(element({ key: 'group-1', datasets: [], elections: [], votes: [] }))
+    expect(screen.queryByTestId('no-collection-vote-button')).not.toBeInTheDocument()
+  })
 })

--- a/test/components/library_card_table/LibraryCardTable.spec.tsx
+++ b/test/components/library_card_table/LibraryCardTable.spec.tsx
@@ -160,4 +160,38 @@ describe('Library Card Table Tests', () => {
       expect(screen.queryByText(card.userEmail)).not.toBeInTheDocument()
     })
   })
+
+  it('shows a loading state until the library cards prop is provided', async () => {
+    let view!: ReturnType<typeof render>
+    await act(async () => {
+      view = render(<LibraryCardTable />)
+    })
+
+    expect(document.querySelector('.table-loading-placeholder')).toBeInTheDocument()
+    expect(screen.queryByText('foo foo')).not.toBeInTheDocument()
+
+    await act(async () => {
+      view.rerender(<LibraryCardTable libraryCards={libraryCardList} />)
+    })
+
+    expect(document.querySelector('.table-loading-placeholder')).not.toBeInTheDocument()
+    expect(screen.getByText('foo foo')).toBeInTheDocument()
+  })
+
+  it('updates the displayed cards when the libraryCards prop changes', async () => {
+    let view!: ReturnType<typeof render>
+    await act(async () => {
+      view = render(<LibraryCardTable libraryCards={[libraryCardList[0]]} />)
+    })
+
+    expect(screen.getByText('foo foo')).toBeInTheDocument()
+    expect(screen.queryByText('bar bar')).not.toBeInTheDocument()
+
+    await act(async () => {
+      view.rerender(<LibraryCardTable libraryCards={[libraryCardList[1]]} />)
+    })
+
+    expect(screen.queryByText('foo foo')).not.toBeInTheDocument()
+    expect(screen.getByText('bar bar')).toBeInTheDocument()
+  })
 })

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -239,8 +239,14 @@ describe('DataAccessRequestApplication', () => {
       resolveSave({ referenceId: 'ref-123' })
     })
 
+    // The Addendum tab is not shown until the user attests.
+    expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
+
     // Click "Attest"
     await clickById('btn_attest')
+
+    // Attesting reveals the Addendum tab.
+    expect(screen.getByRole('tab', { name: /Addendum/i })).toBeInTheDocument()
 
     // Now on Addendum tab, click "Submit"
     await clickById('btn_openSubmitModal')

--- a/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
+++ b/test/pages/data_submission/v2/ds_nih_anvil_use.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { NihAnvilUseRelated, NihAnvilUseRelatedProps } from 'src/pages/data_submission/v2/NihAnvilUseRelated'
-import { NihAnvilUse, NihAnvilUsePreSelectOptions, Study, StudyProperty } from 'src/pages/data_submission/v2/v2-models'
+import { NihAnvilUse, NihAnvilUsePreSelectOptions, PiInstitution, Study, StudyProperty } from 'src/pages/data_submission/v2/v2-models'
 
 const NIH_ANVIL_PRE_SELECTOR_ID = 'nihAnvilUse_pre_selector'
 const NIH_ANVIL_FIELD_ID = 'nihAnvilUse'
@@ -120,5 +120,22 @@ describe('NihAnvilUseRelated', () => {
 
     clickPreSelector(NihAnvilUsePreSelectOptions.YES)
     expect(queryById(NIH_ANVIL_FIELD_ID)).not.toBeNull()
+  })
+
+  it('clears downstream study properties when switching the pre-selector to NO', () => {
+    const setStudyMock = vi.fn()
+    const baseStudy = {
+      properties: [
+        new NihAnvilUse(NihAnvilUse.YES_NHGRI_YES_PHS_ID),
+        new PiInstitution(123),
+      ],
+    } as Study
+
+    render(<NihAnvilUseRelated study={baseStudy} setStudy={setStudyMock} />)
+
+    clickPreSelector(NihAnvilUsePreSelectOptions.NO)
+
+    const nextStudy = getNextStudyFromSetStudyCall(setStudyMock, baseStudy)
+    expect(nextStudy.properties?.some(prop => prop.key === PiInstitution.key)).toBe(false)
   })
 })


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400
https://broadworkbench.atlassian.net/browse/DT-3795

### Summary

Follow up to #3771 

This addresses another chunk of the existing `set-state-in-effect` issues in the codebase, and adds tests so that regressions cause test failures.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
