### PR TITLE
[DT-3325] Implement bulk DAA features.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1763,8 +1763,8 @@ packages:
     resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
     engines: {node: '>=14.16'}
 
-  find-my-way@9.6.0:
-    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+  find-my-way@9.7.0:
+    resolution: {integrity: sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==}
     engines: {node: '>=20'}
 
   find-root@1.1.0:
@@ -3475,7 +3475,7 @@ snapshots:
     dependencies:
       '@fastify/error': 4.2.0
       fastify-plugin: 6.0.0
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       path-to-regexp: 8.4.2
       reusify: 1.1.0
 
@@ -4567,7 +4567,7 @@ snapshots:
       abstract-logging: 2.0.1
       avvio: 9.2.0
       fast-json-stringify: 7.0.1
-      find-my-way: 9.6.0
+      find-my-way: 9.7.0
       light-my-request: 6.6.0
       pino: 10.3.1
       process-warning: 5.0.0
@@ -4597,7 +4597,7 @@ snapshots:
 
   filter-obj@5.1.0: {}
 
-  find-my-way@9.6.0:
+  find-my-way@9.7.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-querystring: 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,5 @@ allowBuilds:
   esbuild: false
 allowedDeprecatedVersions:
   node-domexception: "1.0.0"
+minimumReleaseAgeExclude:
+  - find-my-way@9.6.1

--- a/src/libs/ajax/DAA.ts
+++ b/src/libs/ajax/DAA.ts
@@ -9,7 +9,7 @@ import {
   fetchMultipart,
   type FetchData,
 } from 'src/libs/ajax/fetchAdapter'
-import type { DAAObject } from 'src/types/model'
+import type { DAAObject, DaaBulkRelationResult } from 'src/types/model'
 
 type AuthConfig = ReturnType<typeof Config.authOpts>
 type DeleteBodyConfig<TBody> = AuthConfig & { data: TBody }
@@ -50,30 +50,34 @@ export const DAA = {
     return 200
   },
 
-  bulkAddUsersToDaa: async (daaId: number, userList: number[]): Promise<number> => {
+  bulkAddUsersToDaa: async (daaId: number, userList: number[]): Promise<DaaBulkRelationResult> => {
     const url = `${await Config.getApiUrl()}/api/daa/bulk/${daaId}`
-    await fetchPost<void, number[]>(url, userList, Config.authOpts())
-    return 200
+    const res = await fetchPost<DaaBulkRelationResult, { users: number[] }>(
+      url, { users: userList }, Config.authOpts(),
+    )
+    return res.data
   },
 
-  bulkRemoveUsersFromDaa: async (daaId: number, userList: number[]): Promise<number> => {
+  bulkRemoveUsersFromDaa: async (daaId: number, userList: number[]): Promise<DaaBulkRelationResult> => {
     const url = `${await Config.getApiUrl()}/api/daa/bulk/${daaId}`
-    const config: DeleteBodyConfig<number[]> = { ...Config.authOpts(), data: userList }
-    await fetchDelete<void>(url, config as FetchDeleteConfig<void>)
-    return 200
+    const config: DeleteBodyConfig<{ users: number[] }> = { ...Config.authOpts(), data: { users: userList } }
+    const res = await fetchDelete<DaaBulkRelationResult>(url, config as FetchDeleteConfig<DaaBulkRelationResult>)
+    return res.data
   },
 
-  bulkAddDaasToUser: async (userId: number, daaList: number[]): Promise<number> => {
+  bulkAddDaasToUser: async (userId: number, daaList: number[]): Promise<DaaBulkRelationResult> => {
     const url = `${await Config.getApiUrl()}/api/daa/bulk/user/${userId}`
-    await fetchPost<void, number[]>(url, daaList, Config.authOpts())
-    return 200
+    const res = await fetchPost<DaaBulkRelationResult, { daaList: number[] }>(
+      url, { daaList }, Config.authOpts(),
+    )
+    return res.data
   },
 
-  bulkRemoveDaasFromUser: async (userId: number, daaList: number[]): Promise<number> => {
+  bulkRemoveDaasFromUser: async (userId: number, daaList: number[]): Promise<DaaBulkRelationResult> => {
     const url = `${await Config.getApiUrl()}/api/daa/bulk/user/${userId}`
-    const config: DeleteBodyConfig<number[]> = { ...Config.authOpts(), data: daaList }
-    await fetchDelete<void>(url, config as FetchDeleteConfig<void>)
-    return 200
+    const config: DeleteBodyConfig<{ daaList: number[] }> = { ...Config.authOpts(), data: { daaList } }
+    const res = await fetchDelete<DaaBulkRelationResult>(url, config as FetchDeleteConfig<DaaBulkRelationResult>)
+    return res.data
   },
 
   getDaaFileById: async (daaId: number, daaFileName: string): Promise<void> => {

--- a/src/pages/signing_official_console/DAAAssignment/BulkActionButtons.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/BulkActionButtons.tsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { Box, Button } from '@mui/material'
+
+const BRAND_BLUE = '#0948b7'
+const FONT = 'Montserrat'
+
+interface BulkActionButtonsProps {
+  readonly onApproveAll: () => void
+  readonly onRemoveAll: () => void
+  readonly approveAllDisabled: boolean
+  readonly removeAllDisabled: boolean
+  /** Distinguishes the data-cy hooks per card, e.g. `researcher-12` / `daa-3` */
+  readonly dataCyPrefix: string
+}
+
+/**
+ * "Approve All" / "Remove All" buttons rendered in an accordion card header.
+ *
+ * The header row is itself a toggle button, so every click here calls
+ * `stopPropagation()` to avoid collapsing/expanding the card. A disabled button
+ * does nothing — no dialog, no call — because MUI suppresses the click handler.
+ */
+export default function BulkActionButtons({
+  onApproveAll,
+  onRemoveAll,
+  approveAllDisabled,
+  removeAllDisabled,
+  dataCyPrefix,
+}: BulkActionButtonsProps) {
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+      // Guard against the header toggle even when the click lands between buttons.
+      onClick={e => e.stopPropagation()}
+    >
+      <Button
+        variant="contained"
+        size="small"
+        data-cy={`bulk-approve-all-${dataCyPrefix}`}
+        disabled={approveAllDisabled}
+        onClick={(e) => {
+          e.stopPropagation()
+          onApproveAll()
+        }}
+        sx={{
+          'bgcolor': BRAND_BLUE,
+          'fontFamily': FONT,
+          'fontWeight': 700,
+          'textTransform': 'uppercase',
+          'fontSize': 11,
+          '&:hover': { bgcolor: '#073a94' },
+        }}
+      >
+        Approve All
+      </Button>
+      <Button
+        variant="outlined"
+        size="small"
+        data-cy={`bulk-remove-all-${dataCyPrefix}`}
+        disabled={removeAllDisabled}
+        onClick={(e) => {
+          e.stopPropagation()
+          onRemoveAll()
+        }}
+        sx={{
+          borderColor: '#dc3545',
+          color: '#dc3545',
+          borderWidth: 1.5,
+          fontFamily: FONT,
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          fontSize: 11,
+        }}
+      >
+        Remove All
+      </Button>
+    </Box>
+  )
+}

--- a/src/pages/signing_official_console/DAAAssignment/BulkActionConfirmDialog.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/BulkActionConfirmDialog.tsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Typography,
+} from '@mui/material'
+import { BulkConfirmState } from './types'
+
+const FONT = 'Montserrat'
+const BRAND_BLUE = '#0948b7'
+
+interface BulkActionConfirmDialogProps {
+  dialog: BulkConfirmState | null
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/** The noun for the relationships being changed, given the card scope. */
+function itemNoun(scope: BulkConfirmState['scope'], count: number): string {
+  const singular = scope === 'researcher' ? 'DAA' : 'researcher'
+  return count === 1 ? singular : `${singular}s`
+}
+
+function buildTitle(dialog: BulkConfirmState): string {
+  const noun = itemNoun(dialog.scope, dialog.count)
+  const preposition = dialog.scope === 'researcher' ? 'for' : 'under'
+  return dialog.mode === 'approve'
+    ? `Approve pre-authorization for all ${dialog.count} remaining ${noun} ${preposition} ${dialog.targetLabel}?`
+    : `Remove pre-authorization for all ${dialog.count} ${noun} ${preposition} ${dialog.targetLabel}?`
+}
+
+function buildBody(dialog: BulkConfirmState): string {
+  const noun = itemNoun(dialog.scope, dialog.count)
+  const preposition = dialog.scope === 'researcher' ? 'for' : 'under'
+  if (dialog.mode === 'approve') {
+    return `This will grant pre-authorization for all ${dialog.count} remaining ${noun} ${preposition} ${dialog.targetLabel}. Researchers without a library card will have one created automatically.`
+  }
+  return `This will remove pre-authorization for all ${dialog.count} ${noun} ${preposition} ${dialog.targetLabel}. This will not affect active or previously approved DARs.`
+}
+
+/**
+ * Confirmation dialog shown before a bulk Approve All / Remove All action on a
+ * researcher card or a DAA card.
+ *
+ * Deliberately separate from {@link ResearcherViewConfirmDialog} (the
+ * single-relationship dialog) so the per-row flow stays untouched.
+ */
+export default function BulkActionConfirmDialog({
+  dialog,
+  onConfirm,
+  onCancel,
+}: Readonly<BulkActionConfirmDialogProps>) {
+  if (!dialog) return null
+
+  const isApprove = dialog.mode === 'approve'
+
+  return (
+    <Dialog
+      open
+      onClose={onCancel}
+      maxWidth="sm"
+      fullWidth
+      data-cy="bulk-confirm-dialog"
+    >
+      <DialogTitle sx={{ fontFamily: FONT, fontWeight: 700 }}>
+        {buildTitle(dialog)}
+      </DialogTitle>
+
+      <DialogContent>
+        <Typography sx={{ fontFamily: FONT, fontSize: 14, color: '#555' }}>
+          {buildBody(dialog)}
+        </Typography>
+      </DialogContent>
+
+      <DialogActions sx={{ p: 2, gap: 1 }}>
+        <Button
+          onClick={onCancel}
+          data-cy="bulk-confirm-dialog-cancel"
+          sx={{ fontFamily: FONT, color: '#666' }}
+        >
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          onClick={onConfirm}
+          data-cy="bulk-confirm-dialog-confirm"
+          sx={{
+            'fontFamily': FONT,
+            'fontWeight': 700,
+            'bgcolor': isApprove ? BRAND_BLUE : '#dc3545',
+            '&:hover': { bgcolor: isApprove ? '#073a94' : '#b02a37' },
+          }}
+        >
+          {isApprove ? 'Approve All' : 'Remove All'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/pages/signing_official_console/DAAAssignment/DAAAccordionRow.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAAccordionRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
   Box,
   Chip,
@@ -59,12 +59,14 @@ export default function DAAAccordionRow({
   const label = daaLabel(daa)
   const formattedEffectiveDate = formatDateYYYYMMDD(daa.createDate)
 
-  const unauthorizedUserIds = researcherRows
-    .filter(r => r.status !== 'authorized')
-    .map(r => r.researcher.userId)
-  const authorizedUserIds = researcherRows
-    .filter(r => r.status === 'authorized')
-    .map(r => r.researcher.userId)
+  const unauthorizedUserIds = useMemo(
+    () => researcherRows.filter(r => r.status !== 'authorized').map(r => r.researcher.userId),
+    [researcherRows],
+  )
+  const authorizedUserIds = useMemo(
+    () => researcherRows.filter(r => r.status === 'authorized').map(r => r.researcher.userId),
+    [researcherRows],
+  )
 
   return (
     <Paper

--- a/src/pages/signing_official_console/DAAAssignment/DAAAccordionRow.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAAccordionRow.tsx
@@ -9,8 +9,9 @@ import {
 } from '@mui/material'
 import { DAAObject } from 'src/types/model'
 import DAAResearcherSubtable from './DAAResearcherSubtable'
+import BulkActionButtons from './BulkActionButtons'
 import { DAAResearcherRowData } from './types'
-import { formatDateYYYYMMDD } from './researcherViewHelpers'
+import { daaLabel, formatDateYYYYMMDD } from './researcherViewHelpers'
 
 const FONT = 'Montserrat'
 
@@ -24,6 +25,10 @@ interface DAAAccordionRowProps {
   onToggle: () => void
   onAuthorize: (researcherId: number) => void
   onRevoke: (researcherId: number) => void
+  /** Bulk "Approve All" — receives the ids of every not-yet-authorized researcher */
+  onApproveAll: (researcherIds: number[]) => void
+  /** Bulk "Remove All" — receives the ids of every currently-authorized researcher */
+  onRemoveAll: (researcherIds: number[]) => void
 }
 
 /**
@@ -47,10 +52,19 @@ export default function DAAAccordionRow({
   onToggle,
   onAuthorize,
   onRevoke,
+  onApproveAll,
+  onRemoveAll,
 }: Readonly<DAAAccordionRowProps>) {
   const daaId = daa.daaId
-  const daaLabel = daa.file?.fileName ?? `DAA-${daaId}`
+  const label = daaLabel(daa)
   const formattedEffectiveDate = formatDateYYYYMMDD(daa.createDate)
+
+  const unauthorizedUserIds = researcherRows
+    .filter(r => r.status !== 'authorized')
+    .map(r => r.researcher.userId)
+  const authorizedUserIds = researcherRows
+    .filter(r => r.status === 'authorized')
+    .map(r => r.researcher.userId)
 
   return (
     <Paper
@@ -88,7 +102,7 @@ export default function DAAAccordionRow({
             <Typography
               sx={{ fontFamily: FONT, fontWeight: 700, fontSize: 15, color: '#1a1a2e' }}
             >
-              {daaLabel}
+              {label}
             </Typography>
             <Typography
               sx={{ fontFamily: FONT, fontSize: 13, color: '#888', fontWeight: 400 }}
@@ -131,8 +145,15 @@ export default function DAAAccordionRow({
           </Typography>
         </Box>
 
-        {/* Right: authorized count badge + chevron */}
+        {/* Right: bulk actions + authorized count badge + chevron */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0, ml: 2 }}>
+          <BulkActionButtons
+            dataCyPrefix={`daa-${daaId}`}
+            approveAllDisabled={unauthorizedUserIds.length === 0}
+            removeAllDisabled={authorizedUserIds.length === 0}
+            onApproveAll={() => onApproveAll(unauthorizedUserIds)}
+            onRemoveAll={() => onRemoveAll(authorizedUserIds)}
+          />
           {authorizedCount > 0 && (
             <Chip
               label={`${authorizedCount} pre-authorized`}

--- a/src/pages/signing_official_console/DAAAssignment/DAAView.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAView.tsx
@@ -118,32 +118,32 @@ export default function DAAView({
   }, [allExpanded, filteredRows])
 
   const openAuthorizeDialog = useCallback(
-    (daaId: number, researcherId: number, daaLabel: string, researcherName: string) => {
-      setConfirmDialog({ daaId, researcherId, daaLabel, researcherName, action: 'authorize' })
+    (daaId: number, researcherId: number, daaLabelText: string, researcherName: string) => {
+      setConfirmDialog({ daaId, researcherId, daaLabel: daaLabelText, researcherName, action: 'authorize' })
     },
     [],
   )
 
   const openRevokeDialog = useCallback(
-    (daaId: number, researcherId: number, daaLabel: string, researcherName: string) => {
-      setConfirmDialog({ daaId, researcherId, daaLabel, researcherName, action: 'revoke' })
+    (daaId: number, researcherId: number, daaLabelText: string, researcherName: string) => {
+      setConfirmDialog({ daaId, researcherId, daaLabel: daaLabelText, researcherName, action: 'revoke' })
     },
     [],
   )
 
   const handleConfirm = useCallback(async () => {
     if (!confirmDialog) return
-    const { daaId, researcherId, researcherName, daaLabel, action } = confirmDialog
+    const { daaId, researcherId, researcherName, daaLabel: daaLabelText, action } = confirmDialog
     setConfirmDialog(null)
     try {
       if (action === 'authorize') {
         await DAA.createDaaLcLink(daaId, researcherId)
-        Notifications.showSuccess({ text: `Pre-authorized ${researcherName} for ${daaLabel}` })
+        Notifications.showSuccess({ text: `Pre-authorized ${researcherName} for ${daaLabelText}` })
       }
       else {
         await DAA.deleteDaaLcLink(daaId, researcherId)
         Notifications.showSuccess({
-          text: `Revoked access for ${researcherName} from ${daaLabel}`,
+          text: `Revoked access for ${researcherName} from ${daaLabelText}`,
         })
       }
       await refreshResearchers()
@@ -158,13 +158,13 @@ export default function DAAView({
   // ── Bulk handlers ─────────────────────────────────────────────────────────────
 
   const openBulkDialog = useCallback(
-    (daaId: number, daaLabel: string, mode: 'approve' | 'remove', userIds: number[]) => {
+    (daaId: number, daaLabelText: string, mode: 'approve' | 'remove', userIds: number[]) => {
       if (userIds.length === 0) return
       setBulkDialog({
         scope: 'daa',
         mode,
         targetId: daaId,
-        targetLabel: daaLabel,
+        targetLabel: daaLabelText,
         count: userIds.length,
         ids: userIds,
       })

--- a/src/pages/signing_official_console/DAAAssignment/DAAView.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAView.tsx
@@ -15,11 +15,25 @@ import { Notifications, USER_ROLES } from 'src/libs/utils'
 import DAAAccordionRow from './DAAAccordionRow'
 import ResearcherViewLegend from './ResearcherViewLegend'
 import ResearcherViewConfirmDialog from './ResearcherViewConfirmDialog'
-import { buildDAAViewRows } from './researcherViewHelpers'
-import { ConfirmDialogState, DAAAccordionData } from './types'
+import BulkActionConfirmDialog from './BulkActionConfirmDialog'
+import { buildDAAViewRows, daaLabel } from './researcherViewHelpers'
+import { useBulkPreAuthorization } from './useBulkPreAuthorization'
+import { BulkConfirmState, ConfirmDialogState, DAAAccordionData } from './types'
 
 const FONT = 'Montserrat'
 const BRAND_BLUE = '#0948b7'
+
+/** Success toast text for a bulk action on a DAA card (researchers per DAA). */
+function bulkSuccessText(mode: 'approve' | 'remove', applied: number, daaLabelText: string): string {
+  const plural = applied === 1 ? '' : 's'
+  return mode === 'approve'
+    ? `Pre-authorized ${applied} researcher${plural} for ${daaLabelText}`
+    : `Removed pre-authorization for ${applied} researcher${plural} from ${daaLabelText}`
+}
+
+function bulkErrorText(mode: 'approve' | 'remove', daaLabelText: string): string {
+  return `Failed to ${mode === 'approve' ? 'approve' : 'remove'} all researchers for ${daaLabelText}`
+}
 
 export interface DAAViewProps {
   readonly researchers: readonly DuosUser[]
@@ -52,6 +66,7 @@ export default function DAAView({
   const [search, setSearch] = useState('')
   const [expanded, setExpanded] = useState<Record<number, boolean>>({})
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null)
+  const [bulkDialog, setBulkDialog] = useState<BulkConfirmState | null>(null)
 
   // ── Data ────────────────────────────────────────────────────────────────────
 
@@ -65,7 +80,7 @@ export default function DAAView({
     if (!term) return daaRows
     return daaRows.filter(
       row =>
-        (row.daa.file?.fileName?.toLowerCase() ?? '').includes(term)
+        daaLabel(row.daa).toLowerCase().includes(term)
         || row.dacName.toLowerCase().includes(term),
     )
   }, [daaRows, search])
@@ -139,6 +154,33 @@ export default function DAAView({
       })
     }
   }, [confirmDialog, refreshResearchers])
+
+  // ── Bulk handlers ─────────────────────────────────────────────────────────────
+
+  const openBulkDialog = useCallback(
+    (daaId: number, daaLabel: string, mode: 'approve' | 'remove', userIds: number[]) => {
+      if (userIds.length === 0) return
+      setBulkDialog({
+        scope: 'daa',
+        mode,
+        targetId: daaId,
+        targetLabel: daaLabel,
+        count: userIds.length,
+        ids: userIds,
+      })
+    },
+    [],
+  )
+
+  const handleBulkConfirm = useBulkPreAuthorization({
+    bulkDialog,
+    setBulkDialog,
+    refresh: refreshResearchers,
+    add: DAA.bulkAddUsersToDaa,
+    remove: DAA.bulkRemoveUsersFromDaa,
+    successText: bulkSuccessText,
+    errorText: bulkErrorText,
+  })
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
@@ -239,26 +281,45 @@ export default function DAAView({
             onAuthorize={researcherId => openAuthorizeDialog(
               row.daa.daaId,
               researcherId,
-              row.daa.file?.fileName ?? `DAA-${row.daa.daaId}`,
+              daaLabel(row.daa),
               row.researcherRows.find(r => r.researcher.userId === researcherId)
                 ?.researcher.displayName ?? String(researcherId),
             )}
             onRevoke={researcherId => openRevokeDialog(
               row.daa.daaId,
               researcherId,
-              row.daa.file?.fileName ?? `DAA-${row.daa.daaId}`,
+              daaLabel(row.daa),
               row.researcherRows.find(r => r.researcher.userId === researcherId)
                 ?.researcher.displayName ?? String(researcherId),
+            )}
+            onApproveAll={userIds => openBulkDialog(
+              row.daa.daaId,
+              daaLabel(row.daa),
+              'approve',
+              userIds,
+            )}
+            onRemoveAll={userIds => openBulkDialog(
+              row.daa.daaId,
+              daaLabel(row.daa),
+              'remove',
+              userIds,
             )}
           />
         ))}
       </Box>
 
-      {/* Confirmation dialog (shared with ResearcherView) */}
+      {/* Single-relationship confirmation dialog (shared with ResearcherView) */}
       <ResearcherViewConfirmDialog
         dialog={confirmDialog}
         onConfirm={handleConfirm}
         onCancel={() => setConfirmDialog(null)}
+      />
+
+      {/* Bulk Approve All / Remove All confirmation dialog */}
+      <BulkActionConfirmDialog
+        dialog={bulkDialog}
+        onConfirm={handleBulkConfirm}
+        onCancel={() => setBulkDialog(null)}
       />
     </Box>
   )

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.tsx
@@ -8,6 +8,7 @@ import {
 } from '@mui/material'
 import { DuosUser } from 'src/types/model'
 import ResearcherDAASubtable from './ResearcherDAASubtable'
+import BulkActionButtons from './BulkActionButtons'
 import { DAARowData } from './types'
 
 const FONT = 'Montserrat'
@@ -20,6 +21,10 @@ interface ResearcherAccordionRowProps {
   onToggle: () => void
   onAuthorize: (daaId: number) => void
   onRevoke: (daaId: number) => void
+  /** Bulk "Approve All" — receives the ids of every not-yet-authorized DAA */
+  onApproveAll: (daaIds: number[]) => void
+  /** Bulk "Remove All" — receives the ids of every currently-authorized DAA */
+  onRemoveAll: (daaIds: number[]) => void
 }
 
 /**
@@ -36,8 +41,17 @@ export default function ResearcherAccordionRow({
   onToggle,
   onAuthorize,
   onRevoke,
+  onApproveAll,
+  onRemoveAll,
 }: Readonly<ResearcherAccordionRowProps>) {
   const researcherId = researcher.userId
+
+  const unauthorizedDaaIds = daaRows
+    .filter(r => r.status !== 'authorized')
+    .map(r => r.daa.daaId)
+  const authorizedDaaIds = daaRows
+    .filter(r => r.status === 'authorized')
+    .map(r => r.daa.daaId)
 
   return (
     <Paper
@@ -119,6 +133,13 @@ export default function ResearcherAccordionRow({
               No pre-auth status
             </Typography>
           )}
+          <BulkActionButtons
+            dataCyPrefix={`researcher-${researcherId}`}
+            approveAllDisabled={unauthorizedDaaIds.length === 0}
+            removeAllDisabled={authorizedDaaIds.length === 0}
+            onApproveAll={() => onApproveAll(unauthorizedDaaIds)}
+            onRemoveAll={() => onRemoveAll(authorizedDaaIds)}
+          />
         </Box>
       </Box>
 

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import {
   Box,
   Chip,
@@ -46,12 +46,14 @@ export default function ResearcherAccordionRow({
 }: Readonly<ResearcherAccordionRowProps>) {
   const researcherId = researcher.userId
 
-  const unauthorizedDaaIds = daaRows
-    .filter(r => r.status !== 'authorized')
-    .map(r => r.daa.daaId)
-  const authorizedDaaIds = daaRows
-    .filter(r => r.status === 'authorized')
-    .map(r => r.daa.daaId)
+  const unauthorizedDaaIds = useMemo(
+    () => daaRows.filter(r => r.status !== 'authorized').map(r => r.daa.daaId),
+    [daaRows],
+  )
+  const authorizedDaaIds = useMemo(
+    () => daaRows.filter(r => r.status === 'authorized').map(r => r.daa.daaId),
+    [daaRows],
+  )
 
   return (
     <Paper

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.tsx
@@ -10,7 +10,7 @@ import {
 import AuthStatusChip from './AuthStatusChip'
 import AuthActionButton from './AuthActionButton'
 import { AuthStatus, DAARowData } from './types'
-import { formatDateYYYYMMDD } from './researcherViewHelpers'
+import { daaLabel, formatDateYYYYMMDD } from './researcherViewHelpers'
 
 const FONT = 'Montserrat'
 
@@ -85,7 +85,7 @@ export default function ResearcherDAASubtable({
               <TableCell
                 sx={{ ...tableCellBodySx, fontWeight: 600, color: '#1a1a2e' }}
               >
-                {daa.file?.fileName ?? `DAA-${daa.daaId}`}
+                {daaLabel(daa)}
               </TableCell>
               <TableCell sx={tableCellBodySx}>{dacName}</TableCell>
               <TableCell sx={tableCellBodySx}>

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherView.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherView.tsx
@@ -15,11 +15,25 @@ import { Notifications, USER_ROLES } from 'src/libs/utils'
 import ResearcherAccordionRow from './ResearcherAccordionRow'
 import ResearcherViewLegend from './ResearcherViewLegend'
 import ResearcherViewConfirmDialog from './ResearcherViewConfirmDialog'
-import { ConfirmDialogState, DAARowData, ResearcherRowData } from './types'
-import { buildResearcherRows } from './researcherViewHelpers'
+import BulkActionConfirmDialog from './BulkActionConfirmDialog'
+import { BulkConfirmState, ConfirmDialogState, DAARowData, ResearcherRowData } from './types'
+import { buildResearcherRows, daaLabel } from './researcherViewHelpers'
+import { useBulkPreAuthorization } from './useBulkPreAuthorization'
 
 const FONT = 'Montserrat'
 const BRAND_BLUE = '#0948b7'
+
+/** Success toast text for a bulk action on a researcher card (DAAs per researcher). */
+function bulkSuccessText(mode: 'approve' | 'remove', applied: number, researcherLabel: string): string {
+  const plural = applied === 1 ? '' : 's'
+  return mode === 'approve'
+    ? `Pre-authorized ${researcherLabel} for ${applied} DAA${plural}`
+    : `Removed pre-authorization for ${researcherLabel} from ${applied} DAA${plural}`
+}
+
+function bulkErrorText(mode: 'approve' | 'remove', researcherLabel: string): string {
+  return `Failed to ${mode === 'approve' ? 'approve' : 'remove'} all DAAs for ${researcherLabel}`
+}
 
 export interface ResearcherViewProps {
   readonly researchers: readonly DuosUser[]
@@ -49,6 +63,7 @@ export default function ResearcherView({
   const [search, setSearch] = useState('')
   const [expanded, setExpanded] = useState<Record<number, boolean>>({})
   const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogState | null>(null)
+  const [bulkDialog, setBulkDialog] = useState<BulkConfirmState | null>(null)
 
   // ── Data ────────────────────────────────────────────────────────────────────
 
@@ -102,13 +117,12 @@ export default function ResearcherView({
 
   const openAuthorizeDialog = useCallback(
     (researcher: Readonly<DuosUser>, daaId: number, daaRows: readonly DAARowData[]) => {
-      const daaLabel
-        = daaRows.find(r => r.daa.daaId === daaId)?.daa.file?.fileName ?? `DAA-${daaId}`
+      const daa = daaRows.find(r => r.daa.daaId === daaId)?.daa
       setConfirmDialog({
         daaId,
         researcherId: researcher.userId,
         researcherName: researcher.displayName ?? researcher.email,
-        daaLabel,
+        daaLabel: daa ? daaLabel(daa) : `DAA-${daaId}`,
         action: 'authorize',
       })
     },
@@ -117,13 +131,12 @@ export default function ResearcherView({
 
   const openRevokeDialog = useCallback(
     (researcher: Readonly<DuosUser>, daaId: number, daaRows: readonly DAARowData[]) => {
-      const daaLabel
-        = daaRows.find(r => r.daa.daaId === daaId)?.daa.file?.fileName ?? `DAA-${daaId}`
+      const daa = daaRows.find(r => r.daa.daaId === daaId)?.daa
       setConfirmDialog({
         daaId,
         researcherId: researcher.userId,
         researcherName: researcher.displayName ?? researcher.email,
-        daaLabel,
+        daaLabel: daa ? daaLabel(daa) : `DAA-${daaId}`,
         action: 'revoke',
       })
     },
@@ -153,6 +166,33 @@ export default function ResearcherView({
       })
     }
   }, [confirmDialog, refreshResearchers])
+
+  // ── Bulk handlers ─────────────────────────────────────────────────────────────
+
+  const openBulkDialog = useCallback(
+    (researcher: Readonly<DuosUser>, mode: 'approve' | 'remove', daaIds: number[]) => {
+      if (daaIds.length === 0) return
+      setBulkDialog({
+        scope: 'researcher',
+        mode,
+        targetId: researcher.userId,
+        targetLabel: researcher.displayName ?? researcher.email,
+        count: daaIds.length,
+        ids: daaIds,
+      })
+    },
+    [],
+  )
+
+  const handleBulkConfirm = useBulkPreAuthorization({
+    bulkDialog,
+    setBulkDialog,
+    refresh: refreshResearchers,
+    add: DAA.bulkAddDaasToUser,
+    remove: DAA.bulkRemoveDaasFromUser,
+    successText: bulkSuccessText,
+    errorText: bulkErrorText,
+  })
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
@@ -250,15 +290,24 @@ export default function ResearcherView({
             onToggle={() => toggleRow(row.researcher.userId)}
             onAuthorize={daaId => openAuthorizeDialog(row.researcher, daaId, row.daaRows)}
             onRevoke={daaId => openRevokeDialog(row.researcher, daaId, row.daaRows)}
+            onApproveAll={daaIds => openBulkDialog(row.researcher, 'approve', daaIds)}
+            onRemoveAll={daaIds => openBulkDialog(row.researcher, 'remove', daaIds)}
           />
         ))}
       </Box>
 
-      {/* Confirmation dialog */}
+      {/* Single-relationship confirmation dialog */}
       <ResearcherViewConfirmDialog
         dialog={confirmDialog}
         onConfirm={handleConfirm}
         onCancel={() => setConfirmDialog(null)}
+      />
+
+      {/* Bulk Approve All / Remove All confirmation dialog */}
+      <BulkActionConfirmDialog
+        dialog={bulkDialog}
+        onConfirm={handleBulkConfirm}
+        onCancel={() => setBulkDialog(null)}
       />
     </Box>
   )

--- a/src/pages/signing_official_console/DAAAssignment/index.ts
+++ b/src/pages/signing_official_console/DAAAssignment/index.ts
@@ -13,6 +13,7 @@ export type { ResearcherViewProps } from './ResearcherView'
 export type { DAAViewProps } from './DAAView'
 export type {
   AuthStatus,
+  BulkConfirmState,
   ConfirmDialogState,
   DAAAccordionData,
   DAAResearcherRowData,

--- a/src/pages/signing_official_console/DAAAssignment/researcherViewHelpers.ts
+++ b/src/pages/signing_official_console/DAAAssignment/researcherViewHelpers.ts
@@ -69,6 +69,15 @@ export function getAuthorizedBy(researcher: DuosUser, daaId: number): string | u
 }
 
 /**
+ * Human-readable label for a DAA. Uses the uploaded file's name, falling back to
+ * a stable `DAA-<id>` token when no file name is available. Single source of truth
+ * for the DAA label shown across the DAA-assignment views, dialogs, and toasts.
+ */
+export function daaLabel(daa: DAAObject): string {
+  return daa.file?.fileName ?? `DAA-${daa.daaId}`
+}
+
+/**
  * Returns the display name for a DAA's associated DAC(s).
  * Joins multiple DAC names with " / " when a DAA spans more than one DAC.
  */

--- a/src/pages/signing_official_console/DAAAssignment/types.ts
+++ b/src/pages/signing_official_console/DAAAssignment/types.ts
@@ -47,3 +47,25 @@ export interface ConfirmDialogState {
   daaLabel: string
   action: 'authorize' | 'revoke'
 }
+
+/**
+ * State held while a *bulk* confirm dialog is open.
+ *
+ * Kept deliberately separate from {@link ConfirmDialogState} so the
+ * well-tested single-relationship flow stays untouched.
+ *
+ * - `scope: 'researcher'` — target is one researcher; `ids` are DAA ids.
+ * - `scope: 'daa'` — target is one DAA; `ids` are researcher (user) ids.
+ */
+export interface BulkConfirmState {
+  scope: 'researcher' | 'daa'
+  mode: 'approve' | 'remove'
+  /** userId when scope==='researcher', daaId when scope==='daa' */
+  targetId: number
+  /** Human-readable name of the target card (researcher name or DAA label) */
+  targetLabel: string
+  /** Number of relationships the action will affect */
+  count: number
+  /** The ids to send to the bulk endpoint (daaIds or userIds per scope) */
+  ids: number[]
+}

--- a/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
+++ b/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
@@ -43,9 +43,11 @@ export function useBulkPreAuthorization({
     const { mode, targetId, targetLabel, ids } = bulkDialog
     setBulkDialog(null)
     try {
-      const { applied } = await (mode === 'approve' ? add : remove)(targetId, ids)
+      const result = await (mode === 'approve' ? add : remove)(targetId, ids)
+      const applied = typeof (result as unknown as { applied?: unknown })?.applied === 'number'
+        ? (result as unknown as { applied: number }).applied
+        : ids.length
       Notifications.showSuccess({ text: successText(mode, applied, targetLabel) })
-      await refresh()
     }
     catch (error) {
       // Intentionally do not refresh on error, preserving the displayed state.

--- a/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
+++ b/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
@@ -48,6 +48,7 @@ export function useBulkPreAuthorization({
         ? (result as unknown as { applied: number }).applied
         : ids.length
       Notifications.showSuccess({ text: successText(mode, applied, targetLabel) })
+      await refresh()
     }
     catch (error) {
       // Intentionally do not refresh on error, preserving the displayed state.

--- a/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
+++ b/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
@@ -44,8 +44,23 @@ export function useBulkPreAuthorization({
     setBulkDialog(null)
     try {
       const result = await (mode === 'approve' ? add : remove)(targetId, ids)
-      const applied = typeof (result as unknown as { applied?: unknown })?.applied === 'number'
-        ? (result as unknown as { applied: number }).applied
+
+      // Defensive: the atomic bulk endpoints are all-or-nothing, so `errors` is
+      // expected to be empty. If a partial-failure response ever populates it,
+      // surface the failure and refresh to reflect whatever actually changed
+      // rather than reporting success.
+      if (Array.isArray(result?.errors) && result.errors.length > 0) {
+        console.error(`Bulk ${mode} for ${targetLabel} reported errors`, result.errors)
+        Notifications.showError({ text: errorText(mode, targetLabel) })
+        await refresh()
+        return
+      }
+
+      // TODO(otchet-dt-3325): `applied` may be absent until the companion backend
+      // PR ships the field; fall back to the requested count until then. Drop this
+      // guard (and read `result.applied` directly) once the backend returns it.
+      const applied = typeof (result as { applied?: unknown })?.applied === 'number'
+        ? (result as { applied: number }).applied
         : ids.length
       Notifications.showSuccess({ text: successText(mode, applied, targetLabel) })
       await refresh()

--- a/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
+++ b/src/pages/signing_official_console/DAAAssignment/useBulkPreAuthorization.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react'
+import { Notifications } from 'src/libs/utils'
+import { DaaBulkRelationResult } from 'src/types/model'
+import { BulkConfirmState } from './types'
+
+type BulkMode = BulkConfirmState['mode']
+type BulkMutation = (targetId: number, ids: number[]) => Promise<DaaBulkRelationResult>
+
+export interface UseBulkPreAuthorizationArgs {
+  readonly bulkDialog: BulkConfirmState | null
+  readonly setBulkDialog: (next: BulkConfirmState | null) => void
+  readonly refresh: () => Promise<void>
+  /** Bulk "Approve All" endpoint for this view's scope. */
+  readonly add: BulkMutation
+  /** Bulk "Remove All" endpoint for this view's scope. */
+  readonly remove: BulkMutation
+  /** Success toast text, given the server-applied count and the target card's label. */
+  readonly successText: (mode: BulkMode, applied: number, targetLabel: string) => string
+  /** Error toast text shown when the bulk call fails. */
+  readonly errorText: (mode: BulkMode, targetLabel: string) => string
+}
+
+/**
+ * The shared confirm handler for a bulk Approve All / Remove All action, used by
+ * both ResearcherView (DAAs per researcher) and DAAView (researchers per DAA).
+ *
+ * The two views differ only in which endpoints to call and how the toasts read,
+ * so those are injected; the dialog-close / call / success-toast / refresh flow —
+ * and the "log then error-toast, do not refresh" failure path that preserves the
+ * displayed state — lives here once.
+ */
+export function useBulkPreAuthorization({
+  bulkDialog,
+  setBulkDialog,
+  refresh,
+  add,
+  remove,
+  successText,
+  errorText,
+}: UseBulkPreAuthorizationArgs): () => Promise<void> {
+  return useCallback(async () => {
+    if (!bulkDialog) return
+    const { mode, targetId, targetLabel, ids } = bulkDialog
+    setBulkDialog(null)
+    try {
+      const { applied } = await (mode === 'approve' ? add : remove)(targetId, ids)
+      Notifications.showSuccess({ text: successText(mode, applied, targetLabel) })
+      await refresh()
+    }
+    catch (error) {
+      // Intentionally do not refresh on error, preserving the displayed state.
+      console.error(`Bulk ${mode} for ${targetLabel} failed`, error)
+      Notifications.showError({ text: errorText(mode, targetLabel) })
+    }
+  }, [bulkDialog, setBulkDialog, refresh, add, remove, successText, errorText])
+}

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -121,6 +121,21 @@ export interface DAAObject {
   dacs: Array<DacObject>
 }
 
+/**
+ * Result body returned by the atomic bulk pre-authorization endpoints
+ * (`/api/daa/bulk/...`). The backend operation is all-or-nothing with respect to
+ * failure, so `errors` is always empty on a returned summary. `applied` counts only
+ * the relationships that actually changed; requested items already in the desired
+ * state (re-adding an existing pre-authorization, or removing one that was never
+ * present) are no-ops counted under `skipped`, so `applied + skipped === requested`.
+ */
+export interface DaaBulkRelationResult {
+  requested: number
+  applied: number
+  skipped: number
+  errors: string[]
+}
+
 export interface DacObject {
   dacId?: number
   dacName?: string

--- a/test/libs/ajax/DAA.spec.ts
+++ b/test/libs/ajax/DAA.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { DAA } from 'src/libs/ajax/DAA'
 import { Config } from 'src/libs/config'
-import type { DAAObject } from 'src/types/model'
+import type { DAAObject, DaaBulkRelationResult } from 'src/types/model'
 import type { FetchData } from 'src/libs/ajax/fetchAdapter'
 import { fetchGet, fetchPost, fetchPut, fetchDelete, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
 import * as FileDownload from 'src/utils/FileDownload'
@@ -87,49 +87,53 @@ describe('DAA ajax', () => {
     expect(fetchDelete).toHaveBeenCalledWith(`${apiUrl}/api/daa/${mockDaa.daaId}/2001`, authHeaders)
   })
 
-  it('bulkAddUsersToDaa sends a POST request with user ids and returns 200', async () => {
+  it('bulkAddUsersToDaa sends a POST request with user ids and returns the result body', async () => {
     const users = [1, 2, 3]
-    vi.mocked(fetchPost).mockResolvedValue({} as FetchData<void>)
+    const summary: DaaBulkRelationResult = { requested: 3, applied: 3, skipped: 0, errors: [] }
+    vi.mocked(fetchPost).mockResolvedValue({ data: summary } as FetchData<DaaBulkRelationResult>)
 
     const result = await DAA.bulkAddUsersToDaa(mockDaa.daaId, users)
 
-    expect(result).toBe(200)
-    expect(fetchPost).toHaveBeenCalledWith(`${apiUrl}/api/daa/bulk/${mockDaa.daaId}`, users, authHeaders)
+    expect(result).toEqual(summary)
+    expect(fetchPost).toHaveBeenCalledWith(`${apiUrl}/api/daa/bulk/${mockDaa.daaId}`, { users }, authHeaders)
   })
 
-  it('bulkRemoveUsersFromDaa sends a DELETE request with user ids in body and returns 200', async () => {
+  it('bulkRemoveUsersFromDaa sends a DELETE request with user ids in body and returns the result body', async () => {
     const users = [3, 4]
-    vi.mocked(fetchDelete).mockResolvedValue({} as FetchData<void>)
+    const summary: DaaBulkRelationResult = { requested: 2, applied: 2, skipped: 0, errors: [] }
+    vi.mocked(fetchDelete).mockResolvedValue({ data: summary } as FetchData<DaaBulkRelationResult>)
 
     const result = await DAA.bulkRemoveUsersFromDaa(mockDaa.daaId, users)
 
-    expect(result).toBe(200)
+    expect(result).toEqual(summary)
     expect(fetchDelete).toHaveBeenCalledWith(
       `${apiUrl}/api/daa/bulk/${mockDaa.daaId}`,
-      expect.objectContaining({ data: users }),
+      expect.objectContaining({ data: { users } }),
     )
   })
 
-  it('bulkAddDaasToUser sends a POST request with daa ids and returns 200', async () => {
+  it('bulkAddDaasToUser sends a POST request with daa ids and returns the result body', async () => {
     const daas = [10, 11]
-    vi.mocked(fetchPost).mockResolvedValue({} as FetchData<void>)
+    const summary: DaaBulkRelationResult = { requested: 2, applied: 2, skipped: 0, errors: [] }
+    vi.mocked(fetchPost).mockResolvedValue({ data: summary } as FetchData<DaaBulkRelationResult>)
 
     const result = await DAA.bulkAddDaasToUser(2001, daas)
 
-    expect(result).toBe(200)
-    expect(fetchPost).toHaveBeenCalledWith(`${apiUrl}/api/daa/bulk/user/2001`, daas, authHeaders)
+    expect(result).toEqual(summary)
+    expect(fetchPost).toHaveBeenCalledWith(`${apiUrl}/api/daa/bulk/user/2001`, { daaList: daas }, authHeaders)
   })
 
-  it('bulkRemoveDaasFromUser sends a DELETE request with daa ids in body and returns 200', async () => {
+  it('bulkRemoveDaasFromUser sends a DELETE request with daa ids in body and returns the result body', async () => {
     const daas = [10, 11]
-    vi.mocked(fetchDelete).mockResolvedValue({} as FetchData<void>)
+    const summary: DaaBulkRelationResult = { requested: 2, applied: 2, skipped: 0, errors: [] }
+    vi.mocked(fetchDelete).mockResolvedValue({ data: summary } as FetchData<DaaBulkRelationResult>)
 
     const result = await DAA.bulkRemoveDaasFromUser(2001, daas)
 
-    expect(result).toBe(200)
+    expect(result).toEqual(summary)
     expect(fetchDelete).toHaveBeenCalledWith(
       `${apiUrl}/api/daa/bulk/user/2001`,
-      expect.objectContaining({ data: daas }),
+      expect.objectContaining({ data: { daaList: daas } }),
     )
   })
 

--- a/test/pages/signing_official_console/DAAAssignment/BulkActionButtons.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/BulkActionButtons.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BulkActionButtons from 'src/pages/signing_official_console/DAAAssignment/BulkActionButtons'
+
+describe('BulkActionButtons', () => {
+  let approveSpy: () => void
+  let removeSpy: () => void
+
+  beforeEach(() => {
+    approveSpy = vi.fn()
+    removeSpy = vi.fn()
+  })
+
+  const mount = (overrides: Partial<React.ComponentProps<typeof BulkActionButtons>> = {}) =>
+    render(
+      <BulkActionButtons
+        dataCyPrefix="researcher-7"
+        approveAllDisabled={false}
+        removeAllDisabled={false}
+        onApproveAll={approveSpy}
+        onRemoveAll={removeSpy}
+        {...overrides}
+      />,
+    )
+
+  it('renders both bulk buttons with prefixed data-cy hooks', () => {
+    const { container } = mount()
+    expect(container.querySelector('[data-cy="bulk-approve-all-researcher-7"]')).toHaveTextContent('Approve All')
+    expect(container.querySelector('[data-cy="bulk-remove-all-researcher-7"]')).toHaveTextContent('Remove All')
+  })
+
+  it('calls onApproveAll when Approve All is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-7"]') as HTMLElement)
+    expect(approveSpy).toHaveBeenCalledOnce()
+  })
+
+  it('calls onRemoveAll when Remove All is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-remove-all-researcher-7"]') as HTMLElement)
+    expect(removeSpy).toHaveBeenCalledOnce()
+  })
+
+  it('stops click propagation so an enclosing toggle does not fire', async () => {
+    const user = userEvent.setup()
+    const parentClick = vi.fn()
+    const { container } = render(
+      <div onClick={parentClick}>
+        <BulkActionButtons
+          dataCyPrefix="researcher-7"
+          approveAllDisabled={false}
+          removeAllDisabled={false}
+          onApproveAll={approveSpy}
+          onRemoveAll={removeSpy}
+        />
+      </div>,
+    )
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-7"]') as HTMLElement)
+    expect(approveSpy).toHaveBeenCalledOnce()
+    expect(parentClick).not.toHaveBeenCalled()
+  })
+
+  it('renders a disabled Approve All that does not fire when clicked', async () => {
+    // pointerEventsCheck off: MUI disabled buttons set pointer-events:none, which
+    // otherwise makes userEvent throw before we can assert the click is a no-op.
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const { container } = mount({ approveAllDisabled: true })
+    const btn = container.querySelector('[data-cy="bulk-approve-all-researcher-7"]') as HTMLElement
+    expect(btn).toBeDisabled()
+    await user.click(btn)
+    expect(approveSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders a disabled Remove All that does not fire when clicked', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const { container } = mount({ removeAllDisabled: true })
+    const btn = container.querySelector('[data-cy="bulk-remove-all-researcher-7"]') as HTMLElement
+    expect(btn).toBeDisabled()
+    await user.click(btn)
+    expect(removeSpy).not.toHaveBeenCalled()
+  })
+})

--- a/test/pages/signing_official_console/DAAAssignment/BulkActionConfirmDialog.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/BulkActionConfirmDialog.spec.tsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import BulkActionConfirmDialog from 'src/pages/signing_official_console/DAAAssignment/BulkActionConfirmDialog'
+import { BulkConfirmState } from 'src/pages/signing_official_console/DAAAssignment/types'
+
+describe('BulkActionConfirmDialog', () => {
+  let confirmSpy: () => void
+  let cancelSpy: () => void
+
+  beforeEach(() => {
+    confirmSpy = vi.fn()
+    cancelSpy = vi.fn()
+  })
+
+  const mount = (dialog: BulkConfirmState | null) =>
+    render(
+      <BulkActionConfirmDialog
+        dialog={dialog}
+        onConfirm={confirmSpy}
+        onCancel={cancelSpy}
+      />,
+    )
+
+  it('renders nothing when dialog is null', () => {
+    mount(null)
+    expect(document.body.querySelector('[data-cy="bulk-confirm-dialog"]')).not.toBeInTheDocument()
+  })
+
+  it('shows the approve title/count for a researcher card (DAA noun)', () => {
+    mount({ scope: 'researcher', mode: 'approve', targetId: 1, targetLabel: 'Jane Doe', count: 7, ids: [1, 2, 3, 4, 5, 6, 7] })
+    const dialog = document.body.querySelector('[data-cy="bulk-confirm-dialog"]')
+    expect(dialog).toHaveTextContent('Approve pre-authorization for all 7 remaining DAAs for Jane Doe?')
+    expect(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]')).toHaveTextContent('Approve All')
+  })
+
+  it('shows the remove title/count for a DAA card (researcher noun)', () => {
+    mount({ scope: 'daa', mode: 'remove', targetId: 5, targetLabel: 'DAA-x', count: 12, ids: Array.from({ length: 12 }, (_, i) => i + 1) })
+    const dialog = document.body.querySelector('[data-cy="bulk-confirm-dialog"]')
+    expect(dialog).toHaveTextContent('Remove pre-authorization for all 12 researchers under DAA-x?')
+    expect(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]')).toHaveTextContent('Remove All')
+  })
+
+  it('uses the singular noun when count is 1', () => {
+    mount({ scope: 'researcher', mode: 'approve', targetId: 1, targetLabel: 'Jane Doe', count: 1, ids: [3] })
+    expect(document.body.querySelector('[data-cy="bulk-confirm-dialog"]')).toHaveTextContent('all 1 remaining DAA for Jane Doe?')
+  })
+
+  it('calls onConfirm when the confirm button is clicked', async () => {
+    const user = userEvent.setup()
+    mount({ scope: 'researcher', mode: 'approve', targetId: 1, targetLabel: 'Jane Doe', count: 2, ids: [1, 2] })
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    expect(confirmSpy).toHaveBeenCalledOnce()
+  })
+
+  it('calls onCancel when the cancel button is clicked', async () => {
+    const user = userEvent.setup()
+    mount({ scope: 'daa', mode: 'remove', targetId: 5, targetLabel: 'DAA-x', count: 2, ids: [1, 2] })
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-cancel"]') as HTMLElement)
+    expect(cancelSpy).toHaveBeenCalledOnce()
+  })
+})

--- a/test/pages/signing_official_console/DAAAssignment/DAAAccordionRow.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAAccordionRow.spec.tsx
@@ -65,11 +65,15 @@ describe('DAAAccordionRow', () => {
   let authorizeSpy: (researcherId: number) => void
   let revokeSpy: (researcherId: number) => void
   let toggleSpy: () => void
+  let approveAllSpy: (researcherIds: number[]) => void
+  let removeAllSpy: (researcherIds: number[]) => void
 
   beforeEach(() => {
     authorizeSpy = vi.fn()
     revokeSpy = vi.fn()
     toggleSpy = vi.fn()
+    approveAllSpy = vi.fn()
+    removeAllSpy = vi.fn()
   })
 
   const mount = (overrides: Partial<React.ComponentProps<typeof DAAAccordionRow>> = {}) =>
@@ -84,6 +88,8 @@ describe('DAAAccordionRow', () => {
         onToggle={toggleSpy}
         onAuthorize={authorizeSpy}
         onRevoke={revokeSpy}
+        onApproveAll={approveAllSpy}
+        onRemoveAll={removeAllSpy}
         {...overrides}
       />,
     )
@@ -148,5 +154,46 @@ describe('DAAAccordionRow', () => {
   it('does not show the warning banner when not recently updated', () => {
     const { container } = mount({ isExpanded: true })
     expect(container.querySelector('[data-cy="daa-recently-updated-banner-5"]')).not.toBeInTheDocument()
+  })
+
+  // ── Bulk actions ──────────────────────────────────────────────────────────
+
+  it('calls onApproveAll with only the unauthorized researcher ids, without toggling', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-daa-5"]') as HTMLElement)
+    expect(approveAllSpy).toHaveBeenCalledWith([2])
+    expect(toggleSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls onRemoveAll with only the authorized researcher ids, without toggling', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-remove-all-daa-5"]') as HTMLElement)
+    expect(removeAllSpy).toHaveBeenCalledWith([1])
+    expect(toggleSpy).not.toHaveBeenCalled()
+  })
+
+  it('disables Approve All when every researcher is already authorized', () => {
+    const allAuthorized = mockRows.map(r => ({ ...r, status: 'authorized' as const }))
+    const { container } = mount({ researcherRows: allAuthorized })
+    expect(container.querySelector('[data-cy="bulk-approve-all-daa-5"]')).toBeDisabled()
+    expect(container.querySelector('[data-cy="bulk-remove-all-daa-5"]')).not.toBeDisabled()
+  })
+
+  it('disables Remove All when no researcher is authorized', () => {
+    const noneAuthorized = mockRows.map(r => ({ ...r, status: 'not_requested' as const }))
+    const { container } = mount({ researcherRows: noneAuthorized })
+    expect(container.querySelector('[data-cy="bulk-remove-all-daa-5"]')).toBeDisabled()
+    expect(container.querySelector('[data-cy="bulk-approve-all-daa-5"]')).not.toBeDisabled()
+  })
+
+  it('a disabled bulk button does nothing when clicked', async () => {
+    // pointerEventsCheck off: MUI disabled buttons set pointer-events:none.
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const noneAuthorized = mockRows.map(r => ({ ...r, status: 'not_requested' as const }))
+    const { container } = mount({ researcherRows: noneAuthorized })
+    await user.click(container.querySelector('[data-cy="bulk-remove-all-daa-5"]') as HTMLElement)
+    expect(removeAllSpy).not.toHaveBeenCalled()
   })
 })

--- a/test/pages/signing_official_console/DAAAssignment/DAAView.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAView.spec.tsx
@@ -128,6 +128,11 @@ describe('DAAView', () => {
   beforeEach(() => {
     refreshSpy = vi.fn()
     vi.spyOn(User, 'list').mockResolvedValue(mockResearchers)
+    // Stub the toasts so success/error paths don't spin up real React roots
+    // (createRoot on a body-appended div) that leak across tests. Individual
+    // tests may re-spy to assert on the toast text.
+    vi.spyOn(Notifications, 'showSuccess').mockImplementation(() => undefined)
+    vi.spyOn(Notifications, 'showError').mockImplementation(() => undefined)
   })
 
   afterEach(() => vi.restoreAllMocks())

--- a/test/pages/signing_official_console/DAAAssignment/DAAView.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAView.spec.tsx
@@ -10,8 +10,16 @@ import {
 } from 'src/pages/signing_official_console/DAAAssignment/researcherViewHelpers'
 import { DAA } from 'src/libs/ajax/DAA'
 import { User } from 'src/libs/ajax/User'
-import { DuosUser, DAAObject } from 'src/types/model'
+import { Notifications } from 'src/libs/utils'
+import { DuosUser, DAAObject, DaaBulkRelationResult } from 'src/types/model'
 import { makeDaa, makeResearcher } from './fixtures'
+
+const bulkResult = (applied: number): DaaBulkRelationResult => ({
+  requested: applied,
+  applied,
+  skipped: 0,
+  errors: [],
+})
 
 const mockDaas: DAAObject[] = [
   makeDaa({ broadDaa: true, daaId: 1, fileName: 'Default DUOS DAA', dacId: 10 }),
@@ -283,5 +291,77 @@ describe('DAAView', () => {
     const { container } = mount()
     await user.click(container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement)
     expect(container.querySelector('[data-cy="daa-authorized-by-2"]')).toHaveTextContent('—')
+  })
+
+  // ── Bulk Approve All / Remove All ──────────────────────────────────────────
+
+  // DAA 2 has no authorized researchers → both users (ids 1 & 2) are "remaining".
+  it('opens the bulk dialog with the remaining-researcher count when Approve All is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-daa-2"]') as HTMLElement)
+    const dialog = document.body.querySelector('[data-cy="bulk-confirm-dialog"]')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveTextContent('all 2 remaining researchers under GTEx Access Agreement?')
+  })
+
+  it('calls bulkAddUsersToDaa with exactly the unauthorized ids and refreshes on confirm', async () => {
+    const bulkAdd = vi.spyOn(DAA, 'bulkAddUsersToDaa').mockResolvedValue(bulkResult(2))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-daa-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(bulkAdd).toHaveBeenCalledWith(2, [1, 2]))
+    await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  it('success toast reflects the applied count from the server response, not the client-side count', async () => {
+    // ids sent = [1, 2] (count 2), but the server reports 5 applied — the toast must echo the server.
+    vi.spyOn(DAA, 'bulkAddUsersToDaa').mockResolvedValue(bulkResult(5))
+    const successSpy = vi.spyOn(Notifications, 'showSuccess').mockImplementation(() => undefined)
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-daa-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() =>
+      expect(successSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining('5 researchers') }),
+      ))
+  })
+
+  it('calls bulkRemoveUsersFromDaa with exactly the authorized ids on confirm', async () => {
+    // DAA 1 has one authorized researcher (user 1).
+    const bulkRemove = vi.spyOn(DAA, 'bulkRemoveUsersFromDaa').mockResolvedValue(bulkResult(1))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-remove-all-daa-1"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(bulkRemove).toHaveBeenCalledWith(1, [1]))
+    await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  it('makes no API call when the bulk dialog is cancelled', async () => {
+    const bulkAdd = vi.spyOn(DAA, 'bulkAddUsersToDaa').mockResolvedValue(bulkResult(2))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-daa-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-cancel"]') as HTMLElement)
+    expect(document.body.querySelector('[data-cy="bulk-confirm-dialog"]')).not.toBeInTheDocument()
+    expect(bulkAdd).not.toHaveBeenCalled()
+  })
+
+  it('does not refresh when the bulk call fails (preserves displayed state)', async () => {
+    vi.spyOn(DAA, 'bulkAddUsersToDaa').mockRejectedValue(new Error('boom'))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-daa-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(DAA.bulkAddUsersToDaa).toHaveBeenCalled())
+    expect(User.list).not.toHaveBeenCalled()
+  })
+
+  it('disables Remove All for a DAA with no authorized researchers', () => {
+    const { container } = mount()
+    expect(container.querySelector('[data-cy="bulk-remove-all-daa-2"]')).toBeDisabled()
   })
 })

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.spec.tsx
@@ -32,11 +32,15 @@ describe('ResearcherAccordionRow', () => {
   let authorizeSpy: (daaId: number) => void
   let revokeSpy: (daaId: number) => void
   let toggleSpy: () => void
+  let approveAllSpy: (daaIds: number[]) => void
+  let removeAllSpy: (daaIds: number[]) => void
 
   beforeEach(() => {
     authorizeSpy = vi.fn()
     revokeSpy = vi.fn()
     toggleSpy = vi.fn()
+    approveAllSpy = vi.fn()
+    removeAllSpy = vi.fn()
   })
 
   const mount = (overrides: Partial<React.ComponentProps<typeof ResearcherAccordionRow>> = {}) =>
@@ -49,6 +53,8 @@ describe('ResearcherAccordionRow', () => {
         onToggle={toggleSpy}
         onAuthorize={authorizeSpy}
         onRevoke={revokeSpy}
+        onApproveAll={approveAllSpy}
+        onRemoveAll={removeAllSpy}
         {...overrides}
       />,
     )
@@ -86,5 +92,46 @@ describe('ResearcherAccordionRow', () => {
     expect(container.querySelector('[data-cy="daa-subtable"]')).toBeInTheDocument()
     expect(container.querySelector('[data-cy="daa-row-1"]')).toBeInTheDocument()
     expect(container.querySelector('[data-cy="daa-row-2"]')).toBeInTheDocument()
+  })
+
+  // ── Bulk actions ──────────────────────────────────────────────────────────
+
+  it('calls onApproveAll with only the unauthorized DAA ids, without toggling', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-42"]') as HTMLElement)
+    expect(approveAllSpy).toHaveBeenCalledWith([2])
+    expect(toggleSpy).not.toHaveBeenCalled()
+  })
+
+  it('calls onRemoveAll with only the authorized DAA ids, without toggling', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-remove-all-researcher-42"]') as HTMLElement)
+    expect(removeAllSpy).toHaveBeenCalledWith([1])
+    expect(toggleSpy).not.toHaveBeenCalled()
+  })
+
+  it('disables Approve All when every DAA is already authorized', () => {
+    const allAuthorized = mockDaaRows.map(r => ({ ...r, status: 'authorized' as const }))
+    const { container } = mount({ daaRows: allAuthorized })
+    expect(container.querySelector('[data-cy="bulk-approve-all-researcher-42"]')).toBeDisabled()
+    expect(container.querySelector('[data-cy="bulk-remove-all-researcher-42"]')).not.toBeDisabled()
+  })
+
+  it('disables Remove All when no DAA is authorized', () => {
+    const noneAuthorized = mockDaaRows.map(r => ({ ...r, status: 'not_requested' as const }))
+    const { container } = mount({ daaRows: noneAuthorized })
+    expect(container.querySelector('[data-cy="bulk-remove-all-researcher-42"]')).toBeDisabled()
+    expect(container.querySelector('[data-cy="bulk-approve-all-researcher-42"]')).not.toBeDisabled()
+  })
+
+  it('a disabled bulk button does nothing when clicked', async () => {
+    // pointerEventsCheck off: MUI disabled buttons set pointer-events:none.
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const allAuthorized = mockDaaRows.map(r => ({ ...r, status: 'authorized' as const }))
+    const { container } = mount({ daaRows: allAuthorized })
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-42"]') as HTMLElement)
+    expect(approveAllSpy).not.toHaveBeenCalled()
   })
 })

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherView.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherView.spec.tsx
@@ -107,6 +107,11 @@ describe('ResearcherView', () => {
   beforeEach(() => {
     refreshSpy = vi.fn()
     vi.spyOn(User, 'list').mockResolvedValue(mockResearchers)
+    // Stub the toasts so success/error paths don't spin up real React roots
+    // (createRoot on a body-appended div) that leak across tests. Individual
+    // tests may re-spy to assert on the toast text.
+    vi.spyOn(Notifications, 'showSuccess').mockImplementation(() => undefined)
+    vi.spyOn(Notifications, 'showError').mockImplementation(() => undefined)
   })
 
   afterEach(() => vi.restoreAllMocks())

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherView.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherView.spec.tsx
@@ -11,8 +11,16 @@ import {
 } from 'src/pages/signing_official_console/DAAAssignment/researcherViewHelpers'
 import { DAA } from 'src/libs/ajax/DAA'
 import { User } from 'src/libs/ajax/User'
-import { DuosUser, DAAObject } from 'src/types/model'
+import { Notifications } from 'src/libs/utils'
+import { DuosUser, DAAObject, DaaBulkRelationResult } from 'src/types/model'
 import { makeDaa, makeResearcher } from './fixtures'
+
+const bulkResult = (applied: number): DaaBulkRelationResult => ({
+  requested: applied,
+  applied,
+  skipped: 0,
+  errors: [],
+})
 
 const mockDaas: DAAObject[] = [
   makeDaa({ broadDaa: true, daaId: 1, fileName: 'Default DUOS DAA', dacId: 10 }),
@@ -219,5 +227,77 @@ describe('ResearcherView', () => {
     await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
     await waitFor(() => expect(DAA.deleteDaaLcLink).toHaveBeenCalledOnce())
     await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  // ── Bulk Approve All / Remove All ──────────────────────────────────────────
+
+  // User 2 is authorized for nothing → both DAAs (ids 1 & 2) are "remaining".
+  it('opens the bulk dialog with the remaining-DAA count when Approve All is clicked', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-2"]') as HTMLElement)
+    const dialog = document.body.querySelector('[data-cy="bulk-confirm-dialog"]')
+    expect(dialog).toBeInTheDocument()
+    expect(dialog).toHaveTextContent('all 2 remaining DAAs for Test User Beta?')
+  })
+
+  it('calls bulkAddDaasToUser with exactly the unauthorized ids and refreshes on confirm', async () => {
+    const bulkAdd = vi.spyOn(DAA, 'bulkAddDaasToUser').mockResolvedValue(bulkResult(2))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(bulkAdd).toHaveBeenCalledWith(2, [1, 2]))
+    await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  it('success toast reflects the applied count from the server response, not the client-side count', async () => {
+    // ids sent = [1, 2] (count 2), but the server reports 5 applied — the toast must echo the server.
+    vi.spyOn(DAA, 'bulkAddDaasToUser').mockResolvedValue(bulkResult(5))
+    const successSpy = vi.spyOn(Notifications, 'showSuccess').mockImplementation(() => undefined)
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() =>
+      expect(successSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining('for 5 DAAs') }),
+      ))
+  })
+
+  it('calls bulkRemoveDaasFromUser with exactly the authorized ids on confirm', async () => {
+    // User 1 is authorized for DAA 1 only.
+    const bulkRemove = vi.spyOn(DAA, 'bulkRemoveDaasFromUser').mockResolvedValue(bulkResult(1))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-remove-all-researcher-1"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(bulkRemove).toHaveBeenCalledWith(1, [1]))
+    await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  it('makes no API call when the bulk dialog is cancelled', async () => {
+    const bulkAdd = vi.spyOn(DAA, 'bulkAddDaasToUser').mockResolvedValue(bulkResult(2))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-cancel"]') as HTMLElement)
+    expect(document.body.querySelector('[data-cy="bulk-confirm-dialog"]')).not.toBeInTheDocument()
+    expect(bulkAdd).not.toHaveBeenCalled()
+  })
+
+  it('does not refresh when the bulk call fails (preserves displayed state)', async () => {
+    vi.spyOn(DAA, 'bulkAddDaasToUser').mockRejectedValue(new Error('boom'))
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-2"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="bulk-confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(DAA.bulkAddDaasToUser).toHaveBeenCalled())
+    expect(User.list).not.toHaveBeenCalled()
+  })
+
+  it('disables Remove All for a researcher with no authorizations', () => {
+    const { container } = mount()
+    expect(container.querySelector('[data-cy="bulk-remove-all-researcher-2"]')).toBeDisabled()
   })
 })


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3325](https://broadworkbench.atlassian.net/browse/DT-3325)

### Summary

Adds bulk **Approve All / Remove All** pre-authorization to the SO "Pre-Authorize Researchers"
console, in both directions — all researchers under a DAA (DAAView) and all DAAs for a researcher
(ResearcherView). Each action confirms, calls the atomic bulk endpoint, and toasts the
server-reported count.

> Companion service change: `consent` (`otchet-dt-3325-bulk-daa-assignment`). **Deploy that first** —
> the toast reads the new response body, otherwise the count shows "undefined".

#### Changes
- **UI**: `BulkActionButtons` (per accordion card) + `BulkActionConfirmDialog`, wired into `DAAView`
  and `ResearcherView`. Approve/Remove target only the not-yet-authorized / currently-authorized ids.
- **Shared hook** (`useBulkPreAuthorization`): both views share one confirm→call→toast→refresh flow;
  each injects only its endpoints and toast text. Failures log and error-toast **without** refreshing,
  preserving displayed state.
- **Ajax** (`DAA.ts`): bulk methods send `{ users }` / `{ daaList }` and return the typed
  `DaaBulkRelationResult`; the success toast uses its `applied` count.
- **Types**: new `DaaBulkRelationResult` (`model.ts`) and `BulkConfirmState` (`types.ts`); new
  `daaLabel(daa)` helper as the single source of truth for the DAA label (replaces the inlined
  `file?.fileName ?? DAA-<id>` fallback across the views/dialogs/toasts).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
