### PR TITLE
[DT-3607] Fix `ERR_HTTP_HEADERS_SENT` crash on BFF auth routes

### DIFF
--- a/server/src/auth/callback.ts
+++ b/server/src/auth/callback.ts
@@ -44,6 +44,16 @@ export async function handleCallback(request: FastifyRequest, reply: FastifyRepl
   delete request.session.pkceVerifier
   delete request.session.pkceState
 
+  // Persist the session BEFORE responding. Otherwise, @fastify/session saves it
+  // in an async onSend hook (pgStore.set is a DB round-trip); since this handler
+  // is async, its promise resolves while that save is still in flight, so
+  // reply.sent is still false and Fastify's wrapThenable fires a SECOND
+  // reply.send() — a duplicate onSend/session-save whose late writeHead throws
+  // ERR_HTTP_HEADERS_SENT and crashes the process. Saving here resets the
+  // session's modified-hash, so onSend finds it unmodified, skips the async
+  // store write, and completes synchronously — no second send.
+  await request.session.save()
+
   // returnTo was validated to a same-origin path by safeReturnTo() at login —
   // only sanitized values ever reach the session.
   reply.redirect(request.session.returnTo ?? '/')

--- a/server/src/auth/login.ts
+++ b/server/src/auth/login.ts
@@ -51,5 +51,12 @@ export async function handleLogin(request: FastifyRequest, reply: FastifyReply):
     state,
   })
 
+  // Persist the session BEFORE responding, so @fastify/session's async onSend
+  // save (pgStore.set) doesn't still be in flight when this async handler
+  // resolves — otherwise Fastify's wrapThenable fires a second reply.send() and
+  // the duplicate session write crashes with ERR_HTTP_HEADERS_SENT. See the
+  // fuller note in callback.ts. (This race is why /auth/login was flaky.)
+  await request.session.save()
+
   reply.send({ redirectUrl: redirectUrl.href }) // buildAuthorizationUrl returns a URL
 }

--- a/server/src/auth/login.ts
+++ b/server/src/auth/login.ts
@@ -52,7 +52,7 @@ export async function handleLogin(request: FastifyRequest, reply: FastifyReply):
   })
 
   // Persist the session BEFORE responding, so @fastify/session's async onSend
-  // save (pgStore.set) doesn't still be in flight when this async handler
+  // save (pgStore.set) isn't in flight when this async handler
   // resolves — otherwise Fastify's wrapThenable fires a second reply.send() and
   // the duplicate session write crashes with ERR_HTTP_HEADERS_SENT. See the
   // fuller note in callback.ts. (This race is why /auth/login was flaky.)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -133,10 +133,24 @@ export async function buildApp(): Promise<AppInstance> {
         path: '/',
       },
       saveUninitialized: false,
-      // No `rolling`: sessions get a fixed maxAge from creation. Rolling expiry
-      // would re-save the session (SELECT + UPSERT) on every session-bearing
-      // request just to bump `expire`. Phase 2 adds a throttled sliding expiry
-      // instead — re-save only when the session is near expiry.
+      // `rolling: false` — MUST be set explicitly: @fastify/session defaults it
+      // to true. Two reasons it matters here:
+      //   1. Behavior: sessions get a fixed maxAge from creation. Rolling expiry
+      //      would re-save the session (SELECT + UPSERT) on every session-bearing
+      //      request just to bump `expire`. Phase 2 adds a throttled sliding
+      //      expiry instead — re-save only when the session is near expiry.
+      //   2. Correctness: with rolling on, the onSend save hook fires an async
+      //      DB write on every request that carries a session cookie, even when
+      //      the handler already called `request.session.save()` and nothing
+      //      else mutated the session. That async onSend leaves `reply.sent`
+      //      false when the async route handler resolves, so Fastify's
+      //      wrapThenable fires a SECOND reply.send(); the later save's writeHead
+      //      then throws ERR_HTTP_HEADERS_SENT and crashes the process. With
+      //      rolling off (+ saveUninitialized off + the pre-response save() in
+      //      the auth handlers), onSend finds the session unmodified and skips
+      //      the write synchronously, so the reply is fully sent before the
+      //      handler promise resolves and no second send happens.
+      rolling: false,
     })
 
     // Warm the B2C OIDC discovery cache so the first login doesn't pay the

--- a/server/test/callback.test.ts
+++ b/server/test/callback.test.ts
@@ -42,6 +42,7 @@ function makeRequest(overrides: {
       pkceVerifier: 'pkceVerifier' in overrides ? overrides.pkceVerifier : 'test-verifier',
       pkceState: 'pkceState' in overrides ? overrides.pkceState : 'test-state',
       returnTo: overrides.returnTo,
+      save: vi.fn().mockResolvedValue(undefined),
     },
   } as unknown as FastifyRequest
 }
@@ -169,6 +170,20 @@ describe('handleCallback', () => {
     await handleCallback(makeRequest(), reply)
 
     expect(reply.redirect).toHaveBeenCalledWith('/')
+  })
+
+  it('persists the session before redirecting (guards the ERR_HTTP_HEADERS_SENT double-send fix)', async () => {
+    const request = makeRequest()
+    const reply = makeReply()
+
+    await handleCallback(request, reply)
+
+    // Saving before responding makes @fastify/session's onSend save synchronous,
+    // so Fastify does not fire a second reply.send(). If the save moves after
+    // the redirect (or is removed), the async onSend race returns.
+    const save = vi.mocked(request.session.save as () => Promise<void>)
+    expect(save).toHaveBeenCalled()
+    expect(save.mock.invocationCallOrder[0]).toBeLessThan(reply.redirect.mock.invocationCallOrder[0])
   })
 
   it('rejects with an error naming DUOS_OAUTH_REDIRECT_URI when it is unset', async () => {

--- a/server/test/login.test.ts
+++ b/server/test/login.test.ts
@@ -48,7 +48,7 @@ describe('handleLogin', () => {
   }
 
   function makeRequest(query: Record<string, unknown> = {}): FastifyRequest {
-    return { session: {}, query } as unknown as FastifyRequest
+    return { session: { save: vi.fn().mockResolvedValue(undefined) }, query } as unknown as FastifyRequest
   }
 
   function makeReply(): FastifyReply & { send: ReturnType<typeof vi.fn> } {
@@ -113,6 +113,20 @@ describe('handleLogin', () => {
     await handleLogin(makeRequest(), reply)
 
     expect(reply.send).toHaveBeenCalledWith({ redirectUrl: 'https://duosdev.b2clogin.com/authorize?foo=bar' })
+  })
+
+  it('persists the session before responding (guards the double-send race that made login flaky)', async () => {
+    const request = makeRequest()
+    const reply = makeReply()
+
+    await handleLogin(request, reply)
+
+    // Saving before reply.send makes @fastify/session's onSend save synchronous,
+    // so Fastify does not fire a second reply.send(). See callback.ts for the
+    // full ERR_HTTP_HEADERS_SENT explanation.
+    const save = vi.mocked(request.session.save as () => Promise<void>)
+    expect(save).toHaveBeenCalled()
+    expect(save.mock.invocationCallOrder[0]).toBeLessThan(reply.send.mock.invocationCallOrder[0])
   })
 
   it.each(['DUOS_OAUTH_REDIRECT_URI', 'DUOS_AZURE_CLIENT_ID'])(


### PR DESCRIPTION
### Addresses
Minor fixes in support of https://broadworkbench.atlassian.net/browse/DT-3607

### Summary
The BFF auth routes (`POST /auth/login`, `GET /auth/callback`) could crash the
server process with an uncaught `ERR_HTTP_HEADERS_SENT`, restarting the pod and
failing the request. It reproduced reliably on any auth request that carried an
existing session cookie (e.g. retrying login after a first attempt).

**Root cause:** a double `reply.send()` race between the async route handler and
`@fastify/session`'s async `onSend` save hook:

- `reply.sent` in Fastify 5 is `raw.writableEnded`, which stays `false` while an
  async `onSend` hook is in flight.
- `@fastify/session` defaults `rolling` to `true`, and we never overrode it — so
  its `onSend` hook fired an async DB write on every session-bearing request even
  when the session was unmodified.
- That async `onSend` left `reply.sent === false` when the async handler's promise
  resolved, so Fastify's `wrapThenable` fired a **second** `reply.send()`. The
  later save's `writeHead` ran after headers were already sent → uncaught throw →
  process exit.

**Fix:**
- Set `rolling: false` explicitly on the session registration (`server/src/index.ts`).
  Combined with the existing `saveUninitialized: false` and the pre-response
  `request.session.save()` in the auth handlers, `onSend` now finds the session
  unmodified and skips its write synchronously — so the reply is fully sent before
  the handler promise resolves and no second send occurs. This also matches the
  intended session semantics (fixed maxAge from creation; sliding expiry comes
  later in Phase 2).
- Persist the session before responding in `login.ts` and `callback.ts`
  (`await request.session.save()`), which is required for the synchronous-skip
  path above.
- Updated `login.test.ts` / `callback.test.ts` to assert the session is saved
  before `reply.send`.

### Test plan
- `pnpm --filter duos-server test` — 26 auth tests green; `tsc --noEmit` clean.
- Rebuilt and redeployed the server locally, then hit `POST /auth/login` from the
  browser console repeatedly (including after a session cookie was set) — no
  crash, `redirectUrl` returned each time. Verified the full login → callback
  redirect round-trip completes without a process restart.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
