### PR TITLE
[DT-3952] Replace Library Card wording with Active Researcher Status

### DIFF
--- a/src/components/data_library/LibraryFooter.tsx
+++ b/src/components/data_library/LibraryFooter.tsx
@@ -11,7 +11,7 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
   const hasSelection = selectedDatasetIds.length > 0
   const datasetText = selectedDatasetIds.length === 1 ? 'dataset' : 'datasets'
   const studyText = selectedStudyIds.length === 1 ? 'study' : 'studies'
-  const hasLibraryCard = Storage.getCurrentUser()?.libraryCard != null
+  const hasActiveResearcherStatus = Storage.getCurrentUser()?.libraryCard != null
 
   return (
     <Slide direction="up" in={hasSelection} mountOnEnter unmountOnExit>
@@ -38,7 +38,7 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
           {selectedStudyIds.length} {studyText}
         </Typography>
         <Tooltip
-          title={hasLibraryCard ? '' : 'A Library Card is required to apply for data access'}
+          title={hasActiveResearcherStatus ? '' : 'Active Researcher Status is required to apply for data access'}
           slotProps={{
             tooltip: {
               sx: {
@@ -54,7 +54,7 @@ export const LibraryFooter: React.FC<LibraryFooterProps> = ({
               size="large"
               onClick={onApplyForAccess}
               sx={{ fontWeight: 600 }}
-              disabled={!hasLibraryCard}
+              disabled={!hasActiveResearcherStatus}
             >
               Apply for Access
             </Button>

--- a/src/components/data_library/RequestAccessButton.tsx
+++ b/src/components/data_library/RequestAccessButton.tsx
@@ -13,14 +13,14 @@ interface RequestAccessButtonProps {
 
 export const RequestAccessButton: React.FC<RequestAccessButtonProps> = ({ datasetId, disabledForSelection = false }) => {
   const navigate = useNavigate()
-  const hasLibraryCard = Storage.getCurrentUser()?.libraryCard != null
+  const hasActiveResearcherStatus = Storage.getCurrentUser()?.libraryCard != null
 
   let tooltip = ''
   if (disabledForSelection) {
     tooltip = 'Use \'Apply for Access\' below to request the selected datasets'
   }
-  else if (!hasLibraryCard) {
-    tooltip = 'A Library Card is required to apply for data access'
+  else if (!hasActiveResearcherStatus) {
+    tooltip = 'Active Researcher Status is required to apply for data access'
   }
 
   return (
@@ -31,7 +31,7 @@ export const RequestAccessButton: React.FC<RequestAccessButtonProps> = ({ datase
           size="small"
           onClick={() => applyForAccess([datasetId], navigate)}
           sx={{ fontWeight: 600, fontSize: '12px' }}
-          disabled={disabledForSelection || !hasLibraryCard}
+          disabled={disabledForSelection || !hasActiveResearcherStatus}
         >
           Request Now
         </Button>

--- a/src/components/data_search/DatasetSearchFooter.tsx
+++ b/src/components/data_search/DatasetSearchFooter.tsx
@@ -17,7 +17,7 @@ export const DatasetSearchFooter = (props: DatasetSearchFooterProps) => {
       .map(dataset => dataset.study.studyId))
   const datasetText = selectedDatasets.length > 1 ? 'datasets' : 'dataset'
   const studyText = selectedStudies.length > 1 ? 'studies' : 'study'
-  const hasLibraryCard = !isNil(Storage.getCurrentUser().libraryCard)
+  const hasActiveResearcherStatus = !isNil(Storage.getCurrentUser().libraryCard)
 
   return (
     <div style={{
@@ -45,7 +45,7 @@ export const DatasetSearchFooter = (props: DatasetSearchFooterProps) => {
         {studyText}
       </div>
       <Tooltip
-        title={hasLibraryCard ? '' : 'A Library Card is required to apply for data access'}
+        title={hasActiveResearcherStatus ? '' : 'Active Researcher Status is required to apply for data access'}
         slotProps={{
           tooltip: {
             sx: {
@@ -60,7 +60,7 @@ export const DatasetSearchFooter = (props: DatasetSearchFooterProps) => {
             variant="contained"
             onClick={onClick}
             sx={{ fontWeight: 600, marginRight: 5 }}
-            disabled={!hasLibraryCard}
+            disabled={!hasActiveResearcherStatus}
           >
             Apply for Access
           </Button>

--- a/src/pages/researcher_console/ResearcherConsole.tsx
+++ b/src/pages/researcher_console/ResearcherConsole.tsx
@@ -8,8 +8,6 @@ import { getSearchFilterFunctions, Notifications, searchOnFilteredList, USER_ROL
 import { consoleTypes } from 'src/utils/DarCollectionUtils'
 import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCollectionColumns'
 import SearchBar from 'src/components/SearchBar'
-import BroadLibraryCardAgreementLink from 'src/assets/Library_Card_Agreement_2023_ApplicationVersion.pdf'
-import NihLibraryCardAgreementLink from 'src/assets/NIHLibraryCardAgreement06252025.pdf'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { DarCollectionSummary } from 'src/types/model'
@@ -121,22 +119,6 @@ export default function ResearcherConsole() {
           title="My Data Access Requests"
           description="Select and manage Data Access Requests and Drafts below"
         />
-        <div style={{ ...Styles.MEDIUM_DESCRIPTION, fontSize: '16px', marginTop: '1rem', marginLeft: '1.75em', textAlign: 'justify' }}>
-          <p>By submitting a DAR in DUOS you agree to the
-            {' '}
-            <a target="_blank" rel="noreferrer" href={BroadLibraryCardAgreementLink}>
-              Broad
-            </a>
-            {' '}
-            and
-            {' '}
-            <a target="_blank" rel="noreferrer" href={NihLibraryCardAgreementLink}>
-              NIH
-            </a>
-            {' '}
-            Library Card Agreements.
-          </p>
-        </div>
       </div>
       <div style={{ ...Styles.SEARCH_ACTION_HEADER_SECTION }}>
         <SearchBar handleSearchChange={handleSearchChange} />

--- a/test/components/RequestAccessButton.spec.tsx
+++ b/test/components/RequestAccessButton.spec.tsx
@@ -38,7 +38,7 @@ describe('RequestAccessButton', () => {
     navigate.mockReset()
   })
 
-  it('renders an enabled "Request Now" button when the user has a library card', () => {
+  it('renders an enabled "Request Now" button when the user has Active Researcher Status', () => {
     getCurrentUserSpy.mockReturnValue(buildUser({} as LibraryCard))
 
     render(<RequestAccessButton datasetId={101} />)
@@ -47,7 +47,7 @@ describe('RequestAccessButton', () => {
     expect(button).not.toBeDisabled()
   })
 
-  it('renders a disabled button when the user has no library card', () => {
+  it('renders a disabled button when the user does not have Active Researcher Status', () => {
     getCurrentUserSpy.mockReturnValue(buildUser(undefined))
 
     render(<RequestAccessButton datasetId={101} />)
@@ -55,14 +55,14 @@ describe('RequestAccessButton', () => {
     expect(screen.getByRole('button', { name: 'Request Now' })).toBeDisabled()
   })
 
-  it('shows a library card tooltip on hover when the user has no library card', async () => {
+  it('shows an Active Researcher Status tooltip when the user does not have it', async () => {
     getCurrentUserSpy.mockReturnValue(buildUser(undefined))
 
     render(<RequestAccessButton datasetId={101} />)
 
     fireEvent.mouseOver(screen.getByRole('button', { name: 'Request Now' }).parentElement as HTMLElement)
 
-    expect(await screen.findByText('A Library Card is required to apply for data access')).toBeInTheDocument()
+    expect(await screen.findByText('Active Researcher Status is required to apply for data access')).toBeInTheDocument()
   })
 
   it('creates a DAR draft for the dataset and navigates to the application on click', async () => {
@@ -79,7 +79,7 @@ describe('RequestAccessButton', () => {
     })
   })
 
-  it('is disabled with a selection tooltip when disabledForSelection is set, even with a library card', async () => {
+  it('is disabled with a selection tooltip when disabledForSelection is set, even with Active Researcher Status', async () => {
     getCurrentUserSpy.mockReturnValue(buildUser({} as LibraryCard))
 
     render(<RequestAccessButton datasetId={101} disabledForSelection />)

--- a/test/components/data_library/LibraryFooter.spec.tsx
+++ b/test/components/data_library/LibraryFooter.spec.tsx
@@ -8,12 +8,12 @@ import { Storage } from 'src/libs/storage'
 
 afterEach(() => vi.restoreAllMocks())
 
-const withLibraryCard = () => vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ libraryCard: { cardNumber: '12345' } } as unknown as ReturnType<typeof Storage.getCurrentUser>)
-const withoutLibraryCard = () => vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ libraryCard: null } as unknown as ReturnType<typeof Storage.getCurrentUser>)
+const withActiveResearcherStatus = () => vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ libraryCard: { cardNumber: '12345' } } as unknown as ReturnType<typeof Storage.getCurrentUser>)
+const withoutActiveResearcherStatus = () => vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ libraryCard: null } as unknown as ReturnType<typeof Storage.getCurrentUser>)
 
 describe('LibraryFooter — visibility', () => {
   it('does not render when no datasets are selected', () => {
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     const { container } = render(
       <LibraryFooter selectedDatasetIds={[]} selectedStudyIds={[]} onApplyForAccess={vi.fn()} />,
     )
@@ -21,7 +21,7 @@ describe('LibraryFooter — visibility', () => {
   })
 
   it('renders when at least one dataset is selected', () => {
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     const { container } = render(
       <LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />,
     )
@@ -31,34 +31,34 @@ describe('LibraryFooter — visibility', () => {
 
 describe('LibraryFooter — selection summary text', () => {
   it('displays singular "dataset" and "study" for single selections', () => {
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />)
     expect(screen.getByText('1 dataset selected from 1 study')).toBeInTheDocument()
   })
 
   it('displays plural "datasets" and "studies" for multiple selections', () => {
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1, 2, 3]} selectedStudyIds={[101, 102]} onApplyForAccess={vi.fn()} />)
     expect(screen.getByText('3 datasets selected from 2 studies')).toBeInTheDocument()
   })
 
   it('displays plural "studies" with a single dataset from multiple studies', () => {
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101, 102]} onApplyForAccess={vi.fn()} />)
     expect(screen.getByText('1 dataset selected from 2 studies')).toBeInTheDocument()
   })
 
   it('displays plural "datasets" with multiple datasets from a single study', () => {
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1, 2]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />)
     expect(screen.getByText('2 datasets selected from 1 study')).toBeInTheDocument()
   })
 })
 
 describe('LibraryFooter — tooltip', () => {
-  it('shows a tooltip explaining that a library card is required when the button is disabled', async () => {
+  it('shows a tooltip explaining that Active Researcher Status is required when the button is disabled', async () => {
     const user = userEvent.setup()
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />)
 
     const btn = screen.getByRole('button', { name: 'Apply for Access' })
@@ -66,14 +66,14 @@ describe('LibraryFooter — tooltip', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('tooltip')).toHaveTextContent(
-        'A Library Card is required to apply for data access',
+        'Active Researcher Status is required to apply for data access',
       )
     })
   })
 
-  it('does not show a restricting tooltip when the user has a library card', async () => {
+  it('does not show a restricting tooltip when the user has Active Researcher Status', async () => {
     const user = userEvent.setup()
-    withLibraryCard()
+    withActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />)
 
     const btn = screen.getByRole('button', { name: 'Apply for Access' })
@@ -84,22 +84,22 @@ describe('LibraryFooter — tooltip', () => {
 })
 
 describe('LibraryFooter — Apply for Access button', () => {
-  it('is enabled when the user has a library card', () => {
-    withLibraryCard()
+  it('is enabled when the user has Active Researcher Status', () => {
+    withActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Apply for Access' })).not.toBeDisabled()
   })
 
-  it('is disabled when the user has no library card', () => {
-    withoutLibraryCard()
+  it('is disabled when the user does not have Active Researcher Status', () => {
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={vi.fn()} />)
     expect(screen.getByRole('button', { name: 'Apply for Access' })).toBeDisabled()
   })
 
-  it('calls onApplyForAccess when clicked with a library card', async () => {
+  it('calls onApplyForAccess when clicked with Active Researcher Status', async () => {
     const user = userEvent.setup()
     const onApplyForAccess = vi.fn()
-    withLibraryCard()
+    withActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={onApplyForAccess} />)
     await user.click(screen.getByRole('button', { name: 'Apply for Access' }))
     expect(onApplyForAccess).toHaveBeenCalledOnce()
@@ -107,7 +107,7 @@ describe('LibraryFooter — Apply for Access button', () => {
 
   it('does not call onApplyForAccess when disabled', () => {
     const onApplyForAccess = vi.fn()
-    withoutLibraryCard()
+    withoutActiveResearcherStatus()
     render(<LibraryFooter selectedDatasetIds={[1]} selectedStudyIds={[101]} onApplyForAccess={onApplyForAccess} />)
     fireEvent.click(screen.getByRole('button', { name: 'Apply for Access' }))
     expect(onApplyForAccess).not.toHaveBeenCalled()

--- a/test/components/data_search/DatasetSearchFooter.spec.tsx
+++ b/test/components/data_search/DatasetSearchFooter.spec.tsx
@@ -50,7 +50,7 @@ describe('Dataset Search Footer renders tooltip and disables apply button', () =
     vi.restoreAllMocks()
   })
 
-  it('Disables Apply for Access button when user has no library card', () => {
+  it('Disables Apply for Access button when user does not have Active Researcher Status', () => {
     vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ libraryCard: null } as never)
     render(<DatasetSearchFooter {...oneDatasetProps} />)
     expect(screen.getByRole('button', { name: 'Apply for Access' })).toBeDisabled()
@@ -62,10 +62,10 @@ describe('Dataset Search Footer renders tooltip and disables apply button', () =
     const button = screen.getByRole('button', { name: 'Apply for Access' })
     await userEvent.hover(button.parentElement!)
     const tooltip = await screen.findByRole('tooltip')
-    expect(tooltip).toHaveTextContent('A Library Card is required to apply for data access')
+    expect(tooltip).toHaveTextContent('Active Researcher Status is required to apply for data access')
   })
 
-  it('Enables button when user has a library card', () => {
+  it('Enables button when user has Active Researcher Status', () => {
     vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ libraryCard: { cardNumber: '12345' } } as never)
     render(<DatasetSearchFooter {...oneDatasetProps} />)
     expect(screen.getByRole('button', { name: 'Apply for Access' })).not.toBeDisabled()

--- a/test/pages/researcher_console/ResearcherConsole.spec.tsx
+++ b/test/pages/researcher_console/ResearcherConsole.spec.tsx
@@ -86,9 +86,6 @@ vi.mock('src/components/TableHeaderSection', () => ({
       React.createElement('p', null, description)),
 }))
 
-vi.mock('src/assets/Library_Card_Agreement_2023_ApplicationVersion.pdf', () => ({ default: 'broad-lca.pdf' }))
-vi.mock('src/assets/NIHLibraryCardAgreement06252025.pdf', () => ({ default: 'nih-lca.pdf' }))
-
 const { useResponsiveDarCollectionColumns } = await import('src/hooks/useResponsiveDarCollectionColumns')
 const { searchOnFilteredList } = await import('src/libs/utils')
 
@@ -134,11 +131,10 @@ describe('ResearcherConsole', () => {
     expect(screen.getByText('Select and manage Data Access Requests and Drafts below')).toBeInTheDocument()
   })
 
-  it('renders links to Broad and NIH Library Card Agreements', async () => {
+  it('does not render the outdated Library Card Agreement notice', async () => {
     vi.mocked(Collections.getCollectionSummariesByRoleName).mockResolvedValue([])
     await act(async () => render(<ResearcherConsole />))
-    expect(screen.getByText('Broad')).toBeInTheDocument()
-    expect(screen.getByText('NIH')).toBeInTheDocument()
+    expect(screen.queryByText(/By submitting a DAR in DUOS/)).not.toBeInTheDocument()
   })
 
   it('renders the SearchBar', async () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3952

### Summary

This PR replaces "Library Card" with "Active Researcher Status" in the three data-access gating components:

- `LibraryFooter.tsx` — tooltip (L41) and disabled state (L57)
- `RequestAccessButton.tsx` — tooltip (L23) and disabled state
- `DatasetSearchFooter.tsx` — same pattern

Also removes the Library Card Agreement notice from the Researcher Console (`ResearcherConsole.tsx`) and its two now-unused PDF asset imports. This is beyond the ticket's written description — the removal was PO-confirmed but had no ticket of its own, so it was folded in here. Both PDFs are still used by `LibraryCardAgreementTermsDownload` and `SigningOfficialDaaAgreementWrapper`, so no assets are orphaned.

No behaviour change: the gate is still `Storage.getCurrentUser()?.libraryCard`. Copy and variable names only. Specs updated in step, including a regression test asserting the notice no longer renders.

<img width="1972" height="1038" alt="After" src="https://github.com/user-attachments/assets/3aece400-f794-449c-b39d-c6e725a4e3b6" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment