### PR TITLE
[DT-3987] Source terraUrl from the BFF env for Terra export links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,3 +70,8 @@ DUOS_TDR_URL=https://jade.datarepo-dev.broadinstitute.org
 # Bard (Mixpanel gateway), proxied at /bard-api for identified usage metrics.
 # Optional, same behavior as DUOS_ECM_URL when unset.
 DUOS_BARD_URL=https://terra-bard-dev.appspot.com
+# Terra itself — NOT proxied: overrides config.json's terraUrl, the base for
+# links that send the user to Terra (dataset export). Optional: when unset the
+# static config.json value applies, and where that is empty too (BEEs) the
+# client hides its Terra export links.
+DUOS_TERRA_URL=https://bvdp-saturn-dev.appspot.com

--- a/scripts/render-configs.sh
+++ b/scripts/render-configs.sh
@@ -64,6 +64,9 @@ API_URL_DEFAULT="https://consent.dsde-dev.broadinstitute.org"
 ECM_URL_DEFAULT="https://externalcreds.dsde-dev.broadinstitute.org"
 TDR_URL_DEFAULT="https://jade.datarepo-dev.broadinstitute.org"
 BARD_URL_DEFAULT="https://terra-bard-dev.appspot.com"
+# Not a proxy upstream: the server overrides config.json's terraUrl with this,
+# the base for links that send the user to Terra itself (dataset export).
+TERRA_URL_DEFAULT="https://bvdp-saturn-dev.appspot.com"
 
 parse_cli_args() {
     while [[ $# -gt 0 ]]; do
@@ -170,6 +173,7 @@ write_env() {
   ECM_URL=$(existing_env DUOS_ECM_URL)
   TDR_URL=$(existing_env DUOS_TDR_URL)
   BARD_URL=$(existing_env DUOS_BARD_URL)
+  TERRA_URL=$(existing_env DUOS_TERRA_URL)
 
   if [[ -f "$ENV_FILE" ]]; then
     echo "Backing up existing .env.local to .env.local.bak"
@@ -212,6 +216,7 @@ DUOS_API_URL=${API_URL:-$API_URL_DEFAULT}
 DUOS_ECM_URL=${ECM_URL:-$ECM_URL_DEFAULT}
 DUOS_TDR_URL=${TDR_URL:-$TDR_URL_DEFAULT}
 DUOS_BARD_URL=${BARD_URL:-$BARD_URL_DEFAULT}
+DUOS_TERRA_URL=${TERRA_URL:-$TERRA_URL_DEFAULT}
 EOF
   } > "$ENV_FILE"
   chmod 600 "$ENV_FILE"

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -46,7 +46,11 @@ async function loadAndMerge(configPath: string): Promise<Record<string, unknown>
   // route. Trailing slashes are stripped because the client concatenates
   // `${terraUrl}/#import-data?…` — a slash here would produce `//#`.
   if (process.env.DUOS_TERRA_URL) {
-    config.terraUrl = process.env.DUOS_TERRA_URL.replace(/\/+$/, '')
+    let terraUrl = process.env.DUOS_TERRA_URL
+    while (terraUrl.endsWith('/')) {
+      terraUrl = terraUrl.slice(0, -1)
+    }
+    config.terraUrl = terraUrl
   }
   return config
 }

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -40,6 +40,14 @@ async function loadAndMerge(configPath: string): Promise<Record<string, unknown>
   if (process.env.DUOS_API_URL) {
     config.apiUrl = process.env.DUOS_API_URL
   }
+  // Unlike the DUOS_ECM/TDR/BARD_URL upstreams, Terra is not proxied: `terraUrl`
+  // is the base for links that send the user to Terra itself (the dataset
+  // export button), so the env var feeds the client config rather than a proxy
+  // route. Trailing slashes are stripped because the client concatenates
+  // `${terraUrl}/#import-data?…` — a slash here would produce `//#`.
+  if (process.env.DUOS_TERRA_URL) {
+    config.terraUrl = process.env.DUOS_TERRA_URL.replace(/\/+$/, '')
+  }
   return config
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -253,6 +253,15 @@ export async function buildApp(): Promise<AppInstance> {
         fastify.log.warn(`[server] ${envVar} is not set — the ${prefix} proxy is disabled, so ${feature} will fail in this BFF environment`)
       }
     }
+
+    // DUOS_TERRA_URL is the odd one out among the upstream env vars: Terra is
+    // not proxied — the var overrides config.json's `terraUrl`, the base for
+    // links that send the user to Terra itself (see config.ts). Same optional
+    // posture as the proxies: boot + warn when unset, and the client hides its
+    // Terra export links when the resulting terraUrl is empty (BEEs).
+    if (!process.env.DUOS_TERRA_URL) {
+      fastify.log.warn('[server] DUOS_TERRA_URL is not set — config.json keeps its static terraUrl; where that is empty too, Terra export links are hidden')
+    }
   }
   else {
     fastify.log.info('[server] bffEnabled is not true — BFF auth routes disabled (legacy client-side auth)')

--- a/server/test/config.test.ts
+++ b/server/test/config.test.ts
@@ -29,6 +29,7 @@ describe('readConfig', () => {
 
   afterEach(() => {
     delete process.env.DUOS_API_URL
+    delete process.env.DUOS_TERRA_URL
     resetConfigCache()
     log.error.mockClear()
     // Guarded: rmSync(undefined) throws and would mask the real failure of a
@@ -52,6 +53,23 @@ describe('readConfig', () => {
     const file = writeFixture({ apiUrl: 'https://consent.dsde-dev.broadinstitute.org', env: 'dev' })
     process.env.DUOS_API_URL = 'https://local.dsde-dev.broadinstitute.org:27443'
     expect(await readConfig(file, log)).toEqual({ apiUrl: 'https://local.dsde-dev.broadinstitute.org:27443', env: 'dev' })
+  })
+
+  it('overrides terraUrl with DUOS_TERRA_URL, leaving other fields untouched', async () => {
+    const file = writeFixture({ terraUrl: 'https://bvdp-saturn-dev.appspot.com', env: 'dev' })
+    process.env.DUOS_TERRA_URL = 'https://bvdp-saturn-perf.appspot.com'
+    expect(await readConfig(file, log)).toEqual({ terraUrl: 'https://bvdp-saturn-perf.appspot.com', env: 'dev' })
+  })
+
+  it('strips trailing slashes from DUOS_TERRA_URL so link concatenation stays clean', async () => {
+    const file = writeFixture({ terraUrl: '', env: 'dev' })
+    process.env.DUOS_TERRA_URL = 'https://bvdp-saturn-dev.appspot.com/'
+    expect(await readConfig(file, log)).toEqual({ terraUrl: 'https://bvdp-saturn-dev.appspot.com', env: 'dev' })
+  })
+
+  it('keeps the static terraUrl when DUOS_TERRA_URL is not set', async () => {
+    const file = writeFixture({ terraUrl: 'https://bvdp-saturn-dev.appspot.com', env: 'dev' })
+    expect(await readConfig(file, log)).toEqual({ terraUrl: 'https://bvdp-saturn-dev.appspot.com', env: 'dev' })
   })
 
   it('logs and rethrows on a missing file, without caching the failure', async () => {

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -179,6 +179,7 @@ describe('GET /config.json', () => {
   afterEach(async () => {
     delete process.env.CONFIG_PATH
     delete process.env.DUOS_API_URL
+    delete process.env.DUOS_TERRA_URL
     const { resetConfigCache } = await import('../src/config.js')
     resetConfigCache()
     // Guarded: rmSync(undefined) throws and would mask the real failure of a
@@ -186,12 +187,13 @@ describe('GET /config.json', () => {
     if (dir) rmSync(dir, { recursive: true, force: true })
   })
 
-  it('overrides apiUrl with DUOS_API_URL instead of serving the static file verbatim', async () => {
+  it('overrides apiUrl and terraUrl from the env instead of serving the static file verbatim', async () => {
     dir = mkdtempSync(path.join(tmpdir(), 'duos-config-'))
     const file = path.join(dir, 'config.json')
-    writeFileSync(file, JSON.stringify({ apiUrl: 'https://consent.dsde-dev.broadinstitute.org', env: 'dev' }))
+    writeFileSync(file, JSON.stringify({ apiUrl: 'https://consent.dsde-dev.broadinstitute.org', terraUrl: '', env: 'dev' }))
     process.env.CONFIG_PATH = file
     process.env.DUOS_API_URL = 'https://local.dsde-dev.broadinstitute.org:27443'
+    process.env.DUOS_TERRA_URL = 'https://bvdp-saturn-dev.appspot.com'
 
     // buildApp() now reads config.json eagerly at startup (to gate the BFF
     // auth routes on bffEnabled) — the outer beforeEach's own buildApp() call
@@ -205,7 +207,7 @@ describe('GET /config.json', () => {
 
     const res = await localApp.inject({ method: 'GET', url: '/config.json' })
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ apiUrl: 'https://local.dsde-dev.broadinstitute.org:27443', env: 'dev' })
+    expect(res.json()).toEqual({ apiUrl: 'https://local.dsde-dev.broadinstitute.org:27443', terraUrl: 'https://bvdp-saturn-dev.appspot.com', env: 'dev' })
 
     // HEAD must serve the same (overridden) resource, not fall through to the
     // static file — mismatched GET/HEAD Content-Length corrupts caches.

--- a/src/components/data_search/DatasetExportButton.tsx
+++ b/src/components/data_search/DatasetExportButton.tsx
@@ -20,7 +20,10 @@ export const DatasetExportButton = ({ snapshots }: DatasetExportButtonProps) => 
     })()
   }, [])
 
-  if (snapshots.length === 0) return null
+  // No terraUrl means this environment has no Terra to export to (BEEs define
+  // neither the static config value nor DUOS_TERRA_URL) — hide the links
+  // rather than render them with an empty base.
+  if (snapshots.length === 0 || terraUrl === '') return null
 
   const makeTerraLink = (snapshot: SnapshotSummaryModel) =>
     `${terraUrl}/#import-data?snapshotId=${snapshot.id}&format=tdrexport&tdrSyncPermissions=false`

--- a/src/components/data_search/DatasetExportButton.tsx
+++ b/src/components/data_search/DatasetExportButton.tsx
@@ -16,7 +16,17 @@ export const DatasetExportButton = ({ snapshots }: DatasetExportButtonProps) => 
 
   useEffect(() => {
     (async () => {
-      setTerraUrl(await Config.getTerraUrl())
+      // Strip trailing slashes before the value reaches makeTerraLink's
+      // `${terraUrl}/#import-data?…` concatenation. The BFF normalizes its
+      // DUOS_TERRA_URL override the same way, but a static config.json value
+      // (legacy environments, hand-edited local configs) doesn't pass through
+      // that path — and a bare-slashes value must collapse to '' and hide the
+      // links below rather than produce hrefs with an empty base.
+      let url = (await Config.getTerraUrl()) ?? ''
+      while (url.endsWith('/')) {
+        url = url.slice(0, -1)
+      }
+      setTerraUrl(url)
     })()
   }, [])
 

--- a/test/components/data_search/DatasetExportButton.spec.tsx
+++ b/test/components/data_search/DatasetExportButton.spec.tsx
@@ -49,6 +49,24 @@ describe('DatasetExportButton', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('strips a trailing slash from terraUrl so hrefs do not contain //#', async () => {
+    // The BFF normalizes DUOS_TERRA_URL, but a static config.json value never
+    // passes through that path — the component must not trust the shape.
+    vi.mocked(Config.getTerraUrl).mockResolvedValue('https://terra.example.com/')
+    await renderButton([snapshotA])
+
+    fireEvent.click(screen.getByRole('button', { name: /export to/i }))
+
+    const link = (await screen.findByText('Terra')).closest('a')
+    expect(link?.getAttribute('href')).toMatch(/^https:\/\/terra\.example\.com\/#import-data/)
+  })
+
+  it('renders nothing when terraUrl is only slashes, treating it as unconfigured', async () => {
+    vi.mocked(Config.getTerraUrl).mockResolvedValue('/')
+    const { container } = await renderButton([snapshotA])
+    expect(container.firstChild).toBeNull()
+  })
+
   it('renders an "Export to..." dropdown button', async () => {
     await renderButton([snapshotA])
 

--- a/test/components/data_search/DatasetExportButton.spec.tsx
+++ b/test/components/data_search/DatasetExportButton.spec.tsx
@@ -3,10 +3,11 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { act, render, screen, fireEvent } from '@testing-library/react'
 import { DatasetExportButton } from 'src/components/data_search/DatasetExportButton'
 import { SnapshotSummaryModel } from 'src/types/tdrModel'
+import { Config } from 'src/libs/config'
 
 vi.mock('src/libs/config', () => ({
   Config: {
-    getTerraUrl: vi.fn().mockResolvedValue('https://terra.example.com'),
+    getTerraUrl: vi.fn(),
   },
 }))
 
@@ -32,10 +33,19 @@ const renderButton = async (snapshots: SnapshotSummaryModel[]) => {
 describe('DatasetExportButton', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(Config.getTerraUrl).mockResolvedValue('https://terra.example.com')
   })
 
   it('renders nothing when snapshots is empty', async () => {
     const { container } = await renderButton([])
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when terraUrl is not configured, instead of links with an empty base', async () => {
+    // BEEs define neither config.json's terraUrl nor DUOS_TERRA_URL — the
+    // export button must disappear, not link to `/#import-data?…`.
+    vi.mocked(Config.getTerraUrl).mockResolvedValue('')
+    const { container } = await renderButton([snapshotA])
     expect(container.firstChild).toBeNull()
   })
 

--- a/test/pages/DataLibrary.spec.tsx
+++ b/test/pages/DataLibrary.spec.tsx
@@ -104,7 +104,9 @@ const mockTdrSnapshotResponse = (id: string, role: string) => ({
 // Mock fetch for /config.json (replaces cy.initApplicationConfig())
 const mockConfig = {
   env: 'ci', hash: '', tag: '', bardApiUrl: '', apiUrl: '',
-  terraUrl: '', tdrApiUrl: '', ecmApiUrl: '', features: {},
+  // Non-empty: the export button hides itself when no Terra is configured,
+  // and the datasets-tab specs exercise the export dropdown.
+  terraUrl: 'https://terra.example.com', tdrApiUrl: '', ecmApiUrl: '', features: {},
 }
 const originalFetch = globalThis.fetch
 globalThis.fetch = vi.fn((...args: Parameters<typeof fetch>) => {

--- a/test/pages/DataLibrary.spec.tsx
+++ b/test/pages/DataLibrary.spec.tsx
@@ -566,7 +566,10 @@ describe('DataLibrary', () => {
 
       renderLibraryInStrictMode(DATASETS_TAB_PATH)
 
-      expect(await screen.findByText(EXPORT_LABEL)).toBeInTheDocument()
+      // Generous timeout: the export button only renders once the async
+      // config fetch resolves, and StrictMode's double render makes this the
+      // slowest path through the grid on a loaded CI machine.
+      expect(await screen.findByText(EXPORT_LABEL, undefined, { timeout: 5000 })).toBeInTheDocument()
       expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledTimes(1)
       expect(TerraDataRepo.listSnapshotsByDatasetIds).toHaveBeenCalledWith(['DUOS-000001'])
     })

--- a/test/pages/DatasetStatistics.spec.tsx
+++ b/test/pages/DatasetStatistics.spec.tsx
@@ -25,7 +25,9 @@ const mockConfig = {
   tag: '',
   bardApiUrl: '',
   apiUrl: '',
-  terraUrl: '',
+  // Non-empty: the export button hides itself when no Terra is configured,
+  // and these specs exercise the export dropdown.
+  terraUrl: 'https://terra.example.com',
   tdrApiUrl: '',
   ecmApiUrl: '',
   features: {},


### PR DESCRIPTION
### Addresses
Fully addresses [DT-3987](https://broadworkbench.atlassian.net/browse/DT-3987)
Partially addresses [DT-3608](https://broadworkbench.atlassian.net/browse/DT-3608) (BFF Phase 3 — API proxy)

Stacked on #3856.

### Summary
Terra is the one upstream that is **linked to rather than proxied**: `DatasetExportButton` builds `${terraUrl}/#import-data?…` hyperlinks that forward the user to Terra itself, so there is no route to add — the BFF equivalent of the ECM/TDR/Bard proxy configuration is making `DUOS_TERRA_URL` the source of the client's `terraUrl`.

- The server's `/config.json` now overrides `terraUrl` with `DUOS_TERRA_URL` when set, exactly like the existing `DUOS_API_URL`/`apiUrl` override. Trailing slashes are stripped because the client string-concatenates `${terraUrl}/#import-data?…` (per the terra-helmfile #6482 reviewer note about mixed trailing slashes in the config templates).
- Same optional posture as the single-feature proxies: a BFF deployment without the var boots and logs a startup warning. The values are already staged in terra-helmfile #6482 (dev: `https://bvdp-saturn-dev.appspot.com`); BEEs deliberately omit it.
- `scripts/render-configs.sh --write_env` emits `DUOS_TERRA_URL` with the dev default and carries an existing value forward, joining the ECM/TDR/Bard vars from #3856.
- Client: the export button now hides when `terraUrl` resolves empty (BEEs define neither the static config value nor the env var), instead of rendering `href="/#import-data?…"` links with an empty base.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DT-3987]: https://broadworkbench.atlassian.net/browse/DT-3987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3608]: https://broadworkbench.atlassian.net/browse/DT-3608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ