### PR TITLE
[DT-3948] Remove `dompurify` and add sanitization tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@mui/x-date-pickers": "9.2.0",
     "@tanstack/react-query": "5.101.4",
     "dayjs": "1.11.21",
-    "dompurify": "3.4.13",
     "oidc-client-ts": "3.5.0",
     "query-string": "9.4.1",
     "react": "19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       dayjs:
         specifier: 1.11.21
         version: 1.11.21
-      dompurify:
-        specifier: 3.4.13
-        version: 3.4.13
       oidc-client-ts:
         specifier: 3.5.0
         version: 3.5.0
@@ -1236,9 +1233,6 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
-  '@types/trusted-types@2.0.7':
-    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
-
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1617,9 +1611,6 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
-
-  dompurify@3.4.13:
-    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -4048,9 +4039,6 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@types/trusted-types@2.0.7':
-    optional: true
-
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -4440,10 +4428,6 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
-
-  dompurify@3.4.13:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:

--- a/src/components/ScrollableMarkdownContainer.tsx
+++ b/src/components/ScrollableMarkdownContainer.tsx
@@ -1,5 +1,4 @@
 import ReactMarkdown from 'react-markdown'
-import DOMPurify from 'dompurify'
 import React, { useEffect, useState } from 'react'
 import { isEmpty } from 'src/utils/NodashUtil'
 
@@ -27,7 +26,7 @@ export default function ScrollableMarkdownContainer({ markdown }: Readonly<Scrol
 
   const generateContent = (markdownText: string): React.ReactElement => (
     <ReactMarkdown components={markdownComponents}>
-      {DOMPurify.sanitize(markdownText)}
+      {markdownText}
     </ReactMarkdown>
   )
 

--- a/src/libs/TosService.tsx
+++ b/src/libs/TosService.tsx
@@ -1,5 +1,4 @@
 import ReactMarkdown from 'react-markdown'
-import DOMPurify from 'dompurify'
 import React, { CSSProperties } from 'react'
 import { ToS, ToSStatus } from './ajax/ToS'
 import { UserStatusInfo } from 'src/types/model'
@@ -48,7 +47,7 @@ export const TosService = {
       <ReactMarkdown
         components={{ a: props => <a target="_blank" {...props} /> }}
       >
-        {DOMPurify.sanitize(text)}
+        {text}
       </ReactMarkdown>
     )
   },

--- a/test/components/ScrollableMarkdownContainer.sanitization.spec.tsx
+++ b/test/components/ScrollableMarkdownContainer.sanitization.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, render } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import ScrollableMarkdownContainer from 'src/components/ScrollableMarkdownContainer'
+
+/**
+ * These tests deliberately use the REAL react-markdown (no vi.mock) — the point is to
+ * pin down the sanitization behaviour we now rely on after removing DOMPurify.
+ * If someone later adds `rehype-raw`, a custom `urlTransform`, or `skipHtml={false}`
+ * with raw HTML enabled, these tests fail.
+ */
+
+const mockFetch = (content: string) => {
+  global.fetch = vi.fn().mockResolvedValue({
+    text: () => Promise.resolve(content),
+  } as unknown as Response)
+}
+
+const renderMarkdown = async (markdownSource: string): Promise<HTMLElement> => {
+  mockFetch(markdownSource)
+  let container!: HTMLElement
+  await act(async () => {
+    ;({ container } = render(<ScrollableMarkdownContainer markdown="/doc.md" />))
+  })
+  return container
+}
+
+describe('ScrollableMarkdownContainer sanitization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('raw HTML in the markdown source is escaped, not executed', () => {
+    it('does not create a script element for a raw <script> tag', async () => {
+      const container = await renderMarkdown('<script>window.__pwned = true</script>')
+
+      expect(container.querySelector('script')).toBeNull()
+      expect(container.textContent).toContain('<script>window.__pwned = true</script>')
+      expect((window as unknown as Record<string, unknown>).__pwned).toBeUndefined()
+    })
+
+    it('does not create an img element for a raw <img onerror> tag', async () => {
+      const container = await renderMarkdown('<img src=x onerror="window.__pwned = true">')
+
+      expect(container.querySelector('img')).toBeNull()
+      expect(container.textContent).toContain('onerror')
+      expect((window as unknown as Record<string, unknown>).__pwned).toBeUndefined()
+    })
+
+    it('does not create an iframe element for a raw <iframe> tag', async () => {
+      const container = await renderMarkdown('<iframe src="https://evil.test"></iframe>')
+
+      expect(container.querySelector('iframe')).toBeNull()
+    })
+
+    it('does not create an svg element for a raw <svg onload> tag', async () => {
+      const container = await renderMarkdown('<svg onload="window.__pwned = true"></svg>')
+
+      expect(container.querySelector('svg')).toBeNull()
+      expect((window as unknown as Record<string, unknown>).__pwned).toBeUndefined()
+    })
+
+    it('does not attach inline event handlers to legitimately rendered elements', async () => {
+      const container = await renderMarkdown('# Heading <span onmouseover="window.__pwned = true">hi</span>')
+
+      const heading = container.querySelector('h1')
+      expect(heading).not.toBeNull()
+      expect(heading?.querySelector('span')).toBeNull()
+      expect(heading?.getAttribute('onmouseover')).toBeNull()
+    })
+  })
+
+  describe('dangerous URL schemes are stripped from links', () => {
+    it.each([
+      ['lowercase javascript:', '[click](javascript:alert(1))'],
+      ['mixed-case javascript:', '[click](JaVaScRiPt:alert(1))'],
+      ['entity-encoded javascript:', '[click](&#106;avascript:alert(1))'],
+      ['vbscript:', '[click](vbscript:msgbox(1))'],
+      ['reference-style javascript:', '[click][ref]\n\n[ref]: javascript:alert(1)'],
+      ['autolink javascript:', '<javascript:alert(1)>'],
+    ])('neutralizes %s in an anchor href', async (_label, source) => {
+      const container = await renderMarkdown(source)
+
+      const anchor = container.querySelector('a')
+      expect(anchor).not.toBeNull()
+      expect(anchor?.getAttribute('href')).toBe('')
+      expect(anchor?.getAttribute('href')).not.toMatch(/javascript:|vbscript:/i)
+    })
+  })
+
+  describe('dangerous URL schemes are stripped from images', () => {
+    it.each([
+      ['javascript:', '![x](javascript:alert(1))'],
+      ['data: html payload', '![x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)'],
+    ])('drops the src for %s', async (_label, source) => {
+      const container = await renderMarkdown(source)
+
+      const img = container.querySelector('img')
+      expect(img).not.toBeNull()
+      expect(img?.getAttribute('src')).toBeNull()
+    })
+  })
+
+  describe('safe content still renders (guards against over-blocking)', () => {
+    it('preserves http and https link hrefs', async () => {
+      const container = await renderMarkdown('[ok](https://example.com/path?q=1)')
+
+      expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com/path?q=1')
+    })
+
+    it('preserves mailto links', async () => {
+      const container = await renderMarkdown('[mail](mailto:duos@example.com)')
+
+      expect(container.querySelector('a')?.getAttribute('href')).toBe('mailto:duos@example.com')
+    })
+
+    it('preserves relative links', async () => {
+      const container = await renderMarkdown('[home](/dataset_catalog)')
+
+      expect(container.querySelector('a')?.getAttribute('href')).toBe('/dataset_catalog')
+    })
+
+    it('renders markdown structure rather than the raw source', async () => {
+      const container = await renderMarkdown('# Title\n\n- one\n- two\n\n**bold**')
+
+      expect(container.querySelector('h1')?.textContent).toBe('Title')
+      expect(container.querySelectorAll('li')).toHaveLength(2)
+      expect(container.querySelector('strong')?.textContent).toBe('bold')
+    })
+
+    it('opens rendered links in a new tab', async () => {
+      const container = await renderMarkdown('[ok](https://example.com)')
+
+      expect(container.querySelector('a')?.getAttribute('target')).toBe('_blank')
+    })
+  })
+})

--- a/test/components/ScrollableMarkdownContainer.spec.tsx
+++ b/test/components/ScrollableMarkdownContainer.spec.tsx
@@ -17,10 +17,6 @@ vi.mock('react-markdown', () => ({
   },
 }))
 
-vi.mock('dompurify', () => ({
-  default: { sanitize: (text: string) => text },
-}))
-
 const mockFetch = (content: string) => {
   global.fetch = vi.fn().mockResolvedValue({
     text: () => Promise.resolve(content),

--- a/test/libs/TosService.spec.tsx
+++ b/test/libs/TosService.spec.tsx
@@ -100,6 +100,62 @@ describe('TosService', () => {
     })
   })
 
+  // ── getFormattedText: sanitization ─────────────────────────────────────────
+  //
+  // The ToS body is fetched from Sam and rendered without an explicit sanitizer,
+  // so these tests pin the react-markdown defaults we rely on. They fail if
+  // `rehype-raw`, a custom `urlTransform`, or raw-HTML rendering is ever added.
+
+  describe('getFormattedText sanitization', () => {
+    const renderToS = async (markdown: string) => {
+      vi.mocked(ToS.getDUOSText).mockResolvedValue(markdown)
+      const element = await TosService.getFormattedText()
+      return render(element).container
+    }
+
+    it.each([
+      ['<script>', '<script>window.__pwned = true</script>', 'script'],
+      ['<img onerror>', '<img src=x onerror="window.__pwned = true">', 'img'],
+      ['<iframe>', '<iframe src="https://evil.test"></iframe>', 'iframe'],
+      ['<svg onload>', '<svg onload="window.__pwned = true"></svg>', 'svg'],
+    ])('escapes a raw %s tag instead of rendering it', async (_label, markdown, selector) => {
+      const container = await renderToS(markdown)
+
+      expect(container.querySelector(selector)).toBeNull()
+      expect((window as unknown as Record<string, unknown>).__pwned).toBeUndefined()
+    })
+
+    it.each([
+      ['javascript:', '[click](javascript:alert(1))'],
+      ['mixed-case javascript:', '[click](JaVaScRiPt:alert(1))'],
+      ['entity-encoded javascript:', '[click](&#106;avascript:alert(1))'],
+      ['vbscript:', '[click](vbscript:msgbox(1))'],
+    ])('strips a %s scheme from link hrefs', async (_label, markdown) => {
+      const container = await renderToS(markdown)
+
+      const link = container.querySelector('a')
+      expect(link).not.toBeNull()
+      expect(link?.getAttribute('href')).toBe('')
+      expect(link?.getAttribute('href')).not.toMatch(/javascript:|vbscript:/i)
+    })
+
+    it('strips a data: URL from an image src', async () => {
+      const container = await renderToS(
+        '![x](data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==)',
+      )
+
+      const img = container.querySelector('img')
+      expect(img).not.toBeNull()
+      expect(img?.getAttribute('src')).toBeNull()
+    })
+
+    it('still renders safe https links untouched', async () => {
+      const container = await renderToS('[terms](https://duos.org/terms)')
+
+      expect(container.querySelector('a')?.getAttribute('href')).toBe('https://duos.org/terms')
+    })
+  })
+
   // ── acceptTos ─────────────────────────────────────────────────────────────
 
   describe('acceptTos', () => {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3948

### Summary
Removes the `dompurify` dependency and the two `DOMPurify.sanitize()` calls that used it, and replaces the implicit safety guarantee with explicit test coverage.

- Drops `dompurify` from `package.json` / `pnpm-lock.yaml`.
- Removes `DOMPurify.sanitize()` from `src/components/ScrollableMarkdownContainer.tsx` and `src/libs/TosService.tsx`. In both places `sanitize()` was applied to the **markdown source string** before it was handed to `<ReactMarkdown>` — the wrong layer. react-markdown builds a React element tree (it never touches `innerHTML`), escapes raw HTML by default since no `rehype-raw` is configured anywhere in this repo, and already rewrites `javascript:`/`vbscript:`/`data:` URLs to an empty `href`/absent `src`. The sanitize call was stripping HTML out of markdown *text*, not defending the DOM.
- Adds `test/components/ScrollableMarkdownContainer.sanitization.spec.tsx` exercising the **real** react-markdown — the existing spec mocks it out entirely, so it could not have caught a sanitization regression. 
- Adds a matching `getFormattedText sanitization` block to `test/libs/TosService.spec.tsx` against the ToS body, which is fetched from Sam.

These tests pin behavior we now depend on implicitly: they fail if `rehype-raw`, a custom `urlTransform`, or raw-HTML rendering is ever introduced, or if a react-markdown major bump changes the defaults.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
