### PR TITLE
[DT-3608] BFF Phase 3: ADR-004 — API proxy layer decision (story 3-A)

### DIFF
--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -52,11 +52,11 @@ The work is split into seven phases, delivered in order.
 |---|---|---|---|---|
 | 0 | Environment Configuration | Provision OAuth clients/app registrations for each identity provider and deliver server-side credentials and configuration (client secrets, session secret, database and issuer config) to the deployment environments. | [DT-3605](https://broadworkbench.atlassian.net/browse/DT-3605) | ✅ |
 | 1 | Server Foundation & Session Infrastructure | Add session middleware to the Fastify server with a PostgreSQL-backed session store, automated expired-session cleanup, and a metadata-only session audit trail. No user-visible changes. | [DT-3606](https://broadworkbench.atlassian.net/browse/DT-3606) | ✅ |
-| 2 | Server-Side OAuth Flow | Implement the BFF auth routes (`/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/me`) using `openid-client` against the single Azure B2C client, with PKCE; the callback extracts the sub-provider from the B2C `id_token`. Runs alongside the legacy client-side flow during rollout. | [DT-3607](https://broadworkbench.atlassian.net/browse/DT-3607) | |
-| 3 | API Proxy Layer | Add a reverse proxy so the client calls relative `/api/*` URLs; the server injects the Bearer token from the session and proactively refreshes tokens before expiry. | [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) | |
-| 4 | Client Refactor | Remove all token handling from the React client: drop `oidc-client-ts` and localStorage token storage, switch the fetch layer to relative URLs, and replace the popup sign-in with a full-page redirect to the B2C login page (which presents the Google/Microsoft choice, unchanged). | [DT-3609](https://broadworkbench.atlassian.net/browse/DT-3609) | |
-| 5 | Security Hardening | Layer additional defenses: strict Content Security Policy, end-to-end verification of CSRF coverage (enforcement lands with the endpoints in Phases 2–4), session-fixation protection (session ID regeneration), token revocation on logout, SRI/third-party script audit, and rate limiting on auth endpoints. | [DT-3610](https://broadworkbench.atlassian.net/browse/DT-3610) | |
-| 6 | Testing, Observability & Rollout | E2E test coverage, auth/session metrics and alerting, and a config-driven (`bffEnabled` in `config.json`) per-environment cutover. The legacy flow is removed only after the new flow is stable in production. | [DT-3611](https://broadworkbench.atlassian.net/browse/DT-3611) | |
+| 2 | Server-Side OAuth Flow | Implement the BFF auth routes (`/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/me`) using `openid-client` against the single Azure B2C client, with PKCE; the callback extracts the sub-provider from the B2C `id_token`. Runs alongside the legacy client-side flow during rollout. | [DT-3607](https://broadworkbench.atlassian.net/browse/DT-3607) | ✅ |
+| 3 | API Proxy Layer | Add a reverse proxy so the client calls relative `/api/*` URLs; the server injects the Bearer token from the session and proactively refreshes tokens before expiry. | [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) |        |
+| 4 | Client Refactor | Remove all token handling from the React client: drop `oidc-client-ts` and localStorage token storage, switch the fetch layer to relative URLs, and replace the popup sign-in with a full-page redirect to the B2C login page (which presents the Google/Microsoft choice, unchanged). | [DT-3609](https://broadworkbench.atlassian.net/browse/DT-3609) |        |
+| 5 | Security Hardening | Layer additional defenses: strict Content Security Policy, end-to-end verification of CSRF coverage (enforcement lands with the endpoints in Phases 2–4), session-fixation protection (session ID regeneration), token revocation on logout, SRI/third-party script audit, and rate limiting on auth endpoints. | [DT-3610](https://broadworkbench.atlassian.net/browse/DT-3610) |        |
+| 6 | Testing, Observability & Rollout | E2E test coverage, auth/session metrics and alerting, and a config-driven (`bffEnabled` in `config.json`) per-environment cutover. The legacy flow is removed only after the new flow is stable in production. | [DT-3611](https://broadworkbench.atlassian.net/browse/DT-3611) |        |
 
 ## Rollout strategy
 
@@ -109,6 +109,10 @@ environment before cutting over.
 - **`openid-client` (v6) for all OAuth/OIDC operations** — library-maintained
   PKCE, token exchange, and ID-token validation (signature, `iss`, `aud`,
   `exp`) rather than hand-rolled crypto.
+- **`@fastify/reply-from` for the API proxy, on a single `/duos-api` prefix** —
+  streams multipart uploads and document downloads instead of buffering them,
+  and keeps the auth gate, token refresh, and upstream-401 handling as ordinary
+  route hooks. See [ADR-004](bff_adrs/ADR-004-api-proxy-layer.md).
 
 ## Target Architecture Sequence Diagrams
 

--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -53,7 +53,7 @@ The work is split into seven phases, delivered in order.
 | 0 | Environment Configuration | Provision OAuth clients/app registrations for each identity provider and deliver server-side credentials and configuration (client secrets, session secret, database and issuer config) to the deployment environments. | [DT-3605](https://broadworkbench.atlassian.net/browse/DT-3605) | ✅ |
 | 1 | Server Foundation & Session Infrastructure | Add session middleware to the Fastify server with a PostgreSQL-backed session store, automated expired-session cleanup, and a metadata-only session audit trail. No user-visible changes. | [DT-3606](https://broadworkbench.atlassian.net/browse/DT-3606) | ✅ |
 | 2 | Server-Side OAuth Flow | Implement the BFF auth routes (`/auth/login`, `/auth/callback`, `/auth/logout`, `/auth/me`) using `openid-client` against the single Azure B2C client, with PKCE; the callback extracts the sub-provider from the B2C `id_token`. Runs alongside the legacy client-side flow during rollout. | [DT-3607](https://broadworkbench.atlassian.net/browse/DT-3607) | ✅ |
-| 3 | API Proxy Layer | Add a reverse proxy so the client calls relative `/api/*` URLs; the server injects the Bearer token from the session and proactively refreshes tokens before expiry. | [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) |        |
+| 3 | API Proxy Layer | Add a reverse proxy so the client calls relative `/duos-api/*` URLs; the server injects the Bearer token from the session and proactively refreshes tokens before expiry. | [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) |        |
 | 4 | Client Refactor | Remove all token handling from the React client: drop `oidc-client-ts` and localStorage token storage, switch the fetch layer to relative URLs, and replace the popup sign-in with a full-page redirect to the B2C login page (which presents the Google/Microsoft choice, unchanged). | [DT-3609](https://broadworkbench.atlassian.net/browse/DT-3609) |        |
 | 5 | Security Hardening | Layer additional defenses: strict Content Security Policy, end-to-end verification of CSRF coverage (enforcement lands with the endpoints in Phases 2–4), session-fixation protection (session ID regeneration), token revocation on logout, SRI/third-party script audit, and rate limiting on auth endpoints. | [DT-3610](https://broadworkbench.atlassian.net/browse/DT-3610) |        |
 | 6 | Testing, Observability & Rollout | E2E test coverage, auth/session metrics and alerting, and a config-driven (`bffEnabled` in `config.json`) per-environment cutover. The legacy flow is removed only after the new flow is stable in production. | [DT-3611](https://broadworkbench.atlassian.net/browse/DT-3611) |        |
@@ -179,7 +179,7 @@ sequenceDiagram
     rect rgb(235, 255, 235)
         Note over B,API: Authenticated API Request
 
-        B->>BFF: GET /api/user/me [cookie: sessionId]
+        B->>BFF: GET /duos-api/api/user/me [cookie: sessionId]
         BFF->>PG: Read session — accessToken, tokenExpiry
         PG-->>BFF: session data
 

--- a/docs/plans/bff_adrs/ADR-004-api-proxy-layer.md
+++ b/docs/plans/bff_adrs/ADR-004-api-proxy-layer.md
@@ -1,0 +1,142 @@
+# ADR-004 — API proxy layer: `@fastify/reply-from` in a BFF-owned route
+
+**Status:** Accepted (2026-07-29) &nbsp;|&nbsp; **Phase:** 3, story 3-A
+**Supersedes:** ADR-004 in `BFF_Migration_Plan_v2.md` ("Use `@fastify/http-proxy`")
+
+---
+
+## Context
+
+Phase 3 moves `Authorization` header construction off the browser: the client calls
+relative BFF URLs, and Fastify forwards them to the DUOS API with the session's
+B2C access token attached. The plan sketched a hand-rolled `fetch` proxy for
+development with `@fastify/http-proxy` as the production option, and left the
+choice to this story.
+
+Four properties of the current client decide it. All were confirmed against the
+code rather than assumed:
+
+**1. Real streaming traffic in both directions.** Uploads use `multipart/form-data`
+via `fetchMultipart` — [FileStorageObject.ts:40](../../src/libs/ajax/FileStorageObject.ts:40)
+(arbitrary user-selected `File`), [DataSet.ts:26](../../src/libs/ajax/DataSet.ts:26),
+[DataSet.ts:95](../../src/libs/ajax/DataSet.ts:95),
+[DataSet.ts:118](../../src/libs/ajax/DataSet.ts:118),
+[ProgressReport.ts:8](../../src/libs/ajax/ProgressReport.ts:8) — plus a binary
+`POST` to `/support/upload` ([Support.ts:74](../../src/libs/ajax/Support.ts:74)).
+Downloads use `fetchBlob` in `DAA`, `DAR`, and `FileStorageObject`, and a
+`responseType: 'blob'` GET at [DataSet.ts:133](../../src/libs/ajax/DataSet.ts:133).
+
+**2. Fastify parses nothing useful for a proxy.** Only `application/json` and
+`text/plain` have default parsers, so `multipart/form-data` and
+`application/binary` reject with `FST_ERR_CTP_INVALID_MEDIA_TYPE` (415) *before*
+any proxy handler runs — every upload path breaks. And for JSON, `request.body`
+is an already-parsed object: passing it to `fetch` as `body` sends the string
+`"[object Object]"`.
+
+**3. Not every upstream path lives under `/api`.** Of 104 `getApiUrl()` call
+sites, 9 distinct paths sit outside it: `/status`, `/feature`, `/tos/text/duos`,
+`/ontology/search`, `/ontology/autocomplete`, `/oauth2/configuration`,
+`/support/request`, `/support/upload`, `/api-docs/ISO-3166-countries.json`.
+An `/api/*` wildcard under-covers, and the plan's
+`request.url.replace(/^\/api/, '')` would strip a prefix the upstream paths
+genuinely have.
+
+**4. Five endpoints are called today with no `Authorization` header** —
+`/status`, `/oauth2/configuration`, `/tos/text/duos`, `/support/request`,
+`/support/upload`. The status page and the Contact Us form are reachable while
+signed out.
+
+---
+
+## Decision
+
+Use **`@fastify/reply-from`** (`reply.from()`) inside a route the BFF declares
+itself, rather than `@fastify/http-proxy` or a hand-rolled `fetch` proxy.
+
+```ts
+app.register(fastifyReplyFrom, { base: requireEnv('DUOS_API_URL'), undici: { /* pool opts */ } })
+
+app.all(`${PROXY_PREFIX}/*`, {
+  onRequest: csrfForUnsafeMethods,   // story 3-D
+  preHandler: ensureFreshToken,      // story 3-B — single-flight refresh
+}, (request, reply) => reply.from(upstreamPath(request.url), {
+  rewriteRequestHeaders,             // inject Authorization, strip cookie
+  onResponse,                        // story 3-E — upstream 401 destroys the session
+}))
+```
+
+`@fastify/http-proxy` is `reply-from` plus prefix-mounting plus WebSocket support
+(a `ws` dependency DUOS has no use for). Declaring the route ourselves makes the
+three things this epic actually needs — CSRF enforcement, the single-flight
+refresh, and upstream-401 handling — ordinary Fastify hooks instead of entries in
+a plugin's option bag.
+
+### Sub-decisions
+
+**a. One BFF-owned prefix mapped to the upstream root**, not `/api/*`.
+`/duos-api/<upstream-path>` → `${DUOS_API_URL}/<upstream-path>`. This covers all
+113 paths with a single rule, and it cannot collide with the BFF's own routes —
+`/health`, `/config.json`, `/auth/*`, or the asset routes `@fastify/vite`
+registers. (Proxying bare `/status` or `/feature` at the BFF root would put
+upstream paths in the same namespace the BFF and Vite are already using.)
+
+Phase 4 then becomes a one-line change: `getApiUrl()` returns `'/duos-api'` and
+all 104 call sites keep their literal paths unchanged.
+
+**b. An explicit unauthenticated allowlist.** The five endpoints in Context (4)
+proxy through without a session and without an injected `Authorization` header.
+Everything else 401s when there is no session. Without this, cutover breaks the
+signed-out status page and Contact Us form.
+
+**c. A wildcard content-type parser scoped to the proxy.** Registered inside the
+proxy plugin's encapsulation so `/auth/*` keeps normal JSON parsing:
+
+```ts
+proxyScope.addContentTypeParser('*', (_request, payload, done) => done(null, payload))
+```
+
+The payload stays an unread stream, so bodies are neither buffered in memory nor
+measured against Fastify's 1 MB `bodyLimit`. Pair it with a header-only `getToken`
+for `@fastify/csrf-protection` so CSRF validation never needs a parsed body.
+
+**d. `await request.session.save()` in the refresh preHandler.** This is the
+Phase 2 lesson from `25a71a81`: saving before the reply leaves `@fastify/session`'s
+`onSend` hook on its synchronous no-op path, so Fastify does not fire a second
+`reply.send()` and `ERR_HTTP_HEADERS_SENT` cannot occur. It matters more with a
+streamed reply than it did with a buffered one.
+
+---
+
+## Alternatives considered
+
+**Hand-rolled `fetch` proxy** (the Phase 3 plan's 3-C sketch). Rejected. Beyond
+Context (2) and (3), it has two defects that are invisible in small-payload
+tests: `reply.send(await upstreamRes.arrayBuffer())` buffers every upload *and*
+every document download fully in memory; and undici transparently decompresses
+gzip responses while the sketch copies `content-encoding` and `content-length`
+through verbatim, so a compressed upstream response reaches the browser
+mislabelled and with a wrong length.
+
+**`@fastify/http-proxy`.** Viable — same engine underneath. Rejected for less
+direct control over per-request behaviour (the auth gate, the refresh, and the
+401 path all become plugin options) and an unused WebSocket dependency. Worth
+revisiting only if the BFF ever needs to proxy a WebSocket upgrade.
+
+---
+
+## Consequences
+
+- One new production dependency (`@fastify/reply-from`, which brings `undici`).
+  Connection pooling, hop-by-hop header handling, and chunked encoding come from
+  the library rather than from us.
+- Uploads and downloads stream; the proxy's memory use does not scale with
+  payload size, and `bodyLimit` stays at its default.
+- Because bodies pass through unparsed, nothing server-side inspects request
+  payloads. CSRF must therefore read its token from a header, and any future
+  need to inspect a proxied body means opting that route out of the wildcard
+  parser.
+- The `/duos-api` prefix is public API surface between client and BFF. Changing
+  it later means changing `getApiUrl()` and the route together.
+- Transient refresh failures must map to 502, not 401 — a 401 would sign out a
+  user whose session is healthy and whose upstream is merely briefly unreachable.
+  See `RefreshFailedError` in `../../../server/src/auth/refresh.ts`.

--- a/docs/plans/bff_adrs/ADR-004-api-proxy-layer.md
+++ b/docs/plans/bff_adrs/ADR-004-api-proxy-layer.md
@@ -17,14 +17,14 @@ Four properties of the current client decide it. All were confirmed against the
 code rather than assumed:
 
 **1. Real streaming traffic in both directions.** Uploads use `multipart/form-data`
-via `fetchMultipart` — [FileStorageObject.ts:40](../../src/libs/ajax/FileStorageObject.ts:40)
-(arbitrary user-selected `File`), [DataSet.ts:26](../../src/libs/ajax/DataSet.ts:26),
-[DataSet.ts:95](../../src/libs/ajax/DataSet.ts:95),
-[DataSet.ts:118](../../src/libs/ajax/DataSet.ts:118),
-[ProgressReport.ts:8](../../src/libs/ajax/ProgressReport.ts:8) — plus a binary
-`POST` to `/support/upload` ([Support.ts:74](../../src/libs/ajax/Support.ts:74)).
+via `fetchMultipart` — [FileStorageObject.ts:40](../../../src/libs/ajax/FileStorageObject.ts:40)
+(arbitrary user-selected `File`), [DataSet.ts:26](../../../src/libs/ajax/DataSet.ts:26),
+[DataSet.ts:95](../../../src/libs/ajax/DataSet.ts:95),
+[DataSet.ts:118](../../../src/libs/ajax/DataSet.ts:118),
+[ProgressReport.ts:8](../../../src/libs/ajax/ProgressReport.ts:8) — plus a binary
+`POST` to `/support/upload` ([Support.ts:74](../../../src/libs/ajax/Support.ts:74)).
 Downloads use `fetchBlob` in `DAA`, `DAR`, and `FileStorageObject`, and a
-`responseType: 'blob'` GET at [DataSet.ts:133](../../src/libs/ajax/DataSet.ts:133).
+`responseType: 'blob'` GET at [DataSet.ts:133](../../../src/libs/ajax/DataSet.ts:133).
 
 **2. Fastify parses nothing useful for a proxy.** Only `application/json` and
 `text/plain` have default parsers, so `multipart/form-data` and
@@ -88,16 +88,30 @@ proxy through without a session and without an injected `Authorization` header.
 Everything else 401s when there is no session. Without this, cutover breaks the
 signed-out status page and Contact Us form.
 
-**c. A wildcard content-type parser scoped to the proxy.** Registered inside the
-proxy plugin's encapsulation so `/auth/*` keeps normal JSON parsing:
+**c. Every content-type parser cleared inside the proxy's scope, then one
+wildcard pass-through.** A `'*'` parser alone is not enough: it is only a
+fallback. `ContentTypeParser.getParser` resolves the exact content type first,
+then the media type, then the regex list, and reaches the `'*'` entry last — so
+Fastify's built-in `application/json` and `text/plain` parsers keep winning, and
+those bodies are still buffered, still capped by `bodyLimit`, and still handed to
+the handler pre-parsed. Since DUOS posts JSON through the proxy on nearly every
+mutation, that is the common path, not an edge case.
 
 ```ts
+proxyScope.removeAllContentTypeParsers()
 proxyScope.addContentTypeParser('*', (_request, payload, done) => done(null, payload))
 ```
 
-The payload stays an unread stream, so bodies are neither buffered in memory nor
-measured against Fastify's 1 MB `bodyLimit`. Pair it with a header-only `getToken`
-for `@fastify/csrf-protection` so CSRF validation never needs a parsed body.
+Both calls are encapsulated — `plugin-override.js` rebuilds the parser table per
+plugin instance — so `/auth/*` keeps normal JSON parsing. Clearing wholesale is
+preferred over overriding `application/json` and `text/plain` individually:
+equivalent today, but it cannot be outflanked by a parser some future plugin
+registers in this scope.
+
+The payload then stays an unread stream, so bodies are neither buffered in memory
+nor measured against Fastify's 1 MB `bodyLimit`. Pair it with a header-only
+`getToken` for `@fastify/csrf-protection` so CSRF validation never needs a parsed
+body.
 
 **d. `await request.session.save()` in the refresh preHandler.** This is the
 Phase 2 lesson from `25a71a81`: saving before the reply leaves `@fastify/session`'s
@@ -139,4 +153,5 @@ revisiting only if the BFF ever needs to proxy a WebSocket upgrade.
   it later means changing `getApiUrl()` and the route together.
 - Transient refresh failures must map to 502, not 401 — a 401 would sign out a
   user whose session is healthy and whose upstream is merely briefly unreachable.
-  See `RefreshFailedError` in `../../../server/src/auth/refresh.ts`.
+  Story 3-B carries this as a distinct `RefreshFailedError` for the fatal case,
+  so the proxy has something to branch on.


### PR DESCRIPTION
## Addresses

[DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) — Phase 3 story 3-A: decide between `@fastify/http-proxy` and a hand-rolled `fetch` proxy for the BFF API proxy layer.

Security risk: no (documentation only).

## Summary
Documentation only — no runtime code changes. Records the proxy-layer decision before the implementation stories (3-B … 3-H) build on it, and marks Phase 2 complete in the phase table.

**Decision: `@fastify/reply-from` inside a BFF-declared route**, rather than `@fastify/http-proxy` or the hand-rolled `fetch` proxy the migration plan sketched. `@fastify/http-proxy` is `reply-from` plus prefix-mounting plus WebSocket support (a `ws` dependency DUOS has no use for); declaring the route ourselves keeps CSRF enforcement, token refresh, and upstream-401 handling as ordinary Fastify hooks instead of plugin options.

Four findings from the current client drove it, and three of them change the stories that follow:

- **Streaming is real.** Five multipart upload paths (`fetchMultipart` in `FileStorageObject`, `DataSet` ×3, `ProgressReport`), a binary POST to `/support/upload`, and blob downloads in `DAA`, `DAR`, `FileStorageObject`, and `DataSet`. The `fetch` sketch buffers every upload and download fully in memory, and copies `content-encoding`/`content-length` through verbatim while undici has already decompressed the body.
- **Fastify parses nothing useful for a proxy.** `multipart/form-data` and `application/binary` 415 before any handler runs; JSON arrives pre-parsed, so passing `request.body` to `fetch` sends `"[object Object]"`. Needs a proxy-scoped wildcard content-type parser so bodies stay unread streams.
- **9 of the ~113 upstream paths are not under `/api`** (`/status`, `/feature`, `/tos/text/duos`, `/ontology/*`, `/oauth2/configuration`, `/support/*`, `/api-docs/*`), so an `/api/*` wildcard under-covers and stripping the `/api` prefix breaks the other 95. Use one `/duos-api` prefix mapped to the upstream root — which also makes the Phase 4 client change a one-line `getApiUrl()` edit.
- **5 endpoints are called unauthenticated today**, so the proxy needs an explicit allowlist or cutover breaks the signed-out status page and Contact Us form.

### Test plan

No code changes, so nothing to exercise at runtime. Reviewers should sanity-check:

- The relative links in `ADR-004-api-proxy-layer.md` resolve from `docs/plans/bff_adrs/` (the `../../src/libs/ajax/...` citations and the `BFF_Overview.md` → `bff_adrs/ADR-004-api-proxy-layer.md` pointer).
- The decision itself, especially the `/duos-api` prefix — it becomes public API surface between client and BFF, and changing it later means changing `getApiUrl()` and the route together.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

[DT-3608]: https://broadworkbench.atlassian.net/browse/DT-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ