### PR TITLE
[DT-400] Fix stale file paths in copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ When adding a new filter:
 
 ## Download Links — Use `DownloadLink` for All File Downloads
 
-The shared `DownloadLink` component (`src/components/DownloadLink.jsx`) is the single canonical way to render
+The shared `DownloadLink` component (`src/components/DownloadLink.tsx`) is the single canonical way to render
 file download actions in this UI. It renders a link-style control with a download icon and consistent
 `Theme.palette.link` colour.
 
@@ -81,11 +81,12 @@ for (const daa of daaList) {
 
 ## DAR (Data Access Request) Snapshot API
 
-`DAR.getDatasetDaaSnapshots(referenceId)` (`src/libs/ajax/DAR.js`) fetches the dataset–DAA relationship
+`DAR.getDatasetDaaSnapshots(referenceId)` (`src/libs/ajax/DAR.ts`) fetches the dataset–DAA relationship
 snapshot for a submitted DAR. The response is an array; each element may use either a flat shape
 (`datasetId`, `daaId`, `daaFileName` as top-level fields) or a nested shape (`dataset.datasetId`,
-`daa.daaId`, `daa.file.fileName`). The `DatasetDaaSnapshotRelationships` component
-(`src/pages/dar_application/DatasetDaaSnapshotRelationships.tsx`) normalises both shapes.
+`daa.daaId`, `daa.file.fileName`). `SelectableDatasets`
+(`src/pages/dar_application/SelectableDatasets.tsx`) normalises both shapes, via the
+`getSnapshotDatasetId`, `getSnapshotDaaId`, and `getSnapshotDaaFileName` helpers.
 
 ## DAA Is Always Enabled
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-400

### Summary

Three paths in `.github/copilot-instructions.md` no longer resolve. Since that file steers both Copilot reviews and anyone following the conventions, a bad path sends readers to a file that does not exist.

| Cited | Actual |
|---|---|
| `src/components/DownloadLink.jsx` | `src/components/DownloadLink.tsx` |
| `src/libs/ajax/DAR.js` | `src/libs/ajax/DAR.ts` |
| `DatasetDaaSnapshotRelationships` at `src/pages/dar_application/DatasetDaaSnapshotRelationships.tsx` | no such file — logic lives in `src/pages/dar_application/SelectableDatasets.tsx` |

Security risk modifier: **no** — documentation only.

### The third one is not a rename

That component no longer exists. The flat/nested snapshot normalisation the file attributes to it is now done by the `getSnapshotDatasetId`, `getSnapshotDaaId`, and `getSnapshotDaaFileName` helpers in `SelectableDatasets`, which resolve `snapshot?.datasetId ?? snapshot?.dataset?.datasetId` and the equivalent `daaId` / `daaFileName` pairs. The section now points there and names the helpers.

### Verification

Every other path cited in the file still resolves — `dataLibraryFilterConfig.ts`, `filterRegistry.ts`, `library.ts`, `useLibraryUrlState.ts`, `DAA.ts`, `test-utils.tsx`, `dar_application.css`, and `component-tests.yml`. `DownloadLink` is a named export, so the import example is correct as written.

Found while verifying the paths cited by the plan document in #3828.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
