### PR TITLE
[DT-3867] Add fetchBlob helper and consolidate blob downloads

### DIFF
--- a/src/libs/ajax/DAA.ts
+++ b/src/libs/ajax/DAA.ts
@@ -2,6 +2,7 @@ import { fileDownload } from 'src/utils/FileDownload'
 import { Config } from 'src/libs/config'
 import { isFileEmpty } from 'src/libs/utils'
 import {
+  fetchBlob,
   fetchGet,
   fetchPost,
   fetchPut,
@@ -14,16 +15,6 @@ import type { DAAObject } from 'src/types/model'
 type AuthConfig = ReturnType<typeof Config.authOpts>
 type DeleteBodyConfig<TBody> = AuthConfig & { data: TBody }
 type FetchDeleteConfig<T> = Parameters<typeof fetchDelete<T>>[1]
-
-type DaaBinaryDownloadConfig = {
-  responseType: 'blob'
-  headers: {
-    'Authorization': string
-    'Accept': string
-    'X-App-ID': string
-    'Content-Type': 'application/octet-stream'
-  }
-}
 
 export const DAA = {
   getDaas: async (): Promise<DAAObject[]> => {
@@ -77,35 +68,14 @@ export const DAA = {
   },
 
   getDaaFileById: async (daaId: number, daaFileName: string): Promise<void> => {
-    const auth = Config.authOpts()
-    const authOpts: DaaBinaryDownloadConfig = {
-      ...auth,
-      responseType: 'blob',
-      headers: {
-        ...auth.headers,
-        'Content-Type': 'application/octet-stream',
-        'Accept': 'application/octet-stream',
-      },
-    }
     const url = `${await Config.getApiUrl()}/api/daa/${daaId}/file`
-    const res = await fetchGet<Blob>(url, authOpts)
-    fileDownload(res.data, daaFileName)
+    const blob = await fetchBlob(url, Config.authOpts())
+    fileDownload(blob, daaFileName)
   },
 
   getDaaFileBlob: async (daaId: number): Promise<Blob> => {
-    const auth = Config.authOpts()
-    const authOpts: DaaBinaryDownloadConfig = {
-      ...auth,
-      responseType: 'blob',
-      headers: {
-        ...auth.headers,
-        'Content-Type': 'application/octet-stream',
-        'Accept': 'application/octet-stream',
-      },
-    }
     const url = `${await Config.getApiUrl()}/api/daa/${daaId}/file`
-    const res = await fetchGet<Blob>(url, authOpts)
-    return res.data
+    return fetchBlob(url, Config.authOpts())
   },
 
   createDaa: async (file: File | null | undefined, dacId: number): Promise<FetchData<DAAObject | null>> => {

--- a/src/libs/ajax/DAR.ts
+++ b/src/libs/ajax/DAR.ts
@@ -4,7 +4,7 @@ import { Config } from 'src/libs/config'
 import { isFileEmpty } from 'src/libs/utils'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import eventList from 'src/libs/events'
-import { fetchGet, fetchMultipart, fetchPost, fetchPut, fetchDelete, FetchData } from 'src/libs/ajax/fetchAdapter'
+import { fetchBlob, fetchGet, fetchMultipart, fetchPost, fetchPut, fetchDelete, FetchData } from 'src/libs/ajax/fetchAdapter'
 import { DataAccessRequest, OntologyEntry } from 'src/types/model'
 
 export interface DatasetDaaSnapshot {
@@ -120,18 +120,9 @@ export const DAR = {
    * @param fileName The filename to save as
    */
   downloadDARDocument: async (referenceId: string, fileType: string, fileName: string): Promise<void> => {
-    const authOpts = {
-      ...Config.authOpts(),
-      responseType: 'blob' as const,
-      headers: {
-        ...Config.authOpts().headers,
-        'Content-Type': 'application/octet-stream',
-        'Accept': 'application/octet-stream',
-      },
-    }
     const url = `${await Config.getApiUrl()}/api/dar/v2/${referenceId}/${fileType}`
-    const res = await fetchGet<Blob>(url, authOpts)
-    fileDownload(res.data, fileName)
+    const blob = await fetchBlob(url, Config.authOpts())
+    fileDownload(blob, fileName)
   },
 
   /**
@@ -141,18 +132,8 @@ export const DAR = {
    * @returns The document as a Blob
    */
   getDARDocumentAsBlob: async (referenceId: string, fileType: string): Promise<Blob> => {
-    const authOpts = {
-      ...Config.authOpts(),
-      responseType: 'blob' as const,
-      headers: {
-        ...Config.authOpts().headers,
-        'Content-Type': 'application/octet-stream',
-        'Accept': 'application/octet-stream',
-      },
-    }
     const url = `${await Config.getApiUrl()}/api/dar/v2/${referenceId}/${fileType}`
-    const res = await fetchGet<Blob>(url, authOpts)
-    return res.data
+    return fetchBlob(url, Config.authOpts())
   },
 
   /**

--- a/src/libs/ajax/FileStorageObject.ts
+++ b/src/libs/ajax/FileStorageObject.ts
@@ -1,5 +1,5 @@
 import { Config } from 'src/libs/config'
-import { fetchDelete, fetchGet, fetchMultipart, fetchPut } from 'src/libs/ajax/fetchAdapter'
+import { fetchBlob, fetchDelete, fetchGet, fetchMultipart, fetchPut } from 'src/libs/ajax/fetchAdapter'
 import type { FileStorageObject as SharedFileStorageObject } from 'src/types/model'
 
 export enum FileCategory {
@@ -68,15 +68,7 @@ export async function getDocumentFile(
   id: number,
 ): Promise<Blob> {
   const url = `${await documentPath(entity, entityId, id)}/file`
-  const res = await fetchGet<Blob>(url, {
-    ...Config.authOpts(),
-    responseType: 'blob',
-    headers: {
-      ...Config.authOpts().headers,
-      Accept: 'application/octet-stream',
-    },
-  })
-  return res.data
+  return fetchBlob(url, Config.authOpts())
 }
 
 export async function listDocuments(

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -305,6 +305,20 @@ export const fetchGet = <T>(
   config: FetchRequestConfig = {},
 ) => fetchRequest<T>({ url, ...config, method: 'GET' })
 
+export const fetchBlob = async (
+  url: string,
+  config: FetchRequestConfig = {},
+): Promise<Blob> => {
+  const res = await fetchRequest<Blob>({
+    url,
+    ...config,
+    method: 'GET',
+    responseType: 'blob',
+    headers: { Accept: 'application/octet-stream', ...config.headers },
+  })
+  return res.data
+}
+
 export const fetchPost = <T, TBody = unknown>(
   url: string,
   data?: TBody,

--- a/test/libs/ajax/DAA.spec.ts
+++ b/test/libs/ajax/DAA.spec.ts
@@ -3,10 +3,11 @@ import { DAA } from 'src/libs/ajax/DAA'
 import { Config } from 'src/libs/config'
 import type { DAAObject } from 'src/types/model'
 import type { FetchData } from 'src/libs/ajax/fetchAdapter'
-import { fetchGet, fetchPost, fetchPut, fetchDelete, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { fetchBlob, fetchGet, fetchPost, fetchPut, fetchDelete, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
 import * as FileDownload from 'src/utils/FileDownload'
 
 vi.mock('src/libs/ajax/fetchAdapter', () => ({
+  fetchBlob: vi.fn(),
   fetchGet: vi.fn(),
   fetchPost: vi.fn(),
   fetchPut: vi.fn(),
@@ -133,23 +134,30 @@ describe('DAA ajax', () => {
     )
   })
 
-  it('getDaaFileById fetches blob with octet-stream headers and triggers download', async () => {
+  it('getDaaFileById fetches a blob via fetchBlob and triggers download', async () => {
     const fakeBlob = new Blob(['fake-binary-content'], { type: 'application/octet-stream' })
-    vi.mocked(fetchGet).mockResolvedValue({ data: fakeBlob } as FetchData<Blob>)
+    vi.mocked(fetchBlob).mockResolvedValue(fakeBlob)
 
     await DAA.getDaaFileById(mockDaa.daaId, 'Sample_DAA.pdf')
 
-    expect(fetchGet).toHaveBeenCalledWith(
+    expect(fetchBlob).toHaveBeenCalledWith(
       `${apiUrl}/api/daa/${mockDaa.daaId}/file`,
-      expect.objectContaining({
-        responseType: 'blob',
-        headers: expect.objectContaining({
-          'Accept': 'application/octet-stream',
-          'Content-Type': 'application/octet-stream',
-        }),
-      }),
+      authHeaders,
     )
     expect(FileDownload.fileDownload).toHaveBeenCalledWith(fakeBlob, 'Sample_DAA.pdf')
+  })
+
+  it('getDaaFileBlob fetches a blob via fetchBlob and returns it', async () => {
+    const fakeBlob = new Blob(['fake-binary-content'], { type: 'application/octet-stream' })
+    vi.mocked(fetchBlob).mockResolvedValue(fakeBlob)
+
+    const result = await DAA.getDaaFileBlob(mockDaa.daaId)
+
+    expect(fetchBlob).toHaveBeenCalledWith(
+      `${apiUrl}/api/daa/${mockDaa.daaId}/file`,
+      authHeaders,
+    )
+    expect(result).toBe(fakeBlob)
   })
 
   it('createDaa returns null payload for null file', async () => {

--- a/test/libs/ajax/DAR.spec.ts
+++ b/test/libs/ajax/DAR.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Config } from 'src/libs/config'
-import { fetchDelete, fetchGet, fetchMultipart, fetchPost, fetchPut } from 'src/libs/ajax/fetchAdapter'
+import { fetchBlob, fetchDelete, fetchGet, fetchMultipart, fetchPost, fetchPut } from 'src/libs/ajax/fetchAdapter'
 import { DAR } from 'src/libs/ajax/DAR'
 import { extractConsentError, extractError } from 'src/utils/ErrorUtils'
 
@@ -12,6 +12,7 @@ vi.mock('src/libs/config', () => ({
 }))
 
 vi.mock('src/libs/ajax/fetchAdapter', () => ({
+  fetchBlob: vi.fn(),
   fetchGet: vi.fn(),
   fetchPost: vi.fn(),
   fetchPut: vi.fn(),
@@ -68,6 +69,7 @@ describe('DAR', () => {
     vi.mocked(fetchPut).mockResolvedValue({ data: buildDar() })
     vi.mocked(fetchDelete).mockResolvedValue({ data: undefined })
     vi.mocked(fetchMultipart).mockResolvedValue({ data: buildDar() })
+    vi.mocked(fetchBlob).mockResolvedValue(new Blob([]))
     const { isFileEmpty } = await import('src/libs/utils')
     vi.mocked(isFileEmpty).mockReturnValue(false)
   })
@@ -302,31 +304,25 @@ describe('DAR', () => {
     it('fetches the document as a blob and triggers fileDownload', async () => {
       const { fileDownload } = await import('src/utils/FileDownload')
       const blob = new Blob(['pdf content'], { type: 'application/pdf' })
-      vi.mocked(fetchGet).mockResolvedValue({ data: blob })
+      vi.mocked(fetchBlob).mockResolvedValue(blob)
 
       await DAR.downloadDARDocument('ref-001', 'irbDocument', 'irb.pdf')
 
-      expect(fetchGet).toHaveBeenCalledWith(
+      expect(fetchBlob).toHaveBeenCalledWith(
         'https://duos.example.org/api/dar/v2/ref-001/irbDocument',
-        expect.objectContaining({
-          responseType: 'blob',
-          headers: expect.objectContaining({
-            'Content-Type': 'application/octet-stream',
-            'Accept': 'application/octet-stream',
-          }),
-        }),
+        headers,
       )
       expect(fileDownload).toHaveBeenCalledWith(blob, 'irb.pdf')
     })
 
     it('propagates fetch failures', async () => {
-      vi.mocked(fetchGet).mockRejectedValueOnce(new Error('network failure'))
+      vi.mocked(fetchBlob).mockRejectedValueOnce(new Error('network failure'))
       await expect(DAR.downloadDARDocument('ref-001', 'irbDocument', 'irb.pdf')).rejects.toThrow('network failure')
     })
 
     it('propagates ConsentError rejections so callers can extract a useful error', async () => {
       const consentError = { message: 'Document not found', code: 404 }
-      vi.mocked(fetchGet).mockRejectedValueOnce(consentError)
+      vi.mocked(fetchBlob).mockRejectedValueOnce(consentError)
       const error = await DAR.downloadDARDocument('ref-001', 'irbDocument', 'irb.pdf').then(
         () => { throw new Error('expected rejection') },
         e => e,
@@ -339,25 +335,25 @@ describe('DAR', () => {
   describe('getDARDocumentAsBlob', () => {
     it('fetches the document as a blob and returns it', async () => {
       const blob = new Blob(['pdf content'], { type: 'application/pdf' })
-      vi.mocked(fetchGet).mockResolvedValue({ data: blob })
+      vi.mocked(fetchBlob).mockResolvedValue(blob)
 
       const result = await DAR.getDARDocumentAsBlob('ref-001', 'irbDocument')
 
-      expect(fetchGet).toHaveBeenCalledWith(
+      expect(fetchBlob).toHaveBeenCalledWith(
         'https://duos.example.org/api/dar/v2/ref-001/irbDocument',
-        expect.objectContaining({ responseType: 'blob' }),
+        headers,
       )
       expect(result).toBe(blob)
     })
 
     it('propagates fetch failures', async () => {
-      vi.mocked(fetchGet).mockRejectedValueOnce(new Error('network failure'))
+      vi.mocked(fetchBlob).mockRejectedValueOnce(new Error('network failure'))
       await expect(DAR.getDARDocumentAsBlob('ref-001', 'irbDocument')).rejects.toThrow('network failure')
     })
 
     it('propagates ConsentError rejections so callers can extract a useful error', async () => {
       const consentError = { message: 'Document not found', code: 404 }
-      vi.mocked(fetchGet).mockRejectedValueOnce(consentError)
+      vi.mocked(fetchBlob).mockRejectedValueOnce(consentError)
       const error = await DAR.getDARDocumentAsBlob('ref-001', 'irbDocument').then(
         () => { throw new Error('expected rejection') },
         e => e,

--- a/test/libs/ajax/FileStorageObject.spec.ts
+++ b/test/libs/ajax/FileStorageObject.spec.ts
@@ -12,9 +12,10 @@ import {
 } from 'src/libs/ajax/FileStorageObject'
 import { Config } from 'src/libs/config'
 import type { FetchData } from 'src/libs/ajax/fetchAdapter'
-import { fetchGet, fetchPut, fetchDelete, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { fetchBlob, fetchGet, fetchPut, fetchDelete, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
 
 vi.mock('src/libs/ajax/fetchAdapter', () => ({
+  fetchBlob: vi.fn(),
   fetchGet: vi.fn(),
   fetchPut: vi.fn(),
   fetchDelete: vi.fn(),
@@ -99,19 +100,16 @@ describe('FileStorageObject ajax', () => {
   })
 
   describe('getDocumentFile', () => {
-    it('sends GET with blob responseType and returns a Blob', async () => {
+    it('fetches the file via fetchBlob and returns a Blob', async () => {
       const fakeBlob = new Blob(['file content'], { type: 'application/pdf' })
-      vi.mocked(fetchGet).mockResolvedValue({ data: fakeBlob } as FetchData<Blob>)
+      vi.mocked(fetchBlob).mockResolvedValue(fakeBlob)
 
       const result = await getDocumentFile(EntityType.STUDY, '7', 2)
 
       expect(result).toBeInstanceOf(Blob)
-      expect(fetchGet).toHaveBeenCalledWith(
+      expect(fetchBlob).toHaveBeenCalledWith(
         '/api/document/study/7/2/file',
-        expect.objectContaining({
-          responseType: 'blob',
-          headers: expect.objectContaining({ Accept: 'application/octet-stream' }),
-        }),
+        authHeaders,
       )
     })
   })

--- a/test/libs/ajax/fetchAdapter.spec.ts
+++ b/test/libs/ajax/fetchAdapter.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  fetchBlob,
   fetchGet,
   fetchPost,
   fetchPut,
@@ -107,6 +108,33 @@ describe('fetchAdapter - Fetch methods', () => {
     const result = await fetchGet<Blob>('/api/file', { responseType: 'blob' })
     expect(result.data?.constructor?.name).toBe('Blob')
     expect(result.data.type).toContain('text/plain')
+  })
+
+  it('fetchBlob - should GET a blob with an octet-stream Accept header', async () => {
+    const mockBlob = new Blob(['binary'], { type: 'application/octet-stream' })
+    fetchMock.mockResolvedValue(new Response(mockBlob, { status: 200 }))
+
+    const result = await fetchBlob('/api/file')
+
+    expect(result?.constructor?.name).toBe('Blob')
+    const [url, options] = fetchMock.mock.calls[0] as [string, StubOptions]
+    expect(url).toBe('/api/file')
+    expect(options.method).toBe('GET')
+    expect(options.headers?.Accept).toBe('application/octet-stream')
+    // The old hand-rolled blob configs overrode Content-Type to octet-stream on a
+    // bodyless GET; fetchBlob drops that and inherits the adapter's standard default,
+    // exactly like every other fetchGet call.
+    expect(options.headers?.['Content-Type']).not.toBe('application/octet-stream')
+  })
+
+  it('fetchBlob - should let the caller override the Accept header', async () => {
+    const mockBlob = new Blob(['pdf'], { type: 'application/pdf' })
+    fetchMock.mockResolvedValue(new Response(mockBlob, { status: 200 }))
+
+    await fetchBlob('/api/file', { headers: { Accept: 'application/pdf' } })
+
+    const [, options] = fetchMock.mock.calls[0] as [string, StubOptions]
+    expect(options.headers?.Accept).toBe('application/pdf')
   })
 
   it('fetchGet - should return text when content-type is text/plain', async () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3867

### Summary

The octet-stream "download a file as a Blob" request (responseType: 'blob' + Accept header) was duplicated manually in five places: DAR.downloadDARDocument, DAR.getDARDocumentAsBlob, DAA.getDaaFileById, DAA.getDaaFileBlob, and FileStorageObject.getDocumentFile. Introduce fetchBlob in fetchAdapter to centralize this type of request; callers now pass only the URL and Config.authOpts().

Behaviour is unchanged except that the redundant Content-Type: application/octet-stream override on these bodyless GETs is dropped, fetchBlob inherits the adapter's standard default like every other GET, and DAR/DAA no longer diverge from FileStorageObject (which already omitted it).

This has been flagged a number of times by the `/improve-codebase` skill.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
