### PR TITLE
[DT-3978] Force the B2C login screen on sign-in with prompt=login (BFF Phase 2 gap, story 2-C)

### DIFF
--- a/server/src/auth/login.ts
+++ b/server/src/auth/login.ts
@@ -49,6 +49,13 @@ export async function handleLogin(request: FastifyRequest, reply: FastifyReply):
     code_challenge: await pkce.challenge(verifier),
     code_challenge_method: 'S256',
     state,
+    // Force the B2C login screen even when B2C still holds an SSO cookie.
+    // /auth/logout destroys only the BFF session — without this, a signed-out
+    // user clicking Sign In is silently re-authenticated by B2C's own session,
+    // which matters on shared workstations (DUOS gates dbGaP data). The legacy
+    // client forced the same thing via oidcBroker's `prompt: 'consent login'`.
+    // True B2C session termination (front-channel logout) is epic-5, 5-I.
+    prompt: 'login',
   })
 
   // Persist the session BEFORE responding, so @fastify/session's async onSend

--- a/server/src/auth/login.ts
+++ b/server/src/auth/login.ts
@@ -50,11 +50,6 @@ export async function handleLogin(request: FastifyRequest, reply: FastifyReply):
     code_challenge_method: 'S256',
     state,
     // Force the B2C login screen even when B2C still holds an SSO cookie.
-    // /auth/logout destroys only the BFF session — without this, a signed-out
-    // user clicking Sign In is silently re-authenticated by B2C's own session,
-    // which matters on shared workstations (DUOS gates dbGaP data). The legacy
-    // client forced the same thing via oidcBroker's `prompt: 'consent login'`.
-    // True B2C session termination (front-channel logout) is epic-5, 5-I.
     prompt: 'login',
   })
 

--- a/server/test/login.test.ts
+++ b/server/test/login.test.ts
@@ -91,7 +91,7 @@ describe('handleLogin', () => {
     expect(request.session.returnTo).toBe('/')
   })
 
-  it('builds the authorization URL with the configured redirect_uri, B2C scope quirk, and S256 PKCE params', async () => {
+  it('builds the authorization URL with the configured redirect_uri, B2C scope quirk, S256 PKCE params, and a forced login prompt', async () => {
     await handleLogin(makeRequest(), makeReply())
 
     const oidc = await import('openid-client')
@@ -101,6 +101,9 @@ describe('handleLogin', () => {
       code_challenge: 'test-challenge',
       code_challenge_method: 'S256',
       state: 'test-state',
+      // prompt=login forces the B2C login screen even when B2C's own SSO
+      // cookie survives a DUOS sign-out (front-channel logout is epic-5, 5-I).
+      prompt: 'login',
     })
 
     const oidcClient = await import('../src/auth/oidcClient.js')

--- a/server/test/login.test.ts
+++ b/server/test/login.test.ts
@@ -102,7 +102,7 @@ describe('handleLogin', () => {
       code_challenge_method: 'S256',
       state: 'test-state',
       // prompt=login forces the B2C login screen even when B2C's own SSO
-      // cookie survives a DUOS sign-out (front-channel logout is epic-5, 5-I).
+      // cookie survives a DUOS sign-out.
       prompt: 'login',
     })
 


### PR DESCRIPTION
### Addresses

Fully addresses [DT-3978](https://broadworkbench.atlassian.net/browse/DT-3978)

### Summary

- Adds `prompt: 'login'` to the B2C authorization request in `server/src/auth/login.ts`. `/auth/logout` destroys only the BFF session — B2C's SSO cookie on b2clogin.com survives, so a signed-out user clicking Sign In was silently re-authenticated with no login screen shown. This is a regression vs the legacy client, which forced re-authentication via oidcBroker's `prompt: 'consent login'`, and a shared-workstation concern given DUOS gates dbGaP data.
- Updates the `handleLogin` authorization-URL test in `server/test/login.test.ts` to assert the new parameter.
- True B2C session termination (front-channel logout via `end_session_endpoint`) is a separate Phase 5 story (5-I) and does not replace this parameter — the upstream Google/Microsoft IdP session survives at the provider either way.

### Test plan

- [x] `pnpm --filter duos-server test` — 240 tests pass (13 files), including the updated `login.test.ts` assertion that the authorization URL is built with `prompt: 'login'`
- [x] `pnpm --filter duos-server exec tsc --noEmit` — clean
- [x] Manual: sign in, sign out, click Sign In again — the B2C login screen appears instead of silent re-authentication

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DT-3978]: https://broadworkbench.atlassian.net/browse/DT-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ