### PR TITLE
[DT-400] Update nanoid 3.3.16 -> 3.3.17

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2305,8 +2305,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5290,7 +5290,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   natural-compare@1.4.0: {}
 
@@ -5490,7 +5490,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

Clears the high-severity `nanoid` advisory reported by `pnpm audit`.

| | |
|---|---|
| Advisory | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero |
| Vulnerable | `<3.3.17` |
| Installed | `3.3.16` → `3.3.17` |
| Path | `server>@fastify/vite>vite>postcss>nanoid` |

Security risk modifier: **low** — the vulnerable code path is a build-time transitive dependency, not shipped application code.

### Why no override

`postcss@8.5.25` declares `nanoid: ^3.3.16`, so the patched release is reachable within the existing range and a lockfile update is enough.

The `overrides` block in `pnpm-workspace.yaml` is reserved for advisories where the declared range *cannot* reach a patch — as its own comments record for `@fastify/static` and `brace-expansion` — so adding one here would be permanent maintenance for no benefit.

`pnpm` resolved to 3.3.17 rather than the available 3.3.18 because of the repo's `minimumReleaseAge` setting. 3.3.17 satisfies the advisory.

### Verification

- `pnpm audit --audit-level=high` → **No known vulnerabilities found**
- `pnpm build` exit 0, including the `duos-server` workspace build and `tsc`
- `pnpm run lint` exit 0
- `pnpm run type-check` exit 0
- Lockfile diff is 4 lines, `nanoid` only — no other package moved

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
