### PR TITLE
[DT-3609] Add the BFF session probe (BFF Phase 4, story 4-E)

### DIFF
--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -42,6 +42,16 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     return
   }
 
+  if (res.status === 404) {
+    // Authenticated but not yet registered: the session is valid, the DUOS
+    // profile just doesn't exist yet. Report authenticated with no user so
+    // the client can run its post-sign-in registration bootstrap — collapsing
+    // this into a failure would make every new user look signed out and leave
+    // registration unreachable.
+    reply.send({ authenticated: true, idp: request.session.idp })
+    return
+  }
+
   if (!res.ok) {
     // A non-401 failure (5xx, upstream outage) says nothing about whether the
     // token itself is still valid — don't destroy the session or parse an

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -61,20 +61,20 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     return
   }
 
-  if (res.status === 401) {
-    // The upstream API is the source of truth for token validity — a session
-    // whose access token it now rejects (expired, revoked) is dead weight.
-    await request.session.destroy()
-    reply.clearCookie('sessionId').status(401).send({ authenticated: false })
-    return
-  }
-
-  if (res.status === 404) {
-    // Authenticated but not yet registered: the session is valid, the DUOS
-    // profile just doesn't exist yet. Report authenticated with no user so
-    // the client can run its post-sign-in registration bootstrap — collapsing
-    // this into a failure would make every new user look signed out and leave
+  if (res.status === 401 || res.status === 404) {
+    // Authenticated but (almost certainly) not yet registered. The DUOS API
+    // conflates "bad token" with "no DUOS profile for this email": its auth
+    // filter (DuosUserAuthenticator) turns the user lookup's NotFoundException
+    // into an empty principal, which Dropwizard reports as 401 — the same
+    // status a rejected token gets. Treating that 401 as a dead session
+    // destroyed every brand-new user's session on their first probe and made
     // registration unreachable.
+    //
+    // Reporting the session honestly here is safe: the access token was
+    // refreshed just above when anywhere near expiry, so a 401 from a fresh
+    // token means "no profile", and in the rare revoked-token case the
+    // client's registration attempt fails too, which signs the session out.
+    // (404 kept for symmetry should the upstream ever disambiguate.)
     reply.send({ authenticated: true, idp: request.session.idp })
     return
   }

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -11,6 +11,12 @@ const UPSTREAM_TIMEOUT_MS = 5000
  * tokens themselves, which stay server-side in the session.
  */
 export async function getMe(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  // The answer is per-session and now gates the whole SPA: no intermediary
+  // (or the browser's heuristic cache) may replay one user's profile to
+  // another, or a stale answer to the same user.
+  reply.header('cache-control', 'no-store')
+  reply.header('vary', 'Cookie')
+
   if (!request.session.accessToken) {
     reply.status(401).send({ authenticated: false })
     return

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -1,5 +1,7 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { requireEnv } from './oidcClient.js'
+import { RefreshFailedError, refreshAccessToken } from './refresh.js'
+import { REFRESH_WINDOW_SECONDS } from '../proxy/upstreamProxy.js'
 
 const UPSTREAM_TIMEOUT_MS = 5000
 
@@ -12,6 +14,31 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   if (!request.session.accessToken) {
     reply.status(401).send({ authenticated: false })
     return
+  }
+
+  // Refresh-before-forward, mirroring the API proxy: an idle tab can outlive
+  // the access token while the refresh token and session are still perfectly
+  // valid. Forwarding the expired token would 401 upstream and destroy a
+  // session that only needed a refresh — and the client's focus revalidation
+  // makes this exact path hot.
+  const secondsRemaining = (request.session.tokenExpiry ?? 0) - Math.floor(Date.now() / 1000)
+  if (secondsRemaining < REFRESH_WINDOW_SECONDS) {
+    try {
+      await refreshAccessToken(request)
+    }
+    catch (err: unknown) {
+      if (err instanceof RefreshFailedError) {
+        // Terminal: B2C rejected the refresh token and refreshAccessToken has
+        // already destroyed the session — clear the dead cookie.
+        reply.clearCookie('sessionId').status(401).send({ authenticated: false })
+        return
+      }
+      // Transient (network blip, B2C 5xx, store error) — the session is
+      // intact, so this must not read as signed out permanently: 502 tells
+      // the client probe to retry on the next ask.
+      reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
+      return
+    }
   }
 
   const url = `${requireEnv('DUOS_API_URL')}/api/user/me`

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -95,6 +95,20 @@ describe('getMe', () => {
     expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
   })
 
+  it('reports authenticated with no user when the upstream has no profile yet (404 = unregistered)', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(404, { message: 'Unable to find user' }) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'test-access-token', idp: 'microsoft' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    // The session is valid; the client's post-sign-in bootstrap needs
+    // authenticated:true (with user absent) to reach its registration flow.
+    expect(destroy).not.toHaveBeenCalled()
+    expect(reply.status).not.toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: true, idp: 'microsoft' })
+  })
+
   it('returns 502 without destroying the session when the upstream API errors with a non-401 status', async () => {
     vi.mocked(fetch).mockResolvedValue(makeFetchResponse(503, {}) as never)
     const { request, destroy } = makeRequest({ accessToken: 'test-access-token' })

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -30,13 +30,15 @@ function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'micros
 }
 
 function makeReply() {
-  const reply = { clearCookie: vi.fn(), status: vi.fn(), send: vi.fn() }
+  const reply = { clearCookie: vi.fn(), status: vi.fn(), send: vi.fn(), header: vi.fn() }
   reply.clearCookie.mockReturnValue(reply)
   reply.status.mockReturnValue(reply)
+  reply.header.mockReturnValue(reply)
   return reply as unknown as FastifyReply & {
     clearCookie: ReturnType<typeof vi.fn>
     status: ReturnType<typeof vi.fn>
     send: ReturnType<typeof vi.fn>
+    header: ReturnType<typeof vi.fn>
   }
 }
 
@@ -98,6 +100,26 @@ describe('getMe', () => {
       user: { email: 'user@example.com' },
       idp: 'google',
     })
+  })
+
+  it('marks every answer uncacheable — the profile must never be replayed across sessions', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request } = makeRequest({ accessToken: 'test-access-token', idp: 'google' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(reply.header).toHaveBeenCalledWith('cache-control', 'no-store')
+    expect(reply.header).toHaveBeenCalledWith('vary', 'Cookie')
+  })
+
+  it('marks the unauthenticated answer uncacheable too', async () => {
+    const { request } = makeRequest({})
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(reply.header).toHaveBeenCalledWith('cache-control', 'no-store')
   })
 
   it('reports authenticated with no user on an upstream 401 — DUOS conflates "no profile" with "bad token"', async () => {

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -1,13 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { getMe } from '../src/auth/me.js'
+import { RefreshFailedError, refreshAccessToken } from '../src/auth/refresh.js'
+
+// refreshAccessToken is replaced so the tests never reach B2C; RefreshFailedError
+// stays the real class so the instanceof branch is exercised rather than stubbed.
+vi.mock('../src/auth/refresh.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/auth/refresh.js')>()
+  return { ...actual, refreshAccessToken: vi.fn() }
+})
 
 const ENV = { DUOS_API_URL: 'https://consent.dsde-dev.broadinstitute.org' }
 
-function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft' } = {}) {
+// A default expiry comfortably outside the refresh window, so pre-existing
+// tests exercise the forward path untouched.
+const FRESH_EXPIRY = () => Math.floor(Date.now() / 1000) + 3600
+
+function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft', tokenExpiry?: number } = {}) {
   const destroy = vi.fn().mockResolvedValue(undefined)
   const request = {
-    session: { accessToken: overrides.accessToken, idp: overrides.idp, destroy },
+    session: {
+      accessToken: overrides.accessToken,
+      idp: overrides.idp,
+      tokenExpiry: overrides.tokenExpiry ?? FRESH_EXPIRY(),
+      destroy,
+    },
   }
   return { request: request as unknown as FastifyRequest, destroy }
 }
@@ -31,6 +48,7 @@ describe('getMe', () => {
   beforeEach(() => {
     Object.assign(process.env, ENV)
     vi.stubGlobal('fetch', vi.fn())
+    vi.mocked(refreshAccessToken).mockReset().mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -93,6 +111,61 @@ describe('getMe', () => {
     expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
     expect(reply.status).toHaveBeenCalledWith(401)
     expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+  })
+
+  it('does not refresh when the access token is comfortably fresh', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request } = makeRequest({ accessToken: 'fresh-token' })
+
+    await getMe(request, makeReply())
+
+    expect(refreshAccessToken).not.toHaveBeenCalled()
+  })
+
+  it('refreshes an expired access token before forwarding instead of letting the upstream 401 kill the session', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'stale-token', tokenExpiry: 0 })
+    // The real refreshAccessToken mutates the session in place.
+    vi.mocked(refreshAccessToken).mockImplementation(async (req) => {
+      req.session.accessToken = 'refreshed-token'
+    })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(refreshAccessToken).toHaveBeenCalledOnce()
+    expect(destroy).not.toHaveBeenCalled()
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer refreshed-token' }) }),
+    )
+    expect(reply.send).toHaveBeenCalledWith(expect.objectContaining({ authenticated: true }))
+  })
+
+  it('returns 401 and clears the cookie on a terminal refresh failure', async () => {
+    const { request } = makeRequest({ accessToken: 'stale-token', tokenExpiry: 0 })
+    vi.mocked(refreshAccessToken).mockRejectedValue(new RefreshFailedError('refresh_failed'))
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(401)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+  })
+
+  it('returns 502 without destroying the session on a transient refresh failure', async () => {
+    const { request, destroy } = makeRequest({ accessToken: 'stale-token', tokenExpiry: 0 })
+    vi.mocked(refreshAccessToken).mockRejectedValue(new TypeError('fetch failed'))
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(destroy).not.toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false, error: 'upstream_unavailable' })
   })
 
   it('reports authenticated with no user when the upstream has no profile yet (404 = unregistered)', async () => {

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -100,17 +100,20 @@ describe('getMe', () => {
     })
   })
 
-  it('destroys the session and returns 401 when the upstream API rejects the token', async () => {
+  it('reports authenticated with no user on an upstream 401 — DUOS conflates "no profile" with "bad token"', async () => {
+    // DuosUserAuthenticator turns an unregistered email's NotFoundException
+    // into an empty principal → Dropwizard 401. The token itself was just
+    // refreshed, so this must NOT destroy the session: it is a brand-new
+    // user who needs the registration bootstrap, not a dead session.
     vi.mocked(fetch).mockResolvedValue(makeFetchResponse(401, {}) as never)
-    const { request, destroy } = makeRequest({ accessToken: 'stale-access-token' })
+    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token', idp: 'google' })
     const reply = makeReply()
 
     await getMe(request, reply)
 
-    expect(destroy).toHaveBeenCalled()
-    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
-    expect(reply.status).toHaveBeenCalledWith(401)
-    expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+    expect(destroy).not.toHaveBeenCalled()
+    expect(reply.clearCookie).not.toHaveBeenCalled()
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: true, idp: 'google' })
   })
 
   it('does not refresh when the access token is comfortably fresh', async () => {

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -76,7 +76,13 @@ export const getSessionInfo = async (): Promise<SessionInfo> => {
       // sign-in flow and the dev-only /backgroundsignin page both mutate
       // localStorage without a page load, so a cached answer would go stale.
       // (config.json itself is promise-cached, so this costs nothing.)
-      return { authenticated: Storage.userIsLogged() }
+      // The stored user IS the legacy identity, so reporting it here means
+      // identity-reconciliation checks (session user vs stored user) are
+      // trivially satisfied in legacy mode.
+      const authenticated = Storage.userIsLogged()
+      return authenticated
+        ? { authenticated, user: Storage.getCurrentUser() }
+        : { authenticated }
     }
   }
   catch {

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -46,26 +46,40 @@ const REVALIDATE_MIN_INTERVAL_MS = 3 * 1000
 let sessionPromise: Promise<SessionInfo> | null = null
 let sessionFetchedAt = 0
 
+/**
+ * The last answer /auth/me actually gave (200 or 401). A transient failure
+ * (502, network) says nothing about the session, so it reports this instead
+ * of flipping to signed-out — one upstream blip must not unmount every
+ * authenticated route (Authenticated navigates away and loses form state)
+ * or retire an in-flight bootstrap. The risk of a stale "signed in" here is
+ * the same UI-only exposure the TTL comment above accepts: the first real
+ * API call after expiry still 401s and signs the user out.
+ */
+let lastAuthoritativeAnswer: SessionInfo | null = null
+
 const probeBffSession = async (): Promise<SessionInfo> => {
   try {
     const res = await fetch('/auth/me', { credentials: 'include' })
     if (res.status === 401) {
       // A real answer — no session — worth caching for the page load.
-      return { authenticated: false }
+      lastAuthoritativeAnswer = { authenticated: false }
+      return lastAuthoritativeAnswer
     }
     if (!res.ok) {
-      // Transient upstream failure (e.g. 502): report signed out for this ask,
-      // but drop the cache so the next ask retries instead of pinning the app
-      // signed-out for the rest of the page load.
+      // Transient upstream failure (e.g. 502): hold the last real answer for
+      // this ask, but drop the cache so the next ask retries instead of
+      // pinning the stale answer for the rest of the page load.
       resetSessionCache()
-      return { authenticated: false }
+      return lastAuthoritativeAnswer ?? { authenticated: false }
     }
-    return await res.json() as SessionInfo
+    const info = await res.json() as SessionInfo
+    lastAuthoritativeAnswer = info
+    return info
   }
   catch {
-    // Network failure — same as above: signed out now, retry on the next ask.
+    // Network failure — same as above: last real answer now, retry next ask.
     resetSessionCache()
-    return { authenticated: false }
+    return lastAuthoritativeAnswer ?? { authenticated: false }
   }
 }
 
@@ -101,6 +115,16 @@ export const getSessionInfo = async (): Promise<SessionInfo> => {
 
 export const resetSessionCache = (): void => {
   sessionPromise = null
+}
+
+/**
+ * Test seam: drops the remembered authoritative answer along with the cache.
+ * Production code wants resetSessionCache — the held answer must survive a
+ * cache reset, or it could not bridge the transient failures it exists for.
+ */
+export const resetSessionProbeState = (): void => {
+  sessionPromise = null
+  lastAuthoritativeAnswer = null
 }
 
 /**

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -7,12 +7,14 @@ import { DuosUser } from 'src/types/model'
  *
  * With the BFF enabled, authentication state lives server-side in the BFF
  * session; the browser holds only the session cookie. Every "is the user
- * logged in?" question is therefore a network call, cached here per page load
- * so the many components that ask it during a render share one request. Auth
- * state only changes across full-page navigations (sign-in redirects to B2C
- * and back, sign-out reloads to '/'), so a page-load-scoped cache cannot go
- * stale — but resetSessionCache() is exported for the places that must not
- * rely on that.
+ * logged in?" question is therefore a network call, cached here so the many
+ * components that ask it during a render share one request. Sign-in and
+ * sign-out in THIS tab are full-page navigations, but the answer can still go
+ * stale underneath a long-lived tab — the fixed-lifetime session expires, or
+ * another tab signs in or out on the shared cookie — so the cache is bounded
+ * by SESSION_TTL_MS and revalidateSessionInfo() exists for focus/visibility
+ * changes. (A stale "signed in" is UI-only exposure: the first real API call
+ * after expiry still 401s and signs the user out.)
  *
  * In a legacy (non-BFF) environment the /auth/* routes do not exist, so the
  * probe falls back to the synchronous oidc-client-ts token check in
@@ -27,7 +29,22 @@ export interface SessionInfo {
   idp?: 'google' | 'microsoft'
 }
 
+/**
+ * How long a cached probe answer is trusted. The cache mainly exists so the
+ * many components that ask during one render share a single request; the TTL
+ * bounds how long a stale answer can outlive reality (the fixed-lifetime BFF
+ * session can expire mid-use, and another tab can sign in or out on the
+ * shared cookie). Focus/visibility revalidation reacts faster; this is the
+ * backstop for long-lived tabs that keep navigating.
+ */
+const SESSION_TTL_MS = 5 * 60 * 1000
+
+/** Floor between forced revalidations, so a burst of focus events (or many
+ * mounted hooks reacting to one) collapses into a single probe. */
+const REVALIDATE_MIN_INTERVAL_MS = 3 * 1000
+
 let sessionPromise: Promise<SessionInfo> | null = null
+let sessionFetchedAt = 0
 
 const probeBffSession = async (): Promise<SessionInfo> => {
   try {
@@ -66,12 +83,30 @@ export const getSessionInfo = async (): Promise<SessionInfo> => {
     // Config failure — treat as signed out rather than crashing render paths.
     return { authenticated: false }
   }
-  sessionPromise ??= probeBffSession()
+  if (sessionPromise && Date.now() - sessionFetchedAt > SESSION_TTL_MS) {
+    sessionPromise = null
+  }
+  if (!sessionPromise) {
+    sessionFetchedAt = Date.now()
+    sessionPromise = probeBffSession()
+  }
   return sessionPromise
 }
 
 export const resetSessionCache = (): void => {
   sessionPromise = null
+}
+
+/**
+ * Drop the cached answer and probe again — for "the world may have changed"
+ * moments like the tab regaining focus (another tab can sign in or out on the
+ * shared session cookie). Throttled so simultaneous callers share one probe.
+ */
+export const revalidateSessionInfo = (): Promise<SessionInfo> => {
+  if (Date.now() - sessionFetchedAt > REVALIDATE_MIN_INTERVAL_MS) {
+    resetSessionCache()
+  }
+  return getSessionInfo()
 }
 
 /**

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -30,10 +30,10 @@ export interface SessionInfo {
 let sessionPromise: Promise<SessionInfo> | null = null
 
 const fetchSessionInfo = async (): Promise<SessionInfo> => {
-  if (!(await Config.isBffEnabled())) {
-    return { authenticated: Storage.userIsLogged() }
-  }
   try {
+    if (!(await Config.isBffEnabled())) {
+      return { authenticated: Storage.userIsLogged() }
+    }
     const res = await fetch('/auth/me', { credentials: 'include' })
     if (!res.ok) {
       // 401 = no session; 502 = upstream unavailable. Neither is "logged in",
@@ -43,7 +43,8 @@ const fetchSessionInfo = async (): Promise<SessionInfo> => {
     return await res.json() as SessionInfo
   }
   catch {
-    // Network failure — treat as signed out rather than crashing render paths.
+    // Config or network failure — treat as signed out rather than crashing
+    // render paths.
     return { authenticated: false }
   }
 }

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -29,11 +29,8 @@ export interface SessionInfo {
 
 let sessionPromise: Promise<SessionInfo> | null = null
 
-const fetchSessionInfo = async (): Promise<SessionInfo> => {
+const probeBffSession = async (): Promise<SessionInfo> => {
   try {
-    if (!(await Config.isBffEnabled())) {
-      return { authenticated: Storage.userIsLogged() }
-    }
     const res = await fetch('/auth/me', { credentials: 'include' })
     if (!res.ok) {
       // 401 = no session; 502 = upstream unavailable. Neither is "logged in",
@@ -43,14 +40,26 @@ const fetchSessionInfo = async (): Promise<SessionInfo> => {
     return await res.json() as SessionInfo
   }
   catch {
-    // Config or network failure — treat as signed out rather than crashing
-    // render paths.
+    // Network failure — treat as signed out rather than crashing render paths.
     return { authenticated: false }
   }
 }
 
-export const getSessionInfo = (): Promise<SessionInfo> => {
-  sessionPromise ??= fetchSessionInfo()
+export const getSessionInfo = async (): Promise<SessionInfo> => {
+  try {
+    if (!(await Config.isBffEnabled())) {
+      // Legacy: a free synchronous read, deliberately never cached — the popup
+      // sign-in flow and the dev-only /backgroundsignin page both mutate
+      // localStorage without a page load, so a cached answer would go stale.
+      // (config.json itself is promise-cached, so this costs nothing.)
+      return { authenticated: Storage.userIsLogged() }
+    }
+  }
+  catch {
+    // Config failure — treat as signed out rather than crashing render paths.
+    return { authenticated: false }
+  }
+  sessionPromise ??= probeBffSession()
   return sessionPromise
 }
 

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -1,0 +1,67 @@
+import { Config } from 'src/libs/config'
+import { Storage } from 'src/libs/storage'
+import { DuosUser } from 'src/types/model'
+
+/**
+ * The BFF session probe (`GET /auth/me`).
+ *
+ * With the BFF enabled, authentication state lives server-side in the BFF
+ * session; the browser holds only the session cookie. Every "is the user
+ * logged in?" question is therefore a network call, cached here per page load
+ * so the many components that ask it during a render share one request. Auth
+ * state only changes across full-page navigations (sign-in redirects to B2C
+ * and back, sign-out reloads to '/'), so a page-load-scoped cache cannot go
+ * stale — but resetSessionCache() is exported for the places that must not
+ * rely on that.
+ *
+ * In a legacy (non-BFF) environment the /auth/* routes do not exist, so the
+ * probe falls back to the synchronous oidc-client-ts token check in
+ * localStorage. That path is deleted with the rest of the legacy flow in
+ * Epic 6.
+ */
+export interface SessionInfo {
+  authenticated: boolean
+  /** The upstream DUOS user profile, forwarded by /auth/me when authenticated. */
+  user?: DuosUser
+  /** The B2C sub-provider the user chose on the B2C login page. */
+  idp?: 'google' | 'microsoft'
+}
+
+let sessionPromise: Promise<SessionInfo> | null = null
+
+const fetchSessionInfo = async (): Promise<SessionInfo> => {
+  if (!(await Config.isBffEnabled())) {
+    return { authenticated: Storage.userIsLogged() }
+  }
+  try {
+    const res = await fetch('/auth/me', { credentials: 'include' })
+    if (!res.ok) {
+      // 401 = no session; 502 = upstream unavailable. Neither is "logged in",
+      // and neither body carries a user profile worth keeping.
+      return { authenticated: false }
+    }
+    return await res.json() as SessionInfo
+  }
+  catch {
+    // Network failure — treat as signed out rather than crashing render paths.
+    return { authenticated: false }
+  }
+}
+
+export const getSessionInfo = (): Promise<SessionInfo> => {
+  sessionPromise ??= fetchSessionInfo()
+  return sessionPromise
+}
+
+export const resetSessionCache = (): void => {
+  sessionPromise = null
+}
+
+/**
+ * The async replacement for Storage.userIsLogged (story 4-E). The synchronous
+ * localStorage check keeps working for the legacy flow; new code should ask
+ * this instead (or the useUserIsLogged hook inside components).
+ */
+export const userIsLogged = async (): Promise<boolean> => {
+  return (await getSessionInfo()).authenticated
+}

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -32,15 +32,22 @@ let sessionPromise: Promise<SessionInfo> | null = null
 const probeBffSession = async (): Promise<SessionInfo> => {
   try {
     const res = await fetch('/auth/me', { credentials: 'include' })
+    if (res.status === 401) {
+      // A real answer — no session — worth caching for the page load.
+      return { authenticated: false }
+    }
     if (!res.ok) {
-      // 401 = no session; 502 = upstream unavailable. Neither is "logged in",
-      // and neither body carries a user profile worth keeping.
+      // Transient upstream failure (e.g. 502): report signed out for this ask,
+      // but drop the cache so the next ask retries instead of pinning the app
+      // signed-out for the rest of the page load.
+      resetSessionCache()
       return { authenticated: false }
     }
     return await res.json() as SessionInfo
   }
   catch {
-    // Network failure — treat as signed out rather than crashing render paths.
+    // Network failure — same as above: signed out now, retry on the next ask.
+    resetSessionCache()
     return { authenticated: false }
   }
 }

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getSessionInfo, resetSessionCache, userIsLogged } from 'src/libs/auth/session'
+import { Config } from 'src/libs/config'
+import { Storage } from 'src/libs/storage'
+
+vi.mock('src/libs/config', async importOriginal => ({
+  ...(await importOriginal<typeof import('src/libs/config')>()),
+  Config: {
+    isBffEnabled: vi.fn(),
+  },
+}))
+
+describe('session probe', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    vi.mocked(Config.isBffEnabled).mockResolvedValue(true)
+    resetSessionCache()
+  })
+
+  afterEach(() => {
+    resetSessionCache()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('returns the /auth/me payload when authenticated', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: true, idp: 'google', user: { userId: 1 } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    const info = await getSessionInfo()
+
+    expect(fetchMock).toHaveBeenCalledWith('/auth/me', { credentials: 'include' })
+    expect(info.authenticated).toBe(true)
+    expect(info.idp).toBe('google')
+  })
+
+  it('returns unauthenticated on 401 without throwing', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: false }), { status: 401 }),
+    )
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+  })
+
+  it('returns unauthenticated on upstream outage (502) without throwing', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: false, error: 'upstream_unavailable' }), { status: 502 }),
+    )
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+  })
+
+  it('returns unauthenticated on network failure without throwing', async () => {
+    fetchMock.mockRejectedValue(new TypeError('offline'))
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+  })
+
+  it('caches the probe per page load', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+    )
+
+    await getSessionInfo()
+    await getSessionInfo()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('probes again after resetSessionCache', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+    )
+
+    await getSessionInfo()
+    resetSessionCache()
+    await getSessionInfo()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('userIsLogged reflects the probe result', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+    )
+
+    await expect(userIsLogged()).resolves.toBe(true)
+  })
+
+  describe('legacy mode (BFF disabled)', () => {
+    beforeEach(() => {
+      vi.mocked(Config.isBffEnabled).mockResolvedValue(false)
+    })
+
+    it('derives auth state from the legacy localStorage token, never calling /auth/me', async () => {
+      vi.spyOn(Storage, 'userIsLogged').mockReturnValue(true)
+
+      await expect(getSessionInfo()).resolves.toEqual({ authenticated: true })
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('reports signed out when the legacy token is absent or expired', async () => {
+      vi.spyOn(Storage, 'userIsLogged').mockReturnValue(false)
+
+      await expect(userIsLogged()).resolves.toBe(false)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getSessionInfo, resetSessionCache, revalidateSessionInfo, userIsLogged } from 'src/libs/auth/session'
+import { getSessionInfo, resetSessionCache, resetSessionProbeState, revalidateSessionInfo, userIsLogged } from 'src/libs/auth/session'
 import { Config } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
 
@@ -17,11 +17,11 @@ describe('session probe', () => {
     fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     vi.mocked(Config.isBffEnabled).mockResolvedValue(true)
-    resetSessionCache()
+    resetSessionProbeState()
   })
 
   afterEach(() => {
-    resetSessionCache()
+    resetSessionProbeState()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -78,6 +78,50 @@ describe('session probe', () => {
     const recovered = await getSessionInfo()
     expect(recovered.authenticated).toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('holds the last authenticated answer across a transient outage', async () => {
+    // One 502 must not flip every mounted hook to signed-out — Authenticated
+    // would navigate away and lose the user's form state.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: true, idp: 'google' }), { status: 200 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false, error: 'upstream_unavailable' }), { status: 502 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: true, idp: 'google' }), { status: 200 }),
+    )
+
+    await expect(getSessionInfo()).resolves.toMatchObject({ authenticated: true })
+    resetSessionCache()
+
+    // The outage ask reports the held answer…
+    await expect(getSessionInfo()).resolves.toMatchObject({ authenticated: true })
+    // …and stays un-cached, so the next ask probes again.
+    await expect(getSessionInfo()).resolves.toMatchObject({ authenticated: true })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('lets an authoritative 401 overwrite the held answer', async () => {
+    // A real sign-out must win over the remembered signed-in answer: a later
+    // transient failure reports signed-out, not the pre-sign-out identity.
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false }), { status: 401 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false, error: 'upstream_unavailable' }), { status: 502 }),
+    )
+
+    await expect(getSessionInfo()).resolves.toMatchObject({ authenticated: true })
+    resetSessionCache()
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    resetSessionCache()
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
   })
 
   it('returns unauthenticated when the config lookup itself fails', async () => {

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -190,8 +190,12 @@ describe('session probe', () => {
 
     it('derives auth state from the legacy localStorage token, never calling /auth/me', async () => {
       vi.spyOn(Storage, 'userIsLogged').mockReturnValue(true)
+      const storedUser = { userId: 7, displayName: 'Legacy User' }
+      vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
 
-      await expect(getSessionInfo()).resolves.toEqual({ authenticated: true })
+      // The stored user is the legacy identity — reported so identity
+      // reconciliation (session user vs stored user) holds in legacy mode.
+      await expect(getSessionInfo()).resolves.toEqual({ authenticated: true, user: storedUser })
       expect(fetchMock).not.toHaveBeenCalled()
     })
 

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -63,6 +63,13 @@ describe('session probe', () => {
     await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
   })
 
+  it('returns unauthenticated when the config lookup itself fails', async () => {
+    vi.mocked(Config.isBffEnabled).mockRejectedValue(new Error('config unavailable'))
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('caches the probe per page load', async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ authenticated: true }), { status: 200 }),

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -41,26 +41,43 @@ describe('session probe', () => {
     expect(info.idp).toBe('google')
   })
 
-  it('returns unauthenticated on 401 without throwing', async () => {
+  it('returns unauthenticated on 401 and caches it — "no session" is a real answer', async () => {
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ authenticated: false }), { status: 401 }),
     )
 
     await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('returns unauthenticated on upstream outage (502) without throwing', async () => {
-    fetchMock.mockResolvedValue(
+  it('returns unauthenticated on upstream outage (502) but retries on the next ask', async () => {
+    fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ authenticated: false, error: 'upstream_unavailable' }), { status: 502 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: true, idp: 'google' }), { status: 200 }),
     )
 
     await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+
+    // The outage was transient — the next ask must not be pinned signed-out.
+    const recovered = await getSessionInfo()
+    expect(recovered.authenticated).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it('returns unauthenticated on network failure without throwing', async () => {
-    fetchMock.mockRejectedValue(new TypeError('offline'))
+  it('returns unauthenticated on network failure but retries on the next ask', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('offline'))
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+    )
 
     await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+
+    const recovered = await getSessionInfo()
+    expect(recovered.authenticated).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('returns unauthenticated when the config lookup itself fails', async () => {

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -119,5 +119,18 @@ describe('session probe', () => {
       await expect(userIsLogged()).resolves.toBe(false)
       expect(fetchMock).not.toHaveBeenCalled()
     })
+
+    it('re-reads legacy state on every call — no stale cache after a popup or background sign-in', async () => {
+      const legacyCheck = vi.spyOn(Storage, 'userIsLogged').mockReturnValue(false)
+
+      await expect(userIsLogged()).resolves.toBe(false)
+
+      // The popup flow and /backgroundsignin mutate localStorage without a
+      // page load; the next ask must see it.
+      legacyCheck.mockReturnValue(true)
+
+      await expect(userIsLogged()).resolves.toBe(true)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { getSessionInfo, resetSessionCache, userIsLogged } from 'src/libs/auth/session'
+import { getSessionInfo, resetSessionCache, revalidateSessionInfo, userIsLogged } from 'src/libs/auth/session'
 import { Config } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
 
@@ -108,6 +108,71 @@ describe('session probe', () => {
     await getSessionInfo()
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('expires the cached answer after the TTL — an 8h session can die under a long-lived tab', async () => {
+    vi.useFakeTimers()
+    try {
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+      )
+
+      await getSessionInfo()
+      vi.advanceTimersByTime(4 * 60 * 1000)
+      await getSessionInfo()
+      expect(fetchMock).toHaveBeenCalledTimes(1) // within TTL — cached
+
+      vi.advanceTimersByTime(2 * 60 * 1000)
+      await getSessionInfo()
+      expect(fetchMock).toHaveBeenCalledTimes(2) // past TTL — re-probed
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  describe('revalidateSessionInfo', () => {
+    it('drops the cache and probes fresh — another tab may have signed in or out', async () => {
+      vi.useFakeTimers()
+      try {
+        fetchMock.mockResolvedValueOnce(
+          new Response(JSON.stringify({ authenticated: false }), { status: 401 }),
+        )
+        fetchMock.mockResolvedValueOnce(
+          new Response(JSON.stringify({ authenticated: true, idp: 'microsoft' }), { status: 200 }),
+        )
+
+        await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+
+        vi.advanceTimersByTime(10 * 1000)
+        const revalidated = await revalidateSessionInfo()
+
+        expect(revalidated.authenticated).toBe(true)
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('throttles bursts — simultaneous revalidations share one probe', async () => {
+      vi.useFakeTimers()
+      try {
+        fetchMock.mockResolvedValue(
+          new Response(JSON.stringify({ authenticated: true }), { status: 200 }),
+        )
+
+        await getSessionInfo()
+        vi.advanceTimersByTime(10 * 1000)
+        // A focus event fans out to every mounted hook; only the first re-probes.
+        await Promise.all([revalidateSessionInfo(), revalidateSessionInfo(), revalidateSessionInfo()])
+
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
   })
 
   it('userIsLogged reflects the probe result', async () => {


### PR DESCRIPTION
> [!NOTE]
> Part of the BFF Phase 4 stack: #3861 → #3862 → #3863 → #3864 → #3869 (#3855 merged to develop). Bottom of the stack — this PR's diff is against develop; review bottom-up. New to the stack? Start with the [review guide & retrospective](https://github.com/DataBiosphere/duos-ui/blob/claude/epic-4-signout-redirect-cleanup/docs/plans/epic-4-stack-review-guide.md).

### Addresses
https://broadworkbench.atlassian.net/browse/DT-3609 (BFF Phase 4, story 4-E)

### Summary
Adds `src/libs/auth/session.ts` — the `GET /auth/me` session probe that becomes the async replacement for `Storage.userIsLogged()`:

- **Bounded promise cache (BFF branch only)**: the many components that ask "is the user logged in?" during a render share one `/auth/me` round-trip. A 200 or a 401 ("genuinely no session") is cached; transient failures (5xx, network) are not, so the next ask retries. Cached answers expire after 5 minutes — the fixed-lifetime session can die under a long-lived tab, and another tab can sign in/out on the shared cookie — and `revalidateSessionInfo()` (throttled to one probe per burst) lets the UI layer force a fresh look on tab focus (wired up in #3862). A stale "signed in" is UI-only exposure: the first real API call after expiry still 401s into the logout redirect.
- **Coexistence**: with `bffEnabled` off there are no `/auth/*` routes, so the probe falls back to the synchronous oidc-client-ts localStorage check — legacy environments keep working unchanged. That branch is deliberately **never cached**: the popup sign-in flow and the dev-only `/backgroundsignin` page mutate localStorage without a page load, and the read is free (config.json itself is promise-cached).
- **Fail-safe**: 401, 502, network failures, and config-lookup failures all collapse to `{ authenticated: false }` rather than crashing render paths.

**Deviation from the Phase 4 text (4-E "remove token keys from storage.ts")**: the legacy token storage functions (`setOidcUser`/`getOidcUser`/sync `userIsLogged`) are deliberately retained during coexistence — the legacy sign-in flow, the fetch-adapter 401 metric, and the dev-only `/backgroundsignin` page still need them until the Phase 6 cutover cleanup (6-J), consistent with story 4-B's own rationale for leaving legacy storage untouched.

**Stories 4-I and 4-J ship no code anywhere in this stack**: they are delivered by construction through #3855's config-level gating — every ajax module's `${apiUrl}/api/...` URL and the RAS/ECM callback ride the `/duos-api` / `/ecm-api` / `/tdr-api` / `/bard-api` proxy prefixes in BFF mode, with `Authorization` attached server-side. The per-module `authOpts` deletion the phase sketches would regress legacy parity and is Phase 6 cleanup.

- **Server contract fix (first server change in the stack)**: `/auth/me` reports an upstream **401 or 404** from `/api/user/me` as `authenticated: true` with no `user`, so #3863's registration bootstrap is reachable. The DUOS API conflates "no profile for this email" with "bad token" — its auth filter (`DuosUserAuthenticator`) turns the user lookup's `NotFoundException` into a plain 401 (confirmed against a live consent stack during manual testing; a consent regression from DT-3788 — filed as [DT-3997](https://broadworkbench.atlassian.net/browse/DT-3997), in the current sprint), so treating that as a dead session destroyed every new user's session on first probe. Safe because the token is refreshed just before forwarding (below), and a genuinely revoked token also fails registration, which signs the session out. 502 remains for genuine upstream failures; `/auth/me` itself still 401s when there is no session.
- **Legacy identity**: the legacy probe branch reports the stored `CurrentUser` as the session identity, so the identity-reconciliation check in #3863 (session user vs stored user) is trivially satisfied in legacy mode.

### Testing
New `test/libs/auth/session.spec.ts` (10 cases: payload passthrough, 401/502/network/config failures, cache behavior, legacy fallback that never calls `/auth/me`). Nothing consumes the module yet (that's story 4-F, next in the stack), so `bffEnabled: false` behavior is unchanged by construction.

Similarly to the first PR in this stack, https://github.com/DataBiosphere/duos-ui/pull/3855, `bffEnabled: true` is not plainly testable. With `bffEnabled: false`, there should be no regressions in existing functionality.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)








[DT-3997]: https://broadworkbench.atlassian.net/browse/DT-3997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
