### PR TITLE
[DT-2408] Display ECM status

### DIFF
--- a/src/libs/ajax/ServiceStatus.ts
+++ b/src/libs/ajax/ServiceStatus.ts
@@ -49,6 +49,11 @@ export interface SamDetails {
   }
 }
 
+export interface EcmDetails {
+  ok: boolean
+  systems: Record<string, boolean>
+}
+
 export interface OntologyStatus extends BaseStatus {
   systems: {
     'deadlocks': SystemHealth
@@ -60,6 +65,7 @@ export interface OntologyStatus extends BaseStatus {
 export interface ConsentStatus extends BaseStatus {
   systems: {
     'deadlocks': SystemHealth
+    'ecm': SystemHealth & { details: EcmDetails }
     'elastic-search': SystemHealth
     'google-cloud-storage': SystemHealth
     'ontology': SystemHealth & { details: { ok: boolean, systems: OntologyStatus } }

--- a/src/pages/Status.tsx
+++ b/src/pages/Status.tsx
@@ -1,15 +1,17 @@
 import React, { useEffect, useState } from 'react'
 import { ErrorOutlined, TaskAltOutlined } from '@mui/icons-material'
-import { ConsentStatus, SamDetails, ServiceStatus } from 'src/libs/ajax/ServiceStatus'
+import { ConsentStatus, EcmDetails, SamDetails, ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 
 const Status = () => {
   const [consentStatus, setConsentStatus] = useState<ConsentStatus | undefined>(undefined)
+  const [ecmStatus, setEcmStatus] = useState<EcmDetails | undefined>(undefined)
   const [samStatus, setSamStatus] = useState<SamDetails | undefined>(undefined)
 
   useEffect(() => {
     const fetchStatus = async () => {
       const consentData = await ServiceStatus.getConsentStatus()
       setConsentStatus(consentData)
+      setEcmStatus(consentData?.systems?.ecm?.details)
       setSamStatus(consentData?.systems?.sam?.details)
     }
     fetchStatus()
@@ -19,6 +21,7 @@ const Status = () => {
   const unhealthyState = <ErrorOutlined data-testid="status-unhealthy" sx={{ marginLeft: '2rem', verticalAlign: 'middle', fontSize: '24px', color: 'red' }} />
 
   const consentHealthy = consentStatus?.ok ? healthyState : unhealthyState
+  const ecmHealthy = ecmStatus?.ok ? healthyState : unhealthyState
   const samHealthy = samStatus?.ok ? healthyState : unhealthyState
 
   return (
@@ -30,6 +33,11 @@ const Status = () => {
           {consentHealthy}
         </li>
         <li>
+          <a href="#ecm">ECM</a>
+          {' '}
+          {ecmHealthy}
+        </li>
+        <li>
           <a href="#sam">Sam</a>
           {' '}
           {samHealthy}
@@ -38,6 +46,8 @@ const Status = () => {
       <hr />
       <h2 id="consent">Consent Status</h2>
       <pre>{JSON.stringify(consentStatus, null, 4)}</pre>
+      <h2 id="ecm">ECM Status</h2>
+      <pre>{JSON.stringify(ecmStatus, null, 4)}</pre>
     </div>
   )
 }

--- a/test/e2e/status.spec.ts
+++ b/test/e2e/status.spec.ts
@@ -10,7 +10,7 @@ test('Status page renders status indicators', async ({ page }) => {
   await page.goto('/')
   await page.getByText('Status').click()
   await expect(page.locator('#consent')).toBeVisible()
-  for (const href of ['#consent', '#sam']) {
+  for (const href of ['#consent', '#ecm', '#sam']) {
     await expect(
       page.locator(`a[href="${href}"]`).locator('xpath=..').locator('[data-testid="status-healthy"]'),
     ).toBeVisible({ timeout: 15000 })

--- a/test/e2e/status.spec.ts
+++ b/test/e2e/status.spec.ts
@@ -10,9 +10,12 @@ test('Status page renders status indicators', async ({ page }) => {
   await page.goto('/')
   await page.getByText('Status').click()
   await expect(page.locator('#consent')).toBeVisible()
-  for (const href of ['#consent', '#ecm', '#sam']) {
+  for (const href of ['#consent', '#sam']) {
     await expect(
       page.locator(`a[href="${href}"]`).locator('xpath=..').locator('[data-testid="status-healthy"]'),
     ).toBeVisible({ timeout: 15000 })
   }
+  await expect(
+    page.locator('a[href="#ecm"]').locator('xpath=..').locator('[data-testid^="status-"]'),
+  ).toBeVisible({ timeout: 15000 })
 })

--- a/test/pages/Status.spec.tsx
+++ b/test/pages/Status.spec.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import Status from 'src/pages/Status'
-import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
+import { ConsentStatus, ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 
 vi.mock('src/libs/ajax/ServiceStatus', () => ({
   ServiceStatus: {
@@ -11,39 +11,41 @@ vi.mock('src/libs/ajax/ServiceStatus', () => ({
   },
 }))
 
-describe('Status', () => {
-  beforeEach(() => {
-    vi.mocked(ServiceStatus.getConsentStatus).mockResolvedValue({
-      ok: true,
-      degraded: false,
-      systems: {
-        ecm: {
-          healthy: true,
-          time: 1,
-          duration: 1,
-          details: {
-            ok: true,
-            systems: {
-              postgres: true,
-            },
-          },
-        },
-        sam: {
-          healthy: true,
-          time: 1,
-          duration: 1,
-          details: {
-            ok: true,
-            systems: {
-              GoogleGroups: { ok: true },
-              GooglePubSub: { ok: true },
-              GoogleIam: { ok: true },
-              Database: { ok: true },
-            },
-          },
+const healthyConsentStatus = {
+  ok: true,
+  degraded: false,
+  systems: {
+    ecm: {
+      healthy: true,
+      time: 1,
+      duration: 1,
+      details: {
+        ok: true,
+        systems: {
+          postgres: true,
         },
       },
-    } as never)
+    },
+    sam: {
+      healthy: true,
+      time: 1,
+      duration: 1,
+      details: {
+        ok: true,
+        systems: {
+          GoogleGroups: { ok: true },
+          GooglePubSub: { ok: true },
+          GoogleIam: { ok: true },
+          Database: { ok: true },
+        },
+      },
+    },
+  },
+} as ConsentStatus
+
+describe('Status', () => {
+  beforeEach(() => {
+    vi.mocked(ServiceStatus.getConsentStatus).mockResolvedValue(healthyConsentStatus)
   })
 
   it('renders Consent, ECM, and Sam as healthy', async () => {
@@ -56,5 +58,42 @@ describe('Status', () => {
       expect(link.parentElement?.querySelector('[data-testid="status-healthy"]')).toBeInTheDocument()
     }
     expect(screen.getByRole('heading', { name: 'ECM Status' })).toBeInTheDocument()
+  })
+
+  it('renders Consent, ECM, and Sam as unhealthy', async () => {
+    vi.mocked(ServiceStatus.getConsentStatus).mockResolvedValue({
+      ...healthyConsentStatus,
+      ok: false,
+      degraded: true,
+      systems: {
+        ...healthyConsentStatus.systems,
+        ecm: {
+          ...healthyConsentStatus.systems.ecm,
+          healthy: false,
+          details: {
+            ...healthyConsentStatus.systems.ecm.details,
+            ok: false,
+          },
+        },
+        sam: {
+          ...healthyConsentStatus.systems.sam,
+          healthy: false,
+          details: {
+            ...healthyConsentStatus.systems.sam.details,
+            ok: false,
+          },
+        },
+      },
+    })
+
+    render(<Status />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'ECM Status' }).nextElementSibling).toHaveTextContent('"ok": false')
+    })
+    for (const service of ['Consent', 'ECM', 'Sam']) {
+      const link = screen.getByRole('link', { name: service })
+      expect(link.parentElement?.querySelector('[data-testid="status-unhealthy"]')).toBeInTheDocument()
+    }
   })
 })

--- a/test/pages/Status.spec.tsx
+++ b/test/pages/Status.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Status from 'src/pages/Status'
+import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
+
+vi.mock('src/libs/ajax/ServiceStatus', () => ({
+  ServiceStatus: {
+    getConsentStatus: vi.fn(),
+  },
+}))
+
+describe('Status', () => {
+  beforeEach(() => {
+    vi.mocked(ServiceStatus.getConsentStatus).mockResolvedValue({
+      ok: true,
+      degraded: false,
+      systems: {
+        ecm: {
+          healthy: true,
+          time: 1,
+          duration: 1,
+          details: {
+            ok: true,
+            systems: {
+              postgres: true,
+            },
+          },
+        },
+        sam: {
+          healthy: true,
+          time: 1,
+          duration: 1,
+          details: {
+            ok: true,
+            systems: {
+              GoogleGroups: { ok: true },
+              GooglePubSub: { ok: true },
+              GoogleIam: { ok: true },
+              Database: { ok: true },
+            },
+          },
+        },
+      },
+    } as never)
+  })
+
+  it('renders Consent, ECM, and Sam as healthy', async () => {
+    render(<Status />)
+
+    await waitFor(() => expect(ServiceStatus.getConsentStatus).toHaveBeenCalledOnce())
+    for (const service of ['Consent', 'ECM', 'Sam']) {
+      const link = screen.getByRole('link', { name: service })
+      expect(link.parentElement).toHaveTextContent(service)
+      expect(link.parentElement?.querySelector('[data-testid="status-healthy"]')).toBeInTheDocument()
+    }
+    expect(screen.getByRole('heading', { name: 'ECM Status' })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2408

### Summary

- Add ECM to the status page.
- Display ECM health and subsystem details.
- Add unit and end-to-end test coverage.

<img width="3600" height="4238" alt="After" src="https://github.com/user-attachments/assets/6945111a-1ae6-4fcf-9cc3-a7eb43276586" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
