### PR TITLE
[DT-3315] Change `Permissions` to `Roles` on User table

### DIFF
--- a/src/components/manage_users_table/ManageUsersTable.tsx
+++ b/src/components/manage_users_table/ManageUsersTable.tsx
@@ -80,7 +80,7 @@ const columnHeaderConfig: Record<string, ColumnConfig> = {
   roles: {
     label: 'Roles',
     cellStyle: {
-      width: styles.cellWidth.perms,
+      width: styles.cellWidth.roles,
     },
     cellDataFn: cellData.rolesCellData,
     sortable: false,

--- a/src/components/manage_users_table/ManageUsersTable.tsx
+++ b/src/components/manage_users_table/ManageUsersTable.tsx
@@ -77,7 +77,7 @@ const columnHeaderConfig: Record<string, ColumnConfig> = {
     cellDataFn: cellData.institutionCellData,
     sortable: false,
   },
-  perms: {
+  roles: {
     label: 'Roles',
     cellStyle: {
       width: styles.cellWidth.perms,

--- a/src/components/manage_users_table/ManageUsersTable.tsx
+++ b/src/components/manage_users_table/ManageUsersTable.tsx
@@ -78,11 +78,11 @@ const columnHeaderConfig: Record<string, ColumnConfig> = {
     sortable: false,
   },
   perms: {
-    label: 'Permissions',
+    label: 'Roles',
     cellStyle: {
       width: styles.cellWidth.perms,
     },
-    cellDataFn: cellData.permissionsCellData,
+    cellDataFn: cellData.rolesCellData,
     sortable: false,
   },
 }

--- a/src/components/manage_users_table/ManageUsersTableCellData.tsx
+++ b/src/components/manage_users_table/ManageUsersTableCellData.tsx
@@ -84,21 +84,21 @@ export function emailCellData({ userId, email, label = 'email' }: EmailCellDataP
 
 export function rolesCellData({ userId, roles, libraryCard, label = 'roles' }: RolesCellDataParams): CellData {
   const hasLibraryCard = !isNil(libraryCard)
-  const roleNames = (roles ?? []).map((role): string => role.name).filter(name => name !== 'Researcher')
-  const perms = hasLibraryCard ? roleNames.concat('LibraryCard') : roleNames
+  const filteredRoleNames = (roles ?? []).map((role): string => role.name).filter(name => name !== 'Researcher')
+  const roleNames = hasLibraryCard ? filteredRoleNames.concat('LibraryCard') : filteredRoleNames
 
   // need to split, e.g., SigningOfficial -> Signing Official
-  const formattedPerms = perms.map(perm => perm.replace(/([A-Z])/g, ' $1').trim())
+  const formattedRoles = roleNames.map(role => role.replace(/([A-Z])/g, ' $1').trim())
 
   return {
     isComponent: true,
-    data: sortedUniq(formattedPerms).join('   ') || 'None',
+    data: sortedUniq(formattedRoles).join('   ') || 'None',
     label,
     id: userId,
   }
 }
 
-export function institutionCellData({ userId, institution, label = 'insitution' }: InstitutionCellDataParams): CellData {
+export function institutionCellData({ userId, institution, label = 'institution' }: InstitutionCellDataParams): CellData {
   return {
     isComponent: true,
     data: institution?.name ?? 'N/A',

--- a/src/components/manage_users_table/ManageUsersTableCellData.tsx
+++ b/src/components/manage_users_table/ManageUsersTableCellData.tsx
@@ -26,7 +26,7 @@ interface EmailCellDataParams {
   label?: string
 }
 
-interface PermissionsCellDataParams {
+interface RolesCellDataParams {
   userId: number
   roles: UserRole[]
   libraryCard?: LibraryCard
@@ -82,7 +82,7 @@ export function emailCellData({ userId, email, label = 'email' }: EmailCellDataP
   }
 }
 
-export function permissionsCellData({ userId, roles, libraryCard, label = 'permissions' }: PermissionsCellDataParams): CellData {
+export function rolesCellData({ userId, roles, libraryCard, label = 'roles' }: RolesCellDataParams): CellData {
   const hasLibraryCard = !isNil(libraryCard)
   const roleNames = (roles ?? []).map((role): string => role.name).filter(name => name !== 'Researcher')
   const perms = hasLibraryCard ? roleNames.concat('LibraryCard') : roleNames
@@ -110,7 +110,7 @@ export function institutionCellData({ userId, institution, label = 'insitution' 
 const manageUsersTableCellData = {
   usernameCellData,
   emailCellData,
-  permissionsCellData,
+  rolesCellData,
   institutionCellData,
 }
 

--- a/src/components/manage_users_table/manageUsersTableUtils.ts
+++ b/src/components/manage_users_table/manageUsersTableUtils.ts
@@ -15,8 +15,8 @@ export const styles = {
     borderRadius: '4px',
     margin: '0.5% 0',
   },
-  columnStyle: Object.assign({}, Styles.TABLE.HEADER_ROW, {
-    justifyContent: 'space-between',
+  columnStyle: {
+    ...Styles.TABLE.HEADER_ROW, justifyContent: 'space-between',
     color: '#7B7B7B',
     fontFamily: 'Montserrat',
     fontSize: '1.2rem',
@@ -25,7 +25,7 @@ export const styles = {
     textTransform: 'uppercase',
     backgroundColor: 'B8CDD3',
     border: 'none',
-  }),
+  },
   cellWidth: {
     username: '20%',
     usernameMargin: '5%',
@@ -33,16 +33,16 @@ export const styles = {
     emailMargin: '5%',
     institution: '20%',
     institutionMargin: '5%',
-    perms: '20%',
+    roles: '20%',
   },
   color: {
     username: '#000000',
     email: '#000000',
-    perms: '#000000',
+    roles: '#000000',
   },
   fontSize: {
     username: '1.6rem',
     email: '1.4rem',
-    perms: '1.4rem',
+    roles: '1.4rem',
   },
 }

--- a/src/components/manage_users_table/manageUsersTableUtils.ts
+++ b/src/components/manage_users_table/manageUsersTableUtils.ts
@@ -15,17 +15,17 @@ export const styles = {
     borderRadius: '4px',
     margin: '0.5% 0',
   },
-  columnStyle: Object.assign({}, Styles.TABLE.HEADER_ROW, {
-    justifyContent: 'space-between',
+  columnStyle: {
+    ...Styles.TABLE.HEADER_ROW, justifyContent: 'space-between',
     color: '#7B7B7B',
     fontFamily: 'Montserrat',
     fontSize: '1.2rem',
     fontWeight: 'bold',
     letterSpacing: '0.2px',
     textTransform: 'uppercase',
-    backgroundColor: 'B8CDD3',
+    backgroundColor: '#B8CDD3',
     border: 'none',
-  }),
+  },
   cellWidth: {
     username: '20%',
     usernameMargin: '5%',
@@ -33,16 +33,16 @@ export const styles = {
     emailMargin: '5%',
     institution: '20%',
     institutionMargin: '5%',
-    perms: '20%',
+    roles: '20%',
   },
   color: {
     username: '#000000',
     email: '#000000',
-    perms: '#000000',
+    roles: '#000000',
   },
   fontSize: {
     username: '1.6rem',
     email: '1.4rem',
-    perms: '1.4rem',
+    roles: '1.4rem',
   },
 }

--- a/test/components/manage_users_table/ManageUsersTableCellData.spec.tsx
+++ b/test/components/manage_users_table/ManageUsersTableCellData.spec.tsx
@@ -6,7 +6,7 @@ import { BrowserRouter } from 'react-router'
 import {
   usernameCellData,
   emailCellData,
-  permissionsCellData,
+  rolesCellData,
   institutionCellData,
 } from 'src/components/manage_users_table/ManageUsersTableCellData'
 import { UserRole, LibraryCard, InstitutionInterface } from 'src/types/model'
@@ -63,17 +63,17 @@ describe('emailCellData', () => {
   })
 })
 
-describe('permissionsCellData', () => {
+describe('rolesCellData', () => {
   it('shows None when no roles and no library card', () => {
-    const result = permissionsCellData({ userId: 1, roles: [] })
+    const result = rolesCellData({ userId: 1, roles: [] })
     expect(result.data).toBe('None')
     expect(result.id).toBe(1)
-    expect(result.label).toBe('permissions')
+    expect(result.label).toBe('roles')
     expect(result.isComponent).toBe(true)
   })
 
   it('filters out the Researcher role', () => {
-    const result = permissionsCellData({
+    const result = rolesCellData({
       userId: 1,
       roles: [makeRole('Researcher'), makeRole('Admin')],
     })
@@ -82,7 +82,7 @@ describe('permissionsCellData', () => {
   })
 
   it('formats role names by inserting spaces before uppercase letters', () => {
-    const result = permissionsCellData({
+    const result = rolesCellData({
       userId: 1,
       roles: [makeRole('SigningOfficial')],
     })
@@ -90,7 +90,7 @@ describe('permissionsCellData', () => {
   })
 
   it('appends Library Card when a library card is present', () => {
-    const result = permissionsCellData({
+    const result = rolesCellData({
       userId: 1,
       roles: [],
       libraryCard: makeLibraryCard(),
@@ -99,7 +99,7 @@ describe('permissionsCellData', () => {
   })
 
   it('shows None when Researcher is the only role and no library card', () => {
-    const result = permissionsCellData({
+    const result = rolesCellData({
       userId: 1,
       roles: [makeRole('Researcher')],
     })
@@ -107,7 +107,7 @@ describe('permissionsCellData', () => {
   })
 
   it('accepts a custom label', () => {
-    const result = permissionsCellData({ userId: 1, roles: [], label: 'custom-perms' })
+    const result = rolesCellData({ userId: 1, roles: [], label: 'custom-perms' })
     expect(result.label).toBe('custom-perms')
   })
 })

--- a/test/components/manage_users_table/ManageUsersTableCellData.spec.tsx
+++ b/test/components/manage_users_table/ManageUsersTableCellData.spec.tsx
@@ -107,8 +107,8 @@ describe('rolesCellData', () => {
   })
 
   it('accepts a custom label', () => {
-    const result = rolesCellData({ userId: 1, roles: [], label: 'custom-perms' })
-    expect(result.label).toBe('custom-perms')
+    const result = rolesCellData({ userId: 1, roles: [], label: 'custom-roles' })
+    expect(result.label).toBe('custom-roles')
   })
 })
 
@@ -118,7 +118,7 @@ describe('institutionCellData', () => {
     const result = institutionCellData({ userId: 1, institution })
     expect(result.data).toBe('Test University')
     expect(result.id).toBe(1)
-    expect(result.label).toBe('insitution')
+    expect(result.label).toBe('institution')
     expect(result.isComponent).toBe(true)
   })
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3315

### Summary

This PR changes `Permissions` to `Roles` on the User table.

<img width="3642" height="2620" alt="After" src="https://github.com/user-attachments/assets/35a6220a-1839-479a-8a44-34a8b1aa6cfb" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
