### PR TITLE
[DT-3948] Stabilize ScrollableMarkdownContainer spec

### DIFF
--- a/test/components/ScrollableMarkdownContainer.spec.tsx
+++ b/test/components/ScrollableMarkdownContainer.spec.tsx
@@ -115,7 +115,9 @@ describe('ScrollableMarkdownContainer', () => {
     // render and rerender flush their own updates, so findBy/waitFor carry the async waiting.
     const { rerender } = render(<ScrollableMarkdownContainer markdown="/one.md" onLoadStateChange={onLoadStateChange} />)
     await waitFor(() => expect(screen.getByTestId('markdown-link').textContent).toContain('First body'))
-    expect(onLoadStateChange).toHaveBeenLastCalledWith('loaded')
+    // The callback fires from a passive effect after the commit that waitFor observed, so it needs
+    // its own waitFor rather than a synchronous assertion.
+    await waitFor(() => expect(onLoadStateChange).toHaveBeenLastCalledWith('loaded'))
 
     rerender(<ScrollableMarkdownContainer markdown="/two.md" onLoadStateChange={onLoadStateChange} />)
 
@@ -125,7 +127,7 @@ describe('ScrollableMarkdownContainer', () => {
 
     resolveSecond({ ok: true, text: () => Promise.resolve('Second body') } as unknown as Response)
     await waitFor(() => expect(screen.getByTestId('markdown-link').textContent).toContain('Second body'))
-    expect(onLoadStateChange).toHaveBeenLastCalledWith('loaded')
+    await waitFor(() => expect(onLoadStateChange).toHaveBeenLastCalledWith('loaded'))
   })
 
   it('reports an error state and explains the gap when the document cannot be loaded', async () => {


### PR DESCRIPTION
### Addresses
Related to fixes from https://broadworkbench.atlassian.net/browse/DT-3948

### Summary

* Fixes a flaky assertion in `ScrollableMarkdownContainer.spec.tsx` ("shows no stale body and reports loading again when the markdown prop changes") that intermittently failed in CI with `expected last call with ['loaded']` but received `['loading']`.
* Root cause: `onLoadStateChange` fires from a passive `useEffect`, which React flushes after the DOM commit. The test's `waitFor` on the rendered markdown text can resolve on the MutationObserver tick right after the commit, before the effect runs, so the synchronous `toHaveBeenLastCalledWith('loaded')` assertion raced the effect flush.
* Fix: await the callback assertion itself with `waitFor` instead of asserting it synchronously. The same change is applied to the identical latent race at the end of the test (after the second document resolves).
* No component changes; test-only.

### Test plan

* `pnpm vitest run test/components/ScrollableMarkdownContainer.spec.tsx` — 9/9 passing across 20 consecutive runs.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)