### PR TITLE
[DT-3579] Keep the data use when access management is chosen afterwards

### DIFF
--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -132,6 +132,9 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
 
       setOtherPrimaryText(undefined)
       setSelectedDiseases([])
+      setGSText(undefined)
+      setMORText(undefined)
+      setOtherSecondaryText(undefined)
       setShowOtherSecondaryText(false)
       setShowGSText(false)
       setShowOtherPrimaryText(false)

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -104,27 +104,43 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
   const [editDataLocationUrl, setEditDataLocationUrl] = useState(consentGroup?.dataLocation !== 'Not Determined')
 
   const onAccessTypeChange = ({ _key, value }: { _key: string, value: string }) => {
-    const clearedFields = {} as ConsentGroup2
-    clearedFields.consentGroupName = current.consentGroupName
-    clearedFields.accessManagement = value as AccessManagementType
-    clearedFields.numberOfParticipants = current.numberOfParticipants
-    clearedFields.dataLocation = current.dataLocation
-    clearedFields.url = current.url
-    setCurrent(
-      clearedFields)
-    setShowOtherSecondaryText(false)
-    setShowGSText(false)
-    setShowOtherPrimaryText(false)
-    setShowMORText(false)
+    const accessManagement = value as AccessManagementType
+    const next = structuredClone(current)
+    next.accessManagement = accessManagement
 
-    if (value === 'open') {
-      setOtherPrimaryText(undefined)
-      setShowOtherPrimaryText(false)
-      setSelectedDiseases([])
-      setShowDiseaseSpecificUseSearchbar(false)
-      setShowMORText(false)
+    // Only the fields the new strategy stops showing are cleared. Wiping the data use here marked
+    // it invalid for anyone who filled it in before choosing a strategy (DT-3579).
+    if (accessManagement !== 'controlled') {
+      next.dataAccessCommitteeId = undefined
     }
-    setValidation(calcErrors(clearedFields))
+    if (accessManagement === 'open') {
+      next.generalResearchUse = false
+      next.hmb = false
+      next.diseaseSpecificUse = undefined
+      next.poa = false
+      next.otherPrimary = undefined
+      next.nmds = false
+      next.gso = false
+      next.pub = false
+      next.col = false
+      next.irb = false
+      next.gs = undefined
+      next.mor = false
+      next.morDate = undefined
+      next.npu = false
+      next.otherSecondary = undefined
+
+      setOtherPrimaryText(undefined)
+      setSelectedDiseases([])
+      setShowOtherSecondaryText(false)
+      setShowGSText(false)
+      setShowOtherPrimaryText(false)
+      setShowMORText(false)
+      setShowDiseaseSpecificUseSearchbar(false)
+    }
+
+    setCurrent(next)
+    setValidation(calcErrors(next))
   }
 
   const onPrimaryChange = ({ key, value }: { key: string, value: boolean | string | string[] | { displayText: string, id: string }[] }) => {

--- a/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
+++ b/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
@@ -157,8 +157,8 @@ describe('ConsentGroupAddEdit access management changes', () => {
       await user.click(container.querySelector('#primaryConsent_generalResearchUse')!)
       await user.click(container.querySelector(`#accessManagement_${strategy}`)!)
 
-      const errored = Array.from(container.querySelectorAll('.errored')).map(el => el.textContent)
-      expect(errored).not.toContain('Primary Data Use Terms*')
+      const errored = Array.from(container.querySelectorAll('.errored')).map(el => el.textContent).join(' ')
+      expect(errored).not.toContain('Primary Data Use Terms')
     },
   )
 
@@ -181,5 +181,22 @@ describe('ConsentGroupAddEdit access management changes', () => {
 
     await user.click(container.querySelector('#accessManagement_external')!)
     expect(container.querySelector('#dataAccessCommitteeId')).not.toBeInTheDocument()
+  })
+
+  // Re-checking the toggle writes the retained text back into the consent group, so text cleared
+  // by a switch to open access must not come back with it
+  it('does not restore secondary data use text cleared by open access', async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm()
+
+    await user.click(container.querySelector('#accessManagement_controlled')!)
+    await user.click(container.querySelector('#gs')!)
+    await user.type(container.querySelector('#gsText')!, 'USA only')
+
+    await user.click(container.querySelector('#accessManagement_open')!)
+    await user.click(container.querySelector('#accessManagement_controlled')!)
+    await user.click(container.querySelector('#gs')!)
+
+    expect(container.querySelector<HTMLInputElement>('#gsText')?.value ?? '').toBe('')
   })
 })

--- a/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
+++ b/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
@@ -135,3 +135,51 @@ describe('ConsentGroupAddEdit requestLocation', () => {
     expect(collected[0].requestLocation).toBeUndefined()
   })
 })
+
+describe('ConsentGroupAddEdit access management changes', () => {
+  const renderForm = () => render(
+    <MemoryRouter>
+      <ConsentGroupAddEdit
+        id={0}
+        consentGroups={[]}
+        closeAction={vi.fn()}
+        onConsentGroupChange={vi.fn()}
+      />
+    </MemoryRouter>,
+  )
+
+  it.each(['controlled', 'external'])(
+    'keeps a data use selected before %s access was chosen',
+    async (strategy) => {
+      const user = userEvent.setup()
+      const { container } = renderForm()
+
+      await user.click(container.querySelector('#primaryConsent_generalResearchUse')!)
+      await user.click(container.querySelector(`#accessManagement_${strategy}`)!)
+
+      const errored = Array.from(container.querySelectorAll('.errored')).map(el => el.textContent)
+      expect(errored).not.toContain('Primary Data Use Terms*')
+    },
+  )
+
+  it('clears the data use when switching to open access, which does not use it', async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm()
+
+    await user.click(container.querySelector('#primaryConsent_generalResearchUse')!)
+    await user.click(container.querySelector('#accessManagement_open')!)
+
+    expect(container.querySelector('#primaryConsent_generalResearchUse')).not.toBeInTheDocument()
+  })
+
+  it('drops the DAC when access management leaves controlled', async () => {
+    const user = userEvent.setup()
+    const { container } = renderForm()
+
+    await user.click(container.querySelector('#accessManagement_controlled')!)
+    expect(container.querySelector('#dataAccessCommitteeId')).toBeInTheDocument()
+
+    await user.click(container.querySelector('#accessManagement_external')!)
+    expect(container.querySelector('#dataAccessCommitteeId')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3579

### Summary

`onAccessTypeChange` rebuilt the consent group from five fields, dropping the data use along with everything else, then revalidated — so a data use entered before an access strategy was marked required. The radios are uncontrolled, so the selection still looked checked while the state behind it was gone.  

Now only the fields the new strategy stops showing are cleared: the data use for open access, the DAC when leaving controlled. That also stops the handler from discarding `consentGroupId`, `datasetId`, `name`, file types, and the NIH certification file on every access-management change. 

<img width="560" height="400" alt="After" src="https://github.com/user-attachments/assets/d0159001-2ce7-48b0-b6e4-fb7288cec343" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
