### PR TITLE
[DT-2971] Avoid duplicate TDR API calls

### DIFF
--- a/src/hooks/useLibraryExportableDatasets.ts
+++ b/src/hooks/useLibraryExportableDatasets.ts
@@ -17,7 +17,7 @@ export const useLibraryExportableDatasets = (
     datasets
       .map(dataset => dataset.datasetIdentifier)
       .filter((identifier): identifier is string => Boolean(identifier)),
-  )]
+  )].sort((a, b) => a.localeCompare(b))
 
   return useQuery({
     queryKey: [LIBRARY_EXPORTS_QUERY_KEY, datasetIdentifiers],

--- a/src/hooks/useLibraryExportableDatasets.ts
+++ b/src/hooks/useLibraryExportableDatasets.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { ExportableDatasets } from 'src/types/library'
+import { DatasetTerm } from 'src/types/model'
+import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
+import { chain, intersection } from 'src/utils/NodashUtil'
+
+export const LIBRARY_EXPORTS_QUERY_KEY = 'library-exports'
+
+const EMPTY_EXPORTABLE_DATASETS: ExportableDatasets = {}
+
+export const useLibraryExportableDatasets = (
+  datasets: DatasetTerm[],
+  enabled: boolean,
+) => {
+  const datasetIdentifiers = [...new Set(
+    datasets
+      .map(dataset => dataset.datasetIdentifier)
+      .filter((identifier): identifier is string => Boolean(identifier)),
+  )]
+
+  return useQuery({
+    queryKey: [LIBRARY_EXPORTS_QUERY_KEY, datasetIdentifiers],
+    enabled: enabled && datasetIdentifiers.length > 0,
+    queryFn: async (): Promise<ExportableDatasets> => {
+      try {
+        const snapshots: EnumerateSnapshotModel = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers)
+        if (snapshots.filteredTotal === 0) return EMPTY_EXPORTABLE_DATASETS
+
+        return chain(snapshots.items)
+          .filter((snapshot: SnapshotSummaryModel) =>
+            intersection(snapshots.roleMap?.[snapshot.id] ?? [], ['steward', 'reader']).length > 0)
+          .groupBy('duosId')
+          .value()
+      }
+      catch {
+        return EMPTY_EXPORTABLE_DATASETS
+      }
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState, useCallback } from 'react'
 import { useNavigate, useParams } from 'react-router'
-import { AssetType, ExportableDatasets, LibraryVersionNew, ALL_LIBRARY_TABS } from 'src/types/library'
+import { AssetType, LibraryVersionNew, ALL_LIBRARY_TABS } from 'src/types/library'
 import { DatasetTerm } from 'src/types/model'
 import { applyForAccess } from 'src/utils/accessUtils'
 import { getBrandedLibrary } from 'src/libs/libraryVersions'
@@ -8,11 +8,9 @@ import { Storage } from 'src/libs/storage'
 import { Notifications } from 'src/libs/utils'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import eventList from 'src/libs/events'
-import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
-import { chain, intersection } from 'src/utils/NodashUtil'
-import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
 import { getRadarEnabledDatasetsWithRules } from 'src/utils/DatasetUtils'
 import { useLibraryPageState } from 'src/hooks/useLibraryPageState'
+import { useLibraryExportableDatasets } from 'src/hooks/useLibraryExportableDatasets'
 import LibraryPageShell from 'src/components/data_library/LibraryPageShell'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
 import TableHeaderSection from 'src/components/TableHeaderSection'
@@ -78,8 +76,13 @@ export const DataLibrary: React.FC = () => {
   const { urlState, data, currentAsset, handleSearchChange } = pageState
 
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<number[]>([])
-  const [exportableDatasets, setExportableDatasets] = useState<ExportableDatasets>({})
   const [radarEnabledDatasetIds, setRadarEnabledDatasetIds] = useState<Set<number>>(new Set())
+
+  const datasets = urlState.tab === AssetType.DATASETS && data?.items ? data.items as DatasetTerm[] : []
+  const { data: exportableDatasets = {} } = useLibraryExportableDatasets(
+    datasets,
+    urlState.tab === AssetType.DATASETS,
+  )
 
   const selectedStudyIds = useMemo(() => {
     if (!data?.items) return []
@@ -95,34 +98,6 @@ export const DataLibrary: React.FC = () => {
   }
 
   useEffect(() => {
-    const fetchExportable = async () => {
-      if (urlState.tab !== AssetType.DATASETS || !data?.items?.length) {
-        setExportableDatasets({})
-        return
-      }
-      const datasetIdentifiers = (data.items as DatasetTerm[]).map(d => d.datasetIdentifier).filter(Boolean)
-      if (datasetIdentifiers.length === 0) {
-        setExportableDatasets({})
-        return
-      }
-      try {
-        const result: EnumerateSnapshotModel = await TerraDataRepo.listSnapshotsByDatasetIds(datasetIdentifiers)
-        if (result.filteredTotal > 0) {
-          const mapped = chain(result.items)
-            .filter((snapshot: SnapshotSummaryModel) => intersection(result.roleMap[snapshot.id], ['steward', 'reader']).length > 0)
-            .groupBy('duosId')
-            .value()
-          setExportableDatasets(mapped)
-        }
-        else {
-          setExportableDatasets({})
-        }
-      }
-      catch {
-        setExportableDatasets({})
-      }
-    }
-
     const fetchRadarEnabled = async () => {
       if (urlState.tab !== AssetType.DATASETS || !data?.items?.length) {
         setRadarEnabledDatasetIds(new Set())
@@ -142,7 +117,6 @@ export const DataLibrary: React.FC = () => {
       }
     }
 
-    fetchExportable()
     fetchRadarEnabled()
   }, [data?.items, urlState.tab])
 

--- a/test/hooks/useLibraryExportableDatasets.spec.tsx
+++ b/test/hooks/useLibraryExportableDatasets.spec.tsx
@@ -1,0 +1,146 @@
+import React from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLibraryExportableDatasets } from 'src/hooks/useLibraryExportableDatasets'
+import { TerraDataRepo } from 'src/libs/ajax/TerraDataRepo'
+import { DatasetTerm } from 'src/types/model'
+import { EnumerateSnapshotModel, SnapshotSummaryModel } from 'src/types/tdrModel'
+
+vi.mock('src/libs/ajax/TerraDataRepo', () => ({
+  TerraDataRepo: {
+    listSnapshotsByDatasetIds: vi.fn(),
+  },
+}))
+
+const makeDataset = (datasetId: number, datasetIdentifier?: string) => ({
+  datasetId,
+  datasetIdentifier,
+}) as DatasetTerm
+
+const makeSnapshot = (id: string, duosId: string): SnapshotSummaryModel => ({
+  id,
+  name: id,
+  duosId,
+  cloudPlatform: 'gcp',
+  resourceLocks: {},
+})
+
+const emptyResponse: EnumerateSnapshotModel = {
+  total: 0,
+  filteredTotal: 0,
+  items: [],
+  roleMap: {},
+  errors: [],
+}
+
+let queryClient: QueryClient
+
+const wrapper = ({ children }: React.PropsWithChildren) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+)
+
+beforeEach(() => {
+  queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  })
+})
+
+afterEach(() => {
+  queryClient.clear()
+  vi.clearAllMocks()
+})
+
+describe('useLibraryExportableDatasets', () => {
+  it('deduplicates identifiers and keeps only snapshots with export roles', async () => {
+    const readerSnapshot = makeSnapshot('reader-snapshot', 'DUOS-000001')
+    const stewardSnapshot = makeSnapshot('steward-snapshot', 'DUOS-000002')
+    const discovererSnapshot = makeSnapshot('discoverer-snapshot', 'DUOS-000003')
+    const missingRoleSnapshot = makeSnapshot('missing-role-snapshot', 'DUOS-000004')
+    vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockResolvedValue({
+      total: 4,
+      filteredTotal: 4,
+      items: [readerSnapshot, stewardSnapshot, discovererSnapshot, missingRoleSnapshot],
+      roleMap: {
+        [readerSnapshot.id]: ['reader'],
+        [stewardSnapshot.id]: ['steward'],
+        [discovererSnapshot.id]: ['discoverer'],
+      },
+      errors: [],
+    })
+
+    const { result } = renderHook(
+      () => useLibraryExportableDatasets([
+        makeDataset(1, 'DUOS-000001'),
+        makeDataset(2, 'DUOS-000002'),
+        makeDataset(3, 'DUOS-000001'),
+        makeDataset(4),
+      ], true),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(1)
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledWith([
+      'DUOS-000001',
+      'DUOS-000002',
+    ])
+    expect(result.current.data).toEqual({
+      'DUOS-000001': [readerSnapshot],
+      'DUOS-000002': [stewardSnapshot],
+    })
+  })
+
+  it('does not query TDR when disabled', () => {
+    renderHook(
+      () => useLibraryExportableDatasets([makeDataset(1, 'DUOS-000001')], false),
+      { wrapper },
+    )
+
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).not.toHaveBeenCalled()
+  })
+
+  it('does not query TDR without dataset identifiers', () => {
+    renderHook(
+      () => useLibraryExportableDatasets([makeDataset(1)], true),
+      { wrapper },
+    )
+
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).not.toHaveBeenCalled()
+  })
+
+  it('returns an empty export map when the TDR request fails', async () => {
+    vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockRejectedValue(new Error('TDR unavailable'))
+
+    const { result } = renderHook(
+      () => useLibraryExportableDatasets([makeDataset(1, 'DUOS-000001')], true),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual({})
+  })
+
+  it('reuses the cached result for the same identifiers after remounting', async () => {
+    vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockResolvedValue(emptyResponse)
+    const datasets = [makeDataset(1, 'DUOS-000001')]
+
+    const firstRender = renderHook(
+      () => useLibraryExportableDatasets(datasets, true),
+      { wrapper },
+    )
+    await waitFor(() => expect(firstRender.result.current.isSuccess).toBe(true))
+    firstRender.unmount()
+
+    const secondRender = renderHook(
+      () => useLibraryExportableDatasets(datasets, true),
+      { wrapper },
+    )
+    await waitFor(() => expect(secondRender.result.current.isSuccess).toBe(true))
+
+    expect(secondRender.result.current.data).toEqual({})
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/hooks/useLibraryExportableDatasets.spec.tsx
+++ b/test/hooks/useLibraryExportableDatasets.spec.tsx
@@ -123,9 +123,12 @@ describe('useLibraryExportableDatasets', () => {
     expect(result.current.data).toEqual({})
   })
 
-  it('reuses the cached result for the same identifiers after remounting', async () => {
+  it('reuses the cached result when the same identifiers are reordered', async () => {
     vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockResolvedValue(emptyResponse)
-    const datasets = [makeDataset(1, 'DUOS-000001')]
+    const datasets = [
+      makeDataset(2, 'DUOS-000002'),
+      makeDataset(1, 'DUOS-000001'),
+    ]
 
     const firstRender = renderHook(
       () => useLibraryExportableDatasets(datasets, true),
@@ -135,12 +138,16 @@ describe('useLibraryExportableDatasets', () => {
     firstRender.unmount()
 
     const secondRender = renderHook(
-      () => useLibraryExportableDatasets(datasets, true),
+      () => useLibraryExportableDatasets([...datasets].reverse(), true),
       { wrapper },
     )
     await waitFor(() => expect(secondRender.result.current.isSuccess).toBe(true))
 
     expect(secondRender.result.current.data).toEqual({})
     expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(1)
+    expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledWith([
+      'DUOS-000001',
+      'DUOS-000002',
+    ])
   })
 })

--- a/test/pages/DataLibrary.spec.tsx
+++ b/test/pages/DataLibrary.spec.tsx
@@ -208,6 +208,16 @@ const renderLibrary = (path = '/') => render(
   </QueryClientProvider>,
 )
 
+const renderLibraryInStrictMode = (path = '/') => render(
+  <QueryClientProvider client={queryClient}>
+    <MemoryRouter initialEntries={[path]}>
+      <React.StrictMode>
+        <DataLibrary />
+      </React.StrictMode>
+    </MemoryRouter>
+  </QueryClientProvider>,
+)
+
 const renderBranded = (path: string) => render(
   <QueryClientProvider client={queryClient}>
     <MemoryRouter initialEntries={[path]}>
@@ -540,6 +550,16 @@ describe('DataLibrary', () => {
   })
 
   describe('Export functionality', () => {
+    it('queries TDR only once for the displayed datasets', async () => {
+      vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockResolvedValue(mockTdrSnapshotResponse('snapshot-abc', 'reader'))
+
+      renderLibraryInStrictMode(DATASETS_TAB_PATH)
+
+      expect(await screen.findByText(EXPORT_LABEL)).toBeInTheDocument()
+      expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(1)
+      expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledWith(['DUOS-000001'])
+    })
+
     it('does not show export buttons when TDR returns no snapshots', async () => {
       vi.mocked(TerraDataRepo.listSnapshotsByDatasetIds).mockResolvedValue(emptyTdrResponse)
       renderLibrary(DATASETS_TAB_PATH)


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-2971

### Summary

- Move Data Library export lookup into a cached React Query hook.
- Deduplicate dataset identifiers and reuse identical requests.
- Add hook tests and a Strict Mode regression test confirming TDR is queried once.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
