### PR TITLE
[DT-3327] Remove the Action column from the Admin DAR table

### DIFF
--- a/src/pages/AdminManageDarCollections.tsx
+++ b/src/pages/AdminManageDarCollections.tsx
@@ -4,7 +4,7 @@ import { Collections } from 'src/libs/ajax/Collections'
 import { Notifications, searchOnFilteredList, getSearchFilterFunctions, USER_ROLES } from 'src/libs/utils'
 import { Styles } from 'src/libs/theme'
 import { DarCollectionTable } from 'src/components/dar_collection_table/DarCollectionTable'
-import { cancelCollectionFn, consoleTypes, openCollectionFn, updateCollectionFn } from 'src/utils/DarCollectionUtils'
+import { consoleTypes } from 'src/utils/DarCollectionUtils'
 import { useResponsiveDarCollectionColumns } from 'src/hooks/useResponsiveDarCollectionColumns'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import TableHeaderSection from 'src/components/TableHeaderSection'
@@ -15,12 +15,10 @@ export default function AdminManageDarCollections() {
   const [collections, setCollections] = useState<DarCollectionSummary[]>([])
   const [filteredList, setFilteredList] = useState<DarCollectionSummary[]>([])
   const [isLoading, setIsLoading] = useState(true)
-  const [searchText, setSearchText] = useState('')
   const filterFn = getSearchFilterFunctions().darCollections
   const responsiveColumns = useResponsiveDarCollectionColumns(consoleTypes.ADMIN)
 
   const handleSearchChange = useCallback((searchTerms: string) => {
-    setSearchText(searchTerms)
     searchOnFilteredList(searchTerms, collections, filterFn, setFilteredList)
   }, [collections, filterFn])
 
@@ -39,19 +37,6 @@ export default function AdminManageDarCollections() {
     init()
   }, [])
 
-  const updateCollections = useCallback(
-    (updatedCollection: DarCollectionSummary) => updateCollectionFn({ collections, filterFn, searchText, setCollections, setFilteredList })(updatedCollection),
-    [collections, filterFn, searchText, setCollections, setFilteredList],
-  )
-  const cancelCollection = useCallback(
-    (params: { darCode: string, darCollectionId: number }) => cancelCollectionFn({ updateCollections, role: USER_ROLES.admin })(params),
-    [updateCollections],
-  )
-  const openCollection = useCallback(
-    (params: { darCode: string, darCollectionId: number }) => openCollectionFn({ updateCollections, role: USER_ROLES.admin })(params),
-    [updateCollections],
-  )
-
   return (
     <div style={Styles.PAGE}>
       <div>
@@ -69,9 +54,6 @@ export default function AdminManageDarCollections() {
           collections={filteredList}
           columns={responsiveColumns}
           isLoading={isLoading}
-          cancelCollection={cancelCollection}
-          reviseCollection={null}
-          openCollection={openCollection}
           consoleType={consoleTypes.ADMIN}
         />
       )}

--- a/src/utils/darCollectionColumns.ts
+++ b/src/utils/darCollectionColumns.ts
@@ -20,17 +20,24 @@ const baseColumnsOverrides: Record<string, string[]> = {
   // Add more overrides if needed for other console types
 }
 
+// Columns each console type drops from the default set
+const excludedColumns: Record<string, string[]> = {
+  [consoleTypes.ADMIN]: [DarCollectionTableColumnOptions.ACTIONS],
+}
+
 function getBaseColumns(consoleType: string): string[] {
   const overrides = baseColumnsOverrides[consoleType] || []
   // Insert DAC after DAR_CODE if present in overrides
-  if (overrides.includes(DarCollectionTableColumnOptions.DAC)) {
-    return [
-      DarCollectionTableColumnOptions.DAR_CODE,
-      DarCollectionTableColumnOptions.DAC,
-      ...defaultBaseColumns.slice(1),
-    ]
-  }
-  return [...defaultBaseColumns]
+  const columns = overrides.includes(DarCollectionTableColumnOptions.DAC)
+    ? [
+        DarCollectionTableColumnOptions.DAR_CODE,
+        DarCollectionTableColumnOptions.DAC,
+        ...defaultBaseColumns.slice(1),
+      ]
+    : [...defaultBaseColumns]
+
+  const excluded = excludedColumns[consoleType] || []
+  return columns.filter(col => !excluded.includes(col))
 }
 
 // Responsive breakpoints for each console type

--- a/test/components/dar_collection_table/DarCollectionTable.spec.tsx
+++ b/test/components/dar_collection_table/DarCollectionTable.spec.tsx
@@ -360,12 +360,12 @@ describe('DarCollectionTable - dataset expansion', () => {
 
 describe('useResponsiveDarCollectionColumns', () => {
   describe('Console Type Column Configuration', () => {
-    it('returns columns including dacNames, darCode, and actions for ADMIN', () => {
+    it('returns columns including dacNames and darCode but not actions for ADMIN', () => {
       setViewportWidth(1600)
       const { result } = renderHook(() => useResponsiveDarCollectionColumns(consoleTypes.ADMIN))
       expect(result.current).toContain('dacNames')
       expect(result.current).toContain('darCode')
-      expect(result.current).toContain('actions')
+      expect(result.current).not.toContain('actions')
     })
 
     it('returns columns including darCode and actions but not dacNames for RESEARCHER', () => {

--- a/test/utils/darCollectionColumns.spec.ts
+++ b/test/utils/darCollectionColumns.spec.ts
@@ -78,7 +78,13 @@ describe('darCollectionColumns', () => {
         expect(columns).toContain(DarCollectionTableColumnOptions.DAR_CODE)
         expect(columns).toContain(DarCollectionTableColumnOptions.NAME)
         expect(columns).toContain(DarCollectionTableColumnOptions.STATUS)
-        expect(columns).toContain(DarCollectionTableColumnOptions.ACTIONS)
+      })
+
+      it('omits the Action column, which only the other consoles offer', () => {
+        expect(getDarCollectionColumns(consoleTypes.ADMIN, 1600))
+          .not.toContain(DarCollectionTableColumnOptions.ACTIONS)
+        expect(getDarCollectionColumns(consoleTypes.CHAIR, 1600))
+          .toContain(DarCollectionTableColumnOptions.ACTIONS)
       })
     })
 


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3327

### Summary

Removes the "Action" column from the Admin DAR table. `ACTIONS` is shared by every console, so admin is excluded via a new `excludedColumns` map rather than dropping the column outright — other consoles are unchanged.                                                                                                                                                                                                          

The page's `cancelCollection` and `openCollection` handlers go with it, since the actions cell was their only trigger. Admins can no longer cancel or reopen a DAR from this table.  

<img width="1785" height="904" alt="After" src="https://github.com/user-attachments/assets/5b11aca6-9c57-4db2-956f-a2b078e2c861" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
