### PR TITLE
[DT-3979] Render BFF Configurations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,6 @@ DUOS_SESSION_SECRET=change-me-to-a-random-32-plus-char-string
 # docker network here. Both compose files already default it to false, so you
 # only need this line to override that.
 # DUOS_DB_SSL=false
-# The consent database is named `consent` in every environment.
 DUOS_DB_NAME=consent
 DUOS_DB_PORT=
 DUOS_DB_USER=
@@ -39,9 +38,7 @@ DUOS_DB_PASSWORD=
 # --- Azure B2C OAuth --------------------------------------------------------
 # The single BFF OIDC client — B2C federates Google and Microsoft internally,
 # so no Google OAuth client credentials are used in v2.
-# The value below is the hand-created dev app registration (not secret). B2C
-# sign-in ONLY works with app registrations created by hand — the
-# terraform-created registrations do not work.
+# The value below is the hand-created dev app registration (not secret).
 DUOS_AZURE_CLIENT_ID=a0e99acd-7b8d-400d-a1d3-60e497495806
 # Populated automatically by `./scripts/render-configs.sh --write_env true`
 # (requires the non-split VPN, like the rest of that script). To fetch it

--- a/.env.example
+++ b/.env.example
@@ -21,13 +21,17 @@ DUOS_SESSION_SECRET=change-me-to-a-random-32-plus-char-string
 # Postgres instead). Only set it here to override that overlay default.
 # DUOS_DB_USER/PASSWORD/NAME must match whichever Postgres is actually in
 # play — see docker-compose.yaml and DEVNOTES.md for details.
+# `./scripts/render-configs.sh --write_env true` fills USER/PASSWORD from the
+# dev cluster's `consent-secrets` secret (keys databaseUser/databasePassword)
+# when they aren't already set.
 # DUOS_DB_SSL: app-level TLS to Postgres is ON by default (rejectUnauthorized).
 # It must be explicitly set to `false` when the transport is already
 # plaintext-on-loopback — the Cloud SQL Proxy sidecar in k8s, or the local
 # docker network here. Both compose files already default it to false, so you
 # only need this line to override that.
 # DUOS_DB_SSL=false
-DUOS_DB_NAME=
+# The consent database is named `consent` in every environment.
+DUOS_DB_NAME=consent
 DUOS_DB_PORT=
 DUOS_DB_USER=
 DUOS_DB_PASSWORD=
@@ -35,12 +39,27 @@ DUOS_DB_PASSWORD=
 # --- Azure B2C OAuth --------------------------------------------------------
 # The single BFF OIDC client — B2C federates Google and Microsoft internally,
 # so no Google OAuth client credentials are used in v2.
-DUOS_AZURE_CLIENT_ID=
+# The value below is the hand-created dev app registration (not secret). B2C
+# sign-in ONLY works with app registrations created by hand — the
+# terraform-created registrations do not work.
+DUOS_AZURE_CLIENT_ID=a0e99acd-7b8d-400d-a1d3-60e497495806
+# Populated automatically by `./scripts/render-configs.sh --write_env true`
+# (requires the non-split VPN, like the rest of that script). To fetch it
+# manually instead, read it from the dev cluster and BASE64-DECODE it —
+# kubectl's .data values are base64-wrapped, and pasting the wrapped value
+# here yields AADB2C90081 ("client_secret does not match") at the token
+# exchange. The real value is a 40-char string like Xxx8Q~…:
+#   kubectl get secret duos-azure-client-secret -n terra-dev \
+#     -o jsonpath='{.data.azure-client-secret}' | base64 -d
 DUOS_AZURE_CLIENT_SECRET=
 # Dev B2C discovery URL
 DUOS_AZURE_ISSUER_URL=
 
 # --- OAuth flow ------------------------------------------------------------
+# Both variants are registered in B2C: keep the :3000 port when running the
+# dev server (pnpm start / pnpm run start:server); use
+# https://local.dsde-dev.broadinstitute.org/auth/callback (no port) when
+# running under docker compose, which is closer to how the app runs in k8s.
 DUOS_OAUTH_REDIRECT_URI=http://local.dsde-dev.broadinstitute.org:3000/auth/callback
 
 # --- Downstream API --------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -47,7 +47,7 @@ DUOS_AZURE_CLIENT_ID=a0e99acd-7b8d-400d-a1d3-60e497495806
 # here yields AADB2C90081 ("client_secret does not match") at the token
 # exchange. The real value is a 40-char string like Xxx8Q~…:
 #   kubectl get secret duos-azure-client-secret -n terra-dev \
-#     -o jsonpath='{.data.azure-client-secret}' | base64 -d
+#     -o jsonpath='{.data.azure-client-secret}' | base64 --decode
 DUOS_AZURE_CLIENT_SECRET=
 # Dev B2C discovery URL
 DUOS_AZURE_ISSUER_URL=

--- a/DEVNOTES.md
+++ b/DEVNOTES.md
@@ -31,6 +31,15 @@ pnpm install
 ### Notes on `render-configs`:
 
 * Ensure that `HOST` is not set in your shell environment, as it will override the value in `.env.local`.  You can check like so: `env | grep HOST=`.
+* **BFF env vars**: `--write_env true` also fetches the Azure B2C client secret from the dev cluster
+(`duos-azure-client-secret` in the `terra-dev` namespace, base64-decoded — the decode matters: the wrapped
+`.data` value fails at the token exchange with `AADB2C90081: client_secret does not match`) and generates a
+`DUOS_SESSION_SECRET`. An existing `.env.local` is backed up to `.env.local.bak` and its values (DB
+credentials, redirect URI, etc.) are carried forward, so it's safe to re-run on cert rotation. The
+consent DB user/password are fetched from the dev cluster's `consent-secrets` secret (keys
+`databaseUser`/`databasePassword`) when not already set, and `DUOS_DB_NAME` defaults to `consent`
+(its name in every environment) — a fresh run produces a fully populated `.env.local` with nothing
+left to fill in by hand. See [.env.example](.env.example) for what each variable means.
 * **Development against other envs**: If you want to point to other envs, you can populate public/config.json with the values from any
 environment by looking at the deployed configs in https://duos-k8s.dsde-{%ENV%}.broadinstitute.org/config.json where
 {%ENV%} is any of `dev`, `staging`, `alpha`, or `prod`. Remember to set the `env` value appropriately, for example,
@@ -129,7 +138,7 @@ Visit https://local.dsde-dev.broadinstitute.org/ to see the instance running und
 
 ### Environment variables
 
-The server reads sensitive configuration from `.env.local` in the project root (gitignored). Create this file before running `docker compose up`. The required variables are:
+The server reads sensitive configuration from `.env.local` in the project root (gitignored). Create this file before running `docker compose up` — `./scripts/render-configs.sh --write_env true` generates it fully populated, including the Azure B2C client secret and consent DB credentials fetched from the dev cluster (see the render-configs notes above). Under docker compose, also change `DUOS_OAUTH_REDIRECT_URI` to the portless variant (`https://local.dsde-dev.broadinstitute.org/auth/callback`) — both variants are registered in B2C, but the script's default (with `:3000`) targets the pnpm dev server. The required variables are:
 
 ```properties
 # Fastify session

--- a/scripts/render-configs.sh
+++ b/scripts/render-configs.sh
@@ -59,7 +59,7 @@ OAUTH_REDIRECT_URI_DEFAULT="http://local.dsde-dev.broadinstitute.org:3000/auth/c
 API_URL_DEFAULT="https://consent.dsde-dev.broadinstitute.org"
 
 parse_cli_args() {
-    while [ $# -gt 0 ]; do
+    while [[ $# -gt 0 ]]; do
         case "$1" in
             --project)
                 PROJECT=$2
@@ -97,7 +97,7 @@ write_certs() {
 
 # Echo the current value of a variable from an existing .env.local, if any.
 existing_env() {
-  if [ -f "$ENV_FILE" ]; then
+  if [[ -f "$ENV_FILE" ]]; then
     grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true
   fi
 }
@@ -110,7 +110,7 @@ fetch_azure_client_secret() {
   # a 40-char string like Xxx8Q~…
   AZURE_CLIENT_SECRET=$(kubectl get secret duos-azure-client-secret -n terra-dev \
     -o jsonpath='{.data.azure-client-secret}' | base64 --decode)
-  if [ -z "$AZURE_CLIENT_SECRET" ]; then
+  if [[ -z "$AZURE_CLIENT_SECRET" ]]; then
     error "Could not read azure-client-secret from the terra-dev namespace. Are you on the non-split VPN?"
   fi
 }
@@ -123,7 +123,7 @@ fetch_db_credentials() {
     -o jsonpath='{.data.databaseUser}' | base64 --decode)
   DB_PASSWORD_FETCHED=$(kubectl get secret consent-secrets -n terra-dev \
     -o jsonpath='{.data.databasePassword}' | base64 --decode)
-  if [ -z "$DB_USER_FETCHED" ] || [ -z "$DB_PASSWORD_FETCHED" ]; then
+  if [[ -z "$DB_USER_FETCHED" || -z "$DB_PASSWORD_FETCHED" ]]; then
     error "Could not read databaseUser/databasePassword from consent-secrets in the terra-dev namespace. Are you on the non-split VPN?"
   fi
 }
@@ -134,7 +134,7 @@ write_env() {
   # Per-setup values carry forward from an existing .env.local so a re-run
   # (e.g. on cert rotation) never loses hand-filled configuration.
   SESSION_SECRET=$(existing_env DUOS_SESSION_SECRET)
-  if [ -z "$SESSION_SECRET" ] || [ "$SESSION_SECRET" == "change-me-to-a-random-32-plus-char-string" ]; then
+  if [[ -z "$SESSION_SECRET" || "$SESSION_SECRET" == "change-me-to-a-random-32-plus-char-string" ]]; then
     SESSION_SECRET=$(openssl rand -base64 32)
   fi
   DB_HOST=$(existing_env DUOS_DB_HOST)
@@ -142,7 +142,7 @@ write_env() {
   DB_PORT=$(existing_env DUOS_DB_PORT)
   DB_USER=$(existing_env DUOS_DB_USER)
   DB_PASSWORD=$(existing_env DUOS_DB_PASSWORD)
-  if [ -z "$DB_USER" ] || [ -z "$DB_PASSWORD" ]; then
+  if [[ -z "$DB_USER" || -z "$DB_PASSWORD" ]]; then
     fetch_db_credentials
     DB_USER=${DB_USER:-$DB_USER_FETCHED}
     DB_PASSWORD=${DB_PASSWORD:-$DB_PASSWORD_FETCHED}
@@ -152,7 +152,7 @@ write_env() {
   REDIRECT_URI=$(existing_env DUOS_OAUTH_REDIRECT_URI)
   API_URL=$(existing_env DUOS_API_URL)
 
-  if [ -f "$ENV_FILE" ]; then
+  if [[ -f "$ENV_FILE" ]]; then
     echo "Backing up existing .env.local to .env.local.bak"
     cp "$ENV_FILE" "${ENV_FILE}.bak"
   fi
@@ -173,7 +173,7 @@ DUOS_SESSION_SECRET=$SESSION_SECRET
 # DB values must match whichever Postgres is being used — see DEVNOTES.md.
 # User/password default to the dev cluster's consent-secrets values.
 EOF
-    if [ -n "$DB_HOST" ]; then
+    if [[ -n "$DB_HOST" ]]; then
       echo "DUOS_DB_HOST=$DB_HOST"
     fi
     cat <<EOF
@@ -205,11 +205,11 @@ write_config() {
 parse_cli_args "$@"
 auth_gcloud
 write_certs
-if [ "$WRITE_ENV" == "true" ]
+if [[ "$WRITE_ENV" == "true" ]]
 then
   write_env
 fi
-if [ "$WRITE_CONFIG" == "true" ]
+if [[ "$WRITE_CONFIG" == "true" ]]
 then
   write_config
 fi

--- a/scripts/render-configs.sh
+++ b/scripts/render-configs.sh
@@ -100,9 +100,10 @@ write_certs() {
 # One layer of surrounding quotes is stripped, since this script writes
 # secret values single-quoted.
 existing_env() {
+  local var_name="$1"
   if [[ -f "$ENV_FILE" ]]; then
     local val
-    val=$(grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true)
+    val=$(grep -E "^${var_name}=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true)
     if [[ $val == \'*\' || $val == \"*\" ]]; then
       val=${val:1:${#val}-2}
     fi

--- a/scripts/render-configs.sh
+++ b/scripts/render-configs.sh
@@ -2,7 +2,7 @@
 # Populates configurations necessary for local development.
 # Certs are regenerated on a 3-month rotation so this script is optimized for that task.
 # You MUST be on the Non-Split Broad VPN to have a whitelisted Broad IP.
-# You MUST have jq, gcloud and kubectl installed to run this script.
+# You MUST have jq, gcloud, kubectl and openssl installed to run this script.
 # You MUST authenticate via gcloud
 #
 # See usage section below for more details. All arguments are optional.
@@ -10,12 +10,21 @@
 set -eu
 set -o pipefail
 
+# All output paths below are relative to this script's directory, so the
+# script behaves the same whether invoked from the repo root or from scripts/.
+cd "$(dirname "$0")"
+
 usage() {
     cat <<EOF
 Usage: $0 [OPTION]...
 Generate cert files for local development
   --project PROJECT     Google project where cert files are stored
-  --write_env WRITE_ENV             Write an .env.local file to project root. true|false. Defaults to false
+  --write_env WRITE_ENV             Write an .env.local file to project root, including the BFF
+                                    env vars (fetches the Azure B2C client secret and consent DB
+                                    credentials from the dev cluster and generates a session
+                                    secret). Values already set in an existing .env.local are
+                                    carried forward, and the old file is backed up to
+                                    .env.local.bak. true|false. Defaults to false
   --write_config WRITE_CONFIG       Write a config.json file in public. true|false. Defaults to false
   --help                Display this help and exit
 EOF
@@ -31,6 +40,23 @@ error() {
 PROJECT="broad-dsde-dev"
 WRITE_ENV="false"
 WRITE_CONFIG="false"
+
+ENV_FILE="../.env.local"
+
+# Dev-environment defaults for the BFF block written by --write_env. Only used
+# when the variable has no value in an existing .env.local — existing values
+# always carry forward. See .env.example for what each variable means.
+# The client ID is the hand-created dev app registration (B2C sign-in only
+# works with app registrations created by hand, not the terraform-created
+# ones); it is not secret.
+AZURE_CLIENT_ID_DEFAULT="a0e99acd-7b8d-400d-a1d3-60e497495806"
+# The consent database is named `consent` in every environment.
+DB_NAME_DEFAULT="consent"
+AZURE_ISSUER_URL_DEFAULT="https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin_duos_dev"
+# Both redirect URIs are registered in B2C: this one (with :3000) matches the
+# pnpm-start dev server; drop the port when running under docker compose.
+OAUTH_REDIRECT_URI_DEFAULT="http://local.dsde-dev.broadinstitute.org:3000/auth/callback"
+API_URL_DEFAULT="https://consent.dsde-dev.broadinstitute.org"
 
 parse_cli_args() {
     while [ $# -gt 0 ]; do
@@ -69,13 +95,102 @@ write_certs() {
   kubectl -n local-dev get configmaps kube-root-ca.crt -o 'go-template={{ index .data "ca.crt" }}' > ../ca-bundle.crt
 }
 
+# Echo the current value of a variable from an existing .env.local, if any.
+existing_env() {
+  if [ -f "$ENV_FILE" ]; then
+    grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true
+  fi
+}
+
+fetch_azure_client_secret() {
+  echo "Fetching Azure B2C client secret from the terra-dev namespace"
+  # kubectl's .data values are base64-wrapped, so the decode is mandatory:
+  # writing the wrapped value into .env.local produces AADB2C90081
+  # ("client_secret does not match") at the token exchange. The real value is
+  # a 40-char string like Xxx8Q~…
+  AZURE_CLIENT_SECRET=$(kubectl get secret duos-azure-client-secret -n terra-dev \
+    -o jsonpath='{.data.azure-client-secret}' | base64 --decode)
+  if [ -z "$AZURE_CLIENT_SECRET" ]; then
+    error "Could not read azure-client-secret from the terra-dev namespace. Are you on the non-split VPN?"
+  fi
+}
+
+# Fetches the consent DB user/password from the consent-secrets k8s secret in
+# the terra-dev namespace. Values are base64-decoded, same as the Azure secret.
+fetch_db_credentials() {
+  echo "Fetching consent DB credentials from the terra-dev namespace"
+  DB_USER_FETCHED=$(kubectl get secret consent-secrets -n terra-dev \
+    -o jsonpath='{.data.databaseUser}' | base64 --decode)
+  DB_PASSWORD_FETCHED=$(kubectl get secret consent-secrets -n terra-dev \
+    -o jsonpath='{.data.databasePassword}' | base64 --decode)
+  if [ -z "$DB_USER_FETCHED" ] || [ -z "$DB_PASSWORD_FETCHED" ]; then
+    error "Could not read databaseUser/databasePassword from consent-secrets in the terra-dev namespace. Are you on the non-split VPN?"
+  fi
+}
+
 write_env() {
+  fetch_azure_client_secret
+
+  # Per-setup values carry forward from an existing .env.local so a re-run
+  # (e.g. on cert rotation) never loses hand-filled configuration.
+  SESSION_SECRET=$(existing_env DUOS_SESSION_SECRET)
+  if [ -z "$SESSION_SECRET" ] || [ "$SESSION_SECRET" == "change-me-to-a-random-32-plus-char-string" ]; then
+    SESSION_SECRET=$(openssl rand -base64 32)
+  fi
+  DB_HOST=$(existing_env DUOS_DB_HOST)
+  DB_NAME=$(existing_env DUOS_DB_NAME)
+  DB_PORT=$(existing_env DUOS_DB_PORT)
+  DB_USER=$(existing_env DUOS_DB_USER)
+  DB_PASSWORD=$(existing_env DUOS_DB_PASSWORD)
+  if [ -z "$DB_USER" ] || [ -z "$DB_PASSWORD" ]; then
+    fetch_db_credentials
+    DB_USER=${DB_USER:-$DB_USER_FETCHED}
+    DB_PASSWORD=${DB_PASSWORD:-$DB_PASSWORD_FETCHED}
+  fi
+  AZURE_CLIENT_ID=$(existing_env DUOS_AZURE_CLIENT_ID)
+  ISSUER_URL=$(existing_env DUOS_AZURE_ISSUER_URL)
+  REDIRECT_URI=$(existing_env DUOS_OAUTH_REDIRECT_URI)
+  API_URL=$(existing_env DUOS_API_URL)
+
+  if [ -f "$ENV_FILE" ]; then
+    echo "Backing up existing .env.local to .env.local.bak"
+    cp "$ENV_FILE" "${ENV_FILE}.bak"
+  fi
+
   echo "Generating .env.local file"
-  echo "
+  {
+    cat <<EOF
+# Generated by scripts/render-configs.sh --write_env true. Values already
+# present in a previous .env.local are carried forward; see .env.example for
+# what each variable means.
 HOST=local.dsde-dev.broadinstitute.org
 HTTPS=true
 SSL_CRT_FILE=server.crt
-SSL_KEY_FILE=server.key" > ../.env.local
+SSL_KEY_FILE=server.key
+
+DUOS_SESSION_SECRET=$SESSION_SECRET
+
+# DB values must match whichever Postgres is being used — see DEVNOTES.md.
+# User/password default to the dev cluster's consent-secrets values.
+EOF
+    if [ -n "$DB_HOST" ]; then
+      echo "DUOS_DB_HOST=$DB_HOST"
+    fi
+    cat <<EOF
+DUOS_DB_NAME=${DB_NAME:-$DB_NAME_DEFAULT}
+DUOS_DB_PORT=${DB_PORT:-5432}
+DUOS_DB_USER=$DB_USER
+DUOS_DB_PASSWORD=$DB_PASSWORD
+
+# The client secret below was fetched fresh (and base64-decoded) from the
+# duos-azure-client-secret secret in the terra-dev namespace by this run.
+DUOS_AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-$AZURE_CLIENT_ID_DEFAULT}
+DUOS_AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET
+DUOS_AZURE_ISSUER_URL=${ISSUER_URL:-$AZURE_ISSUER_URL_DEFAULT}
+DUOS_OAUTH_REDIRECT_URI=${REDIRECT_URI:-$OAUTH_REDIRECT_URI_DEFAULT}
+DUOS_API_URL=${API_URL:-$API_URL_DEFAULT}
+EOF
+  } > "$ENV_FILE"
 }
 
 write_config() {

--- a/scripts/render-configs.sh
+++ b/scripts/render-configs.sh
@@ -92,13 +92,21 @@ write_certs() {
   echo "Writing cert files"
   kubectl -n local-dev get secrets local-dev-cert -o 'go-template={{ index .data "tls.crt" | base64decode }}' > ../server.crt
   kubectl -n local-dev get secrets local-dev-cert -o 'go-template={{ index .data "tls.key" | base64decode }}' > ../server.key
+  chmod 600 ../server.key
   kubectl -n local-dev get configmaps kube-root-ca.crt -o 'go-template={{ index .data "ca.crt" }}' > ../ca-bundle.crt
 }
 
 # Echo the current value of a variable from an existing .env.local, if any.
+# One layer of surrounding quotes is stripped, since this script writes
+# secret values single-quoted.
 existing_env() {
   if [[ -f "$ENV_FILE" ]]; then
-    grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true
+    local val
+    val=$(grep -E "^$1=" "$ENV_FILE" | tail -1 | cut -d= -f2- || true)
+    if [[ $val == \'*\' || $val == \"*\" ]]; then
+      val=${val:1:${#val}-2}
+    fi
+    echo "$val"
   fi
 }
 
@@ -155,6 +163,7 @@ write_env() {
   if [[ -f "$ENV_FILE" ]]; then
     echo "Backing up existing .env.local to .env.local.bak"
     cp "$ENV_FILE" "${ENV_FILE}.bak"
+    chmod 600 "${ENV_FILE}.bak"
   fi
 
   echo "Generating .env.local file"
@@ -168,7 +177,7 @@ HTTPS=true
 SSL_CRT_FILE=server.crt
 SSL_KEY_FILE=server.key
 
-DUOS_SESSION_SECRET=$SESSION_SECRET
+DUOS_SESSION_SECRET='$SESSION_SECRET'
 
 # DB values must match whichever Postgres is being used — see DEVNOTES.md.
 # User/password default to the dev cluster's consent-secrets values.
@@ -179,18 +188,19 @@ EOF
     cat <<EOF
 DUOS_DB_NAME=${DB_NAME:-$DB_NAME_DEFAULT}
 DUOS_DB_PORT=${DB_PORT:-5432}
-DUOS_DB_USER=$DB_USER
-DUOS_DB_PASSWORD=$DB_PASSWORD
+DUOS_DB_USER='$DB_USER'
+DUOS_DB_PASSWORD='$DB_PASSWORD'
 
 # The client secret below was fetched fresh (and base64-decoded) from the
 # duos-azure-client-secret secret in the terra-dev namespace by this run.
 DUOS_AZURE_CLIENT_ID=${AZURE_CLIENT_ID:-$AZURE_CLIENT_ID_DEFAULT}
-DUOS_AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET
+DUOS_AZURE_CLIENT_SECRET='$AZURE_CLIENT_SECRET'
 DUOS_AZURE_ISSUER_URL=${ISSUER_URL:-$AZURE_ISSUER_URL_DEFAULT}
 DUOS_OAUTH_REDIRECT_URI=${REDIRECT_URI:-$OAUTH_REDIRECT_URI_DEFAULT}
 DUOS_API_URL=${API_URL:-$API_URL_DEFAULT}
 EOF
   } > "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
 }
 
 write_config() {


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-3979

### Summary
Update `scripts/render-configs.sh` to include an option for writing a BFF configuration block. Pulls secrets from k8s in the same way that we do for cert files and has the same basic requirements, e.g. non-split VPN, jq, kubectl, etc.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
