### PR TITLE
[DT-400] Switch devcontainer to node 26 stable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Node.js",
-    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:dev-26-trixie",
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:26-trixie",
     "postCreateCommand": "./scripts/setup-devcontainer.sh",
     "remoteUser": "node",
     "customizations": {

--- a/.devcontainer/uber/devcontainer.json
+++ b/.devcontainer/uber/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Combined DUOS",
-    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:dev-26-trixie",
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:26-trixie",
     "workspaceFolder": "/workspaces",
     "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/duos-ui,type=bind,consistency=cached",
     "mounts": [


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

Switch devcontainer to node 26 stable

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
