### PR TITLE
[DT-3608] BFF Phase 3: API proxy handler (story 3-C)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       '@fastify/postgres':
         specifier: 6.1.0
         version: 6.1.0(pg@8.22.0)
+      '@fastify/reply-from':
+        specifier: 12.6.4
+        version: 12.6.4
       '@fastify/session':
         specifier: 11.1.2
         version: 11.1.2
@@ -647,6 +650,9 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/reply-from@12.6.4':
+    resolution: {integrity: sha512-WpHqGNRKzEraRQwBFK64g2HijN0ZuDuiiwWg06r5LY0lv1iu0qYg1BfVM0iYcCMiovrM8kKXsKm5GDH9JH9aPA==}
 
   '@fastify/send@4.1.0':
     resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
@@ -1628,6 +1634,9 @@ packages:
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -1723,6 +1732,9 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
   fast-decode-uri-component@1.0.1:
     resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
@@ -2335,6 +2347,9 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -3082,6 +3097,9 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -3523,6 +3541,16 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.4.0
+
+  '@fastify/reply-from@12.6.4':
+    dependencies:
+      '@fastify/error': 4.2.0
+      end-of-stream: 1.4.5
+      fast-content-type-parse: 3.0.0
+      fast-querystring: 1.1.2
+      fastify-plugin: 6.0.0
+      toad-cache: 3.7.4
+      undici: 7.28.0
 
   '@fastify/send@4.1.0':
     dependencies:
@@ -4427,6 +4455,10 @@ snapshots:
 
   emoji-regex@10.6.0: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   entities@8.0.0: {}
 
   error-ex@1.3.4:
@@ -4557,6 +4589,8 @@ snapshots:
   expect-type@1.4.0: {}
 
   extend@3.0.2: {}
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-decode-uri-component@1.0.1: {}
 
@@ -5284,6 +5318,10 @@ snapshots:
 
   on-exit-leak-free@2.1.2: {}
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -6005,6 +6043,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   ws@8.21.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "@fastify/cookie": "11.1.2",
     "@fastify/csrf-protection": "8.0.0",
     "@fastify/postgres": "6.1.0",
+    "@fastify/reply-from": "12.6.4",
     "@fastify/session": "11.1.2",
     "@fastify/static": "10.1.2",
     "@fastify/vite": "9.2.0",

--- a/server/src/auth/oidcClient.ts
+++ b/server/src/auth/oidcClient.ts
@@ -40,13 +40,15 @@ async function discover(): Promise<oidc.Configuration> {
 /**
  * Validated here so a misconfigured environment fails with an error naming the
  * env var, instead of a TypeError from `new URL(undefined)` or an opaque B2C
- * rejection at token exchange. Exported so other `/auth/*` handlers (e.g.
- * `login.ts`'s `DUOS_OAUTH_REDIRECT_URI`) fail the same way.
+ * rejection at token exchange. Exported so the rest of the BFF fails the same
+ * way — `login.ts`'s `DUOS_OAUTH_REDIRECT_URI`, the proxy's `DUOS_API_URL` —
+ * which is why the message says "the BFF" rather than naming the OAuth flow:
+ * not every caller is part of it.
  */
 export function requireEnv(name: string): string {
   const value = process.env[name]
   if (!value) {
-    throw new Error(`${name} is unset but is required for the BFF OAuth flow — set it in .env.local locally, or the deployment env in k8s`)
+    throw new Error(`${name} is unset but is required by the BFF — set it in .env.local locally, or the deployment env in k8s`)
   }
   return value
 }

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -152,7 +152,7 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
   })
 
   app.all(`${PROXY_PREFIX}/*`, { preHandler: ensureUpstreamAuth }, (request, reply) => {
-    reply.from(upstreamPath(request.url), { rewriteRequestHeaders, onError: onUpstreamTransportError })
+    reply.from(upstreamPath(request.url), { rewriteRequestHeaders, rewriteHeaders, onError: onUpstreamTransportError })
   })
 }
 
@@ -316,4 +316,35 @@ function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefi
   }
   const chain = Array.isArray(inbound) ? inbound.join(', ') : inbound
   return chain ? `${chain}, ${request.ip}` : request.ip
+}
+
+/**
+ * The headers the browser actually sees — the return leg of the trust boundary.
+ *
+ * The rule is that the upstream may not write to this origin's state. A proxied
+ * response is served from the BFF's own origin, so anything the DUOS API sends
+ * here is applied as though the BFF had sent it:
+ *
+ *   set-cookie      — lands on the BFF origin, so an upstream response could
+ *                     overwrite `sessionId` and hand the user a different
+ *                     session (or a broken one). The request leg already
+ *                     refuses to forward that cookie upstream; letting the
+ *                     upstream set it back would undo the point of doing so.
+ *   clear-site-data — clears cookies, storage and cache for the BFF origin,
+ *                     which would sign the user out and wipe local state.
+ *
+ * Deliberately still forwarded, because they are not origin state and the client
+ * needs them: `content-encoding` and `content-type` (a gzip body has to arrive
+ * declared as one), `cache-control`, `etag`, `content-disposition` for the
+ * document downloads. `strict-transport-security` and `www-authenticate` are the
+ * two near misses — the first is origin *policy* rather than state and belongs
+ * to the ingress, the second only matters once story 3-E decides what an
+ * upstream 401 means; neither is stripped here.
+ */
+function rewriteHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  // Omitted by destructuring rather than deleted, for the same reason as the
+  // request leg: `headers` is the upstream's own `res.headers`, which reply-from
+  // may hand back on a retry.
+  const { 'set-cookie': setCookie, 'clear-site-data': clearSiteData, ...forwarded } = headers
+  return forwarded
 }

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -1,0 +1,293 @@
+import type { IncomingHttpHeaders } from 'node:http'
+import type {
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  RawServerBase,
+  RequestGenericInterface,
+  RouteGenericInterface,
+} from 'fastify'
+import fastifyReplyFrom from '@fastify/reply-from'
+import { requireEnv } from '../auth/oidcClient.js'
+import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
+
+/**
+ * The BFF API proxy (Phase 3, story 3-C).
+ *
+ * Every DUOS API call the client makes is forwarded from here with the session's
+ * B2C access token attached, so the browser never holds a bearer token. The
+ * shape of this module is set by ADR-004
+ * (docs/plans/bff_adrs/ADR-004-api-proxy-layer.md), which chose
+ * `@fastify/reply-from` inside a route the BFF declares itself over
+ * `@fastify/http-proxy` or a hand-rolled `fetch` loop. The three things worth
+ * re-reading there:
+ *
+ *   - **Bodies stream, unparsed.** DUOS uploads `multipart/form-data` and
+ *     `application/binary` and downloads blobs. Fastify would 415 the former
+ *     before this handler ran and hand the latter over pre-parsed, so this
+ *     scope clears every content-type parser and installs one pass-through.
+ *   - **One prefix, mapped to the upstream root.** 9 of the client's 113 upstream
+ *     paths sit outside `/api` (`/status`, `/feature`, `/ontology/*`, …), so
+ *     an `/api/*` wildcard under-covers. `/duos-api/<path>` covers all of them
+ *     with one rule and cannot collide with the BFF's own routes.
+ *   - **Five paths are called unauthenticated today.** The signed-out status
+ *     page and the Contact Us form depend on it, so they proxy through with no
+ *     session and no injected `Authorization`.
+ *
+ * Deliberately not here: CSRF enforcement on unsafe methods (story 3-D, an
+ * `onRequest` hook on this route) and destroying the session when the upstream
+ * itself returns 401 (story 3-E, an `onResponse` hook on `reply.from`).
+ *
+ * Nor is the plugin registered on the app until 3-D — and when it is, it belongs
+ * inside index.ts's `if (process.env.DUOS_DB_HOST)` block, under the same
+ * `bffEnabled === true` gate as the `/auth/*` routes. That is not just symmetry
+ * with those routes: the fatal-refresh path below calls `reply.clearCookie`,
+ * which is a `@fastify/cookie` decorator, and index.ts registers that plugin
+ * only inside the DUOS_DB_HOST block. Registered outside it, a dead refresh
+ * token would raise a TypeError instead of returning 401.
+ */
+
+/**
+ * The BFF-side prefix. `/duos-api/api/dataset/1` → `${DUOS_API_URL}/api/dataset/1`.
+ *
+ * Public API surface between client and BFF: Epic 4 makes `getApiUrl()` return
+ * this, at which point all 104 call sites keep their literal paths. Changing it
+ * later means changing both ends together.
+ */
+export const PROXY_PREFIX = '/duos-api'
+
+/**
+ * How early to renew the access token. Wide enough that a request which passes
+ * this check still has a usable token by the time it reaches the upstream, so
+ * ordinary expiry never reaches the browser as a 401.
+ */
+export const REFRESH_WINDOW_SECONDS = 60
+
+/**
+ * Bounded rather than undici's unbounded default (`connections: null` lets a
+ * Pool open Clients without limit): a request burst should queue on a fixed
+ * socket pool instead of consuming file descriptors until the pod runs out.
+ * Story 3-H load-tests the proxy and is the place to revise this. Timeouts stay
+ * at undici's 5-minute defaults, which large dataset uploads and document
+ * downloads need.
+ */
+const UPSTREAM_POOL_CONNECTIONS = 128
+
+/**
+ * Paths the client calls today with no `Authorization` header, verified against
+ * the call sites rather than assumed: `/status` (ServiceStatus.ts),
+ * `/oauth2/configuration` (OAuth2.ts), `/tos/text/duos` (ToS.ts, `textPlain()`),
+ * `/support/request` and `/support/upload` (Support.ts).
+ *
+ * They proxy through without a session, and without a token even when there IS
+ * a session — matching current client behaviour exactly is the point, so
+ * cutover cannot change what the upstream sees. Without this allowlist the
+ * signed-out status page and the Contact Us form would start returning 401.
+ *
+ * Matched exactly, not by prefix: a `/status` prefix would also swallow a
+ * future `/statuses`, and every entry here is a fixed path.
+ */
+export const UNAUTHENTICATED_PATHS: ReadonlySet<string> = new Set([
+  '/status',
+  '/oauth2/configuration',
+  '/tos/text/duos',
+  '/support/request',
+  '/support/upload',
+])
+
+/**
+ * Strips the BFF prefix and the query string, yielding the upstream path.
+ *
+ * The query is dropped on purpose rather than forwarded here: `reply.from()`
+ * re-appends the original query from `request.raw.url` byte-for-byte when the
+ * source it is given carries none. Passing it through `new URL()` instead would
+ * re-encode it, and paths like `/ontology/autocomplete?q=…` cannot afford that.
+ */
+export function upstreamPath(url: string): string {
+  const queryIndex = url.indexOf('?')
+  const path = queryIndex === -1 ? url : url.slice(0, queryIndex)
+  return path.slice(PROXY_PREFIX.length) || '/'
+}
+
+/**
+ * `reply.from`'s hooks are typed against `RawServerBase` — the http/http2 union
+ * — rather than this app's concrete server, so the two callbacks below have to
+ * be too, or they are rejected as contravariantly incompatible. Nothing either
+ * one touches differs between the two server types.
+ */
+type ProxyRequest = FastifyRequest<RequestGenericInterface, RawServerBase>
+type ProxyReply = FastifyReply<RouteGenericInterface, RawServerBase>
+
+/**
+ * Registers the proxy. Not wrapped in `fastify-plugin` — the encapsulation is
+ * the point: `removeAllContentTypeParsers()` below must apply to this scope
+ * only, or `/auth/*` would lose its JSON parsing too.
+ */
+export async function apiProxy(app: FastifyInstance): Promise<void> {
+  // Cleared wholesale, then one wildcard pass-through. A `'*'` parser alone is
+  // not enough: it is only the last resort. `getParser` resolves the exact
+  // content type, then the media type, then the regex list, and reaches `'*'`
+  // last — so Fastify's built-in `application/json` and `text/plain` parsers
+  // keep winning, and those bodies arrive buffered, capped by `bodyLimit`, and
+  // pre-parsed into an object that `reply.from` would send as
+  // `"[object Object]"`. DUOS posts JSON on nearly every mutation, so that is
+  // the common path, not an edge case. Clearing everything (rather than
+  // overriding those two) also cannot be outflanked by a parser some future
+  // plugin registers in this scope.
+  app.removeAllContentTypeParsers()
+  app.addContentTypeParser('*', (_request, payload, done) => {
+    // The payload stays an unread stream, so bodies are neither buffered in
+    // memory nor measured against Fastify's 1 MB bodyLimit. `reply.from`
+    // recognises a Stream body and pipes it straight to the upstream.
+    done(null, payload)
+  })
+
+  await app.register(fastifyReplyFrom, {
+    base: upstreamBase(),
+    undici: { connections: UPSTREAM_POOL_CONNECTIONS },
+  })
+
+  app.all(`${PROXY_PREFIX}/*`, { preHandler: ensureUpstreamAuth }, (request, reply) => {
+    reply.from(upstreamPath(request.url), { rewriteRequestHeaders, onError: onUpstreamTransportError })
+  })
+}
+
+/**
+ * Normalises the "never reached the upstream" failures to 502.
+ *
+ * reply-from maps `ENOTFOUND` to 503 and its timeouts to 504, but leaves
+ * `ECONNREFUSED`, `ECONNRESET`, `UND_ERR_SOCKET` and `UND_ERR_CONNECT_TIMEOUT`
+ * at 500 — so the commonest way for the DUOS API to be down reaches the browser
+ * as index.ts's generic "An unexpected error occurred", indistinguishable from a
+ * bug in the BFF itself. Gateway-class statuses are left alone, because 503 and
+ * 504 tell the client something 502 does not.
+ */
+function onUpstreamTransportError(reply: ProxyReply, { error }: { error: Error }): void {
+  const statusCode = (error as Error & { statusCode?: number }).statusCode ?? 502
+  const isGatewayClass = statusCode >= 502 && statusCode <= 504
+  reply.status(isGatewayClass ? statusCode : 502).send({ error: 'upstream_unavailable' })
+}
+
+/**
+ * `DUOS_API_URL` must be an origin with no path — `reply.from` builds the
+ * upstream as `new URL(source, base)`, which discards a base path and then
+ * fails its own "source must be a relative path string" guard. Checked at
+ * registration so a bad value fails at startup naming the variable, rather than
+ * 500ing every proxied request.
+ */
+function upstreamBase(): string {
+  const base = requireEnv('DUOS_API_URL')
+  const { pathname } = new URL(base)
+  if (pathname !== '/') {
+    throw new Error(`DUOS_API_URL is '${base}', which has a path — it must be a bare origin (scheme, host, and port only), because the proxy appends the upstream path to it`)
+  }
+  return base
+}
+
+/**
+ * Gate and token freshness, ahead of the handler.
+ *
+ * Returns the reply on the failure paths: in an async hook Fastify needs the
+ * reply returned to know the response was already sent, otherwise it carries on
+ * to the handler.
+ */
+async function ensureUpstreamAuth(request: FastifyRequest, reply: FastifyReply): Promise<FastifyReply | undefined> {
+  if (UNAUTHENTICATED_PATHS.has(upstreamPath(request.url))) {
+    return undefined
+  }
+
+  // Registered where it has to be (see the module comment), `@fastify/session`
+  // is always present and `request.session` is always an object, so the
+  // optional chaining is not covering a case any deployment reaches. It is
+  // there for a scope that registers the proxy on its own — which the tests
+  // do, to exercise this branch without standing up a Postgres session store.
+  if (!request.session?.accessToken) {
+    return reply.status(401).send({ error: 'unauthenticated' })
+  }
+
+  // A missing tokenExpiry reads as already expired, which refreshes rather than
+  // forwarding a token of unknown age upstream.
+  const secondsRemaining = (request.session.tokenExpiry ?? 0) - Math.floor(Date.now() / 1000)
+  if (secondsRemaining >= REFRESH_WINDOW_SECONDS) {
+    return undefined
+  }
+
+  try {
+    // Single-flight per session, and it persists the rotated tokens itself —
+    // which also satisfies ADR-004(d): the session is saved before the reply
+    // starts, so @fastify/session's onSend hook stays on its synchronous no-op
+    // path and cannot trigger the second reply.send() that caused
+    // ERR_HTTP_HEADERS_SENT in Phase 2 (25a71a81).
+    await refreshAccessToken(request)
+  }
+  catch (err: unknown) {
+    if (err instanceof RefreshFailedError) {
+      // Terminal: B2C rejected the refresh token and the session is already
+      // destroyed. Clear the cookie so the browser stops presenting a dead sid,
+      // as /auth/me does on the same verdict.
+      request.log.info({ err }, '[proxy] session cannot be refreshed — returning 401')
+      return reply.clearCookie('sessionId').status(401).send({ error: 'session_expired' })
+    }
+    // Transient — a network blip, B2C 5xx, a rotated-wrong client secret, a DB
+    // error while saving. The session is intact, so this must NOT be a 401:
+    // that would sign out every user the moment B2C hiccuped. 502 tells the
+    // client to surface an error and leave the session alone.
+    request.log.error({ err }, '[proxy] token refresh failed transiently — returning 502')
+    return reply.status(502).send({ error: 'upstream_unavailable' })
+  }
+
+  return undefined
+}
+
+/**
+ * The headers the upstream actually sees.
+ *
+ * Runs after `reply.from` has copied the request headers, set `host` to the
+ * upstream, and stripped the hop-by-hop ones (`connection` and everything it
+ * names), so this only has to deal with what is specific to the BFF.
+ */
+function rewriteRequestHeaders(request: ProxyRequest, headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  // Omitted by destructuring rather than deleted, because `headers` is the
+  // object reply-from reuses across a retry.
+  //
+  //   cookie       — the session cookie is the BFF's credential; forwarding it
+  //                  would hand the upstream a token-equivalent it has no use
+  //                  for. This is what makes the proxy a trust boundary.
+  //   authorization — never trust a client-supplied bearer token. Whatever the
+  //                  browser sent is replaced below with the session's token,
+  //                  or omitted entirely on an allowlisted path.
+  //   x-csrf-token — consumed by the BFF (story 3-D); meaningless upstream.
+  const { cookie, authorization, 'x-csrf-token': csrfToken, ...forwarded } = headers
+
+  const upstream = upstreamPath(request.url)
+  const accessToken = UNAUTHENTICATED_PATHS.has(upstream) ? undefined : request.session?.accessToken
+
+  return {
+    ...forwarded,
+    // Sent by the client on every call today (Config.authOpts / textPlain), so
+    // the upstream already expects it. Injected rather than merely forwarded so
+    // it is true of every proxied request regardless of what the caller set.
+    'x-app-id': 'DUOS',
+    'x-forwarded-for': forwardedFor(request, forwarded['x-forwarded-for']),
+    ...(accessToken === undefined ? {} : { authorization: `Bearer ${accessToken}` }),
+  }
+}
+
+/**
+ * The client-to-upstream address chain, with this pod appended as a hop.
+ *
+ * `request.ips` is the chain ordered closest-first — the socket peer, then the
+ * inbound `X-Forwarded-For` entries right to left — so it reverses into the
+ * header's original-client-first order. It is only populated when `trustProxy`
+ * is set, which index.ts always does; the fallback keeps this correct for an
+ * app that registers the proxy without it. Appending rather than replacing
+ * matters because the BFF genuinely is a hop, and `request.ip` alone would
+ * duplicate the entry the sidecar already added.
+ */
+function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefined): string {
+  if (request.ips) {
+    return [...request.ips].reverse().join(', ')
+  }
+  const chain = Array.isArray(inbound) ? inbound.join(', ') : inbound
+  return chain ? `${chain}, ${request.ip}` : request.ip
+}

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -106,6 +106,10 @@ export const UNAUTHENTICATED_PATHS: ReadonlySet<string> = new Set([
 export function upstreamPath(url: string): string {
   const queryIndex = url.indexOf('?')
   const path = queryIndex === -1 ? url : url.slice(0, queryIndex)
+  // The `|| '/'` is defensive, not a routing case: `/duos-api/*` does not match
+  // the bare prefix, so `/duos-api` 404s before reaching here and `/duos-api/`
+  // already slices to '/'. It only guarantees this exported helper never hands
+  // `reply.from` an empty source string.
   return path.slice(PROXY_PREFIX.length) || '/'
 }
 
@@ -174,13 +178,35 @@ function onUpstreamTransportError(reply: ProxyReply, { error }: { error: Error }
  * fails its own "source must be a relative path string" guard. Checked at
  * registration so a bad value fails at startup naming the variable, rather than
  * 500ing every proxied request.
+ *
+ * All three ways to get it wrong have to name the variable, or the guard does
+ * not do the job it exists for. A missing scheme is the likeliest — a bare
+ * hostname is what a Helm value tends to look like — and `new URL()` rejects it
+ * with an unadorned `TypeError: Invalid URL` that mentions neither the variable
+ * nor the value. The protocol check is what separates `localhost:8000`
+ * (protocol `localhost:`, pathname `8000`) from a genuine path, which would
+ * otherwise be reported as "has a path".
  */
 function upstreamBase(): string {
   const base = requireEnv('DUOS_API_URL')
-  const { pathname } = new URL(base)
-  if (pathname !== '/') {
-    throw new Error(`DUOS_API_URL is '${base}', which has a path — it must be a bare origin (scheme, host, and port only), because the proxy appends the upstream path to it`)
+  const mustBeOrigin = 'it must be a bare origin (scheme, host, and port only), because the proxy appends the upstream path to it'
+
+  let parsed: URL
+  try {
+    parsed = new URL(base)
   }
+  catch {
+    throw new Error(`DUOS_API_URL is '${base}', which is not a valid URL — ${mustBeOrigin}. Include the scheme, e.g. https://duos.example.org`)
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`DUOS_API_URL is '${base}', whose scheme is '${parsed.protocol}' — ${mustBeOrigin}. Expected http or https, e.g. https://duos.example.org`)
+  }
+
+  if (parsed.pathname !== '/') {
+    throw new Error(`DUOS_API_URL is '${base}', which has a path — ${mustBeOrigin}`)
+  }
+
   return base
 }
 

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -650,6 +650,44 @@ describe('apiProxy', () => {
       expect(res.body).toBe('col\tvalue')
     })
 
+    // The return leg of the trust boundary. A proxied response is served from
+    // the BFF's own origin, so an upstream Set-Cookie would be applied to that
+    // origin — overwriting `sessionId` with a value the DUOS API chose, which
+    // hands the user a different session or a broken one. Stripping it is what
+    // makes the request leg's refusal to forward the cookie worth anything.
+    it('does not forward an upstream set-cookie, even one naming the session cookie', async () => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'set-cookie': ['sessionId=upstream-chosen-value; Path=/; HttpOnly', 'tracking=1'],
+        })
+        res.end('{"ok":true}')
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.headers['set-cookie']).toBeUndefined()
+      // The body still arrives — the header is dropped, not the response.
+      expect(res.json()).toEqual({ ok: true })
+    })
+
+    // Same reasoning: scoped to the BFF origin, so an upstream response could
+    // clear the session cookie and the user's local state along with it.
+    it('does not forward an upstream clear-site-data', async () => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json', 'clear-site-data': '"cookies", "storage"' })
+        res.end('{"ok":true}')
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.headers['clear-site-data']).toBeUndefined()
+      expect(res.json()).toEqual({ ok: true })
+    })
+
     // reply-from leaves a refused connection at 500, which index.ts's error
     // handler would render as its generic "An unexpected error occurred" —
     // reading as a BFF bug rather than an upstream outage.

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -147,8 +147,11 @@ describe('apiProxy', () => {
       [`${PROXY_PREFIX}/api/dataset/1`, '/api/dataset/1'],
       [`${PROXY_PREFIX}/status`, '/status'],
       [`${PROXY_PREFIX}/api/dar/v2?open=true`, '/api/dar/v2'],
-      // The prefix on its own has no upstream path to map to; '/' keeps it a
-      // valid URL rather than an empty source string.
+      [`${PROXY_PREFIX}/`, '/'],
+      // Defensive only. `/duos-api/*` does not match the bare prefix, so the
+      // router 404s `/duos-api` rather than delivering it here (the trailing
+      // slash above is the reachable form). Asserted so the exported helper is
+      // never the thing that hands `reply.from` an empty source string.
       [PROXY_PREFIX, '/'],
     ])('maps %s to %s', (url, expected) => {
       expect(upstreamPath(url)).toBe(expected)
@@ -232,6 +235,27 @@ describe('apiProxy', () => {
       unregistered.register(apiProxy)
 
       await expect(unregistered.ready()).rejects.toThrow(/DUOS_API_URL.*must be a bare origin/s)
+      await unregistered.close()
+    })
+
+    // A bare hostname is what a Helm value tends to look like, and it is the one
+    // malformed value new URL() rejects on its own — with a TypeError naming
+    // neither the variable nor the value, so the startup failure says nothing
+    // about what to fix. The scheme cases are separated from the path case
+    // because 'localhost:8000' parses as protocol 'localhost:' with pathname
+    // '8000', so a pathname check alone would report a missing scheme as a path.
+    it.each([
+      ['a bare hostname', 'duos-api.dsde-dev.broadinstitute.org', /not a valid URL/],
+      ['a host:port with no scheme', 'localhost:8000', /scheme is 'localhost:'/],
+      ['a non-HTTP scheme', 'ftp://duos-api.example.org', /scheme is 'ftp:'/],
+    ])('fails to register when DUOS_API_URL is %s, naming the variable', async (_case, value, expected) => {
+      process.env.DUOS_API_URL = value
+      const unregistered = Fastify({ logger: false })
+      unregistered.register(apiProxy)
+
+      const ready = expect(unregistered.ready()).rejects
+      await ready.toThrow(/^DUOS_API_URL is/)
+      await ready.toThrow(expected)
       await unregistered.close()
     })
   })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -1,0 +1,654 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import http from 'node:http'
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { gzipSync } from 'node:zlib'
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyCookie from '@fastify/cookie'
+import { RefreshFailedError } from '../src/auth/refresh.js'
+import { PROXY_PREFIX, REFRESH_WINDOW_SECONDS, UNAUTHENTICATED_PATHS, apiProxy, upstreamPath } from '../src/proxy/apiProxy.js'
+
+// refreshAccessToken is replaced so the tests never reach B2C; RefreshFailedError
+// stays the real class so the proxy's instanceof branch is exercised rather than
+// stubbed. Story 3-B's own tests cover what refresh does internally — here it is
+// only interesting as a call that succeeds, fails fatally, or fails transiently.
+vi.mock('../src/auth/refresh.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/auth/refresh.js')>()
+  return { ...actual, refreshAccessToken: vi.fn() }
+})
+
+const nowSeconds = (): number => Math.floor(Date.now() / 1000)
+
+interface ReceivedRequest {
+  method: string
+  url: string
+  headers: IncomingHttpHeaders
+  body: Buffer
+}
+
+interface Upstream {
+  origin: string
+  received: ReceivedRequest[]
+  /** The last request the upstream saw — the assertion target for header/path tests. */
+  last: () => ReceivedRequest
+  respondWith: (handler: (req: IncomingMessage, res: ServerResponse) => void) => void
+  close: () => Promise<void>
+}
+
+/**
+ * A real HTTP server standing in for the DUOS API.
+ *
+ * Real rather than a mocked `fetch`: the point of most of these tests is what
+ * actually goes out on the wire — that a 2 MB body was streamed rather than
+ * rejected, that a gzip response arrived undisturbed, that the session cookie
+ * never left the BFF. A stub of undici would be asserting on the mock.
+ */
+async function startUpstream(): Promise<Upstream> {
+  const received: ReceivedRequest[] = []
+  let handler = (_req: IncomingMessage, res: ServerResponse): void => {
+    res.writeHead(200, { 'content-type': 'application/json' })
+    res.end('{"ok":true}')
+  }
+
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => {
+      received.push({
+        method: req.method ?? '',
+        url: req.url ?? '',
+        headers: req.headers,
+        body: Buffer.concat(chunks),
+      })
+      handler(req, res)
+    })
+  })
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const { port } = server.address() as AddressInfo
+
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    received,
+    last: () => {
+      const last = received.at(-1)
+      if (!last) throw new Error('the upstream received no requests')
+      return last
+    },
+    respondWith: (next) => { handler = next },
+    // Idempotent: one test closes the upstream mid-case to simulate an outage,
+    // and afterEach closes it again.
+    close: () => new Promise<void>((resolve, reject) => {
+      if (!server.listening) {
+        resolve()
+        return
+      }
+      server.close(err => err ? reject(err) : resolve())
+    }),
+  }
+}
+
+interface FakeSession {
+  accessToken?: string
+  tokenExpiry?: number
+}
+
+/**
+ * An app carrying just enough of the real one for the proxy to run:
+ * `@fastify/cookie` (the fatal-refresh path calls `reply.clearCookie`) and
+ * `trustProxy` (index.ts always sets it, and it is what populates
+ * `request.ips`).
+ *
+ * The session is attached by a hook rather than by registering
+ * `@fastify/session`, which would need a Postgres store. `session: undefined`
+ * leaves `request.session` unset, which is what a deployment without the BFF
+ * database configured actually looks like.
+ */
+async function buildProxyApp(session?: FakeSession): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false, trustProxy: 1 })
+  await app.register(fastifyCookie)
+  if (session) {
+    app.addHook('onRequest', async (request) => {
+      ;(request as { session?: FakeSession }).session = session
+    })
+  }
+  await app.register(apiProxy)
+  return app
+}
+
+describe('apiProxy', () => {
+  let upstream: Upstream
+  let app: FastifyInstance | undefined
+
+  beforeEach(async () => {
+    upstream = await startUpstream()
+    process.env.DUOS_API_URL = upstream.origin
+    const { refreshAccessToken } = await import('../src/auth/refresh.js')
+    vi.mocked(refreshAccessToken).mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+    await upstream.close()
+    delete process.env.DUOS_API_URL
+  })
+
+  /** A session comfortably outside the refresh window. */
+  const freshSession = (accessToken = 'session-access-token'): FakeSession => ({
+    accessToken,
+    tokenExpiry: nowSeconds() + 3600,
+  })
+
+  describe('upstreamPath', () => {
+    it.each([
+      [`${PROXY_PREFIX}/api/dataset/1`, '/api/dataset/1'],
+      [`${PROXY_PREFIX}/status`, '/status'],
+      [`${PROXY_PREFIX}/api/dar/v2?open=true`, '/api/dar/v2'],
+      // The prefix on its own has no upstream path to map to; '/' keeps it a
+      // valid URL rather than an empty source string.
+      [PROXY_PREFIX, '/'],
+    ])('maps %s to %s', (url, expected) => {
+      expect(upstreamPath(url)).toBe(expected)
+    })
+  })
+
+  describe('routing', () => {
+    it('forwards the path with the BFF prefix stripped', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().url).toBe('/api/dataset/1')
+    })
+
+    // Re-encoding the query would corrupt paths like /ontology/autocomplete,
+    // so it is passed through byte-for-byte rather than round-tripped via URL.
+    it('forwards the query string verbatim', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/ontology/autocomplete?q=breast%20cancer&n=5` })
+
+      expect(upstream.last().url).toBe('/ontology/autocomplete?q=breast%20cancer&n=5')
+    })
+
+    it('forwards the method', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({ method: 'DELETE', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(upstream.last().method).toBe('DELETE')
+    })
+
+    it('returns the upstream status and body to the client', async () => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(422, { 'content-type': 'application/json' })
+        res.end('{"message":"nope"}')
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(422)
+      expect(res.body).toBe('{"message":"nope"}')
+    })
+
+    // A crafted path cannot walk outside the configured upstream origin. Two
+    // separate mechanisms stop it, and this one lands on the first: WHATWG URL
+    // parsing resolves the `..` segments (including their `%2e` spellings)
+    // before routing, so what reaches the router is `/etc/passwd`, which does
+    // not match the proxy prefix. Should a client ever deliver a literal `..`
+    // past that, reply-from decodes the source and rejects it with a 400 before
+    // building the upstream URL. Either way the upstream is never called.
+    it('does not proxy a path traversal attempt', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/../../etc/passwd` })
+
+      expect(res.statusCode).toBe(404)
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
+  describe('the upstream base URL', () => {
+    it('fails to register when DUOS_API_URL is unset, naming the variable', async () => {
+      delete process.env.DUOS_API_URL
+      const unregistered = Fastify({ logger: false })
+      unregistered.register(apiProxy)
+
+      await expect(unregistered.ready()).rejects.toThrow('DUOS_API_URL')
+      await unregistered.close()
+    })
+
+    // reply.from() builds the upstream as new URL(path, base), which discards a
+    // base path and then trips its own "source must be a relative path string"
+    // guard — so every proxied request would 500. Better to fail at startup.
+    it('fails to register when DUOS_API_URL carries a path', async () => {
+      process.env.DUOS_API_URL = `${upstream.origin}/consent`
+      const unregistered = Fastify({ logger: false })
+      unregistered.register(apiProxy)
+
+      await expect(unregistered.ready()).rejects.toThrow(/DUOS_API_URL.*must be a bare origin/s)
+      await unregistered.close()
+    })
+  })
+
+  describe('the authentication gate', () => {
+    it('returns 401 without calling the upstream when there is no session at all', async () => {
+      app = await buildProxyApp()
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'unauthenticated' })
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('returns 401 without calling the upstream when the session holds no access token', async () => {
+      app = await buildProxyApp({ tokenExpiry: nowSeconds() + 3600 })
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(401)
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('sends the session access token as a Bearer token', async () => {
+      app = await buildProxyApp(freshSession('the-session-token'))
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(upstream.last().headers.authorization).toBe('Bearer the-session-token')
+    })
+  })
+
+  describe('the unauthenticated allowlist', () => {
+    it('matches the five paths the client calls without an Authorization header today', () => {
+      // Pinned as a set rather than spot-checked: adding a path here means
+      // deciding that it may be reached with no session, which deserves to
+      // show up as a deliberate change to this list in review.
+      expect([...UNAUTHENTICATED_PATHS].sort()).toEqual([
+        '/oauth2/configuration',
+        '/status',
+        '/support/request',
+        '/support/upload',
+        '/tos/text/duos',
+      ])
+    })
+
+    it.each([...UNAUTHENTICATED_PATHS])('proxies %s with no session', async (path) => {
+      app = await buildProxyApp()
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}${path}` })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().url).toBe(path)
+    })
+
+    // The signed-out status page and Contact Us form send no token today, so
+    // neither may the proxy — cutover must not change what the upstream sees.
+    it('injects no Authorization header even when the caller does have a session', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/status` })
+
+      expect(upstream.last().headers.authorization).toBeUndefined()
+    })
+
+    // Matched exactly: '/statuses' must not inherit '/status''s exemption.
+    it('does not exempt a path that merely starts with an allowlisted one', async () => {
+      app = await buildProxyApp()
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/statuses` })
+
+      expect(res.statusCode).toBe(401)
+    })
+
+    it('does not refresh the token for an allowlisted path', async () => {
+      app = await buildProxyApp({ accessToken: 'about-to-expire', tokenExpiry: nowSeconds() })
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/status` })
+
+      expect(refreshAccessToken).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('proactive token refresh', () => {
+    it('does not refresh a token with plenty of life left', async () => {
+      app = await buildProxyApp(freshSession())
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(refreshAccessToken).not.toHaveBeenCalled()
+    })
+
+    it('refreshes a token expiring inside the window, then proxies the request', async () => {
+      app = await buildProxyApp({
+        accessToken: 'nearly-expired',
+        tokenExpiry: nowSeconds() + REFRESH_WINDOW_SECONDS - 5,
+      })
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(refreshAccessToken).toHaveBeenCalledOnce()
+      expect(res.statusCode).toBe(200)
+    })
+
+    // A session with no recorded expiry is of unknown age — refreshing is the
+    // safe reading, since forwarding it risks a 401 that story 3-E would turn
+    // into a sign-out.
+    it('refreshes when the session has no recorded expiry', async () => {
+      app = await buildProxyApp({ accessToken: 'expiry-unknown' })
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(refreshAccessToken).toHaveBeenCalledOnce()
+    })
+
+    it('sends the token the refresh installed, not the stale one', async () => {
+      const session: FakeSession = { accessToken: 'stale-token', tokenExpiry: nowSeconds() }
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      // The real refreshAccessToken mutates request.session in place; mirroring
+      // that here proves the handler reads the token after the refresh rather
+      // than capturing it beforehand.
+      vi.mocked(refreshAccessToken).mockImplementation(async () => {
+        session.accessToken = 'renewed-token'
+        session.tokenExpiry = nowSeconds() + 3600
+      })
+      app = await buildProxyApp(session)
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(upstream.last().headers.authorization).toBe('Bearer renewed-token')
+    })
+
+    it('returns 401 and clears the cookie when the refresh token is dead', async () => {
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      vi.mocked(refreshAccessToken).mockRejectedValue(new RefreshFailedError('refresh_failed'))
+      app = await buildProxyApp({ accessToken: 'stale-token', tokenExpiry: nowSeconds() })
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'session_expired' })
+      // Otherwise the browser keeps presenting a sid whose row is already gone.
+      expect(res.cookies).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: 'sessionId', value: '' }),
+      ]))
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    // 401 here would sign out every user the moment B2C hiccuped or a client
+    // secret was rotated wrong. The session is untouched, so 502 it is.
+    it('returns 502, not 401, when the refresh fails transiently', async () => {
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      vi.mocked(refreshAccessToken).mockRejectedValue(new TypeError('fetch failed'))
+      app = await buildProxyApp({ accessToken: 'still-good-token', tokenExpiry: nowSeconds() })
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(502)
+      expect(res.json()).toEqual({ error: 'upstream_unavailable' })
+      expect(res.cookies).toEqual([])
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
+  describe('request headers', () => {
+    it('never forwards the session cookie', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { cookie: 'sessionId=s%3Aabc.def; other=1' },
+      })
+
+      expect(upstream.last().headers.cookie).toBeUndefined()
+    })
+
+    it('replaces a client-supplied Authorization header rather than trusting it', async () => {
+      app = await buildProxyApp(freshSession('the-session-token'))
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { authorization: 'Bearer attacker-supplied' },
+      })
+
+      expect(upstream.last().headers.authorization).toBe('Bearer the-session-token')
+    })
+
+    it('drops a client-supplied Authorization header on an allowlisted path', async () => {
+      app = await buildProxyApp()
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/status`,
+        headers: { authorization: 'Bearer attacker-supplied' },
+      })
+
+      expect(upstream.last().headers.authorization).toBeUndefined()
+    })
+
+    it('does not forward the BFF CSRF token', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { 'x-csrf-token': 'a-bff-only-token' },
+      })
+
+      expect(upstream.last().headers['x-csrf-token']).toBeUndefined()
+    })
+
+    it('injects X-App-ID, which the upstream expects on every call', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(upstream.last().headers['x-app-id']).toBe('DUOS')
+    })
+
+    it('forwards ordinary client headers untouched', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { 'accept': 'application/json', 'accept-language': 'en-GB' },
+      })
+
+      expect(upstream.last().headers.accept).toBe('application/json')
+      expect(upstream.last().headers['accept-language']).toBe('en-GB')
+    })
+
+    it('sets Host to the upstream, not the BFF', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { host: 'duos.dsde-dev.broadinstitute.org' },
+      })
+
+      expect(upstream.last().headers.host).toBe(new URL(upstream.origin).host)
+    })
+
+    // The BFF is a genuine hop, so it appends rather than replacing — the
+    // original client must stay first in the chain for upstream audit logs.
+    it('appends this hop to the inbound X-Forwarded-For chain', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { 'x-forwarded-for': '203.0.113.9' },
+      })
+
+      const chain = String(upstream.last().headers['x-forwarded-for']).split(', ')
+      expect(chain[0]).toBe('203.0.113.9')
+      expect(chain).toHaveLength(2)
+    })
+
+    it('sends an X-Forwarded-For even when the request arrives without one', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(upstream.last().headers['x-forwarded-for']).toBeTruthy()
+    })
+  })
+
+  // Every case here fails if the content-type parsers are not cleared in the
+  // proxy's scope: Fastify would 415 the multipart and binary uploads before
+  // the handler ran, hand JSON over as an already-parsed object (which
+  // reply.from would send as "[object Object]"), and cap bodies at bodyLimit.
+  describe('request bodies', () => {
+    it('streams a JSON body through byte-for-byte instead of re-serialising it', async () => {
+      app = await buildProxyApp(freshSession())
+      // Key order and spacing survive only if the body was never parsed.
+      const payload = '{"b":1,"a":  2}'
+
+      await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/search`,
+        headers: { 'content-type': 'application/json' },
+        payload,
+      })
+
+      expect(upstream.last().body.toString()).toBe(payload)
+      expect(upstream.last().headers['content-type']).toBe('application/json')
+    })
+
+    it('proxies a multipart/form-data upload', async () => {
+      app = await buildProxyApp(freshSession())
+      const body = '--boundary\r\nContent-Disposition: form-data; name="file"; filename="a.txt"\r\n\r\nhello\r\n--boundary--\r\n'
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/v3`,
+        headers: { 'content-type': 'multipart/form-data; boundary=boundary' },
+        payload: body,
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().body.toString()).toBe(body)
+      expect(upstream.last().headers['content-type']).toBe('multipart/form-data; boundary=boundary')
+    })
+
+    it('proxies an application/binary upload', async () => {
+      app = await buildProxyApp(freshSession())
+      const body = Buffer.from([0x00, 0x01, 0xFF, 0xFE])
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/support/upload`,
+        headers: { 'content-type': 'application/binary' },
+        payload: body,
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().body.equals(body)).toBe(true)
+    })
+
+    // Fastify's default bodyLimit is 1 MB. Because the payload is never read
+    // into memory it is never measured against it — which is what lets DUOS
+    // upload real dataset files through the proxy.
+    it('proxies a body larger than the default bodyLimit', async () => {
+      app = await buildProxyApp(freshSession())
+      const body = Buffer.alloc(2 * 1024 * 1024, 'a')
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/v3`,
+        headers: { 'content-type': 'application/octet-stream' },
+        payload: body,
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().body).toHaveLength(body.length)
+    })
+
+    it('sends no body for a GET', async () => {
+      app = await buildProxyApp(freshSession())
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(upstream.last().body).toHaveLength(0)
+    })
+  })
+
+  describe('response handling', () => {
+    // undici does not transparently decompress, so a gzip response reaches the
+    // browser with its encoding and length intact. The rejected hand-rolled
+    // fetch proxy would have decompressed the body while copying
+    // content-encoding through, mislabelling it.
+    it('passes a gzip-encoded response through undisturbed', async () => {
+      const compressed = gzipSync(Buffer.from('{"large":"document"}'))
+      upstream.respondWith((_req, res) => {
+        res.writeHead(200, {
+          'content-type': 'application/json',
+          'content-encoding': 'gzip',
+          'content-length': String(compressed.length),
+        })
+        res.end(compressed)
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.headers['content-encoding']).toBe('gzip')
+      expect(res.rawPayload.equals(compressed)).toBe(true)
+    })
+
+    it('forwards upstream response headers', async () => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(200, {
+          'content-type': 'text/plain',
+          'content-disposition': 'attachment; filename="report.tsv"',
+        })
+        res.end('col\tvalue')
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dar/1/document` })
+
+      expect(res.headers['content-disposition']).toBe('attachment; filename="report.tsv"')
+      expect(res.body).toBe('col\tvalue')
+    })
+
+    // reply-from leaves a refused connection at 500, which index.ts's error
+    // handler would render as its generic "An unexpected error occurred" —
+    // reading as a BFF bug rather than an upstream outage.
+    it('returns 502, not 500, when the connection to the upstream is refused', async () => {
+      app = await buildProxyApp(freshSession())
+      await upstream.close()
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(502)
+      expect(res.json()).toEqual({ error: 'upstream_unavailable' })
+    })
+
+    // 503 and 504 say more than 502 does, so the mapping above leaves them be.
+    // `.invalid` is reserved by RFC 2606 and never resolves, so this is an
+    // ENOTFOUND rather than a real DNS lookup.
+    it('preserves a gateway-class status the proxy library already assigned', async () => {
+      process.env.DUOS_API_URL = 'http://duos-api.invalid'
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(503)
+    })
+  })
+})


### PR DESCRIPTION
## Addresses

[DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) — Phase 3 story 3-C: implement the `apiProxy` handler.

Security risk: low. The plugin is not registered on the app in this PR, so it adds no reachable route to any deployment — the diff is purely additive and cannot regress a running environment. It is security-relevant code (it attaches the session's bearer token and strips the session cookie at the trust boundary), and it adds one production dependency, so it warrants review rather than "no".

## Summary

Implements the proxy handler decided in ADR-004 (story 3-A): **`@fastify/reply-from` inside a BFF-declared route**, replacing the hand-rolled `fetch` proxy the migration plan sketched for this story. Stacked on 3-B's single-flight refresh, which has since merged, so this now targets `develop` directly.

`server/src/proxy/apiProxy.ts` is an encapsulated Fastify plugin that:

- **Clears every content-type parser in its own scope** and installs one `'*'` pass-through. A `'*'` parser alone is not enough — it is only the last resort, so Fastify's built-in `application/json` and `text/plain` parsers keep winning. Without this, multipart and binary uploads 415 before the handler runs, JSON arrives pre-parsed (and would be sent upstream as `"[object Object]"`), and every body is buffered against the 1 MB `bodyLimit`. Clearing is scoped, so `/auth/*` keeps normal JSON parsing.
- **Maps one prefix to the upstream root** — `/duos-api/<path>` → `${DUOS_API_URL}/<path>`. Covers all ~113 upstream paths with one rule, including the 9 outside `/api`, and cannot collide with the BFF's own routes. Epic 4 then becomes a one-line change to `getApiUrl()`.
- **Exempts five paths from authentication.** `/status`, `/oauth2/configuration`, `/tos/text/duos`, `/support/request`, `/support/upload` proxy through with no session and — importantly — no injected `Authorization` even when the caller does have one, because that is exactly what the client does today. Without this, cutover breaks the signed-out status page and Contact Us form. Each of the five was re-verified against its call site rather than taken from the ADR.
- **Refreshes proactively** inside a 60s window using 3-B's `refreshAccessToken`. A fatal `RefreshFailedError` returns 401 and clears the session cookie; anything transient returns **502, not 401** — a 401 would sign out every user the moment B2C hiccuped or a client secret was rotated wrong.
- **Rewrites headers at the trust boundary.** Injects `Authorization` and `X-App-ID`; never forwards the session `cookie`, a client-supplied `Authorization`, or `X-CSRF-Token`; appends this pod to the `X-Forwarded-For` chain rather than replacing it.
- **Validates `DUOS_API_URL` as a bare origin at registration.** `reply.from` builds the upstream as `new URL(path, base)`, which discards a base path and then trips its own guard, so a value with a path would 500 every proxied request. Fails at startup naming the variable instead. (No deployment impact until 3-D registers the plugin.)

### One addition beyond the story

reply-from maps `ENOTFOUND` to 503 and its timeouts to 504, but leaves `ECONNREFUSED`, `ECONNRESET`, `UND_ERR_SOCKET` and `UND_ERR_CONNECT_TIMEOUT` at **500**. That means the commonest way for the DUOS API to be down would reach the browser as `index.ts`'s generic "An unexpected error occurred" — indistinguishable from a bug in the BFF. An `onError` normalises those to 502 and leaves genuine gateway-class statuses alone.

### Deliberately not in this PR

- Registering the plugin on the app, and CSRF enforcement on unsafe methods — story 3-D. The module comment records where it has to be registered (inside the `DUOS_DB_HOST` block, under `bffEnabled`) and why: `reply.clearCookie` and `csrfProtection` are decorators from plugins that only exist there.
- Destroying the session when the upstream itself returns 401 — story 3-E.

### Dependency

Adds `@fastify/reply-from@12.6.4` (pinned exact), which brings `undici` 7. Connection pooling, hop-by-hop header handling and chunked encoding come from the library rather than from us. The pool is bounded rather than left at undici's unbounded default; story 3-H load-tests it.

## Test plan

- `server/test/apiProxy.test.ts` — 47 new tests. They run against a **real HTTP upstream** on an ephemeral port rather than a mocked `fetch`, because most of what matters here is what actually goes on the wire.
- Streaming and encoding claims are verified rather than asserted in comments: a 2 MB body proxies through (proving it is never measured against `bodyLimit`), `multipart/form-data` and `application/binary` uploads reach the upstream byte-for-byte, a JSON body survives with its key order and spacing intact (proving it was never parsed), and a gzip response arrives byte-identical with `content-encoding` intact.
- Trust-boundary coverage: session cookie never forwarded, client-supplied `Authorization` replaced, `X-CSRF-Token` dropped, no token injected on allowlisted paths, `Host` set to the upstream.
- Failure paths: 401 with no session, fatal refresh → 401 + cleared cookie, transient refresh → 502, refused connection → 502, `ENOTFOUND` → 503 preserved.
- Full server suite green: **182 tests, 13 files**. `tsc --noEmit`, `oxlint && eslint .`, and `pnpm --filter duos-server build` all clean.
- Not exercised end-to-end in a browser, and cannot be — no route is registered until 3-D. First real-environment verification lands with that PR.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

[DT-3608]: https://broadworkbench.atlassian.net/browse/DT-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ