### PR TITLE
[DT-3805] Use Data Library grid on study details page

### DIFF
--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -27,8 +27,6 @@ const LoadingOverlay = () => (
 interface LibraryDataGridExtendedProps extends LibraryDataGridProps {
   extraColumns?: GridColDef[]
   checkboxSelection?: boolean
-  paginationMode?: 'client' | 'server'
-  sortingMode?: 'client' | 'server'
 }
 
 export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
@@ -46,8 +44,6 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
   radarEnabledDatasetIds = EMPTY_RADAR_IDS,
   extraColumns,
   checkboxSelection = true,
-  paginationMode = 'server',
-  sortingMode,
 }) => {
   const asset = assetRegistry[assetType]
 
@@ -127,13 +123,13 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
       <DataGrid
         rows={data as LibraryRow[]}
         columns={columns}
-        rowCount={paginationMode === 'server' ? total : undefined}
+        rowCount={total}
         loading={loading}
         pageSizeOptions={[25, 50, 100]}
         paginationModel={paginationModel}
-        paginationMode={paginationMode}
+        paginationMode="server"
         onPaginationModelChange={onPaginationChange}
-        sortingMode={sortingMode ?? asset.sortingMode}
+        sortingMode={asset.sortingMode}
         sortModel={sortModel}
         onSortModelChange={(model) => {
           onSortChange(model.map(item => ({
@@ -143,6 +139,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
         }}
         checkboxSelection={checkboxSelection}
         disableRowSelectionOnClick
+        keepNonExistentRowsSelected
         rowSelectionModel={rowSelectionModel}
         onRowSelectionModelChange={handleSelectionChange}
         isRowSelectable={isRowSelectable}

--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -27,6 +27,8 @@ const LoadingOverlay = () => (
 interface LibraryDataGridExtendedProps extends LibraryDataGridProps {
   extraColumns?: GridColDef[]
   checkboxSelection?: boolean
+  paginationMode?: 'client' | 'server'
+  sortingMode?: 'client' | 'server'
 }
 
 export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
@@ -44,6 +46,8 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
   radarEnabledDatasetIds = EMPTY_RADAR_IDS,
   extraColumns,
   checkboxSelection = true,
+  paginationMode = 'server',
+  sortingMode,
 }) => {
   const asset = assetRegistry[assetType]
 
@@ -123,13 +127,13 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
       <DataGrid
         rows={data as LibraryRow[]}
         columns={columns}
-        rowCount={total}
+        rowCount={paginationMode === 'server' ? total : undefined}
         loading={loading}
         pageSizeOptions={[25, 50, 100]}
         paginationModel={paginationModel}
-        paginationMode="server"
+        paginationMode={paginationMode}
         onPaginationModelChange={onPaginationChange}
-        sortingMode={asset.sortingMode}
+        sortingMode={sortingMode ?? asset.sortingMode}
         sortModel={sortModel}
         onSortModelChange={(model) => {
           onSortChange(model.map(item => ({

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -1,17 +1,12 @@
-import React, { useEffect, useState } from 'react'
-import { DataSet } from 'src/libs/ajax/DataSet'
-import { DatasetTerm, StudyTerm } from 'src/types/model'
-import { ElasticsearchQuery } from 'src/types/elastic'
+import React, { useState } from 'react'
 import backArrowIcon from 'src/images/back_arrow.svg'
 import { Link, useParams, useNavigate } from 'react-router-dom'
-import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
-import { chain, intersection } from 'src/utils/NodashUtil'
-import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
 import { applyForAccess } from 'src/utils/accessUtils'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
-import { AssetType, ExportableDatasets, SortOrder } from 'src/types/library'
+import { AssetType, SortOrder, SortState } from 'src/types/library'
+import { useStudyDatasets, useStudyExportableDatasets } from 'src/hooks/useStudyDetailsData'
 
 interface SectionProps {
   style?: React.CSSProperties
@@ -20,123 +15,36 @@ interface SectionProps {
 const Section = ({ style, children }: React.PropsWithChildren<SectionProps>) =>
   <div style={{ paddingTop: 20, paddingRight: 100, ...style }}>{children}</div>
 
-const EMPTY_DATASETS: DatasetTerm[] = []
-const EMPTY_EXPORTABLE_DATASETS: ExportableDatasets = {}
 const INITIAL_PAGINATION = { page: 0, pageSize: 25 }
 
-export const StudyDetails = () => {
-  usePageTitle('Study Details')
-  const params = useParams<{ studyId: string }>()
-  const studyId = params.studyId
+const getErrorMessage = (error: unknown): string | undefined => {
+  if (error instanceof Error) return error.message
+  if (error) return 'Unknown error'
+  return undefined
+}
+
+interface StudyDetailsContentProps {
+  studyId: string
+}
+
+const StudyDetailsContent = ({ studyId }: StudyDetailsContentProps) => {
   const navigate = useNavigate()
-  const [datasetState, setDatasetState] = useState<{
-    studyId?: string
-    datasets: DatasetTerm[]
-    error?: Error
-  }>({ datasets: EMPTY_DATASETS })
-  const [exportableState, setExportableState] = useState<{ studyId?: string, data: ExportableDatasets }>({ data: EMPTY_EXPORTABLE_DATASETS })
-  const [selectionState, setSelectionState] = useState<{ studyId?: string, datasetIds: number[] }>({ datasetIds: [] })
-  const [paginationState, setPaginationState] = useState<{ studyId?: string, model: typeof INITIAL_PAGINATION }>({ model: INITIAL_PAGINATION })
-  const [sortState, setSortState] = useState<{ studyId?: string, model: Array<{ field: string, sort: SortOrder | null }> }>({ model: [] })
-
-  const loading = datasetState.studyId !== studyId
-  const error = loading ? undefined : datasetState.error
-  const datasets = loading ? EMPTY_DATASETS : datasetState.datasets
-  const exportableDatasets = exportableState.studyId === studyId ? exportableState.data : EMPTY_EXPORTABLE_DATASETS
-  const selectedDatasets = selectionState.studyId === studyId ? selectionState.datasetIds : []
-  const paginationModel = paginationState.studyId === studyId ? paginationState.model : INITIAL_PAGINATION
-  const sortModel = sortState.studyId === studyId ? sortState.model : []
-
-  const study: StudyTerm | undefined = datasets.length > 0 ? datasets[0].study : undefined
-  const selectedStudyIds = Array.from(new Set(
-    datasets
-      .filter(dataset => selectedDatasets.includes(dataset.datasetId))
-      .map(dataset => dataset.study.studyId),
-  ))
-
-  useEffect(() => {
-    let active = true
-    const query = {
-      from: 0,
-      size: 10000,
-      query: {
-        bool: {
-          must: [
-            {
-              match: {
-                _index: 'dataset',
-              },
-            },
-            {
-              match: {
-                'study.studyId': studyId,
-              },
-            },
-            {
-              exists: {
-                field: 'study',
-              },
-            },
-          ],
-        },
-      },
-    }
-    DataSet.searchDatasetIndex(query as ElasticsearchQuery)
-      .then((datasets) => {
-        if (active) {
-          setDatasetState({ studyId, datasets })
-        }
-      })
-      .catch((error: unknown) => {
-        if (active) {
-          setDatasetState({
-            studyId,
-            datasets: EMPTY_DATASETS,
-            error: error instanceof Error ? error : new Error('Unknown error'),
-          })
-        }
-      })
-
-    return () => {
-      active = false
-    }
-  }, [studyId])
-
-  useEffect(() => {
-    if (datasets.length === 0) return
-
-    let active = true
-    const fetchExportableDatasets = async () => {
-      // Note the dataset identifier is in each sub-table row.
-      const datasetIdentifiers = datasets.map(row => row.datasetIdentifier)
-      try {
-        const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
-        const data = snapshots.filteredTotal > 0
-          ? chain(snapshots.items)
-              .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
-              .groupBy('duosId')
-              .value()
-          : EMPTY_EXPORTABLE_DATASETS
-        if (active) {
-          setExportableState({ studyId, data })
-        }
-      }
-      catch {
-        if (active) {
-          setExportableState({ studyId, data: EMPTY_EXPORTABLE_DATASETS })
-        }
-      }
-    }
-    fetchExportableDatasets()
-
-    return () => {
-      active = false
-    }
-  }, [datasets, studyId])
-
-  const participantCount = loading || error
-    ? undefined
-    : datasets.reduce((total, dataset) => total + dataset.participantCount, 0)
+  const [selectedDatasets, setSelectedDatasets] = useState<number[]>([])
+  const [paginationModel, setPaginationModel] = useState(INITIAL_PAGINATION)
+  const [sortModel, setSortModel] = useState<Array<{ field: string, sort: SortOrder | null }>>([])
+  const sort: SortState | undefined = sortModel[0]?.sort
+    ? { field: sortModel[0].field, order: sortModel[0].sort }
+    : undefined
+  const { data, isFetching: loading, error } = useStudyDatasets(studyId, paginationModel, sort)
+  const datasets = data?.items ?? []
+  const study = data?.study
+  const participantCount = data?.participantCount
+  const { data: exportableDatasets } = useStudyExportableDatasets(studyId, datasets)
+  const numericStudyId = Number(studyId)
+  const selectedStudyIds = selectedDatasets.length > 0 && !Number.isNaN(numericStudyId)
+    ? [numericStudyId]
+    : []
+  const errorMessage = getErrorMessage(error)
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-start' }}>
@@ -200,21 +108,19 @@ export const StudyDetails = () => {
           </Section>
         )}
         <div style={{ paddingTop: 20, marginTop: 20, borderTop: '1px solid black', width: '100%' }}>
-          {error && <div role="alert">Unable to load datasets: {error.message}</div>}
-          <div style={{ height: 600, marginTop: error ? 20 : 0 }}>
+          {errorMessage && <div role="alert">Unable to load datasets: {errorMessage}</div>}
+          <div style={{ height: 600, marginTop: errorMessage ? 20 : 0 }}>
             <LibraryDataGrid
               assetType={AssetType.DATASETS}
               data={datasets}
               loading={loading}
-              total={datasets.length}
+              total={data?.total ?? 0}
               paginationModel={paginationModel}
-              onPaginationChange={model => setPaginationState({ studyId, model })}
-              paginationMode="client"
+              onPaginationChange={setPaginationModel}
               sortModel={sortModel}
-              onSortChange={model => setSortState({ studyId, model })}
-              sortingMode="client"
+              onSortChange={setSortModel}
               selectedDatasetIds={selectedDatasets}
-              onSelectionChange={datasetIds => setSelectionState({ studyId, datasetIds })}
+              onSelectionChange={setSelectedDatasets}
               exportableDatasets={exportableDatasets}
             />
           </div>
@@ -227,4 +133,12 @@ export const StudyDetails = () => {
       />
     </div>
   )
+}
+
+export const StudyDetails = () => {
+  usePageTitle('Study Details')
+  const { studyId = '' } = useParams<{ studyId: string }>()
+
+  // Remount local grid state when navigating directly between study routes.
+  return <StudyDetailsContent key={studyId} studyId={studyId} />
 }

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -1,18 +1,17 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { DatasetTerm, StudyTerm } from 'src/types/model'
 import { ElasticsearchQuery } from 'src/types/elastic'
 import backArrowIcon from 'src/images/back_arrow.svg'
 import { Link, useParams, useNavigate } from 'react-router-dom'
-import { makeDatasetTableHeader, makeDatasetTableRows } from 'src/components/data_search/DatasetSearchTableConstants'
-import SimpleTable from 'src/components/SimpleTable'
-import { Styles } from 'src/libs/theme'
 import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
-import { chain, Dictionary, intersection, isEmpty } from 'src/utils/NodashUtil'
+import { chain, intersection } from 'src/utils/NodashUtil'
 import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
-import { DatasetSearchFooter } from 'src/components/data_search/DatasetSearchFooter'
 import { applyForAccess } from 'src/utils/accessUtils'
 import { usePageTitle } from 'src/hooks/usePageTitle'
+import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
+import LibraryFooter from 'src/components/data_library/LibraryFooter'
+import { AssetType, ExportableDatasets, SortOrder } from 'src/types/library'
 
 interface SectionProps {
   style?: React.CSSProperties
@@ -21,66 +20,50 @@ interface SectionProps {
 const Section = ({ style, children }: React.PropsWithChildren<SectionProps>) =>
   <div style={{ paddingTop: 20, paddingRight: 100, ...style }}>{children}</div>
 
-const styles = {
-  row: {
-    display: 'flex',
-    alignItems: 'flex-start',
-  },
-  baseStyle: {
-    fontFamily: 'Montserrat',
-    fontSize: '1.4rem',
-    fontWeight: 400,
-    display: 'flex',
-    padding: '1rem 2%',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    whiteSpace: 'pre-wrap',
-    backgroundColor: 'white',
-    border: '1px solid #DEDEDE',
-    borderRadius: '4px',
-    textOverflow: 'ellipsis',
-    height: '4rem',
-    marginTop: 5,
-  },
-  columnStyle: {
-    ...Styles.TABLE.HEADER_ROW, justifyContent: 'space-between',
-    fontFamily: 'Montserrat',
-    fontSize: '1.2rem',
-    fontWeight: 'bold',
-    letterSpacing: '0.2px',
-    backgroundColor: '#E2E8F4',
-    border: 'none',
-    textTransform: 'uppercase',
-    lineHeight: '16px',
-  },
-  containerOverride: {},
-}
-
 export const StudyDetails = () => {
   usePageTitle('Study Details')
   const params = useParams<{ studyId: string }>()
   const studyId = params.studyId
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error>()
   const [datasets, setDatasets] = useState<DatasetTerm[]>([])
-  const [exportableDatasets, setExportableDatasets] = useState<Dictionary<SnapshotSummaryModel[]>>({})
+  const [exportableDatasets, setExportableDatasets] = useState<ExportableDatasets>({})
   const [selectedDatasets, setSelectedDatasets] = useState<number[]>([])
+  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 25 })
+  const [sortModel, setSortModel] = useState<Array<{ field: string, sort: SortOrder | null }>>([])
 
   const study: StudyTerm | undefined = datasets.length > 0 ? datasets[0].study : undefined
-  const headers = makeDatasetTableHeader(datasets, selectedDatasets, setSelectedDatasets, exportableDatasets)
-  const rowData = makeDatasetTableRows(datasets, headers)
+  const selectedStudyIds = useMemo(() => Array.from(new Set(
+    datasets
+      .filter(dataset => selectedDatasets.includes(dataset.datasetId))
+      .map(dataset => dataset.study.studyId),
+  )), [datasets, selectedDatasets])
 
   const getExportableDatasets = async (datasets: DatasetTerm[]) => {
+    if (datasets.length === 0) {
+      setExportableDatasets({})
+      return
+    }
+
     // Note the dataset identifier is in each sub-table row.
     const datasetIdentifiers = datasets.map(row => row.datasetIdentifier)
-    const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
-    if (snapshots.filteredTotal > 0) {
-      const datasetIdToSnapshot = chain(snapshots.items)
-        // Ignore any snapshots that a user does not have export (steward or reader) to
-        .filter((snapshot: { id: string }) => intersection(snapshots.roleMap[snapshot.id], ['steward', 'reader']).length > 0)
-        .groupBy('duosId')
-        .value()
-      setExportableDatasets(datasetIdToSnapshot)
+    try {
+      const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
+      if (snapshots.filteredTotal > 0) {
+        const datasetIdToSnapshot = chain(snapshots.items)
+          // Ignore any snapshots that a user does not have export (steward or reader) to
+          .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap[snapshot.id], ['steward', 'reader']).length > 0)
+          .groupBy('duosId')
+          .value()
+        setExportableDatasets(datasetIdToSnapshot)
+      }
+      else {
+        setExportableDatasets({})
+      }
+    }
+    catch {
+      setExportableDatasets({})
     }
   }
 
@@ -110,11 +93,17 @@ export const StudyDetails = () => {
         },
       },
     }
-    DataSet.searchDatasetIndex(query as ElasticsearchQuery).then((datasets) => {
-      setDatasets(datasets)
-      setLoading(false)
-    })
-  }, [studyId, setDatasets])
+    DataSet.searchDatasetIndex(query as ElasticsearchQuery)
+      .then((datasets) => {
+        setDatasets(datasets)
+        setError(undefined)
+      })
+      .catch((error: Error) => {
+        setDatasets([])
+        setError(error)
+      })
+      .finally(() => setLoading(false))
+  }, [studyId])
 
   useEffect(() => {
     const init = async () => {
@@ -127,12 +116,8 @@ export const StudyDetails = () => {
     .map(dataset => dataset.participantCount)
     .reduce((partialSum, participants) => partialSum + participants, 0)
 
-  if (loading) {
-    return <div>Loading</div>
-  }
-
   return (
-    <div style={styles.row}>
+    <div style={{ display: 'flex', alignItems: 'flex-start' }}>
       <div style={{ paddingLeft: 40 }}>
         <Link
           id="link_datalibrary"
@@ -148,8 +133,8 @@ export const StudyDetails = () => {
           Back to library
         </div>
         <div style={{ fontSize: 20, fontWeight: 600, paddingTop: 20 }}>
-          <Link to={`/DUOS-S${study?.studyId}`}>
-            DUOS-S{study?.studyId}
+          <Link to={`/DUOS-S${study?.studyId ?? studyId}`}>
+            DUOS-S{study?.studyId ?? studyId}
           </Link>
         </div>
         <div style={{ fontSize: 20, fontWeight: 600, paddingTop: 20 }}>
@@ -193,15 +178,31 @@ export const StudyDetails = () => {
           </Section>
         )}
         <div style={{ paddingTop: 20, marginTop: 20, borderTop: '1px solid black', width: '100%' }}>
-          <SimpleTable
-            rowData={rowData}
-            columnHeaders={headers}
-            styles={styles}
-            tableSize={10}
-          />
+          {error && <div role="alert">Unable to load datasets: {error.message}</div>}
+          <div style={{ height: 600, marginTop: error ? 20 : 0 }}>
+            <LibraryDataGrid
+              assetType={AssetType.DATASETS}
+              data={datasets}
+              loading={loading}
+              total={datasets.length}
+              paginationModel={paginationModel}
+              onPaginationChange={setPaginationModel}
+              paginationMode="client"
+              sortModel={sortModel}
+              onSortChange={setSortModel}
+              sortingMode="client"
+              selectedDatasetIds={selectedDatasets}
+              onSelectionChange={setSelectedDatasets}
+              exportableDatasets={exportableDatasets}
+            />
+          </div>
         </div>
       </div>
-      {!isEmpty(selectedDatasets) && <DatasetSearchFooter selectedDatasets={selectedDatasets} datasets={datasets} onClick={() => applyForAccess(selectedDatasets, navigate)} />}
+      <LibraryFooter
+        selectedDatasetIds={selectedDatasets}
+        selectedStudyIds={selectedStudyIds}
+        onApplyForAccess={() => applyForAccess(selectedDatasets, navigate)}
+      />
     </div>
   )
 }

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -17,6 +17,8 @@ const Section = ({ style, children }: React.PropsWithChildren<SectionProps>) =>
 
 const INITIAL_PAGINATION = { page: 0, pageSize: 25 }
 
+type StudySortModel = Array<{ field: string, sort: SortOrder | null }>
+
 const getErrorMessage = (error: unknown): string | undefined => {
   if (error instanceof Error) return error.message
   if (error) return 'Unknown error'
@@ -31,7 +33,8 @@ const StudyDetailsContent = ({ studyId }: StudyDetailsContentProps) => {
   const navigate = useNavigate()
   const [selectedDatasets, setSelectedDatasets] = useState<number[]>([])
   const [paginationModel, setPaginationModel] = useState(INITIAL_PAGINATION)
-  const [sortModel, setSortModel] = useState<Array<{ field: string, sort: SortOrder | null }>>([])
+  const [sortModel, setSortModel] = useState<StudySortModel>([])
+  const handleSortChange = (model: StudySortModel) => setSortModel(model.slice(0, 1))
   const sort: SortState | undefined = sortModel[0]?.sort
     ? { field: sortModel[0].field, order: sortModel[0].sort }
     : undefined
@@ -118,7 +121,7 @@ const StudyDetailsContent = ({ studyId }: StudyDetailsContentProps) => {
               paginationModel={paginationModel}
               onPaginationChange={setPaginationModel}
               sortModel={sortModel}
-              onSortChange={setSortModel}
+              onSortChange={handleSortChange}
               selectedDatasetIds={selectedDatasets}
               onSelectionChange={setSelectedDatasets}
               exportableDatasets={exportableDatasets}

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -21,6 +21,7 @@ const Section = ({ style, children }: React.PropsWithChildren<SectionProps>) =>
   <div style={{ paddingTop: 20, paddingRight: 100, ...style }}>{children}</div>
 
 const EMPTY_DATASETS: DatasetTerm[] = []
+const EMPTY_EXPORTABLE_DATASETS: ExportableDatasets = {}
 const INITIAL_PAGINATION = { page: 0, pageSize: 25 }
 
 export const StudyDetails = () => {
@@ -33,7 +34,7 @@ export const StudyDetails = () => {
     datasets: DatasetTerm[]
     error?: Error
   }>({ datasets: EMPTY_DATASETS })
-  const [exportableDatasets, setExportableDatasets] = useState<ExportableDatasets>({})
+  const [exportableState, setExportableState] = useState<{ studyId?: string, data: ExportableDatasets }>({ data: EMPTY_EXPORTABLE_DATASETS })
   const [selectionState, setSelectionState] = useState<{ studyId?: string, datasetIds: number[] }>({ datasetIds: [] })
   const [paginationState, setPaginationState] = useState<{ studyId?: string, model: typeof INITIAL_PAGINATION }>({ model: INITIAL_PAGINATION })
   const [sortState, setSortState] = useState<{ studyId?: string, model: Array<{ field: string, sort: SortOrder | null }> }>({ model: [] })
@@ -41,6 +42,7 @@ export const StudyDetails = () => {
   const loading = datasetState.studyId !== studyId
   const error = loading ? undefined : datasetState.error
   const datasets = loading ? EMPTY_DATASETS : datasetState.datasets
+  const exportableDatasets = exportableState.studyId === studyId ? exportableState.data : EMPTY_EXPORTABLE_DATASETS
   const selectedDatasets = selectionState.studyId === studyId ? selectionState.datasetIds : []
   const paginationModel = paginationState.studyId === studyId ? paginationState.model : INITIAL_PAGINATION
   const sortModel = sortState.studyId === studyId ? sortState.model : []
@@ -51,32 +53,6 @@ export const StudyDetails = () => {
       .filter(dataset => selectedDatasets.includes(dataset.datasetId))
       .map(dataset => dataset.study.studyId),
   ))
-
-  const getExportableDatasets = async (datasets: DatasetTerm[]) => {
-    if (datasets.length === 0) {
-      setExportableDatasets({})
-      return
-    }
-
-    // Note the dataset identifier is in each sub-table row.
-    const datasetIdentifiers = datasets.map(row => row.datasetIdentifier)
-    try {
-      const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
-      if (snapshots.filteredTotal > 0) {
-        const datasetIdToSnapshot = chain(snapshots.items)
-          .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
-          .groupBy('duosId')
-          .value()
-        setExportableDatasets(datasetIdToSnapshot)
-      }
-      else {
-        setExportableDatasets({})
-      }
-    }
-    catch {
-      setExportableDatasets({})
-    }
-  }
 
   useEffect(() => {
     let active = true
@@ -127,11 +103,36 @@ export const StudyDetails = () => {
   }, [studyId])
 
   useEffect(() => {
-    const init = async () => {
-      await getExportableDatasets(datasets)
+    if (datasets.length === 0) return
+
+    let active = true
+    const fetchExportableDatasets = async () => {
+      // Note the dataset identifier is in each sub-table row.
+      const datasetIdentifiers = datasets.map(row => row.datasetIdentifier)
+      try {
+        const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
+        const data = snapshots.filteredTotal > 0
+          ? chain(snapshots.items)
+              .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
+              .groupBy('duosId')
+              .value()
+          : EMPTY_EXPORTABLE_DATASETS
+        if (active) {
+          setExportableState({ studyId, data })
+        }
+      }
+      catch {
+        if (active) {
+          setExportableState({ studyId, data: EMPTY_EXPORTABLE_DATASETS })
+        }
+      }
     }
-    init()
-  }, [datasets])
+    fetchExportableDatasets()
+
+    return () => {
+      active = false
+    }
+  }, [datasets, studyId])
 
   const participantCount = loading || error
     ? undefined

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -51,9 +51,7 @@ export const StudyDetails = () => {
     try {
       const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
       if (snapshots.filteredTotal > 0) {
-        const datasetIdToSnapshot = chain(snapshots.items)
-          // Ignore any snapshots that a user does not have export (steward or reader) to
-          .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap[snapshot.id], ['steward', 'reader']).length > 0)
+          .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
           .groupBy('duosId')
           .value()
         setExportableDatasets(datasetIdToSnapshot)

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -116,7 +116,7 @@ export const StudyDetails = () => {
           setDatasetState({
             studyId,
             datasets: EMPTY_DATASETS,
-            error: error instanceof Error ? error : new Error('Unable to load datasets'),
+            error: error instanceof Error ? error : new Error('Unknown error'),
           })
         }
       })

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -51,6 +51,7 @@ export const StudyDetails = () => {
     try {
       const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
       if (snapshots.filteredTotal > 0) {
+        const datasetIdToSnapshot = chain(snapshots.items)
           .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
           .groupBy('duosId')
           .value()
@@ -110,9 +111,9 @@ export const StudyDetails = () => {
     init()
   }, [datasets])
 
-  const participantCount = datasets
-    .map(dataset => dataset.participantCount)
-    .reduce((partialSum, participants) => partialSum + participants, 0)
+  const participantCount = loading || error
+    ? undefined
+    : datasets.reduce((total, dataset) => total + dataset.participantCount, 0)
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-start' }}>
@@ -141,7 +142,7 @@ export const StudyDetails = () => {
         <Section>
           {study?.description}
         </Section>
-        {!Number.isNaN(participantCount) && (
+        {participantCount !== undefined && !Number.isNaN(participantCount) && (
           <Section>
             <span style={{ fontWeight: 600 }}>Participants: </span>
             <span>

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -16,6 +16,12 @@ const Section = ({ style, children }: React.PropsWithChildren<SectionProps>) =>
   <div style={{ paddingTop: 20, paddingRight: 100, ...style }}>{children}</div>
 
 const INITIAL_PAGINATION = { page: 0, pageSize: 25 }
+const EMPTY_PAGE = {
+  items: [],
+  total: 0,
+  study: undefined,
+  participantCount: undefined,
+}
 
 type StudySortModel = Array<{ field: string, sort: SortOrder | null }>
 
@@ -34,18 +40,16 @@ const StudyDetailsContent = ({ studyId }: StudyDetailsContentProps) => {
   const [selectedDatasets, setSelectedDatasets] = useState<number[]>([])
   const [paginationModel, setPaginationModel] = useState(INITIAL_PAGINATION)
   const [sortModel, setSortModel] = useState<StudySortModel>([])
-  const handleSortChange = (model: StudySortModel) => setSortModel(model.slice(0, 1))
   const sort: SortState | undefined = sortModel[0]?.sort
     ? { field: sortModel[0].field, order: sortModel[0].sort }
     : undefined
-  const { data, isFetching: loading, error } = useStudyDatasets(studyId, paginationModel, sort)
-  const datasets = data?.items ?? []
-  const study = data?.study
-  const participantCount = data?.participantCount
+  const { data = EMPTY_PAGE, isFetching: loading, error } = useStudyDatasets(studyId, paginationModel, sort)
+  const datasets = data.items
+  const study = data.study
+  const participantCount = data.participantCount
   const { data: exportableDatasets } = useStudyExportableDatasets(studyId, datasets)
-  const numericStudyId = Number(studyId)
-  const selectedStudyIds = selectedDatasets.length > 0 && !Number.isNaN(numericStudyId)
-    ? [numericStudyId]
+  const selectedStudyIds = selectedDatasets.length > 0 && study
+    ? [study.studyId]
     : []
   const errorMessage = getErrorMessage(error)
 
@@ -76,7 +80,7 @@ const StudyDetailsContent = ({ studyId }: StudyDetailsContentProps) => {
         <Section>
           {study?.description}
         </Section>
-        {participantCount !== undefined && !Number.isNaN(participantCount) && (
+        {participantCount !== undefined && (
           <Section>
             <span style={{ fontWeight: 600 }}>Participants: </span>
             <span>
@@ -117,11 +121,11 @@ const StudyDetailsContent = ({ studyId }: StudyDetailsContentProps) => {
               assetType={AssetType.DATASETS}
               data={datasets}
               loading={loading}
-              total={data?.total ?? 0}
+              total={data.total}
               paginationModel={paginationModel}
               onPaginationChange={setPaginationModel}
               sortModel={sortModel}
-              onSortChange={handleSortChange}
+              onSortChange={setSortModel}
               selectedDatasetIds={selectedDatasets}
               onSelectionChange={setSelectedDatasets}
               exportableDatasets={exportableDatasets}

--- a/src/components/study_details/StudyDetails.tsx
+++ b/src/components/study_details/StudyDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { DatasetTerm, StudyTerm } from 'src/types/model'
 import { ElasticsearchQuery } from 'src/types/elastic'
@@ -20,25 +20,37 @@ interface SectionProps {
 const Section = ({ style, children }: React.PropsWithChildren<SectionProps>) =>
   <div style={{ paddingTop: 20, paddingRight: 100, ...style }}>{children}</div>
 
+const EMPTY_DATASETS: DatasetTerm[] = []
+const INITIAL_PAGINATION = { page: 0, pageSize: 25 }
+
 export const StudyDetails = () => {
   usePageTitle('Study Details')
   const params = useParams<{ studyId: string }>()
   const studyId = params.studyId
   const navigate = useNavigate()
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<Error>()
-  const [datasets, setDatasets] = useState<DatasetTerm[]>([])
+  const [datasetState, setDatasetState] = useState<{
+    studyId?: string
+    datasets: DatasetTerm[]
+    error?: Error
+  }>({ datasets: EMPTY_DATASETS })
   const [exportableDatasets, setExportableDatasets] = useState<ExportableDatasets>({})
-  const [selectedDatasets, setSelectedDatasets] = useState<number[]>([])
-  const [paginationModel, setPaginationModel] = useState({ page: 0, pageSize: 25 })
-  const [sortModel, setSortModel] = useState<Array<{ field: string, sort: SortOrder | null }>>([])
+  const [selectionState, setSelectionState] = useState<{ studyId?: string, datasetIds: number[] }>({ datasetIds: [] })
+  const [paginationState, setPaginationState] = useState<{ studyId?: string, model: typeof INITIAL_PAGINATION }>({ model: INITIAL_PAGINATION })
+  const [sortState, setSortState] = useState<{ studyId?: string, model: Array<{ field: string, sort: SortOrder | null }> }>({ model: [] })
+
+  const loading = datasetState.studyId !== studyId
+  const error = loading ? undefined : datasetState.error
+  const datasets = loading ? EMPTY_DATASETS : datasetState.datasets
+  const selectedDatasets = selectionState.studyId === studyId ? selectionState.datasetIds : []
+  const paginationModel = paginationState.studyId === studyId ? paginationState.model : INITIAL_PAGINATION
+  const sortModel = sortState.studyId === studyId ? sortState.model : []
 
   const study: StudyTerm | undefined = datasets.length > 0 ? datasets[0].study : undefined
-  const selectedStudyIds = useMemo(() => Array.from(new Set(
+  const selectedStudyIds = Array.from(new Set(
     datasets
       .filter(dataset => selectedDatasets.includes(dataset.datasetId))
       .map(dataset => dataset.study.studyId),
-  )), [datasets, selectedDatasets])
+  ))
 
   const getExportableDatasets = async (datasets: DatasetTerm[]) => {
     if (datasets.length === 0) {
@@ -51,6 +63,7 @@ export const StudyDetails = () => {
     try {
       const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
       if (snapshots.filteredTotal > 0) {
+        const datasetIdToSnapshot = chain(snapshots.items)
           .filter((snapshot: SnapshotSummaryModel) => intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
           .groupBy('duosId')
           .value()
@@ -66,6 +79,7 @@ export const StudyDetails = () => {
   }
 
   useEffect(() => {
+    let active = true
     const query = {
       from: 0,
       size: 10000,
@@ -93,14 +107,23 @@ export const StudyDetails = () => {
     }
     DataSet.searchDatasetIndex(query as ElasticsearchQuery)
       .then((datasets) => {
-        setDatasets(datasets)
-        setError(undefined)
+        if (active) {
+          setDatasetState({ studyId, datasets })
+        }
       })
-      .catch((error: Error) => {
-        setDatasets([])
-        setError(error)
+      .catch((error: unknown) => {
+        if (active) {
+          setDatasetState({
+            studyId,
+            datasets: EMPTY_DATASETS,
+            error: error instanceof Error ? error : new Error('Unable to load datasets'),
+          })
+        }
       })
-      .finally(() => setLoading(false))
+
+    return () => {
+      active = false
+    }
   }, [studyId])
 
   useEffect(() => {
@@ -110,9 +133,9 @@ export const StudyDetails = () => {
     init()
   }, [datasets])
 
-  const participantCount = datasets
-    .map(dataset => dataset.participantCount)
-    .reduce((partialSum, participants) => partialSum + participants, 0)
+  const participantCount = loading || error
+    ? undefined
+    : datasets.reduce((total, dataset) => total + dataset.participantCount, 0)
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-start' }}>
@@ -141,7 +164,7 @@ export const StudyDetails = () => {
         <Section>
           {study?.description}
         </Section>
-        {!Number.isNaN(participantCount) && (
+        {participantCount !== undefined && !Number.isNaN(participantCount) && (
           <Section>
             <span style={{ fontWeight: 600 }}>Participants: </span>
             <span>
@@ -184,13 +207,13 @@ export const StudyDetails = () => {
               loading={loading}
               total={datasets.length}
               paginationModel={paginationModel}
-              onPaginationChange={setPaginationModel}
+              onPaginationChange={model => setPaginationState({ studyId, model })}
               paginationMode="client"
               sortModel={sortModel}
-              onSortChange={setSortModel}
+              onSortChange={model => setSortState({ studyId, model })}
               sortingMode="client"
               selectedDatasetIds={selectedDatasets}
-              onSelectionChange={setSelectedDatasets}
+              onSelectionChange={datasetIds => setSelectionState({ studyId, datasetIds })}
               exportableDatasets={exportableDatasets}
             />
           </div>

--- a/src/hooks/useStudyDetailsData.ts
+++ b/src/hooks/useStudyDetailsData.ts
@@ -1,0 +1,120 @@
+import { useQuery } from '@tanstack/react-query'
+import { datasetAsset } from 'src/components/data_library/assets/datasetAsset'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { chain, intersection } from 'src/utils/NodashUtil'
+import { AggregationResult, ElasticsearchQuery } from 'src/types/elastic'
+import { ExportableDatasets, PaginationState, SortState } from 'src/types/library'
+import { DatasetTerm, StudyTerm } from 'src/types/model'
+import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
+
+export const STUDY_DATASETS_QUERY_KEY = 'study-details-datasets'
+export const STUDY_EXPORTS_QUERY_KEY = 'study-details-exports'
+
+const EMPTY_EXPORTABLE_DATASETS: ExportableDatasets = {}
+
+interface StudyDetailsPage {
+  items: DatasetTerm[]
+  total: number
+  study?: StudyTerm
+  participantCount?: number
+}
+
+interface StudyDetailsAggregation {
+  hits?: {
+    hits?: Array<{
+      _source?: {
+        study?: StudyTerm
+      }
+    }>
+  }
+}
+
+export const buildStudyDatasetsQuery = (
+  studyId: string,
+  pagination: PaginationState,
+  sort?: SortState,
+): ElasticsearchQuery => {
+  const query = datasetAsset.buildQuery(
+    [
+      { exists: { field: 'study' } },
+      { match: { 'study.studyId': studyId } },
+    ],
+    [],
+    pagination,
+    sort,
+    // Preserve the study page's existing behavior of showing all controlled
+    // datasets, including those still awaiting DAC approval.
+    { showAllControlled: true },
+  )
+
+  return {
+    ...query,
+    aggs: {
+      ...query.aggs,
+      study_details: {
+        top_hits: {
+          size: 1,
+          _source: ['study.*'],
+        },
+      },
+      total_participants: {
+        sum: { field: 'participantCount' },
+      },
+    },
+  }
+}
+
+export const useStudyDatasets = (
+  studyId: string,
+  pagination: PaginationState,
+  sort?: SortState,
+) => useQuery({
+  queryKey: [STUDY_DATASETS_QUERY_KEY, studyId, pagination, sort],
+  enabled: studyId.length > 0,
+  queryFn: async (): Promise<StudyDetailsPage> => {
+    const response = await DataSet.searchDatasetIndexV2(
+      buildStudyDatasetsQuery(studyId, pagination, sort),
+    )
+    const page = datasetAsset.transformResponse(response, pagination)
+    const studyAggregation = response.aggregations?.study_details as StudyDetailsAggregation | undefined
+    const participantAggregation = response.aggregations?.total_participants as AggregationResult | undefined
+    const items = page.items as DatasetTerm[]
+
+    return {
+      items,
+      total: page.total,
+      study: studyAggregation?.hits?.hits?.[0]?._source?.study ?? items[0]?.study,
+      participantCount: participantAggregation?.value,
+    }
+  },
+  staleTime: 5 * 60 * 1000,
+})
+
+export const useStudyExportableDatasets = (
+  studyId: string,
+  datasets: DatasetTerm[],
+) => {
+  const datasetIdentifiers = datasets.map(dataset => dataset.datasetIdentifier)
+
+  return useQuery({
+    queryKey: [STUDY_EXPORTS_QUERY_KEY, studyId, datasetIdentifiers],
+    enabled: datasetIdentifiers.length > 0,
+    queryFn: async (): Promise<ExportableDatasets> => {
+      try {
+        const snapshots = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers) as EnumerateSnapshotModel
+        if (snapshots.filteredTotal === 0) return EMPTY_EXPORTABLE_DATASETS
+
+        return chain(snapshots.items)
+          .filter((snapshot: SnapshotSummaryModel) =>
+            intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
+          .groupBy('duosId')
+          .value()
+      }
+      catch {
+        return EMPTY_EXPORTABLE_DATASETS
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/hooks/useStudyDetailsData.ts
+++ b/src/hooks/useStudyDetailsData.ts
@@ -51,7 +51,6 @@ export const buildStudyDatasetsQuery = (
   return {
     ...query,
     aggs: {
-      ...query.aggs,
       study_details: {
         top_hits: {
           size: 1,

--- a/test/components/data_library/LibraryDataGrid.spec.tsx
+++ b/test/components/data_library/LibraryDataGrid.spec.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import { describe, it, expect, vi, beforeAll } from 'vitest'
 
 vi.mock('src/components/data_search/DatasetExportButton', () => {
@@ -9,7 +9,7 @@ vi.mock('src/components/data_search/DatasetExportButton', () => {
   return { DatasetExportButton, default: DatasetExportButton }
 })
 import '@testing-library/jest-dom/vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { LibraryDataGrid } from 'src/components/data_library/LibraryDataGrid'
@@ -99,26 +99,6 @@ const baseProps = {
   onSortChange: vi.fn(),
   selectedDatasetIds: [] as number[],
   onSelectionChange: vi.fn(),
-}
-
-const ClientGridHarness = ({ data }: { data: DatasetTerm[] }) => {
-  const [pagination, setPagination] = useState(paginationModel)
-  const [sort, setSort] = useState(sortModel)
-
-  return (
-    <LibraryDataGrid
-      assetType={AssetType.DATASETS}
-      data={data}
-      total={data.length}
-      {...baseProps}
-      paginationModel={pagination}
-      onPaginationChange={setPagination}
-      paginationMode="client"
-      sortModel={sort}
-      onSortChange={setSort}
-      sortingMode="client"
-    />
-  )
 }
 
 describe('LibraryDataGrid', () => {
@@ -251,40 +231,6 @@ describe('LibraryDataGrid', () => {
     const checkbox = container.querySelector('.MuiDataGrid-row[data-id="101"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
     await user.click(checkbox)
     expect(onSelectionChange).toHaveBeenCalledWith([101])
-  })
-
-  it('supports client-side sorting when all rows are loaded', async () => {
-    const user = userEvent.setup()
-    const { container } = mountGrid(
-      <ClientGridHarness data={[
-        makeDatasetTerm({ datasetId: 301, datasetName: 'Zulu Dataset' }),
-        makeDatasetTerm({ datasetId: 302, datasetName: 'Alpha Dataset' }),
-      ]}
-      />,
-    )
-
-    await user.click(screen.getByRole('columnheader', { name: /Dataset Name/ }))
-    await waitFor(() => {
-      const rows = Array.from(container.querySelectorAll('.MuiDataGrid-row'))
-      expect(rows[0]).toHaveTextContent('Alpha Dataset')
-      expect(rows[1]).toHaveTextContent('Zulu Dataset')
-    })
-  })
-
-  it('supports client-side pagination when all rows are loaded', async () => {
-    const user = userEvent.setup()
-    const clientDatasets = Array.from({ length: 26 }, (_, index) => makeDatasetTerm({
-      datasetId: index + 1,
-      datasetIdentifier: `DUOS-${index + 1}`,
-      datasetName: `Dataset ${index + 1}`,
-    }))
-    mountGrid(<ClientGridHarness data={clientDatasets} />)
-
-    expect(screen.getByText('Dataset 1')).toBeInTheDocument()
-    expect(screen.queryByText('Dataset 26')).not.toBeInTheDocument()
-    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
-    expect(await screen.findByText('Dataset 26')).toBeInTheDocument()
-    expect(screen.queryByText('Dataset 1')).not.toBeInTheDocument()
   })
 
   it('handles row selection for studies (mapping to dataset IDs)', async () => {

--- a/test/components/data_library/LibraryDataGrid.spec.tsx
+++ b/test/components/data_library/LibraryDataGrid.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { describe, it, expect, vi, beforeAll } from 'vitest'
 
 vi.mock('src/components/data_search/DatasetExportButton', () => {
@@ -9,7 +9,7 @@ vi.mock('src/components/data_search/DatasetExportButton', () => {
   return { DatasetExportButton, default: DatasetExportButton }
 })
 import '@testing-library/jest-dom/vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { LibraryDataGrid } from 'src/components/data_library/LibraryDataGrid'
@@ -99,6 +99,26 @@ const baseProps = {
   onSortChange: vi.fn(),
   selectedDatasetIds: [] as number[],
   onSelectionChange: vi.fn(),
+}
+
+const ClientGridHarness = ({ data }: { data: DatasetTerm[] }) => {
+  const [pagination, setPagination] = useState(paginationModel)
+  const [sort, setSort] = useState(sortModel)
+
+  return (
+    <LibraryDataGrid
+      assetType={AssetType.DATASETS}
+      data={data}
+      total={data.length}
+      {...baseProps}
+      paginationModel={pagination}
+      onPaginationChange={setPagination}
+      paginationMode="client"
+      sortModel={sort}
+      onSortChange={setSort}
+      sortingMode="client"
+    />
+  )
 }
 
 describe('LibraryDataGrid', () => {
@@ -231,6 +251,40 @@ describe('LibraryDataGrid', () => {
     const checkbox = container.querySelector('.MuiDataGrid-row[data-id="101"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
     await user.click(checkbox)
     expect(onSelectionChange).toHaveBeenCalledWith([101])
+  })
+
+  it('supports client-side sorting when all rows are loaded', async () => {
+    const user = userEvent.setup()
+    const { container } = mountGrid(
+      <ClientGridHarness data={[
+        makeDatasetTerm({ datasetId: 301, datasetName: 'Zulu Dataset' }),
+        makeDatasetTerm({ datasetId: 302, datasetName: 'Alpha Dataset' }),
+      ]}
+      />,
+    )
+
+    await user.click(screen.getByRole('columnheader', { name: /Dataset Name/ }))
+    await waitFor(() => {
+      const rows = Array.from(container.querySelectorAll('.MuiDataGrid-row'))
+      expect(rows[0]).toHaveTextContent('Alpha Dataset')
+      expect(rows[1]).toHaveTextContent('Zulu Dataset')
+    })
+  })
+
+  it('supports client-side pagination when all rows are loaded', async () => {
+    const user = userEvent.setup()
+    const clientDatasets = Array.from({ length: 26 }, (_, index) => makeDatasetTerm({
+      datasetId: index + 1,
+      datasetIdentifier: `DUOS-${index + 1}`,
+      datasetName: `Dataset ${index + 1}`,
+    }))
+    mountGrid(<ClientGridHarness data={clientDatasets} />)
+
+    expect(screen.getByText('Dataset 1')).toBeInTheDocument()
+    expect(screen.queryByText('Dataset 26')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    expect(await screen.findByText('Dataset 26')).toBeInTheDocument()
+    expect(screen.queryByText('Dataset 1')).not.toBeInTheDocument()
   })
 
   it('handles row selection for studies (mapping to dataset IDs)', async () => {

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -171,6 +171,14 @@ afterEach(() => {
 })
 
 describe('Study details test', () => {
+  it('does not show a participant total while datasets are loading', () => {
+    vi.mocked(DataSet.searchDatasetIndex).mockReturnValueOnce(new Promise(() => {}) as never)
+    mountComponent()
+
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
+    expect(screen.queryByText('Participants:')).not.toBeInTheDocument()
+  })
+
   it('shows the appropriate data for fields', async () => {
     mountComponent()
     await screen.findByText(datasets[0].datasetName)
@@ -220,6 +228,7 @@ describe('Study details test', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load datasets: search failed')
     expect(screen.getByText('No datasets found matching your criteria')).toBeInTheDocument()
+    expect(screen.queryByText('Participants:')).not.toBeInTheDocument()
     expect(document.querySelector('.MuiCircularProgress-root')).not.toBeInTheDocument()
   })
 })

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -276,4 +276,12 @@ describe('Study details test', () => {
     expect(screen.queryByText('Participants:')).not.toBeInTheDocument()
     expect(document.querySelector('.MuiCircularProgress-root')).not.toBeInTheDocument()
   })
+
+  it('shows a non-duplicated fallback message for non-Error rejections', async () => {
+    vi.mocked(DataSet.searchDatasetIndex).mockRejectedValueOnce('unexpected rejection')
+    mountComponent()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load datasets: Unknown error')
+    expect(screen.getByRole('alert')).not.toHaveTextContent('Unable to load datasets: Unable to load datasets')
+  })
 })

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -8,6 +8,7 @@ import { StudyDetails } from 'src/components/study_details/StudyDetails'
 import { Storage } from 'src/libs/storage'
 import { applyForAccess } from 'src/utils/accessUtils'
 import { DuosUser, LibraryCard } from 'src/types/model'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
 
 vi.mock('src/libs/config', () => ({
   Config: {
@@ -222,6 +223,41 @@ describe('Study details test', () => {
     expect(await screen.findByText('Study 2 Dataset')).toBeInTheDocument()
     expect(screen.getAllByText('second study')).toHaveLength(2)
     expect(screen.queryByText(/dataset selected from/i)).not.toBeInTheDocument()
+  })
+
+  it('ignores exportable snapshots returned for a previous study', async () => {
+    const user = userEvent.setup()
+    const nextStudyDatasets = [{
+      ...datasets[0],
+      datasetId: 223456,
+      datasetIdentifier: 'DUOS-223456',
+      datasetName: 'Study 2 Dataset',
+      study: { ...datasets[0].study, studyId: 2, studyName: 'second study' },
+    }]
+    let resolvePreviousSnapshots: (response: unknown) => void = () => {}
+    const previousSnapshotRequest = new Promise((resolve) => {
+      resolvePreviousSnapshots = resolve
+    })
+    vi.mocked(DataSet.searchDatasetIndex)
+      .mockResolvedValueOnce(datasets as never)
+      .mockResolvedValueOnce(nextStudyDatasets as never)
+    vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds)
+      .mockReturnValueOnce(previousSnapshotRequest as never)
+      .mockResolvedValueOnce({ filteredTotal: 0, items: [], roleMap: {} } as never)
+
+    mountComponent(true)
+    await screen.findByText(datasets[0].datasetName)
+    await waitFor(() => expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(1))
+    await user.click(screen.getByRole('button', { name: 'View study 2' }))
+    await screen.findByText('Study 2 Dataset')
+    await waitFor(() => expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(2))
+
+    resolvePreviousSnapshots({
+      filteredTotal: 1,
+      items: [{ id: 'old-snapshot', name: 'Old Snapshot', duosId: 'DUOS-123456' }],
+      roleMap: { 'old-snapshot': ['reader'] },
+    })
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'Export to...' })).not.toBeInTheDocument())
   })
 
   it('shows the appropriate data for fields', async () => {

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -9,6 +9,8 @@ import { Storage } from 'src/libs/storage'
 import { applyForAccess } from 'src/utils/accessUtils'
 import { DuosUser, LibraryCard } from 'src/types/model'
 import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ElasticsearchQuery } from 'src/types/elastic'
 
 vi.mock('src/libs/config', () => ({
   Config: {
@@ -26,7 +28,7 @@ vi.mock('src/libs/ajax/TerraDataRepo', () => ({
 
 vi.mock('src/libs/ajax/DataSet', () => ({
   DataSet: {
-    searchDatasetIndex: vi.fn(),
+    searchDatasetIndexV2: vi.fn(),
   },
 }))
 
@@ -141,19 +143,44 @@ const datasets = [
   },
 ]
 
+const makeSearchResponse = (
+  pageDatasets = datasets,
+  total = pageDatasets.length,
+  participantCount = pageDatasets.reduce((sum, dataset) => sum + dataset.participantCount, 0),
+) => ({
+  hits: {
+    total: { value: total },
+    hits: pageDatasets.map(dataset => ({ _source: dataset })),
+  },
+  aggregations: {
+    study_details: {
+      hits: {
+        hits: pageDatasets.length > 0
+          ? [{ _source: { study: pageDatasets[0].study } }]
+          : [],
+      },
+    },
+    total_participants: { value: participantCount },
+  },
+})
+
 const StudySwitcher = () => {
   const navigate = useNavigate()
   return <button onClick={() => navigate('/studies/2')}>View study 2</button>
 }
 
+let queryClient: QueryClient
+
 const mountComponent = (withStudySwitcher = false) =>
   render(
-    <MemoryRouter initialEntries={['/studies/1']}>
-      {withStudySwitcher && <StudySwitcher />}
-      <Routes>
-        <Route path="/studies/:studyId" element={<StudyDetails />} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={['/studies/1']}>
+        {withStudySwitcher && <StudySwitcher />}
+        <Routes>
+          <Route path="/studies/:studyId" element={<StudyDetails />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 
 beforeAll(() => {
@@ -165,7 +192,12 @@ beforeAll(() => {
 })
 
 beforeEach(() => {
-  vi.mocked(DataSet.searchDatasetIndex).mockResolvedValue(datasets as never)
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+  vi.mocked(DataSet.searchDatasetIndexV2).mockResolvedValue(makeSearchResponse() as never)
   vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({
     userId: 42,
     libraryCard: {} as LibraryCard,
@@ -173,13 +205,14 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  queryClient.clear()
   vi.restoreAllMocks()
   vi.clearAllMocks()
 })
 
 describe('Study details test', () => {
   it('does not show a participant total while datasets are loading', () => {
-    vi.mocked(DataSet.searchDatasetIndex).mockReturnValueOnce(new Promise(() => {}) as never)
+    vi.mocked(DataSet.searchDatasetIndexV2).mockReturnValueOnce(new Promise(() => {}) as never)
     mountComponent()
 
     expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
@@ -199,12 +232,12 @@ describe('Study details test', () => {
         studyName: 'second study',
       },
     }]
-    let resolveNextStudy: (datasets: typeof nextStudyDatasets) => void = () => {}
-    const nextStudyRequest = new Promise<typeof nextStudyDatasets>((resolve) => {
+    let resolveNextStudy: (response: ReturnType<typeof makeSearchResponse>) => void = () => {}
+    const nextStudyRequest = new Promise<ReturnType<typeof makeSearchResponse>>((resolve) => {
       resolveNextStudy = resolve
     })
-    vi.mocked(DataSet.searchDatasetIndex)
-      .mockResolvedValueOnce(datasets as never)
+    vi.mocked(DataSet.searchDatasetIndexV2)
+      .mockResolvedValueOnce(makeSearchResponse() as never)
       .mockReturnValueOnce(nextStudyRequest as never)
 
     const { container } = mountComponent(true)
@@ -219,7 +252,7 @@ describe('Study details test', () => {
     expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
     await waitFor(() => expect(screen.queryByText(/1 dataset selected from 1 study/i)).not.toBeInTheDocument())
 
-    resolveNextStudy(nextStudyDatasets)
+    resolveNextStudy(makeSearchResponse(nextStudyDatasets))
     expect(await screen.findByText('Study 2 Dataset')).toBeInTheDocument()
     expect(screen.getAllByText('second study')).toHaveLength(2)
     expect(screen.queryByText(/dataset selected from/i)).not.toBeInTheDocument()
@@ -238,9 +271,9 @@ describe('Study details test', () => {
     const previousSnapshotRequest = new Promise((resolve) => {
       resolvePreviousSnapshots = resolve
     })
-    vi.mocked(DataSet.searchDatasetIndex)
-      .mockResolvedValueOnce(datasets as never)
-      .mockResolvedValueOnce(nextStudyDatasets as never)
+    vi.mocked(DataSet.searchDatasetIndexV2)
+      .mockResolvedValueOnce(makeSearchResponse() as never)
+      .mockResolvedValueOnce(makeSearchResponse(nextStudyDatasets) as never)
     vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds)
       .mockReturnValueOnce(previousSnapshotRequest as never)
       .mockResolvedValueOnce({ filteredTotal: 0, items: [], roleMap: {} } as never)
@@ -275,6 +308,62 @@ describe('Study details test', () => {
     expect(document.querySelectorAll('[role=row]')).toHaveLength(datasets.length + 1)
   })
 
+  it('requests server-side pages for the current study without a fixed result cap', async () => {
+    const user = userEvent.setup()
+    vi.mocked(DataSet.searchDatasetIndexV2).mockResolvedValue(makeSearchResponse(datasets, 26) as never)
+    mountComponent()
+    await screen.findByText(datasets[0].datasetName)
+
+    const initialQuery = vi.mocked(DataSet.searchDatasetIndexV2).mock.calls[0][0] as ElasticsearchQuery
+    expect(initialQuery.from).toBe(0)
+    expect(initialQuery.size).toBe(25)
+    expect(initialQuery.size).not.toBe(10000)
+    expect(initialQuery.query?.bool.must).toContainEqual({ match: { 'study.studyId': '1' } })
+    expect(initialQuery.aggs).toHaveProperty('study_details')
+    expect(initialQuery.aggs).toHaveProperty('total_participants')
+
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    await waitFor(() => expect(DataSet.searchDatasetIndexV2).toHaveBeenCalledTimes(2))
+    const nextPageQuery = vi.mocked(DataSet.searchDatasetIndexV2).mock.calls[1][0] as ElasticsearchQuery
+    expect(nextPageQuery.from).toBe(25)
+    expect(nextPageQuery.size).toBe(25)
+  })
+
+  it('uses the dataset asset server-side sort mapping', async () => {
+    const user = userEvent.setup()
+    mountComponent()
+    await screen.findByText(datasets[0].datasetName)
+
+    await user.click(screen.getByRole('columnheader', { name: /Dataset Name/ }))
+    await waitFor(() => expect(DataSet.searchDatasetIndexV2).toHaveBeenCalledTimes(2))
+    const sortQuery = vi.mocked(DataSet.searchDatasetIndexV2).mock.calls[1][0] as ElasticsearchQuery
+    expect(sortQuery.sort).toEqual([{ 'datasetName.keyword': { order: 'asc' } }])
+  })
+
+  it('preserves selected datasets across server-side pages', async () => {
+    const user = userEvent.setup()
+    const nextPageDatasets = [{
+      ...datasets[0],
+      datasetId: 223456,
+      datasetIdentifier: 'DUOS-223456',
+      datasetName: 'Next Page Dataset',
+    }]
+    vi.mocked(DataSet.searchDatasetIndexV2).mockImplementation(async (query: ElasticsearchQuery) =>
+      (query.from === 25
+        ? makeSearchResponse(nextPageDatasets, 26, 6)
+        : makeSearchResponse(datasets, 26, 6)) as never)
+
+    const { container } = mountComponent()
+    await screen.findByText(datasets[0].datasetName)
+    const checkbox = container.querySelector('.MuiDataGrid-row[data-id="123456"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    await user.click(checkbox)
+    expect(await screen.findByText(/1 dataset selected from 1 study/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Go to next page' }))
+    expect(await screen.findByText('Next Page Dataset')).toBeInTheDocument()
+    expect(screen.getByText(/1 dataset selected from 1 study/i)).toBeInTheDocument()
+  })
+
   it('selects controlled datasets, displays LibraryFooter, and applies for access', async () => {
     const user = userEvent.setup()
     const { container } = mountComponent()
@@ -304,7 +393,7 @@ describe('Study details test', () => {
   })
 
   it('shows the grid empty state and an error instead of remaining in loading state when loading fails', async () => {
-    vi.mocked(DataSet.searchDatasetIndex).mockRejectedValueOnce(new Error('search failed'))
+    vi.mocked(DataSet.searchDatasetIndexV2).mockRejectedValueOnce(new Error('search failed'))
     mountComponent()
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load datasets: search failed')
@@ -314,7 +403,7 @@ describe('Study details test', () => {
   })
 
   it('shows a non-duplicated fallback message for non-Error rejections', async () => {
-    vi.mocked(DataSet.searchDatasetIndex).mockRejectedValueOnce('unexpected rejection')
+    vi.mocked(DataSet.searchDatasetIndexV2).mockRejectedValueOnce('unexpected rejection')
     mountComponent()
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load datasets: Unknown error')

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { StudyDetails } from 'src/components/study_details/StudyDetails'
+import { Storage } from 'src/libs/storage'
+import { applyForAccess } from 'src/utils/accessUtils'
+import { DuosUser, LibraryCard } from 'src/types/model'
 
 vi.mock('src/libs/config', () => ({
   Config: {
@@ -16,7 +19,7 @@ vi.mock('src/libs/config', () => ({
 
 vi.mock('src/libs/ajax/TerraDataRepo', () => ({
   TerraDataRepo: {
-    listSnapshotsByDatasetIds: vi.fn().mockResolvedValue({}),
+    listSnapshotsByDatasetIds: vi.fn().mockResolvedValue({ filteredTotal: 0, items: [], roleMap: {} }),
   },
 }))
 
@@ -24,6 +27,10 @@ vi.mock('src/libs/ajax/DataSet', () => ({
   DataSet: {
     searchDatasetIndex: vi.fn(),
   },
+}))
+
+vi.mock('src/utils/accessUtils', () => ({
+  applyForAccess: vi.fn(),
 }))
 
 import { DataSet } from 'src/libs/ajax/DataSet'
@@ -70,7 +77,41 @@ const datasets = [
     participantCount: 2,
     dacId: 0,
     dacApproval: false,
-    accessManagement: 'controlled',
+    accessManagement: 'external',
+    approvedUserIds: [],
+    createUserId: 0,
+    createUserDisplayName: 'user',
+    deletable: false,
+    dataLocation: '',
+    url: '',
+    dataUse: { primary: [], secondary: [] },
+    submitter: { userId: 0, displayName: 'user', institution: { id: 0, name: '' } },
+    updateUser: { userId: 0, displayName: 'user', institution: { id: 0, name: '' } },
+    dac: { dacId: 0, dacName: 'DAC', dacEmail: '' },
+    piName: '',
+    study: {
+      studyId: 1,
+      studyName: 'study name',
+      description: 'study description',
+      phenotype: 'phenotype',
+      species: 'species',
+      piName: 'piName',
+      dataCustodianEmail: ['custodian1@foo.bar', 'custodian2@foo.bar'],
+      dataSubmitterEmail: '',
+      dataSubmitterId: 0,
+      phsId: '',
+      publicVisibility: false,
+      dataTypes: [],
+    },
+  },
+  {
+    datasetId: 123458,
+    datasetIdentifier: 'DUOS-123458',
+    datasetName: 'Some Dataset 3',
+    participantCount: 3,
+    dacId: 0,
+    dacApproval: false,
+    accessManagement: 'open',
     approvedUserIds: [],
     createUserId: 0,
     createUserDisplayName: 'user',
@@ -108,38 +149,77 @@ const mountComponent = () =>
     </MemoryRouter>,
   )
 
-beforeEach(() => {
-  vi.mocked(DataSet.searchDatasetIndex).mockResolvedValue(datasets as never)
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
 })
 
-afterEach(() => vi.clearAllMocks())
+beforeEach(() => {
+  vi.mocked(DataSet.searchDatasetIndex).mockResolvedValue(datasets as never)
+  vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({
+    userId: 42,
+    libraryCard: {} as LibraryCard,
+  } as DuosUser)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+})
 
 describe('Study details test', () => {
   it('shows the appropriate data for fields', async () => {
     mountComponent()
-    await waitFor(() => expect(screen.queryByText('Loading')).not.toBeInTheDocument())
+    await screen.findByText(datasets[0].datasetName)
     expect(screen.getByText(`DUOS-S${datasets[0].study.studyId}`)).toBeInTheDocument()
     expect(screen.getAllByText(datasets[0].study.studyName)[0]).toBeInTheDocument()
     expect(screen.getAllByText(datasets[0].study.description)[0]).toBeInTheDocument()
-    expect(screen.getByText((datasets[0].participantCount + datasets[1].participantCount).toString())).toBeInTheDocument()
+    expect(screen.getByText(datasets.reduce((total, dataset) => total + dataset.participantCount, 0).toString())).toBeInTheDocument()
     expect(screen.getByText(datasets[0].study.phenotype)).toBeInTheDocument()
     expect(screen.getByText(datasets[0].study.species)).toBeInTheDocument()
     expect(screen.getByText(datasets[0].study.piName)).toBeInTheDocument()
     expect(screen.getByText(datasets[0].study.dataCustodianEmail.join(', '))).toBeInTheDocument()
+    expect(screen.getByRole('grid').closest('.MuiDataGrid-root')).toBeInTheDocument()
     expect(document.querySelectorAll('[role=row]')).toHaveLength(datasets.length + 1)
   })
 
-  it('displays DatasetSearchFooter when dataset is selected', async () => {
+  it('selects controlled datasets, displays LibraryFooter, and applies for access', async () => {
     const user = userEvent.setup()
     const { container } = mountComponent()
-    await waitFor(() => expect(screen.queryByText('Loading')).not.toBeInTheDocument())
-    await user.click(container.querySelector('.row-data-0 input')!)
-    expect(screen.getByText(/1 dataset selected from 1 study/i)).toBeInTheDocument()
+    await screen.findByText(datasets[0].datasetName)
+    const checkbox = container.querySelector('.MuiDataGrid-row[data-id="123456"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    await user.click(checkbox)
+    expect(await screen.findByText(/1 dataset selected from 1 study/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Apply for Access' }))
+    expect(applyForAccess).toHaveBeenCalledWith([123456], expect.any(Function))
+  })
+
+  it('does not allow open or externally managed datasets to be selected', async () => {
+    const { container } = mountComponent()
+    await screen.findByText(datasets[0].datasetName)
+
+    const externalCheckbox = container.querySelector('.MuiDataGrid-row[data-id="123457"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    const openCheckbox = container.querySelector('.MuiDataGrid-row[data-id="123458"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    expect(externalCheckbox).toBeDisabled()
+    expect(openCheckbox).toBeDisabled()
   })
 
   it('allows navigation back to datalibrary', async () => {
     mountComponent()
-    await waitFor(() => expect(screen.queryByText('Loading')).not.toBeInTheDocument())
+    await screen.findByText(datasets[0].datasetName)
     expect(document.getElementById('link_datalibrary')).toHaveAttribute('href', '/datalibrary')
+  })
+
+  it('shows the grid empty state and an error instead of remaining in loading state when loading fails', async () => {
+    vi.mocked(DataSet.searchDatasetIndex).mockRejectedValueOnce(new Error('search failed'))
+    mountComponent()
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load datasets: search failed')
+    expect(screen.getByText('No datasets found matching your criteria')).toBeInTheDocument()
+    expect(document.querySelector('.MuiCircularProgress-root')).not.toBeInTheDocument()
   })
 })

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -329,15 +329,24 @@ describe('Study details test', () => {
     expect(nextPageQuery.size).toBe(25)
   })
 
-  it('uses the dataset asset server-side sort mapping', async () => {
+  it('uses the dataset asset server-side sort mapping with one active sort', async () => {
     const user = userEvent.setup()
     mountComponent()
     await screen.findByText(datasets[0].datasetName)
 
     await user.click(screen.getByRole('columnheader', { name: /Dataset Name/ }))
     await waitFor(() => expect(DataSet.searchDatasetIndexV2).toHaveBeenCalledTimes(2))
-    const sortQuery = vi.mocked(DataSet.searchDatasetIndexV2).mock.calls[1][0] as ElasticsearchQuery
-    expect(sortQuery.sort).toEqual([{ 'datasetName.keyword': { order: 'asc' } }])
+    const datasetNameSortQuery = vi.mocked(DataSet.searchDatasetIndexV2).mock.calls[1][0] as ElasticsearchQuery
+    expect(datasetNameSortQuery.sort).toEqual([{ 'datasetName.keyword': { order: 'asc' } }])
+
+    await user.keyboard('{Shift>}')
+    await user.click(screen.getByRole('columnheader', { name: /Identifier/ }))
+    await user.keyboard('{/Shift}')
+    await waitFor(() => expect(DataSet.searchDatasetIndexV2).toHaveBeenCalledTimes(3))
+    const identifierSortQuery = vi.mocked(DataSet.searchDatasetIndexV2).mock.calls[2][0] as ElasticsearchQuery
+    expect(identifierSortQuery.sort).toEqual([{ 'datasetIdentifier.keyword': { order: 'asc' } }])
+    expect(screen.getByRole('columnheader', { name: /Dataset Name/ })).toHaveAttribute('aria-sort', 'none')
+    expect(screen.getByRole('columnheader', { name: /Identifier/ })).toHaveAttribute('aria-sort', 'ascending')
   })
 
   it('preserves selected datasets across server-side pages', async () => {

--- a/test/components/study_details/StudyDetails.spec.tsx
+++ b/test/components/study_details/StudyDetails.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom'
 import { StudyDetails } from 'src/components/study_details/StudyDetails'
 import { Storage } from 'src/libs/storage'
 import { applyForAccess } from 'src/utils/accessUtils'
@@ -140,9 +140,15 @@ const datasets = [
   },
 ]
 
-const mountComponent = () =>
+const StudySwitcher = () => {
+  const navigate = useNavigate()
+  return <button onClick={() => navigate('/studies/2')}>View study 2</button>
+}
+
+const mountComponent = (withStudySwitcher = false) =>
   render(
     <MemoryRouter initialEntries={['/studies/1']}>
+      {withStudySwitcher && <StudySwitcher />}
       <Routes>
         <Route path="/studies/:studyId" element={<StudyDetails />} />
       </Routes>
@@ -171,6 +177,53 @@ afterEach(() => {
 })
 
 describe('Study details test', () => {
+  it('does not show a participant total while datasets are loading', () => {
+    vi.mocked(DataSet.searchDatasetIndex).mockReturnValueOnce(new Promise(() => {}) as never)
+    mountComponent()
+
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
+    expect(screen.queryByText('Participants:')).not.toBeInTheDocument()
+  })
+
+  it('clears stale data and selection while navigating to another study', async () => {
+    const user = userEvent.setup()
+    const nextStudyDatasets = [{
+      ...datasets[0],
+      datasetId: 223456,
+      datasetIdentifier: 'DUOS-223456',
+      datasetName: 'Study 2 Dataset',
+      study: {
+        ...datasets[0].study,
+        studyId: 2,
+        studyName: 'second study',
+      },
+    }]
+    let resolveNextStudy: (datasets: typeof nextStudyDatasets) => void = () => {}
+    const nextStudyRequest = new Promise<typeof nextStudyDatasets>((resolve) => {
+      resolveNextStudy = resolve
+    })
+    vi.mocked(DataSet.searchDatasetIndex)
+      .mockResolvedValueOnce(datasets as never)
+      .mockReturnValueOnce(nextStudyRequest as never)
+
+    const { container } = mountComponent(true)
+    await screen.findByText(datasets[0].datasetName)
+    const checkbox = container.querySelector('.MuiDataGrid-row[data-id="123456"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    await user.click(checkbox)
+    expect(await screen.findByText(/1 dataset selected from 1 study/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'View study 2' }))
+    expect(screen.queryByText(datasets[0].datasetName)).not.toBeInTheDocument()
+    expect(screen.queryByText('Participants:')).not.toBeInTheDocument()
+    expect(document.querySelector('.MuiCircularProgress-root')).toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText(/1 dataset selected from 1 study/i)).not.toBeInTheDocument())
+
+    resolveNextStudy(nextStudyDatasets)
+    expect(await screen.findByText('Study 2 Dataset')).toBeInTheDocument()
+    expect(screen.getAllByText('second study')).toHaveLength(2)
+    expect(screen.queryByText(/dataset selected from/i)).not.toBeInTheDocument()
+  })
+
   it('shows the appropriate data for fields', async () => {
     mountComponent()
     await screen.findByText(datasets[0].datasetName)
@@ -220,6 +273,7 @@ describe('Study details test', () => {
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load datasets: search failed')
     expect(screen.getByText('No datasets found matching your criteria')).toBeInTheDocument()
+    expect(screen.queryByText('Participants:')).not.toBeInTheDocument()
     expect(document.querySelector('.MuiCircularProgress-root')).not.toBeInTheDocument()
   })
 })

--- a/test/hooks/useStudyDetailsData.spec.tsx
+++ b/test/hooks/useStudyDetailsData.spec.tsx
@@ -1,0 +1,189 @@
+import React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import {
+  buildStudyDatasetsQuery,
+  useStudyDatasets,
+  useStudyExportableDatasets,
+} from 'src/hooks/useStudyDetailsData'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { ElasticsearchResponse } from 'src/types/elastic'
+import { DatasetTerm, StudyTerm } from 'src/types/model'
+import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
+
+vi.mock('src/libs/ajax/DataSet', () => ({
+  DataSet: {
+    searchDatasetIndexV2: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/ajax/TerraDataRepo', () => ({
+  TerraDataRepo: {
+    listSnapshotsByDatasetIds: vi.fn(),
+  },
+}))
+
+const study = {
+  studyId: 7,
+  studyName: 'Study Seven',
+  description: 'Study description',
+} as StudyTerm
+
+const datasets = [
+  {
+    datasetId: 71,
+    datasetIdentifier: 'DUOS-000071',
+    datasetName: 'Dataset 71',
+    participantCount: 10,
+    study,
+  },
+  {
+    datasetId: 72,
+    datasetIdentifier: 'DUOS-000072',
+    datasetName: 'Dataset 72',
+    participantCount: 20,
+    study,
+  },
+] as DatasetTerm[]
+
+const makeSearchResponse = () => ({
+  hits: {
+    total: { value: 42 },
+    hits: datasets.map(dataset => ({ _source: dataset })),
+  },
+  aggregations: {
+    study_details: {
+      hits: {
+        hits: [{ _source: { study } }],
+      },
+    },
+    total_participants: { value: 1234 },
+  },
+}) as unknown as ElasticsearchResponse
+
+const makeSnapshot = (id: string, duosId: string): SnapshotSummaryModel => ({
+  id,
+  name: id,
+  duosId,
+  cloudPlatform: 'gcp',
+  resourceLocks: {},
+})
+
+let queryClient: QueryClient
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+})
+
+afterEach(() => {
+  queryClient.clear()
+  vi.clearAllMocks()
+})
+
+describe('buildStudyDatasetsQuery', () => {
+  it('builds a page-sized study query using the dataset server sort mapping', () => {
+    const query = buildStudyDatasetsQuery(
+      '7',
+      { page: 2, pageSize: 50 },
+      { field: 'dac', order: 'desc' },
+    )
+
+    expect(query.from).toBe(100)
+    expect(query.size).toBe(50)
+    expect(query.query?.bool.must).toContainEqual({ exists: { field: 'study' } })
+    expect(query.query?.bool.must).toContainEqual({ match: { 'study.studyId': '7' } })
+    expect(query.query?.bool.should).toBeUndefined()
+    expect(query.sort).toEqual([{ 'dac.dacName.keyword': { order: 'desc' } }])
+    expect(query.aggs).toHaveProperty('study_details')
+    expect(query.aggs).toHaveProperty('total_participants')
+  })
+})
+
+describe('useStudyDatasets', () => {
+  it('returns the server page with study metadata and the aggregated participant total', async () => {
+    vi.mocked(DataSet.searchDatasetIndexV2).mockResolvedValue(makeSearchResponse())
+
+    const { result } = renderHook(
+      () => useStudyDatasets('7', { page: 0, pageSize: 25 }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data?.items).toEqual(datasets)
+    expect(result.current.data?.total).toBe(42)
+    expect(result.current.data?.study).toEqual(study)
+    expect(result.current.data?.participantCount).toBe(1234)
+    expect(DataSet.searchDatasetIndexV2).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not issue a request without a study id', () => {
+    renderHook(
+      () => useStudyDatasets('', { page: 0, pageSize: 25 }),
+      { wrapper },
+    )
+
+    expect(DataSet.searchDatasetIndexV2).not.toHaveBeenCalled()
+  })
+})
+
+describe('useStudyExportableDatasets', () => {
+  it('fetches exports for the current page and keeps only snapshots with export roles', async () => {
+    const exportable = makeSnapshot('reader-snapshot', 'DUOS-000071')
+    const missingRole = makeSnapshot('missing-role-snapshot', 'DUOS-000072')
+    const response: EnumerateSnapshotModel = {
+      items: [exportable, missingRole],
+      roleMap: {
+        [exportable.id]: ['reader'],
+      },
+      filteredTotal: 2,
+      total: 2,
+      errors: [],
+    }
+    vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockResolvedValue(response)
+
+    const { result } = renderHook(
+      () => useStudyExportableDatasets('7', datasets),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledWith([
+      'DUOS-000071',
+      'DUOS-000072',
+    ])
+    expect(result.current.data).toEqual({
+      'DUOS-000071': [exportable],
+    })
+  })
+
+  it('does not issue a dependent request without datasets', () => {
+    renderHook(
+      () => useStudyExportableDatasets('7', []),
+      { wrapper },
+    )
+
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty export map when the snapshot lookup fails', async () => {
+    vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockRejectedValue(new Error('TDR unavailable'))
+
+    const { result } = renderHook(
+      () => useStudyExportableDatasets('7', datasets),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({})
+  })
+})

--- a/test/hooks/useStudyDetailsData.spec.tsx
+++ b/test/hooks/useStudyDetailsData.spec.tsx
@@ -106,6 +106,10 @@ describe('buildStudyDatasetsQuery', () => {
     expect(query.sort).toEqual([{ 'dac.dacName.keyword': { order: 'desc' } }])
     expect(query.aggs).toHaveProperty('study_details')
     expect(query.aggs).toHaveProperty('total_participants')
+    expect(query.aggs).not.toHaveProperty('access_management')
+    expect(query.aggs).not.toHaveProperty('data_use')
+    expect(query.aggs).not.toHaveProperty('data_type')
+    expect(query.aggs).not.toHaveProperty('dac')
   })
 })
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3805

### Summary

- Replace the legacy dataset table with the shared Data Library grid
- Use the modern selection and access-request footer, preserving selections across pages
- Add server-side pagination and single-column sorting for study datasets
- Preserve dataset exports and prevent stale results when navigating between studies
- Improve loading, empty, and error states and update grid and hook tests

**Before**

<img width="3600" height="2216" alt="Before" src="https://github.com/user-attachments/assets/78d5b6c3-d10e-4eb4-95d4-3d3611163f48" />

**After**

<img width="3600" height="2478" alt="After" src="https://github.com/user-attachments/assets/afeedde2-f6c4-47d8-9924-f9eec46f5375" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
