### PR TITLE
[DT-3974] Remove duplicate manual-review warning banner

### DIFF
--- a/src/pages/dar_collection_review/DarCollectionReview.tsx
+++ b/src/pages/dar_collection_review/DarCollectionReview.tsx
@@ -291,7 +291,6 @@ export default function DarCollectionReview({ adminPage = false, readOnly = fals
         )}
         {!adminPage && selectedTab === tabs.memberVote && (
           <MultiDatasetVotingTab
-            darInfo={darInfo}
             collection={collection}
             buckets={dataUseBuckets}
             isChair={false}
@@ -303,7 +302,6 @@ export default function DarCollectionReview({ adminPage = false, readOnly = fals
         )}
         {selectedTab === tabs.chairVote && (
           <MultiDatasetVotingTab
-            darInfo={darInfo}
             collection={collection}
             buckets={dataUseBuckets}
             isChair={true}

--- a/src/pages/dar_collection_review/MultiDatasetVotingTab.tsx
+++ b/src/pages/dar_collection_review/MultiDatasetVotingTab.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { get, isNil } from 'src/utils/NodashUtil'
 import { Alert } from 'src/components/Alert'
-import ManualReviewWarningBanner from 'src/components/ManualReviewWarningBanner'
 import MultiDatasetVoteSlab from 'src/components/collection_voting_slab/MultiDatasetVoteSlab'
 import { User } from 'src/libs/ajax/User'
 import { Bucket } from 'src/utils/BucketUtils'
-import { DarCollection, DataAccessRequestData } from 'src/types/model'
+import { DarCollection } from 'src/types/model'
 
 interface MultiDatasetVotingTabProps {
-  readonly darInfo: Partial<DataAccessRequestData>
   readonly buckets: Bucket[]
   readonly collection: DarCollection | Record<string, never>
   readonly isChair?: boolean
@@ -80,7 +78,6 @@ const styles = {
 }
 
 export default function MultiDatasetVotingTab({
-  darInfo,
   buckets,
   collection,
   isChair = false,
@@ -114,7 +111,6 @@ export default function MultiDatasetVotingTab({
 
   return (
     <div style={styles.baseStyle}>
-      <ManualReviewWarningBanner darInfo={darInfo} />
       {dataAccessApprovalDisabled() && !readOnly && (
         <Alert
           type="danger"

--- a/test/pages/dar_collection_review/DarCollectionReview.spec.tsx
+++ b/test/pages/dar_collection_review/DarCollectionReview.spec.tsx
@@ -100,6 +100,7 @@ const dar = {
         rus: 'One good RUS\n',
         nonTechRus: 'One non-technical RUS\n',
         diseases: true,
+        stigmatizedDiseases: true,
         aiLlmUse: false,
         darCode: 'DAR-XXX',
         createDate: 1667971415440,
@@ -262,6 +263,15 @@ beforeEach(() => {
 })
 
 describe('DAR Review', () => {
+  it('renders one manual-review warning while the Vote tab is open', async () => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(chair)
+    renderReview({ adminPage: false })
+
+    const warnings = await screen.findAllByText(/This Data Access Request includes a data use term that requires manual review/)
+
+    expect(warnings).toHaveLength(1)
+  })
+
   it('renders Vote tab (not Chair Vote) for Chairs', async () => {
     vi.mocked(Storage.getCurrentUser).mockReturnValue(chair)
     renderReview({ adminPage: false })

--- a/test/pages/dar_collection_review/DarCollectionReview.spec.tsx
+++ b/test/pages/dar_collection_review/DarCollectionReview.spec.tsx
@@ -267,9 +267,10 @@ describe('DAR Review', () => {
     vi.mocked(Storage.getCurrentUser).mockReturnValue(chair)
     renderReview({ adminPage: false })
 
-    const warnings = await screen.findAllByText(/This Data Access Request includes a data use term that requires manual review/)
+    const alerts = await screen.findAllByRole('alert')
+    const banners = alerts.filter(alert => alert.getAttribute('data-cy') === 'manual-review-warning-banner')
 
-    expect(warnings).toHaveLength(1)
+    expect(banners).toHaveLength(1)
   })
 
   it('renders Vote tab (not Chair Vote) for Chairs', async () => {

--- a/test/pages/dar_collection_review/MultiDatasetVotingTab.spec.tsx
+++ b/test/pages/dar_collection_review/MultiDatasetVotingTab.spec.tsx
@@ -54,11 +54,6 @@ vi.mock('src/libs/utils', async (importActual) => {
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-const darInfo = {
-  rus: 'test',
-  diseases: true,
-}
-
 const bucket1 = {
   key: 'bucket1',
   label: 'GROUP 1',
@@ -166,7 +161,6 @@ const mockUser = (userId: number) =>
 const renderTab = (props: Record<string, unknown> = {}) =>
   render(
     <MultiDatasetVotingTab
-      darInfo={darInfo}
       buckets={[bucket1]}
       collection={collection}
       {...props}


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3974

### Summary

- Removes the duplicate warning from the Vote tab.
- Keeps the warning visible once at the DAR review page level.
- Removes the unused darInfo prop.
- Adds regression coverage confirming only one banner appears.

<img width="1807" height="1181" alt="After" src="https://github.com/user-attachments/assets/7d905422-3b2d-4316-b91f-ce067338028f" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
