### PR TITLE
[DT-3976] Proxy TDR for snapshot enumeration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,6 @@ DUOS_API_URL=https://consent.dsde-dev.broadinstitute.org
 # ECM (externalcreds), proxied at /ecm-api for RAS/eRA Commons linking.
 # Optional: when unset, the BFF boots without the ECM proxy and logs a warning.
 DUOS_ECM_URL=https://externalcreds.dsde-dev.broadinstitute.org
+# TDR, proxied at /tdr-api for snapshot enumeration on dataset pages.
+# Optional, same behavior as DUOS_ECM_URL when unset.
+DUOS_TDR_URL=https://jade.datarepo-dev.broadinstitute.org

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,7 +17,8 @@ import { handleCallback } from './auth/callback.js'
 import { handleLogout } from './auth/logout.js'
 import { getMe } from './auth/me.js'
 import { apiProxy } from './proxy/apiProxy.js'
-import { ecmProxy } from './proxy/ecmProxy.js'
+import { ECM_PROXY_PREFIX, ecmProxy } from './proxy/ecmProxy.js'
+import { TDR_PROXY_PREFIX, tdrProxy } from './proxy/tdrProxy.js'
 import { configPath, readConfig } from './config.js'
 import './types/session.js'
 import FastifyVite from '@fastify/vite'
@@ -234,18 +235,24 @@ export async function buildApp(): Promise<AppInstance> {
     // exposes no proxy route at all.
     await fastify.register(apiProxy)
 
-    // The ECM proxy (story 3-I) — RAS/eRA Commons account linking. Same gates
-    // as the DUOS API proxy, plus one more: DUOS_ECM_URL itself. Conditional
-    // rather than required, unlike DUOS_API_URL above, because ECM serves
-    // exactly one feature — a BFF deployment whose env predates the variable
-    // (the terra-helmfile change ships separately) should boot with linking
-    // broken and a warning naming the fix, not crash-loop the whole app.
-    if (process.env.DUOS_ECM_URL) {
-      fastify.log.info('[server] DUOS_ECM_URL is set — registering the ECM proxy')
-      await fastify.register(ecmProxy)
-    }
-    else {
-      fastify.log.warn('[server] DUOS_ECM_URL is not set — the /ecm-api proxy is disabled, so RAS/eRA Commons account linking will fail in this BFF environment')
+    // The single-feature upstream proxies. Same gates as the DUOS API proxy,
+    // plus one more each: their own env var. Conditional rather than required,
+    // unlike DUOS_API_URL above, because each serves exactly one feature — a
+    // BFF deployment whose env predates the variable (the terra-helmfile
+    // change ships separately) should boot with that feature broken and a
+    // warning naming the fix, not crash-loop the whole app.
+    const optionalProxies = [
+      { envVar: 'DUOS_ECM_URL', prefix: ECM_PROXY_PREFIX, register: ecmProxy, feature: 'RAS/eRA Commons account linking' },
+      { envVar: 'DUOS_TDR_URL', prefix: TDR_PROXY_PREFIX, register: tdrProxy, feature: 'TDR snapshot enumeration on dataset pages' },
+    ] as const
+    for (const { envVar, prefix, register, feature } of optionalProxies) {
+      if (process.env[envVar]) {
+        fastify.log.info(`[server] ${envVar} is set — registering the ${prefix} proxy`)
+        await fastify.register(register)
+      }
+      else {
+        fastify.log.warn(`[server] ${envVar} is not set — the ${prefix} proxy is disabled, so ${feature} will fail in this BFF environment`)
+      }
     }
   }
   else {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -237,9 +237,7 @@ export async function buildApp(): Promise<AppInstance> {
 
     // The single-feature upstream proxies. Same gates as the DUOS API proxy,
     // plus one more each: their own env var. Conditional rather than required,
-    // unlike DUOS_API_URL above, because each serves exactly one feature — a
-    // BFF deployment should boot with that feature broken and a warning naming
-    // the fix, not crash-loop the whole app.
+    // unlike DUOS_API_URL above, because each serves exactly one feature.
     const optionalProxies = [
       { envVar: 'DUOS_ECM_URL', prefix: ECM_PROXY_PREFIX, register: ecmProxy, feature: 'RAS/eRA Commons account linking' },
       { envVar: 'DUOS_TDR_URL', prefix: TDR_PROXY_PREFIX, register: tdrProxy, feature: 'TDR snapshot enumeration on dataset pages' },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -238,9 +238,8 @@ export async function buildApp(): Promise<AppInstance> {
     // The single-feature upstream proxies. Same gates as the DUOS API proxy,
     // plus one more each: their own env var. Conditional rather than required,
     // unlike DUOS_API_URL above, because each serves exactly one feature — a
-    // BFF deployment whose env predates the variable (the terra-helmfile
-    // change ships separately) should boot with that feature broken and a
-    // warning naming the fix, not crash-loop the whole app.
+    // BFF deployment should boot with that feature broken and a warning naming
+    // the fix, not crash-loop the whole app.
     const optionalProxies = [
       { envVar: 'DUOS_ECM_URL', prefix: ECM_PROXY_PREFIX, register: ecmProxy, feature: 'RAS/eRA Commons account linking' },
       { envVar: 'DUOS_TDR_URL', prefix: TDR_PROXY_PREFIX, register: tdrProxy, feature: 'TDR snapshot enumeration on dataset pages' },

--- a/server/src/proxy/tdrProxy.ts
+++ b/server/src/proxy/tdrProxy.ts
@@ -1,0 +1,52 @@
+import type { FastifyInstance } from 'fastify'
+import {
+  registerUpstreamProxy,
+  upstreamPath as stripPrefix,
+  type UpstreamProxyOptions,
+} from './upstreamProxy.js'
+
+/**
+ * The TDR proxy.
+ *
+ * Dataset pages enumerate the Terra Data Repository snapshots linked to DUOS
+ * datasets: `TerraDataRepo.listSnapshotsByDatasetIds` issues
+ * `GET /api/repository/v1/snapshots?limit=1000&duosDatasetIds=…`, batched 70
+ * ids per request and fired concurrently. Two properties of the shared
+ * machinery matter for that shape: the query string is forwarded byte-for-byte
+ * (the repeated `duosDatasetIds` params must not be re-encoded or collapsed),
+ * and the bounded upstream socket pool absorbs the concurrent burst.
+ *
+ * Same rules as the ECM proxy, for the same reasons — see ecmProxy.ts:
+ *   - **No unauthenticated paths.** Snapshot enumeration is signed-in only.
+ *   - **No CSRF exemptions.** The client only GETs today; any future unsafe
+ *     method must present an `X-CSRF-Token`.
+ *   - **An upstream 401 does NOT end the session.** TDR is a Terra service
+ *     authenticating on its own terms (via Sam), so its 401 is not
+ *     authoritative about the BFF session; it passes through
+ *     (response-hardened, `www-authenticate` stripped) for the dataset UI to
+ *     surface as a failed enumeration.
+ */
+export const TDR_PROXY_PREFIX = '/tdr-api'
+
+const NO_PATHS: ReadonlySet<string> = new Set()
+
+/** `upstreamPath` bound to this proxy's prefix, kept for the tests' table cases. */
+export function tdrUpstreamPath(url: string): string {
+  return stripPrefix(url, TDR_PROXY_PREFIX)
+}
+
+/**
+ * Registers the TDR proxy. Handed to `fastify.register()` (never wrapped in
+ * `fastify-plugin`) so the shared machinery's parser and error-handler
+ * overrides stay encapsulated in this scope — see upstreamProxy.ts.
+ */
+export async function tdrProxy(app: FastifyInstance, options: UpstreamProxyOptions = {}): Promise<void> {
+  await registerUpstreamProxy(app, {
+    prefix: TDR_PROXY_PREFIX,
+    upstreamEnvVar: 'DUOS_TDR_URL',
+    logTag: 'tdr-proxy',
+    unauthenticatedPaths: NO_PATHS,
+    csrfExemptUnsafeRequests: NO_PATHS,
+    destroySessionOnUpstream401: false,
+  }, options)
+}

--- a/server/src/proxy/tdrProxy.ts
+++ b/server/src/proxy/tdrProxy.ts
@@ -35,11 +35,6 @@ export function tdrUpstreamPath(url: string): string {
   return stripPrefix(url, TDR_PROXY_PREFIX)
 }
 
-/**
- * Registers the TDR proxy. Handed to `fastify.register()` (never wrapped in
- * `fastify-plugin`) so the shared machinery's parser and error-handler
- * overrides stay encapsulated in this scope — see upstreamProxy.ts.
- */
 export async function tdrProxy(app: FastifyInstance, options: UpstreamProxyOptions = {}): Promise<void> {
   await registerUpstreamProxy(app, {
     prefix: TDR_PROXY_PREFIX,

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -274,6 +274,7 @@ describe('BFF auth route registration', () => {
   afterEach(async () => {
     delete process.env.CONFIG_PATH
     delete process.env.DUOS_ECM_URL
+    delete process.env.DUOS_TDR_URL
     const { resetConfigCache } = await import('../src/config.js')
     resetConfigCache()
     // Guarded: rmSync(undefined) throws and would mask the real failure of a
@@ -409,6 +410,42 @@ describe('BFF auth route registration', () => {
     const localApp = await buildAppWithConfig({ bffEnabled: false })
 
     const res = await localApp.inject({ method: 'GET', url: '/ecm-api/api/oauth/v1/ras/authorization-url' })
+
+    expect(res.statusCode).toBe(200)
+
+    await localApp.close()
+  })
+
+  // Same three-way gating as /ecm-api, against the TDR env var and prefix.
+  it('registers the /tdr-api proxy route when bffEnabled is true and DUOS_TDR_URL is set', async () => {
+    process.env.DUOS_TDR_URL = 'https://jade.datarepo-dev.broadinstitute.org'
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const res = await localApp.inject({ method: 'GET', url: '/tdr-api/api/repository/v1/snapshots' })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json()).toEqual({ error: 'unauthenticated' })
+
+    await localApp.close()
+  })
+
+  it('boots without the /tdr-api route when bffEnabled is true but DUOS_TDR_URL is not set', async () => {
+    delete process.env.DUOS_TDR_URL
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const res = await localApp.inject({ method: 'GET', url: '/tdr-api/api/repository/v1/snapshots' })
+
+    // Falls through to the SPA fallback instead of the proxy's 401.
+    expect(res.statusCode).toBe(200)
+
+    await localApp.close()
+  })
+
+  it('does not register the /tdr-api proxy route when bffEnabled is false, even with DUOS_TDR_URL set', async () => {
+    process.env.DUOS_TDR_URL = 'https://jade.datarepo-dev.broadinstitute.org'
+    const localApp = await buildAppWithConfig({ bffEnabled: false })
+
+    const res = await localApp.inject({ method: 'GET', url: '/tdr-api/api/repository/v1/snapshots' })
 
     expect(res.statusCode).toBe(200)
 

--- a/server/test/tdrProxy.test.ts
+++ b/server/test/tdrProxy.test.ts
@@ -129,9 +129,6 @@ describe('tdrProxy', () => {
   })
 
   describe('no unauthenticated paths', () => {
-    // The DUOS API proxy allowlists five paths; TDR allowlists none. Pinned
-    // against a path the sibling proxy would wave through, so the two configs
-    // cannot be conflated.
     it.each(['/status', SNAPSHOTS_PATH, '/'])('%s is unreachable without a session', async (path) => {
       app = await buildTdrApp()
 
@@ -144,8 +141,6 @@ describe('tdrProxy', () => {
   })
 
   describe('CSRF enforcement', () => {
-    // The client only GETs TDR today, but the wildcard route proxies every
-    // method — an unsafe one must present a token like anywhere else.
     it('rejects a POST without a token before it reaches TDR', async () => {
       app = await buildTdrApp(freshSession())
       const { cookie } = await csrfCredentials(app)
@@ -161,9 +156,6 @@ describe('tdrProxy', () => {
       expect(upstream.received).toHaveLength(0)
     })
 
-    // The DUOS API proxy exempts the signed-out Contact Us POSTs; the TDR
-    // config's exemption set is empty, and this is what proves it stays that
-    // way — the same path that is exempt through /duos-api is enforced here.
     it('has no unsafe-request exemptions: POST /support/request is enforced through this prefix', async () => {
       app = await buildTdrApp(freshSession())
 
@@ -208,9 +200,7 @@ describe('tdrProxy', () => {
         res.end('{"total":0,"items":[]}')
       })
 
-      // The request carries an existing session cookie — a cookieless GET
-      // would mint a session, and @fastify/session's own legitimate
-      // Set-Cookie would be indistinguishable from a leaked upstream one.
+      // The request carries an existing session cookie
       const { cookie } = await csrfCredentials(app)
       const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}`, headers: { cookie } })
 
@@ -221,9 +211,6 @@ describe('tdrProxy', () => {
   })
 
   describe('an upstream 401 does not end the session', () => {
-    // The divergence from the DUOS API proxy, and the reason it exists: TDR
-    // authenticates on its own terms (via Sam), so its 401 must surface to the
-    // dataset UI as a failed enumeration rather than sign the user out of DUOS.
     it('passes the 401 through with the session and cookie intact', async () => {
       app = await buildTdrApp(freshSession())
       const tracked = trackSession(app)
@@ -276,9 +263,6 @@ describe('tdrProxy', () => {
   })
 
   describe('DUOS_TDR_URL validation', () => {
-    // Same guard as DUOS_API_URL, and the error must name THIS variable — a
-    // misconfigured TDR origin diagnosed as an API-proxy problem would send
-    // whoever reads the crash log to the wrong Helm value.
     it.each([
       ['unset', undefined],
       ['a bare hostname', 'jade.datarepo-dev.broadinstitute.org'],

--- a/server/test/tdrProxy.test.ts
+++ b/server/test/tdrProxy.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { type FastifyInstance } from 'fastify'
+import { RefreshFailedError } from '../src/auth/refresh.js'
+import { CSRF_ERROR_CODE } from '../src/proxy/upstreamProxy.js'
+import { TDR_PROXY_PREFIX, tdrProxy, tdrUpstreamPath } from '../src/proxy/tdrProxy.js'
+import {
+  SESSION_COOKIE,
+  type SessionSeed,
+  type Upstream,
+  buildAppShell,
+  csrfCredentials,
+  nowSeconds,
+  seedSession,
+  startUpstream,
+  trackSession,
+} from './proxyTestHarness.js'
+
+/**
+ * The TDR proxy suite.
+ *
+ * Same division of labor as ecmProxy.test.ts: the shared machinery is
+ * exercised across the 100+ cases in apiProxy.test.ts, and this suite pins
+ * down the TDR *configuration* — the prefix and upstream env var, no
+ * unauthenticated paths, no CSRF exemptions, the upstream-401 pass-through —
+ * against the one call the client actually makes: batched, concurrent
+ * `GET /api/repository/v1/snapshots?limit=1000&duosDatasetIds=…` requests
+ * (TerraDataRepo.listSnapshotsByDatasetIds), whose repeated query params must
+ * survive the proxy byte-for-byte.
+ */
+
+vi.mock('../src/auth/refresh.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/auth/refresh.js')>()
+  return { ...actual, refreshAccessToken: vi.fn() }
+})
+
+// The one path the client calls today (TerraDataRepo.ts).
+const SNAPSHOTS_PATH = '/api/repository/v1/snapshots'
+
+async function buildTdrApp(seed?: SessionSeed): Promise<FastifyInstance> {
+  const app = await buildAppShell()
+  if (seed) {
+    seedSession(app, seed)
+  }
+  await app.register(tdrProxy)
+  return app
+}
+
+describe('tdrProxy', () => {
+  let upstream: Upstream
+  let app: FastifyInstance | undefined
+
+  beforeEach(async () => {
+    upstream = await startUpstream()
+    process.env.DUOS_TDR_URL = upstream.origin
+    const { refreshAccessToken } = await import('../src/auth/refresh.js')
+    vi.mocked(refreshAccessToken).mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+    await upstream.close()
+    delete process.env.DUOS_TDR_URL
+  })
+
+  /** A session comfortably outside the refresh window. */
+  const freshSession = (accessToken = 'session-access-token'): SessionSeed => ({
+    accessToken,
+    tokenExpiry: nowSeconds() + 3600,
+  })
+
+  describe('tdrUpstreamPath', () => {
+    it.each([
+      [`${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}?limit=1000&duosDatasetIds=DUOS-000852`, SNAPSHOTS_PATH],
+      [`${TDR_PROXY_PREFIX}/`, '/'],
+      [TDR_PROXY_PREFIX, '/'],
+    ])('maps %s to %s', (url, expected) => {
+      expect(tdrUpstreamPath(url)).toBe(expected)
+    })
+  })
+
+  describe('routing and the request leg', () => {
+    // The client batches 70 ids into one query string as repeated
+    // duosDatasetIds params — the enumeration breaks if the proxy re-encodes,
+    // collapses, or reorders them, so the assertion is byte-for-byte.
+    it('forwards the batched snapshot query verbatim, with the session token injected', async () => {
+      app = await buildTdrApp(freshSession('the-session-token'))
+      const ids = Array.from({ length: 70 }, (_, i) => `DUOS-${String(i).padStart(6, '0')}`)
+      const query = `limit=1000&duosDatasetIds=${ids.join('&duosDatasetIds=')}`
+
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}?${query}` })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().url).toBe(`${SNAPSHOTS_PATH}?${query}`)
+      expect(upstream.last().headers.authorization).toBe('Bearer the-session-token')
+      expect(upstream.last().headers['x-app-id']).toBe('DUOS')
+    })
+
+    // listSnapshotsByDatasetIds fires its batches with Promise.all — the
+    // proxy's socket pool must serve them all, not just the first.
+    it('serves concurrent batched requests', async () => {
+      app = await buildTdrApp(freshSession())
+      const localApp = app
+
+      const responses = await Promise.all(Array.from({ length: 5 }, (_, i) =>
+        localApp.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}?limit=1000&duosDatasetIds=DUOS-${i}` }),
+      ))
+
+      expect(responses.map(r => r.statusCode)).toEqual([200, 200, 200, 200, 200])
+      expect(upstream.received).toHaveLength(5)
+    })
+
+    it('strips the session cookie and the client Authorization header before forwarding', async () => {
+      app = await buildTdrApp(freshSession('the-session-token'))
+
+      const { cookie } = await csrfCredentials(app)
+      await app.inject({
+        method: 'GET',
+        url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}?limit=1000`,
+        // The legacy client constructed its own bearer header; whatever a
+        // client sends must never reach TDR.
+        headers: { cookie, authorization: 'Bearer browser-held-token' },
+      })
+
+      const forwarded = upstream.last().headers
+      expect(forwarded.cookie).toBeUndefined()
+      expect(forwarded.authorization).toBe('Bearer the-session-token')
+    })
+  })
+
+  describe('no unauthenticated paths', () => {
+    // The DUOS API proxy allowlists five paths; TDR allowlists none. Pinned
+    // against a path the sibling proxy would wave through, so the two configs
+    // cannot be conflated.
+    it.each(['/status', SNAPSHOTS_PATH, '/'])('%s is unreachable without a session', async (path) => {
+      app = await buildTdrApp()
+
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${path}` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'unauthenticated' })
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
+  describe('CSRF enforcement', () => {
+    // The client only GETs TDR today, but the wildcard route proxies every
+    // method — an unsafe one must present a token like anywhere else.
+    it('rejects a POST without a token before it reaches TDR', async () => {
+      app = await buildTdrApp(freshSession())
+      const { cookie } = await csrfCredentials(app)
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}`,
+        headers: { cookie },
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toMatchObject({ error: CSRF_ERROR_CODE })
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    // The DUOS API proxy exempts the signed-out Contact Us POSTs; the TDR
+    // config's exemption set is empty, and this is what proves it stays that
+    // way — the same path that is exempt through /duos-api is enforced here.
+    it('has no unsafe-request exemptions: POST /support/request is enforced through this prefix', async () => {
+      app = await buildTdrApp(freshSession())
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${TDR_PROXY_PREFIX}/support/request`,
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toMatchObject({ error: CSRF_ERROR_CODE })
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('passes a GET without a token', async () => {
+      app = await buildTdrApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}` })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.received).toHaveLength(1)
+    })
+  })
+
+  describe('the response leg', () => {
+    it('hardens every proxied response against executing on the SPA origin', async () => {
+      app = await buildTdrApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}?limit=1000` })
+
+      expect(res.headers['x-content-type-options']).toBe('nosniff')
+      expect(res.headers['content-security-policy']).toBe('sandbox')
+    })
+
+    it('strips set-cookie and www-authenticate from the upstream response', async () => {
+      app = await buildTdrApp(freshSession())
+      upstream.respondWith((_req, res) => {
+        res.writeHead(200, {
+          'set-cookie': 'sessionId=upstream-forged; Path=/',
+          'www-authenticate': 'Bearer realm="tdr"',
+          'content-type': 'application/json',
+        })
+        res.end('{"total":0,"items":[]}')
+      })
+
+      // The request carries an existing session cookie — a cookieless GET
+      // would mint a session, and @fastify/session's own legitimate
+      // Set-Cookie would be indistinguishable from a leaked upstream one.
+      const { cookie } = await csrfCredentials(app)
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}`, headers: { cookie } })
+
+      expect(res.headers['set-cookie']).toBeUndefined()
+      expect(res.headers['www-authenticate']).toBeUndefined()
+      expect(res.json()).toEqual({ total: 0, items: [] })
+    })
+  })
+
+  describe('an upstream 401 does not end the session', () => {
+    // The divergence from the DUOS API proxy, and the reason it exists: TDR
+    // authenticates on its own terms (via Sam), so its 401 must surface to the
+    // dataset UI as a failed enumeration rather than sign the user out of DUOS.
+    it('passes the 401 through with the session and cookie intact', async () => {
+      app = await buildTdrApp(freshSession())
+      const tracked = trackSession(app)
+      upstream.respondWith((_req, res) => {
+        res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer error="invalid_token"' })
+        res.end('{"message":"token rejected by TDR"}')
+      })
+
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}?limit=1000` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ message: 'token rejected by TDR' })
+      // The upstream's bearer challenge still may not reach the browser.
+      expect(res.headers['www-authenticate']).toBeUndefined()
+      // No Set-Cookie clearing the session — the DUOS session survives.
+      expect(res.cookies.find(cookie => cookie.name === SESSION_COOKIE && cookie.value === '')).toBeUndefined()
+      expect(await tracked.stored()).not.toBeNull()
+    })
+  })
+
+  describe('token freshness', () => {
+    it('refreshes a near-expiry token before forwarding', async () => {
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      vi.mocked(refreshAccessToken).mockImplementation(async (request) => {
+        request.session.accessToken = 'renewed-token'
+        request.session.tokenExpiry = nowSeconds() + 3600
+      })
+      app = await buildTdrApp({ accessToken: 'stale-token', tokenExpiry: nowSeconds() })
+
+      await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}` })
+
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1)
+      expect(upstream.last().headers.authorization).toBe('Bearer renewed-token')
+    })
+
+    it('returns 401 and clears the cookie when the refresh fails terminally', async () => {
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      vi.mocked(refreshAccessToken).mockRejectedValue(new RefreshFailedError('refresh_failed'))
+      app = await buildTdrApp({ accessToken: 'stale-token', tokenExpiry: nowSeconds() })
+
+      const res = await app.inject({ method: 'GET', url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'session_expired' })
+      expect(res.cookies).toContainEqual(
+        expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
+      )
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
+  describe('DUOS_TDR_URL validation', () => {
+    // Same guard as DUOS_API_URL, and the error must name THIS variable — a
+    // misconfigured TDR origin diagnosed as an API-proxy problem would send
+    // whoever reads the crash log to the wrong Helm value.
+    it.each([
+      ['unset', undefined],
+      ['a bare hostname', 'jade.datarepo-dev.broadinstitute.org'],
+      ['an origin with a path', 'https://jade.datarepo-dev.broadinstitute.org/api'],
+    ])('refuses to register when DUOS_TDR_URL is %s', async (_label, value) => {
+      if (value === undefined) {
+        delete process.env.DUOS_TDR_URL
+      }
+      else {
+        process.env.DUOS_TDR_URL = value
+      }
+      const shell = await buildAppShell()
+      shell.register(tdrProxy)
+
+      await expect(shell.ready()).rejects.toThrow('DUOS_TDR_URL')
+      await shell.close()
+    })
+  })
+})


### PR DESCRIPTION
### Addresses
Partially addresses [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) (BFF Phase 3 — API proxy, story 3-J)
Fully addresses https://broadworkbench.atlassian.net/browse/DT-3976

### Summary
- Adds `server/src/proxy/tdrProxy.ts`: `/tdr-api/*` → new `DUOS_TDR_URL` env var, built on the shared `upstreamProxy.ts` machinery from #3846 and configured exactly like the ECM proxy — no unauthenticated paths, no CSRF exemptions, and an upstream 401 passes through **without** destroying the BFF session (TDR authenticates via Sam, so its 401 is not authoritative about the session; a failed enumeration should surface on the dataset page, not sign the user out).
- The client's one call is batched, concurrent `GET /api/repository/v1/snapshots?limit=1000&duosDatasetIds=…` requests (70 ids per batch, `Promise.all`). The test suite pins the two properties that call depends on: the repeated query params survive the proxy byte-for-byte, and concurrent batches are all served.
- With two single-feature proxies, `index.ts`'s conditional registration becomes a loop over `[ECM, TDR]`; each env var stays optional — a BFF deployment without it boots, logs a warning naming the variable and the broken feature, and leaves that route dark. `DUOS_TDR_URL` is already staged in terra-helmfile ([#6482](https://github.com/broadinstitute/terra-helmfile/pull/6482), dev: `https://jade.datarepo-dev.broadinstitute.org`).

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DT-3608]: https://broadworkbench.atlassian.net/browse/DT-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ