### PR TITLE
[DT-3608] BFF Phase 3-E: The proxy's response leg

### DIFF
--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -97,11 +97,11 @@ environment before cutting over.
 ## Architecture decision records
 
 One sequence, numbered continuously. ADR-001 through ADR-008 were settled with
-the migration plan and are summarised below; the two that needed fuller
+the migration plan and are summarised below; the ones that needed fuller
 treatment — because they were resolved during implementation, with alternatives
 and residual risk worth recording — have their own files under
-[`bff_adrs/`](bff_adrs/). That is why the directory holds 004 and 009 rather than
-001 and 002: the numbers belong to this list, not to the directory.
+[`bff_adrs/`](bff_adrs/). That is why the directory holds 004, 009 and 010 rather
+than 001 through 003: the numbers belong to this list, not to the directory.
 
 | ADR | Decision | Phase |
 |---|---|---|
@@ -114,6 +114,7 @@ and residual risk worth recording — have their own files under
 | [007](#adr-007--idp-stored-in-session-as-sub-provider) | `idp` stored as sub-provider, from the B2C `id_token` claim | 2 |
 | [008](#adr-008--azure-b2c-as-single-oidc-entry-point) | Azure B2C as the single OIDC entry point | 0, 2 |
 | [009](#adr-009--state-changing-upstream-gets-are-proxied-not-blocked) | State-changing upstream GETs are proxied, not blocked | 3 |
+| [010](#adr-010--the-proxy-scope-declares-its-own-error-shape) | The proxy scope declares its own error shape | 3, 4 |
 
 ### ADR-001 — PostgreSQL-backed sessions via `@fastify/session`
 
@@ -208,6 +209,20 @@ guard a GET, which leaves two upstream endpoints that mutate state on GET
 forgeable by a plain link. Blocking either breaks the app — one is how the client
 learns who the user is — so the residual risk is accepted, documented, and the
 real fix (making the side effect a POST) belongs upstream in Consent.
+
+### ADR-010 — The proxy scope declares its own error shape
+
+**Full record:** [bff_adrs/ADR-010-proxy-error-shape.md](bff_adrs/ADR-010-proxy-error-shape.md)
+— the experiment behind it, the alternatives, and what the client keys on.
+
+The proxy is an encapsulated plugin, so it captured Fastify's default error
+handler and never inherits the app's sanitizing one. Rather than reorder the
+registrations, the proxy declares its own: CSRF rejections return
+`{ error: 'csrf_validation_failed', reason }` and everything else returns the
+same generic body as the rest of the app. The client needs that one code because
+403 is otherwise ambiguous through the proxy — an upstream authorization denial
+arrives as a 403 too, as an ordinary proxied response — so Phase 4 keys its single
+refetch-and-retry on the body, not the status.
 
 ### Decisions not tracked as ADRs
 

--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -292,8 +292,17 @@ sequenceDiagram
         end
 
         BFF->>API: GET /api/user/me + Authorization: Bearer <b2c-token> + X-App-ID: DUOS
-        API-->>BFF: 200 user data
-        BFF-->>B: 200 user data
+
+        alt upstream accepts the token
+            API-->>BFF: 200 user data
+            BFF-->>B: 200 user data
+        else upstream rejects the token
+            API-->>BFF: 401
+            Note over BFF: The upstream is the authority on the token —<br/>a session it rejects cannot recover
+            BFF->>PG: Delete session row
+            PG-->>BFF: ok
+            BFF-->>B: 401 { error: 'session_expired' } + cleared sessionId cookie
+        end
     end
 ```
 

--- a/docs/plans/bff_adrs/ADR-010-proxy-error-shape.md
+++ b/docs/plans/bff_adrs/ADR-010-proxy-error-shape.md
@@ -61,36 +61,28 @@ the root handler returns.
 ```
 
 Both plugin codes are allowlisted — `FST_CSRF_MISSING_SECRET` and
-`FST_CSRF_INVALID_TOKEN` — and both map to the same `error`, because both mean
-the same thing to the client: refetch the token and retry once. The `reason`
-distinguishes them for a human reading a network tab or a support ticket; a
-missing secret is what a session rotation that discards the secret (Phase 5, 5-D)
-will look like, which is worth being able to see without server logs.
+`FST_CSRF_INVALID_TOKEN` — and both map to the same `error`, because both call
+for the same single retry. `reason` is diagnostic, not contractual: it separates
+the two for a human reading a network tab (a missing secret is what a Phase 5
+session rotation will look like), and it is what lets the tests assert *which*
+rejection fired — the drift story 3-D's review caught, where cases meant to
+exercise one path had silently moved onto the other.
 
-`error` is named for the check that failed rather than for either cause, so
-neither half is mislabelled. The generic body is shared as `GENERIC_ERROR_BODY`
-in `server/src/errors.ts` rather than written out in both handlers: the point of
-the second branch is that the browser cannot tell which scope failed, and two
-string literals drift invisibly — both would still return *a* generic body, just
-not the same one.
+The generic body is shared as `GENERIC_ERROR_BODY` in `server/src/errors.ts`
+rather than written out in both handlers: the point of the second branch is that
+the browser cannot tell which scope failed, and two string literals drift
+invisibly.
 
 ### The plugin's error code is not on the wire
 
-`FST_CSRF_*` stays in the log line and out of the response. Two reasons:
-
-1. It is `@fastify/csrf-protection` internals, renameable on a major bump. A
-   client branching on it breaks silently.
-2. `code` in an error body already means something else to this client.
-   [`DataAccessRequestApplication.tsx:559`](../../../src/pages/dar_application/DataAccessRequestApplication.tsx)
-   reads it as *"the upstream sent a structured error, so its `message` is safe
-   to render as markdown"*. Putting a Fastify identifier there gives the field a
-   third meaning, in a codebase that already types it inconsistently
-   (`code?: number` in `fetchAdapter.ts` and `types/model.ts`, `code?: string` at
-   that call site).
-
-Nothing breaks today either way — the CSRF body carries no `message`, so that
-call site's `&&` short-circuits — but publishing under a BFF-owned key costs
-nothing and needs no client type change at all.
+`FST_CSRF_*` stays in the log line and out of the response. It is
+`@fastify/csrf-protection` internals, renameable on a major bump — and `code` in
+an error body already means something else to this client:
+[`DataAccessRequestApplication.tsx:559`](../../../src/pages/dar_application/DataAccessRequestApplication.tsx)
+reads it as *"the upstream sent a structured error, so its `message` is safe to
+render as markdown"*. Nothing breaks either way, since the CSRF body carries no
+`message`, but publishing under a BFF-owned key costs nothing and needs no client
+type change.
 
 ## Alternatives rejected
 
@@ -98,25 +90,19 @@ nothing and needs no client type change at all.
 and it does fix the leaked message. Rejected because it flattens the CSRF
 rejection into the generic body, which is the one distinction the client needs.
 
-Worth recording accurately, since it is the obvious objection to the option
-actually chosen: the blast radius of moving that line is **exactly the proxy
-scope, nothing more**. Every plugin `index.ts` registers before it —
-`@fastify/postgres`, `@fastify/cookie`, `@fastify/session`,
-`@fastify/csrf-protection`, `@fastify/vite` — wraps itself in `fastify-plugin`
-and therefore runs in the root scope, inheriting the handler wherever the call
-sits. `apiProxy` is the only encapsulated child in the app. The case against
-this option is the 403 ambiguity alone; it is not a risky change, just a lossy
-one.
+Recorded accurately because it is the obvious objection to the option chosen:
+the blast radius of moving that line is **exactly the proxy scope**. Every plugin
+registered before it wraps itself in `fastify-plugin` and so already runs in the
+root scope, `@fastify/vite` included; `apiProxy` is the only encapsulated child
+in the app. The case against it is the 403 ambiguity alone — lossy, not risky.
 
 **Leave the incidental shape and document it.** Rejected: the leaked `message`
 on an unexpected 500 is a real (if minor) disclosure, and a shape that depends
-on plugin registration order is one refactor away from changing without anyone
-noticing.
+on plugin registration order is one refactor away from changing silently.
 
-**Reject CSRF failures in the `onRequest` hook instead of an error handler** —
-intercepting `csrfProtection`'s `done(err)` and replying directly. Works for the
-expected case, but leaves the unexpected-500 sanitising still to be solved, so it
-is the same amount of code in two places instead of one.
+**Reject CSRF failures in the `onRequest` hook instead of an error handler.**
+Works for the expected case, but leaves the unexpected-500 sanitising still to be
+solved — the same amount of code in two places instead of one.
 
 ## Consequences
 
@@ -130,11 +116,11 @@ is the same amount of code in two places instead of one.
   carries the real error and the request id.
 - `reply.from`'s transport failures never reach this handler —
   `onUpstreamTransportError` answers those with 502 `upstream_unavailable` — so
-  the generic branch is reached only by a bug on a proxy path.
+  the generic branch means a bug on a proxy path.
 - The five CSRF assertions added by story 3-D's review were pinning Fastify's
-  default serialisation (`code: 'FST_CSRF_INVALID_TOKEN'`), which their own
-  comment admitted was "what this harness exposes". They now assert the body
-  above, against a harness that registers the app's real handler ordering.
+  default serialisation, which their own comment admitted was "what this harness
+  exposes". They now assert the body above, against a harness that registers the
+  app's real handler ordering.
 
 ## Revisit when
 

--- a/docs/plans/bff_adrs/ADR-010-proxy-error-shape.md
+++ b/docs/plans/bff_adrs/ADR-010-proxy-error-shape.md
@@ -1,0 +1,146 @@
+# ADR-010 — The proxy scope declares its own error shape, preserving CSRF as the one client-actionable code
+
+**Status:** Accepted (2026-08-07) &nbsp;|&nbsp; **Phase:** 3, story 3-E(c)
+**Related:** [ADR-004](ADR-004-api-proxy-layer.md) (the encapsulation this works around), [ADR-009](ADR-009-state-changing-gets.md) (the CSRF guard whose rejections this shapes)
+**Consumed by:** Phase 4, story 4-D — the fetch layer's CSRF refetch-and-retry keys on the code decided here
+
+---
+
+## Context
+
+The proxy is registered with `fastify.register(apiProxy)` and deliberately **not**
+wrapped in `fastify-plugin`: `removeAllContentTypeParsers()` has to apply to the
+proxy's routes and nowhere else, or `/auth/*` loses its JSON parsing. That makes
+the proxy an encapsulated child context.
+
+A child context copies the error handler that exists when it is created.
+`index.ts` calls `setErrorHandler` near the end of `buildApp()`, *after*
+`register(apiProxy)` — so the proxy captured Fastify's **default** handler and
+the app's sanitizing one never reaches it. The `/auth/*` routes are declared on
+the root instance, so they do get it. The asymmetry is the proxy's alone.
+
+Verified by experiment on Fastify 5, both orderings:
+
+```
+setErrorHandler AFTER  register(apiProxy)
+  CSRF rejection  →  403 {"statusCode":403,"code":"FST_CSRF_INVALID_TOKEN","error":"Forbidden","message":"Invalid csrf token"}
+  proxy-path bug  →  500 {"statusCode":500,"error":"Internal Server Error","message":"<the thrown message>"}
+
+setErrorHandler BEFORE register(apiProxy)
+  CSRF rejection  →  403 {"error":"An unexpected error occurred."}
+  proxy-path bug  →  500 {"error":"An unexpected error occurred."}
+```
+
+So CSRF rejections did reach the browser with a usable code — but by accident,
+and nothing else from the scope was sanitised either: an unexpected 500 from a
+bug on a proxy path returned its `message` (no stack) rather than the generic
+body the rest of the app returns. **The defect is that the shape was incidental
+rather than chosen**, and the 500's leaked message is what it cost.
+
+### What the client actually needs
+
+Phase 4's fetch layer refetches a CSRF token and retries once when the guard
+rejects a request. It cannot key that on the status, because **403 is ambiguous
+through this proxy**: an upstream authorization denial from the DUOS API is an
+ordinary proxied response and arrives as a 403 with the upstream's own body,
+never touching the error handler. Retrying on the status alone would replay
+every write Consent refused.
+
+So the client needs a positive, stable discriminator in the body — and that is
+the only thing about a proxy error it needs.
+
+## Decision
+
+**A scope-local error handler inside `apiProxy`,** which preserves CSRF as the
+one machine-actionable failure and sanitises everything else to the same body
+the root handler returns.
+
+```
+403  { "error": "csrf_validation_failed", "reason": "missing_secret" | "invalid_token" }
+5xx  { "error": "An unexpected error occurred." }
+```
+
+Both plugin codes are allowlisted — `FST_CSRF_MISSING_SECRET` and
+`FST_CSRF_INVALID_TOKEN` — and both map to the same `error`, because both mean
+the same thing to the client: refetch the token and retry once. The `reason`
+distinguishes them for a human reading a network tab or a support ticket; a
+missing secret is what a session rotation that discards the secret (Phase 5, 5-D)
+will look like, which is worth being able to see without server logs.
+
+`error` is named for the check that failed rather than for either cause, so
+neither half is mislabelled. The generic body is shared as `GENERIC_ERROR_BODY`
+in `server/src/errors.ts` rather than written out in both handlers: the point of
+the second branch is that the browser cannot tell which scope failed, and two
+string literals drift invisibly — both would still return *a* generic body, just
+not the same one.
+
+### The plugin's error code is not on the wire
+
+`FST_CSRF_*` stays in the log line and out of the response. Two reasons:
+
+1. It is `@fastify/csrf-protection` internals, renameable on a major bump. A
+   client branching on it breaks silently.
+2. `code` in an error body already means something else to this client.
+   [`DataAccessRequestApplication.tsx:559`](../../../src/pages/dar_application/DataAccessRequestApplication.tsx)
+   reads it as *"the upstream sent a structured error, so its `message` is safe
+   to render as markdown"*. Putting a Fastify identifier there gives the field a
+   third meaning, in a codebase that already types it inconsistently
+   (`code?: number` in `fetchAdapter.ts` and `types/model.ts`, `code?: string` at
+   that call site).
+
+Nothing breaks today either way — the CSRF body carries no `message`, so that
+call site's `&&` short-circuits — but publishing under a BFF-owned key costs
+nothing and needs no client type change at all.
+
+## Alternatives rejected
+
+**Move `index.ts`'s `setErrorHandler` above the BFF registrations.** One line,
+and it does fix the leaked message. Rejected because it flattens the CSRF
+rejection into the generic body, which is the one distinction the client needs.
+
+Worth recording accurately, since it is the obvious objection to the option
+actually chosen: the blast radius of moving that line is **exactly the proxy
+scope, nothing more**. Every plugin `index.ts` registers before it —
+`@fastify/postgres`, `@fastify/cookie`, `@fastify/session`,
+`@fastify/csrf-protection`, `@fastify/vite` — wraps itself in `fastify-plugin`
+and therefore runs in the root scope, inheriting the handler wherever the call
+sits. `apiProxy` is the only encapsulated child in the app. The case against
+this option is the 403 ambiguity alone; it is not a risky change, just a lossy
+one.
+
+**Leave the incidental shape and document it.** Rejected: the leaked `message`
+on an unexpected 500 is a real (if minor) disclosure, and a shape that depends
+on plugin registration order is one refactor away from changing without anyone
+noticing.
+
+**Reject CSRF failures in the `onRequest` hook instead of an error handler** —
+intercepting `csrfProtection`'s `done(err)` and replying directly. Works for the
+expected case, but leaves the unexpected-500 sanitising still to be solved, so it
+is the same amount of code in two places instead of one.
+
+## Consequences
+
+- The client gets one thing to branch on: `error === 'csrf_validation_failed'`.
+  Phase 4, story 4-D must key its single retry on that and **not** on "any 403" —
+  the story text said the latter and has been corrected.
+- No change is needed to `fetchAdapter`'s `ErrorData` type. Had the Fastify code
+  been exposed, `code` would have had to widen to `number | string`.
+- Anything else the proxy scope throws is indistinguishable from a failure
+  elsewhere in the app, which is the intent. Operators read `request.log`, which
+  carries the real error and the request id.
+- `reply.from`'s transport failures never reach this handler —
+  `onUpstreamTransportError` answers those with 502 `upstream_unavailable` — so
+  the generic branch is reached only by a bug on a proxy path.
+- The five CSRF assertions added by story 3-D's review were pinning Fastify's
+  default serialisation (`code: 'FST_CSRF_INVALID_TOKEN'`), which their own
+  comment admitted was "what this harness exposes". They now assert the body
+  above, against a harness that registers the app's real handler ordering.
+
+## Revisit when
+
+- `@fastify/csrf-protection` changes its error codes — the allowlist is the only
+  place that names them, and a rename there fails the tests loudly.
+- The proxy stops being encapsulated (if raw-body handling ever moves), at which
+  point the scope-local handler becomes redundant rather than wrong.
+- A second client-actionable proxy failure appears. The shape extends by adding
+  an `error` code, not by widening what `reason` means.

--- a/docs/plans/bff_adrs/ADR-010-proxy-error-shape.md
+++ b/docs/plans/bff_adrs/ADR-010-proxy-error-shape.md
@@ -68,10 +68,10 @@ session rotation will look like), and it is what lets the tests assert *which*
 rejection fired — the drift story 3-D's review caught, where cases meant to
 exercise one path had silently moved onto the other.
 
-The generic body is shared as `GENERIC_ERROR_BODY` in `server/src/errors.ts`
-rather than written out in both handlers: the point of the second branch is that
-the browser cannot tell which scope failed, and two string literals drift
-invisibly.
+The generic body, `{ "error": "An unexpected error occurred." }`, is written out
+inline in both handlers rather than shared from a constant: with only two call
+sites and no risk of drift beyond a literal string, the shared symbol cost more
+to look up than it saved.
 
 ### The plugin's error code is not on the wire
 

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * The body the app returns for an error it did not plan for.
+ *
+ * Shared rather than written out twice. Two scopes answer errors — the root
+ * instance and the encapsulated proxy (see ADR-010) — and the whole point of the
+ * proxy having its own handler is that the browser cannot tell which of the two
+ * failed. A string literal in each place drifts, and the drift is invisible:
+ * both still return *a* generic body, just not the same one.
+ */
+export const GENERIC_ERROR_BODY = { error: 'An unexpected error occurred.' }

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,10 +1,5 @@
 /**
- * The body the app returns for an error it did not plan for.
- *
- * Shared rather than written out twice. Two scopes answer errors — the root
- * instance and the encapsulated proxy (see ADR-010) — and the whole point of the
- * proxy having its own handler is that the browser cannot tell which of the two
- * failed. A string literal in each place drifts, and the drift is invisible:
- * both still return *a* generic body, just not the same one.
+ * The generic error body, shared by the root and proxy error handlers (ADR-010).
+ * Shared so the two cannot drift into returning different "generic" bodies.
  */
 export const GENERIC_ERROR_BODY = { error: 'An unexpected error occurred.' }

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,2 +1,0 @@
-/** The generic error body, shared by the root and proxy error handlers (ADR-010). */
-export const GENERIC_ERROR_BODY = { error: 'An unexpected error occurred.' }

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -1,5 +1,2 @@
-/**
- * The generic error body, shared by the root and proxy error handlers (ADR-010).
- * Shared so the two cannot drift into returning different "generic" bodies.
- */
+/** The generic error body, shared by the root and proxy error handlers (ADR-010). */
 export const GENERIC_ERROR_BODY = { error: 'An unexpected error occurred.' }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,7 +10,6 @@ import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
 import { createPgSessionStore } from './session/pgStore.js'
-import { GENERIC_ERROR_BODY } from './errors.js'
 import { csrfPluginOptions } from './auth/csrf.js'
 import { getOidcConfig } from './auth/oidcClient.js'
 import { handleLogin } from './auth/login.js'
@@ -278,7 +277,7 @@ export async function buildApp(): Promise<AppInstance> {
   // proxy's — that scope is encapsulated and declares its own (ADR-010).
   fastify.setErrorHandler((err: FastifyError, request, reply) => {
     request.log.error({ err }, '[server] Unhandled error:')
-    return reply.status(err.statusCode ?? 500).send(GENERIC_ERROR_BODY)
+    return reply.status(err.statusCode ?? 500).send({ error: 'An unexpected error occurred.' })
   })
 
   return fastify

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -274,15 +274,9 @@ export async function buildApp(): Promise<AppInstance> {
   // but does not register routes; we wire the catch-all ourselves.
   fastify.setNotFoundHandler((_req, reply) => reply.html())
 
-  // Error handler — suppresses stack traces from responses.
-  //
-  // Applies to this instance and every plugin that shares it, which is all of
-  // them bar one: each @fastify/* plugin registered above wraps itself in
-  // `fastify-plugin`, so they run in this scope and inherit this handler
-  // regardless of where the call sits. `apiProxy` is the single exception —
-  // deliberately not wrapped, so it is a child context that captured Fastify's
-  // default before this line ran and declares its own handler instead. That is
-  // a decision, not an accident of ordering: see ADR-010.
+  // Error handler — suppresses stack traces from responses. Reaches every route
+  // except the proxy's: `apiProxy` is deliberately encapsulated and declares its
+  // own handler rather than inheriting this one (ADR-010).
   fastify.setErrorHandler((err: FastifyError, request, reply) => {
     request.log.error({ err }, '[server] Unhandled error:')
     return reply.status(err.statusCode ?? 500).send(GENERIC_ERROR_BODY)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,6 +10,7 @@ import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
 import { createPgSessionStore } from './session/pgStore.js'
+import { GENERIC_ERROR_BODY } from './errors.js'
 import { csrfPluginOptions } from './auth/csrf.js'
 import { getOidcConfig } from './auth/oidcClient.js'
 import { handleLogin } from './auth/login.js'
@@ -273,10 +274,18 @@ export async function buildApp(): Promise<AppInstance> {
   // but does not register routes; we wire the catch-all ourselves.
   fastify.setNotFoundHandler((_req, reply) => reply.html())
 
-  // Error handler — suppresses stack traces from responses
-  fastify.setErrorHandler((err: FastifyError, _req, reply) => {
-    fastify.log.error({ err }, '[server] Unhandled error:')
-    return reply.status(err.statusCode ?? 500).send({ error: 'An unexpected error occurred.' })
+  // Error handler — suppresses stack traces from responses.
+  //
+  // Applies to this instance and every plugin that shares it, which is all of
+  // them bar one: each @fastify/* plugin registered above wraps itself in
+  // `fastify-plugin`, so they run in this scope and inherit this handler
+  // regardless of where the call sits. `apiProxy` is the single exception —
+  // deliberately not wrapped, so it is a child context that captured Fastify's
+  // default before this line ran and declares its own handler instead. That is
+  // a decision, not an accident of ordering: see ADR-010.
+  fastify.setErrorHandler((err: FastifyError, request, reply) => {
+    request.log.error({ err }, '[server] Unhandled error:')
+    return reply.status(err.statusCode ?? 500).send(GENERIC_ERROR_BODY)
   })
 
   return fastify

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -274,9 +274,8 @@ export async function buildApp(): Promise<AppInstance> {
   // but does not register routes; we wire the catch-all ourselves.
   fastify.setNotFoundHandler((_req, reply) => reply.html())
 
-  // Error handler — suppresses stack traces from responses. Reaches every route
-  // except the proxy's: `apiProxy` is deliberately encapsulated and declares its
-  // own handler rather than inheriting this one (ADR-010).
+  // Suppresses stack traces from responses. Reaches every route except the
+  // proxy's — that scope is encapsulated and declares its own (ADR-010).
   fastify.setErrorHandler((err: FastifyError, request, reply) => {
     request.log.error({ err }, '[server] Unhandled error:')
     return reply.status(err.statusCode ?? 500).send(GENERIC_ERROR_BODY)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -273,8 +273,7 @@ export async function buildApp(): Promise<AppInstance> {
   // but does not register routes; we wire the catch-all ourselves.
   fastify.setNotFoundHandler((_req, reply) => reply.html())
 
-  // Suppresses stack traces from responses. Reaches every route except the
-  // proxy's — that scope is encapsulated and declares its own (ADR-010).
+  // The encapsulated proxy declares its own error handler (ADR-010).
   fastify.setErrorHandler((err: FastifyError, request, reply) => {
     request.log.error({ err }, '[server] Unhandled error:')
     return reply.status(err.statusCode ?? 500).send({ error: 'An unexpected error occurred.' })

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -1,5 +1,6 @@
 import type { IncomingHttpHeaders, IncomingMessage } from 'node:http'
 import type {
+  FastifyError,
   FastifyInstance,
   FastifyReply,
   FastifyRequest,
@@ -11,6 +12,7 @@ import type {
 import fastifyReplyFrom from '@fastify/reply-from'
 import { requireEnv } from '../auth/oidcClient.js'
 import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
+import { GENERIC_ERROR_BODY } from '../errors.js'
 
 /**
  * The BFF API proxy (Phase 3, stories 3-C, 3-D and 3-E).
@@ -129,6 +131,46 @@ export const CSRF_EXEMPT_UNSAFE_REQUESTS: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * The `error` code a CSRF rejection returns, and the one thing about a proxy
+ * error the client is meant to branch on (ADR-010).
+ *
+ * Epic 4's fetch layer refetches a token and retries once when it sees this, and
+ * only when it sees this. Status alone cannot carry that signal: an upstream
+ * authorization denial is an ordinary proxied response and also arrives as a
+ * 403, so retrying on the status would replay every write the DUOS API refused.
+ *
+ * Named for the check that failed rather than for either cause, because both
+ * causes below mean the same thing to the client.
+ */
+export const CSRF_ERROR_CODE = 'csrf_validation_failed'
+
+/**
+ * The two ways `@fastify/csrf-protection` rejects a request, mapped to the
+ * reason the BFF publishes for each.
+ *
+ * `FST_CSRF_MISSING_SECRET` means the request carried no session to verify
+ * against, so enforcement stopped before it reached the token — the signed-out
+ * caller, and the shape a session rotation that discards the secret (Epic 5,
+ * 5-D) will produce. `FST_CSRF_INVALID_TOKEN` means there was a secret and the
+ * token did not verify against it, including when `getToken` found no token at
+ * all.
+ *
+ * The plugin's own code is deliberately not what goes on the wire, for two
+ * reasons. It is `@fastify/csrf-protection` internals, renameable on a major
+ * bump, and a client branching on it would break silently. And the `code` field
+ * of an error body already means something else to this client:
+ * `DataAccessRequestApplication.tsx` reads it as "the upstream sent a structured
+ * error, so its `message` is safe to render as markdown". So the distinction
+ * travels under a key of the BFF's own, and is there for a human reading a
+ * network tab or a support ticket — the client branches on `error`, never on
+ * this.
+ */
+const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
+  ['FST_CSRF_MISSING_SECRET', 'missing_secret'],
+  ['FST_CSRF_INVALID_TOKEN', 'invalid_token'],
+])
+
+/**
  * Strips the BFF prefix and the query string, yielding the upstream path.
  *
  * The query is dropped on purpose rather than forwarded here: `reply.from()`
@@ -202,6 +244,40 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
   if (!app.hasDecorator('csrfProtection')) {
     throw new Error('apiProxy requires @fastify/csrf-protection to be registered first — it enforces CSRF on unsafe methods and must not be registered without it')
   }
+
+  /**
+   * The proxy scope's error shape (story 3-E, ADR-010).
+   *
+   * Declared here rather than inherited from the root instance, and that is not
+   * a preference: a child context copies the error handler that exists when it
+   * is created, and index.ts calls `setErrorHandler` *after* it registers this
+   * plugin. Without this line the scope keeps Fastify's default handler, which
+   * puts `err.message` on the wire for an unexpected 500 while every other route
+   * in the app returns the generic body. Moving index.ts's call above the
+   * registration would fix that half, but it would also flatten the CSRF
+   * rejection into the same generic body — and that one the client has to be
+   * able to recognise, since a 403 through this proxy is otherwise an upstream
+   * authorization denial passed through as an ordinary response.
+   *
+   * So: CSRF rejections keep a stable, BFF-owned code, and everything else is
+   * indistinguishable from a failure anywhere else in the app. `reply.from`'s
+   * transport failures never arrive here — `onUpstreamTransportError` answers
+   * those — so the second branch is reached only by a bug on a proxy path.
+   */
+  app.setErrorHandler((err: FastifyError, request, reply) => {
+    const reason = err.code === undefined ? undefined : CSRF_REJECTION_REASONS.get(err.code)
+    if (reason !== undefined) {
+      // Logged at info, not error: a rejected token is the guard working, and
+      // the commonest cause is a client whose token went stale. `err.code` is
+      // kept here — this is where the plugin's own identifier belongs.
+      request.log.info({ err }, '[proxy] CSRF validation failed — rejecting')
+      // 403 stated rather than taken from `err.statusCode`, because it is part
+      // of the contract ADR-010 pins, not a detail of the plugin that raised it.
+      return reply.status(403).send({ error: CSRF_ERROR_CODE, reason })
+    }
+    request.log.error({ err }, '[proxy] unhandled error')
+    return reply.status(err.statusCode ?? 500).send(GENERIC_ERROR_BODY)
+  })
 
   /**
    * CSRF on state-changing methods. The proxy turns every DUOS API write into a

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -15,7 +15,7 @@ import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
 import { GENERIC_ERROR_BODY } from '../errors.js'
 
 /**
- * The BFF API proxy (Phase 3, stories 3-C, 3-D and 3-E).
+ * The BFF API proxy (Phase 3).
  *
  * Every DUOS API call the client makes is forwarded from here with the session's
  * B2C access token attached, so the browser never holds a bearer token. The
@@ -48,7 +48,7 @@ import { GENERIC_ERROR_BODY } from '../errors.js'
 /**
  * The BFF-side prefix. `/duos-api/api/dataset/1` → `${DUOS_API_URL}/api/dataset/1`.
  *
- * Public API surface between client and BFF: Epic 4 makes `getApiUrl()` return
+ * Public API surface between client and BFF: Phase 4 makes `getApiUrl()` return
  * this, at which point all 104 call sites keep their literal paths. Changing it
  * later means changing both ends together.
  */
@@ -134,7 +134,7 @@ export const CSRF_EXEMPT_UNSAFE_REQUESTS: ReadonlySet<string> = new Set([
  * The `error` code a CSRF rejection returns, and the one thing about a proxy
  * error the client branches on (ADR-010).
  *
- * Epic 4's fetch layer refetches a token and retries once when it sees this, and
+ * Phase 4's fetch layer refetches a token and retries once when it sees this, and
  * only when it sees this. Status alone cannot carry that signal: an upstream
  * authorization denial is an ordinary proxied response and also arrives as a
  * 403, so retrying on the status would replay every write the DUOS API refused.
@@ -145,7 +145,7 @@ export const CSRF_ERROR_CODE = 'csrf_validation_failed'
  * The two ways `@fastify/csrf-protection` rejects a request, mapped to the
  * reason the BFF publishes. `FST_CSRF_MISSING_SECRET` means there was no session
  * to verify against, so enforcement stopped before the token — including the
- * shape a session rotation that discards the secret (Epic 5, 5-D) will produce.
+ * shape a session rotation that discards the secret (Phase 5, 5-D) will produce.
  * `FST_CSRF_INVALID_TOKEN` means there was a secret and the token did not verify
  * against it.
  *
@@ -188,7 +188,7 @@ const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
  *
  * Safe for the client — `fetch` ignores both headers, and every document path is
  * a `fetchBlob` download initiated by the SPA's own document. Verified against
- * the call sites; re-check when Epic 4 rewrites the fetch layer. See the epic's
+ * the call sites; re-check when Phase 4 rewrites the fetch layer. See the epic's
  * story 3-E(b) for the full argument and for what this costs (direct navigation
  * to the upstream's Swagger UI renders inert).
  */

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -171,6 +171,63 @@ const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
 ])
 
 /**
+ * Added to every proxied response, so nothing the upstream returns can execute
+ * on the SPA's origin (story 3-E(b)).
+ *
+ * **Why the proxy creates this problem.** DUOS serves user-uploaded documents
+ * back through the API — `GET /api/daa/{id}/file`, DAR documents,
+ * `FileStorageObject` documents. Proxied, those are served *from the BFF's own
+ * origin*. A top-level navigation to `/duos-api/api/daa/{id}/file` carries the
+ * `SameSite=Lax` session cookie, the proxy injects the bearer, and the browser
+ * renders attacker-uploaded markup on the origin that holds the session.
+ * `HttpOnly` is no help: the script does not need to read the cookie, only to
+ * make same-origin requests back through the proxy with it.
+ *
+ * This is genuinely new with the proxy. Today the same file comes from the
+ * Consent API's origin, where a cookie-less top-level navigation simply 401s.
+ *
+ *   x-content-type-options — no MIME sniffing, so an `.html` uploaded as
+ *                            `application/octet-stream` is not promoted to a
+ *                            document by the browser guessing at its bytes.
+ *   content-security-policy — `sandbox` with no tokens is the maximally
+ *                            restrictive form: opaque origin, no scripts, no
+ *                            forms, no same-origin access. A document that does
+ *                            get rendered can do nothing with this origin.
+ *
+ * **Safe to apply to everything.** Verified against the call sites rather than
+ * assumed: every document path is consumed with `fetchBlob` and handed to
+ * `fileDownload` (`DAA.ts`, `DAR.ts`, `FileStorageObject.ts`), and there is no
+ * top-level navigation, `href`, or `src` pointing at an API URL anywhere in
+ * `src/` — even `/api-docs/ISO-3166-countries.json` is fetched (`Countries.ts`).
+ * `fetch` ignores both headers entirely, and a blob download is initiated by the
+ * SPA's own document, so neither can reach the client. Re-check when Epic 4
+ * rewrites the fetch layer.
+ *
+ * **What it does cost.** Anything reached by navigating a browser at a proxied
+ * path renders inert — the upstream's Swagger UI under `/api-docs/*` being the
+ * realistic example. No client code does that; an operator poking at the proxy
+ * by hand would notice.
+ *
+ * Deliberately not added: forcing `content-disposition: attachment` for content
+ * types outside a safe list. `sandbox` already makes a rendered document
+ * harmless, so it buys little, and it is the piece most likely to break a future
+ * inline preview. ADR-009's deferred `Sec-Fetch-Mode: navigate` rejection would
+ * close the same vector at the request leg; these are worth having regardless,
+ * since they do not depend on a decision that has not been taken.
+ *
+ * **Applied in `onSend`, not `rewriteHeaders`.** The story sketched it on the
+ * latter, which reaches only the responses that come from the upstream. `onSend`
+ * runs for every reply the scope produces — including the 401 that replaces a
+ * rejected one, whose header-strip loop would otherwise have to except these two
+ * by name, and the proxy's own 401/403/500/502 bodies. Uniform is both easier to
+ * state and easier to test than "every response except the ones the BFF wrote".
+ */
+const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
+  'x-content-type-options': 'nosniff',
+  'content-security-policy': 'sandbox',
+}
+
+/**
  * Strips the BFF prefix and the query string, yielding the upstream path.
  *
  * The query is dropped on purpose rather than forwarded here: `reply.from()`
@@ -307,6 +364,21 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
     }
     app.csrfProtection(request, reply, done)
   }
+
+  // Nothing the upstream returns may execute on this origin — see
+  // RESPONSE_HARDENING. Set here rather than merged into `rewriteHeaders` so it
+  // covers every reply the scope writes, not only the ones proxied back from the
+  // upstream, and so it lands after `onUpstreamResponse` has stripped the
+  // upstream's headers off a replaced 401.
+  //
+  // Callback style with a bare `done()`: an async onSend returning undefined
+  // would be read as "no change", but the callback form says so without relying
+  // on that, and it must not touch the payload — it is a stream on the proxied
+  // path.
+  app.addHook('onSend', (_request, reply, _payload, done) => {
+    reply.headers(RESPONSE_HARDENING)
+    done()
+  })
 
   // Cleared wholesale, then one wildcard pass-through. A `'*'` parser alone is
   // not enough: it is only the last resort. `getParser` resolves the exact
@@ -536,6 +608,10 @@ function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefi
  * origin *policy* rather than state and belongs to the ingress, but relaying the
  * upstream's copy changes nothing about this origin that the ingress has not
  * already settled, so it is left alone.
+ *
+ * What this function does *not* do is add anything: `RESPONSE_HARDENING` is
+ * applied in an `onSend` hook instead, so it also covers the replies the proxy
+ * writes itself. See its comment.
  */
 function rewriteHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
   // Omitted by destructuring rather than deleted, for the same reason as the
@@ -600,7 +676,8 @@ function onUpstreamResponse(request: ProxyRequest, reply: ProxyReply, res: Upstr
   // and anything the BFF set is kept. `connection` is the one exception:
   // reply-from sets it to `close` when the upstream answered before the request
   // body was fully read, which is about this connection rather than about the
-  // response being discarded.
+  // response being discarded. The `RESPONSE_HARDENING` pair needs no exception —
+  // it is applied in `onSend`, which runs after this.
   for (const name of Object.keys(upstreamHeaders(res))) {
     if (name !== 'connection') {
       reply.removeHeader(name)

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -37,12 +37,10 @@ import { GENERIC_ERROR_BODY } from '../errors.js'
  *     page and the Contact Us form depend on it, so they proxy through with no
  *     session and no injected `Authorization`.
  *
- * The plugin is registered inside index.ts's `if (process.env.DUOS_DB_HOST)`
- * block, under the same `bffEnabled === true` gate as the `/auth/*` routes. That
- * is not just symmetry with those routes: the two session-ending paths below
- * call `reply.clearCookie`, which is a `@fastify/cookie` decorator, and index.ts
- * registers that plugin only inside the DUOS_DB_HOST block. Registered outside
- * it, a dead token would raise a TypeError instead of returning 401.
+ * Registered inside index.ts's `if (process.env.DUOS_DB_HOST)` block, under the
+ * same `bffEnabled === true` gate as the `/auth/*` routes — not just for
+ * symmetry: the session-ending paths below call `reply.clearCookie`, a
+ * `@fastify/cookie` decorator index.ts registers only inside that block.
  */
 
 /**
@@ -131,28 +129,17 @@ export const CSRF_EXEMPT_UNSAFE_REQUESTS: ReadonlySet<string> = new Set([
 ])
 
 /**
- * The `error` code a CSRF rejection returns, and the one thing about a proxy
- * error the client branches on (ADR-010).
- *
- * Phase 4's fetch layer refetches a token and retries once when it sees this, and
- * only when it sees this. Status alone cannot carry that signal: an upstream
- * authorization denial is an ordinary proxied response and also arrives as a
- * 403, so retrying on the status would replay every write the DUOS API refused.
+ * The one thing about a proxy error the client branches on (ADR-010): Phase 4's
+ * fetch layer refetches a token and retries once on it. The status cannot carry
+ * that signal — an upstream authorization denial also arrives as a 403, so
+ * retrying on the status would replay every write the DUOS API refused.
  */
 export const CSRF_ERROR_CODE = 'csrf_validation_failed'
 
 /**
- * The two ways `@fastify/csrf-protection` rejects a request, mapped to the
- * reason the BFF publishes. `FST_CSRF_MISSING_SECRET` means there was no session
- * to verify against, so enforcement stopped before the token — including the
- * shape a session rotation that discards the secret (Phase 5, 5-D) will produce.
- * `FST_CSRF_INVALID_TOKEN` means there was a secret and the token did not verify
- * against it.
- *
- * Both map to the same `error`, since both call for the same single retry;
- * `reason` is diagnostic, and the tests below are its other consumer — asserting
- * which rejection fired is what stops a case meant to exercise one path from
- * silently drifting onto the other, as story 3-D's review found had happened.
+ * `@fastify/csrf-protection`'s rejections, mapped to the reason the BFF
+ * publishes. Both share one `error`, since both call for the same single retry;
+ * `reason` is diagnostic, and lets a test assert which path actually fired.
  *
  * The plugin's own code stays off the wire: it is renameable internals, and
  * `code` in an error body already means something else to this client
@@ -166,31 +153,23 @@ const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
 
 /**
  * Added to every response the proxy scope emits, so nothing the upstream returns
- * can execute on the SPA's origin (story 3-E(b)).
+ * can execute on the SPA's origin.
  *
- * The proxy introduces this risk. DUOS serves user-uploaded documents back
- * through the API, and proxied they come from the BFF's *own* origin: a
- * top-level navigation to one carries the `SameSite=Lax` session cookie, the
- * proxy injects the bearer, and the browser renders attacker-uploaded markup on
- * the origin that holds the session. `HttpOnly` does not help — the script needs
- * to make same-origin requests with the cookie, not to read it.
+ * The proxy introduces this risk: DUOS serves user-uploaded documents back
+ * through the API, and proxied they come from the BFF's *own* origin, so a
+ * top-level navigation to one renders attacker-uploaded markup on the origin
+ * holding the session. `sandbox` gives such a document an opaque origin and no
+ * scripts; `nosniff` stops one being promoted to a document by content sniffing.
+ * Unconditional, and overriding an upstream that sends either header, because
+ * the safety must not depend on the content type the upstream declared.
  *
- * `sandbox` with no tokens gives any document that does get rendered an opaque
- * origin and no scripts; `nosniff` stops one being promoted to a document by the
- * browser guessing at its bytes. Unconditional, and overriding an upstream that
- * sends either header, because the safety must not depend on the content type
- * the upstream chose to declare.
+ * Applied in `onSend` rather than `rewriteHeaders`, which reaches only responses
+ * that came back from the upstream: `onSend` runs after `onUpstreamResponse`
+ * strips the upstream's headers off a replaced 401, and covers the replies the
+ * proxy writes for itself.
  *
- * Applied in `onSend` rather than `rewriteHeaders`, which reaches only the
- * responses that come back from the upstream: `onSend` runs after
- * `onUpstreamResponse` strips the upstream's headers off a replaced 401, and
- * covers the replies the proxy writes for itself.
- *
- * Safe for the client — `fetch` ignores both headers, and every document path is
- * a `fetchBlob` download initiated by the SPA's own document. Verified against
- * the call sites; re-check when Phase 4 rewrites the fetch layer. See the epic's
- * story 3-E(b) for the full argument and for what this costs (direct navigation
- * to the upstream's Swagger UI renders inert).
+ * Inert for the client — `fetch` ignores both, and every document path is a
+ * `fetchBlob` download. Re-check when Phase 4 rewrites the fetch layer.
  */
 const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
   'x-content-type-options': 'nosniff',
@@ -198,27 +177,19 @@ const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
 }
 
 /**
- * Connection-specific response header fields, stripped on the way back because
- * they describe the BFF↔upstream hop rather than the response (RFC 9110 §7.6.1
- * — a proxy must not forward them, since the browser↔BFF connection is a
- * different one with different parameters).
+ * Stripped on the way back: they describe the BFF↔upstream hop rather than the
+ * response (RFC 9110 §7.6.1), and the browser is on a different connection.
  *
- * Not a theoretical list. `keep-alive` is emitted *automatically* by Node's HTTP
- * server on any keep-alive connection, so a Node upstream leaks its own socket
- * timeout to every browser on every proxied response until this strips it.
+ * Not a theoretical list. Node's HTTP server emits `keep-alive` automatically,
+ * so a Node upstream leaks its own socket timeout to every browser until this
+ * strips it; `proxy-authenticate` is `www-authenticate`'s proxy-side twin, and
+ * relaying it reintroduces on the BFF's origin exactly the credential prompt
+ * that header is stripped below to prevent.
  *
- * `proxy-authenticate` is the one with teeth, and it is the reason this set is
- * not merely tidiness: it is `www-authenticate`'s proxy-side twin, so relaying it
- * would reintroduce on the BFF's origin exactly the credential prompt that header
- * is stripped below to prevent. Stripping one and forwarding the other was an
- * inconsistency, not a decision.
- *
- * `connection` and `transfer-encoding` are deliberately absent: both are framing
- * the HTTP layer owns, and neither reaches the browser with the upstream's value
- * anyway. reply-from sets `connection` itself (see `onUpstreamResponse`, which
- * preserves it for that reason), and an upstream `transfer-encoding` is
- * renormalised by undici and Fastify to match the framing actually used on the
- * way out — verified rather than assumed, and pinned by a test below.
+ * `connection` and `transfer-encoding` are deliberately absent: reply-from sets
+ * `connection` itself (see `onUpstreamResponse`, which preserves it for that
+ * reason), and an upstream `transfer-encoding` is renormalised by undici and
+ * Fastify to the framing actually used on the way out — pinned by a test.
  */
 const CONNECTION_SPECIFIC_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
   'keep-alive',
@@ -249,13 +220,9 @@ export function upstreamPath(url: string): string {
 
 /**
  * The token this proxy will inject for a request, or undefined when it injects
- * none.
- *
- * Shared by the request leg (which sets the header) and the response leg (which
- * reads an upstream 401 as a verdict on that header) so the two cannot disagree
- * about whether a given request borrowed the session's authority. Only the
- * requests that did are signed out by a 401 — a 401 on an allowlisted path is
- * about the upstream, not about the caller's session.
+ * none. Shared by the request leg (which sets the header) and the response leg
+ * (which reads an upstream 401 as a verdict on it), so only requests that
+ * borrowed the session's authority are signed out by a 401.
  */
 function injectedAccessToken(request: ProxyRequest): string | undefined {
   if (UNAUTHENTICATED_PATHS.has(upstreamPath(request.url))) {
@@ -276,12 +243,10 @@ type ProxyReply = FastifyReply<RouteGenericInterface, RawServerBase>
 /**
  * What `reply.from` hands `onResponse`: the upstream reply, body still unread.
  *
- * Mirrors reply-from's own `RawServerResponse` exactly, because the hook's
- * parameter position is contravariant and would reject anything wider — which
- * means mirroring its one inaccuracy too. The declaration says `ServerResponse`,
- * the outgoing end of an exchange; the object is really undici's incoming
- * response, so `statusCode` and `stream` line up but `headers` is undeclared.
- * `upstreamHeaders` below is where that is reconciled, in one place.
+ * Mirrors reply-from's own `RawServerResponse`, because the hook's parameter
+ * position is contravariant and rejects anything wider — inaccuracy included.
+ * The declared `ServerResponse` is really undici's incoming response, so
+ * `statusCode` and `stream` line up but `headers` is undeclared.
  */
 type UpstreamResponse = RawReplyDefaultExpression<RawServerBase> & { stream: IncomingMessage }
 
@@ -305,26 +270,21 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
   }
 
   /**
-   * The proxy scope's error shape — see ADR-010 for the decision and the
-   * alternatives.
+   * The proxy scope's error shape (ADR-010). Declared here because an
+   * encapsulated scope copies whatever error handler exists when it is created,
+   * and index.ts sets the app's *after* registering this plugin.
    *
-   * Declared here because an encapsulated scope copies the error handler that
-   * exists when it is created, and index.ts sets the app's *after* registering
-   * this plugin. CSRF rejections keep a stable, BFF-owned code because the
-   * client has to tell them from an upstream 403; everything else is
-   * indistinguishable from a failure elsewhere in the app. `reply.from`'s
-   * transport failures never arrive here — `onUpstreamTransportError` answers
-   * those — so the second branch means a bug on a proxy path.
+   * reply.from's transport failures never arrive here — `onUpstreamTransportError`
+   * answers those — so the generic branch means a bug on a proxy path.
    */
   app.setErrorHandler((err: FastifyError, request, reply) => {
     const reason = err.code === undefined ? undefined : CSRF_REJECTION_REASONS.get(err.code)
     if (reason !== undefined) {
-      // Logged at info, not error: a rejected token is the guard working, and
-      // the commonest cause is a client whose token went stale. `err.code` is
-      // kept here — this is where the plugin's own identifier belongs.
+      // Info, not error: a rejected token is the guard working, usually against
+      // a client whose token went stale.
       request.log.info({ err }, '[proxy] CSRF validation failed — rejecting')
-      // 403 stated rather than taken from `err.statusCode`, because it is part
-      // of the contract ADR-010 pins, not a detail of the plugin that raised it.
+      // 403 stated rather than taken from `err.statusCode`: part of the contract
+      // ADR-010 pins, not a detail of the plugin that raised it.
       return reply.status(403).send({ error: CSRF_ERROR_CODE, reason })
     }
     request.log.error({ err }, '[proxy] unhandled error')
@@ -360,12 +320,9 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
     app.csrfProtection(request, reply, done)
   }
 
-  // Nothing the upstream returns may execute on this origin — see
-  // RESPONSE_HARDENING for why it is here rather than in `rewriteHeaders`.
-  //
-  // Callback style with a bare `done()`: the payload must be passed through
-  // untouched — it is a stream on the proxied path — and the callback form says
-  // so without relying on how an async hook treats an undefined return.
+  // See RESPONSE_HARDENING for why a hook rather than `rewriteHeaders`. Callback
+  // style so the payload — a stream on the proxied path — passes through
+  // untouched, rather than relying on how an async hook reads an undefined return.
   app.addHook('onSend', (_request, reply, _payload, done) => {
     reply.headers(RESPONSE_HARDENING)
     done()
@@ -582,71 +539,54 @@ function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefi
  *                     upstream set it back would undo the point of doing so.
  *   clear-site-data — clears cookies, storage and cache for the BFF origin,
  *                     which would sign the user out and wipe local state.
- *   www-authenticate — the upstream's own challenge, describing a bearer scheme
- *                     that is no longer how this origin authenticates: the
- *                     browser holds a session cookie and has no token to
- *                     re-present. Relayed unchanged it is at best noise, and a
- *                     `Basic` challenge would pop a native credential dialog on
- *                     the BFF's origin — a password prompt the BFF did not ask
- *                     for. Stripped on every status, not just the 401s handled
- *                     below, since the 401s an allowlisted path passes through
+ *   www-authenticate — a challenge for a bearer scheme this origin no longer
+ *                     uses: the browser holds a session cookie and has no token
+ *                     to re-present, and a `Basic` challenge would pop a native
+ *                     credential dialog on the BFF's origin. Stripped on every
+ *                     status, since the 401s an allowlisted path passes through
  *                     carry it too.
  *
  * Deliberately still forwarded, because they are not origin state and the client
  * needs them: `content-encoding` and `content-type` (a gzip body has to arrive
  * declared as one), `cache-control`, `etag`, `content-disposition` for the
- * document downloads. `strict-transport-security` is the near miss — it is
- * origin *policy* rather than state and belongs to the ingress, but relaying the
- * upstream's copy changes nothing about this origin that the ingress has not
- * already settled, so it is left alone.
+ * document downloads. `strict-transport-security` is the near miss — origin
+ * *policy* rather than state, already settled by the ingress, so left alone.
  *
- * The other class it drops is `CONNECTION_SPECIFIC_RESPONSE_HEADERS` — not origin
- * state but the wrong hop, and `proxy-authenticate` among them for the same
- * reason `www-authenticate` is named above.
- *
- * What this function does *not* do is add anything: `RESPONSE_HARDENING` is
- * applied in an `onSend` hook instead, so it also covers the replies the proxy
- * writes itself. See its comment.
+ * The second class dropped is the wrong hop rather than origin state; see
+ * `CONNECTION_SPECIFIC_RESPONSE_HEADERS`.
  */
 function rewriteHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
   // Omitted by destructuring rather than deleted, for the same reason as the
   // request leg: `headers` is the upstream's own `res.headers`, which reply-from
-  // may hand back on a retry. The connection-specific set is filtered rather
-  // than destructured because those six share one reason, where the three above
-  // each have their own.
+  // may hand back on a retry.
   const {
     'set-cookie': setCookie,
     'clear-site-data': clearSiteData,
     'www-authenticate': wwwAuthenticate,
     ...forwarded
   } = headers
+  // Node lower-cases incoming header names, so a direct lookup needs no folding.
   return Object.fromEntries(
-    // Node lower-cases incoming header names, so a direct lookup is the whole
-    // comparison — no case folding needed.
     Object.entries(forwarded).filter(([name]) => !CONNECTION_SPECIFIC_RESPONSE_HEADERS.has(name)),
   )
 }
 
 /**
- * The upstream's verdict on the token this proxy injected (story 3-E).
+ * The upstream's verdict on the token this proxy injected.
  *
- * A 401 from the DUOS API means it rejected that access token — expired early,
- * revoked, or issued to a user it no longer knows — even though the session
- * looked valid enough for `ensureUpstreamAuth` to forward the request. The
- * session cannot recover on its own, so it is destroyed and the browser gets a
- * 401 to redirect on, exactly as `/auth/me` does on the same verdict.
+ * A 401 means the DUOS API rejected that access token — expired early, revoked,
+ * or issued to a user it no longer knows — even though the session looked valid
+ * enough for `ensureUpstreamAuth` to forward the request. It cannot recover on
+ * its own, so it is destroyed and the browser gets a 401 to redirect on, exactly
+ * as `/auth/me` does on the same verdict. Not new behaviour: the legacy client
+ * already signs out on any 401 from the DUOS API
+ * (`fetchAdapter.handleResponse` → `redirectOnLogout`). Its `GET /api/user/me`
+ * exemption is not carried over — that exists to stop a *client-side* redirect
+ * loop on the auth probe, and me.ts already destroys on it.
  *
- * This is not new behaviour arriving with the proxy: the legacy client already
- * signs the user out on any 401 from the DUOS API (`fetchAdapter.handleResponse`
- * → `redirectOnLogout`). Its one exemption, `GET /api/user/me`, is not carried
- * over — that exists to stop a *client-side* redirect loop on the auth probe,
- * not because such a 401 leaves the session usable, and me.ts already destroys
- * on it. So a 401 the upstream returns for authorization rather than
- * authentication reasons ends the session here as it does today.
- *
- * Everything else streams through untouched, which is what reply-from's default
- * `onResponse` does — by the time this runs it has already put the (rewritten)
- * upstream headers and status on the reply, so the default is only the body.
+ * Everything else streams through untouched, which is all reply-from's default
+ * `onResponse` does by this point: the (rewritten) headers and status are on the
+ * reply already, so only the body is left.
  */
 function onUpstreamResponse(request: ProxyRequest, reply: ProxyReply, res: UpstreamResponse): void {
   if (res.statusCode !== 401 || injectedAccessToken(request) === undefined) {
@@ -654,51 +594,45 @@ function onUpstreamResponse(request: ProxyRequest, reply: ProxyReply, res: Upstr
     return
   }
 
-  // The upstream's 401 body is replaced by the reply below, but it still has to
-  // be read: an unconsumed response keeps its undici socket checked out of the
-  // pool. Drained rather than destroyed because draining preserves connection
-  // reuse. The error listener is required, not defensive: an 'error' on a stream
-  // with no listener is an unhandled exception, and reply-from's default path
-  // only gets one because `reply.send` attaches it.
+  // The discarded 401 body still has to be read: an unconsumed response keeps
+  // its undici socket checked out of the pool. Drained rather than destroyed,
+  // which preserves connection reuse. The error listener is required, not
+  // defensive — an 'error' with no listener is an unhandled exception, and
+  // reply-from's default path only gets one because `reply.send` attaches it.
   res.stream.on('error', (err: Error) => {
     request.log.debug({ err }, '[proxy] discarded upstream 401 body errored')
   })
   res.stream.resume()
 
-  // The upstream headers reply-from has already copied onto the reply describe a
-  // body that is no longer being sent. Left in place, `content-type` alone is
-  // fatal: Fastify only serialises an object payload when the content type is
-  // JSON or unset, so an upstream `text/plain` 401 would reach the socket as an
-  // un-serialised object and throw FST_ERR_REP_INVALID_PAYLOAD_TYPE. The rest
-  // mislead — `content-encoding: gzip` on plain JSON the browser then fails to
-  // decode, a stale `etag`, a `content-length` for the discarded body.
+  // The upstream headers reply-from already copied onto the reply describe a
+  // body that is no longer being sent. `content-type` alone is fatal: Fastify
+  // only serialises an object payload when the type is JSON or unset, so an
+  // upstream `text/plain` 401 would throw FST_ERR_REP_INVALID_PAYLOAD_TYPE. The
+  // rest merely mislead — a gzip label, a stale etag, a length for a body nobody
+  // received.
   //
-  // Keyed off `res.headers` so exactly what came from the upstream is removed
-  // and anything the BFF set is kept. `connection` is the one exception:
-  // reply-from sets it to `close` when the upstream answered before the request
-  // body was fully read, which is about this connection rather than about the
-  // response being discarded. The `RESPONSE_HARDENING` pair needs no exception —
-  // it is applied in `onSend`, which runs after this.
+  // Keyed off `res.headers` so only what came from the upstream goes, except
+  // `connection`: reply-from sets that to `close` when the upstream answered
+  // before the request body was read, which describes this connection rather
+  // than the discarded response.
   for (const name of Object.keys(upstreamHeaders(res))) {
     if (name !== 'connection') {
       reply.removeHeader(name)
     }
   }
 
-  // Deliberately not awaited — reply-from's onResponse is synchronous and
-  // ignores what it returns, so an unhandled rejection here would take the pod
-  // down with it. `endRejectedSession` therefore resolves every failure into a
-  // reply of its own.
+  // Not awaited: reply-from's onResponse is synchronous and ignores what it
+  // returns, so an unhandled rejection would take the pod down with it.
+  // `endRejectedSession` resolves every failure into a reply of its own.
   void endRejectedSession(request, reply)
 }
 
 /**
  * Destroys the session the upstream just rejected, then answers the browser.
  *
- * The reply is sent after the destroy resolves, which is what keeps
- * `@fastify/session`'s onSend hook out of the way: `destroy()` nulls
- * `request.session`, so the hook finds nothing to save and returns
- * synchronously, rather than writing the dead session back on the way out.
+ * Replying after the destroy resolves is what keeps `@fastify/session`'s onSend
+ * hook out of the way: `destroy()` nulls `request.session`, so the hook finds
+ * nothing to save rather than writing the dead session back on the way out.
  */
 async function endRejectedSession(request: ProxyRequest, reply: ProxyReply): Promise<void> {
   try {
@@ -706,14 +640,12 @@ async function endRejectedSession(request: ProxyRequest, reply: ProxyReply): Pro
     request.log.info('[proxy] upstream rejected the session access token — session destroyed, returning 401')
   }
   catch (err: unknown) {
-    // The row is left to expire on its own schedule. The 401 and the cleared
-    // cookie still go out: this browser stops presenting the sid either way, and
-    // the alternative — a 500 — would tell the client to retry a request that
-    // can only earn another 401.
+    // The row is left to expire on its own schedule, and the 401 still goes out:
+    // a 500 would only tell the client to retry a request that can earn another
+    // 401, and the cleared cookie stops this browser presenting the sid anyway.
     request.log.error({ err }, '[proxy] upstream rejected the session access token but the session could not be destroyed — returning 401 anyway')
   }
-  // Clear the cookie for the same reason the fatal-refresh path does: the row is
-  // gone, so a browser still presenting the sid gets a new empty session on
-  // every subsequent request.
+  // Cleared for the same reason the fatal-refresh path does: with the row gone,
+  // a browser still presenting the sid gets a new empty session every request.
   reply.clearCookie('sessionId').status(401).send({ error: 'session_expired' })
 }

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -12,7 +12,6 @@ import type {
 import fastifyReplyFrom from '@fastify/reply-from'
 import { requireEnv } from '../auth/oidcClient.js'
 import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
-import { GENERIC_ERROR_BODY } from '../errors.js'
 
 /**
  * The BFF API proxy (Phase 3).
@@ -288,7 +287,7 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
       return reply.status(403).send({ error: CSRF_ERROR_CODE, reason })
     }
     request.log.error({ err }, '[proxy] unhandled error')
-    return reply.status(err.statusCode ?? 500).send(GENERIC_ERROR_BODY)
+    return reply.status(err.statusCode ?? 500).send({ error: 'An unexpected error occurred.' })
   })
 
   /**

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -127,69 +127,21 @@ export const CSRF_EXEMPT_UNSAFE_REQUESTS: ReadonlySet<string> = new Set([
   'POST /support/upload',
 ])
 
-/**
- * The one thing about a proxy error the client branches on (ADR-010): Phase 4's
- * fetch layer refetches a token and retries once on it. The status cannot carry
- * that signal — an upstream authorization denial also arrives as a 403, so
- * retrying on the status would replay every write the DUOS API refused.
- */
+// A 403 alone is ambiguous because the upstream can also deny writes.
 export const CSRF_ERROR_CODE = 'csrf_validation_failed'
 
-/**
- * `@fastify/csrf-protection`'s rejections, mapped to the reason the BFF
- * publishes. Both share one `error`, since both call for the same single retry;
- * `reason` is diagnostic, and lets a test assert which path actually fired.
- *
- * The plugin's own code stays off the wire: it is renameable internals, and
- * `code` in an error body already means something else to this client
- * (`DataAccessRequestApplication.tsx` reads it as "the upstream sent a structured
- * error, so render its `message`").
- */
 const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
   ['FST_CSRF_MISSING_SECRET', 'missing_secret'],
   ['FST_CSRF_INVALID_TOKEN', 'invalid_token'],
 ])
 
-/**
- * Added to every response the proxy scope emits, so nothing the upstream returns
- * can execute on the SPA's origin.
- *
- * The proxy introduces this risk: DUOS serves user-uploaded documents back
- * through the API, and proxied they come from the BFF's *own* origin, so a
- * top-level navigation to one renders attacker-uploaded markup on the origin
- * holding the session. `sandbox` gives such a document an opaque origin and no
- * scripts; `nosniff` stops one being promoted to a document by content sniffing.
- * Unconditional, and overriding an upstream that sends either header, because
- * the safety must not depend on the content type the upstream declared.
- *
- * Applied in `onSend` rather than `rewriteHeaders`, which reaches only responses
- * that came back from the upstream: `onSend` runs after `onUpstreamResponse`
- * strips the upstream's headers off a replaced 401, and covers the replies the
- * proxy writes for itself.
- *
- * Inert for the client — `fetch` ignores both, and every document path is a
- * `fetchBlob` download. Re-check when Phase 4 rewrites the fetch layer.
- */
+// Proxied uploads are served from the SPA's origin, so they must not execute there.
 const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
   'x-content-type-options': 'nosniff',
   'content-security-policy': 'sandbox',
 }
 
-/**
- * Stripped on the way back: they describe the BFF↔upstream hop rather than the
- * response (RFC 9110 §7.6.1), and the browser is on a different connection.
- *
- * Not a theoretical list. Node's HTTP server emits `keep-alive` automatically,
- * so a Node upstream leaks its own socket timeout to every browser until this
- * strips it; `proxy-authenticate` is `www-authenticate`'s proxy-side twin, and
- * relaying it reintroduces on the BFF's origin exactly the credential prompt
- * that header is stripped below to prevent.
- *
- * `connection` and `transfer-encoding` are deliberately absent: reply-from sets
- * `connection` itself (see `onUpstreamResponse`, which preserves it for that
- * reason), and an upstream `transfer-encoding` is renormalised by undici and
- * Fastify to the framing actually used on the way out — pinned by a test.
- */
+// These describe the upstream hop, not the browser connection (RFC 9110 §7.6.1).
 const CONNECTION_SPECIFIC_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
   'keep-alive',
   'proxy-authenticate',
@@ -217,12 +169,6 @@ export function upstreamPath(url: string): string {
   return path.slice(PROXY_PREFIX.length) || '/'
 }
 
-/**
- * The token this proxy will inject for a request, or undefined when it injects
- * none. Shared by the request leg (which sets the header) and the response leg
- * (which reads an upstream 401 as a verdict on it), so only requests that
- * borrowed the session's authority are signed out by a 401.
- */
 function injectedAccessToken(request: ProxyRequest): string | undefined {
   if (UNAUTHENTICATED_PATHS.has(upstreamPath(request.url))) {
     return undefined
@@ -239,17 +185,9 @@ function injectedAccessToken(request: ProxyRequest): string | undefined {
 type ProxyRequest = FastifyRequest<RequestGenericInterface, RawServerBase>
 type ProxyReply = FastifyReply<RouteGenericInterface, RawServerBase>
 
-/**
- * What `reply.from` hands `onResponse`: the upstream reply, body still unread.
- *
- * Mirrors reply-from's own `RawServerResponse`, because the hook's parameter
- * position is contravariant and rejects anything wider — inaccuracy included.
- * The declared `ServerResponse` is really undici's incoming response, so
- * `statusCode` and `stream` line up but `headers` is undeclared.
- */
+// reply-from types this as a ServerResponse even though the stream is incoming.
 type UpstreamResponse = RawReplyDefaultExpression<RawServerBase> & { stream: IncomingMessage }
 
-/** The upstream's response headers, which `UpstreamResponse` cannot declare. */
 function upstreamHeaders(res: UpstreamResponse): IncomingHttpHeaders {
   return (res as unknown as { headers: IncomingHttpHeaders }).headers
 }
@@ -268,22 +206,11 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
     throw new Error('apiProxy requires @fastify/csrf-protection to be registered first — it enforces CSRF on unsafe methods and must not be registered without it')
   }
 
-  /**
-   * The proxy scope's error shape (ADR-010). Declared here because an
-   * encapsulated scope copies whatever error handler exists when it is created,
-   * and index.ts sets the app's *after* registering this plugin.
-   *
-   * reply.from's transport failures never arrive here — `onUpstreamTransportError`
-   * answers those — so the generic branch means a bug on a proxy path.
-   */
+  // Encapsulation prevents the root handler registered later from applying here.
   app.setErrorHandler((err: FastifyError, request, reply) => {
     const reason = err.code === undefined ? undefined : CSRF_REJECTION_REASONS.get(err.code)
     if (reason !== undefined) {
-      // Info, not error: a rejected token is the guard working, usually against
-      // a client whose token went stale.
       request.log.info({ err }, '[proxy] CSRF validation failed — rejecting')
-      // 403 stated rather than taken from `err.statusCode`: part of the contract
-      // ADR-010 pins, not a detail of the plugin that raised it.
       return reply.status(403).send({ error: CSRF_ERROR_CODE, reason })
     }
     request.log.error({ err }, '[proxy] unhandled error')
@@ -319,9 +246,6 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
     app.csrfProtection(request, reply, done)
   }
 
-  // See RESPONSE_HARDENING for why a hook rather than `rewriteHeaders`. Callback
-  // style so the payload — a stream on the proxied path — passes through
-  // untouched, rather than relying on how an async hook reads an undefined return.
   app.addHook('onSend', (_request, reply, _payload, done) => {
     reply.headers(RESPONSE_HARDENING)
     done()
@@ -564,87 +488,41 @@ function rewriteHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
     'www-authenticate': wwwAuthenticate,
     ...forwarded
   } = headers
-  // Node lower-cases incoming header names, so a direct lookup needs no folding.
   return Object.fromEntries(
     Object.entries(forwarded).filter(([name]) => !CONNECTION_SPECIFIC_RESPONSE_HEADERS.has(name)),
   )
 }
 
-/**
- * The upstream's verdict on the token this proxy injected.
- *
- * A 401 means the DUOS API rejected that access token — expired early, revoked,
- * or issued to a user it no longer knows — even though the session looked valid
- * enough for `ensureUpstreamAuth` to forward the request. It cannot recover on
- * its own, so it is destroyed and the browser gets a 401 to redirect on, exactly
- * as `/auth/me` does on the same verdict. Not new behaviour: the legacy client
- * already signs out on any 401 from the DUOS API
- * (`fetchAdapter.handleResponse` → `redirectOnLogout`). Its `GET /api/user/me`
- * exemption is not carried over — that exists to stop a *client-side* redirect
- * loop on the auth probe, and me.ts already destroys on it.
- *
- * Everything else streams through untouched, which is all reply-from's default
- * `onResponse` does by this point: the (rewritten) headers and status are on the
- * reply already, so only the body is left.
- */
 function onUpstreamResponse(request: ProxyRequest, reply: ProxyReply, res: UpstreamResponse): void {
   if (res.statusCode !== 401 || injectedAccessToken(request) === undefined) {
     reply.send(res.stream)
     return
   }
 
-  // The discarded 401 body still has to be read: an unconsumed response keeps
-  // its undici socket checked out of the pool. Drained rather than destroyed,
-  // which preserves connection reuse. The error listener is required, not
-  // defensive — an 'error' with no listener is an unhandled exception, and
-  // reply-from's default path only gets one because `reply.send` attaches it.
+  // Drain the replaced response so undici can reuse its socket.
   res.stream.on('error', (err: Error) => {
     request.log.debug({ err }, '[proxy] discarded upstream 401 body errored')
   })
   res.stream.resume()
 
-  // The upstream headers reply-from already copied onto the reply describe a
-  // body that is no longer being sent. `content-type` alone is fatal: Fastify
-  // only serialises an object payload when the type is JSON or unset, so an
-  // upstream `text/plain` 401 would throw FST_ERR_REP_INVALID_PAYLOAD_TYPE. The
-  // rest merely mislead — a gzip label, a stale etag, a length for a body nobody
-  // received.
-  //
-  // Keyed off `res.headers` so only what came from the upstream goes, except
-  // `connection`: reply-from sets that to `close` when the upstream answered
-  // before the request body was read, which describes this connection rather
-  // than the discarded response.
+  // Remove metadata for the discarded body; preserve reply-from's connection header.
   for (const name of Object.keys(upstreamHeaders(res))) {
     if (name !== 'connection') {
       reply.removeHeader(name)
     }
   }
 
-  // Not awaited: reply-from's onResponse is synchronous and ignores what it
-  // returns, so an unhandled rejection would take the pod down with it.
-  // `endRejectedSession` resolves every failure into a reply of its own.
+  // reply-from's onResponse callback is synchronous.
   void endRejectedSession(request, reply)
 }
 
-/**
- * Destroys the session the upstream just rejected, then answers the browser.
- *
- * Replying after the destroy resolves is what keeps `@fastify/session`'s onSend
- * hook out of the way: `destroy()` nulls `request.session`, so the hook finds
- * nothing to save rather than writing the dead session back on the way out.
- */
 async function endRejectedSession(request: ProxyRequest, reply: ProxyReply): Promise<void> {
   try {
     await request.session.destroy()
     request.log.info('[proxy] upstream rejected the session access token — session destroyed, returning 401')
   }
   catch (err: unknown) {
-    // The row is left to expire on its own schedule, and the 401 still goes out:
-    // a 500 would only tell the client to retry a request that can earn another
-    // 401, and the cleared cookie stops this browser presenting the sid anyway.
     request.log.error({ err }, '[proxy] upstream rejected the session access token but the session could not be destroyed — returning 401 anyway')
   }
-  // Cleared for the same reason the fatal-refresh path does: with the row gone,
-  // a browser still presenting the sid gets a new empty session every request.
   reply.clearCookie('sessionId').status(401).send({ error: 'session_expired' })
 }

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -198,6 +198,38 @@ const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
 }
 
 /**
+ * Connection-specific response header fields, stripped on the way back because
+ * they describe the BFF↔upstream hop rather than the response (RFC 9110 §7.6.1
+ * — a proxy must not forward them, since the browser↔BFF connection is a
+ * different one with different parameters).
+ *
+ * Not a theoretical list. `keep-alive` is emitted *automatically* by Node's HTTP
+ * server on any keep-alive connection, so a Node upstream leaks its own socket
+ * timeout to every browser on every proxied response until this strips it.
+ *
+ * `proxy-authenticate` is the one with teeth, and it is the reason this set is
+ * not merely tidiness: it is `www-authenticate`'s proxy-side twin, so relaying it
+ * would reintroduce on the BFF's origin exactly the credential prompt that header
+ * is stripped below to prevent. Stripping one and forwarding the other was an
+ * inconsistency, not a decision.
+ *
+ * `connection` and `transfer-encoding` are deliberately absent: both are framing
+ * the HTTP layer owns, and neither reaches the browser with the upstream's value
+ * anyway. reply-from sets `connection` itself (see `onUpstreamResponse`, which
+ * preserves it for that reason), and an upstream `transfer-encoding` is
+ * renormalised by undici and Fastify to match the framing actually used on the
+ * way out — verified rather than assumed, and pinned by a test below.
+ */
+const CONNECTION_SPECIFIC_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'upgrade',
+])
+
+/**
  * Strips the BFF prefix and the query string, yielding the upstream path.
  *
  * The query is dropped on purpose rather than forwarded here: `reply.from()`
@@ -568,6 +600,10 @@ function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefi
  * upstream's copy changes nothing about this origin that the ingress has not
  * already settled, so it is left alone.
  *
+ * The other class it drops is `CONNECTION_SPECIFIC_RESPONSE_HEADERS` — not origin
+ * state but the wrong hop, and `proxy-authenticate` among them for the same
+ * reason `www-authenticate` is named above.
+ *
  * What this function does *not* do is add anything: `RESPONSE_HARDENING` is
  * applied in an `onSend` hook instead, so it also covers the replies the proxy
  * writes itself. See its comment.
@@ -575,14 +611,20 @@ function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefi
 function rewriteHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
   // Omitted by destructuring rather than deleted, for the same reason as the
   // request leg: `headers` is the upstream's own `res.headers`, which reply-from
-  // may hand back on a retry.
+  // may hand back on a retry. The connection-specific set is filtered rather
+  // than destructured because those six share one reason, where the three above
+  // each have their own.
   const {
     'set-cookie': setCookie,
     'clear-site-data': clearSiteData,
     'www-authenticate': wwwAuthenticate,
     ...forwarded
   } = headers
-  return forwarded
+  return Object.fromEntries(
+    // Node lower-cases incoming header names, so a direct lookup is the whole
+    // comparison — no case folding needed.
+    Object.entries(forwarded).filter(([name]) => !CONNECTION_SPECIFIC_RESPONSE_HEADERS.has(name)),
+  )
 }
 
 /**

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -1,8 +1,9 @@
-import type { IncomingHttpHeaders } from 'node:http'
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http'
 import type {
   FastifyInstance,
   FastifyReply,
   FastifyRequest,
+  RawReplyDefaultExpression,
   RawServerBase,
   RequestGenericInterface,
   RouteGenericInterface,
@@ -12,7 +13,7 @@ import { requireEnv } from '../auth/oidcClient.js'
 import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
 
 /**
- * The BFF API proxy (Phase 3, story 3-C).
+ * The BFF API proxy (Phase 3, stories 3-C, 3-D and 3-E).
  *
  * Every DUOS API call the client makes is forwarded from here with the session's
  * B2C access token attached, so the browser never holds a bearer token. The
@@ -34,17 +35,12 @@ import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
  *     page and the Contact Us form depend on it, so they proxy through with no
  *     session and no injected `Authorization`.
  *
- * Deliberately not here: CSRF enforcement on unsafe methods (story 3-D, an
- * `onRequest` hook on this route) and destroying the session when the upstream
- * itself returns 401 (story 3-E, an `onResponse` hook on `reply.from`).
- *
- * Nor is the plugin registered on the app until 3-D — and when it is, it belongs
- * inside index.ts's `if (process.env.DUOS_DB_HOST)` block, under the same
- * `bffEnabled === true` gate as the `/auth/*` routes. That is not just symmetry
- * with those routes: the fatal-refresh path below calls `reply.clearCookie`,
- * which is a `@fastify/cookie` decorator, and index.ts registers that plugin
- * only inside the DUOS_DB_HOST block. Registered outside it, a dead refresh
- * token would raise a TypeError instead of returning 401.
+ * The plugin is registered inside index.ts's `if (process.env.DUOS_DB_HOST)`
+ * block, under the same `bffEnabled === true` gate as the `/auth/*` routes. That
+ * is not just symmetry with those routes: the two session-ending paths below
+ * call `reply.clearCookie`, which is a `@fastify/cookie` decorator, and index.ts
+ * registers that plugin only inside the DUOS_DB_HOST block. Registered outside
+ * it, a dead token would raise a TypeError instead of returning 401.
  */
 
 /**
@@ -151,13 +147,47 @@ export function upstreamPath(url: string): string {
 }
 
 /**
+ * The token this proxy will inject for a request, or undefined when it injects
+ * none.
+ *
+ * Shared by the request leg (which sets the header) and the response leg (which
+ * reads an upstream 401 as a verdict on that header) so the two cannot disagree
+ * about whether a given request borrowed the session's authority. Only the
+ * requests that did are signed out by a 401 — a 401 on an allowlisted path is
+ * about the upstream, not about the caller's session.
+ */
+function injectedAccessToken(request: ProxyRequest): string | undefined {
+  if (UNAUTHENTICATED_PATHS.has(upstreamPath(request.url))) {
+    return undefined
+  }
+  return request.session?.accessToken
+}
+
+/**
  * `reply.from`'s hooks are typed against `RawServerBase` — the http/http2 union
- * — rather than this app's concrete server, so the two callbacks below have to
- * be too, or they are rejected as contravariantly incompatible. Nothing either
- * one touches differs between the two server types.
+ * — rather than this app's concrete server, so the callbacks below have to be
+ * too, or they are rejected as contravariantly incompatible. Nothing any of them
+ * touches differs between the two server types.
  */
 type ProxyRequest = FastifyRequest<RequestGenericInterface, RawServerBase>
 type ProxyReply = FastifyReply<RouteGenericInterface, RawServerBase>
+
+/**
+ * What `reply.from` hands `onResponse`: the upstream reply, body still unread.
+ *
+ * Mirrors reply-from's own `RawServerResponse` exactly, because the hook's
+ * parameter position is contravariant and would reject anything wider — which
+ * means mirroring its one inaccuracy too. The declaration says `ServerResponse`,
+ * the outgoing end of an exchange; the object is really undici's incoming
+ * response, so `statusCode` and `stream` line up but `headers` is undeclared.
+ * `upstreamHeaders` below is where that is reconciled, in one place.
+ */
+type UpstreamResponse = RawReplyDefaultExpression<RawServerBase> & { stream: IncomingMessage }
+
+/** The upstream's response headers, which `UpstreamResponse` cannot declare. */
+function upstreamHeaders(res: UpstreamResponse): IncomingHttpHeaders {
+  return (res as unknown as { headers: IncomingHttpHeaders }).headers
+}
 
 /**
  * Registers the proxy. Not wrapped in `fastify-plugin` — the encapsulation is
@@ -229,7 +259,12 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
     onRequest: csrfForUnsafeMethods,
     preHandler: ensureUpstreamAuth,
   }, (request, reply) => {
-    reply.from(upstreamPath(request.url), { rewriteRequestHeaders, rewriteHeaders, onError: onUpstreamTransportError })
+    reply.from(upstreamPath(request.url), {
+      rewriteRequestHeaders,
+      rewriteHeaders,
+      onResponse: onUpstreamResponse,
+      onError: onUpstreamTransportError,
+    })
   })
 }
 
@@ -362,8 +397,7 @@ function rewriteRequestHeaders(request: ProxyRequest, headers: IncomingHttpHeade
   //   x-csrf-token — consumed by the BFF (story 3-D); meaningless upstream.
   const { cookie, authorization, 'x-csrf-token': csrfToken, ...forwarded } = headers
 
-  const upstream = upstreamPath(request.url)
-  const accessToken = UNAUTHENTICATED_PATHS.has(upstream) ? undefined : request.session?.accessToken
+  const accessToken = injectedAccessToken(request)
 
   return {
     ...forwarded,
@@ -409,19 +443,123 @@ function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefi
  *                     upstream set it back would undo the point of doing so.
  *   clear-site-data — clears cookies, storage and cache for the BFF origin,
  *                     which would sign the user out and wipe local state.
+ *   www-authenticate — the upstream's own challenge, describing a bearer scheme
+ *                     that is no longer how this origin authenticates: the
+ *                     browser holds a session cookie and has no token to
+ *                     re-present. Relayed unchanged it is at best noise, and a
+ *                     `Basic` challenge would pop a native credential dialog on
+ *                     the BFF's origin — a password prompt the BFF did not ask
+ *                     for. Stripped on every status, not just the 401s handled
+ *                     below, since the 401s an allowlisted path passes through
+ *                     carry it too.
  *
  * Deliberately still forwarded, because they are not origin state and the client
  * needs them: `content-encoding` and `content-type` (a gzip body has to arrive
  * declared as one), `cache-control`, `etag`, `content-disposition` for the
- * document downloads. `strict-transport-security` and `www-authenticate` are the
- * two near misses — the first is origin *policy* rather than state and belongs
- * to the ingress, the second only matters once story 3-E decides what an
- * upstream 401 means; neither is stripped here.
+ * document downloads. `strict-transport-security` is the near miss — it is
+ * origin *policy* rather than state and belongs to the ingress, but relaying the
+ * upstream's copy changes nothing about this origin that the ingress has not
+ * already settled, so it is left alone.
  */
 function rewriteHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
   // Omitted by destructuring rather than deleted, for the same reason as the
   // request leg: `headers` is the upstream's own `res.headers`, which reply-from
   // may hand back on a retry.
-  const { 'set-cookie': setCookie, 'clear-site-data': clearSiteData, ...forwarded } = headers
+  const {
+    'set-cookie': setCookie,
+    'clear-site-data': clearSiteData,
+    'www-authenticate': wwwAuthenticate,
+    ...forwarded
+  } = headers
   return forwarded
+}
+
+/**
+ * The upstream's verdict on the token this proxy injected (story 3-E).
+ *
+ * A 401 from the DUOS API means it rejected that access token — expired early,
+ * revoked, or issued to a user it no longer knows — even though the session
+ * looked valid enough for `ensureUpstreamAuth` to forward the request. The
+ * session cannot recover on its own, so it is destroyed and the browser gets a
+ * 401 to redirect on, exactly as `/auth/me` does on the same verdict.
+ *
+ * This is not new behaviour arriving with the proxy: the legacy client already
+ * signs the user out on any 401 from the DUOS API (`fetchAdapter.handleResponse`
+ * → `redirectOnLogout`). Its one exemption, `GET /api/user/me`, is not carried
+ * over — that exists to stop a *client-side* redirect loop on the auth probe,
+ * not because such a 401 leaves the session usable, and me.ts already destroys
+ * on it. So a 401 the upstream returns for authorization rather than
+ * authentication reasons ends the session here as it does today.
+ *
+ * Everything else streams through untouched, which is what reply-from's default
+ * `onResponse` does — by the time this runs it has already put the (rewritten)
+ * upstream headers and status on the reply, so the default is only the body.
+ */
+function onUpstreamResponse(request: ProxyRequest, reply: ProxyReply, res: UpstreamResponse): void {
+  if (res.statusCode !== 401 || injectedAccessToken(request) === undefined) {
+    reply.send(res.stream)
+    return
+  }
+
+  // The upstream's 401 body is replaced by the reply below, but it still has to
+  // be read: an unconsumed response keeps its undici socket checked out of the
+  // pool. Drained rather than destroyed so the connection stays reusable — a 401
+  // body is a sentence of JSON. The error listener is required, not defensive:
+  // an 'error' on a stream with no listener is an unhandled exception, and
+  // reply-from's default path only gets one because `reply.send` attaches it.
+  res.stream.on('error', (err: Error) => {
+    request.log.debug({ err }, '[proxy] discarded upstream 401 body errored')
+  })
+  res.stream.resume()
+
+  // The upstream headers reply-from has already copied onto the reply describe a
+  // body that is no longer being sent. Left in place, `content-type` alone is
+  // fatal: Fastify only serialises an object payload when the content type is
+  // JSON or unset, so an upstream `text/plain` 401 would reach the socket as an
+  // un-serialised object and throw FST_ERR_REP_INVALID_PAYLOAD_TYPE. The rest
+  // mislead — `content-encoding: gzip` on plain JSON the browser then fails to
+  // decode, a stale `etag`, a `content-length` for the discarded body.
+  //
+  // Keyed off `res.headers` so exactly what came from the upstream is removed
+  // and anything the BFF set is kept. `connection` is the one exception:
+  // reply-from sets it to `close` when the upstream answered before the request
+  // body was fully read, which is about this connection rather than about the
+  // response being discarded.
+  for (const name of Object.keys(upstreamHeaders(res))) {
+    if (name !== 'connection') {
+      reply.removeHeader(name)
+    }
+  }
+
+  // Deliberately not awaited — reply-from's onResponse is synchronous and
+  // ignores what it returns, so an unhandled rejection here would take the pod
+  // down with it. `endRejectedSession` therefore resolves every failure into a
+  // reply of its own.
+  void endRejectedSession(request, reply)
+}
+
+/**
+ * Destroys the session the upstream just rejected, then answers the browser.
+ *
+ * The reply is sent after the destroy resolves, which is what keeps
+ * `@fastify/session`'s onSend hook out of the way: `destroy()` nulls
+ * `request.session`, so the hook finds nothing to save and returns
+ * synchronously, rather than writing the dead session back on the way out.
+ */
+async function endRejectedSession(request: ProxyRequest, reply: ProxyReply): Promise<void> {
+  try {
+    await request.session.destroy()
+    request.log.info('[proxy] upstream rejected the session access token — session destroyed, returning 401')
+  }
+  catch (err: unknown) {
+    // The row is left to expire on its own schedule. The 401 and the cleared
+    // cookie still go out: this browser stops presenting the sid either way, and
+    // the alternative — a 500 — would tell the client to retry a request that
+    // can only earn another 401.
+    request.log.error({ err }, '[proxy] upstream rejected the session access token but the session could not be destroyed — returning 401 anyway')
+  }
+  // Clear the cookie for the same reason the fatal-refresh path does: the row is
+  // gone, so a browser still presenting the sid gets a new empty session on
+  // every subsequent request.
+  reply.clearCookie('sessionId').status(401).send({ error: 'session_expired' })
 }

--- a/server/src/proxy/apiProxy.ts
+++ b/server/src/proxy/apiProxy.ts
@@ -132,38 +132,32 @@ export const CSRF_EXEMPT_UNSAFE_REQUESTS: ReadonlySet<string> = new Set([
 
 /**
  * The `error` code a CSRF rejection returns, and the one thing about a proxy
- * error the client is meant to branch on (ADR-010).
+ * error the client branches on (ADR-010).
  *
  * Epic 4's fetch layer refetches a token and retries once when it sees this, and
  * only when it sees this. Status alone cannot carry that signal: an upstream
  * authorization denial is an ordinary proxied response and also arrives as a
  * 403, so retrying on the status would replay every write the DUOS API refused.
- *
- * Named for the check that failed rather than for either cause, because both
- * causes below mean the same thing to the client.
  */
 export const CSRF_ERROR_CODE = 'csrf_validation_failed'
 
 /**
  * The two ways `@fastify/csrf-protection` rejects a request, mapped to the
- * reason the BFF publishes for each.
+ * reason the BFF publishes. `FST_CSRF_MISSING_SECRET` means there was no session
+ * to verify against, so enforcement stopped before the token — including the
+ * shape a session rotation that discards the secret (Epic 5, 5-D) will produce.
+ * `FST_CSRF_INVALID_TOKEN` means there was a secret and the token did not verify
+ * against it.
  *
- * `FST_CSRF_MISSING_SECRET` means the request carried no session to verify
- * against, so enforcement stopped before it reached the token — the signed-out
- * caller, and the shape a session rotation that discards the secret (Epic 5,
- * 5-D) will produce. `FST_CSRF_INVALID_TOKEN` means there was a secret and the
- * token did not verify against it, including when `getToken` found no token at
- * all.
+ * Both map to the same `error`, since both call for the same single retry;
+ * `reason` is diagnostic, and the tests below are its other consumer — asserting
+ * which rejection fired is what stops a case meant to exercise one path from
+ * silently drifting onto the other, as story 3-D's review found had happened.
  *
- * The plugin's own code is deliberately not what goes on the wire, for two
- * reasons. It is `@fastify/csrf-protection` internals, renameable on a major
- * bump, and a client branching on it would break silently. And the `code` field
- * of an error body already means something else to this client:
- * `DataAccessRequestApplication.tsx` reads it as "the upstream sent a structured
- * error, so its `message` is safe to render as markdown". So the distinction
- * travels under a key of the BFF's own, and is there for a human reading a
- * network tab or a support ticket — the client branches on `error`, never on
- * this.
+ * The plugin's own code stays off the wire: it is renameable internals, and
+ * `code` in an error body already means something else to this client
+ * (`DataAccessRequestApplication.tsx` reads it as "the upstream sent a structured
+ * error, so render its `message`").
  */
 const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
   ['FST_CSRF_MISSING_SECRET', 'missing_secret'],
@@ -171,56 +165,32 @@ const CSRF_REJECTION_REASONS: ReadonlyMap<string, string> = new Map([
 ])
 
 /**
- * Added to every proxied response, so nothing the upstream returns can execute
- * on the SPA's origin (story 3-E(b)).
+ * Added to every response the proxy scope emits, so nothing the upstream returns
+ * can execute on the SPA's origin (story 3-E(b)).
  *
- * **Why the proxy creates this problem.** DUOS serves user-uploaded documents
- * back through the API — `GET /api/daa/{id}/file`, DAR documents,
- * `FileStorageObject` documents. Proxied, those are served *from the BFF's own
- * origin*. A top-level navigation to `/duos-api/api/daa/{id}/file` carries the
- * `SameSite=Lax` session cookie, the proxy injects the bearer, and the browser
- * renders attacker-uploaded markup on the origin that holds the session.
- * `HttpOnly` is no help: the script does not need to read the cookie, only to
- * make same-origin requests back through the proxy with it.
+ * The proxy introduces this risk. DUOS serves user-uploaded documents back
+ * through the API, and proxied they come from the BFF's *own* origin: a
+ * top-level navigation to one carries the `SameSite=Lax` session cookie, the
+ * proxy injects the bearer, and the browser renders attacker-uploaded markup on
+ * the origin that holds the session. `HttpOnly` does not help — the script needs
+ * to make same-origin requests with the cookie, not to read it.
  *
- * This is genuinely new with the proxy. Today the same file comes from the
- * Consent API's origin, where a cookie-less top-level navigation simply 401s.
+ * `sandbox` with no tokens gives any document that does get rendered an opaque
+ * origin and no scripts; `nosniff` stops one being promoted to a document by the
+ * browser guessing at its bytes. Unconditional, and overriding an upstream that
+ * sends either header, because the safety must not depend on the content type
+ * the upstream chose to declare.
  *
- *   x-content-type-options — no MIME sniffing, so an `.html` uploaded as
- *                            `application/octet-stream` is not promoted to a
- *                            document by the browser guessing at its bytes.
- *   content-security-policy — `sandbox` with no tokens is the maximally
- *                            restrictive form: opaque origin, no scripts, no
- *                            forms, no same-origin access. A document that does
- *                            get rendered can do nothing with this origin.
+ * Applied in `onSend` rather than `rewriteHeaders`, which reaches only the
+ * responses that come back from the upstream: `onSend` runs after
+ * `onUpstreamResponse` strips the upstream's headers off a replaced 401, and
+ * covers the replies the proxy writes for itself.
  *
- * **Safe to apply to everything.** Verified against the call sites rather than
- * assumed: every document path is consumed with `fetchBlob` and handed to
- * `fileDownload` (`DAA.ts`, `DAR.ts`, `FileStorageObject.ts`), and there is no
- * top-level navigation, `href`, or `src` pointing at an API URL anywhere in
- * `src/` — even `/api-docs/ISO-3166-countries.json` is fetched (`Countries.ts`).
- * `fetch` ignores both headers entirely, and a blob download is initiated by the
- * SPA's own document, so neither can reach the client. Re-check when Epic 4
- * rewrites the fetch layer.
- *
- * **What it does cost.** Anything reached by navigating a browser at a proxied
- * path renders inert — the upstream's Swagger UI under `/api-docs/*` being the
- * realistic example. No client code does that; an operator poking at the proxy
- * by hand would notice.
- *
- * Deliberately not added: forcing `content-disposition: attachment` for content
- * types outside a safe list. `sandbox` already makes a rendered document
- * harmless, so it buys little, and it is the piece most likely to break a future
- * inline preview. ADR-009's deferred `Sec-Fetch-Mode: navigate` rejection would
- * close the same vector at the request leg; these are worth having regardless,
- * since they do not depend on a decision that has not been taken.
- *
- * **Applied in `onSend`, not `rewriteHeaders`.** The story sketched it on the
- * latter, which reaches only the responses that come from the upstream. `onSend`
- * runs for every reply the scope produces — including the 401 that replaces a
- * rejected one, whose header-strip loop would otherwise have to except these two
- * by name, and the proxy's own 401/403/500/502 bodies. Uniform is both easier to
- * state and easier to test than "every response except the ones the BFF wrote".
+ * Safe for the client — `fetch` ignores both headers, and every document path is
+ * a `fetchBlob` download initiated by the SPA's own document. Verified against
+ * the call sites; re-check when Epic 4 rewrites the fetch layer. See the epic's
+ * story 3-E(b) for the full argument and for what this costs (direct navigation
+ * to the upstream's Swagger UI renders inert).
  */
 const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
   'x-content-type-options': 'nosniff',
@@ -303,23 +273,16 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
   }
 
   /**
-   * The proxy scope's error shape (story 3-E, ADR-010).
+   * The proxy scope's error shape — see ADR-010 for the decision and the
+   * alternatives.
    *
-   * Declared here rather than inherited from the root instance, and that is not
-   * a preference: a child context copies the error handler that exists when it
-   * is created, and index.ts calls `setErrorHandler` *after* it registers this
-   * plugin. Without this line the scope keeps Fastify's default handler, which
-   * puts `err.message` on the wire for an unexpected 500 while every other route
-   * in the app returns the generic body. Moving index.ts's call above the
-   * registration would fix that half, but it would also flatten the CSRF
-   * rejection into the same generic body — and that one the client has to be
-   * able to recognise, since a 403 through this proxy is otherwise an upstream
-   * authorization denial passed through as an ordinary response.
-   *
-   * So: CSRF rejections keep a stable, BFF-owned code, and everything else is
-   * indistinguishable from a failure anywhere else in the app. `reply.from`'s
+   * Declared here because an encapsulated scope copies the error handler that
+   * exists when it is created, and index.ts sets the app's *after* registering
+   * this plugin. CSRF rejections keep a stable, BFF-owned code because the
+   * client has to tell them from an upstream 403; everything else is
+   * indistinguishable from a failure elsewhere in the app. `reply.from`'s
    * transport failures never arrive here — `onUpstreamTransportError` answers
-   * those — so the second branch is reached only by a bug on a proxy path.
+   * those — so the second branch means a bug on a proxy path.
    */
   app.setErrorHandler((err: FastifyError, request, reply) => {
     const reason = err.code === undefined ? undefined : CSRF_REJECTION_REASONS.get(err.code)
@@ -366,15 +329,11 @@ export async function apiProxy(app: FastifyInstance): Promise<void> {
   }
 
   // Nothing the upstream returns may execute on this origin — see
-  // RESPONSE_HARDENING. Set here rather than merged into `rewriteHeaders` so it
-  // covers every reply the scope writes, not only the ones proxied back from the
-  // upstream, and so it lands after `onUpstreamResponse` has stripped the
-  // upstream's headers off a replaced 401.
+  // RESPONSE_HARDENING for why it is here rather than in `rewriteHeaders`.
   //
-  // Callback style with a bare `done()`: an async onSend returning undefined
-  // would be read as "no change", but the callback form says so without relying
-  // on that, and it must not touch the payload — it is a stream on the proxied
-  // path.
+  // Callback style with a bare `done()`: the payload must be passed through
+  // untouched — it is a stream on the proxied path — and the callback form says
+  // so without relying on how an async hook treats an undefined return.
   app.addHook('onSend', (_request, reply, _payload, done) => {
     reply.headers(RESPONSE_HARDENING)
     done()
@@ -655,10 +614,10 @@ function onUpstreamResponse(request: ProxyRequest, reply: ProxyReply, res: Upstr
 
   // The upstream's 401 body is replaced by the reply below, but it still has to
   // be read: an unconsumed response keeps its undici socket checked out of the
-  // pool. Drained rather than destroyed so the connection stays reusable — a 401
-  // body is a sentence of JSON. The error listener is required, not defensive:
-  // an 'error' on a stream with no listener is an unhandled exception, and
-  // reply-from's default path only gets one because `reply.send` attaches it.
+  // pool. Drained rather than destroyed because draining preserves connection
+  // reuse. The error listener is required, not defensive: an 'error' on a stream
+  // with no listener is an unhandled exception, and reply-from's default path
+  // only gets one because `reply.send` attaches it.
   res.stream.on('error', (err: Error) => {
     request.log.debug({ err }, '[proxy] discarded upstream 401 body errored')
   })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -997,6 +997,112 @@ describe('apiProxy', () => {
     })
 
     /**
+     * The hop-by-hop class, as distinct from the origin-state one above: these
+     * describe the BFF↔upstream connection, not the response, so relaying them
+     * tells the browser about a connection it is not on.
+     */
+    describe('connection-specific headers', () => {
+      // `proxy-authenticate` is why this matters rather than being tidiness: it is
+      // `www-authenticate`'s proxy-side twin, and a `Basic` challenge relayed to
+      // the browser pops a native credential dialog on the BFF's own origin —
+      // exactly what stripping `www-authenticate` exists to prevent.
+      it('never forwards an upstream proxy-authenticate challenge', async () => {
+        upstream.respondWith((_req, res) => {
+          res.writeHead(407, {
+            'content-type': 'application/json',
+            'proxy-authenticate': 'Basic realm="upstream-proxy"',
+          })
+          res.end('{"message":"Proxy Authentication Required"}')
+        })
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+        expect(res.headers['proxy-authenticate']).toBeUndefined()
+        // The status and body still reach the client — the header is dropped, not
+        // the response, so a misconfigured upstream is still diagnosable.
+        expect(res.statusCode).toBe(407)
+        expect(res.json()).toEqual({ message: 'Proxy Authentication Required' })
+      })
+
+      it.each(['keep-alive', 'proxy-authorization', 'te', 'trailer', 'upgrade'])(
+        'does not forward an upstream %s',
+        async (header) => {
+          upstream.respondWith((_req, res) => {
+            res.writeHead(200, { 'content-type': 'application/json', [header]: 'upstream-hop-value' })
+            res.end('{"ok":true}')
+          })
+          app = await buildProxyApp(freshSession())
+
+          const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+          expect(res.headers[header]).toBeUndefined()
+          expect(res.json()).toEqual({ ok: true })
+        },
+      )
+
+      // The case that makes this a real bug rather than a contrived one: Node's
+      // HTTP server adds `Keep-Alive: timeout=5` by itself on any keep-alive
+      // connection, so an upstream that never sets the header still sends one.
+      // Before the strip, every proxied response carried the upstream's socket
+      // timeout to the browser.
+      it('does not forward the keep-alive an upstream emits without being asked', async () => {
+        upstream.respondWith((_req, res) => {
+          res.writeHead(200, { 'content-type': 'application/json' })
+          res.end('{"ok":true}')
+        })
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+        expect(res.headers['keep-alive']).toBeUndefined()
+      })
+
+      /**
+       * `connection` and `transfer-encoding` are the two the story's checklist
+       * names, and the two `CONNECTION_SPECIFIC_RESPONSE_HEADERS` deliberately
+       * leaves out: the HTTP layer owns the framing, so the upstream's values
+       * never reach the browser regardless of this module. Pinned because that
+       * is a property of undici and Fastify rather than of the code here — if it
+       * stopped holding, the strip set is where the fix would belong, and this is
+       * the test that would say so.
+       *
+       * The upstream keeps its connection alive and streams its body, which is
+       * what a real one does; the reply carries the framing Fastify chose for the
+       * body it actually wrote, not the upstream's.
+       */
+      it('gives the browser the transport hop\'s own framing, not the upstream\'s', async () => {
+        upstream.respondWith((_req, res) => {
+          res.writeHead(200, { 'content-type': 'application/json', 'connection': 'keep-alive' })
+          res.write('{"streamed":')
+          res.end('true}')
+        })
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+        // The upstream said keep-alive; this hop is its own to describe.
+        expect(res.headers.connection).not.toBe('keep-alive')
+        expect(res.headers['transfer-encoding']).toBe('chunked')
+        // Chunked framing, and the streamed body reassembled from it.
+        expect(res.json()).toEqual({ streamed: true })
+      })
+
+      // The strip is on the upstream's headers, not a blanket denylist, so a
+      // header the BFF itself needs to send is unaffected even when its name is
+      // in the set. Nothing sets these today; this pins that the mechanism is
+      // keyed on where the header came from.
+      it('leaves the origin-state and hardening headers the BFF sets in place', async () => {
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+        expect(res.headers['x-content-type-options']).toBe('nosniff')
+        expect(res.cookies.map(cookie => cookie.name)).toContain(SESSION_COOKIE)
+      })
+    })
+
+    /**
      * Story 3-E(b) — a user-uploaded document served back through the proxy comes
      * from the SPA's own origin, so it must not be able to execute there.
      *

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -9,7 +9,8 @@ import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
 import { csrfPluginOptions } from '../src/auth/csrf.js'
 import { RefreshFailedError } from '../src/auth/refresh.js'
-import { CSRF_EXEMPT_UNSAFE_REQUESTS, PROXY_PREFIX, REFRESH_WINDOW_SECONDS, UNAUTHENTICATED_PATHS, apiProxy, upstreamPath } from '../src/proxy/apiProxy.js'
+import { GENERIC_ERROR_BODY } from '../src/errors.js'
+import { CSRF_ERROR_CODE, CSRF_EXEMPT_UNSAFE_REQUESTS, PROXY_PREFIX, REFRESH_WINDOW_SECONDS, UNAUTHENTICATED_PATHS, apiProxy, upstreamPath } from '../src/proxy/apiProxy.js'
 
 // refreshAccessToken is replaced so the tests never reach B2C; RefreshFailedError
 // stays the real class so the proxy's instanceof branch is exercised rather than
@@ -400,12 +401,18 @@ describe('apiProxy', () => {
      * `MISSING_SECRET` means the request had no session to verify against, so
      * enforcement never got as far as the token. `INVALID_TOKEN` means there was
      * a secret and the token did not verify against it — including when
-     * `getToken` found no token at all. The codes are Fastify's default error
-     * serialisation, which is what this harness (no error handler of its own)
-     * exposes.
+     * `getToken` found no token at all.
+     *
+     * These are the proxy's own reasons, not the plugin's error codes. Until
+     * story 3-E these assertions read `code: 'FST_CSRF_INVALID_TOKEN'` off
+     * Fastify's default error serialisation — which was never a decision, just
+     * what a harness with no error handler happened to expose. ADR-010 replaced
+     * it with the body below; `error` is what the client branches on and `reason`
+     * is what a human reads.
      */
-    const MISSING_SECRET = 'FST_CSRF_MISSING_SECRET'
-    const INVALID_TOKEN = 'FST_CSRF_INVALID_TOKEN'
+    const MISSING_SECRET = 'missing_secret'
+    const INVALID_TOKEN = 'invalid_token'
+    const rejection = (reason: string) => ({ error: CSRF_ERROR_CODE, reason })
 
     // No cookie, so every request builds a fresh session with no CSRF secret in
     // it. That is the signed-out attacker's request, and it stops at the secret.
@@ -417,7 +424,7 @@ describe('apiProxy', () => {
         const res = await app.inject({ method, url: `${PROXY_PREFIX}/api/dataset/1` })
 
         expect(res.statusCode).toBe(403)
-        expect(res.json()).toMatchObject({ code: MISSING_SECRET })
+        expect(res.json()).toEqual(rejection(MISSING_SECRET))
         expect(upstream.received).toHaveLength(0)
       },
     )
@@ -433,7 +440,7 @@ describe('apiProxy', () => {
       const res = await app.inject({ method: 'POST', url: `${PROXY_PREFIX}/api/dataset/1`, headers: { cookie } })
 
       expect(res.statusCode).toBe(403)
-      expect(res.json()).toMatchObject({ code: INVALID_TOKEN })
+      expect(res.json()).toEqual(rejection(INVALID_TOKEN))
       expect(upstream.received).toHaveLength(0)
     })
 
@@ -457,7 +464,7 @@ describe('apiProxy', () => {
       })
 
       expect(res.statusCode).toBe(403)
-      expect(res.json()).toMatchObject({ code: INVALID_TOKEN })
+      expect(res.json()).toEqual(rejection(INVALID_TOKEN))
       expect(upstream.received).toHaveLength(0)
     })
 
@@ -475,7 +482,7 @@ describe('apiProxy', () => {
       })
 
       expect(res.statusCode).toBe(403)
-      expect(res.json()).toMatchObject({ code: MISSING_SECRET })
+      expect(res.json()).toEqual(rejection(MISSING_SECRET))
       expect(upstream.received).toHaveLength(0)
     })
 
@@ -497,7 +504,7 @@ describe('apiProxy', () => {
       // The secret is present and no token was found, so this is the
       // failed-verification path, not the missing-secret one.
       expect(res.statusCode).toBe(403)
-      expect(res.json()).toMatchObject({ code: INVALID_TOKEN })
+      expect(res.json()).toEqual(rejection(INVALID_TOKEN))
     })
 
     it.each(['GET', 'HEAD', 'OPTIONS'] as const)('does not require a token on %s', async (method) => {
@@ -1170,6 +1177,98 @@ describe('apiProxy', () => {
 
       expect(res.statusCode).toBe(401)
       expect(res.headers['www-authenticate']).toBeUndefined()
+    })
+  })
+
+  /**
+   * Story 3-E(c) / ADR-010 — what a failure inside the proxy scope looks like to
+   * the browser.
+   *
+   * The scope is encapsulated (`removeAllContentTypeParsers` must not escape it),
+   * so it does not inherit the root instance's error handler and index.ts sets
+   * that one after registering the proxy anyway. The shape below is therefore a
+   * decision the plugin makes for itself, and these are the tests that hold it
+   * to that rather than to whatever the plugin ordering happens to produce.
+   */
+  describe('the error shape', () => {
+    /**
+     * An app whose proxy scope also holds a route that throws, standing in for a
+     * bug on a proxy path — there is no natural one to provoke, since the auth
+     * gate answers its own failures and `onUpstreamTransportError` answers
+     * reply-from's.
+     *
+     * `apiProxy` is called on the scope rather than registered into it, so the
+     * throwing route lands in the same context as the proxy's routes and hooks
+     * and is answered by the same error handler. The root handler is registered
+     * afterwards, exactly as index.ts does it, which is the ordering the whole
+     * decision turns on.
+     */
+    async function buildAppWithRootErrorHandler(): Promise<FastifyInstance> {
+      const app = await buildAppShell()
+      await app.register(async (scope) => {
+        await apiProxy(scope)
+        scope.get(`${PROXY_PREFIX}-boom`, async () => {
+          throw new Error('a stack trace and an internal path')
+        })
+      })
+      app.setErrorHandler((_err, _request, reply) =>
+        reply.status(500).send({ error: 'the root handler answered' }))
+      app.get('/boom', async () => {
+        throw new Error('a stack trace and an internal path')
+      })
+      return app
+    }
+
+    it('sanitises an unexpected proxy-scope error instead of returning its message', async () => {
+      app = await buildAppWithRootErrorHandler()
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}-boom` })
+
+      expect(res.statusCode).toBe(500)
+      expect(res.json()).toEqual(GENERIC_ERROR_BODY)
+      expect(res.payload).not.toContain('a stack trace and an internal path')
+    })
+
+    // The root handler still owns everything outside the proxy. Asserted in the
+    // same app as the case above so the two cannot be read as different setups:
+    // one registration order, two scopes, two answers.
+    it('leaves errors outside the proxy scope to the root handler', async () => {
+      app = await buildAppWithRootErrorHandler()
+
+      const res = await app.inject({ method: 'GET', url: '/boom' })
+
+      expect(res.json()).toEqual({ error: 'the root handler answered' })
+    })
+
+    // The regression this whole decision exists to prevent: index.ts registering
+    // its handler after the proxy must not be what determines the proxy's shape.
+    // Before ADR-010 this request returned Fastify's default body, message and
+    // all, purely because of that ordering.
+    it('is not affected by a root error handler registered after the proxy', async () => {
+      app = await buildAppWithRootErrorHandler()
+
+      const res = await app.inject({ method: 'POST', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: CSRF_ERROR_CODE, reason: 'missing_secret' })
+    })
+
+    // The client's discriminator has to be the body, not the status: an upstream
+    // authorization denial is an ordinary proxied response and arrives as a 403
+    // too. Retrying on the status alone would replay every write the DUOS API
+    // refused, which is why Epic 4 keys its one retry on `error` instead.
+    it('passes an upstream 403 through with its own body, unlike a CSRF rejection', async () => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(403, { 'content-type': 'application/json' })
+        res.end('{"code":403,"message":"User is not an admin"}')
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await injectWithCsrf(app, { method: 'POST', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ code: 403, message: 'User is not an admin' })
+      expect(res.json()).not.toHaveProperty('error', CSRF_ERROR_CODE)
     })
   })
 })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -141,19 +141,10 @@ async function buildProxyApp(seed?: SessionSeed): Promise<FastifyInstance> {
   return app
 }
 
-/**
- * Whether the session a request used still exists once the request is over.
- *
- * It cannot be read off the response: `buildProxyApp`'s seed hook hands every
- * request a session, so a follow-up inject finds a live one either way. With
- * `saveUninitialized: false` the row is written by `@fastify/session`'s onSend
- * hook, which skips a session destroyed mid-request — so "is there a row for the
- * sid this request used" is what separates destroyed from intact.
- */
+// Capture the request's original session ID before the proxy can destroy it.
 function trackSession(app: FastifyInstance): { stored: () => Promise<Session | null> } {
   let sid: string | undefined
   let store: FastifyRequest['sessionStore'] | undefined
-  // A root onRequest hook, so it runs before anything the proxy does.
   app.addHook('onRequest', async (request) => {
     sid = request.session.sessionId
     store = request.sessionStore
@@ -387,21 +378,6 @@ describe('apiProxy', () => {
   // The proxy turns every DUOS API write into a cookie-authenticated request,
   // so without this any site could drive them using a signed-in victim's cookie.
   describe('CSRF enforcement', () => {
-    /**
-     * The plugin rejects for two different reasons, both with a 403, and the
-     * tests below assert which one they got rather than the status alone —
-     * otherwise a case meant to exercise one path can silently drift onto the
-     * other, which review of story 3-D found had already happened to the
-     * no-token cases.
-     *
-     * `MISSING_SECRET` means the request had no session to verify against, so
-     * enforcement never got as far as the token. `INVALID_TOKEN` means there was
-     * a secret and the token did not verify against it — including when
-     * `getToken` found no token at all.
-     *
-     * These are the proxy's own reasons (ADR-010), not the plugin's error codes:
-     * `error` is what the client branches on, `reason` is what a human reads.
-     */
     const MISSING_SECRET = 'missing_secret'
     const INVALID_TOKEN = 'invalid_token'
     const rejection = (reason: string) => ({ error: CSRF_ERROR_CODE, reason })
@@ -988,12 +964,7 @@ describe('apiProxy', () => {
       expect(res.json()).toEqual({ ok: true })
     })
 
-    // The hop-by-hop class, as distinct from the origin-state one above: these
-    // describe the BFF↔upstream connection, not the response.
     describe('connection-specific headers', () => {
-      // `proxy-authenticate` is `www-authenticate`'s proxy-side twin: a `Basic`
-      // challenge relayed to the browser pops a native credential dialog on the
-      // BFF's own origin.
       it('never forwards an upstream proxy-authenticate challenge', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(407, {
@@ -1007,8 +978,6 @@ describe('apiProxy', () => {
         const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
         expect(res.headers['proxy-authenticate']).toBeUndefined()
-        // The header is dropped, not the response, so a misconfigured upstream
-        // is still diagnosable.
         expect(res.statusCode).toBe(407)
         expect(res.json()).toEqual({ message: 'Proxy Authentication Required' })
       })
@@ -1029,8 +998,6 @@ describe('apiProxy', () => {
         },
       )
 
-      // Node's HTTP server adds `Keep-Alive: timeout=5` by itself, so an upstream
-      // that never sets the header still leaks its socket timeout to the browser.
       it('does not forward the keep-alive an upstream emits without being asked', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(200, { 'content-type': 'application/json' })
@@ -1043,14 +1010,6 @@ describe('apiProxy', () => {
         expect(res.headers['keep-alive']).toBeUndefined()
       })
 
-      /**
-       * `connection` and `transfer-encoding` are the two
-       * `CONNECTION_SPECIFIC_RESPONSE_HEADERS` deliberately leaves out: the HTTP
-       * layer owns the framing, so the upstream's values never reach the browser
-       * regardless of this module. Pinned because that is a property of undici
-       * and Fastify rather than of the code here — if it stopped holding, the
-       * strip set is where the fix would belong.
-       */
       it('gives the browser the transport hop\'s own framing, not the upstream\'s', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(200, { 'content-type': 'application/json', 'connection': 'keep-alive' })
@@ -1061,14 +1020,11 @@ describe('apiProxy', () => {
 
         const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
-        // The upstream said keep-alive; this hop is its own to describe.
         expect(res.headers.connection).not.toBe('keep-alive')
         expect(res.headers['transfer-encoding']).toBe('chunked')
         expect(res.json()).toEqual({ streamed: true })
       })
 
-      // The strip is keyed on where a header came from, not a blanket denylist,
-      // so one the BFF sets itself survives even if the upstream sent the name too.
       it('leaves the origin-state and hardening headers the BFF sets in place', async () => {
         app = await buildProxyApp(freshSession())
 
@@ -1079,13 +1035,7 @@ describe('apiProxy', () => {
       })
     })
 
-    // A user-uploaded document served back through the proxy comes from the SPA's
-    // own origin, so it must not be able to execute there.
     describe('response hardening', () => {
-      // The threat itself: a `.html` uploaded as a DAA document, fetched by a
-      // top-level navigation that carries the SameSite=Lax session cookie. The
-      // upstream sends weaker versions of both headers, so this also pins that it
-      // cannot relax what the BFF applies.
       it('neuters an uploaded document served back as text/html', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(200, {
@@ -1103,9 +1053,6 @@ describe('apiProxy', () => {
         expect(res.headers['content-security-policy']).toBe('sandbox')
       })
 
-      // The headers are inert to the client — `fetch` ignores both, and a blob
-      // download is initiated by the SPA's own document — so they cannot disturb
-      // the document paths that motivated them.
       it('leaves a blob download byte-for-byte intact', async () => {
         const document = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x00, 0xff, 0xfe, 0x0a])
         upstream.respondWith((_req, res) => {
@@ -1125,9 +1072,6 @@ describe('apiProxy', () => {
         expect(res.headers['x-content-type-options']).toBe('nosniff')
       })
 
-      // Why onSend rather than rewriteHeaders: it lands after
-      // `onUpstreamResponse`'s header-strip loop, which is keyed on the
-      // upstream's header names and would otherwise take the BFF's values with it.
       it('hardens a reply the proxy writes itself, not only a proxied one', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(401, {
@@ -1141,17 +1085,12 @@ describe('apiProxy', () => {
 
         const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
-        // The BFF's own 401, with the upstream's headers stripped off it.
         expect(res.statusCode).toBe(401)
         expect(res.json()).toEqual({ error: 'session_expired' })
         expect(res.headers['x-content-type-options']).toBe('nosniff')
         expect(res.headers['content-security-policy']).toBe('sandbox')
       })
 
-      // The hook must stay inside the proxy's encapsulation: escaped to the root
-      // instance it would land on the SPA's own HTML, where `sandbox` means an
-      // opaque origin and no scripts — the entire app dead, in a way no proxy
-      // test would notice. `/auth/csrf-token` stands in for a root-scope route.
       it('does not leak the headers onto routes outside the proxy scope', async () => {
         app = await buildProxyApp(freshSession())
 
@@ -1189,10 +1128,7 @@ describe('apiProxy', () => {
     })
   })
 
-  // The upstream is the authority on whether the token this proxy injected is
-  // any good; a session it rejects cannot recover on its own.
   describe('an upstream 401', () => {
-    /** An upstream that rejects everything, the way it would a revoked token. */
     const rejectingUpstream = (headers: Record<string, string> = {}): void => {
       upstream.respondWith((_req, res) => {
         res.writeHead(401, { 'content-type': 'application/json', ...headers })
@@ -1200,7 +1136,6 @@ describe('apiProxy', () => {
       })
     }
 
-    // One case, because it is one behaviour: the user is signed out.
     it('signs the user out — its own 401, session destroyed, cookie cleared', async () => {
       rejectingUpstream()
       app = await buildProxyApp(freshSession())
@@ -1209,8 +1144,6 @@ describe('apiProxy', () => {
       const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
       expect(res.statusCode).toBe(401)
-      // The BFF's vocabulary, not the upstream's: the client distinguishes this
-      // from `unauthenticated` (never had a session) and `upstream_unavailable`.
       expect(res.json()).toEqual({ error: 'session_expired' })
       expect(await session.stored()).toBeNull()
       expect(res.cookies).toEqual(expect.arrayContaining([
@@ -1218,8 +1151,6 @@ describe('apiProxy', () => {
       ]))
     })
 
-    // The control for the destroy above: the same lookup finds a row when the
-    // upstream is happy, so "no row" means destroyed rather than never-written.
     it('leaves the session alone when the upstream is happy', async () => {
       app = await buildProxyApp(freshSession())
       const session = trackSession(app)
@@ -1246,9 +1177,6 @@ describe('apiProxy', () => {
       expect(await session.stored()).toBeNull()
     })
 
-    // `content-type` is the fatal one: Fastify only serialises an object payload
-    // when the content type is JSON or unset, so a `text/plain` 401 would throw
-    // FST_ERR_REP_INVALID_PAYLOAD_TYPE — a 500 in place of the 401.
     it('does not leave the upstream response headers describing the reply that replaces it', async () => {
       const compressed = gzipSync(Buffer.from('token rejected'))
       upstream.respondWith((_req, res) => {
@@ -1272,9 +1200,6 @@ describe('apiProxy', () => {
       expect(res.headers['content-length']).toBe(String(res.rawPayload.length))
     })
 
-    // An allowlisted path is proxied with no token at all, so its 401 says
-    // nothing about the caller's session — signing them out over it would be a
-    // logout triggered by an unrelated endpoint.
     it('passes through untouched on an allowlisted path, session intact', async () => {
       rejectingUpstream()
       app = await buildProxyApp(freshSession())
@@ -1290,9 +1215,6 @@ describe('apiProxy', () => {
       ]))
     })
 
-    // A `Basic` challenge relayed to the browser would pop a native credential
-    // dialog on the BFF's own origin. Asserted on the pass-through path because
-    // that is the one where the upstream's headers survive at all.
     it('never forwards an upstream WWW-Authenticate challenge', async () => {
       rejectingUpstream({ 'www-authenticate': 'Basic realm="DUOS API"' })
       app = await buildProxyApp(freshSession())
@@ -1304,22 +1226,7 @@ describe('apiProxy', () => {
     })
   })
 
-  /**
-   * ADR-010 — what a failure inside the proxy scope looks like to the browser.
-   *
-   * The scope is encapsulated, so it does not inherit the root error handler,
-   * which index.ts registers after the proxy anyway. These tests hold the shape
-   * to the plugin's own decision rather than to that ordering.
-   */
   describe('the error shape', () => {
-    /**
-     * An app whose proxy scope also holds a route that throws, standing in for a
-     * bug on a proxy path — there is no natural one to provoke, since the auth
-     * gate answers its own failures and `onUpstreamTransportError` answers
-     * reply-from's. `apiProxy` is called on the scope rather than registered into
-     * it so the throwing route shares the proxy's context, and the root handler
-     * is registered afterwards exactly as index.ts does it.
-     */
     async function buildAppWithRootErrorHandler(): Promise<FastifyInstance> {
       const app = await buildAppShell()
       await app.register(async (scope) => {
@@ -1346,8 +1253,6 @@ describe('apiProxy', () => {
       expect(res.payload).not.toContain('a stack trace and an internal path')
     })
 
-    // Asserted in the same app as the case above: one registration order, two
-    // scopes, two answers.
     it('leaves errors outside the proxy scope to the root handler', async () => {
       app = await buildAppWithRootErrorHandler()
 
@@ -1356,9 +1261,6 @@ describe('apiProxy', () => {
       expect(res.json()).toEqual({ error: 'the root handler answered' })
     })
 
-    // The regression this decision exists to prevent: before ADR-010 this
-    // request returned Fastify's default body, message and all, purely because
-    // index.ts registers its handler after the proxy.
     it('is not affected by a root error handler registered after the proxy', async () => {
       app = await buildAppWithRootErrorHandler()
 
@@ -1368,9 +1270,6 @@ describe('apiProxy', () => {
       expect(res.json()).toEqual({ error: CSRF_ERROR_CODE, reason: 'missing_secret' })
     })
 
-    // The client's discriminator has to be the body, not the status: an upstream
-    // authorization denial arrives as a 403 too, and retrying on the status
-    // alone would replay every write the DUOS API refused.
     it('passes an upstream 403 through with its own body, unlike a CSRF rejection', async () => {
       upstream.respondWith((_req, res) => {
         res.writeHead(403, { 'content-type': 'application/json' })
@@ -1384,8 +1283,6 @@ describe('apiProxy', () => {
       expect(res.statusCode).toBe(403)
       expect(res.json()).toEqual({ code: 403, message: 'User is not an admin' })
       expect(res.json()).not.toHaveProperty('error', CSRF_ERROR_CODE)
-      // Only a 401 ends the session — a denial is about this request, not the
-      // token that carried it.
       expect(await session.stored()).not.toBeNull()
     })
   })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -9,7 +9,6 @@ import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
 import { csrfPluginOptions } from '../src/auth/csrf.js'
 import { RefreshFailedError } from '../src/auth/refresh.js'
-import { GENERIC_ERROR_BODY } from '../src/errors.js'
 import { CSRF_ERROR_CODE, CSRF_EXEMPT_UNSAFE_REQUESTS, PROXY_PREFIX, REFRESH_WINDOW_SECONDS, UNAUTHENTICATED_PATHS, apiProxy, upstreamPath } from '../src/proxy/apiProxy.js'
 
 // refreshAccessToken is replaced so the tests never reach B2C; RefreshFailedError
@@ -1343,7 +1342,7 @@ describe('apiProxy', () => {
       const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}-boom` })
 
       expect(res.statusCode).toBe(500)
-      expect(res.json()).toEqual(GENERIC_ERROR_BODY)
+      expect(res.json()).toEqual({ error: 'An unexpected error occurred.' })
       expect(res.payload).not.toContain('a stack trace and an internal path')
     })
 

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -145,19 +145,16 @@ async function buildProxyApp(seed?: SessionSeed): Promise<FastifyInstance> {
 /**
  * Whether the session a request used still exists once the request is over.
  *
- * That is the question story 3-E's tests are really asking, and it cannot be read
- * off the response: `buildProxyApp`'s seed hook hands every request a session, so
- * a follow-up inject would find a live one either way. With
+ * It cannot be read off the response: `buildProxyApp`'s seed hook hands every
+ * request a session, so a follow-up inject finds a live one either way. With
  * `saveUninitialized: false` the row is written by `@fastify/session`'s onSend
  * hook, which skips a session destroyed mid-request — so "is there a row for the
- * sid this request used" is what separates destroyed from intact, and the
- * upstream-is-happy case is asserted alongside as the control.
+ * sid this request used" is what separates destroyed from intact.
  */
 function trackSession(app: FastifyInstance): { stored: () => Promise<Session | null> } {
   let sid: string | undefined
   let store: FastifyRequest['sessionStore'] | undefined
-  // A root onRequest hook, so it runs before the route's own hooks and therefore
-  // before anything the proxy does to the session.
+  // A root onRequest hook, so it runs before anything the proxy does.
   app.addHook('onRequest', async (request) => {
     sid = request.session.sessionId
     store = request.sessionStore
@@ -403,12 +400,8 @@ describe('apiProxy', () => {
      * a secret and the token did not verify against it — including when
      * `getToken` found no token at all.
      *
-     * These are the proxy's own reasons, not the plugin's error codes. Until
-     * story 3-E these assertions read `code: 'FST_CSRF_INVALID_TOKEN'` off
-     * Fastify's default error serialisation — which was never a decision, just
-     * what a harness with no error handler happened to expose. ADR-010 replaced
-     * it with the body below; `error` is what the client branches on and `reason`
-     * is what a human reads.
+     * These are the proxy's own reasons (ADR-010), not the plugin's error codes:
+     * `error` is what the client branches on, `reason` is what a human reads.
      */
     const MISSING_SECRET = 'missing_secret'
     const INVALID_TOKEN = 'invalid_token'
@@ -996,16 +989,12 @@ describe('apiProxy', () => {
       expect(res.json()).toEqual({ ok: true })
     })
 
-    /**
-     * The hop-by-hop class, as distinct from the origin-state one above: these
-     * describe the BFF↔upstream connection, not the response, so relaying them
-     * tells the browser about a connection it is not on.
-     */
+    // The hop-by-hop class, as distinct from the origin-state one above: these
+    // describe the BFF↔upstream connection, not the response.
     describe('connection-specific headers', () => {
-      // `proxy-authenticate` is why this matters rather than being tidiness: it is
-      // `www-authenticate`'s proxy-side twin, and a `Basic` challenge relayed to
-      // the browser pops a native credential dialog on the BFF's own origin —
-      // exactly what stripping `www-authenticate` exists to prevent.
+      // `proxy-authenticate` is `www-authenticate`'s proxy-side twin: a `Basic`
+      // challenge relayed to the browser pops a native credential dialog on the
+      // BFF's own origin.
       it('never forwards an upstream proxy-authenticate challenge', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(407, {
@@ -1019,8 +1008,8 @@ describe('apiProxy', () => {
         const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
         expect(res.headers['proxy-authenticate']).toBeUndefined()
-        // The status and body still reach the client — the header is dropped, not
-        // the response, so a misconfigured upstream is still diagnosable.
+        // The header is dropped, not the response, so a misconfigured upstream
+        // is still diagnosable.
         expect(res.statusCode).toBe(407)
         expect(res.json()).toEqual({ message: 'Proxy Authentication Required' })
       })
@@ -1041,11 +1030,8 @@ describe('apiProxy', () => {
         },
       )
 
-      // The case that makes this a real bug rather than a contrived one: Node's
-      // HTTP server adds `Keep-Alive: timeout=5` by itself on any keep-alive
-      // connection, so an upstream that never sets the header still sends one.
-      // Before the strip, every proxied response carried the upstream's socket
-      // timeout to the browser.
+      // Node's HTTP server adds `Keep-Alive: timeout=5` by itself, so an upstream
+      // that never sets the header still leaks its socket timeout to the browser.
       it('does not forward the keep-alive an upstream emits without being asked', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(200, { 'content-type': 'application/json' })
@@ -1059,17 +1045,12 @@ describe('apiProxy', () => {
       })
 
       /**
-       * `connection` and `transfer-encoding` are the two the story's checklist
-       * names, and the two `CONNECTION_SPECIFIC_RESPONSE_HEADERS` deliberately
-       * leaves out: the HTTP layer owns the framing, so the upstream's values
-       * never reach the browser regardless of this module. Pinned because that
-       * is a property of undici and Fastify rather than of the code here — if it
-       * stopped holding, the strip set is where the fix would belong, and this is
-       * the test that would say so.
-       *
-       * The upstream keeps its connection alive and streams its body, which is
-       * what a real one does; the reply carries the framing Fastify chose for the
-       * body it actually wrote, not the upstream's.
+       * `connection` and `transfer-encoding` are the two
+       * `CONNECTION_SPECIFIC_RESPONSE_HEADERS` deliberately leaves out: the HTTP
+       * layer owns the framing, so the upstream's values never reach the browser
+       * regardless of this module. Pinned because that is a property of undici
+       * and Fastify rather than of the code here — if it stopped holding, the
+       * strip set is where the fix would belong.
        */
       it('gives the browser the transport hop\'s own framing, not the upstream\'s', async () => {
         upstream.respondWith((_req, res) => {
@@ -1084,14 +1065,11 @@ describe('apiProxy', () => {
         // The upstream said keep-alive; this hop is its own to describe.
         expect(res.headers.connection).not.toBe('keep-alive')
         expect(res.headers['transfer-encoding']).toBe('chunked')
-        // Chunked framing, and the streamed body reassembled from it.
         expect(res.json()).toEqual({ streamed: true })
       })
 
-      // The strip is on the upstream's headers, not a blanket denylist, so a
-      // header the BFF itself needs to send is unaffected even when its name is
-      // in the set. Nothing sets these today; this pins that the mechanism is
-      // keyed on where the header came from.
+      // The strip is keyed on where a header came from, not a blanket denylist,
+      // so one the BFF sets itself survives even if the upstream sent the name too.
       it('leaves the origin-state and hardening headers the BFF sets in place', async () => {
         app = await buildProxyApp(freshSession())
 
@@ -1102,19 +1080,13 @@ describe('apiProxy', () => {
       })
     })
 
-    /**
-     * Story 3-E(b) — a user-uploaded document served back through the proxy comes
-     * from the SPA's own origin, so it must not be able to execute there.
-     *
-     * The `text/html` case is the threat itself: a `.html` uploaded as a DAA or
-     * DAR document, fetched by a top-level navigation that carries the
-     * `SameSite=Lax` session cookie.
-     */
+    // A user-uploaded document served back through the proxy comes from the SPA's
+    // own origin, so it must not be able to execute there.
     describe('response hardening', () => {
       // The threat itself: a `.html` uploaded as a DAA document, fetched by a
       // top-level navigation that carries the SameSite=Lax session cookie. The
-      // upstream sends weaker versions of both headers, so this also pins that an
-      // upstream cannot relax what the BFF applies.
+      // upstream sends weaker versions of both headers, so this also pins that it
+      // cannot relax what the BFF applies.
       it('neuters an uploaded document served back as text/html', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(200, {
@@ -1133,9 +1105,8 @@ describe('apiProxy', () => {
       })
 
       // The headers are inert to the client — `fetch` ignores both, and a blob
-      // download is initiated by the SPA's own document — so adding them cannot
-      // disturb the document paths that motivated them. Binary rather than text
-      // so a byte-for-byte comparison means something.
+      // download is initiated by the SPA's own document — so they cannot disturb
+      // the document paths that motivated them.
       it('leaves a blob download byte-for-byte intact', async () => {
         const document = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x00, 0xff, 0xfe, 0x0a])
         upstream.respondWith((_req, res) => {
@@ -1155,11 +1126,9 @@ describe('apiProxy', () => {
         expect(res.headers['x-content-type-options']).toBe('nosniff')
       })
 
-      // Applied in onSend rather than rewriteHeaders precisely so the replies the
-      // proxy writes itself are covered too, and so it lands after
-      // `onUpstreamResponse`'s header-strip loop — which, keyed on the upstream's
-      // header names, would otherwise take the BFF's own values with it whenever
-      // the upstream happened to send either name.
+      // Why onSend rather than rewriteHeaders: it lands after
+      // `onUpstreamResponse`'s header-strip loop, which is keyed on the
+      // upstream's header names and would otherwise take the BFF's values with it.
       it('hardens a reply the proxy writes itself, not only a proxied one', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(401, {
@@ -1180,15 +1149,10 @@ describe('apiProxy', () => {
         expect(res.headers['content-security-policy']).toBe('sandbox')
       })
 
-      /**
-       * The hook must stay inside the proxy's encapsulation.
-       *
-       * If it escaped to the root instance it would land on the SPA's own HTML,
-       * where `sandbox` means an opaque origin and no scripts — the entire app
-       * dead, in a way no proxy test would notice. `/auth/csrf-token` stands in
-       * for a root-scope route here because it is the one the shell registers;
-       * in production the responses that matter are index.html and `/auth/*`.
-       */
+      // The hook must stay inside the proxy's encapsulation: escaped to the root
+      // instance it would land on the SPA's own HTML, where `sandbox` means an
+      // opaque origin and no scripts — the entire app dead, in a way no proxy
+      // test would notice. `/auth/csrf-token` stands in for a root-scope route.
       it('does not leak the headers onto routes outside the proxy scope', async () => {
         app = await buildProxyApp(freshSession())
 
@@ -1226,8 +1190,8 @@ describe('apiProxy', () => {
     })
   })
 
-  // Story 3-E. The upstream is the authority on whether the token this proxy
-  // injected is any good; a session it rejects cannot recover on its own.
+  // The upstream is the authority on whether the token this proxy injected is
+  // any good; a session it rejects cannot recover on its own.
   describe('an upstream 401', () => {
     /** An upstream that rejects everything, the way it would a revoked token. */
     const rejectingUpstream = (headers: Record<string, string> = {}): void => {
@@ -1237,9 +1201,7 @@ describe('apiProxy', () => {
       })
     }
 
-    // The whole behaviour in one case, because it is one behaviour: the user is
-    // signed out. Splitting it would repeat the setup three times to assert three
-    // halves of the same outcome.
+    // One case, because it is one behaviour: the user is signed out.
     it('signs the user out — its own 401, session destroyed, cookie cleared', async () => {
       rejectingUpstream()
       app = await buildProxyApp(freshSession())
@@ -1252,8 +1214,6 @@ describe('apiProxy', () => {
       // from `unauthenticated` (never had a session) and `upstream_unavailable`.
       expect(res.json()).toEqual({ error: 'session_expired' })
       expect(await session.stored()).toBeNull()
-      // Without clearing it the browser keeps presenting a sid whose row is
-      // already gone, and every later request silently starts a new empty session.
       expect(res.cookies).toEqual(expect.arrayContaining([
         expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
       ]))
@@ -1287,10 +1247,8 @@ describe('apiProxy', () => {
       expect(await session.stored()).toBeNull()
     })
 
-    // The upstream headers reply-from copied onto the reply describe the body
-    // being discarded. `content-type` is the fatal one: Fastify only serialises
-    // an object payload when the content type is JSON or unset, so a `text/plain`
-    // 401 would otherwise reach the socket as an un-serialised object and throw
+    // `content-type` is the fatal one: Fastify only serialises an object payload
+    // when the content type is JSON or unset, so a `text/plain` 401 would throw
     // FST_ERR_REP_INVALID_PAYLOAD_TYPE — a 500 in place of the 401.
     it('does not leave the upstream response headers describing the reply that replaces it', async () => {
       const compressed = gzipSync(Buffer.from('token rejected'))
@@ -1310,21 +1268,14 @@ describe('apiProxy', () => {
       expect(res.statusCode).toBe(401)
       expect(res.json()).toEqual({ error: 'session_expired' })
       expect(res.headers['content-type']).toMatch(/^application\/json/)
-      // A stale gzip label the browser would fail to decode, and a length and
-      // validator for a body nobody received.
       expect(res.headers['content-encoding']).toBeUndefined()
       expect(res.headers.etag).toBeUndefined()
       expect(res.headers['content-length']).toBe(String(res.rawPayload.length))
     })
 
-    // Only a 401 says the token was rejected. A 403 is the upstream answering
-    // "not for you" to a request it authenticated fine, and signing the user out
-    // of a session it just accepted would be a regression the client would feel
-    // as a random logout.
-    // An allowlisted path is proxied with no token at all, so its 401 is about
-    // the upstream's own state — it says nothing about the caller's session, and
-    // signing them out over it would be a logout triggered by an unrelated
-    // endpoint.
+    // An allowlisted path is proxied with no token at all, so its 401 says
+    // nothing about the caller's session — signing them out over it would be a
+    // logout triggered by an unrelated endpoint.
     it('passes through untouched on an allowlisted path, session intact', async () => {
       rejectingUpstream()
       app = await buildProxyApp(freshSession())
@@ -1340,11 +1291,9 @@ describe('apiProxy', () => {
       ]))
     })
 
-    // Relayed to the browser this describes a bearer scheme the client cannot
-    // satisfy — it holds a cookie, not a token — and a `Basic` challenge would
-    // pop a native credential dialog on the BFF's own origin. Asserted on the
-    // pass-through path because that is the one where the upstream's headers
-    // survive at all; the replaced 401 above drops every one of them.
+    // A `Basic` challenge relayed to the browser would pop a native credential
+    // dialog on the BFF's own origin. Asserted on the pass-through path because
+    // that is the one where the upstream's headers survive at all.
     it('never forwards an upstream WWW-Authenticate challenge', async () => {
       rejectingUpstream({ 'www-authenticate': 'Basic realm="DUOS API"' })
       app = await buildProxyApp(freshSession())
@@ -1357,27 +1306,20 @@ describe('apiProxy', () => {
   })
 
   /**
-   * Story 3-E(c) / ADR-010 — what a failure inside the proxy scope looks like to
-   * the browser.
+   * ADR-010 — what a failure inside the proxy scope looks like to the browser.
    *
-   * The scope is encapsulated (`removeAllContentTypeParsers` must not escape it),
-   * so it does not inherit the root instance's error handler and index.ts sets
-   * that one after registering the proxy anyway. The shape below is therefore a
-   * decision the plugin makes for itself, and these are the tests that hold it
-   * to that rather than to whatever the plugin ordering happens to produce.
+   * The scope is encapsulated, so it does not inherit the root error handler,
+   * which index.ts registers after the proxy anyway. These tests hold the shape
+   * to the plugin's own decision rather than to that ordering.
    */
   describe('the error shape', () => {
     /**
      * An app whose proxy scope also holds a route that throws, standing in for a
      * bug on a proxy path — there is no natural one to provoke, since the auth
      * gate answers its own failures and `onUpstreamTransportError` answers
-     * reply-from's.
-     *
-     * `apiProxy` is called on the scope rather than registered into it, so the
-     * throwing route lands in the same context as the proxy's routes and hooks
-     * and is answered by the same error handler. The root handler is registered
-     * afterwards, exactly as index.ts does it, which is the ordering the whole
-     * decision turns on.
+     * reply-from's. `apiProxy` is called on the scope rather than registered into
+     * it so the throwing route shares the proxy's context, and the root handler
+     * is registered afterwards exactly as index.ts does it.
      */
     async function buildAppWithRootErrorHandler(): Promise<FastifyInstance> {
       const app = await buildAppShell()
@@ -1405,9 +1347,8 @@ describe('apiProxy', () => {
       expect(res.payload).not.toContain('a stack trace and an internal path')
     })
 
-    // The root handler still owns everything outside the proxy. Asserted in the
-    // same app as the case above so the two cannot be read as different setups:
-    // one registration order, two scopes, two answers.
+    // Asserted in the same app as the case above: one registration order, two
+    // scopes, two answers.
     it('leaves errors outside the proxy scope to the root handler', async () => {
       app = await buildAppWithRootErrorHandler()
 
@@ -1416,10 +1357,9 @@ describe('apiProxy', () => {
       expect(res.json()).toEqual({ error: 'the root handler answered' })
     })
 
-    // The regression this whole decision exists to prevent: index.ts registering
-    // its handler after the proxy must not be what determines the proxy's shape.
-    // Before ADR-010 this request returned Fastify's default body, message and
-    // all, purely because of that ordering.
+    // The regression this decision exists to prevent: before ADR-010 this
+    // request returned Fastify's default body, message and all, purely because
+    // index.ts registers its handler after the proxy.
     it('is not affected by a root error handler registered after the proxy', async () => {
       app = await buildAppWithRootErrorHandler()
 
@@ -1430,9 +1370,8 @@ describe('apiProxy', () => {
     })
 
     // The client's discriminator has to be the body, not the status: an upstream
-    // authorization denial is an ordinary proxied response and arrives as a 403
-    // too. Retrying on the status alone would replay every write the DUOS API
-    // refused, which is why Epic 4 keys its one retry on `error` instead.
+    // authorization denial arrives as a 403 too, and retrying on the status
+    // alone would replay every write the DUOS API refused.
     it('passes an upstream 403 through with its own body, unlike a CSRF rejection', async () => {
       upstream.respondWith((_req, res) => {
         res.writeHead(403, { 'content-type': 'application/json' })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -1005,40 +1005,25 @@ describe('apiProxy', () => {
      * `SameSite=Lax` session cookie.
      */
     describe('response hardening', () => {
-      const respondWithUploadedHtml = (): void => {
-        upstream.respondWith((_req, res) => {
-          res.writeHead(200, { 'content-type': 'text/html' })
-          res.end('<script>fetch("/duos-api/api/user/me")</script>')
-        })
-      }
-
+      // The threat itself: a `.html` uploaded as a DAA document, fetched by a
+      // top-level navigation that carries the SameSite=Lax session cookie. The
+      // upstream sends weaker versions of both headers, so this also pins that an
+      // upstream cannot relax what the BFF applies.
       it('neuters an uploaded document served back as text/html', async () => {
-        respondWithUploadedHtml()
-        app = await buildProxyApp(freshSession())
-
-        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/daa/1/file` })
-
-        expect(res.headers['x-content-type-options']).toBe('nosniff')
-        expect(res.headers['content-security-policy']).toBe('sandbox')
-      })
-
-      // An upstream that sends either header must not be able to relax it — the
-      // BFF's value is the one that reaches the browser.
-      it('overrides an upstream that sends a weaker policy of its own', async () => {
         upstream.respondWith((_req, res) => {
           res.writeHead(200, {
             'content-type': 'text/html',
             'content-security-policy': 'default-src \'self\' \'unsafe-inline\'',
             'x-content-type-options': 'sniff-away',
           })
-          res.end('<p>hello</p>')
+          res.end('<script>fetch("/duos-api/api/user/me")</script>')
         })
         app = await buildProxyApp(freshSession())
 
         const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/daa/1/file` })
 
-        expect(res.headers['content-security-policy']).toBe('sandbox')
         expect(res.headers['x-content-type-options']).toBe('nosniff')
+        expect(res.headers['content-security-policy']).toBe('sandbox')
       })
 
       // The headers are inert to the client — `fetch` ignores both, and a blob
@@ -1146,9 +1131,13 @@ describe('apiProxy', () => {
       })
     }
 
-    it('returns its own 401 in place of the upstream response', async () => {
+    // The whole behaviour in one case, because it is one behaviour: the user is
+    // signed out. Splitting it would repeat the setup three times to assert three
+    // halves of the same outcome.
+    it('signs the user out — its own 401, session destroyed, cookie cleared', async () => {
       rejectingUpstream()
       app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
 
       const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
@@ -1156,19 +1145,15 @@ describe('apiProxy', () => {
       // The BFF's vocabulary, not the upstream's: the client distinguishes this
       // from `unauthenticated` (never had a session) and `upstream_unavailable`.
       expect(res.json()).toEqual({ error: 'session_expired' })
-    })
-
-    it('destroys the session', async () => {
-      rejectingUpstream()
-      app = await buildProxyApp(freshSession())
-      const session = trackSession(app)
-
-      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
-
       expect(await session.stored()).toBeNull()
+      // Without clearing it the browser keeps presenting a sid whose row is
+      // already gone, and every later request silently starts a new empty session.
+      expect(res.cookies).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
+      ]))
     })
 
-    // The control for the assertion above: the same lookup finds a row when the
+    // The control for the destroy above: the same lookup finds a row when the
     // upstream is happy, so "no row" means destroyed rather than never-written.
     it('leaves the session alone when the upstream is happy', async () => {
       app = await buildProxyApp(freshSession())
@@ -1177,19 +1162,6 @@ describe('apiProxy', () => {
       await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
       expect(await session.stored()).not.toBeNull()
-    })
-
-    it('clears the session cookie', async () => {
-      rejectingUpstream()
-      app = await buildProxyApp(freshSession())
-
-      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
-
-      // Otherwise the browser keeps presenting a sid whose row is already gone,
-      // and every later request silently starts a new empty session.
-      expect(res.cookies).toEqual(expect.arrayContaining([
-        expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
-      ]))
     })
 
     it('ends the session on a rejected write as well as a read', async () => {
@@ -1243,21 +1215,6 @@ describe('apiProxy', () => {
     // "not for you" to a request it authenticated fine, and signing the user out
     // of a session it just accepted would be a regression the client would feel
     // as a random logout.
-    it('passes a 403 through without touching the session', async () => {
-      upstream.respondWith((_req, res) => {
-        res.writeHead(403, { 'content-type': 'application/json' })
-        res.end('{"message":"Forbidden"}')
-      })
-      app = await buildProxyApp(freshSession())
-      const session = trackSession(app)
-
-      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
-
-      expect(res.statusCode).toBe(403)
-      expect(res.json()).toEqual({ message: 'Forbidden' })
-      expect(await session.stored()).not.toBeNull()
-    })
-
     // An allowlisted path is proxied with no token at all, so its 401 is about
     // the upstream's own state — it says nothing about the caller's session, and
     // signing them out over it would be a logout triggered by an unrelated
@@ -1376,12 +1333,16 @@ describe('apiProxy', () => {
         res.end('{"code":403,"message":"User is not an admin"}')
       })
       app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
 
       const res = await injectWithCsrf(app, { method: 'POST', url: `${PROXY_PREFIX}/api/dataset/1` })
 
       expect(res.statusCode).toBe(403)
       expect(res.json()).toEqual({ code: 403, message: 'User is not an admin' })
       expect(res.json()).not.toHaveProperty('error', CSRF_ERROR_CODE)
+      // Only a 401 ends the session — a denial is about this request, not the
+      // token that carried it.
+      expect(await session.stored()).not.toBeNull()
     })
   })
 })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -3,7 +3,7 @@ import http from 'node:http'
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { gzipSync } from 'node:zlib'
-import Fastify, { type FastifyInstance } from 'fastify'
+import Fastify, { type FastifyInstance, type FastifyRequest, type Session } from 'fastify'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
@@ -139,6 +139,43 @@ async function buildProxyApp(seed?: SessionSeed): Promise<FastifyInstance> {
   }
   await app.register(apiProxy)
   return app
+}
+
+/**
+ * Whether the session a request used still exists once the request is over.
+ *
+ * That is the question story 3-E's tests are really asking, and it cannot be read
+ * off the response: `buildProxyApp`'s seed hook hands every request a session, so
+ * a follow-up inject would find a live one either way. With
+ * `saveUninitialized: false` the row is written by `@fastify/session`'s onSend
+ * hook, which skips a session destroyed mid-request — so "is there a row for the
+ * sid this request used" is what separates destroyed from intact, and the
+ * upstream-is-happy case is asserted alongside as the control.
+ */
+function trackSession(app: FastifyInstance): { stored: () => Promise<Session | null> } {
+  let sid: string | undefined
+  let store: FastifyRequest['sessionStore'] | undefined
+  // A root onRequest hook, so it runs before the route's own hooks and therefore
+  // before anything the proxy does to the session.
+  app.addHook('onRequest', async (request) => {
+    sid = request.session.sessionId
+    store = request.sessionStore
+  })
+  return {
+    stored: () => new Promise((resolve, reject) => {
+      if (!sid || !store) {
+        reject(new Error('no request reached the session-tracking hook'))
+        return
+      }
+      store.get(sid, (err: unknown, session?: Session | null) => {
+        if (err) {
+          reject(err instanceof Error ? err : new Error('session store read failed'))
+          return
+        }
+        resolve(session ?? null)
+      })
+    }),
+  }
 }
 
 /**
@@ -975,6 +1012,164 @@ describe('apiProxy', () => {
       const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
 
       expect(res.statusCode).toBe(503)
+    })
+  })
+
+  // Story 3-E. The upstream is the authority on whether the token this proxy
+  // injected is any good; a session it rejects cannot recover on its own.
+  describe('an upstream 401', () => {
+    /** An upstream that rejects everything, the way it would a revoked token. */
+    const rejectingUpstream = (headers: Record<string, string> = {}): void => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(401, { 'content-type': 'application/json', ...headers })
+        res.end('{"message":"Unauthorized"}')
+      })
+    }
+
+    it('returns its own 401 in place of the upstream response', async () => {
+      rejectingUpstream()
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(401)
+      // The BFF's vocabulary, not the upstream's: the client distinguishes this
+      // from `unauthenticated` (never had a session) and `upstream_unavailable`.
+      expect(res.json()).toEqual({ error: 'session_expired' })
+    })
+
+    it('destroys the session', async () => {
+      rejectingUpstream()
+      app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(await session.stored()).toBeNull()
+    })
+
+    // The control for the assertion above: the same lookup finds a row when the
+    // upstream is happy, so "no row" means destroyed rather than never-written.
+    it('leaves the session alone when the upstream is happy', async () => {
+      app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
+
+      await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(await session.stored()).not.toBeNull()
+    })
+
+    it('clears the session cookie', async () => {
+      rejectingUpstream()
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      // Otherwise the browser keeps presenting a sid whose row is already gone,
+      // and every later request silently starts a new empty session.
+      expect(res.cookies).toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
+      ]))
+    })
+
+    it('ends the session on a rejected write as well as a read', async () => {
+      rejectingUpstream()
+      app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
+
+      const res = await injectWithCsrf(app, {
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { 'content-type': 'application/json' },
+        payload: '{"name":"a dataset"}',
+      })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'session_expired' })
+      expect(await session.stored()).toBeNull()
+    })
+
+    // The upstream headers reply-from copied onto the reply describe the body
+    // being discarded. `content-type` is the fatal one: Fastify only serialises
+    // an object payload when the content type is JSON or unset, so a `text/plain`
+    // 401 would otherwise reach the socket as an un-serialised object and throw
+    // FST_ERR_REP_INVALID_PAYLOAD_TYPE — a 500 in place of the 401.
+    it('does not leave the upstream response headers describing the reply that replaces it', async () => {
+      const compressed = gzipSync(Buffer.from('token rejected'))
+      upstream.respondWith((_req, res) => {
+        res.writeHead(401, {
+          'content-type': 'text/plain',
+          'content-encoding': 'gzip',
+          'content-length': String(compressed.length),
+          'etag': '"upstream-401"',
+        })
+        res.end(compressed)
+      })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'session_expired' })
+      expect(res.headers['content-type']).toMatch(/^application\/json/)
+      // A stale gzip label the browser would fail to decode, and a length and
+      // validator for a body nobody received.
+      expect(res.headers['content-encoding']).toBeUndefined()
+      expect(res.headers.etag).toBeUndefined()
+      expect(res.headers['content-length']).toBe(String(res.rawPayload.length))
+    })
+
+    // Only a 401 says the token was rejected. A 403 is the upstream answering
+    // "not for you" to a request it authenticated fine, and signing the user out
+    // of a session it just accepted would be a regression the client would feel
+    // as a random logout.
+    it('passes a 403 through without touching the session', async () => {
+      upstream.respondWith((_req, res) => {
+        res.writeHead(403, { 'content-type': 'application/json' })
+        res.end('{"message":"Forbidden"}')
+      })
+      app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ message: 'Forbidden' })
+      expect(await session.stored()).not.toBeNull()
+    })
+
+    // An allowlisted path is proxied with no token at all, so its 401 is about
+    // the upstream's own state — it says nothing about the caller's session, and
+    // signing them out over it would be a logout triggered by an unrelated
+    // endpoint.
+    it('passes through untouched on an allowlisted path, session intact', async () => {
+      rejectingUpstream()
+      app = await buildProxyApp(freshSession())
+      const session = trackSession(app)
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/status` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ message: 'Unauthorized' })
+      expect(await session.stored()).not.toBeNull()
+      expect(res.cookies).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
+      ]))
+    })
+
+    // Relayed to the browser this describes a bearer scheme the client cannot
+    // satisfy — it holds a cookie, not a token — and a `Basic` challenge would
+    // pop a native credential dialog on the BFF's own origin. Asserted on the
+    // pass-through path because that is the one where the upstream's headers
+    // survive at all; the replaced 401 above drops every one of them.
+    it('never forwards an upstream WWW-Authenticate challenge', async () => {
+      rejectingUpstream({ 'www-authenticate': 'Basic realm="DUOS API"' })
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/status` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.headers['www-authenticate']).toBeUndefined()
     })
   })
 })

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -996,6 +996,119 @@ describe('apiProxy', () => {
       expect(res.json()).toEqual({ ok: true })
     })
 
+    /**
+     * Story 3-E(b) — a user-uploaded document served back through the proxy comes
+     * from the SPA's own origin, so it must not be able to execute there.
+     *
+     * The `text/html` case is the threat itself: a `.html` uploaded as a DAA or
+     * DAR document, fetched by a top-level navigation that carries the
+     * `SameSite=Lax` session cookie.
+     */
+    describe('response hardening', () => {
+      const respondWithUploadedHtml = (): void => {
+        upstream.respondWith((_req, res) => {
+          res.writeHead(200, { 'content-type': 'text/html' })
+          res.end('<script>fetch("/duos-api/api/user/me")</script>')
+        })
+      }
+
+      it('neuters an uploaded document served back as text/html', async () => {
+        respondWithUploadedHtml()
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/daa/1/file` })
+
+        expect(res.headers['x-content-type-options']).toBe('nosniff')
+        expect(res.headers['content-security-policy']).toBe('sandbox')
+      })
+
+      // An upstream that sends either header must not be able to relax it — the
+      // BFF's value is the one that reaches the browser.
+      it('overrides an upstream that sends a weaker policy of its own', async () => {
+        upstream.respondWith((_req, res) => {
+          res.writeHead(200, {
+            'content-type': 'text/html',
+            'content-security-policy': 'default-src \'self\' \'unsafe-inline\'',
+            'x-content-type-options': 'sniff-away',
+          })
+          res.end('<p>hello</p>')
+        })
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/daa/1/file` })
+
+        expect(res.headers['content-security-policy']).toBe('sandbox')
+        expect(res.headers['x-content-type-options']).toBe('nosniff')
+      })
+
+      // The headers are inert to the client — `fetch` ignores both, and a blob
+      // download is initiated by the SPA's own document — so adding them cannot
+      // disturb the document paths that motivated them. Binary rather than text
+      // so a byte-for-byte comparison means something.
+      it('leaves a blob download byte-for-byte intact', async () => {
+        const document = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37, 0x00, 0xff, 0xfe, 0x0a])
+        upstream.respondWith((_req, res) => {
+          res.writeHead(200, {
+            'content-type': 'application/pdf',
+            'content-length': String(document.length),
+            'content-disposition': 'attachment; filename="daa.pdf"',
+          })
+          res.end(document)
+        })
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/daa/1/file` })
+
+        expect(res.rawPayload.equals(document)).toBe(true)
+        expect(res.headers['content-disposition']).toBe('attachment; filename="daa.pdf"')
+        expect(res.headers['x-content-type-options']).toBe('nosniff')
+      })
+
+      // Applied in onSend rather than rewriteHeaders precisely so the replies the
+      // proxy writes itself are covered too, and so it lands after
+      // `onUpstreamResponse`'s header-strip loop — which, keyed on the upstream's
+      // header names, would otherwise take the BFF's own values with it whenever
+      // the upstream happened to send either name.
+      it('hardens a reply the proxy writes itself, not only a proxied one', async () => {
+        upstream.respondWith((_req, res) => {
+          res.writeHead(401, {
+            'content-type': 'text/plain',
+            'content-security-policy': 'default-src \'self\'',
+            'x-content-type-options': 'nosniff',
+          })
+          res.end('Unauthorized')
+        })
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/dataset/1` })
+
+        // The BFF's own 401, with the upstream's headers stripped off it.
+        expect(res.statusCode).toBe(401)
+        expect(res.json()).toEqual({ error: 'session_expired' })
+        expect(res.headers['x-content-type-options']).toBe('nosniff')
+        expect(res.headers['content-security-policy']).toBe('sandbox')
+      })
+
+      /**
+       * The hook must stay inside the proxy's encapsulation.
+       *
+       * If it escaped to the root instance it would land on the SPA's own HTML,
+       * where `sandbox` means an opaque origin and no scripts — the entire app
+       * dead, in a way no proxy test would notice. `/auth/csrf-token` stands in
+       * for a root-scope route here because it is the one the shell registers;
+       * in production the responses that matter are index.html and `/auth/*`.
+       */
+      it('does not leak the headers onto routes outside the proxy scope', async () => {
+        app = await buildProxyApp(freshSession())
+
+        const res = await app.inject({ method: 'GET', url: '/auth/csrf-token' })
+
+        expect(res.statusCode).toBe(200)
+        expect(res.headers['content-security-policy']).toBeUndefined()
+        expect(res.headers['x-content-type-options']).toBeUndefined()
+      })
+    })
+
     // reply-from leaves a refused connection at 500, which index.ts's error
     // handler would render as its generic "An unexpected error occurred" —
     // reading as a BFF bug rather than an upstream outage.


### PR DESCRIPTION
### Addresses
[DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) — BFF Phase 3: API Proxy Layer, story 3-E and 3-F

Security risk: **low** — this story only closes gaps (an XSS vector, an error-message leak, and a relayed-header leak). No new attack surface; the one behavior change visible to a client is the shape of the proxy's CSRF rejection body, which nothing consumes until Phase 4.

### Summary
Everything the proxy does on the way back to the browser. (b) and (c) came out of the peer review of story 3-D (#3812) — they are properties of the proxy's own response handling, not app-wide hardening, so they belong here rather than in Epic 5.

**(a) Destroy the session on an upstream 401.** If the DUOS API rejects the token the proxy injected, the session cannot recover on its own — so it is destroyed and the browser gets a 401 to redirect on, the same verdict `/auth/me` already acts on. Only requests that borrowed the session's authority are signed out; an allowlisted path is proxied with no token, so its 401 is about the upstream and passes through untouched.

**(b) Neuter proxied responses.** DUOS serves user-uploaded documents back through the API. Once proxied they come from the BFF's *own* origin, so a top-level navigation to one carries the `SameSite=Lax` session cookie, the proxy injects the bearer, and the browser renders attacker-uploaded markup on the origin that holds the session. `HttpOnly` does not help — the script needs same-origin requests, not the cookie's value. This is new with the proxy: today the same file comes from the Consent API's origin, where a cookie-less navigation simply 401s. Every proxied response now carries `X-Content-Type-Options: nosniff` and `Content-Security-Policy: sandbox`, overriding an upstream that sends either itself.

**(c) A chosen error shape for the proxy scope — [ADR-010](docs/plans/bff_adrs/ADR-010-proxy-error-shape.md).** The proxy is deliberately encapsulated, and the app sets its error handler after registering it, so the scope kept Fastify's default and returned `err.message` on an unexpected 500 while the rest of the app returned a generic body. The shape being incidental rather than chosen was the defect. The proxy now declares its own: `403 { error: 'csrf_validation_failed', reason }` for CSRF rejections, the app's generic body for everything else. The client needs that code because **403 is ambiguous through this proxy** — an upstream authorization denial is an ordinary proxied response and arrives as a 403 too — so Epic 4 must key its refetch-and-retry on the body, not the status.

ADR-010 records the one-line alternative (moving the error handler above the BFF registrations) and why it was rejected: lossy, not risky.

**Also: the connection-specific response headers were being relayed.** Found while closing out story 3-F's test coverage against this code — the checklist asks for the hop-by-hop exclusion and nothing asserted it. `rewriteHeaders` stripped the three origin-state headers and forwarded the rest, so `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer` and `upgrade` reached the browser carrying the upstream's values, describing the BFF↔upstream hop to a client that is not on it (RFC 9110 §7.6.1).

Two reasons to fix it here rather than note it:

- **`proxy-authenticate` is `www-authenticate`'s proxy-side twin.** This proxy already strips the latter to stop a `Basic` challenge popping a native credential dialog on the BFF's own origin — and then forwarded the header that does the same thing. An inconsistency, not a decision.
- **`keep-alive` leaked on every response, unprompted.** Node's HTTP server adds `Keep-Alive: timeout=5` by itself on any keep-alive connection, so a Node upstream published its own socket timeout to every browser on every proxied response. Not a contrived header.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-3608]: https://broadworkbench.atlassian.net/browse/DT-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ