### PR TITLE
[DT-400] Update dompurify 3.4.12 -> 3.4.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@mui/x-date-pickers": "9.2.0",
     "@tanstack/react-query": "5.101.4",
     "dayjs": "1.11.21",
-    "dompurify": "3.4.12",
+    "dompurify": "3.4.13",
     "oidc-client-ts": "3.5.0",
     "query-string": "9.4.1",
     "react": "19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 1.11.21
         version: 1.11.21
       dompurify:
-        specifier: 3.4.12
-        version: 3.4.12
+        specifier: 3.4.13
+        version: 3.4.13
       oidc-client-ts:
         specifier: 3.5.0
         version: 3.5.0
@@ -1618,8 +1618,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.12:
-    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -4441,7 +4441,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dompurify@3.4.12:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-400

### Summary
Bump dompurify 3.4.12 -> [3.4.13](https://github.com/cure53/DOMPurify/releases/tag/3.4.13) to fix:
```
┌─────────────────────┬────────────────────────────────────────────────────────┐
│ moderate            │ DOMPurify: IN_PLACE hook removal leaves a detached     │
│                     │ subtree executable, causing XSS                        │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Package             │ dompurify                                              │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Vulnerable versions │ <=3.4.12                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Patched versions    │ >=3.4.13                                               │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ Paths               │ .>dompurify                                            │
├─────────────────────┼────────────────────────────────────────────────────────┤
│ More info           │ https://github.com/advisories/GHSA-55q2-fjhq-7xh7      │
└─────────────────────┴────────────────────────────────────────────────────────┘
```

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
