### PR TITLE
[DT-3977] Proxy Bard to restore identified metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,3 +67,6 @@ DUOS_ECM_URL=https://externalcreds.dsde-dev.broadinstitute.org
 # TDR, proxied at /tdr-api for snapshot enumeration on dataset pages.
 # Optional, same behavior as DUOS_ECM_URL when unset.
 DUOS_TDR_URL=https://jade.datarepo-dev.broadinstitute.org
+# Bard (Mixpanel gateway), proxied at /bard-api for identified usage metrics.
+# Optional, same behavior as DUOS_ECM_URL when unset.
+DUOS_BARD_URL=https://terra-bard-dev.appspot.com

--- a/scripts/render-configs.sh
+++ b/scripts/render-configs.sh
@@ -57,6 +57,13 @@ AZURE_ISSUER_URL_DEFAULT="https://terradevb2c.b2clogin.com/terradevb2c.onmicroso
 # pnpm-start dev server; drop the port when running under docker compose.
 OAUTH_REDIRECT_URI_DEFAULT="http://local.dsde-dev.broadinstitute.org:3000/auth/callback"
 API_URL_DEFAULT="https://consent.dsde-dev.broadinstitute.org"
+# The single-feature proxy upstreams (ECM, TDR, Bard). Optional server-side —
+# the BFF boots without them and leaves each route dark — but written here so
+# a locally-run BFF exercises RAS linking, snapshot enumeration, and
+# identified metrics out of the box.
+ECM_URL_DEFAULT="https://externalcreds.dsde-dev.broadinstitute.org"
+TDR_URL_DEFAULT="https://jade.datarepo-dev.broadinstitute.org"
+BARD_URL_DEFAULT="https://terra-bard-dev.appspot.com"
 
 parse_cli_args() {
     while [[ $# -gt 0 ]]; do
@@ -160,6 +167,9 @@ write_env() {
   ISSUER_URL=$(existing_env DUOS_AZURE_ISSUER_URL)
   REDIRECT_URI=$(existing_env DUOS_OAUTH_REDIRECT_URI)
   API_URL=$(existing_env DUOS_API_URL)
+  ECM_URL=$(existing_env DUOS_ECM_URL)
+  TDR_URL=$(existing_env DUOS_TDR_URL)
+  BARD_URL=$(existing_env DUOS_BARD_URL)
 
   if [[ -f "$ENV_FILE" ]]; then
     echo "Backing up existing .env.local to .env.local.bak"
@@ -199,6 +209,9 @@ DUOS_AZURE_CLIENT_SECRET='$AZURE_CLIENT_SECRET'
 DUOS_AZURE_ISSUER_URL=${ISSUER_URL:-$AZURE_ISSUER_URL_DEFAULT}
 DUOS_OAUTH_REDIRECT_URI=${REDIRECT_URI:-$OAUTH_REDIRECT_URI_DEFAULT}
 DUOS_API_URL=${API_URL:-$API_URL_DEFAULT}
+DUOS_ECM_URL=${ECM_URL:-$ECM_URL_DEFAULT}
+DUOS_TDR_URL=${TDR_URL:-$TDR_URL_DEFAULT}
+DUOS_BARD_URL=${BARD_URL:-$BARD_URL_DEFAULT}
 EOF
   } > "$ENV_FILE"
   chmod 600 "$ENV_FILE"

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import { getMe } from './auth/me.js'
 import { apiProxy } from './proxy/apiProxy.js'
 import { ECM_PROXY_PREFIX, ecmProxy } from './proxy/ecmProxy.js'
 import { TDR_PROXY_PREFIX, tdrProxy } from './proxy/tdrProxy.js'
+import { BARD_PROXY_PREFIX, bardProxy } from './proxy/bardProxy.js'
 import { configPath, readConfig } from './config.js'
 import './types/session.js'
 import FastifyVite from '@fastify/vite'
@@ -241,6 +242,7 @@ export async function buildApp(): Promise<AppInstance> {
     const optionalProxies = [
       { envVar: 'DUOS_ECM_URL', prefix: ECM_PROXY_PREFIX, register: ecmProxy, feature: 'RAS/eRA Commons account linking' },
       { envVar: 'DUOS_TDR_URL', prefix: TDR_PROXY_PREFIX, register: tdrProxy, feature: 'TDR snapshot enumeration on dataset pages' },
+      { envVar: 'DUOS_BARD_URL', prefix: BARD_PROXY_PREFIX, register: bardProxy, feature: 'identified usage metrics (signed-in Bard events fall back to anonymous)' },
     ] as const
     for (const { envVar, prefix, register, feature } of optionalProxies) {
       if (process.env[envVar]) {

--- a/server/src/proxy/bardProxy.ts
+++ b/server/src/proxy/bardProxy.ts
@@ -11,11 +11,8 @@ import {
  * Bard (Terra's Mixpanel gateway) is how DUOS reports usage metrics:
  * `Metrics.ts` POSTs `/api/event`, `/api/identify`, and `/api/syncProfile`.
  * The signed-in legs require a bearer token Bard-side, which the browser no
- * longer holds under the BFF — without this route, the Phase 4 client had to
- * downgrade `captureEvent` to anonymous-only and leave `identify`/
- * `syncProfile` as inert no-ops. Proxying restores identified metrics: the
- * signed-in client calls these paths through /bard-api and the session token
- * is injected here.
+ * longer holds under the BFF. The signed-in client calls these paths through
+ * /bard-api and the session token is injected here.
  *
  * Anonymous events are NOT this proxy's concern: a signed-out `captureEvent`
  * never carried a token, so the client keeps sending it directly to Bard

--- a/server/src/proxy/bardProxy.ts
+++ b/server/src/proxy/bardProxy.ts
@@ -1,0 +1,56 @@
+import type { FastifyInstance } from 'fastify'
+import {
+  registerUpstreamProxy,
+  upstreamPath as stripPrefix,
+  type UpstreamProxyOptions,
+} from './upstreamProxy.js'
+
+/**
+ * The Bard proxy.
+ *
+ * Bard (Terra's Mixpanel gateway) is how DUOS reports usage metrics:
+ * `Metrics.ts` POSTs `/api/event`, `/api/identify`, and `/api/syncProfile`.
+ * The signed-in legs require a bearer token Bard-side, which the browser no
+ * longer holds under the BFF — without this route, the Phase 4 client had to
+ * downgrade `captureEvent` to anonymous-only and leave `identify`/
+ * `syncProfile` as inert no-ops. Proxying restores identified metrics: the
+ * signed-in client calls these paths through /bard-api and the session token
+ * is injected here.
+ *
+ * Anonymous events are NOT this proxy's concern: a signed-out `captureEvent`
+ * never carried a token, so the client keeps sending it directly to Bard
+ * (`bardApiUrl` in config.json), exactly as the legacy client does. That is
+ * why the configuration matches ECM/TDR instead of growing an unauthenticated
+ * allowlist:
+ *   - **No unauthenticated paths.** Everything routed here is signed-in; the
+ *     signed-out traffic never arrives. A sessionless POST through this
+ *     prefix is a client bug, and 401s loudly rather than proxying an
+ *     anonymous event.
+ *   - **No CSRF exemptions.** All three calls are POSTs from an
+ *     authenticated client, which can and must present an `X-CSRF-Token`.
+ *   - **An upstream 401 does NOT end the session.** Bard is a Terra service
+ *     authenticating on its own terms (via Sam), so its 401 is not
+ *     authoritative about the BFF session; it passes through
+ *     (response-hardened, `www-authenticate` stripped). The client treats
+ *     metrics as best-effort, but the pass-through keeps a misconfigured
+ *     Bard visible in the network tab and the BFF logs rather than silent.
+ */
+export const BARD_PROXY_PREFIX = '/bard-api'
+
+const NO_PATHS: ReadonlySet<string> = new Set()
+
+/** `upstreamPath` bound to this proxy's prefix, kept for the tests' table cases. */
+export function bardUpstreamPath(url: string): string {
+  return stripPrefix(url, BARD_PROXY_PREFIX)
+}
+
+export async function bardProxy(app: FastifyInstance, options: UpstreamProxyOptions = {}): Promise<void> {
+  await registerUpstreamProxy(app, {
+    prefix: BARD_PROXY_PREFIX,
+    upstreamEnvVar: 'DUOS_BARD_URL',
+    logTag: 'bard-proxy',
+    unauthenticatedPaths: NO_PATHS,
+    csrfExemptUnsafeRequests: NO_PATHS,
+    destroySessionOnUpstream401: false,
+  }, options)
+}

--- a/server/test/bardProxy.test.ts
+++ b/server/test/bardProxy.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { type FastifyInstance } from 'fastify'
+import { RefreshFailedError } from '../src/auth/refresh.js'
+import { CSRF_ERROR_CODE } from '../src/proxy/upstreamProxy.js'
+import { BARD_PROXY_PREFIX, bardProxy, bardUpstreamPath } from '../src/proxy/bardProxy.js'
+import {
+  SESSION_COOKIE,
+  type SessionSeed,
+  type Upstream,
+  buildAppShell,
+  csrfCredentials,
+  injectWithCsrf,
+  nowSeconds,
+  seedSession,
+  startUpstream,
+  trackSession,
+} from './proxyTestHarness.js'
+
+/**
+ * The Bard proxy suite.
+ *
+ * Same division of labor as ecmProxy.test.ts: the shared machinery is
+ * exercised across the 100+ cases in apiProxy.test.ts, and this suite pins
+ * down the Bard *configuration* — the prefix and upstream env var, no
+ * unauthenticated paths, no CSRF exemptions, the upstream-401 pass-through —
+ * against the three POSTs Metrics.ts actually makes. The sessionless-POST
+ * rejection is load-bearing here: anonymous events go direct to Bard, never
+ * through this prefix, and the 401 is what keeps that split honest.
+ */
+
+vi.mock('../src/auth/refresh.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/auth/refresh.js')>()
+  return { ...actual, refreshAccessToken: vi.fn() }
+})
+
+// The three paths the client calls today (Metrics.ts).
+const EVENT_PATH = '/api/event'
+const IDENTIFY_PATH = '/api/identify'
+const SYNC_PROFILE_PATH = '/api/syncProfile'
+
+async function buildBardApp(seed?: SessionSeed): Promise<FastifyInstance> {
+  const app = await buildAppShell()
+  if (seed) {
+    seedSession(app, seed)
+  }
+  await app.register(bardProxy)
+  return app
+}
+
+describe('bardProxy', () => {
+  let upstream: Upstream
+  let app: FastifyInstance | undefined
+
+  beforeEach(async () => {
+    upstream = await startUpstream()
+    process.env.DUOS_BARD_URL = upstream.origin
+    const { refreshAccessToken } = await import('../src/auth/refresh.js')
+    vi.mocked(refreshAccessToken).mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+    await upstream.close()
+    delete process.env.DUOS_BARD_URL
+  })
+
+  /** A session comfortably outside the refresh window. */
+  const freshSession = (accessToken = 'session-access-token'): SessionSeed => ({
+    accessToken,
+    tokenExpiry: nowSeconds() + 3600,
+  })
+
+  describe('bardUpstreamPath', () => {
+    it.each([
+      [`${BARD_PROXY_PREFIX}${EVENT_PATH}`, EVENT_PATH],
+      [`${BARD_PROXY_PREFIX}${IDENTIFY_PATH}`, IDENTIFY_PATH],
+      [`${BARD_PROXY_PREFIX}${SYNC_PROFILE_PATH}`, SYNC_PROFILE_PATH],
+      [`${BARD_PROXY_PREFIX}/`, '/'],
+      [BARD_PROXY_PREFIX, '/'],
+    ])('maps %s to %s', (url, expected) => {
+      expect(bardUpstreamPath(url)).toBe(expected)
+    })
+  })
+
+  describe('routing and the request leg', () => {
+    it('forwards the path with the prefix stripped, with the session token injected', async () => {
+      app = await buildBardApp(freshSession('the-session-token'))
+
+      const res = await injectWithCsrf(app, {
+        method: 'POST',
+        url: `${BARD_PROXY_PREFIX}${SYNC_PROFILE_PATH}`,
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.last().url).toBe(SYNC_PROFILE_PATH)
+      expect(upstream.last().headers.authorization).toBe('Bearer the-session-token')
+      expect(upstream.last().headers['x-app-id']).toBe('DUOS')
+    })
+
+    it('strips the session cookie, the client Authorization header, and the CSRF token before forwarding', async () => {
+      app = await buildBardApp(freshSession('the-session-token'))
+
+      await injectWithCsrf(app, {
+        method: 'POST',
+        url: `${BARD_PROXY_PREFIX}${IDENTIFY_PATH}`,
+        // The legacy client constructed its own bearer header; whatever a
+        // client sends must never reach Bard.
+        headers: { authorization: 'Bearer browser-held-token' },
+      })
+
+      const forwarded = upstream.last().headers
+      expect(forwarded.cookie).toBeUndefined()
+      expect(forwarded['x-csrf-token']).toBeUndefined()
+      expect(forwarded.authorization).toBe('Bearer the-session-token')
+    })
+
+    // captureEvent's payload nests details, distinct_id and the bard-client
+    // default properties — the proxy must not parse or re-serialize any of it.
+    it('streams the JSON event body through untouched', async () => {
+      app = await buildBardApp(freshSession())
+      const body = '{"event":"duos:dataset_search","properties":{"appId":"DUOS","hostname":"duos.example.org"}}'
+
+      await injectWithCsrf(app, {
+        method: 'POST',
+        url: `${BARD_PROXY_PREFIX}${EVENT_PATH}`,
+        headers: { 'content-type': 'application/json' },
+        payload: body,
+      })
+
+      expect(upstream.last().body.toString()).toBe(body)
+    })
+  })
+
+  describe('no unauthenticated paths', () => {
+    // Anonymous captureEvent goes direct to Bard, not through the proxy — a
+    // sessionless request through this prefix is a client bug and must 401
+    // loudly, not proxy an anonymous event. /api/event is the path where the
+    // distinction bites.
+    it.each(['/status', EVENT_PATH, '/'])('%s is unreachable without a session', async (path) => {
+      app = await buildBardApp()
+
+      const res = await app.inject({ method: 'GET', url: `${BARD_PROXY_PREFIX}${path}` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'unauthenticated' })
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
+  describe('CSRF enforcement', () => {
+    it('rejects a POST without a token before it reaches Bard', async () => {
+      app = await buildBardApp(freshSession())
+      const { cookie } = await csrfCredentials(app)
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${BARD_PROXY_PREFIX}${EVENT_PATH}`,
+        headers: { cookie },
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toMatchObject({ error: CSRF_ERROR_CODE })
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    // The DUOS API proxy exempts the signed-out Contact Us POSTs; the Bard
+    // config's exemption set is empty, and this is what proves it stays that
+    // way — the same path that is exempt through /duos-api is enforced here.
+    it('has no unsafe-request exemptions: POST /support/request is enforced through this prefix', async () => {
+      app = await buildBardApp(freshSession())
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${BARD_PROXY_PREFIX}/support/request`,
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toMatchObject({ error: CSRF_ERROR_CODE })
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('passes a GET without a token', async () => {
+      app = await buildBardApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${BARD_PROXY_PREFIX}${EVENT_PATH}` })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.received).toHaveLength(1)
+    })
+  })
+
+  describe('the response leg', () => {
+    it('hardens every proxied response against executing on the SPA origin', async () => {
+      app = await buildBardApp(freshSession())
+
+      const res = await injectWithCsrf(app, { method: 'POST', url: `${BARD_PROXY_PREFIX}${EVENT_PATH}` })
+
+      expect(res.headers['x-content-type-options']).toBe('nosniff')
+      expect(res.headers['content-security-policy']).toBe('sandbox')
+    })
+
+    it('strips set-cookie and www-authenticate from the upstream response', async () => {
+      app = await buildBardApp(freshSession())
+      upstream.respondWith((_req, res) => {
+        res.writeHead(200, {
+          'set-cookie': 'sessionId=upstream-forged; Path=/',
+          'www-authenticate': 'Bearer realm="bard"',
+          'content-type': 'application/json',
+        })
+        res.end('{}')
+      })
+
+      const res = await injectWithCsrf(app, { method: 'POST', url: `${BARD_PROXY_PREFIX}${EVENT_PATH}` })
+
+      expect(res.headers['set-cookie']).toBeUndefined()
+      expect(res.headers['www-authenticate']).toBeUndefined()
+      expect(res.json()).toEqual({})
+    })
+  })
+
+  describe('an upstream 401 does not end the session', () => {
+    it('passes the 401 through with the session and cookie intact', async () => {
+      app = await buildBardApp(freshSession())
+      const tracked = trackSession(app)
+      upstream.respondWith((_req, res) => {
+        res.writeHead(401, { 'content-type': 'application/json', 'www-authenticate': 'Bearer error="invalid_token"' })
+        res.end('{"message":"token rejected by Bard"}')
+      })
+
+      const res = await injectWithCsrf(app, { method: 'POST', url: `${BARD_PROXY_PREFIX}${SYNC_PROFILE_PATH}` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ message: 'token rejected by Bard' })
+      // The upstream's bearer challenge still may not reach the browser.
+      expect(res.headers['www-authenticate']).toBeUndefined()
+      // No Set-Cookie clearing the session — the DUOS session survives.
+      expect(res.cookies.find(cookie => cookie.name === SESSION_COOKIE && cookie.value === '')).toBeUndefined()
+      expect(await tracked.stored()).not.toBeNull()
+    })
+  })
+
+  describe('token freshness', () => {
+    it('refreshes a near-expiry token before forwarding', async () => {
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      vi.mocked(refreshAccessToken).mockImplementation(async (request) => {
+        request.session.accessToken = 'renewed-token'
+        request.session.tokenExpiry = nowSeconds() + 3600
+      })
+      app = await buildBardApp({ accessToken: 'stale-token', tokenExpiry: nowSeconds() })
+
+      await injectWithCsrf(app, { method: 'POST', url: `${BARD_PROXY_PREFIX}${EVENT_PATH}` })
+
+      expect(refreshAccessToken).toHaveBeenCalledTimes(1)
+      expect(upstream.last().headers.authorization).toBe('Bearer renewed-token')
+    })
+
+    it('returns 401 and clears the cookie when the refresh fails terminally', async () => {
+      const { refreshAccessToken } = await import('../src/auth/refresh.js')
+      vi.mocked(refreshAccessToken).mockRejectedValue(new RefreshFailedError('refresh_failed'))
+      app = await buildBardApp({ accessToken: 'stale-token', tokenExpiry: nowSeconds() })
+
+      const res = await injectWithCsrf(app, { method: 'POST', url: `${BARD_PROXY_PREFIX}${EVENT_PATH}` })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'session_expired' })
+      expect(res.cookies).toContainEqual(
+        expect.objectContaining({ name: SESSION_COOKIE, value: '' }),
+      )
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
+  describe('DUOS_BARD_URL validation', () => {
+    it.each([
+      ['unset', undefined],
+      ['a bare hostname', 'terra-bard-dev.appspot.com'],
+      ['an origin with a path', 'https://terra-bard-dev.appspot.com/api'],
+    ])('refuses to register when DUOS_BARD_URL is %s', async (_label, value) => {
+      if (value === undefined) {
+        delete process.env.DUOS_BARD_URL
+      }
+      else {
+        process.env.DUOS_BARD_URL = value
+      }
+      const shell = await buildAppShell()
+      shell.register(bardProxy)
+
+      await expect(shell.ready()).rejects.toThrow('DUOS_BARD_URL')
+      await shell.close()
+    })
+  })
+})

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -275,6 +275,7 @@ describe('BFF auth route registration', () => {
     delete process.env.CONFIG_PATH
     delete process.env.DUOS_ECM_URL
     delete process.env.DUOS_TDR_URL
+    delete process.env.DUOS_BARD_URL
     const { resetConfigCache } = await import('../src/config.js')
     resetConfigCache()
     // Guarded: rmSync(undefined) throws and would mask the real failure of a
@@ -446,6 +447,42 @@ describe('BFF auth route registration', () => {
     const localApp = await buildAppWithConfig({ bffEnabled: false })
 
     const res = await localApp.inject({ method: 'GET', url: '/tdr-api/api/repository/v1/snapshots' })
+
+    expect(res.statusCode).toBe(200)
+
+    await localApp.close()
+  })
+
+  // Same three-way gating again, against the Bard env var and prefix.
+  it('registers the /bard-api proxy route when bffEnabled is true and DUOS_BARD_URL is set', async () => {
+    process.env.DUOS_BARD_URL = 'https://terra-bard-dev.appspot.com'
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const res = await localApp.inject({ method: 'GET', url: '/bard-api/api/event' })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json()).toEqual({ error: 'unauthenticated' })
+
+    await localApp.close()
+  })
+
+  it('boots without the /bard-api route when bffEnabled is true but DUOS_BARD_URL is not set', async () => {
+    delete process.env.DUOS_BARD_URL
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const res = await localApp.inject({ method: 'GET', url: '/bard-api/api/event' })
+
+    // Falls through to the SPA fallback instead of the proxy's 401.
+    expect(res.statusCode).toBe(200)
+
+    await localApp.close()
+  })
+
+  it('does not register the /bard-api proxy route when bffEnabled is false, even with DUOS_BARD_URL set', async () => {
+    process.env.DUOS_BARD_URL = 'https://terra-bard-dev.appspot.com'
+    const localApp = await buildAppWithConfig({ bffEnabled: false })
+
+    const res = await localApp.inject({ method: 'GET', url: '/bard-api/api/event' })
 
     expect(res.statusCode).toBe(200)
 


### PR DESCRIPTION
### Addresses
Partially addresses [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) (BFF Phase 3 — API proxy, story 3-K)
Fully addresses https://broadworkbench.atlassian.net/browse/DT-3977

### Summary
- Adds `server/src/proxy/bardProxy.ts`: `/bard-api/*` → new `DUOS_BARD_URL` env var, configured exactly like the ECM and TDR proxies — no unauthenticated paths, no CSRF exemptions (all three Bard calls are POSTs from an authenticated client, which holds an `X-CSRF-Token`), and an upstream 401 passes through **without** destroying the BFF session (Bard authenticates via Sam, so its 401 is not authoritative about the session).
- **Only the signed-in legs route through the proxy.** A signed-out `captureEvent` never carried a token, so the client keeps sending it directly to Bard (`bardApiUrl`), exactly as today. That split is what keeps the config free of an unauthenticated allowlist: a sessionless request through `/bard-api` is a client bug and 401s loudly rather than proxying an anonymous event. No silent 401s in the other direction either — signed-in requests carry a freshly-refreshed session token, and any Bard-side rejection passes through visibly instead of being swallowed.
- `DUOS_BARD_URL` joins the optional-proxies loop in `index.ts` (boot + warn + dark route when unset) and is staged in the same terra-helmfile branch as the ECM/TDR vars (dev: `https://terra-bard-dev.appspot.com`).
- Server-side only: un-inerting `Metrics.identify`/`syncProfile` and the identified `captureEvent` path is part of the Phase 4 client refactor (Epic 4), which should also flag the `distinct_id` population shift for the Phase 6 RUM regression checks.
- Also fixes `scripts/render-configs.sh --write_env` for all three optional proxies: the generated `.env.local` never included `DUOS_ECM_URL`/`DUOS_TDR_URL`/`DUOS_BARD_URL` (so a locally-run BFF booted with those routes dark), and a re-run dropped any hand-added lines. All three are now emitted with dev defaults and carried forward like `DUOS_API_URL`.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DT-3608]: https://broadworkbench.atlassian.net/browse/DT-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
