### PR TITLE
[DT-400] Update base image hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN pnpm --filter duos-server run build
 RUN pnpm --filter duos-server deploy --prod --legacy /tmp/server-deploy
 
 # Commit hash to us.gcr.io/broad-dsp-gcr-public/base/nodejs:26-debian-fips
-FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs@sha256:54f2b33bd865b8fd7f5de9b1f82c4a107b1a8498ab4e217d50913dcd49749034
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs@sha256:467f12f846e059b2d9e57efbe8e99264c5f7dd17068afffb2a22ba6d4df1600f
 ARG NODE_ENV=production
 ARG PORT=8080
 ENV NODE_ENV=${NODE_ENV}


### PR DESCRIPTION
### Addresses
https://broadworkbench.atlassian.net/browse/DT-400

### Summary
The node 26-debian-fips image was updated 8/13/2026: https://console.cloud.google.com/artifacts/docker/broad-dsp-gcr-public/us/us.gcr.io/base%2Fnodejs

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
