### PR TITLE
[DT-2405] Replace `window.location` usages

### DIFF
--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -14,7 +14,7 @@ import { OidcUser } from 'src/libs/auth/oidcBroker'
 import { DuosUser } from 'src/types/model'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 import 'src/styles/tooltip.css'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { extractError } from 'src/utils/ErrorUtils'
 
@@ -33,6 +33,7 @@ interface HttpError extends Error {
 }
 
 export const SignInButton = () => {
+  const location = useLocation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [errorDisplay, setErrorDisplay] = useState<ErrorDisplay>({})
@@ -54,14 +55,12 @@ export const SignInButton = () => {
         navigate(redirectPath)
       }
     }
-    else {
+    else if (isNil(redirectPath)) {
       // User has authenticated, but has not accepted ToS
-      if (isNil(redirectPath)) {
-        navigate(`/tos_acceptance`)
-      }
-      else {
-        navigate(`/tos_acceptance?redirectTo=${redirectPath}`)
-      }
+      navigate(`/tos_acceptance`)
+    }
+    else {
+      navigate(`/tos_acceptance?redirectTo=${redirectPath}`)
     }
   }
 
@@ -103,8 +102,8 @@ export const SignInButton = () => {
   }
 
   const getRedirectTo = (): string => {
-    const queryParams = new URLSearchParams(window.location.search)
-    return queryParams.get('redirectTo') || window.location.pathname
+    const queryParams = new URLSearchParams(location.search)
+    return queryParams.get('redirectTo') || location.pathname
   }
 
   const shouldRedirectTo = (page: string): boolean => page !== '/' && page !== '/home'
@@ -120,11 +119,12 @@ export const SignInButton = () => {
 
   const registerAndRedirectNewUser = async (redirectTo: string, shouldRedirect: boolean) => {
     const registeredUser: DuosUser = await User.registerUser()
+    const redirectParam = shouldRedirect ? `?redirectTo=${redirectTo}` : ''
     setUserRoleStatuses(registeredUser, Storage)
     // New identity — same cache reset as the normal sign-in path above.
     queryClient.clear()
     syncSignInOrRegistrationEvent(eventList.userRegister)
-    navigate(`/tos_acceptance${shouldRedirect ? `?redirectTo=${redirectTo}` : ''}`)
+    navigate(`/tos_acceptance${redirectParam}`)
   }
 
   const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
@@ -170,7 +170,7 @@ export const SignInButton = () => {
     try {
       await checkToSAndRedirect(shouldRedirect ? redirectTo : null)
     }
-    catch (_error) {
+    catch {
       await Auth.signOut()
     }
   }
@@ -252,6 +252,7 @@ export const SignInButton = () => {
                 <div style={tooltipStyle}>
                   <span>
                     DUOS is currently unavailable. Please check the
+                    {' '}
                     <a href="status">status page</a>
                     {' '}
                     for more details.

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -14,7 +14,7 @@ import { OidcUser } from 'src/libs/auth/oidcBroker'
 import { DuosUser } from 'src/types/model'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 import 'src/styles/tooltip.css'
-import { useLocation, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { extractError } from 'src/utils/ErrorUtils'
 
@@ -33,7 +33,6 @@ interface HttpError extends Error {
 }
 
 export const SignInButton = () => {
-  const location = useLocation()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [errorDisplay, setErrorDisplay] = useState<ErrorDisplay>({})
@@ -102,8 +101,8 @@ export const SignInButton = () => {
   }
 
   const getRedirectTo = (): string => {
-    const queryParams = new URLSearchParams(location.search)
-    return queryParams.get('redirectTo') || location.pathname
+    const queryParams = new URLSearchParams(globalThis.location.search)
+    return queryParams.get('redirectTo') || globalThis.location.pathname
   }
 
   const shouldRedirectTo = (page: string): boolean => page !== '/' && page !== '/home'

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -22,7 +22,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import CloudUploadIcon from '@mui/icons-material/CloudUpload'
 import AttachFileIcon from '@mui/icons-material/AttachFile'
 import Dropzone from 'react-dropzone'
-import { Link } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import { Support } from 'src/libs/ajax/Support'
 import { Storage } from 'src/libs/storage'
 import { Notifications, isEmailAddress } from 'src/libs/utils'
@@ -42,13 +42,14 @@ interface RedirectLinkProps {
 
 const RedirectLink: React.FC<RedirectLinkProps> = (props) => {
   const { isLogged, closeHandler } = props
+  const navigate = useNavigate()
   return (
     <Link
       to={isLogged ? '/datalibrary' : '#'}
       onClick={(e) => {
         if (!isLogged) {
           e.preventDefault()
-          handleSignIn('/datalibrary')
+          handleSignIn('/datalibrary', navigate)
         }
         closeHandler()
       }}
@@ -325,9 +326,9 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
                     {hasAttachments && (
                       <Box>
                         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, justifyContent: 'center', mb: 1 }}>
-                          {formData.attachment.map((file, index) => (
+                          {formData.attachment.map(file => (
                             <Chip
-                              key={index}
+                              key={`${file.name}-${file.size}-${file.lastModified}`}
                               icon={<AttachFileIcon />}
                               label={file.name}
                               size="small"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,8 +18,8 @@ const load = async () => {
   //   5a. Logging in from the home page
   //   5b. Logging in from a link, i.e. `<origin>/dataLibrary`
   //   5c. Logging in from a link with a `redirectTo` query param, i.e. `<origin>?redirectTo=/dataLibrary`
-  if (window.location.pathname.startsWith('/redirect-from-oauth')) {
-    await OidcBroker.getUserManager().signinPopupCallback(window.location.href)
+  if (globalThis.location.pathname.startsWith('/redirect-from-oauth')) {
+    await OidcBroker.getUserManager().signinPopupCallback(globalThis.location.href)
   }
   const container = document.getElementById('root')
   const root = createRoot(container!)

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -43,8 +43,8 @@ const captureEventFn = async (event: MetricsEventName, signal: AbortSignal, deta
       ...details,
       distinct_id: isRegistered ? undefined : Storage.getAnonymousId(),
       appId: 'DUOS',
-      hostname: window.location.hostname,
-      appPath: window.location.pathname,
+      hostname: globalThis.location.hostname,
+      appPath: globalThis.location.pathname,
       ...getDefaultProperties(),
     },
   }

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -42,5 +42,5 @@ export const Auth = {
 
 export const redirectOnLogout = () => {
   Auth.signOut()
-  window.location.href = `/home?redirectTo=${window.location.pathname}`
+  globalThis.location.href = `/home?redirectTo=${globalThis.location.pathname}`
 }

--- a/src/libs/signInUtils.ts
+++ b/src/libs/signInUtils.ts
@@ -1,8 +1,10 @@
-export const handleSignIn = (redirectPath: string) => {
+import type { NavigateFunction } from 'react-router'
+
+export const handleSignIn = (redirectPath: string, navigate: NavigateFunction) => {
   // Set the redirectTo parameter without forcing a page reload
   const currentUrl = new URL(globalThis.location.href)
   currentUrl.searchParams.set('redirectTo', redirectPath)
-  globalThis.history.replaceState({}, '', currentUrl)
+  navigate(`${currentUrl.pathname}${currentUrl.search}${currentUrl.hash}`, { replace: true })
   // Find the existing sign-in button in the header and programmatically click it
   // This will trigger the existing authentication flow with all proper session handling
   const signInButtons = document.querySelectorAll('button')

--- a/src/libs/signInUtils.ts
+++ b/src/libs/signInUtils.ts
@@ -1,19 +1,19 @@
 export const handleSignIn = (redirectPath: string) => {
   // Set the redirectTo parameter without forcing a page reload
-  const currentUrl = new URL(window.location.href)
+  const currentUrl = new URL(globalThis.location.href)
   currentUrl.searchParams.set('redirectTo', redirectPath)
-  window.history.replaceState({}, '', currentUrl)
+  globalThis.history.replaceState({}, '', currentUrl)
   // Find the existing sign-in button in the header and programmatically click it
   // This will trigger the existing authentication flow with all proper session handling
   const signInButtons = document.querySelectorAll('button')
   const signInButton = Array.from(signInButtons).find(button =>
-    button.textContent && button.textContent.trim() === 'Sign In',
+    button.textContent?.trim() === 'Sign In',
   )
   if (signInButton) {
     signInButton.click()
   }
   else {
     // Fallback - scroll to top where the sign-in button is located
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    globalThis.scrollTo({ top: 0, behavior: 'smooth' })
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,7 +7,7 @@ import dacIcon from 'src/images/dac_icon.svg'
 import signingOfficialIcon from 'src/images/icon_add_user.png'
 import datasetIcon from 'src/images/icon_dataset_.png'
 import { OverflowTooltip } from 'src/components/Tooltips'
-import { Link, useLocation } from 'react-router'
+import { Link, useLocation, useNavigate } from 'react-router'
 import { getLibraryVersions } from 'src/libs/libraryVersions'
 import { handleSignIn } from 'src/libs/signInUtils'
 import { SupportRequestModal } from 'src/components/modals/SupportRequestModal'
@@ -108,6 +108,7 @@ const CheckIcon = ({ color }: { color: string }) => (
 
 const Home = ({ isLogged }: Readonly<HomeProps>) => {
   const location = useLocation()
+  const navigate = useNavigate()
   const [showContactModal, setShowContactModal] = useState(false)
 
   const featuredLibraries = useMemo(() => {
@@ -466,7 +467,7 @@ const Home = ({ isLogged }: Readonly<HomeProps>) => {
                   <button
                     type="button"
                     className="audience-cta-primary audience-cta-primary-teal"
-                    onClick={() => handleSignIn('/datalibrary')}
+                    onClick={() => handleSignIn('/datalibrary', navigate)}
                   >
                     Sign In to Browse Data
                   </button>
@@ -517,7 +518,7 @@ const Home = ({ isLogged }: Readonly<HomeProps>) => {
                             onClick={(e) => {
                               if (!isLogged) {
                                 e.preventDefault()
-                                handleSignIn(libraryPath)
+                                handleSignIn(libraryPath, navigate)
                               }
                             }}
                             style={{ textDecoration: 'none', display: 'flex', width: '100%', height: '100%', justifyContent: 'center', alignItems: 'center', cursor: 'pointer' }}

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -79,10 +79,10 @@ const LocationDisplay = () => {
   return <div data-testid="location">{pathname}</div>
 }
 
-const mountComponent = () =>
+const mountComponent = (initialEntries = ['/']) =>
   render(
     <QueryClientProvider client={new QueryClient()}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <SignInButton />
         <LocationDisplay />
       </MemoryRouter>
@@ -130,6 +130,20 @@ describe('Sign In: Component Loads', () => {
     expect(vi.mocked(Metrics.identify)).toHaveBeenCalled()
     expect(vi.mocked(Metrics.syncProfile)).toHaveBeenCalled()
     expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalled()
+  })
+
+  it('Sign In: Redirects to the route from the redirectTo query parameter', async () => {
+    const tosAcceptedUser = { userStatusInfo: userStatus, ...duosUser }
+    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
+    vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
+    mountComponent(['/?redirectTo=/datalibrary'])
+
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('location').textContent).toBe('/datalibrary'),
+    )
   })
 
   it('Sign In: No Roles Error Reporter Is Called', async () => {

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -75,14 +75,14 @@ const consentStatus = {
 
 // Helper: renders SignInButton inside a MemoryRouter and exposes the current location
 const LocationDisplay = () => {
-  const { pathname } = useLocation()
-  return <div data-testid="location">{pathname}</div>
+  const { pathname, search } = useLocation()
+  return <div data-testid="location">{pathname + search}</div>
 }
 
-const mountComponent = (initialEntries = ['/']) =>
+const mountComponent = () =>
   render(
     <QueryClientProvider client={new QueryClient()}>
-      <MemoryRouter initialEntries={initialEntries}>
+      <MemoryRouter>
         <SignInButton />
         <LocationDisplay />
       </MemoryRouter>
@@ -91,6 +91,7 @@ const mountComponent = (initialEntries = ['/']) =>
 
 describe('Sign In: Component Loads', () => {
   beforeEach(() => {
+    globalThis.history.replaceState({}, '', '/')
     vi.mocked(ServiceStatus.getConsentStatus).mockResolvedValue(consentStatus as never)
     vi.mocked(ServiceStatus.isConsentHealthy).mockResolvedValue(true)
     vi.mocked(ServiceStatus.isSamHealthy).mockResolvedValue(true)
@@ -132,17 +133,17 @@ describe('Sign In: Component Loads', () => {
     expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalled()
   })
 
-  it('Sign In: Redirects to the route from the redirectTo query parameter', async () => {
-    const tosAcceptedUser = { userStatusInfo: userStatus, ...duosUser }
+  it('Sign In: Preserves a redirectTo query parameter added outside the router', async () => {
     vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
-    mountComponent(['/?redirectTo=/datalibrary'])
+    vi.mocked(User.getMe).mockResolvedValue(duosUser as never)
+    mountComponent()
+    globalThis.history.replaceState({}, '', '/?redirectTo=/datalibrary')
 
     await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
     await userEvent.click(screen.getByRole('button'))
 
     await waitFor(() =>
-      expect(screen.getByTestId('location').textContent).toBe('/datalibrary'),
+      expect(screen.getByTestId('location').textContent).toBe('/tos_acceptance?redirectTo=/datalibrary'),
     )
   })
 

--- a/test/libs/signInUtils.spec.ts
+++ b/test/libs/signInUtils.spec.ts
@@ -1,22 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { handleSignIn } from 'src/libs/signInUtils'
+import type { NavigateFunction } from 'react-router'
 
 describe('signInUtils', () => {
   describe('handleSignIn', () => {
+    const navigate = vi.fn() as unknown as NavigateFunction
+
     beforeEach(() => {
       globalThis.history.replaceState({}, '', '/')
       vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {})
+      vi.mocked(navigate).mockClear()
     })
 
     afterEach(() => {
       vi.restoreAllMocks()
     })
 
-    it('should set redirectTo parameter in URL', () => {
-      const replaceState = vi.spyOn(globalThis.history, 'replaceState')
-      handleSignIn('/datalibrary')
-      expect(replaceState).toHaveBeenCalled()
-      expect(globalThis.location.search).toContain('redirectTo=%2Fdatalibrary')
+    it('should replace the current route with the redirectTo parameter', () => {
+      handleSignIn('/datalibrary', navigate)
+      expect(navigate).toHaveBeenCalledWith('/?redirectTo=%2Fdatalibrary', { replace: true })
     })
 
     it('should find and click the Sign In button if it exists', () => {
@@ -26,7 +28,7 @@ describe('signInUtils', () => {
       button.addEventListener('click', clickSpy)
       document.body.appendChild(button)
 
-      handleSignIn('/datalibrary')
+      handleSignIn('/datalibrary', navigate)
 
       expect(clickSpy).toHaveBeenCalled()
       button.remove()
@@ -42,7 +44,7 @@ describe('signInUtils', () => {
         }
       })
 
-      handleSignIn('/dashboard')
+      handleSignIn('/dashboard', navigate)
       expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
     })
 
@@ -50,16 +52,21 @@ describe('signInUtils', () => {
       'should handle redirect path %s',
       (path) => {
         globalThis.history.replaceState({}, '', '/')
-        handleSignIn(path)
-        expect(globalThis.location.search).toContain(`redirectTo=${encodeURIComponent(path)}`)
+        handleSignIn(path, navigate)
+        expect(navigate).toHaveBeenCalledWith(
+          `/?redirectTo=${encodeURIComponent(path)}`,
+          { replace: true },
+        )
       },
     )
 
     it('should preserve existing query parameters when setting redirectTo', () => {
       globalThis.history.replaceState({}, '', '/?existingParam=value')
-      handleSignIn('/datalibrary')
-      expect(globalThis.location.search).toContain('existingParam=value')
-      expect(globalThis.location.search).toContain('redirectTo=%2Fdatalibrary')
+      handleSignIn('/datalibrary', navigate)
+      expect(navigate).toHaveBeenCalledWith(
+        '/?existingParam=value&redirectTo=%2Fdatalibrary',
+        { replace: true },
+      )
     })
 
     it('should find Sign In button with extra whitespace', () => {
@@ -69,7 +76,7 @@ describe('signInUtils', () => {
       button.addEventListener('click', clickSpy)
       document.body.appendChild(button)
 
-      handleSignIn('/datalibrary')
+      handleSignIn('/datalibrary', navigate)
 
       expect(clickSpy).toHaveBeenCalled()
       button.remove()

--- a/test/libs/signInUtils.spec.ts
+++ b/test/libs/signInUtils.spec.ts
@@ -4,8 +4,8 @@ import { handleSignIn } from 'src/libs/signInUtils'
 describe('signInUtils', () => {
   describe('handleSignIn', () => {
     beforeEach(() => {
-      window.history.replaceState({}, '', '/')
-      vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
+      globalThis.history.replaceState({}, '', '/')
+      vi.spyOn(globalThis, 'scrollTo').mockImplementation(() => {})
     })
 
     afterEach(() => {
@@ -13,10 +13,10 @@ describe('signInUtils', () => {
     })
 
     it('should set redirectTo parameter in URL', () => {
-      const replaceState = vi.spyOn(window.history, 'replaceState')
+      const replaceState = vi.spyOn(globalThis.history, 'replaceState')
       handleSignIn('/datalibrary')
       expect(replaceState).toHaveBeenCalled()
-      expect(window.location.search).toContain('redirectTo=%2Fdatalibrary')
+      expect(globalThis.location.search).toContain('redirectTo=%2Fdatalibrary')
     })
 
     it('should find and click the Sign In button if it exists', () => {
@@ -33,7 +33,7 @@ describe('signInUtils', () => {
     })
 
     it('should scroll to top if Sign In button is not found (fallback)', () => {
-      const scrollTo = vi.mocked(window.scrollTo)
+      const scrollTo = vi.mocked(globalThis.scrollTo)
 
       // Ensure no Sign In button exists
       document.querySelectorAll('button').forEach((button) => {
@@ -49,17 +49,17 @@ describe('signInUtils', () => {
     it.each(['/datalibrary', '/dashboard', '/profile', '/datasets'])(
       'should handle redirect path %s',
       (path) => {
-        window.history.replaceState({}, '', '/')
+        globalThis.history.replaceState({}, '', '/')
         handleSignIn(path)
-        expect(window.location.search).toContain(`redirectTo=${encodeURIComponent(path)}`)
+        expect(globalThis.location.search).toContain(`redirectTo=${encodeURIComponent(path)}`)
       },
     )
 
     it('should preserve existing query parameters when setting redirectTo', () => {
-      window.history.replaceState({}, '', '/?existingParam=value')
+      globalThis.history.replaceState({}, '', '/?existingParam=value')
       handleSignIn('/datalibrary')
-      expect(window.location.search).toContain('existingParam=value')
-      expect(window.location.search).toContain('redirectTo=%2Fdatalibrary')
+      expect(globalThis.location.search).toContain('existingParam=value')
+      expect(globalThis.location.search).toContain('redirectTo=%2Fdatalibrary')
     })
 
     it('should find Sign In button with extra whitespace', () => {

--- a/test/pages/Home.spec.tsx
+++ b/test/pages/Home.spec.tsx
@@ -115,7 +115,7 @@ describe('Home page', () => {
       await act(async () => {
         fireEvent.click(libraryLink)
       })
-      expect(handleSignIn).toHaveBeenCalledWith('/datalibrary')
+      expect(handleSignIn).toHaveBeenCalledWith('/datalibrary', expect.any(Function))
     })
   })
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2405

### Summary

- Replace `window.location` references with `globalThis.location`
- Preserve redirect parameters updated outside React Router
- Add regression coverage for sign-in redirects
- Preserve existing OIDC and logout behavior

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
