### PR TITLE
[DT-3607] Add POST /auth/logout and GET /auth/me endpoints (BFF Phase 2, 2-E, 2-F)

### DIFF
--- a/server/src/auth/logout.ts
+++ b/server/src/auth/logout.ts
@@ -9,18 +9,27 @@ import { getOidcConfig } from './oidcClient.js'
  * best-effort on top of it.
  */
 export async function handleLogout(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const config = await getOidcConfig()
+  // Revocation is best-effort on top of session destruction (the primary
+  // logout control below) — a discovery failure here (network blip, missing
+  // Azure env var) must not stop logout from completing.
+  try {
+    const config = await getOidcConfig()
 
-  // B2C does not reliably expose a revocation_endpoint in its discovery
-  // document, so revocation is typically skipped here. v6: the endpoint is
-  // read from config.serverMetadata(), and revocation is tokenRevocation().
-  if (config.serverMetadata().revocation_endpoint) {
-    if (request.session.accessToken) {
-      await oidc.tokenRevocation(config, request.session.accessToken).catch(() => {})
+    // B2C does not reliably expose a revocation_endpoint in its discovery
+    // document, so revocation is typically skipped here. v6: the endpoint is
+    // read from config.serverMetadata(), and revocation is tokenRevocation().
+    if (config.serverMetadata().revocation_endpoint) {
+      if (request.session.accessToken) {
+        await oidc.tokenRevocation(config, request.session.accessToken).catch(() => {})
+      }
+      if (request.session.refreshToken) {
+        await oidc.tokenRevocation(config, request.session.refreshToken).catch(() => {})
+      }
     }
-    if (request.session.refreshToken) {
-      await oidc.tokenRevocation(config, request.session.refreshToken).catch(() => {})
-    }
+  }
+  catch {
+    // getOidcConfig() failed — skip revocation and fall through to session
+    // destruction below.
   }
 
   // user_session_audit + its sid_hash-keyed triggers are Epic 1 infrastructure

--- a/server/src/auth/logout.ts
+++ b/server/src/auth/logout.ts
@@ -19,12 +19,14 @@ export async function handleLogout(request: FastifyRequest, reply: FastifyReply)
     // document, so revocation is typically skipped here. v6: the endpoint is
     // read from config.serverMetadata(), and revocation is tokenRevocation().
     if (config.serverMetadata().revocation_endpoint) {
+      const revocations: Promise<unknown>[] = []
       if (request.session.accessToken) {
-        await oidc.tokenRevocation(config, request.session.accessToken).catch(() => {})
+        revocations.push(oidc.tokenRevocation(config, request.session.accessToken))
       }
       if (request.session.refreshToken) {
-        await oidc.tokenRevocation(config, request.session.refreshToken).catch(() => {})
+        revocations.push(oidc.tokenRevocation(config, request.session.refreshToken))
       }
+      await Promise.all(revocations.map(revocation => revocation.catch(() => {})))
     }
   }
   catch {
@@ -32,15 +34,24 @@ export async function handleLogout(request: FastifyRequest, reply: FastifyReply)
     // destruction below.
   }
 
-  // user_session_audit + its sid_hash-keyed triggers are Epic 1 infrastructure
-  // (DT-3606) — the same hashing convention as the INSERT trigger there, so
-  // this UPDATE targets the row that trigger created for this sid.
-  await request.server.pg.query(
-    `UPDATE user_session_audit
-        SET end_reason = 'logout'
-      WHERE sid_hash = encode(sha256($1::bytea), 'hex') AND ended_at IS NULL`,
-    [request.session.sessionId],
-  )
+  // Best-effort, like revocation above — the audit trail is the least
+  // critical step here, so a transient DB error must not leave the session
+  // (and its cookie) alive.
+  try {
+    // user_session_audit + its sid_hash-keyed triggers are Epic 1
+    // infrastructure (DT-3606) — the same hashing convention as the INSERT
+    // trigger there, so this UPDATE targets the row that trigger created for
+    // this sid.
+    await request.server.pg.query(
+      `UPDATE user_session_audit
+          SET end_reason = 'logout'
+        WHERE sid_hash = encode(sha256($1::bytea), 'hex') AND ended_at IS NULL`,
+      [request.session.sessionId],
+    )
+  }
+  catch {
+    // Audit write failed — fall through to session destruction below.
+  }
 
   await request.session.destroy()
   reply.clearCookie('sessionId').status(204).send()

--- a/server/src/auth/logout.ts
+++ b/server/src/auth/logout.ts
@@ -1,0 +1,38 @@
+import * as oidc from 'openid-client'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { getOidcConfig } from './oidcClient.js'
+
+/**
+ * Stamps the audit record, attempts token revocation (if B2C exposes a
+ * revocation endpoint), destroys the session, and clears the cookie. Session
+ * destruction is the primary logout control in the BFF model — revocation is
+ * best-effort on top of it.
+ */
+export async function handleLogout(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const config = await getOidcConfig()
+
+  // B2C does not reliably expose a revocation_endpoint in its discovery
+  // document, so revocation is typically skipped here. v6: the endpoint is
+  // read from config.serverMetadata(), and revocation is tokenRevocation().
+  if (config.serverMetadata().revocation_endpoint) {
+    if (request.session.accessToken) {
+      await oidc.tokenRevocation(config, request.session.accessToken).catch(() => {})
+    }
+    if (request.session.refreshToken) {
+      await oidc.tokenRevocation(config, request.session.refreshToken).catch(() => {})
+    }
+  }
+
+  // user_session_audit + its sid_hash-keyed triggers are Epic 1 infrastructure
+  // (DT-3606) — the same hashing convention as the INSERT trigger there, so
+  // this UPDATE targets the row that trigger created for this sid.
+  await request.server.pg.query(
+    `UPDATE user_session_audit
+        SET end_reason = 'logout'
+      WHERE sid_hash = encode(sha256($1::bytea), 'hex') AND ended_at IS NULL`,
+    [request.session.sessionId],
+  )
+
+  await request.session.destroy()
+  reply.clearCookie('sessionId').status(204).send()
+}

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -13,7 +13,11 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   }
 
   const res = await fetch(`${requireEnv('DUOS_API_URL')}/api/user/me`, {
-    headers: { Authorization: `Bearer ${request.session.accessToken}` },
+    headers: {
+      'Authorization': `Bearer ${request.session.accessToken}`,
+      'Accept': 'application/json',
+      'X-App-ID': 'DUOS',
+    },
   })
 
   if (res.status === 401) {
@@ -21,6 +25,14 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     // whose access token it now rejects (expired, revoked) is dead weight.
     await request.session.destroy()
     reply.status(401).send({ authenticated: false })
+    return
+  }
+
+  if (!res.ok) {
+    // A non-401 failure (5xx, upstream outage) says nothing about whether the
+    // token itself is still valid — don't destroy the session or parse an
+    // error body as if it were a user profile.
+    reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
     return
   }
 

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -1,9 +1,11 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { requireEnv } from './oidcClient.js'
 
+const UPSTREAM_TIMEOUT_MS = 5000
+
 /**
  * Confirms the user is authenticated against the upstream Consent API.
- * Returns safe user-profile fields and the active sub-provider — never the
+ * Forwards the upstream user profile and the active sub-provider — never the
  * tokens themselves, which stay server-side in the session.
  */
 export async function getMe(request: FastifyRequest, reply: FastifyReply): Promise<void> {
@@ -12,19 +14,31 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     return
   }
 
-  const res = await fetch(`${requireEnv('DUOS_API_URL')}/api/user/me`, {
-    headers: {
-      'Authorization': `Bearer ${request.session.accessToken}`,
-      'Accept': 'application/json',
-      'X-App-ID': 'DUOS',
-    },
-  })
+  const url = `${requireEnv('DUOS_API_URL')}/api/user/me`
+
+  let res: Response
+  try {
+    res = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${request.session.accessToken}`,
+        'Accept': 'application/json',
+        'X-App-ID': 'DUOS',
+      },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    })
+  }
+  catch {
+    // Network failure or timeout — same as any other upstream outage below:
+    // says nothing about the token's validity, so don't destroy the session.
+    reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
+    return
+  }
 
   if (res.status === 401) {
     // The upstream API is the source of truth for token validity — a session
     // whose access token it now rejects (expired, revoked) is dead weight.
     await request.session.destroy()
-    reply.status(401).send({ authenticated: false })
+    reply.clearCookie('sessionId').status(401).send({ authenticated: false })
     return
   }
 
@@ -36,7 +50,15 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     return
   }
 
-  const user = await res.json()
+  let user: unknown
+  try {
+    user = await res.json()
+  }
+  catch {
+    reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
+    return
+  }
+
   reply.send({
     authenticated: true,
     user,

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -1,0 +1,33 @@
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { requireEnv } from './oidcClient.js'
+
+/**
+ * Confirms the user is authenticated against the upstream Consent API.
+ * Returns safe user-profile fields and the active sub-provider — never the
+ * tokens themselves, which stay server-side in the session.
+ */
+export async function getMe(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!request.session.accessToken) {
+    reply.status(401).send({ authenticated: false })
+    return
+  }
+
+  const res = await fetch(`${requireEnv('DUOS_API_URL')}/api/user/me`, {
+    headers: { Authorization: `Bearer ${request.session.accessToken}` },
+  })
+
+  if (res.status === 401) {
+    // The upstream API is the source of truth for token validity — a session
+    // whose access token it now rejects (expired, revoked) is dead weight.
+    await request.session.destroy()
+    reply.status(401).send({ authenticated: false })
+    return
+  }
+
+  const user = await res.json()
+  reply.send({
+    authenticated: true,
+    user,
+    idp: request.session.idp, // 'google' | 'microsoft'
+  })
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,10 @@ import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import { createPgSessionStore } from './session/pgStore.js'
 import { getOidcConfig } from './auth/oidcClient.js'
+import { handleLogin } from './auth/login.js'
+import { handleCallback } from './auth/callback.js'
+import { handleLogout } from './auth/logout.js'
+import { getMe } from './auth/me.js'
 import { configPath, readConfig } from './config.js'
 import './types/session.js'
 import FastifyVite from '@fastify/vite'
@@ -52,12 +56,17 @@ export async function buildApp(): Promise<AppInstance> {
     : Fastify({ logger: { level: process.env.FASTIFY_LOG_LEVEL ?? 'info' }, trustProxy: 1 })
   ) as AppInstance
 
+  // Path to the static client config.json — computed once so both the
+  // /config.json route below and the bffEnabled startup check read the same
+  // (memoized) config.
+  const configJsonPath = configPath(PROJECT_ROOT, isDev)
+
   // 1. DB pool + session — registered only when the deployment provides the
   // BFF database configuration. Session infrastructure is deployment config
   // (env vars via helmfile/compose), not a runtime flag: every pod of a given
   // deployment behaves identically, with no network dependency at boot.
   // Directing users to the BFF sign-in flow is a separate switch — the
-  // boolean `bffEnabled` in config.json, checked at startup (Phase 2+) — see
+  // boolean `bffEnabled` in config.json, checked at startup — see
   // docs/plans/BFF_Overview.md.
   if (process.env.DUOS_DB_HOST) {
     fastify.log.info('[server] DUOS_DB_HOST is set — enabling BFF session infrastructure')
@@ -147,6 +156,30 @@ export async function buildApp(): Promise<AppInstance> {
     fastify.log.info('[server] DUOS_DB_HOST is not set — starting without DB/session infrastructure (legacy client-side auth)')
   }
 
+  // 2. BFF auth routes — the cutover switch. Checked once at startup via the
+  // same readConfig() the /config.json route below serves, so the server and
+  // client agree on bffEnabled by construction. A missing key defaults to
+  // false and the routes stay dark — the fail-safe is the legacy
+  // client-side flow. See docs/plans/BFF_Overview.md § Rollout strategy.
+  const { bffEnabled } = await readConfig(configJsonPath, fastify.log)
+  if (bffEnabled === true) {
+    // The two switches are meant to be independent (session infra can be on
+    // ahead of cutover), but not in this direction: routing users into the
+    // BFF flow without the session infrastructure configured would register
+    // routes that 500 on first use instead of failing loudly at startup.
+    if (!process.env.DUOS_DB_HOST) {
+      throw new Error('bffEnabled is true in config.json but DUOS_DB_HOST is not set — the BFF auth routes require the session infrastructure to be configured')
+    }
+    fastify.log.info('[server] bffEnabled is true — registering BFF auth routes')
+    fastify.post('/auth/login', handleLogin)
+    fastify.get('/auth/callback', handleCallback)
+    fastify.post('/auth/logout', handleLogout)
+    fastify.get('/auth/me', getMe)
+  }
+  else {
+    fastify.log.info('[server] bffEnabled is not true — BFF auth routes disabled (legacy client-side auth)')
+  }
+
   // Health check — registered before Vite middleware so it always resolves
   fastify.get('/health', async () => ({ status: 'ok' }))
 
@@ -163,7 +196,6 @@ export async function buildApp(): Promise<AppInstance> {
   // disagree with GET's body (mismatched Content-Length for caches/validators).
   // Node itself omits the body for HEAD responses; sending the same payload
   // yields matching headers.
-  const configJsonPath = configPath(PROJECT_ROOT, isDev)
   fastify.addHook('onRequest', async (request, reply) => {
     if ((request.method === 'GET' || request.method === 'HEAD')
       && (request.url === '/config.json' || request.url.startsWith('/config.json?'))) {

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -58,6 +58,7 @@ vi.mock('../src/auth/me.js', () => ({
 // Setup
 // ---------------------------------------------------------------------------
 let app: FastifyInstance
+let defaultConfigDir: string
 
 beforeEach(async () => {
   // DUOS_DB_HOST gates the DB/cookie/session registration; set the full DB
@@ -70,6 +71,17 @@ beforeEach(async () => {
   delete process.env.DUOS_DB_PORT
   process.env.DUOS_SESSION_SECRET = 'test-secret-that-is-at-least-32-characters'
   vi.clearAllMocks()
+
+  // buildApp() reads config.json eagerly at startup (to gate the BFF auth
+  // routes on bffEnabled). public/config.json is a dev/deploy-time artifact
+  // that's gitignored and won't exist in a fresh checkout (e.g. CI) — point
+  // every test at an isolated fixture so this suite never depends on it.
+  defaultConfigDir = mkdtempSync(path.join(tmpdir(), 'duos-index-config-'))
+  process.env.CONFIG_PATH = path.join(defaultConfigDir, 'config.json')
+  writeFileSync(process.env.CONFIG_PATH, JSON.stringify({}))
+  const { resetConfigCache } = await import('../src/config.js')
+  resetConfigCache()
+
   // Do NOT call app.ready() here — it finalises the Fastify lifecycle and
   // prevents routes from being added inside individual tests.
   const { buildApp } = await import('../src/index.js')
@@ -78,6 +90,10 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await app.close()
+  delete process.env.CONFIG_PATH
+  const { resetConfigCache } = await import('../src/config.js')
+  resetConfigCache()
+  rmSync(defaultConfigDir, { recursive: true, force: true })
 })
 
 // ---------------------------------------------------------------------------

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
@@ -36,6 +36,23 @@ vi.mock('@fastify/vite', () => {
   ;(plugin as any)[Symbol.for('skip-override')] = true
   return { default: plugin }
 })
+
+// The auth handlers themselves are covered by their own dedicated test files
+// (login.test.ts, callback.test.ts, ...) — here we only need to know whether
+// buildApp() wired the route to the handler, so a stub that proves it was
+// called (and sends a response) is enough.
+vi.mock('../src/auth/login.js', () => ({
+  handleLogin: vi.fn(async (_req: FastifyRequest, reply: FastifyReply) => reply.send({ stub: 'login' })),
+}))
+vi.mock('../src/auth/callback.js', () => ({
+  handleCallback: vi.fn(async (_req: FastifyRequest, reply: FastifyReply) => reply.send({ stub: 'callback' })),
+}))
+vi.mock('../src/auth/logout.js', () => ({
+  handleLogout: vi.fn(async (_req: FastifyRequest, reply: FastifyReply) => reply.status(204).send()),
+}))
+vi.mock('../src/auth/me.js', () => ({
+  getMe: vi.fn(async (_req: FastifyRequest, reply: FastifyReply) => reply.send({ stub: 'me' })),
+}))
 
 // ---------------------------------------------------------------------------
 // Setup
@@ -132,6 +149,13 @@ describe('GET /config.json', () => {
     process.env.CONFIG_PATH = file
     process.env.DUOS_API_URL = 'https://local.dsde-dev.broadinstitute.org:27443'
 
+    // buildApp() now reads config.json eagerly at startup (to gate the BFF
+    // auth routes on bffEnabled) — the outer beforeEach's own buildApp() call
+    // already cached the real, un-overridden file before this test set
+    // CONFIG_PATH, so the cache must be cleared for this fixture to take effect.
+    const { resetConfigCache } = await import('../src/config.js')
+    resetConfigCache()
+
     const { buildApp } = await import('../src/index.js')
     const localApp = await buildApp()
 
@@ -197,6 +221,90 @@ describe('BFF env-config gating', () => {
 
     const { buildApp } = await import('../src/index.js')
     await expect(buildApp()).rejects.toThrow('DUOS_DB_PORT')
+  })
+})
+
+describe('BFF auth route registration', () => {
+  let dir: string
+
+  afterEach(async () => {
+    delete process.env.CONFIG_PATH
+    const { resetConfigCache } = await import('../src/config.js')
+    resetConfigCache()
+    // Guarded: rmSync(undefined) throws and would mask the real failure of a
+    // test that died before mkdtempSync assigned dir.
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  // buildApp() reads config.json eagerly at startup (to gate the BFF auth
+  // routes on bffEnabled) and caches it process-wide — the outer beforeEach's
+  // own buildApp() call already cached the real, un-overridden file before
+  // any of these tests get to set CONFIG_PATH, so the cache must be cleared
+  // again right before building the app under test for the fixture to apply.
+  async function buildAppWithConfig(config: Record<string, unknown>) {
+    dir = mkdtempSync(path.join(tmpdir(), 'duos-bff-config-'))
+    const file = path.join(dir, 'config.json')
+    writeFileSync(file, JSON.stringify(config))
+    process.env.CONFIG_PATH = file
+
+    const { resetConfigCache } = await import('../src/config.js')
+    resetConfigCache()
+
+    const { buildApp } = await import('../src/index.js')
+    return buildApp()
+  }
+
+  it('registers all four /auth/* routes when bffEnabled is true', async () => {
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const { handleLogin } = await import('../src/auth/login.js')
+    const { handleCallback } = await import('../src/auth/callback.js')
+    const { handleLogout } = await import('../src/auth/logout.js')
+    const { getMe } = await import('../src/auth/me.js')
+
+    await localApp.inject({ method: 'POST', url: '/auth/login' })
+    expect(handleLogin).toHaveBeenCalled()
+
+    await localApp.inject({ method: 'GET', url: '/auth/callback' })
+    expect(handleCallback).toHaveBeenCalled()
+
+    await localApp.inject({ method: 'POST', url: '/auth/logout' })
+    expect(handleLogout).toHaveBeenCalled()
+
+    await localApp.inject({ method: 'GET', url: '/auth/me' })
+    expect(getMe).toHaveBeenCalled()
+
+    await localApp.close()
+  })
+
+  // The app's setNotFoundHandler() serves the SPA shell (200) for any
+  // unmatched route, so an unregistered /auth/* route can't be distinguished
+  // from a registered one by status code alone — assert the handler itself
+  // was never invoked instead.
+  it('does not register the /auth/* routes when bffEnabled is explicitly false', async () => {
+    const localApp = await buildAppWithConfig({ bffEnabled: false })
+
+    const { handleLogin } = await import('../src/auth/login.js')
+    await localApp.inject({ method: 'POST', url: '/auth/login' })
+    expect(handleLogin).not.toHaveBeenCalled()
+
+    await localApp.close()
+  })
+
+  it('does not register the /auth/* routes when bffEnabled is missing from config.json', async () => {
+    const localApp = await buildAppWithConfig({ apiUrl: 'https://consent.dsde-dev.broadinstitute.org' })
+
+    const { handleLogin } = await import('../src/auth/login.js')
+    await localApp.inject({ method: 'POST', url: '/auth/login' })
+    expect(handleLogin).not.toHaveBeenCalled()
+
+    await localApp.close()
+  })
+
+  it('fails loud when bffEnabled is true but DUOS_DB_HOST is not set', async () => {
+    delete process.env.DUOS_DB_HOST
+
+    await expect(buildAppWithConfig({ bffEnabled: true })).rejects.toThrow('DUOS_DB_HOST')
   })
 })
 

--- a/server/test/logout.test.ts
+++ b/server/test/logout.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import type { Configuration } from 'openid-client'
+import { handleLogout } from '../src/auth/logout.js'
+
+// Mock getOidcConfig() (network) — tokenRevocation() is also mocked since it
+// would otherwise perform a real network call.
+vi.mock('../src/auth/oidcClient.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/auth/oidcClient.js')>()
+  return { ...actual, getOidcConfig: vi.fn() }
+})
+
+vi.mock('openid-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('openid-client')>()
+  return { ...actual, tokenRevocation: vi.fn() }
+})
+
+function makeConfig(revocationEndpoint?: string): Configuration {
+  return { serverMetadata: () => ({ revocation_endpoint: revocationEndpoint }) } as unknown as Configuration
+}
+
+function makeRequest(overrides: {
+  accessToken?: string
+  refreshToken?: string
+  sessionId?: string
+} = {}) {
+  const query = vi.fn().mockResolvedValue({ rows: [] })
+  const destroy = vi.fn().mockResolvedValue(undefined)
+  const request = {
+    session: {
+      accessToken: overrides.accessToken,
+      refreshToken: overrides.refreshToken,
+      sessionId: overrides.sessionId ?? 'test-sid',
+      destroy,
+    },
+    server: { pg: { query } },
+  }
+  return { request: request as unknown as FastifyRequest, query, destroy }
+}
+
+function makeReply() {
+  const reply = { clearCookie: vi.fn(), status: vi.fn(), send: vi.fn() }
+  reply.clearCookie.mockReturnValue(reply)
+  reply.status.mockReturnValue(reply)
+  return reply as unknown as FastifyReply & {
+    clearCookie: ReturnType<typeof vi.fn>
+    status: ReturnType<typeof vi.fn>
+    send: ReturnType<typeof vi.fn>
+  }
+}
+
+describe('handleLogout', () => {
+  beforeEach(async () => {
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    vi.mocked(oidcClient.getOidcConfig).mockReset().mockResolvedValue(makeConfig(undefined))
+
+    const oidc = await import('openid-client')
+    vi.mocked(oidc.tokenRevocation).mockReset().mockResolvedValue(undefined)
+  })
+
+  it('stamps the audit record for the session sid, destroys the session, and clears the cookie', async () => {
+    const { request, query, destroy } = makeRequest({ sessionId: 'the-sid' })
+    const reply = makeReply()
+
+    await handleLogout(request, reply)
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE user_session_audit'),
+      ['the-sid'],
+    )
+    expect(query.mock.calls[0][0]).toContain('end_reason = \'logout\'')
+    expect(query.mock.calls[0][0]).toContain('sid_hash = encode(sha256($1::bytea), \'hex\')')
+    expect(destroy).toHaveBeenCalled()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(204)
+    expect(reply.send).toHaveBeenCalled()
+  })
+
+  it('stamps the audit record before destroying the session', async () => {
+    const { request, query, destroy } = makeRequest()
+
+    await handleLogout(request, makeReply())
+
+    const queryOrder = query.mock.invocationCallOrder[0]
+    const destroyOrder = destroy.mock.invocationCallOrder[0]
+    expect(queryOrder).toBeLessThan(destroyOrder)
+  })
+
+  it('does not attempt token revocation when B2C exposes no revocation_endpoint', async () => {
+    const { request } = makeRequest({ accessToken: 'access', refreshToken: 'refresh' })
+
+    await handleLogout(request, makeReply())
+
+    const oidc = await import('openid-client')
+    expect(oidc.tokenRevocation).not.toHaveBeenCalled()
+  })
+
+  it('revokes both access and refresh tokens when a revocation_endpoint is present', async () => {
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    vi.mocked(oidcClient.getOidcConfig).mockResolvedValue(makeConfig('https://duosdev.b2clogin.com/revoke'))
+    const config = await oidcClient.getOidcConfig()
+    const { request } = makeRequest({ accessToken: 'access-token', refreshToken: 'refresh-token' })
+
+    await handleLogout(request, makeReply())
+
+    const oidc = await import('openid-client')
+    expect(oidc.tokenRevocation).toHaveBeenCalledWith(config, 'access-token')
+    expect(oidc.tokenRevocation).toHaveBeenCalledWith(config, 'refresh-token')
+    expect(oidc.tokenRevocation).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips revocation for tokens absent from the session', async () => {
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    vi.mocked(oidcClient.getOidcConfig).mockResolvedValue(makeConfig('https://duosdev.b2clogin.com/revoke'))
+    const { request } = makeRequest({ accessToken: 'access-token' }) // no refreshToken
+
+    await handleLogout(request, makeReply())
+
+    const oidc = await import('openid-client')
+    expect(oidc.tokenRevocation).toHaveBeenCalledTimes(1)
+    expect(oidc.tokenRevocation).toHaveBeenCalledWith(expect.anything(), 'access-token')
+  })
+
+  it('completes logout even when token revocation rejects', async () => {
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    vi.mocked(oidcClient.getOidcConfig).mockResolvedValue(makeConfig('https://duosdev.b2clogin.com/revoke'))
+    const oidc = await import('openid-client')
+    vi.mocked(oidc.tokenRevocation).mockRejectedValue(new Error('revocation endpoint unreachable'))
+    const { request, destroy } = makeRequest({ accessToken: 'access-token' })
+    const reply = makeReply()
+
+    await expect(handleLogout(request, reply)).resolves.toBeUndefined()
+
+    expect(destroy).toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(204)
+  })
+})

--- a/server/test/logout.test.ts
+++ b/server/test/logout.test.ts
@@ -135,6 +135,19 @@ describe('handleLogout', () => {
     expect(reply.status).toHaveBeenCalledWith(204)
   })
 
+  it('completes logout (session destroy, cookie clear) even when the audit UPDATE rejects', async () => {
+    const { request, query, destroy } = makeRequest({ sessionId: 'the-sid' })
+    query.mockRejectedValue(new Error('connection terminated unexpectedly'))
+    const reply = makeReply()
+
+    await expect(handleLogout(request, reply)).resolves.toBeUndefined()
+
+    expect(query).toHaveBeenCalled()
+    expect(destroy).toHaveBeenCalled()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(204)
+  })
+
   it('completes logout (audit stamp, session destroy, cookie clear) even when getOidcConfig() rejects', async () => {
     const oidcClient = await import('../src/auth/oidcClient.js')
     vi.mocked(oidcClient.getOidcConfig).mockRejectedValue(new Error('B2C discovery unreachable'))

--- a/server/test/logout.test.ts
+++ b/server/test/logout.test.ts
@@ -134,4 +134,20 @@ describe('handleLogout', () => {
     expect(destroy).toHaveBeenCalled()
     expect(reply.status).toHaveBeenCalledWith(204)
   })
+
+  it('completes logout (audit stamp, session destroy, cookie clear) even when getOidcConfig() rejects', async () => {
+    const oidcClient = await import('../src/auth/oidcClient.js')
+    vi.mocked(oidcClient.getOidcConfig).mockRejectedValue(new Error('B2C discovery unreachable'))
+    const { request, query, destroy } = makeRequest({ sessionId: 'the-sid' })
+    const reply = makeReply()
+
+    await expect(handleLogout(request, reply)).resolves.toBeUndefined()
+
+    const oidc = await import('openid-client')
+    expect(oidc.tokenRevocation).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith(expect.stringContaining('UPDATE user_session_audit'), ['the-sid'])
+    expect(destroy).toHaveBeenCalled()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(204)
+  })
 })

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -19,7 +19,7 @@ function makeReply() {
 }
 
 function makeFetchResponse(status: number, body: unknown) {
-  return { status, json: vi.fn().mockResolvedValue(body) }
+  return { status, ok: status >= 200 && status < 300, json: vi.fn().mockResolvedValue(body) }
 }
 
 describe('getMe', () => {
@@ -52,7 +52,13 @@ describe('getMe', () => {
 
     expect(fetch).toHaveBeenCalledWith(
       `${ENV.DUOS_API_URL}/api/user/me`,
-      { headers: { Authorization: 'Bearer test-access-token' } },
+      {
+        headers: {
+          'Authorization': 'Bearer test-access-token',
+          'Accept': 'application/json',
+          'X-App-ID': 'DUOS',
+        },
+      },
     )
   })
 
@@ -80,6 +86,18 @@ describe('getMe', () => {
     expect(destroy).toHaveBeenCalled()
     expect(reply.status).toHaveBeenCalledWith(401)
     expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+  })
+
+  it('returns 502 without destroying the session when the upstream API errors with a non-401 status', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(503, {}) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'test-access-token' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(destroy).not.toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false, error: 'upstream_unavailable' })
   })
 
   it('rejects with an error naming DUOS_API_URL when it is unset', async () => {

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { FastifyReply, FastifyRequest } from 'fastify'
+import { getMe } from '../src/auth/me.js'
+
+const ENV = { DUOS_API_URL: 'https://consent.dsde-dev.broadinstitute.org' }
+
+function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft' } = {}) {
+  const destroy = vi.fn().mockResolvedValue(undefined)
+  const request = {
+    session: { accessToken: overrides.accessToken, idp: overrides.idp, destroy },
+  }
+  return { request: request as unknown as FastifyRequest, destroy }
+}
+
+function makeReply() {
+  const reply = { status: vi.fn(), send: vi.fn() }
+  reply.status.mockReturnValue(reply)
+  return reply as unknown as FastifyReply & { status: ReturnType<typeof vi.fn>, send: ReturnType<typeof vi.fn> }
+}
+
+function makeFetchResponse(status: number, body: unknown) {
+  return { status, json: vi.fn().mockResolvedValue(body) }
+}
+
+describe('getMe', () => {
+  beforeEach(() => {
+    Object.assign(process.env, ENV)
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    for (const key of Object.keys(ENV)) delete process.env[key]
+    vi.unstubAllGlobals()
+  })
+
+  it('returns 401 without calling the upstream API when there is no access token', async () => {
+    const { request } = makeRequest()
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(401)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+  })
+
+  it('calls the upstream /api/user/me with a Bearer token from the session', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request } = makeRequest({ accessToken: 'test-access-token' })
+
+    await getMe(request, makeReply())
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${ENV.DUOS_API_URL}/api/user/me`,
+      { headers: { Authorization: 'Bearer test-access-token' } },
+    )
+  })
+
+  it('returns the user profile and idp on success', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request } = makeRequest({ accessToken: 'test-access-token', idp: 'google' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(reply.send).toHaveBeenCalledWith({
+      authenticated: true,
+      user: { email: 'user@example.com' },
+      idp: 'google',
+    })
+  })
+
+  it('destroys the session and returns 401 when the upstream API rejects the token', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(401, {}) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'stale-access-token' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(destroy).toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(401)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+  })
+
+  it('rejects with an error naming DUOS_API_URL when it is unset', async () => {
+    delete process.env.DUOS_API_URL
+    const { request } = makeRequest({ accessToken: 'test-access-token' })
+
+    await expect(getMe(request, makeReply())).rejects.toThrow('DUOS_API_URL')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -13,9 +13,14 @@ function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'micros
 }
 
 function makeReply() {
-  const reply = { status: vi.fn(), send: vi.fn() }
+  const reply = { clearCookie: vi.fn(), status: vi.fn(), send: vi.fn() }
+  reply.clearCookie.mockReturnValue(reply)
   reply.status.mockReturnValue(reply)
-  return reply as unknown as FastifyReply & { status: ReturnType<typeof vi.fn>, send: ReturnType<typeof vi.fn> }
+  return reply as unknown as FastifyReply & {
+    clearCookie: ReturnType<typeof vi.fn>
+    status: ReturnType<typeof vi.fn>
+    send: ReturnType<typeof vi.fn>
+  }
 }
 
 function makeFetchResponse(status: number, body: unknown) {
@@ -58,6 +63,7 @@ describe('getMe', () => {
           'Accept': 'application/json',
           'X-App-ID': 'DUOS',
         },
+        signal: expect.any(AbortSignal),
       },
     )
   })
@@ -84,12 +90,38 @@ describe('getMe', () => {
     await getMe(request, reply)
 
     expect(destroy).toHaveBeenCalled()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
     expect(reply.status).toHaveBeenCalledWith(401)
     expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
   })
 
   it('returns 502 without destroying the session when the upstream API errors with a non-401 status', async () => {
     vi.mocked(fetch).mockResolvedValue(makeFetchResponse(503, {}) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'test-access-token' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(destroy).not.toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false, error: 'upstream_unavailable' })
+  })
+
+  it('returns 502 without destroying the session when the upstream fetch rejects (network failure or timeout)', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('the operation was aborted'))
+    const { request, destroy } = makeRequest({ accessToken: 'test-access-token' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(destroy).not.toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false, error: 'upstream_unavailable' })
+  })
+
+  it('returns 502 without destroying the session when the upstream body fails to parse as JSON', async () => {
+    const badBody = { status: 200, ok: true, json: vi.fn().mockRejectedValue(new Error('invalid JSON')) }
+    vi.mocked(fetch).mockResolvedValue(badBody as never)
     const { request, destroy } = makeRequest({ accessToken: 'test-access-token' })
     const reply = makeReply()
 


### PR DESCRIPTION
### Addresses
Partially addresses https://broadworkbench.atlassian.net/browse/DT-3607

### Summary
Implements BFF Migration Plan v2 epic-2, sections 2-E and 2-F — the remaining two `/auth/*` handlers before route registration (2-G).

- **`POST /auth/logout`** (`handleLogout`): stamps `end_reason = 'logout'` on the `user_session_audit` row for the current session (table/triggers already landed in Epic 1, DT-3606), destroys the session, and clears the `sessionId` cookie. Token revocation is attempted only when B2C's discovery document exposes a `revocation_endpoint` and only for tokens actually present in the session — B2C doesn't reliably expose one, so session destruction remains the primary logout control, and a revocation failure never blocks logout from completing.
- **`GET /auth/me`** (`getMe`): confirms the session is authenticated by calling the upstream Consent API's `/api/user/me` with the session's access token. Returns `{ authenticated: false }` (401) immediately if there's no access token, destroys the session and returns 401 if the upstream rejects the token (expired/revoked), or returns `{ authenticated: true, user, idp }` on success. Never exposes tokens.

Both handlers are new files only — neither is wired into Fastify routing yet. Route registration for all of `/auth/*`, gated on `bffEnabled`, lands in story 2-G.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
