### PR TITLE
[DT-3878] Fix stale researcher status on user profile

### DIFF
--- a/src/pages/user_profile/UserProfile.tsx
+++ b/src/pages/user_profile/UserProfile.tsx
@@ -67,7 +67,8 @@ export default function UserProfile() {
   useEffect(() => {
     const init = async () => {
       try {
-        const user = Storage.getCurrentUser()
+        const user = await User.getMe()
+        setUserRoleStatuses(user, Storage)
         setUser(user)
         setName(user.displayName)
         setNotificationData(await NotificationService.getBannerObjectById('eRACommonsOutage'))

--- a/test/pages/user_profile/UserProfile.spec.tsx
+++ b/test/pages/user_profile/UserProfile.spec.tsx
@@ -16,6 +16,7 @@ vi.mock('src/libs/storage', () => ({
 
 vi.mock('src/libs/ajax/User', () => ({
   User: {
+    getMe: vi.fn(),
     updateSelf: vi.fn(),
   },
 }))
@@ -44,7 +45,11 @@ vi.mock('src/pages/user_profile/AffiliationAndRoles', () => ({
 }))
 
 vi.mock('src/pages/user_profile/ResearcherStatus', () => ({
-  default: () => <div data-testid="researcher-status" />,
+  default: ({ user }: { user: DuosUser }) => (
+    <div data-testid="researcher-status">
+      {user.libraryCard ? 'Active' : 'Inactive'}
+    </div>
+  ),
 }))
 
 vi.mock('src/pages/user_profile/AcceptedAcknowledgements', () => ({
@@ -134,6 +139,7 @@ describe('UserProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(Storage.getCurrentUser).mockReturnValue(mockUser)
+    vi.mocked(User.getMe).mockResolvedValue(mockUser)
     vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(null)
   })
 
@@ -145,12 +151,36 @@ describe('UserProfile', () => {
     })
   })
 
-  it('displays user name and email loaded from Storage on mount', async () => {
+  it('displays user name and email loaded from the API on mount', async () => {
     renderUserProfile()
 
     await waitFor(() => {
+      expect(User.getMe).toHaveBeenCalledOnce()
       expect(screen.getByDisplayValue('Test User')).toBeInTheDocument()
       expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the current researcher status when cached user data is stale', async () => {
+    const currentUser = {
+      ...mockUser,
+      libraryCard: {
+        id: 1,
+        userId: mockUser.userId,
+        userName: mockUser.displayName,
+        userEmail: mockUser.email,
+        createDate: new Date(),
+        createUserId: 2,
+        daaIds: [],
+      },
+    }
+    vi.mocked(User.getMe).mockResolvedValue(currentUser)
+
+    renderUserProfile()
+
+    await waitFor(() => {
+      expect(screen.getByTestId('researcher-status')).toHaveTextContent('Active')
+      expect(Storage.getCurrentUser).not.toHaveBeenCalled()
     })
   })
 
@@ -199,9 +229,7 @@ describe('UserProfile', () => {
   })
 
   it('shows an error notification when initialization fails', async () => {
-    vi.mocked(Storage.getCurrentUser).mockImplementation(() => {
-      throw new Error('storage error')
-    })
+    vi.mocked(User.getMe).mockRejectedValue(new Error('API error'))
 
     renderUserProfile()
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3878

### Summary

Fetch the latest user data when loading the profile so researcher status matches the Signing Official admin page. Adds regression coverage for stale cached library-card data.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
