### PR TITLE
[DT-400] Prevent PresentationAddEdit test from timing out in CI

### DIFF
--- a/test/components/presentations_list/PresentationAddEdit.spec.tsx
+++ b/test/components/presentations_list/PresentationAddEdit.spec.tsx
@@ -25,7 +25,8 @@ import { Presentation } from 'src/types/model'
 
 describe('PresentationAddEdit component', () => {
   it('opens add form and enforces validation disabling save then adds', async () => {
-    const user = userEvent.setup()
+    // delay: null skips the timer between keystrokes; ~138 chars here otherwise times out on CI.
+    const user = userEvent.setup({ delay: null })
     const closeAction = vi.fn()
     const onPresentationChange = vi.fn()
 
@@ -60,5 +61,5 @@ describe('PresentationAddEdit component', () => {
     expect(changedPresentations).toHaveLength(1)
     expect(changedPresentations[0].title).toBe('New Title')
     expect(closeAction).toHaveBeenCalledTimes(1)
-  })
+  }, 15000)
 })


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

`PresentationAddEdit.spec` intermittently times out in CI at the default 5000ms:

```
FAIL  test/components/presentations_list/PresentationAddEdit.spec.tsx
  > opens add form and enforces validation disabling save then adds
Error: Test timed out in 5000ms.
```

### Cause

The test types ~138 characters across 12 fields. `userEvent.setup()` defaults to `delay: 0`, which awaits a real timer between *every* keystroke, and each one re-renders a controlled form.

Locally the test body runs ~600ms. The CI run that failed spent 275s on a suite that is far quicker here — roughly a 10x slowdown, which puts this test right on the 5000ms limit. That is why it fails intermittently rather than every run.

### Fix

| Change | Effect |
|---|---|
| `userEvent.setup({ delay: null })` | Drops the inter-keystroke timer: ~600ms -> ~380ms locally (~35% faster) |
| `}, 15000)` on the `it()` | Headroom on a slow runner |

`delay: null` addresses the cause; the timeout is insurance, since 380ms at a 10x slowdown still leaves only ~1s of margin.

The timeout is scoped to this one test rather than raising `testTimeout` globally — a global bump would mask genuine slowness elsewhere. This is the only test in the repo typing at this volume, so there was no existing convention to follow.

### Verification

- 3 consecutive local runs pass at ~400ms
- `tsc --noEmit` exit 0
- `oxlint` exit 0

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
