### PR TITLE
[DT-3986] Stabilize FundingResourceAddEdit test

### DIFF
--- a/test/components/funding_resource_list/FundingResourceAddEdit.spec.tsx
+++ b/test/components/funding_resource_list/FundingResourceAddEdit.spec.tsx
@@ -21,7 +21,9 @@ const sampleFunding: FundingResource = {
 
 describe('FundingResourceAddEdit component', () => {
   it('opens add form and enforces validation disabling save then adds', async () => {
-    const user = userEvent.setup()
+    // delay: null skips the timer between keystrokes; ~48 chars here otherwise
+    // risks timing out on CI, and a timeout mid-type leaks keystrokes into the next test.
+    const user = userEvent.setup({ delay: null })
     const collected: FundingResource[] = []
     const { container } = render(
       <FundingResourceAddEdit
@@ -43,7 +45,7 @@ describe('FundingResourceAddEdit component', () => {
   })
 
   it('edits existing funding resource and saves changes', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     const resources: FundingResource[] = [sampleFunding]
     const onFundingResourcesChange = vi.fn((updated: FundingResource[]) => {
       expect(updated[0].funderName).toBe('Funder A Edited')


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3986

### Summary

`FundingResourceAddEdit.spec.tsx` intermittently failed on CI with a garbled assertion like `expected 'rant Fnuunmdbeerr A Edited' to be 'Funder A Edited'`. The scrambled text is test 1's `'New Grant number'` interleaved with test 2's `'Funder A Edited'`: with the default `userEvent` inter-keystroke delay, test 1's ~48 typed characters can exceed the 5s test timeout on a slow CI runner, and vitest then starts test 2 while the timed-out `user.type` call keeps dispatching its remaining keystrokes into the newly focused input.

Fixed by using `userEvent.setup({ delay: null })` so typing runs without timers, matching the existing pattern in `PresentationAddEdit.spec.tsx`.

### Test plan

- Reproduced the interleaved-keystroke failure deterministically with `--testTimeout=400` before the fix; after the fix, test 2 stays clean even under that artificial timeout
- 5 consecutive passing runs of the file at the default timeout

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)