### PR TITLE
[DT-3609] Read auth state from the session probe in components (BFF Phase 4, story 4-F)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { useNavigate, useLocation } from 'react-router'
 import { Storage } from 'src/libs/storage'
 import AppRoutes from 'src/routing/AppRoutes'
 import { Notifications, setUserRoleStatuses } from 'src/libs/utils'
+import { useUserIsLogged } from 'src/hooks/useSession'
 import { extractError } from 'src/utils/ErrorUtils'
 import { Spinner } from 'src/components/Spinner'
 
@@ -27,11 +28,12 @@ const queryClient = new QueryClient({
 })
 
 function App() {
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
   const [env, setEnv] = useState('')
   const navigate = useNavigate()
   const location = useLocation()
   const [isLoading, setIsLoading] = useState(false)
+  // Auth state comes from the BFF session probe (GET /auth/me), not localStorage.
+  const isLoggedIn = useUserIsLogged() ?? false
 
   useEffect(() => {
     const setEnvironment = async () => {
@@ -40,14 +42,6 @@ function App() {
       Storage.setEnv(environment)
     }
     setEnvironment()
-  })
-
-  useEffect(() => {
-    const setUserIsLogged = () => {
-      const isLogged = Storage.userIsLogged()
-      setIsLoggedIn(isLogged)
-    }
-    setUserIsLogged()
   })
 
   /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,7 +42,9 @@ function App() {
       Storage.setEnv(environment)
     }
     setEnvironment()
-  })
+    // The environment never changes within a page load — look it up once on
+    // mount instead of on every render.
+  }, [])
 
   /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect

--- a/src/components/DuosHeader.tsx
+++ b/src/components/DuosHeader.tsx
@@ -18,7 +18,7 @@ import { Notification } from './Notification'
 import { useLocation, useNavigate } from 'react-router'
 import { DuosUser } from 'src/types/model'
 import { useNavigationState } from 'src/contexts/NavigationStateContext'
-import { useQueryClient } from '@tanstack/react-query'
+import { useUserIsLogged } from 'src/hooks/useSession'
 import { SO_CONSOLE_SECTIONS, SO_DASHBOARD_ROUTE } from 'src/pages/signing_official_console/signingOfficialConsoleRoutes'
 import { RESEARCHER_CONSOLE_SECTIONS, RESEARCHER_DASHBOARD_ROUTE } from 'src/pages/researcher_console/researcherConsoleRoutes'
 
@@ -154,7 +154,6 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
   })
 
   const { activeTab, setActiveTab } = useNavigationState()
-  const queryClient = useQueryClient()
 
   useEffect(() => {
     const fetchNotificationData = async (): Promise<void> => {
@@ -175,9 +174,9 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
   }
 
   const signOut = (): void => {
-    queryClient.clear()
-    navigate('/home')
     toggleDrawer(false)
+    // Auth.signOut destroys the BFF session and reloads to '/', which also
+    // drops the in-memory query cache — no queryClient.clear() needed.
     void Auth.signOut()
   }
 
@@ -212,7 +211,7 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
     toggleDrawer(false)
   }
 
-  const isLogged = Storage.userIsLogged()
+  const isLogged = useUserIsLogged() ?? false
   let currentUser: DuosUser = {
     createDate: new Date(),
     displayName: '',

--- a/src/components/DuosHeader.tsx
+++ b/src/components/DuosHeader.tsx
@@ -18,6 +18,7 @@ import { Notification } from './Notification'
 import { useLocation, useNavigate } from 'react-router'
 import { DuosUser } from 'src/types/model'
 import { useNavigationState } from 'src/contexts/NavigationStateContext'
+import { useQueryClient } from '@tanstack/react-query'
 import { useUserIsLogged } from 'src/hooks/useSession'
 import { SO_CONSOLE_SECTIONS, SO_DASHBOARD_ROUTE } from 'src/pages/signing_official_console/signingOfficialConsoleRoutes'
 import { RESEARCHER_CONSOLE_SECTIONS, RESEARCHER_DASHBOARD_ROUTE } from 'src/pages/researcher_console/researcherConsoleRoutes'
@@ -154,6 +155,7 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
   })
 
   const { activeTab, setActiveTab } = useNavigationState()
+  const queryClient = useQueryClient()
 
   useEffect(() => {
     const fetchNotificationData = async (): Promise<void> => {
@@ -174,10 +176,13 @@ const DuosHeader: React.FC<DuosHeaderProps> = (props) => {
   }
 
   const signOut = (): void => {
+    // The SPA navigation covers the legacy flow, where Auth.signOut only
+    // clears local state; in BFF mode Auth.signOut follows up with a full-page
+    // reload to the same destination, which supersedes both of these.
+    queryClient.clear()
+    navigate('/home')
     toggleDrawer(false)
-    // Auth.signOut destroys the BFF session and reloads to '/', which also
-    // drops the in-memory query cache — no queryClient.clear() needed.
-    void Auth.signOut()
+    void Auth.signOut('/home')
   }
 
   const supportRequestModal = (): void => {

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -95,11 +95,15 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
 
   // The session probe resolves after mount; re-derive the prefill when it
   // flips so a signed-in user's name/email land in the form (the documented
-  // adjust-state-during-render pattern, not an effect).
+  // adjust-state-during-render pattern, not an effect). Only the prefilled
+  // fields change — the probe can resolve (or focus revalidation can flip the
+  // state) while the user is mid-typing, and their subject, description, and
+  // attachments must survive.
   const [prevIsLogged, setPrevIsLogged] = useState(isLogged)
   if (prevIsLogged !== isLogged) {
     setPrevIsLogged(isLogged)
-    setFormData(resetFormData(isLogged))
+    const { name, email } = resetFormData(isLogged)
+    setFormData(prev => ({ ...prev, name, email }))
   }
 
   const closeHandler = () => {

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -93,17 +93,20 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
   const [formData, setFormData] = useState<FormData>(() => resetFormData(isLogged))
   const isEmailValid = isEmailAddress(formData.email)
 
-  // The session probe resolves after mount; re-derive the prefill when it
-  // flips so a signed-in user's name/email land in the form (the documented
-  // adjust-state-during-render pattern, not an effect). Only the prefilled
-  // fields change — the probe can resolve (or focus revalidation can flip the
-  // state) while the user is mid-typing, and their subject, description, and
-  // attachments must survive.
-  const [prevIsLogged, setPrevIsLogged] = useState(isLogged)
-  if (prevIsLogged !== isLogged) {
-    setPrevIsLogged(isLogged)
-    const { name, email } = resetFormData(isLogged)
-    setFormData(prev => ({ ...prev, name, email }))
+  // The prefill tracks the identity, not the auth boolean: on a BFF callback
+  // authentication flips true before the post-sign-in bootstrap persists
+  // CurrentUser, so keying on isLogged alone would freeze an empty (or a
+  // previous user's) prefill. Deriving the key from the prefill values means
+  // any change — sign-in, sign-out, the bootstrap persisting the profile,
+  // identity reconciliation swapping accounts — re-derives exactly once
+  // (adjust-state-during-render pattern). Only the prefilled fields change:
+  // typed subject/description/attachments must survive.
+  const { name: prefillName, email: prefillEmail } = resetFormData(isLogged)
+  const prefillKey = `${isLogged}:${prefillName}:${prefillEmail}`
+  const [prevPrefillKey, setPrevPrefillKey] = useState(prefillKey)
+  if (prevPrefillKey !== prefillKey) {
+    setPrevPrefillKey(prefillKey)
+    setFormData(prev => ({ ...prev, name: prefillName, email: prefillEmail }))
   }
 
   const closeHandler = () => {

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -70,25 +70,27 @@ interface FormData {
   email: string
 }
 
-// CurrentUser is only populated while signed in (sign-out resets it to the
-// empty default), so prefilled name/email fall back to '' when signed out.
-const resetFormData = (): FormData => {
+// The prefill is gated on the live session state, not just on CurrentUser:
+// an expired session never runs clearStorage(), so localStorage can retain
+// the previous user's name/email — they must not leak into the signed-out
+// support form.
+const resetFormData = (isLogged: boolean): FormData => {
   const currentUser = Storage.getCurrentUser()
   return {
-    name: currentUser.displayName,
+    name: isLogged ? currentUser.displayName : '',
     type: 'question',
     subject: '',
     description: '',
     attachment: [],
-    email: currentUser.email,
+    email: isLogged ? currentUser.email : '',
   }
 }
 
 export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) => {
   const { showModal, onCloseRequest, url } = props
-  const [formData, setFormData] = useState<FormData>(resetFormData)
 
   const isLogged = useUserIsLogged() ?? false
+  const [formData, setFormData] = useState<FormData>(() => resetFormData(isLogged))
   const isEmailValid = isEmailAddress(formData.email)
 
   // The session probe resolves after mount; re-derive the prefill when it
@@ -97,11 +99,11 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
   const [prevIsLogged, setPrevIsLogged] = useState(isLogged)
   if (prevIsLogged !== isLogged) {
     setPrevIsLogged(isLogged)
-    setFormData(resetFormData())
+    setFormData(resetFormData(isLogged))
   }
 
   const closeHandler = () => {
-    setFormData(resetFormData())
+    setFormData(resetFormData(isLogged))
     onCloseRequest('support')
   }
 

--- a/src/components/modals/SupportRequestModal.tsx
+++ b/src/components/modals/SupportRequestModal.tsx
@@ -27,6 +27,7 @@ import { Support } from 'src/libs/ajax/Support'
 import { Storage } from 'src/libs/storage'
 import { Notifications, isEmailAddress } from 'src/libs/utils'
 import { handleSignIn } from 'src/libs/signInUtils'
+import { useUserIsLogged } from 'src/hooks/useSession'
 import { AsyncSpinnerMuiButton } from 'src/components/AsyncSpinnerMuiButton'
 
 interface SupportRequestModalProps {
@@ -69,16 +70,17 @@ interface FormData {
   email: string
 }
 
+// CurrentUser is only populated while signed in (sign-out resets it to the
+// empty default), so prefilled name/email fall back to '' when signed out.
 const resetFormData = (): FormData => {
-  const isLogged = Storage.userIsLogged()
   const currentUser = Storage.getCurrentUser()
   return {
-    name: isLogged ? currentUser.displayName : '',
+    name: currentUser.displayName,
     type: 'question',
     subject: '',
     description: '',
     attachment: [],
-    email: isLogged ? currentUser.email : '',
+    email: currentUser.email,
   }
 }
 
@@ -86,8 +88,17 @@ export const SupportRequestModal: React.FC<SupportRequestModalProps> = (props) =
   const { showModal, onCloseRequest, url } = props
   const [formData, setFormData] = useState<FormData>(resetFormData)
 
-  const isLogged = Storage.userIsLogged()
+  const isLogged = useUserIsLogged() ?? false
   const isEmailValid = isEmailAddress(formData.email)
+
+  // The session probe resolves after mount; re-derive the prefill when it
+  // flips so a signed-in user's name/email land in the form (the documented
+  // adjust-state-during-render pattern, not an effect).
+  const [prevIsLogged, setPrevIsLogged] = useState(isLogged)
+  if (prevIsLogged !== isLogged) {
+    setPrevIsLogged(isLogged)
+    setFormData(resetFormData())
+  }
 
   const closeHandler = () => {
     setFormData(resetFormData())

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { SessionInfo, getSessionInfo } from 'src/libs/auth/session'
+
+/**
+ * React view of the BFF session probe (`GET /auth/me`, cached per page load in
+ * session.ts). Returns `undefined` while the probe is in flight so render
+ * paths can distinguish "still checking" from "signed out".
+ */
+export const useSessionInfo = (): SessionInfo | undefined => {
+  const [sessionInfo, setSessionInfo] = useState<SessionInfo | undefined>(undefined)
+
+  useEffect(() => {
+    let cancelled = false
+    getSessionInfo().then((info) => {
+      if (!cancelled) setSessionInfo(info)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return sessionInfo
+}
+
+/**
+ * Async replacement for the old synchronous `Storage.userIsLogged()`:
+ * `undefined` while the session probe is in flight, then the answer.
+ */
+export const useUserIsLogged = (): boolean | undefined => {
+  const sessionInfo = useSessionInfo()
+  return sessionInfo === undefined ? undefined : sessionInfo.authenticated
+}

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 import { SessionInfo, getSessionInfo, revalidateSessionInfo } from 'src/libs/auth/session'
 
@@ -18,35 +18,45 @@ import { SessionInfo, getSessionInfo, revalidateSessionInfo } from 'src/libs/aut
 export const useSessionInfo = (): SessionInfo | undefined => {
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | undefined>(undefined)
   const location = useLocation()
+  // Monotonic id of the most recently STARTED probe. The navigation and focus
+  // effects race each other, and per-effect cancellation cannot order them —
+  // a slow initial probe must not overwrite a newer revalidation's answer, or
+  // downstream consumers (identity reconciliation in App) see time go backwards.
+  const latestRequestId = useRef(0)
+
+  const publishLatest = useCallback((probe: Promise<SessionInfo>) => {
+    const requestId = ++latestRequestId.current
+    probe.then((info) => {
+      if (latestRequestId.current === requestId) setSessionInfo(info)
+    })
+  }, [])
 
   useEffect(() => {
-    let cancelled = false
-    getSessionInfo().then((info) => {
-      if (!cancelled) setSessionInfo(info)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [location])
+    publishLatest(getSessionInfo())
+  }, [location, publishLatest])
 
   // Revalidate when the tab regains focus: another tab can sign in or out on
   // the shared session cookie, and the fixed-lifetime session can expire while
   // the tab sits in the background. session.ts throttles the fan-out, so many
   // mounted hooks reacting to one focus event share a single probe.
   useEffect(() => {
-    let cancelled = false
     const revalidate = () => {
       if (document.visibilityState !== 'visible') return
-      revalidateSessionInfo().then((info) => {
-        if (!cancelled) setSessionInfo(info)
-      })
+      publishLatest(revalidateSessionInfo())
     }
     globalThis.addEventListener('focus', revalidate)
     document.addEventListener('visibilitychange', revalidate)
     return () => {
-      cancelled = true
       globalThis.removeEventListener('focus', revalidate)
       document.removeEventListener('visibilitychange', revalidate)
+    }
+  }, [publishLatest])
+
+  // Retire every in-flight probe on unmount so none of them publish late.
+  useEffect(() => {
+    const requests = latestRequestId
+    return () => {
+      requests.current++
     }
   }, [])
 

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -7,11 +7,13 @@ import { SessionInfo, getSessionInfo } from 'src/libs/auth/session'
  * session.ts). Returns `undefined` while the probe is in flight so render
  * paths can distinguish "still checking" from "signed out".
  *
- * Re-probes on every route change: in legacy mode auth state lives in
- * localStorage and changes without a page load (popup sign-in,
- * /backgroundsignin), and the sign-in flows all end in a navigation. In BFF
- * mode the re-probe hits session.ts's page-load cache, so it costs nothing.
- * The previous answer is kept (not reset to `undefined`) while re-probing.
+ * Re-probes on every navigation (`location` is a new object per history entry,
+ * including same-path navigations like signing out on /home): in legacy mode
+ * auth state lives in localStorage and changes without a page load (popup
+ * sign-in, /backgroundsignin), and the sign-in/out flows all end in a
+ * navigation. In BFF mode the re-probe hits session.ts's page-load cache, so
+ * it costs nothing. The previous answer is kept (not reset to `undefined`)
+ * while re-probing.
  */
 export const useSessionInfo = (): SessionInfo | undefined => {
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | undefined>(undefined)
@@ -25,7 +27,7 @@ export const useSessionInfo = (): SessionInfo | undefined => {
     return () => {
       cancelled = true
     }
-  }, [location.pathname])
+  }, [location])
 
   return sessionInfo
 }

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,13 +1,21 @@
 import { useEffect, useState } from 'react'
+import { useLocation } from 'react-router'
 import { SessionInfo, getSessionInfo } from 'src/libs/auth/session'
 
 /**
  * React view of the BFF session probe (`GET /auth/me`, cached per page load in
  * session.ts). Returns `undefined` while the probe is in flight so render
  * paths can distinguish "still checking" from "signed out".
+ *
+ * Re-probes on every route change: in legacy mode auth state lives in
+ * localStorage and changes without a page load (popup sign-in,
+ * /backgroundsignin), and the sign-in flows all end in a navigation. In BFF
+ * mode the re-probe hits session.ts's page-load cache, so it costs nothing.
+ * The previous answer is kept (not reset to `undefined`) while re-probing.
  */
 export const useSessionInfo = (): SessionInfo | undefined => {
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | undefined>(undefined)
+  const location = useLocation()
 
   useEffect(() => {
     let cancelled = false
@@ -17,7 +25,7 @@ export const useSessionInfo = (): SessionInfo | undefined => {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [location.pathname])
 
   return sessionInfo
 }

--- a/src/hooks/useSession.ts
+++ b/src/hooks/useSession.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router'
-import { SessionInfo, getSessionInfo } from 'src/libs/auth/session'
+import { SessionInfo, getSessionInfo, revalidateSessionInfo } from 'src/libs/auth/session'
 
 /**
  * React view of the BFF session probe (`GET /auth/me`, cached per page load in
@@ -28,6 +28,27 @@ export const useSessionInfo = (): SessionInfo | undefined => {
       cancelled = true
     }
   }, [location])
+
+  // Revalidate when the tab regains focus: another tab can sign in or out on
+  // the shared session cookie, and the fixed-lifetime session can expire while
+  // the tab sits in the background. session.ts throttles the fan-out, so many
+  // mounted hooks reacting to one focus event share a single probe.
+  useEffect(() => {
+    let cancelled = false
+    const revalidate = () => {
+      if (document.visibilityState !== 'visible') return
+      revalidateSessionInfo().then((info) => {
+        if (!cancelled) setSessionInfo(info)
+      })
+    }
+    globalThis.addEventListener('focus', revalidate)
+    document.addEventListener('visibilitychange', revalidate)
+    return () => {
+      cancelled = true
+      globalThis.removeEventListener('focus', revalidate)
+      document.removeEventListener('visibilitychange', revalidate)
+    }
+  }, [])
 
   return sessionInfo
 }

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -1,14 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { Auth } from 'src/libs/auth/auth'
-import { Storage } from 'src/libs/storage'
 import { TosService } from 'src/libs/TosService'
 import SimpleButton from 'src/components/SimpleButton'
-import { useNavigate } from 'react-router'
+import { useUserIsLogged } from 'src/hooks/useSession'
 
 export default function TermsOfService() {
-  const navigate = useNavigate()
   const [tosText, setTosText] = useState<React.ReactElement | null>(null)
-  const isLogged = Storage.userIsLogged()
+  const isLogged = useUserIsLogged() ?? false
 
   useEffect(() => {
     const init = async () => {
@@ -22,9 +20,8 @@ export default function TermsOfService() {
     // update Sam that ToS was rejected
     await TosService.rejectTos()
 
-    // log user out and send them back home.
+    // log user out — Auth.signOut redirects back home.
     await Auth.signOut()
-    navigate('/')
   }
 
   return (

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -2,9 +2,11 @@ import React, { useEffect, useState } from 'react'
 import { Auth } from 'src/libs/auth/auth'
 import { TosService } from 'src/libs/TosService'
 import SimpleButton from 'src/components/SimpleButton'
+import { useNavigate } from 'react-router'
 import { useUserIsLogged } from 'src/hooks/useSession'
 
 export default function TermsOfService() {
+  const navigate = useNavigate()
   const [tosText, setTosText] = useState<React.ReactElement | null>(null)
   const isLogged = useUserIsLogged() ?? false
 
@@ -20,8 +22,11 @@ export default function TermsOfService() {
     // update Sam that ToS was rejected
     await TosService.rejectTos()
 
-    // log user out — Auth.signOut redirects back home.
+    // Log the user out and send them back home. The navigation covers the
+    // legacy flow, where Auth.signOut only clears local state; in BFF mode
+    // Auth.signOut follows up with a full-page reload to '/'.
     await Auth.signOut()
+    navigate('/')
   }
 
   return (

--- a/src/pages/TermsOfServiceAcceptance.tsx
+++ b/src/pages/TermsOfServiceAcceptance.tsx
@@ -29,8 +29,11 @@ export default function TermsOfServiceAcceptance() {
   }, [navigate])
 
   const signOut = async () => {
-    // Auth.signOut redirects back home with a full page load.
+    // The navigation covers the legacy flow, where Auth.signOut only clears
+    // local state; in BFF mode Auth.signOut follows up with a full-page
+    // reload to '/'.
     await Auth.signOut()
+    navigate('/')
   }
 
   return (

--- a/src/pages/TermsOfServiceAcceptance.tsx
+++ b/src/pages/TermsOfServiceAcceptance.tsx
@@ -29,8 +29,8 @@ export default function TermsOfServiceAcceptance() {
   }, [navigate])
 
   const signOut = async () => {
+    // Auth.signOut redirects back home with a full page load.
     await Auth.signOut()
-    navigate('/')
   }
 
   return (

--- a/src/routing/Authenticated.tsx
+++ b/src/routing/Authenticated.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
-import { Storage } from 'src/libs/storage'
 import { Navigate, Outlet, useLocation } from 'react-router'
+import { useUserIsLogged } from 'src/hooks/useSession'
 
 const Authenticated = () => {
   const location = useLocation()
+  const isLogged = useUserIsLogged()
 
-  return Storage.userIsLogged()
+  // Session probe still in flight — render nothing rather than bouncing a
+  // signed-in user to the sign-in page before the answer arrives.
+  if (isLogged === undefined) {
+    return null
+  }
+
+  return isLogged
     ? <Outlet />
     : <Navigate to={location.pathname ? `/?redirectTo=${location.pathname}` : '/'} />
 }

--- a/test/browser/components/modals/SupportRequestModal.spec.tsx
+++ b/test/browser/components/modals/SupportRequestModal.spec.tsx
@@ -5,11 +5,15 @@ import { render } from '@testing-library/react'
 import { BrowserRouter } from 'react-router'
 import { Storage } from 'src/libs/storage'
 import { Support } from 'src/libs/ajax/Support'
+import { useUserIsLogged } from 'src/hooks/useSession'
 import { SupportRequestModal } from 'src/components/modals/SupportRequestModal'
 import { DuosUser } from 'src/types/model'
 
 vi.mock('src/libs/storage')
 vi.mock('src/libs/ajax/Support')
+vi.mock('src/hooks/useSession', () => ({
+  useUserIsLogged: vi.fn(),
+}))
 // Avoid importOriginal — only mock what SupportRequestModal uses from utils
 vi.mock('src/libs/utils', () => ({
   Notifications: { showError: vi.fn(), showSuccess: vi.fn() },
@@ -34,10 +38,12 @@ describe('SupportRequestModal - RedirectLink cursor styling (browser)', () => {
   })
 
   it.each([
+    // getCurrentUser never returns undefined — signed-out storage holds the
+    // default (empty) user, and the prefill falls back to empty strings.
     { label: 'logged in', isLogged: true, currentUser: mockUser as DuosUser },
-    { label: 'not logged in', isLogged: false, currentUser: undefined as unknown as DuosUser },
+    { label: 'not logged in', isLogged: false, currentUser: { displayName: '', email: '' } as DuosUser },
   ])('DUOS Data Library link has cursor:pointer when $label', ({ isLogged, currentUser }) => {
-    vi.mocked(Storage.userIsLogged).mockReturnValue(isLogged)
+    vi.mocked(useUserIsLogged).mockReturnValue(isLogged)
     vi.mocked(Storage.getCurrentUser).mockReturnValue(currentUser)
     vi.mocked(Support.createSupportRequest).mockResolvedValue(undefined)
     mountModal()

--- a/test/components/DuosHeader.spec.tsx
+++ b/test/components/DuosHeader.spec.tsx
@@ -7,8 +7,13 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import DuosHeader, { headerTabsConfig } from 'src/components/DuosHeader'
 import { visibleSubTabs } from 'src/components/navigation/subTabVisibility'
 import { Storage } from 'src/libs/storage'
+import { useUserIsLogged } from 'src/hooks/useSession'
 import { NavigationStateProvider } from 'src/contexts/NavigationStateContext'
 import { DuosUser } from 'src/types/model'
+
+vi.mock('src/hooks/useSession', () => ({
+  useUserIsLogged: vi.fn(),
+}))
 
 vi.mock('src/libs/notificationService', () => ({
   NotificationService: {
@@ -83,7 +88,8 @@ const defaultUser: DuosUser = {
 afterEach(() => vi.restoreAllMocks())
 
 const mountHeader = async (path: string, user?: DuosUser) => {
-  vi.spyOn(Storage, 'userIsLogged').mockReturnValue(!!user)
+  // Auth state comes from the BFF session probe now, not localStorage.
+  vi.mocked(useUserIsLogged).mockReturnValue(!!user)
   vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(user ?? defaultUser)
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   render(

--- a/test/components/modals/SupportRequestModal.spec.tsx
+++ b/test/components/modals/SupportRequestModal.spec.tsx
@@ -21,8 +21,9 @@ vi.mock('src/libs/utils', async (importOriginal) => {
 vi.mock('src/libs/signInUtils', () => ({ handleSignIn: vi.fn() }))
 
 const mockUser = { displayName: 'Display Name', email: 'email@test.com' }
-// getCurrentUser never returns undefined — signed-out storage holds the
-// default (empty) user, and the form prefill falls back to empty strings.
+// getCurrentUser never returns undefined — signed-out storage usually holds
+// the default (empty) user, but an expired session can leave a previous
+// user's data behind, so the prefill is gated on the session state.
 const signedOutUser = { displayName: '', email: '' }
 const handler = vi.fn()
 
@@ -95,6 +96,18 @@ describe('Support Request Modal Tests', () => {
     expect(document.querySelector('[data-cy="supportFormAttachment"]')).toBeInTheDocument()
     expect(document.querySelector('[data-cy="supportFormSubmit"]')).toBeDisabled()
     expect(document.querySelector('[data-cy="supportFormCancel"]')).not.toBeDisabled()
+  })
+
+  it('does not leak a previous user\'s name/email into the signed-out form', () => {
+    // An expired session never runs clearStorage(), so CurrentUser can still
+    // hold the previous user's data while the session probe reports signed out.
+    vi.mocked(useUserIsLogged).mockReturnValue(false)
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(mockUser as never)
+    mountModal()
+    const nameInput = document.querySelector('[data-cy="supportFormName"] input') as HTMLInputElement
+    const emailInput = document.querySelector('[data-cy="supportFormEmail"] input') as HTMLInputElement
+    expect(nameInput.value).toBe('')
+    expect(emailInput.value).toBe('')
   })
 
   describe('When a user is logged in:', () => {

--- a/test/components/modals/SupportRequestModal.spec.tsx
+++ b/test/components/modals/SupportRequestModal.spec.tsx
@@ -6,10 +6,14 @@ import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router'
 import { Storage } from 'src/libs/storage'
 import { Support } from 'src/libs/ajax/Support'
+import { useUserIsLogged } from 'src/hooks/useSession'
 import { SupportRequestModal } from 'src/components/modals/SupportRequestModal'
 
 vi.mock('src/libs/storage')
 vi.mock('src/libs/ajax/Support')
+vi.mock('src/hooks/useSession', () => ({
+  useUserIsLogged: vi.fn(),
+}))
 vi.mock('src/libs/utils', async (importOriginal) => {
   const actual = await importOriginal<typeof import('src/libs/utils')>()
   return { ...actual, Notifications: { showError: vi.fn(), showSuccess: vi.fn() } }
@@ -17,6 +21,9 @@ vi.mock('src/libs/utils', async (importOriginal) => {
 vi.mock('src/libs/signInUtils', () => ({ handleSignIn: vi.fn() }))
 
 const mockUser = { displayName: 'Display Name', email: 'email@test.com' }
+// getCurrentUser never returns undefined — signed-out storage holds the
+// default (empty) user, and the form prefill falls back to empty strings.
+const signedOutUser = { displayName: '', email: '' }
 const handler = vi.fn()
 
 const mountModal = () =>
@@ -27,13 +34,13 @@ const mountModal = () =>
   )
 
 const setupLoggedIn = () => {
-  vi.mocked(Storage.userIsLogged).mockReturnValue(true)
+  vi.mocked(useUserIsLogged).mockReturnValue(true)
   vi.mocked(Storage.getCurrentUser).mockReturnValue(mockUser as never)
 }
 
 const setupLoggedOut = () => {
-  vi.mocked(Storage.userIsLogged).mockReturnValue(false)
-  vi.mocked(Storage.getCurrentUser).mockReturnValue(undefined as never)
+  vi.mocked(useUserIsLogged).mockReturnValue(false)
+  vi.mocked(Storage.getCurrentUser).mockReturnValue(signedOutUser as never)
 }
 
 const selectType = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
@@ -66,10 +73,10 @@ describe('Support Request Modal Tests', () => {
 
   it.each([
     { label: 'logged in', isLogged: true, currentUser: mockUser as never, showEmailName: false },
-    { label: 'not logged in', isLogged: false, currentUser: undefined as never, showEmailName: true },
+    { label: 'not logged in', isLogged: false, currentUser: signedOutUser as never, showEmailName: true },
     { label: 'logged in with undefined user values', isLogged: true, currentUser: { displayName: undefined, email: undefined } as never, showEmailName: false },
   ])('Renders form correctly when $label', ({ isLogged, currentUser, showEmailName }) => {
-    vi.mocked(Storage.userIsLogged).mockReturnValue(isLogged)
+    vi.mocked(useUserIsLogged).mockReturnValue(isLogged)
     vi.mocked(Storage.getCurrentUser).mockReturnValue(currentUser)
     mountModal()
     expect(document.querySelector('[data-cy="closeButton"]')).toBeInTheDocument()
@@ -163,7 +170,7 @@ describe('Support Request Modal Tests', () => {
 
   describe('When a user is logged in but current user values are undefined:', () => {
     beforeEach(() => {
-      vi.mocked(Storage.userIsLogged).mockReturnValue(true)
+      vi.mocked(useUserIsLogged).mockReturnValue(true)
       vi.mocked(Storage.getCurrentUser).mockReturnValue({
         displayName: undefined,
         email: undefined,

--- a/test/components/modals/SupportRequestModal.spec.tsx
+++ b/test/components/modals/SupportRequestModal.spec.tsx
@@ -110,6 +110,31 @@ describe('Support Request Modal Tests', () => {
     expect(emailInput.value).toBe('')
   })
 
+  it('preserves typed content when the session probe resolves mid-typing', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useUserIsLogged).mockReturnValue(false)
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(signedOutUser as never)
+    const view = mountModal()
+
+    await user.type(document.querySelector('[data-cy="supportFormSubject"] input')!, 'Half-typed subject')
+    await user.type(document.querySelector('[data-cy="supportFormDescription"] textarea')!, 'Details so far')
+
+    // The probe (or a focus revalidation) flips the auth state mid-typing.
+    vi.mocked(useUserIsLogged).mockReturnValue(true)
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(mockUser as never)
+    view.rerender(
+      <BrowserRouter>
+        <SupportRequestModal onCloseRequest={handler} url="url" showModal={true} />
+      </BrowserRouter>,
+    )
+
+    // Only the prefill re-derives; the user's work survives.
+    const subjectInput = document.querySelector('[data-cy="supportFormSubject"] input') as HTMLInputElement
+    const descriptionInput = document.querySelector('[data-cy="supportFormDescription"] textarea') as HTMLTextAreaElement
+    expect(subjectInput.value).toBe('Half-typed subject')
+    expect(descriptionInput.value).toBe('Details so far')
+  })
+
   describe('When a user is logged in:', () => {
     beforeEach(setupLoggedIn)
 

--- a/test/components/modals/SupportRequestModal.spec.tsx
+++ b/test/components/modals/SupportRequestModal.spec.tsx
@@ -110,6 +110,44 @@ describe('Support Request Modal Tests', () => {
     expect(emailInput.value).toBe('')
   })
 
+  it('picks up the profile the post-sign-in bootstrap persists AFTER authentication flips', async () => {
+    // BFF callback ordering: the probe reports authenticated before
+    // completeSignIn has persisted CurrentUser. The prefill must not freeze
+    // on the empty profile it sees at that moment.
+    vi.mocked(useUserIsLogged).mockReturnValue(false)
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(signedOutUser as never)
+    const view = mountModal()
+
+    // Auth flips true while storage still holds the empty default.
+    vi.mocked(useUserIsLogged).mockReturnValue(true)
+    view.rerender(
+      <BrowserRouter>
+        <SupportRequestModal onCloseRequest={handler} url="url" showModal={true} />
+      </BrowserRouter>,
+    )
+
+    // The bootstrap persists the real profile afterward.
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(mockUser as never)
+    view.rerender(
+      <BrowserRouter>
+        <SupportRequestModal onCloseRequest={handler} url="url" showModal={true} />
+      </BrowserRouter>,
+    )
+
+    // Submit uses formData.name/email even though the fields are hidden when
+    // signed in — a frozen empty prefill would make the form unsubmittable.
+    const user = userEvent.setup()
+    await user.type(document.querySelector('[data-cy="supportFormSubject"] input')!, 'Subject')
+    await user.type(document.querySelector('[data-cy="supportFormDescription"] textarea')!, 'Description')
+    await selectType(user, 'Bug')
+    expect(document.querySelector('[data-cy="supportFormSubmit"]')).not.toBeDisabled()
+
+    await user.click(document.querySelector('[data-cy="supportFormSubmit"]')!)
+    await waitFor(() => expect(vi.mocked(Support.createTicket)).toHaveBeenCalledWith(
+      mockUser.displayName, expect.anything(), mockUser.email, 'Subject', 'Description', expect.anything(), expect.anything(),
+    ))
+  })
+
   it('preserves typed content when the session probe resolves mid-typing', async () => {
     const user = userEvent.setup()
     vi.mocked(useUserIsLogged).mockReturnValue(false)

--- a/test/hooks/useSession.spec.tsx
+++ b/test/hooks/useSession.spec.tsx
@@ -4,6 +4,7 @@ import { renderHook, act, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import { useSessionInfo, useUserIsLogged } from 'src/hooks/useSession'
 import { getSessionInfo, revalidateSessionInfo } from 'src/libs/auth/session'
+import type { SessionInfo } from 'src/libs/auth/session'
 
 vi.mock('src/libs/auth/session', () => ({
   getSessionInfo: vi.fn(),
@@ -61,6 +62,29 @@ describe('useSession hooks', () => {
     finally {
       visibilitySpy.mockRestore()
     }
+  })
+
+  it('ignores a stale probe that resolves after a newer revalidation (latest request wins)', async () => {
+    let resolveInitialProbe!: (info: SessionInfo) => void
+    vi.mocked(getSessionInfo).mockReturnValue(new Promise((resolve) => {
+      resolveInitialProbe = resolve
+    }))
+    vi.mocked(revalidateSessionInfo).mockResolvedValue({ authenticated: true, idp: 'google' })
+
+    const { result } = renderHook(() => useSessionInfo(), { wrapper })
+
+    // The focus revalidation starts later but finishes first.
+    act(() => {
+      globalThis.dispatchEvent(new Event('focus'))
+    })
+    await waitFor(() => expect(result.current).toEqual({ authenticated: true, idp: 'google' }))
+
+    // The slow initial probe finally resolves signed-out — it must not
+    // overwrite the newer answer.
+    await act(async () => {
+      resolveInitialProbe({ authenticated: false })
+    })
+    expect(result.current).toEqual({ authenticated: true, idp: 'google' })
   })
 
   it('stops listening after unmount', async () => {

--- a/test/hooks/useSession.spec.tsx
+++ b/test/hooks/useSession.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { useSessionInfo, useUserIsLogged } from 'src/hooks/useSession'
+import { getSessionInfo, revalidateSessionInfo } from 'src/libs/auth/session'
+
+vi.mock('src/libs/auth/session', () => ({
+  getSessionInfo: vi.fn(),
+  revalidateSessionInfo: vi.fn(),
+}))
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+)
+
+describe('useSession hooks', () => {
+  beforeEach(() => {
+    vi.mocked(getSessionInfo).mockResolvedValue({ authenticated: false })
+    vi.mocked(revalidateSessionInfo).mockResolvedValue({ authenticated: false })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('useUserIsLogged is undefined while the probe is in flight, then the answer', async () => {
+    vi.mocked(getSessionInfo).mockResolvedValue({ authenticated: true })
+
+    const { result } = renderHook(() => useUserIsLogged(), { wrapper })
+
+    expect(result.current).toBeUndefined()
+    await waitFor(() => expect(result.current).toBe(true))
+  })
+
+  it('revalidates on window focus — another tab may have signed in or out', async () => {
+    vi.mocked(revalidateSessionInfo).mockResolvedValue({ authenticated: true, idp: 'google' })
+
+    const { result } = renderHook(() => useSessionInfo(), { wrapper })
+    await waitFor(() => expect(result.current).toEqual({ authenticated: false }))
+
+    act(() => {
+      globalThis.dispatchEvent(new Event('focus'))
+    })
+
+    await waitFor(() => expect(result.current).toEqual({ authenticated: true, idp: 'google' }))
+    expect(vi.mocked(revalidateSessionInfo)).toHaveBeenCalled()
+  })
+
+  it('does not revalidate while the tab is hidden', async () => {
+    const { result } = renderHook(() => useSessionInfo(), { wrapper })
+    await waitFor(() => expect(result.current).toEqual({ authenticated: false }))
+
+    const visibilitySpy = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('hidden')
+    try {
+      act(() => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      expect(vi.mocked(revalidateSessionInfo)).not.toHaveBeenCalled()
+    }
+    finally {
+      visibilitySpy.mockRestore()
+    }
+  })
+
+  it('stops listening after unmount', async () => {
+    const { result, unmount } = renderHook(() => useSessionInfo(), { wrapper })
+    await waitFor(() => expect(result.current).toEqual({ authenticated: false }))
+
+    unmount()
+    globalThis.dispatchEvent(new Event('focus'))
+
+    expect(vi.mocked(revalidateSessionInfo)).not.toHaveBeenCalled()
+  })
+})

--- a/test/pages/TermsOfService.spec.tsx
+++ b/test/pages/TermsOfService.spec.tsx
@@ -4,13 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router'
 import TermsOfService from 'src/pages/TermsOfService'
-
-const mockNavigate = vi.fn()
-
-vi.mock('react-router', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('react-router')>()
-  return { ...actual, useNavigate: () => mockNavigate }
-})
+import { useUserIsLogged } from 'src/hooks/useSession'
 
 vi.mock('src/libs/TosService', () => ({
   TosService: {
@@ -24,16 +18,16 @@ vi.mock('src/libs/TosService', () => ({
   },
 }))
 
+// Auth.signOut handles the post-sign-out navigation itself (full-page reload
+// to '/'), so the page no longer calls navigate.
 vi.mock('src/libs/auth/auth', () => ({
   Auth: {
     signOut: vi.fn().mockResolvedValue(undefined),
   },
 }))
 
-vi.mock('src/libs/storage', () => ({
-  Storage: {
-    userIsLogged: vi.fn().mockReturnValue(false),
-  },
+vi.mock('src/hooks/useSession', () => ({
+  useUserIsLogged: vi.fn(),
 }))
 
 const renderComponent = async () => {
@@ -49,6 +43,7 @@ const renderComponent = async () => {
 describe('Terms of Service Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(useUserIsLogged).mockReturnValue(false)
   })
 
   it('renders the page heading', async () => {
@@ -67,24 +62,28 @@ describe('Terms of Service Page', () => {
     expect(screen.queryByText('Reject Terms of Service')).not.toBeInTheDocument()
   })
 
+  it('does not show the reject button while the session probe is in flight', async () => {
+    vi.mocked(useUserIsLogged).mockReturnValue(undefined)
+    await renderComponent()
+    expect(screen.queryByText('Reject Terms of Service')).not.toBeInTheDocument()
+  })
+
   it('shows the reject button when user is logged in', async () => {
-    const { Storage } = await import('src/libs/storage')
-    vi.mocked(Storage.userIsLogged).mockReturnValue(true)
+    vi.mocked(useUserIsLogged).mockReturnValue(true)
     await renderComponent()
     expect(screen.getByText('Reject Terms of Service')).toBeInTheDocument()
   })
 
-  it('clicking reject calls rejectTos, signOut, and navigates to /', async () => {
+  it('clicking reject calls rejectTos and signs the user out', async () => {
     const { TosService } = await import('src/libs/TosService')
     const { Auth } = await import('src/libs/auth/auth')
-    const { Storage } = await import('src/libs/storage')
-    vi.mocked(Storage.userIsLogged).mockReturnValue(true)
+    vi.mocked(useUserIsLogged).mockReturnValue(true)
     await renderComponent()
     await act(async () => {
       fireEvent.click(screen.getByText('Reject Terms of Service'))
     })
     await waitFor(() => expect(TosService.rejectTos).toHaveBeenCalledOnce())
+    // Auth.signOut redirects back home itself — no navigate call to assert.
     expect(Auth.signOut).toHaveBeenCalledOnce()
-    expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 })

--- a/test/pages/TermsOfService.spec.tsx
+++ b/test/pages/TermsOfService.spec.tsx
@@ -6,6 +6,13 @@ import { MemoryRouter } from 'react-router'
 import TermsOfService from 'src/pages/TermsOfService'
 import { useUserIsLogged } from 'src/hooks/useSession'
 
+const mockNavigate = vi.fn()
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router')>()
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
 vi.mock('src/libs/TosService', () => ({
   TosService: {
     getFormattedText: vi.fn().mockResolvedValue(
@@ -18,8 +25,6 @@ vi.mock('src/libs/TosService', () => ({
   },
 }))
 
-// Auth.signOut handles the post-sign-out navigation itself (full-page reload
-// to '/'), so the page no longer calls navigate.
 vi.mock('src/libs/auth/auth', () => ({
   Auth: {
     signOut: vi.fn().mockResolvedValue(undefined),
@@ -74,7 +79,7 @@ describe('Terms of Service Page', () => {
     expect(screen.getByText('Reject Terms of Service')).toBeInTheDocument()
   })
 
-  it('clicking reject calls rejectTos and signs the user out', async () => {
+  it('clicking reject calls rejectTos, signOut, and navigates to /', async () => {
     const { TosService } = await import('src/libs/TosService')
     const { Auth } = await import('src/libs/auth/auth')
     vi.mocked(useUserIsLogged).mockReturnValue(true)
@@ -83,7 +88,9 @@ describe('Terms of Service Page', () => {
       fireEvent.click(screen.getByText('Reject Terms of Service'))
     })
     await waitFor(() => expect(TosService.rejectTos).toHaveBeenCalledOnce())
-    // Auth.signOut redirects back home itself — no navigate call to assert.
     expect(Auth.signOut).toHaveBeenCalledOnce()
+    // The navigation covers the legacy flow, where Auth.signOut does not
+    // redirect; in BFF mode the full-page reload supersedes it.
+    expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 })

--- a/test/pages/TermsOfServiceAcceptance.spec.tsx
+++ b/test/pages/TermsOfServiceAcceptance.spec.tsx
@@ -63,7 +63,8 @@ describe('Terms of Service Acceptance Page', () => {
       fireEvent.click(screen.getByText('Reject Terms of Service'))
     })
     await waitFor(() => expect(Auth.signOut).toHaveBeenCalledOnce())
-    expect(mockNavigate).toHaveBeenCalledWith('/')
+    // Auth.signOut performs the full-page redirect home itself — no router navigation.
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   it('clicking the accept button calls acceptTos and navigates', async () => {

--- a/test/pages/TermsOfServiceAcceptance.spec.tsx
+++ b/test/pages/TermsOfServiceAcceptance.spec.tsx
@@ -63,8 +63,9 @@ describe('Terms of Service Acceptance Page', () => {
       fireEvent.click(screen.getByText('Reject Terms of Service'))
     })
     await waitFor(() => expect(Auth.signOut).toHaveBeenCalledOnce())
-    // Auth.signOut performs the full-page redirect home itself — no router navigation.
-    expect(mockNavigate).not.toHaveBeenCalled()
+    // The router navigation covers the legacy flow, where Auth.signOut does
+    // not redirect; in BFF mode the full-page reload supersedes it.
+    expect(mockNavigate).toHaveBeenCalledWith('/')
   })
 
   it('clicking the accept button calls acceptTos and navigates', async () => {

--- a/test/routing/AppRoutes.spec.tsx
+++ b/test/routing/AppRoutes.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router'
@@ -7,9 +7,17 @@ import AppRoutes from 'src/routing/AppRoutes'
 import { Storage } from 'src/libs/storage'
 import { USER_ROLES } from 'src/libs/utils'
 import { DuosUser } from 'src/types/model'
+import { useUserIsLogged } from 'src/hooks/useSession'
 
 vi.mock('src/libs/libraryVersions', () => ({
   getLibraryVersions: () => ({}),
+}))
+
+// The session probe (GET /auth/me) is mocked resolved so <Authenticated />
+// decides synchronously: signed out by default, overridden per-describe.
+vi.mock('src/hooks/useSession', () => ({
+  useUserIsLogged: vi.fn(() => false),
+  useSessionInfo: vi.fn(() => ({ authenticated: false })),
 }))
 
 vi.mock('src/components/modals/SupportRequestModal', () => ({
@@ -77,9 +85,6 @@ const roleBACRoutes: string[] = [
 ]
 
 describe('AppRoutes — RoleBAC routes redirect unauthenticated users', () => {
-  beforeEach(() => {
-    vi.spyOn(Storage, 'userIsLogged').mockReturnValue(false)
-  })
   afterEach(() => vi.restoreAllMocks())
 
   it.each(roleBACRoutes)('redirects unauthenticated user visiting "%s" to /?redirectTo=<route>', (route) => {
@@ -101,7 +106,7 @@ describe('AppRoutes — legacy DAC console redirects', () => {
   } as DuosUser)
 
   beforeEach(() => {
-    vi.spyOn(Storage, 'userIsLogged').mockReturnValue(true)
+    vi.mocked(useUserIsLogged).mockReturnValue(true)
   })
 
   afterEach(() => vi.restoreAllMocks())

--- a/test/routing/AppRoutes.spec.tsx
+++ b/test/routing/AppRoutes.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render } from '@testing-library/react'
 import { MemoryRouter, useLocation } from 'react-router'

--- a/test/routing/Authenticated.spec.tsx
+++ b/test/routing/Authenticated.spec.tsx
@@ -4,12 +4,10 @@ import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router'
 import Authenticated from 'src/routing/Authenticated'
-import { Storage } from 'src/libs/storage'
+import { useUserIsLogged } from 'src/hooks/useSession'
 
-vi.mock('src/libs/storage', () => ({
-  Storage: {
-    userIsLogged: vi.fn(),
-  },
+vi.mock('src/hooks/useSession', () => ({
+  useUserIsLogged: vi.fn(),
 }))
 
 const ProtectedComponent = () => <div data-testid="protected-content">Protected Content</div>
@@ -19,49 +17,54 @@ interface LocationSpyProps {
   onLocationChange: (location: string) => void
 }
 
+const renderRoutes = (extra?: React.ReactNode) =>
+  render(
+    <MemoryRouter initialEntries={['/protected']}>
+      {extra}
+      <Routes>
+        <Route element={<Authenticated />}>
+          <Route path="/protected" element={<ProtectedComponent />} />
+        </Route>
+        <Route path="/" element={<HomeComponent />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+
 describe('Authenticated', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should render the protected component if the user is logged in', () => {
-    vi.mocked(Storage.userIsLogged).mockReturnValue(true)
+  it('should render nothing while the session probe is in flight', () => {
+    vi.mocked(useUserIsLogged).mockReturnValue(undefined)
 
-    render(
-      <MemoryRouter initialEntries={['/protected']}>
-        <Routes>
-          <Route element={<Authenticated />}>
-            <Route path="/protected" element={<ProtectedComponent />} />
-          </Route>
-          <Route path="/" element={<HomeComponent />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderRoutes()
+
+    // Neither the protected content nor a redirect to home — just wait.
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('home-content')).not.toBeInTheDocument()
+  })
+
+  it('should render the protected component if the user is logged in', () => {
+    vi.mocked(useUserIsLogged).mockReturnValue(true)
+
+    renderRoutes()
 
     expect(screen.getByTestId('protected-content')).toBeInTheDocument()
     expect(screen.queryByTestId('home-content')).not.toBeInTheDocument()
   })
 
   it('should redirect to the home page if the user is not logged in', () => {
-    vi.mocked(Storage.userIsLogged).mockReturnValue(false)
+    vi.mocked(useUserIsLogged).mockReturnValue(false)
 
-    render(
-      <MemoryRouter initialEntries={['/protected']}>
-        <Routes>
-          <Route element={<Authenticated />}>
-            <Route path="/protected" element={<ProtectedComponent />} />
-          </Route>
-          <Route path="/" element={<HomeComponent />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderRoutes()
 
     expect(screen.getByTestId('home-content')).toBeInTheDocument()
     expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument()
   })
 
   it('should redirect with a redirectTo query param if the user is not logged in', () => {
-    vi.mocked(Storage.userIsLogged).mockReturnValue(false)
+    vi.mocked(useUserIsLogged).mockReturnValue(false)
     const pageVisitStub = vi.fn()
     const LocationSpy = ({ onLocationChange }: LocationSpyProps) => {
       const location = useLocation()
@@ -71,17 +74,7 @@ describe('Authenticated', () => {
       return null
     }
 
-    render(
-      <MemoryRouter initialEntries={['/protected']}>
-        <LocationSpy onLocationChange={pageVisitStub} />
-        <Routes>
-          <Route element={<Authenticated />}>
-            <Route path="/protected" element={<ProtectedComponent />} />
-          </Route>
-          <Route path="/" element={<HomeComponent />} />
-        </Routes>
-      </MemoryRouter>,
-    )
+    renderRoutes(<LocationSpy onLocationChange={pageVisitStub} />)
 
     expect(screen.getByTestId('home-content')).toBeInTheDocument()
     expect(pageVisitStub).toHaveBeenCalledWith('/protected')


### PR DESCRIPTION
> [!NOTE]
> Part of the BFF Phase 4 stack: #3861 → #3862 → #3863 → #3864 → #3869 (#3855 merged to develop). This PR's diff is against #3861; review bottom-up. New to the stack? Start with the [review guide & retrospective](https://github.com/DataBiosphere/duos-ui/blob/claude/epic-4-signout-redirect-cleanup/docs/plans/epic-4-stack-review-guide.md).

### Addresses
https://broadworkbench.atlassian.net/browse/DT-3609 (BFF Phase 4, story 4-F)

### Summary
Migrates every component call site off the synchronous `Storage.userIsLogged()` and onto the session probe from #3861:

- **New `src/hooks/useSession.ts`**: `useSessionInfo()` / `useUserIsLogged()` return `undefined` while the probe is in flight so render paths can distinguish "still checking" from "signed out". The hooks re-probe on every navigation and revalidate on window focus / visibilitychange (throttled in session.ts so many mounted hooks share one probe) — a background tab can outlive its session or watch another tab sign in/out on the shared cookie.
- **`Authenticated.tsx`** renders nothing while the probe is in flight rather than bouncing an actually-signed-in user to `/?redirectTo=…` before the answer arrives.
- **`App.tsx`, `DuosHeader`, `SupportRequestModal`, `TermsOfService`** read the hook (`?? false`). The support modal re-derives its name/email prefill when the probe resolves (adjust-state-during-render, not an effect).
- **Sign-out call sites** (`DuosHeader`, both ToS pages) keep their SPA `navigate()` / `queryClient.clear()`: legacy `Auth.signOut()` only clears local state (`OidcBroker.signOut()` does not navigate), so the caller's navigation is what actually moves a legacy user off the page — and it also triggers the hook's re-probe that refreshes the header. In BFF mode `Auth.signOut()` follows up with a full-page reload to the same destination (`DuosHeader` passes `/home` through), which supersedes the SPA navigation harmlessly. The hook re-probes on every navigation — `location` identity, not just pathname — so signing out while already on `/home` still refreshes auth state.

The synchronous check deliberately survives in `auth.ts` (legacy fallback), `Metrics.ts` (legacy identified events), and `storage.ts` until the Epic 6 cutover cleanup — see the deviation note on #3861.

### Testing
Specs updated in lockstep: `Authenticated` (new in-flight-renders-nothing case), `AppRoutes` (session probe mocked; the legacy-DAC-console block now flips the hook, not the storage spy), `DuosHeader`, `SupportRequestModal` (jsdom + browser), `TermsOfService` (new in-flight reject-button case), `TermsOfServiceAcceptance`. With `bffEnabled: false` the probe resolves from legacy storage, so behavior is unchanged.

Similarly to the first PR in this stack, https://github.com/DataBiosphere/duos-ui/pull/3855, `bffEnabled: true` is not plainly testable. With `bffEnabled: false`, there should be no regressions in existing functionality.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)




