### PR TITLE
[DT-3932] Improve unit and Playwright test stability

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,14 +3,20 @@ import { BASE_URL } from './test/e2e/support/baseUrl'
 
 export default defineConfig({
   testDir: 'test/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
   use: {
     baseURL: BASE_URL,
     ignoreHTTPSErrors: true,
+    navigationTimeout: 30_000,
   },
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      retries: process.env.CI ? 1 : 0,
     },
   ],
   webServer: {

--- a/test/components/presentations_list/PresentationAddEdit.spec.tsx
+++ b/test/components/presentations_list/PresentationAddEdit.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
-import '@testing-library/jest-dom/vitest'
-import { render, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 vi.mock('src/components/DuosDatePicker', () => ({
@@ -27,30 +26,39 @@ import { Presentation } from 'src/types/model'
 describe('PresentationAddEdit component', () => {
   it('opens add form and enforces validation disabling save then adds', async () => {
     const user = userEvent.setup()
-    const collected: Presentation[] = []
-    const { container } = render(
+    const closeAction = vi.fn()
+    const onPresentationChange = vi.fn()
+
+    render(
       <PresentationAddEdit
         id={-1}
         presentations={[]}
-        closeAction={vi.fn()}
-        onPresentationChange={(items) => { collected.splice(0, collected.length, ...items) }}
+        closeAction={closeAction}
+        onPresentationChange={onPresentationChange}
       />,
     )
-    await user.type(container.querySelector('#title')!, 'New Title')
-    const dateInput = container.querySelector('#date') as HTMLInputElement
-    fireEvent.change(dateInput, { target: { value: '2024-01-15' } })
-    await user.type(container.querySelector('#url')!, 'https://example.org/new')
-    await user.type(container.querySelector('#authors')!, 'Author One; Author Two')
-    await user.type(container.querySelector('#datasetCitation')!, 'Dataset Y')
-    await user.click(container.querySelector('input[type="radio"]')!)
-    await user.type(container.querySelector('#presenterName')!, 'Presenter X')
-    await user.type(container.querySelector('#presenterEmail')!, 'presenterx@example.org')
-    await user.type(container.querySelector('#event')!, 'Event 2024')
-    await user.type(container.querySelector('#location')!, 'Location Z')
-    await user.type(container.querySelector('#format')!, 'Poster')
-    await user.type(container.querySelector('#access')!, 'Public')
-    await user.click(container.querySelector('.collaborator-form-add-save-button')!)
-    expect(collected).toHaveLength(1)
-    expect(collected[0].title).toBe('New Title')
+
+    await user.type(screen.getByLabelText(/Presentation Title/i) as HTMLInputElement, 'New Title')
+    await user.type(screen.getByLabelText(/Presentation Date/i) as HTMLInputElement, '2024-01-15')
+    await user.type(screen.getByLabelText(/Presentation URL/i) as HTMLInputElement, 'https://example.org/new')
+    await user.type(screen.getByLabelText(/Authors/i) as HTMLInputElement, 'Author One; Author Two')
+    await user.type(screen.getByLabelText(/Dataset Citation/i) as HTMLInputElement, 'Dataset Y')
+    await user.click(screen.getByRole('radio', { name: 'Yes' }))
+    await user.type(screen.getByLabelText(/Presenter Name/i) as HTMLInputElement, 'Presenter X')
+    await user.type(screen.getByLabelText(/Presenter Email/i) as HTMLInputElement, 'presenterx@example.org')
+    await user.type(screen.getByLabelText(/Event/i) as HTMLInputElement, 'Event 2024')
+    await user.type(screen.getByLabelText(/Location/i) as HTMLInputElement, 'Location Z')
+    await user.type(screen.getByLabelText(/Format/i) as HTMLInputElement, 'Poster')
+    await user.type(screen.getByLabelText(/Access/i) as HTMLInputElement, 'Public')
+    await user.click(screen.getByRole('button', { name: 'Add' }))
+
+    await waitFor(() => {
+      expect(onPresentationChange).toHaveBeenCalledTimes(1)
+    })
+
+    const changedPresentations = onPresentationChange.mock.calls[0][0] as Presentation[]
+    expect(changedPresentations).toHaveLength(1)
+    expect(changedPresentations[0].title).toBe('New Title')
+    expect(closeAction).toHaveBeenCalledTimes(1)
   })
 })

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -39,9 +39,10 @@ type AuthFixtures = {
 }
 
 export const test = base.extend<AuthFixtures>({
-  signInAs: async ({ page }, use) => {
-    // oxlint-disable-next-line react-hooks/rules-of-hooks -- Playwright's fixture callback, not a React hook
-    await use(async (role: Role) => {
+  // Playwright passes this callback positionally; it's named `provideSignIn` rather than
+  // the conventional `use` so linters don't mistake the call for React's `use()` hook.
+  signInAs: async ({ page }, provideSignIn) => {
+    await provideSignIn(async (role: Role) => {
       const accessToken = await getAccessToken(role)
       await page.goto('/backgroundsignin')
       await page.locator('textarea[name="accessToken"]').fill(accessToken)

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -1,5 +1,5 @@
 import { auth, JWT } from 'google-auth-library'
-import { test as base } from '@playwright/test'
+import { test as base, expect } from '@playwright/test'
 import { BASE_URL } from './baseUrl'
 
 export const ROLES = ['ADMIN', 'CHAIR', 'MEMBER', 'RESEARCHER', 'SIGNING_OFFICIAL'] as const
@@ -44,7 +44,10 @@ export const test = base.extend<AuthFixtures>({
       await page.goto('/backgroundsignin')
       await page.locator('textarea[name="accessToken"]').fill(accessToken)
       await page.locator('input[type="submit"]').click()
-      await page.waitForLoadState('networkidle')
+      // Sign-in redirects client-side to whichever console the role lands on
+      // (Navigation.console), so assert we've left this page rather than guessing the
+      // destination or waiting on network idle.
+      await expect(page).not.toHaveURL(/backgroundsignin/)
     })
   },
 })

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -1,6 +1,5 @@
-import { auth, JWT } from 'google-auth-library'
+import { JWT } from 'google-auth-library'
 import { test as base, expect } from '@playwright/test'
-import { BASE_URL } from './baseUrl'
 
 export const ROLES = ['ADMIN', 'CHAIR', 'MEMBER', 'RESEARCHER', 'SIGNING_OFFICIAL'] as const
 export type Role = typeof ROLES[number]
@@ -19,11 +18,14 @@ export const getAccessToken = async (role: Role): Promise<string> => {
   const parsed = JSON.parse(keysJson)
   const serviceAccountKey = parsed.key ?? parsed
 
-  // fromJSON's return type covers every credential shape it supports, but a service
-  // account key (what DUOS_AUTOMATION_*_SA holds) always yields a JWT client.
-  const client = auth.fromJSON(serviceAccountKey) as JWT
-  client.scopes = ['email', 'profile']
-  await client.request({ url: BASE_URL })
+  // Construct JWT directly; DUOS_AUTOMATION_*_SA is always a service account key, so the
+  // credential-type-specific constructor is the right fit.
+  const client = new JWT({
+    email: serviceAccountKey.client_email,
+    key: serviceAccountKey.private_key,
+    scopes: ['email', 'profile'],
+  })
+  await client.authorize()
 
   const accessToken = client.credentials.access_token
   if (!accessToken) {

--- a/test/e2e/support/auth.ts
+++ b/test/e2e/support/auth.ts
@@ -44,6 +44,7 @@ export const test = base.extend<AuthFixtures>({
       await page.goto('/backgroundsignin')
       await page.locator('textarea[name="accessToken"]').fill(accessToken)
       await page.locator('input[type="submit"]').click()
+      await page.waitForLoadState('networkidle')
     })
   },
 })


### PR DESCRIPTION
### Addresses

Fully addresses [DT-3932](https://broadworkbench.atlassian.net/browse/DT-3932)

### Summary

Removes two sources of test flakiness — one in the unit suite, one in the e2e suite.

**`test/components/presentations_list/PresentationAddEdit.spec.tsx`**
- Replaces `container.querySelector('#id')` lookups with accessible queries (`screen.getByLabelText`, `getByRole`), so the test exercises the form the way a user does and no longer breaks on DOM/id changes.
- Drops the `fireEvent.change` on the date input in favor of `user.type`, keeping all interactions on a single `userEvent` timeline instead of mixing event models.
- Asserts against `vi.fn()` spies (`onPresentationChange`, `closeAction`) wrapped in `waitFor`, rather than a mutable `collected` array read synchronously right after the click — this was the actual race, since the assertion could run before React flushed the state update.
- Adds an assertion that `closeAction` is called, which the previous version didn't cover.
- Drops the now-unused `@testing-library/jest-dom/vitest` import (no jest-dom matchers remain in this file; it's already registered globally by the vitest setup).

**`playwright.config.ts`**
- Adds explicit `timeout: 30s` (test), `expect.timeout: 10s`, and `navigationTimeout: 30s` so slow-but-passing steps get room instead of failing at the default expect timeout.
- Adds `retries: 1` on the chromium project when `process.env.CI` is set; local runs stay at 0 so flakes remain visible during development.

**`test/e2e/support/auth.ts`**
- The `signInAs` fixture now waits for an observable application state after submitting the background sign-in form — `await expect(page).not.toHaveURL(/backgroundsignin/)` — instead of returning as soon as the click resolves. Sign-in redirects client-side via `Navigation.console`, so the destination varies by role; leaving `/backgroundsignin` is the role-agnostic signal, and each spec then asserts its own role's console heading.
- Replaces the deprecated `GoogleAuth#fromJSON` with the credential-type-specific `new JWT({ email, key, scopes })` constructor, and mints the token via `authorize()` instead of an incidental authenticated request to `BASE_URL`. `fromJSON` is deprecated because it accepts any credential shape without validation; these env vars always hold a service account key, so the narrower constructor is both the recommended path and removes the `as JWT` cast.
- Renames the fixture's setup callback from `use` to `provideSignIn`, which drops a `rules-of-hooks` suppression comment and clears the equivalent Sonar S6440 warning — both linters read a call to `use()` as React's `use()` hook. Playwright passes this callback positionally, so the name is behaviorally irrelevant.

### Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm test test/components/presentations_list/PresentationAddEdit.spec.tsx` passes (1/1)
- [x] Full unit suite green: `pnpm test`
- [x] `pnpm test:e2e` green in CI (requires `DUOS_AUTOMATION_*_SA`, so it can't be run locally)
- [x] Re-run the e2e suite a few times (or via CI re-run) to confirm the previously flaky sign-in path is stable across all five roles
- [x] CI green, including the retry path on the chromium project

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

[DT-3932]: https://broadworkbench.atlassian.net/browse/DT-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ