### PR TITLE
[DT-3986] Raise FundingResourceAddEdit test timeouts to 15s

### DIFF
--- a/test/components/funding_resource_list/FundingResourceAddEdit.spec.tsx
+++ b/test/components/funding_resource_list/FundingResourceAddEdit.spec.tsx
@@ -23,6 +23,9 @@ describe('FundingResourceAddEdit component', () => {
   it('opens add form and enforces validation disabling save then adds', async () => {
     // delay: null skips the timer between keystrokes; ~48 chars here otherwise
     // risks timing out on CI, and a timeout mid-type leaks keystrokes into the next test.
+    // Each keystroke still re-renders the whole form (incl. react-select), so a
+    // saturated CI runner can exceed 5s regardless — hence the 15s timeout below,
+    // matching PresentationAddEdit.spec.tsx.
     const user = userEvent.setup({ delay: null })
     const collected: FundingResource[] = []
     const { container } = render(
@@ -42,7 +45,7 @@ describe('FundingResourceAddEdit component', () => {
     expect(collected).toHaveLength(1)
     expect(collected[0].funderName).toBe('New Funder')
     expect(collected[0].projectTitle).toBe('New Project')
-  })
+  }, 15000)
 
   it('edits existing funding resource and saves changes', async () => {
     const user = userEvent.setup({ delay: null })
@@ -62,5 +65,5 @@ describe('FundingResourceAddEdit component', () => {
     await user.clear(container.querySelector('#funderName')!)
     await user.type(container.querySelector('#funderName')!, 'Funder A Edited')
     await user.click(container.querySelector('.collaborator-form-add-save-button')!)
-  })
+  }, 15000)
 })


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3986

### Summary

Follow-up to #3845. `delay: null` removed the inter-keystroke timers (and with them the keystroke-leak corruption), but the add-form test still timed out at 5s on a saturated CI runner: each of its ~48 keystrokes re-renders the whole form, including a react-select, so under heavy load the test body alone can exceed the default timeout. The failing run's suite took 356s with 290s of import time — a heavily loaded machine.

This raises both tests' timeouts to 15s, the same pattern `PresentationAddEdit.spec.tsx` uses for its heavy-typing test.

### Test plan

- File passes locally in ~0.6s of test time; the 15s ceiling only matters under CI load
- Same `delay: null` + per-test timeout combination already proven on `PresentationAddEdit.spec.tsx`

### Reviewer Note
If other test files start timing out under CI load too, the better fix would be raising `testTimeout` globally in `vitest.config.ts` rather than accumulating per-test overrides. With only two files affected so far, the targeted fix matches existing convention.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)