### PR TITLE
[DT-3609] Complete BFF sign-in after the OAuth redirect (BFF Phase 4, story 4-G)

### DIFF
--- a/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md
+++ b/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md
@@ -40,7 +40,9 @@ multi-account applications do — by discarding the stale tab's state:
   the reconciliation spinner. This needs no conflict machinery: nothing else
   is in flight.
 - An identity conflict that appears **under an in-flight bootstrap** cancels
-  that run and **hard-reloads the tab** (`Redirect.to(location.href)`). The
+  that run and **hard-reloads the tab** (`Redirect.reload()` — a true
+  `location.reload()`, because assigning `location.href` to a URL with a
+  `#fragment` is a same-document navigation that reloads nothing). The
   fresh page load reconciles from scratch; the reload kills all in-flight
   JavaScript, so no obsolete run can persist a user, emit metrics, navigate,
   or destroy the session after being overtaken.
@@ -72,6 +74,37 @@ withheld for the one render until the fresh profile commits.
   repeatedly), reload more than once. Each reload converges on the current
   session, so there is no livelock — the fresh load either matches storage
   (hydrate) or bootstraps in place.
+
+## Accepted risks
+
+Two residual windows, surfaced by the cross-tab review on #3863
+(2026-08-17), are accepted rather than engineered around:
+
+1. **A registration run can adopt a different unregistered identity.**
+   `/auth/me` cannot distinguish unregistered accounts — every one of them
+   reports `authenticated: true` with no user, so a registration run's
+   target identity is "none". If, during the seconds a registration run is
+   in flight, another tab signs the shared cookie into a *different*
+   unregistered account, a focus revalidation in the first tab joins the
+   run (same "none" target) and the in-flight `registerUser()` registers
+   whoever now owns the cookie. The tab converges on that account rather
+   than reloading. Detecting this needs a stable per-session identifier for
+   unregistered sessions from `/auth/me`; the join rule cannot be tightened
+   without also reloading on the legitimate joins (StrictMode double
+   invocation, focus revalidation) that the run-once machinery exists for.
+   The window is seconds wide and requires two different unregistered
+   accounts switching mid-registration.
+
+2. **A transient upstream 401 for a registered user drives one
+   registration POST.** `/auth/me` reports an upstream 401 as "valid
+   session, no profile" (the upstream conflates the two — see #3861). For
+   a *registered* user this shape only appears when the upstream 401s a
+   freshly refreshed token: a revoked token, or upstream auth outage. The
+   bootstrap then attempts `registerUser()`; the expected `409 Conflict`
+   recovers into a normal sign-in, and any other failure signs the session
+   out — which is the correct end state for a genuinely revoked token. The
+   cost of the window is one spurious POST and, during an upstream auth
+   outage, a sign-out instead of an error banner.
 
 ## Alternative considered
 

--- a/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md
+++ b/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md
@@ -1,0 +1,83 @@
+# ADR-011 — One identity per browser: cross-tab account switching reloads the stale tab
+
+**Status:** Accepted (2026-08-15) &nbsp;|&nbsp; **Phase:** 4, stories 4-E/4-F/4-G
+**Related:** [ADR-004](ADR-004-api-proxy-layer.md) (the session cookie all tabs share)
+**Implemented by:** `src/hooks/useSessionReconciler.ts` (duos-ui #3863)
+
+---
+
+## Context
+
+With the BFF, authentication state lives in one server-side session addressed
+by one cookie, shared by every tab of the browser profile. "Two different
+users in two different tabs" is therefore not a state the system can be in:
+every API call from every tab acts as whoever authenticated most recently.
+The only real phenomenon is **serial account switching with a stale tab** —
+tab A still *displaying* user X while the shared session has become user Y
+(or has been signed out, or belongs to a not-yet-registered account).
+
+The client reconciles the session identity against the locally stored profile
+(`CurrentUser`, also shared across tabs) whenever the session probe
+(`GET /auth/me`) returns a fresh answer — on navigation, focus/visibility
+changes, and cache expiry. Review of the reconciliation logic (ten findings
+across four rounds) kept surfacing new interleavings of the same underlying
+problem: making a stale tab converge **gracefully, in place**, requires
+supersede semantics for in-flight bootstraps, provenance tracking for which
+run wrote which identity to shared storage, and a distinguishable identity
+for unregistered sessions (which `/auth/me` cannot provide — every
+unregistered account looks the same). Each mechanism fixed one interleaving
+and exposed another.
+
+## Decision
+
+**Concurrent different-user usage across tabs is unsupported.** The
+reconciler handles a detected identity conflict the way mainstream
+multi-account applications do — by discarding the stale tab's state:
+
+- An identity conflict that appears **while no reconciliation is running**
+  (a fresh probe naming a different user, or reporting no profile over a
+  stored identity) runs the normal post-sign-in bootstrap in place, behind
+  the reconciliation spinner. This needs no conflict machinery: nothing else
+  is in flight.
+- An identity conflict that appears **under an in-flight bootstrap** cancels
+  that run and **hard-reloads the tab** (`Redirect.to(location.href)`). The
+  fresh page load reconciles from scratch; the reload kills all in-flight
+  JavaScript, so no obsolete run can persist a user, emit metrics, navigate,
+  or destroy the session after being overtaken.
+- Within one tab, `localStorage` consequently has a **single writer** during
+  a reconciliation run. The only join rule that remains is the one the
+  single-writer assumption makes sound: a probe naming the user that a
+  registration run (target = no identity) itself just persisted joins that
+  run; anything else conflicting reloads.
+- A probe turning **unauthenticated**, and hook **unmount**, cancel the
+  in-flight run via the same token (`completeSignIn` polls it before every
+  side-effecting step). These are same-user events (sign-out in another tab,
+  session expiry) and remain fully supported.
+
+What remains supported and graceful: the same user in many tabs, including
+sign-out from any of them; same-user profile changes (roles, DAC
+assignments, ToS state) hydrating on revalidation — with identity-bearing UI
+withheld for the one render until the fresh profile commits.
+
+## Consequences
+
+- The reconciler shrinks: no supersede generations, no storage-provenance
+  tracking, no unregistered-identity disambiguation. The review surface for
+  cross-tab interleavings closes — conflicts have exactly one behavior.
+- A user who switches accounts in another tab loses transient state (e.g. a
+  half-typed form) in stale tabs when they next touch them: the tab reloads.
+  This is the accepted cost, identical to the trade made by mainstream
+  multi-account web applications.
+- The reload can, in a pathological ping-pong (two tabs switching accounts
+  repeatedly), reload more than once. Each reload converges on the current
+  session, so there is no livelock — the fresh load either matches storage
+  (hydrate) or bootstraps in place.
+
+## Alternative considered
+
+Full in-place reconciliation: record the identity each run commits, expose a
+stable session identity for unregistered accounts from `/auth/me`, and
+supersede-with-cancellation across every interleaving. Rejected as
+disproportionate: it re-implements a session manager in the client to
+polish an unsupported workflow, and each review round demonstrated the
+interleaving space is larger than the value of handling it.

--- a/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md
+++ b/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md
@@ -95,16 +95,18 @@ Two residual windows, surfaced by the cross-tab review on #3863
    The window is seconds wide and requires two different unregistered
    accounts switching mid-registration.
 
-2. **A transient upstream 401 for a registered user drives one
+2. **An upstream 401 on a session's first-ever probe drives one
    registration POST.** `/auth/me` reports an upstream 401 as "valid
-   session, no profile" (the upstream conflates the two — see #3861). For
-   a *registered* user this shape only appears when the upstream 401s a
-   freshly refreshed token: a revoked token, or upstream auth outage. The
-   bootstrap then attempts `registerUser()`; the expected `409 Conflict`
-   recovers into a normal sign-in, and any other failure signs the session
-   out — which is the correct end state for a genuinely revoked token. The
-   cost of the window is one spurious POST and, during an upstream auth
-   outage, a sign-out instead of an error banner.
+   session, no profile" (the upstream conflates the two — see #3861). The
+   session's `profileSeen` flag narrows the exposure: once a session has
+   served a profile, a later 401/404 is treated as a terminal token
+   verdict (revoked mid-lifetime, disabled account) and destroys the
+   session instead of reading as "unregistered". What remains is the
+   first-contact case — a token revoked between login and the session's
+   first probe. The bootstrap then attempts `registerUser()`; the expected
+   `409 Conflict` recovers into a normal sign-in, and any other failure
+   signs the session out — the correct end state for a revoked token. The
+   cost of the residual window is one spurious POST.
 
 ## Alternative considered
 

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -5,6 +5,38 @@ import { REFRESH_WINDOW_SECONDS, RefreshFailedError, refreshAccessToken } from '
 const UPSTREAM_TIMEOUT_MS = 5000
 
 /**
+ * Answers an upstream 401/404. The DUOS API conflates "bad token" with "no
+ * DUOS profile for this email" (both 401 — DuosUserAuthenticator turns the
+ * lookup's NotFoundException into an empty principal), so the session's
+ * `profileSeen` flag is the disambiguator this endpoint controls.
+ */
+async function answerNoProfile(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (request.session.profileSeen) {
+    // This session has served a profile before, so "no profile" cannot be
+    // the explanation. The upstream is rejecting the token itself — revoked
+    // mid-lifetime (before refresh-before-forward would touch it) or the
+    // account was disabled. The terminal 401 is the honest answer; leaving
+    // the session alive would send the client into re-registering an
+    // existing user.
+    try {
+      await request.session.destroy()
+    }
+    catch (err: unknown) {
+      request.log.error({ err }, '[auth] upstream rejected a profile-seen session but it could not be destroyed — returning 401 anyway')
+    }
+    reply.clearCookie('sessionId').status(401).send({ authenticated: false })
+    return
+  }
+  // Never seen a profile: authenticated but not yet registered. Treating
+  // this 401 as a dead session destroyed every brand-new user's session on
+  // their first probe and made registration unreachable. In the rare case
+  // of a token revoked before first contact, the client's registration
+  // attempt fails too, which signs the session out. (404 kept deliberately:
+  // DT-3997 restores the upstream's 404 for unregistered users.)
+  reply.send({ authenticated: true, idp: request.session.idp })
+}
+
+/**
  * Confirms the user is authenticated against the upstream Consent API.
  * Forwards the upstream user profile and the active sub-provider — never the
  * tokens themselves, which stay server-side in the session.
@@ -67,34 +99,7 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   }
 
   if (res.status === 401 || res.status === 404) {
-    // The DUOS API conflates "bad token" with "no DUOS profile for this
-    // email": its auth filter (DuosUserAuthenticator) turns the user lookup's
-    // NotFoundException into an empty principal, which Dropwizard reports as
-    // 401 — the same status a rejected token gets. `profileSeen` is the
-    // disambiguator this endpoint controls:
-    if (request.session.profileSeen) {
-      // This session has served a profile before, so "no profile" cannot be
-      // the explanation. The upstream is rejecting the token itself — revoked
-      // mid-lifetime (before refresh-before-forward would touch it) or the
-      // account was disabled. The terminal 401 is the honest answer; leaving
-      // the session alive would send the client into re-registering an
-      // existing user.
-      try {
-        await request.session.destroy()
-      }
-      catch (err: unknown) {
-        request.log.error({ err }, '[auth] upstream rejected a profile-seen session but it could not be destroyed — returning 401 anyway')
-      }
-      reply.clearCookie('sessionId').status(401).send({ authenticated: false })
-      return
-    }
-    // Never seen a profile: authenticated but not yet registered. Treating
-    // this 401 as a dead session destroyed every brand-new user's session on
-    // their first probe and made registration unreachable. In the rare case
-    // of a token revoked before first contact, the client's registration
-    // attempt fails too, which signs the session out. (404 kept deliberately:
-    // DT-3997 restores the upstream's 404 for unregistered users.)
-    reply.send({ authenticated: true, idp: request.session.idp })
+    await answerNoProfile(request, reply)
     return
   }
 

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -1,7 +1,6 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
 import { requireEnv } from './oidcClient.js'
-import { RefreshFailedError, refreshAccessToken } from './refresh.js'
-import { REFRESH_WINDOW_SECONDS } from '../proxy/upstreamProxy.js'
+import { REFRESH_WINDOW_SECONDS, RefreshFailedError, refreshAccessToken } from './refresh.js'
 
 const UPSTREAM_TIMEOUT_MS = 5000
 
@@ -68,19 +67,33 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   }
 
   if (res.status === 401 || res.status === 404) {
-    // Authenticated but (almost certainly) not yet registered. The DUOS API
-    // conflates "bad token" with "no DUOS profile for this email": its auth
-    // filter (DuosUserAuthenticator) turns the user lookup's NotFoundException
-    // into an empty principal, which Dropwizard reports as 401 — the same
-    // status a rejected token gets. Treating that 401 as a dead session
-    // destroyed every brand-new user's session on their first probe and made
-    // registration unreachable.
-    //
-    // Reporting the session honestly here is safe: the access token was
-    // refreshed just above when anywhere near expiry, so a 401 from a fresh
-    // token means "no profile", and in the rare revoked-token case the
-    // client's registration attempt fails too, which signs the session out.
-    // (404 kept for symmetry should the upstream ever disambiguate.)
+    // The DUOS API conflates "bad token" with "no DUOS profile for this
+    // email": its auth filter (DuosUserAuthenticator) turns the user lookup's
+    // NotFoundException into an empty principal, which Dropwizard reports as
+    // 401 — the same status a rejected token gets. `profileSeen` is the
+    // disambiguator this endpoint controls:
+    if (request.session.profileSeen) {
+      // This session has served a profile before, so "no profile" cannot be
+      // the explanation. The upstream is rejecting the token itself — revoked
+      // mid-lifetime (before refresh-before-forward would touch it) or the
+      // account was disabled. The terminal 401 is the honest answer; leaving
+      // the session alive would send the client into re-registering an
+      // existing user.
+      try {
+        await request.session.destroy()
+      }
+      catch (err: unknown) {
+        request.log.error({ err }, '[auth] upstream rejected a profile-seen session but it could not be destroyed — returning 401 anyway')
+      }
+      reply.clearCookie('sessionId').status(401).send({ authenticated: false })
+      return
+    }
+    // Never seen a profile: authenticated but not yet registered. Treating
+    // this 401 as a dead session destroyed every brand-new user's session on
+    // their first probe and made registration unreachable. In the rare case
+    // of a token revoked before first contact, the client's registration
+    // attempt fails too, which signs the session out. (404 kept deliberately:
+    // DT-3997 restores the upstream's 404 for unregistered users.)
     reply.send({ authenticated: true, idp: request.session.idp })
     return
   }
@@ -100,6 +113,15 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   catch {
     reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
     return
+  }
+
+  if (!request.session.profileSeen) {
+    request.session.profileSeen = true
+    // Saved explicitly before the reply, once per session (the flag never
+    // flips back): with rolling off, the onSend hook only skips its async
+    // save when the session is unmodified — see index.ts on the
+    // ERR_HTTP_HEADERS_SENT hazard a post-reply async save creates.
+    await request.session.save()
   }
 
   reply.send({

--- a/server/src/auth/refresh.ts
+++ b/server/src/auth/refresh.ts
@@ -47,6 +47,14 @@ interface RefreshedTokens {
  * store write, so it is not removed until the rotated token is persisted — see
  * `refreshAccessToken`.
  */
+/**
+ * How early to renew the access token. Wide enough that a request which passes
+ * this check still has a usable token by the time it reaches the upstream, so
+ * ordinary expiry never reaches the browser as a 401. Refresh policy, so it
+ * lives here; the proxy layer re-exports it for its existing consumers.
+ */
+export const REFRESH_WINDOW_SECONDS = 60
+
 const inFlight = new Map<string, Promise<RefreshedTokens>>()
 
 /**

--- a/server/src/proxy/upstreamProxy.ts
+++ b/server/src/proxy/upstreamProxy.ts
@@ -11,7 +11,7 @@ import type {
 } from 'fastify'
 import fastifyReplyFrom from '@fastify/reply-from'
 import { requireEnv } from '../auth/oidcClient.js'
-import { RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
+import { REFRESH_WINDOW_SECONDS, RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
 
 /**
  * The BFF upstream proxy machinery.
@@ -84,12 +84,9 @@ export interface UpstreamProxyConfig {
   destroySessionOnUpstream401: boolean
 }
 
-/**
- * How early to renew the access token. Wide enough that a request which passes
- * this check still has a usable token by the time it reaches the upstream, so
- * ordinary expiry never reaches the browser as a 401.
- */
-export const REFRESH_WINDOW_SECONDS = 60
+// Re-exported for existing consumers; the constant is refresh policy and
+// lives with refreshAccessToken (auth/refresh.ts), not in the proxy layer.
+export { REFRESH_WINDOW_SECONDS } from '../auth/refresh.js'
 
 /**
  * Bounded rather than undici's unbounded default (`connections: null` lets a

--- a/server/src/types/session.ts
+++ b/server/src/types/session.ts
@@ -23,5 +23,10 @@ declare module 'fastify' {
     // regardless — this field exists for the audit trail and observability,
     // not client selection.
     idp?: 'google' | 'microsoft'
+    // Set once /auth/me has served a DUOS profile on this session. The
+    // upstream conflates "no profile" with "bad token" (both 401), and this
+    // is the disambiguator: a 401/404 on a profile-seen session cannot mean
+    // "unregistered", so it is treated as a terminal token verdict.
+    profileSeen?: boolean
   }
 }

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -16,17 +16,21 @@ const ENV = { DUOS_API_URL: 'https://consent.dsde-dev.broadinstitute.org' }
 // tests exercise the forward path untouched.
 const FRESH_EXPIRY = () => Math.floor(Date.now() / 1000) + 3600
 
-function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft', tokenExpiry?: number } = {}) {
+function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft', tokenExpiry?: number, profileSeen?: boolean } = {}) {
   const destroy = vi.fn().mockResolvedValue(undefined)
+  const save = vi.fn().mockResolvedValue(undefined)
   const request = {
     session: {
       accessToken: overrides.accessToken,
       idp: overrides.idp,
       tokenExpiry: overrides.tokenExpiry ?? FRESH_EXPIRY(),
+      profileSeen: overrides.profileSeen,
       destroy,
+      save,
     },
+    log: { error: vi.fn(), info: vi.fn() },
   }
-  return { request: request as unknown as FastifyRequest, destroy }
+  return { request: request as unknown as FastifyRequest, destroy, save }
 }
 
 function makeReply() {
@@ -100,6 +104,43 @@ describe('getMe', () => {
       user: { email: 'user@example.com' },
       idp: 'google',
     })
+  })
+
+  it('marks the session profile-seen on the first served profile, with an explicit pre-reply save', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request, save } = makeRequest({ accessToken: 'test-access-token' })
+
+    await getMe(request, makeReply())
+
+    expect(request.session.profileSeen).toBe(true)
+    expect(save).toHaveBeenCalledOnce()
+  })
+
+  it('does not re-save a session already marked profile-seen', async () => {
+    // Focus revalidation makes this path hot — the flag costs one DB write
+    // per session, not one per probe.
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
+    const { request, save } = makeRequest({ accessToken: 'test-access-token', profileSeen: true })
+
+    await getMe(request, makeReply())
+
+    expect(save).not.toHaveBeenCalled()
+  })
+
+  it.each([401, 404])('destroys a profile-seen session on an upstream %i — "no profile" cannot explain it', async (status) => {
+    // A registered user's token revoked mid-lifetime forwards (no refresh due)
+    // and 401s. Answering "authenticated, no user" here sent the client into
+    // re-registering an existing account; the terminal 401 is the honest end.
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(status, {}) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token', idp: 'google', profileSeen: true })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(destroy).toHaveBeenCalledOnce()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(401)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
   })
 
   it('marks every answer uncacheable — the profile must never be replayed across sessions', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { ThemeProvider } from '@mui/material/styles'
 import { NavigationStateProvider } from 'src/contexts/NavigationStateContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -12,6 +12,7 @@ import { useNavigate, useLocation } from 'react-router'
 import { Storage } from 'src/libs/storage'
 import AppRoutes from 'src/routing/AppRoutes'
 import { Notifications, setUserRoleStatuses } from 'src/libs/utils'
+import { completeSignIn } from 'src/libs/auth/postSignIn'
 import { useUserIsLogged } from 'src/hooks/useSession'
 import { extractError } from 'src/utils/ErrorUtils'
 import { Spinner } from 'src/components/Spinner'
@@ -34,6 +35,12 @@ function App() {
   const [isLoading, setIsLoading] = useState(false)
   // Auth state comes from the BFF session probe (GET /auth/me), not localStorage.
   const isLoggedIn = useUserIsLogged() ?? false
+  const [signInBootstrapDone, setSignInBootstrapDone] = useState(false)
+  const signInBootstrapStarted = useRef(false)
+  // A session with no local user state means we just returned from the OAuth
+  // redirect — the routes stay hidden behind the spinner until the user
+  // bootstrap below resolves.
+  const isBootstrappingSignIn = isLoggedIn && !signInBootstrapDone && Storage.getCurrentUser().userId === 0
 
   useEffect(() => {
     const setEnvironment = async () => {
@@ -45,6 +52,19 @@ function App() {
     // The environment never changes within a page load — look it up once on
     // mount instead of on every render.
   }, [])
+
+  /**
+   * Post-sign-in bootstrap: the OAuth flow is a full-page redirect through the
+   * BFF (/auth/login → B2C → /auth/callback → back here), so the first render
+   * after signing in has a session but no local user state. Detect that and
+   * run the user fetch / registration / ToS flow.
+   */
+  useEffect(() => {
+    if (!isBootstrappingSignIn || signInBootstrapStarted.current) return
+    signInBootstrapStarted.current = true
+    completeSignIn({ navigate, queryClient, redirectPath: location.pathname })
+      .finally(() => setSignInBootstrapDone(true))
+  }, [isBootstrappingSignIn, navigate, location.pathname])
 
   /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect
@@ -98,8 +118,8 @@ function App() {
             <div className="wrap">
               <div className="main">
                 <DuosHeader />
-                {isLoading && <div style={loadingSyle}><Spinner /></div>}
-                {!isLoading && <AppRoutes isLogged={isLoggedIn} env={env} />}
+                {(isLoading || isBootstrappingSignIn) && <div style={loadingSyle}><Spinner /></div>}
+                {!(isLoading || isBootstrappingSignIn) && <AppRoutes isLogged={isLoggedIn} env={env} />}
               </div>
             </div>
             <DuosFooter />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,11 +36,17 @@ function App() {
   // Auth state comes from the BFF session probe (GET /auth/me), not localStorage.
   const isLoggedIn = useUserIsLogged() ?? false
   const [signInBootstrapDone, setSignInBootstrapDone] = useState(false)
-  const signInBootstrapStarted = useRef(false)
+  // State (render-visible) tracks that the bootstrap is underway; the ref is
+  // only the effect's run-once guard, never read during render.
+  const [signInBootstrapStarted, setSignInBootstrapStarted] = useState(false)
+  const signInBootstrapKickedOff = useRef(false)
   // A session with no local user state means we just returned from the OAuth
   // redirect — the routes stay hidden behind the spinner until the user
-  // bootstrap below resolves.
-  const isBootstrappingSignIn = isLoggedIn && !signInBootstrapDone && Storage.getCurrentUser().userId === 0
+  // bootstrap below resolves. Once the bootstrap has started it stays "on"
+  // until it settles: completeSignIn populates CurrentUser mid-flight, and the
+  // userId check alone would reveal the routes before the ToS gate has routed.
+  const isBootstrappingSignIn = isLoggedIn && !signInBootstrapDone
+    && (signInBootstrapStarted || Storage.getCurrentUser().userId === 0)
 
   useEffect(() => {
     const setEnvironment = async () => {
@@ -60,11 +66,16 @@ function App() {
    * run the user fetch / registration / ToS flow.
    */
   useEffect(() => {
-    if (!isBootstrappingSignIn || signInBootstrapStarted.current) return
-    signInBootstrapStarted.current = true
-    completeSignIn({ navigate, queryClient, redirectPath: location.pathname })
+    if (!isBootstrappingSignIn || signInBootstrapKickedOff.current) return
+    signInBootstrapKickedOff.current = true
+    setSignInBootstrapStarted(true)
+    // The BFF callback lands the browser on the destination itself, so the
+    // pathname is the redirect target; the legacy popup flow reloads on the
+    // landing page with the destination still in ?redirectTo=.
+    const redirectTo = new URLSearchParams(location.search).get('redirectTo')
+    completeSignIn({ navigate, queryClient, redirectPath: redirectTo ?? location.pathname })
       .finally(() => setSignInBootstrapDone(true))
-  }, [isBootstrappingSignIn, navigate, location.pathname])
+  }, [isBootstrappingSignIn, navigate, location.pathname, location.search])
 
   /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import AppRoutes from 'src/routing/AppRoutes'
 import { Notifications, setUserRoleStatuses } from 'src/libs/utils'
 import { completeSignIn } from 'src/libs/auth/postSignIn'
 import { useSessionInfo } from 'src/hooks/useSession'
+import type { SessionInfo } from 'src/libs/auth/session'
 import { extractError } from 'src/utils/ErrorUtils'
 import { Spinner } from 'src/components/Spinner'
 
@@ -38,18 +39,18 @@ function App() {
   const isLoggedIn = sessionInfo?.authenticated ?? false
   const [signInBootstrapDone, setSignInBootstrapDone] = useState(false)
   // State (render-visible) tracks that the bootstrap is underway; the ref is
-  // only the effect's run-once-per-identity guard, never read during render.
+  // only the effect's consumed-probe marker, never read during render.
   const [signInBootstrapStarted, setSignInBootstrapStarted] = useState(false)
-  const signInBootstrapKickedOffFor = useRef<number | null>(null)
+  const consumedProbeRef = useRef<SessionInfo | null>(null)
   // The session identity and the locally stored profile can disagree: after a
   // session expires and someone signs in as a different account (or another
   // tab switches accounts on the shared cookie), CurrentUser still holds the
-  // previous user. Only a session that NAMES a different user counts — a
-  // session with no user is what the cached probe looks like right after
-  // registration persists the new profile, and treating that as a mismatch
-  // re-armed the bootstrap into a run the once-per-identity guard blocks,
-  // pinning the app on the spinner. In legacy mode the probe reports the
-  // stored user itself, so this can never fire there.
+  // previous user. Render-visibly, only a session that NAMES a different user
+  // counts — a session with no user is also what the cached probe looks like
+  // right after registration persists the new profile. The effect below tells
+  // those two apart by probe freshness (each probe result is classified once),
+  // so a genuinely unregistered session still re-bootstraps. In legacy mode
+  // the probe reports the stored user itself, so this can never fire there.
   const storedUserId = Storage.getCurrentUser().userId
   const sessionUserId = sessionInfo?.user?.userId
   const identityMismatch = isLoggedIn && storedUserId !== 0
@@ -83,27 +84,52 @@ function App() {
   }, [])
 
   /**
-   * Post-sign-in bootstrap: the OAuth flow is a full-page redirect through the
-   * BFF (/auth/login → B2C → /auth/callback → back here), so the first render
-   * after signing in has a session but no local user state. Detect that and
-   * run the user fetch / registration / ToS flow.
+   * Session reconciliation. Each FRESH probe result is classified exactly once
+   * (the ref remembers the last consumed result object; the cached probe
+   * returns the same object, so re-renders and StrictMode double-invocations
+   * are no-ops):
+   *
+   * - Session names the stored user → hydrate: refresh the local profile from
+   *   the probe's server-fetched user (roles/ToS can change between page
+   *   loads — the popup flow used to reconcile on every sign-in) and route to
+   *   the ToS gate if acceptance is missing. No metrics, no navigation churn.
+   * - Anything else (no local user after the OAuth callback, a session naming
+   *   a different user, or a fresh probe with no profile = unregistered — the
+   *   cross-tab-switch case) → the full post-sign-in bootstrap.
    */
   useEffect(() => {
-    if (!isBootstrappingSignIn) return
-    // Keyed by the session identity (0 = unregistered), so a StrictMode
-    // double-invocation is blocked while a re-arm for a different account
-    // passes through.
-    const targetUserId = sessionInfo?.user?.userId ?? 0
-    if (signInBootstrapKickedOffFor.current === targetUserId) return
-    signInBootstrapKickedOffFor.current = targetUserId
+    if (!sessionInfo?.authenticated || consumedProbeRef.current === sessionInfo) return
+    consumedProbeRef.current = sessionInfo
+
+    const storedId = Storage.getCurrentUser().userId
+    const sessionUser = sessionInfo.user
+    if (sessionUser?.userId !== undefined && sessionUser.userId === storedId) {
+      Storage.setCurrentUser(sessionUser)
+      setUserRoleStatuses(sessionUser, Storage)
+      // Only an explicit "not accepted" routes to the gate — a profile without
+      // status info (older legacy sessions, service accounts) is left alone.
+      const tosRejected = sessionUser.userStatusInfo?.tosAccepted === false
+      const onTosPage = location.pathname.startsWith('/tos')
+      if (tosRejected && !onTosPage) {
+        navigate('/tos_acceptance')
+      }
+      return
+    }
+
+    // Arm the spinner in the same tick the bootstrap kicks off — deliberate:
+    // the effect's real work is the external completeSignIn call below, and
+    // these flags are how the render layer tracks it.
+    // oxlint-disable-next-line react/react-compiler
     setSignInBootstrapStarted(true)
+    // oxlint-disable-next-line react/react-compiler
+    setSignInBootstrapDone(false)
     // The BFF callback lands the browser on the destination itself, so the
     // pathname is the redirect target; the legacy popup flow reloads on the
     // landing page with the destination still in ?redirectTo=.
     const redirectTo = new URLSearchParams(location.search).get('redirectTo')
     completeSignIn({ navigate, queryClient, redirectPath: redirectTo ?? location.pathname })
       .finally(() => setSignInBootstrapDone(true))
-  }, [isBootstrappingSignIn, sessionInfo, navigate, location.pathname, location.search])
+  }, [sessionInfo, navigate, location.pathname, location.search])
 
   /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -100,7 +100,10 @@ function App() {
           <div className="body">
             <div className="wrap">
               <div className="main">
-                <DuosHeader />
+                {/* The header derives role tabs and the profile menu from
+                    Storage.getCurrentUser() — it is identity-bearing UI and
+                    must hide during reconciliation like the routes do. */}
+                {!reconciling && <DuosHeader />}
                 {(isLoading || reconciling) && <div style={loadingSyle}><Spinner /></div>}
                 {!(isLoading || reconciling) && <AppRoutes isLogged={isLoggedIn} env={env} />}
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { ThemeProvider } from '@mui/material/styles'
 import { NavigationStateProvider } from 'src/contexts/NavigationStateContext'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
@@ -12,9 +12,7 @@ import { useNavigate, useLocation } from 'react-router'
 import { Storage } from 'src/libs/storage'
 import AppRoutes from 'src/routing/AppRoutes'
 import { Notifications, setUserRoleStatuses } from 'src/libs/utils'
-import { completeSignIn } from 'src/libs/auth/postSignIn'
-import { useSessionInfo } from 'src/hooks/useSession'
-import type { SessionInfo } from 'src/libs/auth/session'
+import { useSessionReconciler } from 'src/hooks/useSessionReconciler'
 import { extractError } from 'src/utils/ErrorUtils'
 import { Spinner } from 'src/components/Spinner'
 
@@ -34,43 +32,11 @@ function App() {
   const navigate = useNavigate()
   const location = useLocation()
   const [isLoading, setIsLoading] = useState(false)
-  // Auth state comes from the BFF session probe (GET /auth/me), not localStorage.
-  const sessionInfo = useSessionInfo()
-  const isLoggedIn = sessionInfo?.authenticated ?? false
-  const [signInBootstrapDone, setSignInBootstrapDone] = useState(false)
-  // State (render-visible) tracks that the bootstrap is underway; the ref is
-  // only the effect's consumed-probe marker, never read during render.
-  const [signInBootstrapStarted, setSignInBootstrapStarted] = useState(false)
-  const consumedProbeRef = useRef<SessionInfo | null>(null)
-  // The session identity and the locally stored profile can disagree: after a
-  // session expires and someone signs in as a different account (or another
-  // tab switches accounts on the shared cookie), CurrentUser still holds the
-  // previous user. Render-visibly, only a session that NAMES a different user
-  // counts — a session with no user is also what the cached probe looks like
-  // right after registration persists the new profile. The effect below tells
-  // those two apart by probe freshness (each probe result is classified once),
-  // so a genuinely unregistered session still re-bootstraps. In legacy mode
-  // the probe reports the stored user itself, so this can never fire there.
-  const storedUserId = Storage.getCurrentUser().userId
-  const sessionUserId = sessionInfo?.user?.userId
-  const identityMismatch = isLoggedIn && storedUserId !== 0
-    && sessionUserId !== undefined && sessionUserId !== storedUserId
-  // A session with no local user state means we just returned from the OAuth
-  // redirect — the routes stay hidden behind the spinner until the user
-  // bootstrap below resolves. Once the bootstrap has started it stays "on"
-  // until it settles: completeSignIn populates CurrentUser mid-flight, and the
-  // userId check alone would reveal the routes before the ToS gate has routed.
-  const isBootstrappingSignIn = isLoggedIn && !signInBootstrapDone
-    && (signInBootstrapStarted || storedUserId === 0 || identityMismatch)
-
-  // If the session identity changes after the bootstrap already ran (focus
-  // revalidation caught another tab switching accounts), re-arm it so the
-  // fresh completeSignIn overwrites the stale profile, resets the query
-  // cache, and re-runs the ToS gate (adjust-state-during-render pattern).
-  if (identityMismatch && signInBootstrapDone) {
-    setSignInBootstrapStarted(false)
-    setSignInBootstrapDone(false)
-  }
+  // Auth state comes from the BFF session probe (GET /auth/me), not
+  // localStorage. The reconciler classifies every fresh probe (hydrate the
+  // stored profile, or run the full post-sign-in bootstrap) and reports when
+  // the routes must stay hidden — see useSessionReconciler for the rules.
+  const { isLoggedIn, reconciling } = useSessionReconciler(queryClient)
 
   useEffect(() => {
     const setEnvironment = async () => {
@@ -82,54 +48,6 @@ function App() {
     // The environment never changes within a page load — look it up once on
     // mount instead of on every render.
   }, [])
-
-  /**
-   * Session reconciliation. Each FRESH probe result is classified exactly once
-   * (the ref remembers the last consumed result object; the cached probe
-   * returns the same object, so re-renders and StrictMode double-invocations
-   * are no-ops):
-   *
-   * - Session names the stored user → hydrate: refresh the local profile from
-   *   the probe's server-fetched user (roles/ToS can change between page
-   *   loads — the popup flow used to reconcile on every sign-in) and route to
-   *   the ToS gate if acceptance is missing. No metrics, no navigation churn.
-   * - Anything else (no local user after the OAuth callback, a session naming
-   *   a different user, or a fresh probe with no profile = unregistered — the
-   *   cross-tab-switch case) → the full post-sign-in bootstrap.
-   */
-  useEffect(() => {
-    if (!sessionInfo?.authenticated || consumedProbeRef.current === sessionInfo) return
-    consumedProbeRef.current = sessionInfo
-
-    const storedId = Storage.getCurrentUser().userId
-    const sessionUser = sessionInfo.user
-    if (sessionUser?.userId !== undefined && sessionUser.userId === storedId) {
-      Storage.setCurrentUser(sessionUser)
-      setUserRoleStatuses(sessionUser, Storage)
-      // Only an explicit "not accepted" routes to the gate — a profile without
-      // status info (older legacy sessions, service accounts) is left alone.
-      const tosRejected = sessionUser.userStatusInfo?.tosAccepted === false
-      const onTosPage = location.pathname.startsWith('/tos')
-      if (tosRejected && !onTosPage) {
-        navigate('/tos_acceptance')
-      }
-      return
-    }
-
-    // Arm the spinner in the same tick the bootstrap kicks off — deliberate:
-    // the effect's real work is the external completeSignIn call below, and
-    // these flags are how the render layer tracks it.
-    // oxlint-disable-next-line react/react-compiler
-    setSignInBootstrapStarted(true)
-    // oxlint-disable-next-line react/react-compiler
-    setSignInBootstrapDone(false)
-    // The BFF callback lands the browser on the destination itself, so the
-    // pathname is the redirect target; the legacy popup flow reloads on the
-    // landing page with the destination still in ?redirectTo=.
-    const redirectTo = new URLSearchParams(location.search).get('redirectTo')
-    completeSignIn({ navigate, queryClient, redirectPath: redirectTo ?? location.pathname })
-      .finally(() => setSignInBootstrapDone(true))
-  }, [sessionInfo, navigate, location.pathname, location.search])
 
   /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect
@@ -183,8 +101,8 @@ function App() {
             <div className="wrap">
               <div className="main">
                 <DuosHeader />
-                {(isLoading || isBootstrappingSignIn) && <div style={loadingSyle}><Spinner /></div>}
-                {!(isLoading || isBootstrappingSignIn) && <AppRoutes isLogged={isLoggedIn} env={env} />}
+                {(isLoading || reconciling) && <div style={loadingSyle}><Spinner /></div>}
+                {!(isLoading || reconciling) && <AppRoutes isLogged={isLoggedIn} env={env} />}
               </div>
             </div>
             <DuosFooter />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { Storage } from 'src/libs/storage'
 import AppRoutes from 'src/routing/AppRoutes'
 import { Notifications, setUserRoleStatuses } from 'src/libs/utils'
 import { completeSignIn } from 'src/libs/auth/postSignIn'
-import { useUserIsLogged } from 'src/hooks/useSession'
+import { useSessionInfo } from 'src/hooks/useSession'
 import { extractError } from 'src/utils/ErrorUtils'
 import { Spinner } from 'src/components/Spinner'
 
@@ -34,19 +34,38 @@ function App() {
   const location = useLocation()
   const [isLoading, setIsLoading] = useState(false)
   // Auth state comes from the BFF session probe (GET /auth/me), not localStorage.
-  const isLoggedIn = useUserIsLogged() ?? false
+  const sessionInfo = useSessionInfo()
+  const isLoggedIn = sessionInfo?.authenticated ?? false
   const [signInBootstrapDone, setSignInBootstrapDone] = useState(false)
   // State (render-visible) tracks that the bootstrap is underway; the ref is
-  // only the effect's run-once guard, never read during render.
+  // only the effect's run-once-per-identity guard, never read during render.
   const [signInBootstrapStarted, setSignInBootstrapStarted] = useState(false)
-  const signInBootstrapKickedOff = useRef(false)
+  const signInBootstrapKickedOffFor = useRef<number | null>(null)
+  // The session identity and the locally stored profile can disagree: after a
+  // session expires and someone signs in as a different account (or another
+  // tab switches accounts on the shared cookie), CurrentUser still holds the
+  // previous user. An unregistered session reports no user at all, which is
+  // also a mismatch against any nonzero stored profile. In legacy mode the
+  // probe reports the stored user itself, so this can never fire there.
+  const storedUserId = Storage.getCurrentUser().userId
+  const identityMismatch = isLoggedIn && storedUserId !== 0
+    && sessionInfo?.user?.userId !== storedUserId
   // A session with no local user state means we just returned from the OAuth
   // redirect — the routes stay hidden behind the spinner until the user
   // bootstrap below resolves. Once the bootstrap has started it stays "on"
   // until it settles: completeSignIn populates CurrentUser mid-flight, and the
   // userId check alone would reveal the routes before the ToS gate has routed.
   const isBootstrappingSignIn = isLoggedIn && !signInBootstrapDone
-    && (signInBootstrapStarted || Storage.getCurrentUser().userId === 0)
+    && (signInBootstrapStarted || storedUserId === 0 || identityMismatch)
+
+  // If the session identity changes after the bootstrap already ran (focus
+  // revalidation caught another tab switching accounts), re-arm it so the
+  // fresh completeSignIn overwrites the stale profile, resets the query
+  // cache, and re-runs the ToS gate (adjust-state-during-render pattern).
+  if (identityMismatch && signInBootstrapDone) {
+    setSignInBootstrapStarted(false)
+    setSignInBootstrapDone(false)
+  }
 
   useEffect(() => {
     const setEnvironment = async () => {
@@ -66,8 +85,13 @@ function App() {
    * run the user fetch / registration / ToS flow.
    */
   useEffect(() => {
-    if (!isBootstrappingSignIn || signInBootstrapKickedOff.current) return
-    signInBootstrapKickedOff.current = true
+    if (!isBootstrappingSignIn) return
+    // Keyed by the session identity (0 = unregistered), so a StrictMode
+    // double-invocation is blocked while a re-arm for a different account
+    // passes through.
+    const targetUserId = sessionInfo?.user?.userId ?? 0
+    if (signInBootstrapKickedOffFor.current === targetUserId) return
+    signInBootstrapKickedOffFor.current = targetUserId
     setSignInBootstrapStarted(true)
     // The BFF callback lands the browser on the destination itself, so the
     // pathname is the redirect target; the legacy popup flow reloads on the
@@ -75,7 +99,7 @@ function App() {
     const redirectTo = new URLSearchParams(location.search).get('redirectTo')
     completeSignIn({ navigate, queryClient, redirectPath: redirectTo ?? location.pathname })
       .finally(() => setSignInBootstrapDone(true))
-  }, [isBootstrappingSignIn, navigate, location.pathname, location.search])
+  }, [isBootstrappingSignIn, sessionInfo, navigate, location.pathname, location.search])
 
   /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,12 +44,16 @@ function App() {
   // The session identity and the locally stored profile can disagree: after a
   // session expires and someone signs in as a different account (or another
   // tab switches accounts on the shared cookie), CurrentUser still holds the
-  // previous user. An unregistered session reports no user at all, which is
-  // also a mismatch against any nonzero stored profile. In legacy mode the
-  // probe reports the stored user itself, so this can never fire there.
+  // previous user. Only a session that NAMES a different user counts — a
+  // session with no user is what the cached probe looks like right after
+  // registration persists the new profile, and treating that as a mismatch
+  // re-armed the bootstrap into a run the once-per-identity guard blocks,
+  // pinning the app on the spinner. In legacy mode the probe reports the
+  // stored user itself, so this can never fire there.
   const storedUserId = Storage.getCurrentUser().userId
+  const sessionUserId = sessionInfo?.user?.userId
   const identityMismatch = isLoggedIn && storedUserId !== 0
-    && sessionInfo?.user?.userId !== storedUserId
+    && sessionUserId !== undefined && sessionUserId !== storedUserId
   // A session with no local user state means we just returned from the OAuth
   // redirect — the routes stay hidden behind the spinner until the user
   // bootstrap below resolves. Once the bootstrap has started it stays "on"

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { isEmpty } from 'src/utils/NodashUtil'
 import { Alert } from 'src/components/Alert'
-import { Auth } from 'src/libs/auth/auth'
+import { Auth, Redirect } from 'src/libs/auth/auth'
 import loadingIndicator from 'src/images/loading-indicator.svg'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
@@ -43,7 +43,12 @@ export const SignInButton = () => {
     try {
       const redirectTo = getRedirectTo()
       await Auth.signIn(shouldRedirectTo(redirectTo) ? redirectTo : undefined)
-      // Auth.signIn navigates the page to B2C — keep the spinner up until then.
+      // In BFF mode Auth.signIn navigates the page to B2C and never resolves —
+      // the spinner stays up until the browser leaves. Only the legacy popup
+      // flow reaches this line: reload in place (query string included) so the
+      // fresh page load re-probes auth state and App.tsx runs the post-sign-in
+      // bootstrap, the same path the BFF callback takes.
+      Redirect.to(globalThis.location.href)
     }
     catch {
       setErrorDisplay({ show: true, title: 'Error', description: Auth.signInError() })

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { isEmpty } from 'src/utils/NodashUtil'
 import { Alert } from 'src/components/Alert'
 import { Auth, Redirect } from 'src/libs/auth/auth'
+import { Storage } from 'src/libs/storage'
 import loadingIndicator from 'src/images/loading-indicator.svg'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
@@ -47,11 +48,27 @@ export const SignInButton = () => {
       // the spinner stays up until the browser leaves. Only the legacy popup
       // flow reaches this line: reload in place (query string included) so the
       // fresh page load re-probes auth state and App.tsx runs the post-sign-in
-      // bootstrap, the same path the BFF callback takes.
-      Redirect.to(globalThis.location.href)
+      // bootstrap, the same path the BFF callback takes. Redirect.reload, not
+      // Redirect.to(href) — on a #fragment URL the latter reloads nothing and
+      // a successful sign-in appears to do nothing.
+      Redirect.reload()
     }
-    catch {
-      setErrorDisplay({ show: true, title: 'Error', description: Auth.signInError() })
+    catch (error) {
+      // The legacy popup flow rejects here (BFF mode navigates away instead).
+      // Mirror the old onFailure: drop whatever partial auth state the popup
+      // left behind, and tell a deliberate cancel apart from a real failure —
+      // oidc-client-ts PopupWindow rejects with "Popup closed by user".
+      Storage.clearStorage()
+      if (String(error).includes('Popup closed by user')) {
+        setErrorDisplay({
+          show: true,
+          title: 'Sign in cancelled',
+          description: 'Sign in cancelled by closing the sign in window',
+        })
+      }
+      else {
+        setErrorDisplay({ show: true, title: 'Error', description: Auth.signInError() })
+      }
       setIsLoading(false)
     }
   }

--- a/src/components/SignInButton.tsx
+++ b/src/components/SignInButton.tsx
@@ -1,22 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import { isEmpty, isNil } from 'src/utils/NodashUtil'
+import { isEmpty } from 'src/utils/NodashUtil'
 import { Alert } from 'src/components/Alert'
 import { Auth } from 'src/libs/auth/auth'
-import { User } from 'src/libs/ajax/User'
-import { Metrics } from 'src/libs/ajax/Metrics'
-import { Storage } from 'src/libs/storage'
-import { Navigation, setUserRoleStatuses } from 'src/libs/utils'
 import loadingIndicator from 'src/images/loading-indicator.svg'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
-import eventList, { MetricsEventName } from 'src/libs/events'
-import { ErrorReporter } from 'src/libs/ErrorReporter'
-import { OidcUser } from 'src/libs/auth/oidcBroker'
-import { DuosUser } from 'src/types/model'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 import 'src/styles/tooltip.css'
-import { useNavigate } from 'react-router'
-import { useQueryClient } from '@tanstack/react-query'
-import { extractError } from 'src/utils/ErrorUtils'
 
 interface ErrorInfo {
   title?: string
@@ -27,78 +16,20 @@ interface ErrorInfo {
 
 type ErrorDisplay = ErrorInfo | React.JSX.Element
 
-interface HttpError extends Error {
-  status?: number
-  body?: ReadableStream<Uint8Array>
-}
-
+/**
+ * A single sign-in button that starts the BFF login flow: POST /auth/login
+ * returns the B2C authorization URL and the whole page redirects there. The
+ * B2C login page presents the provider choice (Google / Microsoft), so no
+ * provider selection happens here. After B2C, the server-side /auth/callback
+ * establishes the session and redirects back; App.tsx's post-sign-in bootstrap
+ * takes it from there (user fetch, registration, ToS gate).
+ */
 export const SignInButton = () => {
-  const navigate = useNavigate()
-  const queryClient = useQueryClient()
   const [errorDisplay, setErrorDisplay] = useState<ErrorDisplay>({})
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const [isConsentDown, setIsConsentDown] = useState<boolean>(false)
   const [isSamDown, setIsSamDown] = useState<boolean>(false)
   const [isButtonActive, setIsButtonActive] = useState<boolean>(false)
-
-  // Utility function called in the normal success case and in the undocumented 409 case
-  // Check for ToS Acceptance - redirect user if not set.
-  const checkToSAndRedirect = async (redirectPath: string | null) => {
-    // Check if the user has accepted ToS yet or not:
-    const tosAccepted = Storage.getCurrentUser().userStatusInfo?.tosAccepted || false
-    if (tosAccepted) {
-      if (isNil(redirectPath)) {
-        await Navigation.console(Storage.getCurrentUser(), navigate)
-      }
-      else {
-        navigate(redirectPath)
-      }
-    }
-    else if (isNil(redirectPath)) {
-      // User has authenticated, but has not accepted ToS
-      navigate(`/tos_acceptance`)
-    }
-    else {
-      navigate(`/tos_acceptance?redirectTo=${redirectPath}`)
-    }
-  }
-
-  const onSuccess = async (_: OidcUser) => {
-    const redirectTo = getRedirectTo()
-    const shouldRedirect = shouldRedirectTo(redirectTo)
-    try {
-      const duosUser: DuosUser = await User.getMe()
-      if (duosUser) {
-        Storage.setCurrentUser(duosUser)
-        setUserRoleStatuses(duosUser, Storage)
-        // Drop any query results cached before sign-in: cached library queries
-        // (data, tab counts, filter metadata) were built with the anonymous /
-        // previous user's role-based visibility clauses and would otherwise be
-        // served from cache under the new user's identity. Sign-out does the
-        // same in DuosHeader.signOut.
-        queryClient.clear()
-        if (!duosUser.roles) {
-          await ErrorReporter.report('roles not found for user: ' + duosUser.email)
-        }
-        syncSignInOrRegistrationEvent(eventList.userSignIn)
-        await checkToSAndRedirect(shouldRedirect ? redirectTo : null)
-      }
-      else {
-        await handleRegistration(redirectTo, shouldRedirect)
-      }
-    }
-    catch (error) {
-      // Explicitly handle AzureB2C errors from Sam
-      const errorMessage = extractError(error)
-      if (errorMessage.toLowerCase().includes('azureb2c authentication error')) {
-        await Auth.signOut()
-        setErrorDisplay({ show: true, title: 'Error', description: errorMessage })
-      }
-      else {
-        await handleRegistration(redirectTo, shouldRedirect)
-      }
-    }
-  }
 
   const getRedirectTo = (): string => {
     const queryParams = new URLSearchParams(globalThis.location.search)
@@ -107,82 +38,16 @@ export const SignInButton = () => {
 
   const shouldRedirectTo = (page: string): boolean => page !== '/' && page !== '/home'
 
-  const handleRegistration = async (redirectTo: string, shouldRedirect: boolean) => {
+  const handleSignIn = async () => {
+    setIsLoading(true)
     try {
-      await registerAndRedirectNewUser(redirectTo, shouldRedirect)
-    }
-    catch (error) {
-      await handleErrors(error as HttpError, redirectTo, shouldRedirect)
-    }
-  }
-
-  const registerAndRedirectNewUser = async (redirectTo: string, shouldRedirect: boolean) => {
-    const registeredUser: DuosUser = await User.registerUser()
-    const redirectParam = shouldRedirect ? `?redirectTo=${redirectTo}` : ''
-    setUserRoleStatuses(registeredUser, Storage)
-    // New identity — same cache reset as the normal sign-in path above.
-    queryClient.clear()
-    syncSignInOrRegistrationEvent(eventList.userRegister)
-    navigate(`/tos_acceptance${redirectParam}`)
-  }
-
-  const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
-    Storage.setAnonymousId()
-    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
-    Metrics.identify(`${Storage.getAnonymousId()}`)
-    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
-    Metrics.syncProfile()
-    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
-    Metrics.captureEvent(event)
-  }
-
-  const errorStreamToString = async (error: HttpError) => {
-    const body = await new Response(error.body).json()
-    return body.message || JSON.stringify(body)
-  }
-
-  const handleServerError = async (error: HttpError) => {
-    const errorMessage = await errorStreamToString(error)
-    setErrorDisplay({ show: true, title: 'Error', description: errorMessage })
-  }
-
-  const handleErrors = async (error: HttpError, redirectTo: string, shouldRedirect: boolean) => {
-    const status = error.status
-
-    switch (status) {
-      case 400:
-        setErrorDisplay({ show: true, title: 'Error', description: JSON.stringify(error) })
-        break
-      case 409:
-        await handleConflictError(redirectTo, shouldRedirect)
-        break
-      case 500:
-        await handleServerError(error)
-        break
-      default:
-        setErrorDisplay({ show: true, title: 'Error', description: 'Unexpected error, please try again' })
-        break
-    }
-  }
-
-  const handleConflictError = async (redirectTo: string, shouldRedirect: boolean) => {
-    try {
-      await checkToSAndRedirect(shouldRedirect ? redirectTo : null)
+      const redirectTo = getRedirectTo()
+      await Auth.signIn(shouldRedirectTo(redirectTo) ? redirectTo : undefined)
+      // Auth.signIn navigates the page to B2C — keep the spinner up until then.
     }
     catch {
-      await Auth.signOut()
-    }
-  }
-
-  const onFailure = (response: Error) => {
-    Storage.clearStorage()
-    // Known error case from oidc-client-ts PopupWindow: "new Error("Popup closed by user")"
-    if (response.toString().includes('Popup closed by user')) {
-      setErrorDisplay(
-        { title: 'Sign in cancelled', description: 'Sign in cancelled by closing the sign in window' })
-    }
-    else {
-      setErrorDisplay({ title: 'Error', description: response.toString() })
+      setErrorDisplay({ show: true, title: 'Error', description: Auth.signInError() })
+      setIsLoading(false)
     }
   }
 
@@ -230,10 +95,8 @@ export const SignInButton = () => {
             onMouseLeave={() => setIsButtonActive(false)}
             onFocus={() => setIsButtonActive(true)}
             onBlur={() => setIsButtonActive(false)}
-            onClick={async () => {
-              setIsLoading(true)
-              Auth.signIn().then(onSuccess, onFailure)
-              setIsLoading(false)
+            onClick={() => {
+              void handleSignIn()
             }}
             disabled={isSignInDisabled}
           >

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -1,0 +1,126 @@
+import { useEffect, useRef, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+import type { QueryClient } from '@tanstack/react-query'
+import type { SessionInfo } from 'src/libs/auth/session'
+import { useSessionInfo } from 'src/hooks/useSession'
+import { completeSignIn } from 'src/libs/auth/postSignIn'
+import { Storage } from 'src/libs/storage'
+import { setUserRoleStatuses } from 'src/libs/utils'
+
+/**
+ * Reconciles the BFF session identity with the locally stored profile.
+ *
+ * Each FRESH probe result (a new object from useSessionInfo — the cached
+ * probe returns the same object, so re-renders and StrictMode double
+ * invocations are inert) is classified exactly once:
+ *
+ * - Names the stored user → HYDRATE: refresh the local profile from the
+ *   probe's server-fetched user (roles/ToS change between page loads; the
+ *   popup flow reconciled on every sign-in) and route to the ToS gate on an
+ *   explicit rejection. Classification is recorded in React state so the
+ *   refreshed profile re-renders — a bare localStorage write is invisible to
+ *   mounted components.
+ * - Anything else (no local user after the OAuth callback, a session naming
+ *   a different user, or a fresh probe with no profile — the cross-tab
+ *   switch to an unregistered account) → the full post-sign-in BOOTSTRAP
+ *   (user fetch / registration / metrics / ToS gate) via completeSignIn.
+ *
+ * Bootstraps are generation-guarded: a probe for the identity an in-flight
+ * bootstrap is already handling joins that run; a genuinely different
+ * identity supersedes it, and a superseded run's completion can no longer
+ * unlock the routes.
+ */
+
+interface ReconcilerSnapshot {
+  /** The probe whose classification is recorded — in state, not just a ref,
+   * so classification itself causes the re-render that propagates a
+   * hydrated profile. */
+  classifiedProbe: SessionInfo | null
+  /** True while the render-blocking full bootstrap is in flight. */
+  bootstrapRunning: boolean
+}
+
+export interface SessionReconciliation {
+  sessionInfo: SessionInfo | undefined
+  isLoggedIn: boolean
+  /** Render-visible: the routes must stay hidden while this is true, or they
+   * commit a stale identity (previous user's roles under a new session). */
+  reconciling: boolean
+}
+
+export const useSessionReconciler = (queryClient: QueryClient): SessionReconciliation => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const sessionInfo = useSessionInfo()
+  const [snapshot, setSnapshot] = useState<ReconcilerSnapshot>({
+    classifiedProbe: null,
+    bootstrapRunning: false,
+  })
+  // Effect-only guards (never read during render): idempotence for StrictMode
+  // double-invocations, and the active bootstrap's generation + target.
+  const consumedProbeRef = useRef<SessionInfo | null>(null)
+  const bootstrapGenerationRef = useRef(0)
+  const activeBootstrapRef = useRef<{ generation: number, targetUserId: number } | null>(null)
+
+  useEffect(() => {
+    if (!sessionInfo?.authenticated || consumedProbeRef.current === sessionInfo) return
+    consumedProbeRef.current = sessionInfo
+
+    const storedUserId = Storage.getCurrentUser().userId
+    const sessionUser = sessionInfo.user
+    const targetUserId = sessionUser?.userId ?? 0
+
+    // A probe for work the in-flight bootstrap already covers joins that run:
+    // same target identity, or a probe that now names the user the bootstrap
+    // just persisted (the post-registration re-probe). Starting a concurrent
+    // completeSignIn here would duplicate registration, metrics, and routing.
+    const active = activeBootstrapRef.current
+    if (active && (targetUserId === active.targetUserId || (sessionUser !== undefined && sessionUser.userId === storedUserId))) {
+      setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
+      return
+    }
+
+    if (!active && sessionUser !== undefined && sessionUser.userId === storedUserId) {
+      Storage.setCurrentUser(sessionUser)
+      setUserRoleStatuses(sessionUser, Storage)
+      // Recorded in state → clean re-render off the refreshed profile.
+      setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
+      // Only an explicit "not accepted" routes to the gate — a profile without
+      // status info (older legacy sessions, service accounts) is left alone.
+      const tosRejected = sessionUser.userStatusInfo?.tosAccepted === false
+      if (tosRejected && !location.pathname.startsWith('/tos')) {
+        navigate('/tos_acceptance')
+      }
+      return
+    }
+
+    // Full bootstrap. Superseding an in-flight run bumps the generation, so
+    // the older run's completion below cannot unlock the routes early.
+    const generation = ++bootstrapGenerationRef.current
+    activeBootstrapRef.current = { generation, targetUserId }
+    setSnapshot({ classifiedProbe: sessionInfo, bootstrapRunning: true })
+    // The BFF callback lands the browser on the destination itself, so the
+    // pathname is the redirect target; the legacy popup flow reloads on the
+    // landing page with the destination still in ?redirectTo=.
+    const redirectTo = new URLSearchParams(location.search).get('redirectTo')
+    completeSignIn({ navigate, queryClient, redirectPath: redirectTo ?? location.pathname })
+      .finally(() => {
+        if (activeBootstrapRef.current?.generation !== generation) return
+        activeBootstrapRef.current = null
+        setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
+      })
+  }, [sessionInfo, navigate, location.pathname, location.search, queryClient])
+
+  const isLoggedIn = sessionInfo?.authenticated ?? false
+  // An unclassified probe hides the routes only when it could change the
+  // rendered identity (fresh callback, no profile, or a different user) —
+  // a probe naming the stored user hydrates without blanking the screen on
+  // every focus revalidation.
+  const storedUserId = Storage.getCurrentUser().userId
+  const sessionUserId = sessionInfo?.user?.userId
+  const unclassifiedIdentityChange = sessionInfo !== snapshot.classifiedProbe
+    && (storedUserId === 0 || sessionUserId === undefined || sessionUserId !== storedUserId)
+  const reconciling = isLoggedIn && (snapshot.bootstrapRunning || unclassifiedIdentityChange)
+
+  return { sessionInfo, isLoggedIn, reconciling }
+}

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -100,14 +100,24 @@ const probeCoveredByRun = (active: ActiveBootstrap, sessionUser: DuosUser | unde
  * completes. Same explicit-rejection rule as the hydrate path. The router
  * location closure may be stale by completion time — read the live one
  * (they coincide outside MemoryRouter tests). */
+/** Only an explicit "not accepted" routes to the gate — a profile without
+ * status info (older legacy sessions, service accounts) is left alone. */
+const tosExplicitlyRejected = (user: DuosUser, pathname: string): boolean =>
+  user.userStatusInfo?.tosAccepted === false && !pathname.startsWith('/tos')
+
 const applyPendingHydration = (fresh: DuosUser, navigate: NavigateFunction): void => {
   Storage.setCurrentUser(fresh)
   setUserRoleStatuses(fresh, Storage)
-  if (fresh.userStatusInfo?.tosAccepted === false
-    && !globalThis.location.pathname.startsWith('/tos')) {
+  if (tosExplicitlyRejected(fresh, globalThis.location.pathname)) {
     navigate('/tos_acceptance')
   }
 }
+
+/** A probe that names the stored user (a real identity, not the empty
+ * default) hydrates the local profile instead of bootstrapping. */
+const probeNamesStoredUser = (sessionUser: DuosUser | undefined, storedUserId: number): sessionUser is DuosUser =>
+  sessionUser !== undefined && sessionUser.userId !== 0
+  && sessionUser.userId === storedUserId
 
 export const useSessionReconciler = (queryClient: QueryClient): SessionReconciliation => {
   const navigate = useNavigate()
@@ -176,18 +186,16 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       return
     }
 
-    if (sessionUser !== undefined && sessionUser.userId !== 0
-      && sessionUser.userId === storedUserId) {
+    if (probeNamesStoredUser(sessionUser, storedUserId)) {
       Storage.setCurrentUser(sessionUser)
       setUserRoleStatuses(sessionUser, Storage)
       // Recorded in state → clean re-render off the refreshed profile (the
       // localStorage write above is invisible to React without it).
       // oxlint-disable-next-line react/react-compiler
       setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
-      // Only an explicit "not accepted" routes to the gate — a profile without
-      // status info (older legacy sessions, service accounts) is left alone.
-      const tosRejected = sessionUser.userStatusInfo?.tosAccepted === false
-      if (tosRejected && !location.pathname.startsWith('/tos')) {
+      // The hydrate path reads the router location — it is live here, unlike
+      // at run completion (see applyPendingHydration).
+      if (tosExplicitlyRejected(sessionUser, location.pathname)) {
         navigate('/tos_acceptance')
       }
       return

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -44,6 +44,11 @@ import { setUserRoleStatuses } from 'src/libs/utils'
 interface ActiveBootstrap {
   targetUserId: number
   cancelled: boolean
+  /** The freshest same-user profile carried by a probe that JOINED this run.
+   * The run's own (older) getMe response may land after that probe, so the
+   * joined profile is applied when the run completes — otherwise a
+   * same-user authorization change arriving mid-bootstrap would be lost. */
+  pendingHydration?: DuosUser
 }
 
 interface ReconcilerSnapshot {
@@ -99,11 +104,18 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
 
   useEffect(() => {
     if (!sessionInfo?.authenticated) {
-      // The session disappeared (signed out in this or another tab, expiry).
-      // An in-flight bootstrap must not keep persisting a user, emitting
-      // metrics, or navigating for a session that no longer exists.
+      // The session disappeared — genuine sign-out/expiry, or a transient
+      // failure the probe reports as unauthenticated. An in-flight bootstrap
+      // must not keep acting, and the token must be RETIRED, not just
+      // cancelled: if it stayed registered, the next authenticated probe
+      // (e.g. after a network blip) would join a dead run and either hang
+      // behind the spinner or unlock routes with nothing persisted.
       if (activeBootstrapRef.current) {
         activeBootstrapRef.current.cancelled = true
+        activeBootstrapRef.current = null
+        // The retired run's finally no longer owns this flag.
+        // oxlint-disable-next-line react/react-compiler
+        setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
       }
       return
     }
@@ -126,6 +138,12 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
         || (active.targetUserId === 0 && sessionUser !== undefined
           && sessionUser.userId !== 0 && sessionUser.userId === storedUserId)
       if (coveredByRun) {
+        // A joined probe carrying a profile is fresher than the run's own
+        // in-flight getMe response — remember it so the run's completion
+        // applies it (latest join wins).
+        if (sessionUser !== undefined && sessionUser.userId !== 0) {
+          active.pendingHydration = sessionUser
+        }
         // Recording classification IS this effect's externally-visible work
         // for a joined probe (see ReconcilerSnapshot.classifiedProbe).
         // oxlint-disable-next-line react/react-compiler
@@ -173,6 +191,20 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
     }).finally(() => {
       if (activeBootstrapRef.current !== token) return
       activeBootstrapRef.current = null
+      // Apply the freshest profile a joined probe carried: the run's own
+      // getMe response may have been older and overwritten storage after it.
+      if (!token.cancelled && token.pendingHydration) {
+        const fresh = token.pendingHydration
+        Storage.setCurrentUser(fresh)
+        setUserRoleStatuses(fresh, Storage)
+        // Same explicit-rejection rule as the hydrate path. The router
+        // location closure may be stale by completion time — read the live
+        // one (they coincide outside MemoryRouter tests).
+        if (fresh.userStatusInfo?.tosAccepted === false
+          && !globalThis.location.pathname.startsWith('/tos')) {
+          navigate('/tos_acceptance')
+        }
+      }
       setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
     })
   }, [sessionInfo, navigate, location.pathname, location.search, queryClient])

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -96,17 +96,17 @@ const probeCoveredByRun = (active: ActiveBootstrap, sessionUser: DuosUser | unde
       && sessionUser.userId !== 0 && sessionUser.userId === storedUserId)
 }
 
-/** Persist the freshest profile a joined probe carried, once its run
- * completes. Same explicit-rejection rule as the hydrate path. The router
- * location closure may be stale by completion time — read the live one
- * (they coincide outside MemoryRouter tests). */
 /** Only an explicit "not accepted" routes to the gate — a profile without
  * status info (older legacy sessions, service accounts) is left alone. */
 const tosExplicitlyRejected = (user: DuosUser, pathname: string): boolean =>
   user.userStatusInfo?.tosAccepted === false && !pathname.startsWith('/tos')
 
+/** Persist the freshest profile a joined probe carried, once its run
+ * completes. Same explicit-rejection rule as the hydrate path. The router
+ * location closure may be stale by completion time — read the live one
+ * (they coincide outside MemoryRouter tests). */
 const applyPendingHydration = (fresh: DuosUser, navigate: NavigateFunction): void => {
-  Storage.setCurrentUser(fresh)
+  // setUserRoleStatuses persists the user itself (utils.ts).
   setUserRoleStatuses(fresh, Storage)
   if (tosExplicitlyRejected(fresh, globalThis.location.pathname)) {
     navigate('/tos_acceptance')
@@ -213,7 +213,7 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
 
     if (probeNamesStoredUser(sessionUser, storedUserId)) {
       ensureCacheIdentity(cacheIdentityRef, queryClient, sessionUser.userId)
-      Storage.setCurrentUser(sessionUser)
+      // setUserRoleStatuses persists the user itself (utils.ts).
       setUserRoleStatuses(sessionUser, Storage)
       // Recorded in state → clean re-render off the refreshed profile (the
       // localStorage write above is invisible to React without it).
@@ -280,7 +280,13 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
   const authEquivalent = sessionUser !== undefined && sessionUser.userId !== 0
     && authProfileEquivalent(sessionUser, Storage.getCurrentUser())
   const unclassifiedIdentityChange = sessionInfo !== snapshot.classifiedProbe && !authEquivalent
-  const reconciling = isLoggedIn && (snapshot.bootstrapRunning || unclassifiedIdentityChange)
+  // An in-flight first probe (sessionInfo undefined) reconciles too: rendering
+  // the signed-out chrome to a signed-in user invites a click that starts a
+  // sign-in flow (Home's library cards) or bounces a deep link. The cost is
+  // one probe round-trip behind the spinner on a BFF hard load; the legacy
+  // probe answers synchronously.
+  const reconciling = sessionInfo === undefined
+    || (isLoggedIn && (snapshot.bootstrapRunning || unclassifiedIdentityChange))
 
   return { sessionInfo, isLoggedIn, reconciling }
 }

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -5,11 +5,20 @@ import type { SessionInfo } from 'src/libs/auth/session'
 import type { DuosUser } from 'src/types/model'
 import { useSessionInfo } from 'src/hooks/useSession'
 import { completeSignIn } from 'src/libs/auth/postSignIn'
+import { Redirect } from 'src/libs/auth/auth'
 import { Storage } from 'src/libs/storage'
 import { setUserRoleStatuses } from 'src/libs/utils'
 
 /**
  * Reconciles the BFF session identity with the locally stored profile.
+ *
+ * SCOPE POLICY: concurrent different-user tabs are unsupported. The session
+ * cookie is shared, so "two users in two tabs" was never real — only serial
+ * account switching with a stale tab. A stale tab that detects an identity
+ * conflict UNDER AN IN-FLIGHT BOOTSTRAP hard-reloads (the fresh page load
+ * reconciles from scratch and kills all in-flight work); this deliberately
+ * replaces in-place supersede/join-provenance machinery. Within a single
+ * tab, localStorage therefore has a single writer.
  *
  * Each FRESH probe result (a new object from useSessionInfo — the cached
  * probe returns the same object, so re-renders and StrictMode double
@@ -20,26 +29,20 @@ import { setUserRoleStatuses } from 'src/libs/utils'
  *   to the ToS gate on an explicit rejection. Classification is recorded in
  *   React state so the refreshed profile re-renders mounted consumers.
  * - Anything else (no local identity, a session naming a different user, or
- *   a fresh probe with no profile — the cross-tab switch to an unregistered
- *   account) → the full post-sign-in BOOTSTRAP via completeSignIn.
+ *   a fresh probe with no profile) → the full post-sign-in BOOTSTRAP via
+ *   completeSignIn.
  *
- * Bootstrap lifecycle guarantees:
- * - JOIN with provenance: a probe joins the in-flight run only for the same
- *   target identity, or when it names a user that storage acquired DURING
- *   the run (the run's own output, e.g. the post-registration re-probe). A
- *   probe naming the user storage held BEFORE the run started is an identity
- *   reversal and supersedes instead.
- * - SUPERSEDE with cancellation: superseding marks the old run's token
- *   cancelled — completeSignIn checks the token before each side-effecting
- *   step, so an obsolete run cannot persist a user, clear caches, emit
- *   metrics, navigate, or sign out after it has been replaced — and only the
- *   token still active at completion may unlock the routes.
+ * Bootstrap lifecycle:
+ * - A probe covered by the in-flight run joins it: same target identity, or
+ *   naming the user the run itself persisted (single-writer, per the policy
+ *   above — storage changes during a run are the run's own output).
+ * - A conflicting identity during a run → cancel + hard reload (policy).
+ * - The probe turning unauthenticated, or unmount, cancels the run: a
+ *   cancelled completeSignIn performs no further side effects.
  */
 
 interface ActiveBootstrap {
   targetUserId: number
-  /** What CurrentUser held when this run started — provenance for joins. */
-  storedUserIdAtStart: number
   cancelled: boolean
 }
 
@@ -59,15 +62,19 @@ export interface SessionReconciliation {
   reconciling: boolean
 }
 
-/** The auth-relevant surface of a profile: identity, role set, ToS state.
+/** The auth-relevant surface of a profile: identity, role assignments
+ * (including which DAC each role is scoped to), and account/ToS status.
  * Cosmetic fields (display name, email) may lag one render — they cannot
  * grant access. */
 const authProfileEquivalent = (a: DuosUser, b: DuosUser): boolean => {
-  const roleNames = (u: DuosUser): string =>
-    (u.roles ?? []).map(r => r.name).sort().join(',')
+  const roleKeys = (u: DuosUser): string =>
+    (u.roles ?? []).map(r => `${r.name}:${r.dacId ?? ''}`).sort().join(',')
+  const status = (u: DuosUser) => u.userStatusInfo
   return a.userId === b.userId
-    && a.userStatusInfo?.tosAccepted === b.userStatusInfo?.tosAccepted
-    && roleNames(a) === roleNames(b)
+    && status(a)?.tosAccepted === status(b)?.tosAccepted
+    && status(a)?.enabled === status(b)?.enabled
+    && status(a)?.adminEnabled === status(b)?.adminEnabled
+    && roleKeys(a) === roleKeys(b)
 }
 
 export const useSessionReconciler = (queryClient: QueryClient): SessionReconciliation => {
@@ -79,36 +86,67 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
     bootstrapRunning: false,
   })
   // Effect-only guards (never read during render): idempotence for StrictMode
-  // double-invocations, and the active bootstrap's token.
+  // double-invocations, and the active bootstrap's cancellation token.
   const consumedProbeRef = useRef<SessionInfo | null>(null)
   const activeBootstrapRef = useRef<ActiveBootstrap | null>(null)
 
+  // Unmount cancels whatever is in flight.
+  useEffect(() => () => {
+    if (activeBootstrapRef.current) {
+      activeBootstrapRef.current.cancelled = true
+    }
+  }, [])
+
   useEffect(() => {
-    if (!sessionInfo?.authenticated || consumedProbeRef.current === sessionInfo) return
+    if (!sessionInfo?.authenticated) {
+      // The session disappeared (signed out in this or another tab, expiry).
+      // An in-flight bootstrap must not keep persisting a user, emitting
+      // metrics, or navigating for a session that no longer exists.
+      if (activeBootstrapRef.current) {
+        activeBootstrapRef.current.cancelled = true
+      }
+      return
+    }
+    if (consumedProbeRef.current === sessionInfo) return
     consumedProbeRef.current = sessionInfo
 
     const storedUserId = Storage.getCurrentUser().userId
     const sessionUser = sessionInfo.user
     const targetUserId = sessionUser?.userId ?? 0
 
-    // Join the in-flight bootstrap when this probe is covered by it: same
-    // target identity, or it names a user that storage acquired DURING the
-    // run (that run's own output — the post-registration re-probe). A probe
-    // naming the user storage held before the run started is an identity
-    // reversal and falls through to supersede.
     const active = activeBootstrapRef.current
-    const namesRunOutput = sessionUser !== undefined && sessionUser.userId !== 0
-      && sessionUser.userId === storedUserId && storedUserId !== active?.storedUserIdAtStart
-    if (active && (targetUserId === active.targetUserId || namesRunOutput)) {
-      setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
+    if (active) {
+      // Covered by the in-flight run: same target identity, or — for a
+      // registration run (target 0) only — naming the user the run itself
+      // persisted (single-writer, per the scope policy: storage changes
+      // during a run are the run's own output). Runs targeting a named user
+      // are already covered by the target match, so a probe naming a
+      // DIFFERENT stored user during one is a genuine conflict.
+      const coveredByRun = targetUserId === active.targetUserId
+        || (active.targetUserId === 0 && sessionUser !== undefined
+          && sessionUser.userId !== 0 && sessionUser.userId === storedUserId)
+      if (coveredByRun) {
+        // Recording classification IS this effect's externally-visible work
+        // for a joined probe (see ReconcilerSnapshot.classifiedProbe).
+        // oxlint-disable-next-line react/react-compiler
+        setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
+        return
+      }
+      // A different identity appeared under an in-flight bootstrap — only an
+      // unsupported cross-tab account switch produces this. Cancel and hard
+      // reload: the fresh page load reconciles from scratch.
+      active.cancelled = true
+      Redirect.to(globalThis.location.href)
       return
     }
 
-    if (!active && sessionUser !== undefined && sessionUser.userId !== 0
+    if (sessionUser !== undefined && sessionUser.userId !== 0
       && sessionUser.userId === storedUserId) {
       Storage.setCurrentUser(sessionUser)
       setUserRoleStatuses(sessionUser, Storage)
-      // Recorded in state → clean re-render off the refreshed profile.
+      // Recorded in state → clean re-render off the refreshed profile (the
+      // localStorage write above is invisible to React without it).
+      // oxlint-disable-next-line react/react-compiler
       setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
       // Only an explicit "not accepted" routes to the gate — a profile without
       // status info (older legacy sessions, service accounts) is left alone.
@@ -119,17 +157,8 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       return
     }
 
-    // Full bootstrap, superseding any in-flight run: the old token is
-    // cancelled so its remaining side effects are suppressed inside
-    // completeSignIn and its completion cannot unlock the routes.
-    if (active) {
-      active.cancelled = true
-    }
-    const token: ActiveBootstrap = {
-      targetUserId,
-      storedUserIdAtStart: storedUserId,
-      cancelled: false,
-    }
+    // Full bootstrap: no local identity, a different user, or no profile.
+    const token: ActiveBootstrap = { targetUserId, cancelled: false }
     activeBootstrapRef.current = token
     setSnapshot({ classifiedProbe: sessionInfo, bootstrapRunning: true })
     // The BFF callback lands the browser on the destination itself, so the
@@ -151,8 +180,8 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
   const isLoggedIn = sessionInfo?.authenticated ?? false
   // An unclassified probe hides identity-bearing UI unless it matches the
   // stored profile on every auth-relevant field — same user with changed
-  // roles or ToS state must not be committed off stale storage, while a
-  // routine no-change revalidation must not blank the screen.
+  // roles, DAC assignments, or status must not be committed off stale
+  // storage, while a routine no-change revalidation must not blank the screen.
   const sessionUser = sessionInfo?.user
   const authEquivalent = sessionUser !== undefined && sessionUser.userId !== 0
     && authProfileEquivalent(sessionUser, Storage.getCurrentUser())

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router'
 import type { QueryClient } from '@tanstack/react-query'
 import type { SessionInfo } from 'src/libs/auth/session'
+import type { DuosUser } from 'src/types/model'
 import { useSessionInfo } from 'src/hooks/useSession'
 import { completeSignIn } from 'src/libs/auth/postSignIn'
 import { Storage } from 'src/libs/storage'
@@ -14,38 +15,59 @@ import { setUserRoleStatuses } from 'src/libs/utils'
  * probe returns the same object, so re-renders and StrictMode double
  * invocations are inert) is classified exactly once:
  *
- * - Names the stored user → HYDRATE: refresh the local profile from the
- *   probe's server-fetched user (roles/ToS change between page loads; the
- *   popup flow reconciled on every sign-in) and route to the ToS gate on an
- *   explicit rejection. Classification is recorded in React state so the
- *   refreshed profile re-renders — a bare localStorage write is invisible to
- *   mounted components.
- * - Anything else (no local user after the OAuth callback, a session naming
- *   a different user, or a fresh probe with no profile — the cross-tab
- *   switch to an unregistered account) → the full post-sign-in BOOTSTRAP
- *   (user fetch / registration / metrics / ToS gate) via completeSignIn.
+ * - Names the stored user (a real identity, not the empty default) → HYDRATE:
+ *   refresh the local profile from the probe's server-fetched user and route
+ *   to the ToS gate on an explicit rejection. Classification is recorded in
+ *   React state so the refreshed profile re-renders mounted consumers.
+ * - Anything else (no local identity, a session naming a different user, or
+ *   a fresh probe with no profile — the cross-tab switch to an unregistered
+ *   account) → the full post-sign-in BOOTSTRAP via completeSignIn.
  *
- * Bootstraps are generation-guarded: a probe for the identity an in-flight
- * bootstrap is already handling joins that run; a genuinely different
- * identity supersedes it, and a superseded run's completion can no longer
- * unlock the routes.
+ * Bootstrap lifecycle guarantees:
+ * - JOIN with provenance: a probe joins the in-flight run only for the same
+ *   target identity, or when it names a user that storage acquired DURING
+ *   the run (the run's own output, e.g. the post-registration re-probe). A
+ *   probe naming the user storage held BEFORE the run started is an identity
+ *   reversal and supersedes instead.
+ * - SUPERSEDE with cancellation: superseding marks the old run's token
+ *   cancelled — completeSignIn checks the token before each side-effecting
+ *   step, so an obsolete run cannot persist a user, clear caches, emit
+ *   metrics, navigate, or sign out after it has been replaced — and only the
+ *   token still active at completion may unlock the routes.
  */
+
+interface ActiveBootstrap {
+  targetUserId: number
+  /** What CurrentUser held when this run started — provenance for joins. */
+  storedUserIdAtStart: number
+  cancelled: boolean
+}
 
 interface ReconcilerSnapshot {
   /** The probe whose classification is recorded — in state, not just a ref,
-   * so classification itself causes the re-render that propagates a
-   * hydrated profile. */
+   * so classification itself re-renders consumers of a hydrated profile. */
   classifiedProbe: SessionInfo | null
-  /** True while the render-blocking full bootstrap is in flight. */
+  /** True while a render-blocking full bootstrap is in flight. */
   bootstrapRunning: boolean
 }
 
 export interface SessionReconciliation {
   sessionInfo: SessionInfo | undefined
   isLoggedIn: boolean
-  /** Render-visible: the routes must stay hidden while this is true, or they
-   * commit a stale identity (previous user's roles under a new session). */
+  /** Render-visible: all identity-bearing UI (routes AND header) must stay
+   * hidden while true, or it commits a stale identity. */
   reconciling: boolean
+}
+
+/** The auth-relevant surface of a profile: identity, role set, ToS state.
+ * Cosmetic fields (display name, email) may lag one render — they cannot
+ * grant access. */
+const authProfileEquivalent = (a: DuosUser, b: DuosUser): boolean => {
+  const roleNames = (u: DuosUser): string =>
+    (u.roles ?? []).map(r => r.name).sort().join(',')
+  return a.userId === b.userId
+    && a.userStatusInfo?.tosAccepted === b.userStatusInfo?.tosAccepted
+    && roleNames(a) === roleNames(b)
 }
 
 export const useSessionReconciler = (queryClient: QueryClient): SessionReconciliation => {
@@ -57,10 +79,9 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
     bootstrapRunning: false,
   })
   // Effect-only guards (never read during render): idempotence for StrictMode
-  // double-invocations, and the active bootstrap's generation + target.
+  // double-invocations, and the active bootstrap's token.
   const consumedProbeRef = useRef<SessionInfo | null>(null)
-  const bootstrapGenerationRef = useRef(0)
-  const activeBootstrapRef = useRef<{ generation: number, targetUserId: number } | null>(null)
+  const activeBootstrapRef = useRef<ActiveBootstrap | null>(null)
 
   useEffect(() => {
     if (!sessionInfo?.authenticated || consumedProbeRef.current === sessionInfo) return
@@ -70,17 +91,21 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
     const sessionUser = sessionInfo.user
     const targetUserId = sessionUser?.userId ?? 0
 
-    // A probe for work the in-flight bootstrap already covers joins that run:
-    // same target identity, or a probe that now names the user the bootstrap
-    // just persisted (the post-registration re-probe). Starting a concurrent
-    // completeSignIn here would duplicate registration, metrics, and routing.
+    // Join the in-flight bootstrap when this probe is covered by it: same
+    // target identity, or it names a user that storage acquired DURING the
+    // run (that run's own output — the post-registration re-probe). A probe
+    // naming the user storage held before the run started is an identity
+    // reversal and falls through to supersede.
     const active = activeBootstrapRef.current
-    if (active && (targetUserId === active.targetUserId || (sessionUser !== undefined && sessionUser.userId === storedUserId))) {
+    const namesRunOutput = sessionUser !== undefined && sessionUser.userId !== 0
+      && sessionUser.userId === storedUserId && storedUserId !== active?.storedUserIdAtStart
+    if (active && (targetUserId === active.targetUserId || namesRunOutput)) {
       setSnapshot(prev => ({ ...prev, classifiedProbe: sessionInfo }))
       return
     }
 
-    if (!active && sessionUser !== undefined && sessionUser.userId === storedUserId) {
+    if (!active && sessionUser !== undefined && sessionUser.userId !== 0
+      && sessionUser.userId === storedUserId) {
       Storage.setCurrentUser(sessionUser)
       setUserRoleStatuses(sessionUser, Storage)
       // Recorded in state → clean re-render off the refreshed profile.
@@ -94,32 +119,44 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       return
     }
 
-    // Full bootstrap. Superseding an in-flight run bumps the generation, so
-    // the older run's completion below cannot unlock the routes early.
-    const generation = ++bootstrapGenerationRef.current
-    activeBootstrapRef.current = { generation, targetUserId }
+    // Full bootstrap, superseding any in-flight run: the old token is
+    // cancelled so its remaining side effects are suppressed inside
+    // completeSignIn and its completion cannot unlock the routes.
+    if (active) {
+      active.cancelled = true
+    }
+    const token: ActiveBootstrap = {
+      targetUserId,
+      storedUserIdAtStart: storedUserId,
+      cancelled: false,
+    }
+    activeBootstrapRef.current = token
     setSnapshot({ classifiedProbe: sessionInfo, bootstrapRunning: true })
     // The BFF callback lands the browser on the destination itself, so the
     // pathname is the redirect target; the legacy popup flow reloads on the
     // landing page with the destination still in ?redirectTo=.
     const redirectTo = new URLSearchParams(location.search).get('redirectTo')
-    completeSignIn({ navigate, queryClient, redirectPath: redirectTo ?? location.pathname })
-      .finally(() => {
-        if (activeBootstrapRef.current?.generation !== generation) return
-        activeBootstrapRef.current = null
-        setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
-      })
+    completeSignIn({
+      navigate,
+      queryClient,
+      redirectPath: redirectTo ?? location.pathname,
+      isCancelled: () => token.cancelled,
+    }).finally(() => {
+      if (activeBootstrapRef.current !== token) return
+      activeBootstrapRef.current = null
+      setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
+    })
   }, [sessionInfo, navigate, location.pathname, location.search, queryClient])
 
   const isLoggedIn = sessionInfo?.authenticated ?? false
-  // An unclassified probe hides the routes only when it could change the
-  // rendered identity (fresh callback, no profile, or a different user) —
-  // a probe naming the stored user hydrates without blanking the screen on
-  // every focus revalidation.
-  const storedUserId = Storage.getCurrentUser().userId
-  const sessionUserId = sessionInfo?.user?.userId
-  const unclassifiedIdentityChange = sessionInfo !== snapshot.classifiedProbe
-    && (storedUserId === 0 || sessionUserId === undefined || sessionUserId !== storedUserId)
+  // An unclassified probe hides identity-bearing UI unless it matches the
+  // stored profile on every auth-relevant field — same user with changed
+  // roles or ToS state must not be committed off stale storage, while a
+  // routine no-change revalidation must not blank the screen.
+  const sessionUser = sessionInfo?.user
+  const authEquivalent = sessionUser !== undefined && sessionUser.userId !== 0
+    && authProfileEquivalent(sessionUser, Storage.getCurrentUser())
+  const unclassifiedIdentityChange = sessionInfo !== snapshot.classifiedProbe && !authEquivalent
   const reconciling = isLoggedIn && (snapshot.bootstrapRunning || unclassifiedIdentityChange)
 
   return { sessionInfo, isLoggedIn, reconciling }

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router'
+import type { NavigateFunction } from 'react-router'
 import type { QueryClient } from '@tanstack/react-query'
 import type { SessionInfo } from 'src/libs/auth/session'
 import type { DuosUser } from 'src/types/model'
@@ -73,13 +74,39 @@ export interface SessionReconciliation {
  * grant access. */
 const authProfileEquivalent = (a: DuosUser, b: DuosUser): boolean => {
   const roleKeys = (u: DuosUser): string =>
-    (u.roles ?? []).map(r => `${r.name}:${r.dacId ?? ''}`).sort().join(',')
+    (u.roles ?? []).map(r => `${r.name}:${r.dacId ?? ''}`).sort((x, y) => x.localeCompare(y)).join(',')
   const status = (u: DuosUser) => u.userStatusInfo
   return a.userId === b.userId
     && status(a)?.tosAccepted === status(b)?.tosAccepted
     && status(a)?.enabled === status(b)?.enabled
     && status(a)?.adminEnabled === status(b)?.adminEnabled
     && roleKeys(a) === roleKeys(b)
+}
+
+/** Whether a fresh probe is covered by the in-flight run: same target
+ * identity, or — for a registration run (target 0) only — naming the user the
+ * run itself persisted (single-writer, per the scope policy: storage changes
+ * during a run are the run's own output). Runs targeting a named user are
+ * already covered by the target match, so a probe naming a DIFFERENT stored
+ * user during one is a genuine conflict. */
+const probeCoveredByRun = (active: ActiveBootstrap, sessionUser: DuosUser | undefined, storedUserId: number): boolean => {
+  const targetUserId = sessionUser?.userId ?? 0
+  return targetUserId === active.targetUserId
+    || (active.targetUserId === 0 && sessionUser !== undefined
+      && sessionUser.userId !== 0 && sessionUser.userId === storedUserId)
+}
+
+/** Persist the freshest profile a joined probe carried, once its run
+ * completes. Same explicit-rejection rule as the hydrate path. The router
+ * location closure may be stale by completion time — read the live one
+ * (they coincide outside MemoryRouter tests). */
+const applyPendingHydration = (fresh: DuosUser, navigate: NavigateFunction): void => {
+  Storage.setCurrentUser(fresh)
+  setUserRoleStatuses(fresh, Storage)
+  if (fresh.userStatusInfo?.tosAccepted === false
+    && !globalThis.location.pathname.startsWith('/tos')) {
+    navigate('/tos_acceptance')
+  }
 }
 
 export const useSessionReconciler = (queryClient: QueryClient): SessionReconciliation => {
@@ -128,16 +155,7 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
 
     const active = activeBootstrapRef.current
     if (active) {
-      // Covered by the in-flight run: same target identity, or — for a
-      // registration run (target 0) only — naming the user the run itself
-      // persisted (single-writer, per the scope policy: storage changes
-      // during a run are the run's own output). Runs targeting a named user
-      // are already covered by the target match, so a probe naming a
-      // DIFFERENT stored user during one is a genuine conflict.
-      const coveredByRun = targetUserId === active.targetUserId
-        || (active.targetUserId === 0 && sessionUser !== undefined
-          && sessionUser.userId !== 0 && sessionUser.userId === storedUserId)
-      if (coveredByRun) {
+      if (probeCoveredByRun(active, sessionUser, storedUserId)) {
         // A joined probe carrying a profile is fresher than the run's own
         // in-flight getMe response — remember it so the run's completion
         // applies it (latest join wins).
@@ -209,16 +227,7 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       // reload. (Joins that landed before the run's persist/routing step were
       // already applied inside completeSignIn via latestJoinedProfile.)
       if (outcome === 'completed' && !token.cancelled && token.pendingHydration) {
-        const fresh = token.pendingHydration
-        Storage.setCurrentUser(fresh)
-        setUserRoleStatuses(fresh, Storage)
-        // Same explicit-rejection rule as the hydrate path. The router
-        // location closure may be stale by completion time — read the live
-        // one (they coincide outside MemoryRouter tests).
-        if (fresh.userStatusInfo?.tosAccepted === false
-          && !globalThis.location.pathname.startsWith('/tos')) {
-          navigate('/tos_acceptance')
-        }
+        applyPendingHydration(token.pendingHydration, navigate)
       }
       setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
     })

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -188,12 +188,21 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       queryClient,
       redirectPath: redirectTo ?? location.pathname,
       isCancelled: () => token.cancelled,
-    }).finally(() => {
+      latestJoinedProfile: () => token.pendingHydration,
+    }).then(
+      outcome => outcome,
+      // An unexpected rejection is not a completion — treat like a failure so
+      // pending hydration is discarded along with it.
+      () => 'failed' as const,
+    ).then((outcome) => {
       if (activeBootstrapRef.current !== token) return
       activeBootstrapRef.current = null
-      // Apply the freshest profile a joined probe carried: the run's own
-      // getMe response may have been older and overwritten storage after it.
-      if (!token.cancelled && token.pendingHydration) {
+      // Apply the freshest profile a joined probe carried — but ONLY when the
+      // run completed. A 'signed-out' run just cleared storage; re-populating
+      // it here would resurrect a stale identity that survives the sign-out
+      // reload. (Joins that landed before the run's persist/routing step were
+      // already applied inside completeSignIn via latestJoinedProfile.)
+      if (outcome === 'completed' && !token.cancelled && token.pendingHydration) {
         const fresh = token.pendingHydration
         Storage.setCurrentUser(fresh)
         setUserRoleStatuses(fresh, Storage)

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -189,6 +189,12 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       redirectPath: redirectTo ?? location.pathname,
       isCancelled: () => token.cancelled,
       latestJoinedProfile: () => token.pendingHydration,
+      // Only the BFF probe can be authenticated without a user — the legacy
+      // probe always mirrors storage (session.ts). That answer means
+      // "unregistered": completeSignIn must go straight to registration, as
+      // its usual getMe would hit the same upstream 401 the probe just saw
+      // and the /duos-api proxy answers that by destroying the session.
+      sessionReportsNoProfile: sessionUser === undefined,
     }).then(
       outcome => outcome,
       // An unexpected rejection is not a completion — treat like a failure so

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -131,6 +131,13 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
   // double-invocations, and the active bootstrap's cancellation token.
   const consumedProbeRef = useRef<SessionInfo | null>(null)
   const activeBootstrapRef = useRef<ActiveBootstrap | null>(null)
+  // The identity this tab's QueryClient was populated under. localStorage is
+  // shared across tabs but the query cache is per-tab: when another tab
+  // switches accounts, this tab's next probe MATCHES the (already-switched)
+  // stored user and hydrates — with the previous user's role-scoped query
+  // results still resident. Storage cannot answer "whose data does THIS
+  // tab's cache hold", so the tab tracks it itself and clears on change.
+  const cacheIdentityRef = useRef<number>(Storage.getCurrentUser().userId)
 
   // Unmount cancels whatever is in flight.
   useEffect(() => () => {
@@ -182,11 +189,21 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       // unsupported cross-tab account switch produces this. Cancel and hard
       // reload: the fresh page load reconciles from scratch.
       active.cancelled = true
-      Redirect.to(globalThis.location.href)
+      // Redirect.reload, not Redirect.to(href): on a #fragment URL the href
+      // assignment is a same-document navigation — nothing reloads, the
+      // conflict is never classified, and the spinner never clears.
+      Redirect.reload()
       return
     }
 
     if (probeNamesStoredUser(sessionUser, storedUserId)) {
+      // A cross-tab account switch arrives here looking like a routine
+      // hydrate (shared storage already names the new user). The per-tab
+      // query cache still holds the previous identity's data — drop it.
+      if (cacheIdentityRef.current !== sessionUser.userId) {
+        queryClient.clear()
+        cacheIdentityRef.current = sessionUser.userId
+      }
       Storage.setCurrentUser(sessionUser)
       setUserRoleStatuses(sessionUser, Storage)
       // Recorded in state → clean re-render off the refreshed profile (the
@@ -237,6 +254,10 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
       if (outcome === 'completed' && !token.cancelled && token.pendingHydration) {
         applyPendingHydration(token.pendingHydration, navigate)
       }
+      // completeSignIn cleared and repopulated the cache under whatever
+      // identity it persisted (the empty default after a signed-out run) —
+      // that is who this tab's cache belongs to now.
+      cacheIdentityRef.current = Storage.getCurrentUser().userId
       setSnapshot(prev => ({ ...prev, bootstrapRunning: false }))
     })
   }, [sessionInfo, navigate, location.pathname, location.search, queryClient])

--- a/src/hooks/useSessionReconciler.ts
+++ b/src/hooks/useSessionReconciler.ts
@@ -113,6 +113,21 @@ const applyPendingHydration = (fresh: DuosUser, navigate: NavigateFunction): voi
   }
 }
 
+/** Drops the per-tab query cache when the tab starts serving a different
+ * identity than the one the cache was populated under. A cross-tab account
+ * switch arrives at the hydrate path looking routine (shared storage already
+ * names the new user), but this tab's cache still holds the previous
+ * identity's role-scoped results. */
+const ensureCacheIdentity = (
+  cacheIdentity: { current: number },
+  queryClient: QueryClient,
+  userId: number,
+): void => {
+  if (cacheIdentity.current === userId) return
+  queryClient.clear()
+  cacheIdentity.current = userId
+}
+
 /** A probe that names the stored user (a real identity, not the empty
  * default) hydrates the local profile instead of bootstrapping. */
 const probeNamesStoredUser = (sessionUser: DuosUser | undefined, storedUserId: number): sessionUser is DuosUser =>
@@ -197,13 +212,7 @@ export const useSessionReconciler = (queryClient: QueryClient): SessionReconcili
     }
 
     if (probeNamesStoredUser(sessionUser, storedUserId)) {
-      // A cross-tab account switch arrives here looking like a routine
-      // hydrate (shared storage already names the new user). The per-tab
-      // query cache still holds the previous identity's data — drop it.
-      if (cacheIdentityRef.current !== sessionUser.userId) {
-        queryClient.clear()
-        cacheIdentityRef.current = sessionUser.userId
-      }
+      ensureCacheIdentity(cacheIdentityRef, queryClient, sessionUser.userId)
       Storage.setCurrentUser(sessionUser)
       setUserRoleStatuses(sessionUser, Storage)
       // Recorded in state → clean re-render off the refreshed profile (the

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -41,7 +41,13 @@ export const Metrics = {
  */
 // oxlint-disable-next-line @typescript-eslint/no-explicit-any
 const captureEventFn = async (event: MetricsEventName, signal: AbortSignal, details: object = {}): Promise<any> => {
+  // Legacy: the synchronous oidc-client-ts token check. BFF: the browser
+  // holds no token (the legacy keys are purged), so a persisted registered
+  // profile is what "signed in" looks like — without this every BFF event
+  // posted anonymously, while identify/syncProfile in the same sign-in flow
+  // posted identified, and Bard saw two disagreeing users.
   const isSignedIn = Storage.userIsLogged()
+    || (await Config.isBffEnabled() && Storage.getCurrentUser().userId !== 0)
   const isRegistered = isSignedIn && Storage.getCurrentUser()
 
   if (!isRegistered && !Storage.getAnonymousId()) {

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -23,6 +23,15 @@ export const Redirect = {
   to: (url: string): void => {
     globalThis.location.href = url
   },
+  /**
+   * A guaranteed reload of the current page. Assigning location.href to the
+   * current URL does NOT reload when the URL carries a #fragment — the
+   * browser treats it as a same-document navigation — so "reload in place"
+   * must never go through Redirect.to.
+   */
+  reload: (): void => {
+    globalThis.location.reload()
+  },
 }
 
 export const Auth = {

--- a/src/libs/auth/auth.ts
+++ b/src/libs/auth/auth.ts
@@ -9,6 +9,7 @@
 import { OidcBroker, OidcUser } from './oidcBroker'
 import { Storage } from './../storage'
 import { Config } from './../config'
+import { resetSessionCache } from './session'
 import { getCsrfToken, isCsrfRejection, resetCsrfToken } from './../ajax/csrf'
 import { UserManager } from 'oidc-client-ts'
 
@@ -108,19 +109,17 @@ export const Auth = {
       // The session (and with it the server-side CSRF secret) is gone — any cached token is stale.
       resetCsrfToken()
       Storage.clearStorage()
+      // The probe cache still holds the pre-logout "authenticated" answer;
+      // callers navigate before the redirect below unloads the page, and a
+      // re-render in that window must not paint a signed-in header around
+      // the just-cleared (empty) stored user.
+      resetSessionCache()
       purgeLegacyOidcKeys()
       Redirect.to(redirectTo)
       return
     }
     Storage.clearStorage()
     await OidcBroker.signOut()
-  },
-  isAuthenticated: async (): Promise<boolean> => {
-    if (await Config.isBffEnabled()) {
-      const res = await fetch('/auth/me', { credentials: 'include' })
-      return res.ok
-    }
-    return Storage.userIsLogged()
   },
 }
 

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -178,7 +178,8 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     // response could apply outdated roles or ToS state.
     const resolveEffectiveUser = (base: DuosUser): DuosUser => {
       const joined = latestJoinedProfile?.()
-      return joined !== undefined && joined.userId === base.userId ? joined : base
+      if (joined === undefined) return base
+      return joined.userId === base.userId ? joined : base
     }
     let effectiveUser = resolveEffectiveUser(duosUser)
     Storage.setCurrentUser(effectiveUser)

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -14,6 +14,7 @@ import { User } from 'src/libs/ajax/User'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import { Storage } from 'src/libs/storage'
 import { Auth } from 'src/libs/auth/auth'
+import { resetSessionCache } from 'src/libs/auth/session'
 import { Navigation, Notifications, setUserRoleStatuses } from 'src/libs/utils'
 import { ErrorReporter } from 'src/libs/ErrorReporter'
 import eventList, { MetricsEventName } from 'src/libs/events'
@@ -90,8 +91,12 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
     const registeredUser: DuosUser = await User.registerUser()
     const redirectParam = redirectTo ? `?redirectTo=${redirectTo}` : ''
     setUserRoleStatuses(registeredUser, Storage)
-    // New identity — same cache reset as the normal sign-in path below.
+    // New identity — same cache reset as the normal sign-in path below. The
+    // cached /auth/me answer predates the registration (authenticated, no
+    // user), so drop it too: the navigation below re-probes and picks up the
+    // newly registered identity.
     queryClient.clear()
+    resetSessionCache()
     syncSignInOrRegistrationEvent(eventList.userRegister)
     navigate(`/tos_acceptance${redirectParam}`)
   }
@@ -134,8 +139,11 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
     // Drop any query results cached before sign-in: cached library queries
     // (data, tab counts, filter metadata) were built with the anonymous /
     // previous user's role-based visibility clauses and would otherwise be
-    // served from cache under the new user's identity.
+    // served from cache under the new user's identity. The session cache can
+    // likewise predate this identity (the 409 path arrives here with an
+    // authenticated-no-user probe answer cached).
     queryClient.clear()
+    resetSessionCache()
     if (!duosUser.roles) {
       await ErrorReporter.report('roles not found for user: ' + duosUser.email)
     }

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -39,6 +39,17 @@ export interface CompleteSignInOptions {
    * roles/ToS state.
    */
   latestJoinedProfile?: () => DuosUser | undefined
+  /**
+   * True when the session probe that triggered this run reported an
+   * authenticated session with no DUOS profile — /auth/me's "valid session,
+   * unregistered user" answer. The initial getMe is skipped: the probe fetched
+   * /api/user/me moments ago, and repeating the call through /duos-api hits
+   * the same upstream 401 that the proxy treats as an authoritative token
+   * rejection (destroySessionOnUpstream401) — destroying the session that
+   * registerUser() is about to need. A stale no-profile answer (the user
+   * registered in another tab meanwhile) is recovered by the 409 branch.
+   */
+  sessionReportsNoProfile?: boolean
 }
 
 /**
@@ -80,7 +91,7 @@ const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
   Metrics.captureEvent(event)
 }
 
-export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCancelled, latestJoinedProfile }: CompleteSignInOptions): Promise<CompleteSignInOutcome> => {
+export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCancelled, latestJoinedProfile, sessionReportsNoProfile }: CompleteSignInOptions): Promise<CompleteSignInOutcome> => {
   const cancelled = () => isCancelled?.() === true
   // '/' and '/home' are landing pages, not destinations worth returning to —
   // signed-in users on those go to their console instead.
@@ -198,6 +209,13 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     syncSignInOrRegistrationEvent(eventList.userSignIn)
     await checkToSAndRedirect(redirectTo)
     return cancelled() ? 'cancelled' : 'completed'
+  }
+
+  // The probe already answered "authenticated, no profile" — registration is
+  // the only next step, and the getMe below must not run first (it would
+  // destroy the session; see sessionReportsNoProfile).
+  if (sessionReportsNoProfile) {
+    return await handleRegistration()
   }
 
   try {

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -157,6 +157,8 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     resetSessionCache()
     if (!duosUser.roles) {
       await ErrorReporter.report('roles not found for user: ' + duosUser.email)
+      // The report awaits env lookup + delivery — long enough to be superseded.
+      if (cancelled()) return
     }
     syncSignInOrRegistrationEvent(eventList.userSignIn)
     await checkToSAndRedirect(redirectTo)

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -26,6 +26,12 @@ export interface CompleteSignInOptions {
   queryClient: QueryClient
   /** The path the /auth/callback redirect landed on (location.pathname). */
   redirectPath: string
+  /**
+   * Polled before every side-effecting step. When a newer reconciliation has
+   * superseded this run, it must not persist a user, clear caches, emit
+   * metrics, navigate, or sign out — the newer run owns the session now.
+   */
+  isCancelled?: () => boolean
 }
 
 interface HttpishError {
@@ -59,7 +65,8 @@ const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
   Metrics.captureEvent(event)
 }
 
-export const completeSignIn = async ({ navigate, queryClient, redirectPath }: CompleteSignInOptions): Promise<void> => {
+export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCancelled }: CompleteSignInOptions): Promise<void> => {
+  const cancelled = () => isCancelled?.() === true
   // '/' and '/home' are landing pages, not destinations worth returning to —
   // signed-in users on those go to their console instead.
   const shouldRedirect = redirectPath !== '/' && redirectPath !== '/home'
@@ -70,6 +77,7 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
   // an accepted user with a destination usually stays put; the legacy popup
   // flow reloads on the sign-in page instead, so navigate when not there yet.
   const checkToSAndRedirect = async (redirectPath: string | null) => {
+    if (cancelled()) return
     const tosAccepted = Storage.getCurrentUser().userStatusInfo?.tosAccepted || false
     if (tosAccepted) {
       if (redirectPath === null) {
@@ -89,6 +97,7 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
 
   const registerAndRedirectNewUser = async () => {
     const registeredUser: DuosUser = await User.registerUser()
+    if (cancelled()) return
     const redirectParam = redirectTo ? `?redirectTo=${redirectTo}` : ''
     setUserRoleStatuses(registeredUser, Storage)
     // New identity — same cache reset as the normal sign-in path below. The
@@ -116,10 +125,11 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
           await completeExistingUserSignIn(await User.getMe())
         }
         catch {
-          await Auth.signOut()
+          if (!cancelled()) await Auth.signOut()
         }
       }
       else {
+        if (cancelled()) return
         Notifications.showError({
           text: 'Error during sign in: ' + extractError(error),
           description: 'There was an error completing your registration. Please try again.',
@@ -134,6 +144,7 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
   }
 
   const completeExistingUserSignIn = async (duosUser: DuosUser): Promise<void> => {
+    if (cancelled()) return
     Storage.setCurrentUser(duosUser)
     setUserRoleStatuses(duosUser, Storage)
     // Drop any query results cached before sign-in: cached library queries
@@ -161,6 +172,7 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
     }
   }
   catch (error) {
+    if (cancelled()) return
     // Explicitly handle AzureB2C errors from Sam
     const errorMessage = extractError(error)
     if (errorMessage.toLowerCase().includes('azureb2c authentication error')) {

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -53,14 +53,18 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
   const shouldRedirect = redirectPath !== '/' && redirectPath !== '/home'
   const redirectTo = shouldRedirect ? redirectPath : null
 
-  // Check for ToS acceptance — redirect the user if not accepted yet. Unlike
-  // the old popup flow, the /auth/callback redirect already landed the browser
-  // on redirectPath, so an accepted user with a destination stays put.
+  // Check for ToS acceptance — redirect the user if not accepted yet. The
+  // BFF /auth/callback redirect lands the browser on redirectPath itself, so
+  // an accepted user with a destination usually stays put; the legacy popup
+  // flow reloads on the sign-in page instead, so navigate when not there yet.
   const checkToSAndRedirect = async (redirectPath: string | null) => {
     const tosAccepted = Storage.getCurrentUser().userStatusInfo?.tosAccepted || false
     if (tosAccepted) {
       if (redirectPath === null) {
         await Navigation.console(Storage.getCurrentUser(), navigate)
+      }
+      else if (globalThis.location.pathname !== redirectPath) {
+        navigate(redirectPath)
       }
     }
     else if (redirectPath === null) {
@@ -88,9 +92,13 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
     catch (error) {
       switch (errorStatus(error)) {
         case 409:
-          // Already registered — treat like a normal sign-in.
+          // Already registered (raced by another tab, or the earlier getMe
+          // failed transiently) — complete as a normal sign-in from a fresh
+          // user fetch. Routing off whatever CurrentUser happens to be in
+          // storage (usually the empty default) would send an accepted user
+          // back to the ToS gate without the cache reset or sign-in metric.
           try {
-            await checkToSAndRedirect(redirectTo)
+            await completeExistingUserSignIn(await User.getMe())
           }
           catch {
             await Auth.signOut()
@@ -106,21 +114,25 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
     }
   }
 
+  const completeExistingUserSignIn = async (duosUser: DuosUser): Promise<void> => {
+    Storage.setCurrentUser(duosUser)
+    setUserRoleStatuses(duosUser, Storage)
+    // Drop any query results cached before sign-in: cached library queries
+    // (data, tab counts, filter metadata) were built with the anonymous /
+    // previous user's role-based visibility clauses and would otherwise be
+    // served from cache under the new user's identity.
+    queryClient.clear()
+    if (!duosUser.roles) {
+      await ErrorReporter.report('roles not found for user: ' + duosUser.email)
+    }
+    syncSignInOrRegistrationEvent(eventList.userSignIn)
+    await checkToSAndRedirect(redirectTo)
+  }
+
   try {
     const duosUser: DuosUser = await User.getMe()
     if (duosUser) {
-      Storage.setCurrentUser(duosUser)
-      setUserRoleStatuses(duosUser, Storage)
-      // Drop any query results cached before sign-in: cached library queries
-      // (data, tab counts, filter metadata) were built with the anonymous /
-      // previous user's role-based visibility clauses and would otherwise be
-      // served from cache under the new user's identity.
-      queryClient.clear()
-      if (!duosUser.roles) {
-        await ErrorReporter.report('roles not found for user: ' + duosUser.email)
-      }
-      syncSignInOrRegistrationEvent(eventList.userSignIn)
-      await checkToSAndRedirect(redirectTo)
+      await completeExistingUserSignIn(duosUser)
     }
     else {
       await handleRegistration()

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -30,11 +30,22 @@ export interface CompleteSignInOptions {
 interface HttpishError {
   status?: number
   response?: { status?: number, data?: { message?: string } }
+  cause?: unknown
 }
 
+/**
+ * fetchAdapter throws the axios-like { response: { status } } error wrapped
+ * inside Error.cause (its outer catch re-wraps everything it didn't itself
+ * construct), so the HTTP status must be dug out of the cause chain.
+ */
 const errorStatus = (error: unknown): number | undefined => {
-  const e = error as HttpishError
-  return e.response?.status ?? e.status
+  let e = error as HttpishError | undefined
+  while (e) {
+    const status = e.response?.status ?? e.status
+    if (status !== undefined) return status
+    e = e.cause as HttpishError | undefined
+  }
+  return undefined
 }
 
 const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
@@ -108,6 +119,11 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
           text: 'Error during sign in: ' + extractError(error),
           description: 'There was an error completing your registration. Please try again.',
         })
+        // Authenticated but unregistered and unregisterable: resolving here
+        // would let App mark the bootstrap done and unlock the routes with an
+        // empty CurrentUser. Destroy the session instead — the reload lands
+        // the user cleanly signed out, and signing in again retries.
+        await Auth.signOut()
       }
     }
   }

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -165,8 +165,11 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     // Prefer the freshest same-user profile a joined probe delivered while
     // this run's getMe was in flight — persisting and routing off the older
     // response could apply outdated roles or ToS state.
-    const joined = latestJoinedProfile?.()
-    const effectiveUser = joined !== undefined && joined.userId === duosUser.userId ? joined : duosUser
+    const resolveEffectiveUser = (base: DuosUser): DuosUser => {
+      const joined = latestJoinedProfile?.()
+      return joined !== undefined && joined.userId === base.userId ? joined : base
+    }
+    let effectiveUser = resolveEffectiveUser(duosUser)
     Storage.setCurrentUser(effectiveUser)
     setUserRoleStatuses(effectiveUser, Storage)
     // Drop any query results cached before sign-in: cached library queries
@@ -179,8 +182,18 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     resetSessionCache()
     if (!effectiveUser.roles) {
       await ErrorReporter.report('roles not found for user: ' + effectiveUser.email)
-      // The report awaits env lookup + delivery — long enough to be superseded.
+      // The report awaits env lookup + delivery — long enough to be superseded…
       if (cancelled()) return 'cancelled'
+      // …or for a fresher profile to join. Resample before metrics and
+      // routing: checkToSAndRedirect reads storage, and routing off the
+      // pre-report profile could send an accepted user to the ToS gate — a
+      // navigation the reconciler's post-completion apply cannot repair.
+      const resampled = resolveEffectiveUser(effectiveUser)
+      if (resampled !== effectiveUser) {
+        effectiveUser = resampled
+        Storage.setCurrentUser(effectiveUser)
+        setUserRoleStatuses(effectiveUser, Storage)
+      }
     }
     syncSignInOrRegistrationEvent(eventList.userSignIn)
     await checkToSAndRedirect(redirectTo)

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -32,7 +32,22 @@ export interface CompleteSignInOptions {
    * metrics, navigate, or sign out — the newer run owns the session now.
    */
   isCancelled?: () => boolean
+  /**
+   * The freshest same-user profile a probe delivered while this run was in
+   * flight (the reconciler's joined-probe hydration). Consulted at persist
+   * and routing time so an older getMe response does not route off outdated
+   * roles/ToS state.
+   */
+  latestJoinedProfile?: () => DuosUser | undefined
 }
+
+/**
+ * How the run ended. The caller applies follow-up work (e.g. joined-probe
+ * hydration) only on 'completed' — a 'signed-out' run has just cleared
+ * storage, and re-populating it would resurrect a stale identity that
+ * survives the sign-out reload.
+ */
+export type CompleteSignInOutcome = 'completed' | 'signed-out' | 'cancelled'
 
 interface HttpishError {
   status?: number
@@ -65,7 +80,7 @@ const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
   Metrics.captureEvent(event)
 }
 
-export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCancelled }: CompleteSignInOptions): Promise<void> => {
+export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCancelled, latestJoinedProfile }: CompleteSignInOptions): Promise<CompleteSignInOutcome> => {
   const cancelled = () => isCancelled?.() === true
   // '/' and '/home' are landing pages, not destinations worth returning to —
   // signed-in users on those go to their console instead.
@@ -95,9 +110,9 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     }
   }
 
-  const registerAndRedirectNewUser = async () => {
+  const registerAndRedirectNewUser = async (): Promise<CompleteSignInOutcome> => {
     const registeredUser: DuosUser = await User.registerUser()
-    if (cancelled()) return
+    if (cancelled()) return 'cancelled'
     const redirectParam = redirectTo ? `?redirectTo=${redirectTo}` : ''
     setUserRoleStatuses(registeredUser, Storage)
     // New identity — same cache reset as the normal sign-in path below. The
@@ -108,11 +123,12 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     resetSessionCache()
     syncSignInOrRegistrationEvent(eventList.userRegister)
     navigate(`/tos_acceptance${redirectParam}`)
+    return 'completed'
   }
 
-  const handleRegistration = async () => {
+  const handleRegistration = async (): Promise<CompleteSignInOutcome> => {
     try {
-      await registerAndRedirectNewUser()
+      return await registerAndRedirectNewUser()
     }
     catch (error) {
       if (errorStatus(error) === 409) {
@@ -122,31 +138,37 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
         // storage (usually the empty default) would send an accepted user
         // back to the ToS gate without the cache reset or sign-in metric.
         try {
-          await completeExistingUserSignIn(await User.getMe())
+          return await completeExistingUserSignIn(await User.getMe())
         }
         catch {
-          if (!cancelled()) await Auth.signOut()
+          if (cancelled()) return 'cancelled'
+          await Auth.signOut()
+          return 'signed-out'
         }
       }
-      else {
-        if (cancelled()) return
-        Notifications.showError({
-          text: 'Error during sign in: ' + extractError(error),
-          description: 'There was an error completing your registration. Please try again.',
-        })
-        // Authenticated but unregistered and unregisterable: resolving here
-        // would let App mark the bootstrap done and unlock the routes with an
-        // empty CurrentUser. Destroy the session instead — the reload lands
-        // the user cleanly signed out, and signing in again retries.
-        await Auth.signOut()
-      }
+      if (cancelled()) return 'cancelled'
+      Notifications.showError({
+        text: 'Error during sign in: ' + extractError(error),
+        description: 'There was an error completing your registration. Please try again.',
+      })
+      // Authenticated but unregistered and unregisterable: resolving here
+      // would let App mark the bootstrap done and unlock the routes with an
+      // empty CurrentUser. Destroy the session instead — the reload lands
+      // the user cleanly signed out, and signing in again retries.
+      await Auth.signOut()
+      return 'signed-out'
     }
   }
 
-  const completeExistingUserSignIn = async (duosUser: DuosUser): Promise<void> => {
-    if (cancelled()) return
-    Storage.setCurrentUser(duosUser)
-    setUserRoleStatuses(duosUser, Storage)
+  const completeExistingUserSignIn = async (duosUser: DuosUser): Promise<CompleteSignInOutcome> => {
+    if (cancelled()) return 'cancelled'
+    // Prefer the freshest same-user profile a joined probe delivered while
+    // this run's getMe was in flight — persisting and routing off the older
+    // response could apply outdated roles or ToS state.
+    const joined = latestJoinedProfile?.()
+    const effectiveUser = joined !== undefined && joined.userId === duosUser.userId ? joined : duosUser
+    Storage.setCurrentUser(effectiveUser)
+    setUserRoleStatuses(effectiveUser, Storage)
     // Drop any query results cached before sign-in: cached library queries
     // (data, tab counts, filter metadata) were built with the anonymous /
     // previous user's role-based visibility clauses and would otherwise be
@@ -155,34 +177,32 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
     // authenticated-no-user probe answer cached).
     queryClient.clear()
     resetSessionCache()
-    if (!duosUser.roles) {
-      await ErrorReporter.report('roles not found for user: ' + duosUser.email)
+    if (!effectiveUser.roles) {
+      await ErrorReporter.report('roles not found for user: ' + effectiveUser.email)
       // The report awaits env lookup + delivery — long enough to be superseded.
-      if (cancelled()) return
+      if (cancelled()) return 'cancelled'
     }
     syncSignInOrRegistrationEvent(eventList.userSignIn)
     await checkToSAndRedirect(redirectTo)
+    return cancelled() ? 'cancelled' : 'completed'
   }
 
   try {
     const duosUser: DuosUser = await User.getMe()
     if (duosUser) {
-      await completeExistingUserSignIn(duosUser)
+      return await completeExistingUserSignIn(duosUser)
     }
-    else {
-      await handleRegistration()
-    }
+    return await handleRegistration()
   }
   catch (error) {
-    if (cancelled()) return
+    if (cancelled()) return 'cancelled'
     // Explicitly handle AzureB2C errors from Sam
     const errorMessage = extractError(error)
     if (errorMessage.toLowerCase().includes('azureb2c authentication error')) {
       Notifications.showError({ text: errorMessage })
       await Auth.signOut()
+      return 'signed-out'
     }
-    else {
-      await handleRegistration()
-    }
+    return await handleRegistration()
   }
 }

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -117,14 +117,18 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
       navigate('/tos_acceptance')
     }
     else {
-      navigate(`/tos_acceptance?redirectTo=${redirectPath}`)
+      // Encoded, or a destination with its own query string ('?filter=a&b=c')
+      // splits at the first '&' and its tail becomes sibling params of the
+      // ToS page. The readers decode via URLSearchParams.
+      navigate(`/tos_acceptance?redirectTo=${encodeURIComponent(redirectPath)}`)
     }
   }
 
   const registerAndRedirectNewUser = async (): Promise<CompleteSignInOutcome> => {
     const registeredUser: DuosUser = await User.registerUser()
     if (cancelled()) return 'cancelled'
-    const redirectParam = redirectTo ? `?redirectTo=${redirectTo}` : ''
+    // Encoded for the same reason as checkToSAndRedirect above.
+    const redirectParam = redirectTo ? `?redirectTo=${encodeURIComponent(redirectTo)}` : ''
     setUserRoleStatuses(registeredUser, Storage)
     // New identity — same cache reset as the normal sign-in path below. The
     // cached /auth/me answer predates the registration (authenticated, no
@@ -182,7 +186,8 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
       return joined.userId === base.userId ? joined : base
     }
     let effectiveUser = resolveEffectiveUser(duosUser)
-    Storage.setCurrentUser(effectiveUser)
+    // setUserRoleStatuses persists the user itself (utils.ts) — no separate
+    // Storage.setCurrentUser call.
     setUserRoleStatuses(effectiveUser, Storage)
     // Drop any query results cached before sign-in: cached library queries
     // (data, tab counts, filter metadata) were built with the anonymous /
@@ -203,7 +208,6 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
       const resampled = resolveEffectiveUser(effectiveUser)
       if (resampled !== effectiveUser) {
         effectiveUser = resampled
-        Storage.setCurrentUser(effectiveUser)
         setUserRoleStatuses(effectiveUser, Storage)
       }
     }

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -1,0 +1,140 @@
+/**
+ * Post-sign-in bootstrap.
+ *
+ * With the BFF, sign-in is a full-page redirect: the browser leaves for B2C,
+ * returns via the server-side /auth/callback, and lands back on the app with a
+ * session cookie but no local user state. This module is the code that used to
+ * run in SignInButton's popup onSuccess handler — fetch (or register) the DUOS
+ * user, persist it, fire the sign-in metrics, and route through the ToS gate.
+ * App.tsx runs it once whenever a session exists but CurrentUser is empty.
+ */
+import type { NavigateFunction } from 'react-router'
+import type { QueryClient } from '@tanstack/react-query'
+import { User } from 'src/libs/ajax/User'
+import { Metrics } from 'src/libs/ajax/Metrics'
+import { Storage } from 'src/libs/storage'
+import { Auth } from 'src/libs/auth/auth'
+import { Navigation, Notifications, setUserRoleStatuses } from 'src/libs/utils'
+import { ErrorReporter } from 'src/libs/ErrorReporter'
+import eventList, { MetricsEventName } from 'src/libs/events'
+import { extractError } from 'src/utils/ErrorUtils'
+import { DuosUser } from 'src/types/model'
+
+export interface CompleteSignInOptions {
+  navigate: NavigateFunction
+  queryClient: QueryClient
+  /** The path the /auth/callback redirect landed on (location.pathname). */
+  redirectPath: string
+}
+
+interface HttpishError {
+  status?: number
+  response?: { status?: number, data?: { message?: string } }
+}
+
+const errorStatus = (error: unknown): number | undefined => {
+  const e = error as HttpishError
+  return e.response?.status ?? e.status
+}
+
+const syncSignInOrRegistrationEvent = (event: MetricsEventName) => {
+  Storage.setAnonymousId()
+  // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
+  Metrics.identify(`${Storage.getAnonymousId()}`)
+  // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
+  Metrics.syncProfile()
+  // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
+  Metrics.captureEvent(event)
+}
+
+export const completeSignIn = async ({ navigate, queryClient, redirectPath }: CompleteSignInOptions): Promise<void> => {
+  // '/' and '/home' are landing pages, not destinations worth returning to —
+  // signed-in users on those go to their console instead.
+  const shouldRedirect = redirectPath !== '/' && redirectPath !== '/home'
+  const redirectTo = shouldRedirect ? redirectPath : null
+
+  // Check for ToS acceptance — redirect the user if not accepted yet. Unlike
+  // the old popup flow, the /auth/callback redirect already landed the browser
+  // on redirectPath, so an accepted user with a destination stays put.
+  const checkToSAndRedirect = async (redirectPath: string | null) => {
+    const tosAccepted = Storage.getCurrentUser().userStatusInfo?.tosAccepted || false
+    if (tosAccepted) {
+      if (redirectPath === null) {
+        await Navigation.console(Storage.getCurrentUser(), navigate)
+      }
+    }
+    else if (redirectPath === null) {
+      navigate('/tos_acceptance')
+    }
+    else {
+      navigate(`/tos_acceptance?redirectTo=${redirectPath}`)
+    }
+  }
+
+  const registerAndRedirectNewUser = async () => {
+    const registeredUser: DuosUser = await User.registerUser()
+    const redirectParam = redirectTo ? `?redirectTo=${redirectTo}` : ''
+    setUserRoleStatuses(registeredUser, Storage)
+    // New identity — same cache reset as the normal sign-in path below.
+    queryClient.clear()
+    syncSignInOrRegistrationEvent(eventList.userRegister)
+    navigate(`/tos_acceptance${redirectParam}`)
+  }
+
+  const handleRegistration = async () => {
+    try {
+      await registerAndRedirectNewUser()
+    }
+    catch (error) {
+      switch (errorStatus(error)) {
+        case 409:
+          // Already registered — treat like a normal sign-in.
+          try {
+            await checkToSAndRedirect(redirectTo)
+          }
+          catch {
+            await Auth.signOut()
+          }
+          break
+        default:
+          Notifications.showError({
+            text: 'Error during sign in: ' + extractError(error),
+            description: 'There was an error completing your registration. Please try again.',
+          })
+          break
+      }
+    }
+  }
+
+  try {
+    const duosUser: DuosUser = await User.getMe()
+    if (duosUser) {
+      Storage.setCurrentUser(duosUser)
+      setUserRoleStatuses(duosUser, Storage)
+      // Drop any query results cached before sign-in: cached library queries
+      // (data, tab counts, filter metadata) were built with the anonymous /
+      // previous user's role-based visibility clauses and would otherwise be
+      // served from cache under the new user's identity.
+      queryClient.clear()
+      if (!duosUser.roles) {
+        await ErrorReporter.report('roles not found for user: ' + duosUser.email)
+      }
+      syncSignInOrRegistrationEvent(eventList.userSignIn)
+      await checkToSAndRedirect(redirectTo)
+    }
+    else {
+      await handleRegistration()
+    }
+  }
+  catch (error) {
+    // Explicitly handle AzureB2C errors from Sam
+    const errorMessage = extractError(error)
+    if (errorMessage.toLowerCase().includes('azureb2c authentication error')) {
+      Notifications.showError({ text: errorMessage })
+      await Auth.signOut()
+    }
+    else {
+      await handleRegistration()
+    }
+  }
+}

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -90,26 +90,24 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath }: Co
       await registerAndRedirectNewUser()
     }
     catch (error) {
-      switch (errorStatus(error)) {
-        case 409:
-          // Already registered (raced by another tab, or the earlier getMe
-          // failed transiently) — complete as a normal sign-in from a fresh
-          // user fetch. Routing off whatever CurrentUser happens to be in
-          // storage (usually the empty default) would send an accepted user
-          // back to the ToS gate without the cache reset or sign-in metric.
-          try {
-            await completeExistingUserSignIn(await User.getMe())
-          }
-          catch {
-            await Auth.signOut()
-          }
-          break
-        default:
-          Notifications.showError({
-            text: 'Error during sign in: ' + extractError(error),
-            description: 'There was an error completing your registration. Please try again.',
-          })
-          break
+      if (errorStatus(error) === 409) {
+        // Already registered (raced by another tab, or the earlier getMe
+        // failed transiently) — complete as a normal sign-in from a fresh
+        // user fetch. Routing off whatever CurrentUser happens to be in
+        // storage (usually the empty default) would send an accepted user
+        // back to the ToS gate without the cache reset or sign-in metric.
+        try {
+          await completeExistingUserSignIn(await User.getMe())
+        }
+        catch {
+          await Auth.signOut()
+        }
+      }
+      else {
+        Notifications.showError({
+          text: 'Error during sign in: ' + extractError(error),
+          description: 'There was an error completing your registration. Please try again.',
+        })
       }
     }
   }

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -33,6 +33,17 @@ vi.mock('src/libs/notificationService', () => ({
   },
 }))
 
+// Both vi.fn()s default to undefined: the probe reads as in-flight, so every
+// pre-existing test runs signed out exactly as before these mocks existed.
+vi.mock('src/hooks/useSession', () => ({
+  useSessionInfo: vi.fn(),
+  useUserIsLogged: vi.fn(),
+}))
+
+vi.mock('src/libs/auth/postSignIn', () => ({
+  completeSignIn: vi.fn(),
+}))
+
 // BaseModal calls Modal.setAppElement('#root') at module load time; prevent
 // the error by no-op-ing it before the import chain resolves.
 vi.mock('react-modal', async (importOriginal) => {
@@ -44,6 +55,8 @@ vi.mock('react-modal', async (importOriginal) => {
 import App from 'src/App'
 import { AuthenticateNIH } from 'src/libs/ajax/AuthenticateNIH'
 import { Storage } from 'src/libs/storage'
+import { useSessionInfo } from 'src/hooks/useSession'
+import { completeSignIn } from 'src/libs/auth/postSignIn'
 
 const duosUser = {
   userId: 2,
@@ -134,5 +147,65 @@ describe('Main App Functions', () => {
     await waitFor(() => expect(vi.mocked(AuthenticateNIH.getECMProviderLinkInfo)).toHaveBeenCalledWith(code, state))
     await waitFor(() => expect(vi.mocked(AuthenticateNIH.getSyncedUser)).toHaveBeenCalledOnce())
     expect(pageVisitStub).toHaveBeenCalledWith('/')
+  })
+})
+
+describe('post-sign-in bootstrap', () => {
+  const renderApp = () =>
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(completeSignIn).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('starts the bootstrap for an authenticated session with no DUOS profile yet (new-user registration path)', async () => {
+    // /auth/me reports a valid session but no user — the shape an
+    // unregistered user produces right after the B2C callback. CurrentUser
+    // holds the empty default (userId 0).
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    renderApp()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+  })
+
+  it('re-bootstraps when the session identity differs from the stored profile', async () => {
+    // Another tab switched accounts (or the user re-signed-in after expiry):
+    // the session says userId 2, storage still holds userId 7.
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ ...duosUser, userId: 7 } as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: duosUser as never })
+
+    renderApp()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+  })
+
+  it('does not bootstrap when the stored profile already matches the session identity', async () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(duosUser as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: duosUser as never })
+
+    renderApp()
+
+    await waitFor(() => expect(document.querySelector('.main')).toBeInTheDocument())
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('does not bootstrap while signed out', async () => {
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
+
+    renderApp()
+
+    await waitFor(() => expect(document.querySelector('.main')).toBeInTheDocument())
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
   })
 })

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -44,6 +44,12 @@ vi.mock('src/libs/auth/postSignIn', () => ({
   completeSignIn: vi.fn(),
 }))
 
+// The hydrate-path ToS test navigates here; the real page fetches ToS text
+// through unmocked config plumbing. Only the route transition matters.
+vi.mock('src/pages/TermsOfServiceAcceptance', () => ({
+  default: () => null,
+}))
+
 // BaseModal calls Modal.setAppElement('#root') at module load time; prevent
 // the error by no-op-ing it before the import chain resolves.
 vi.mock('react-modal', async (importOriginal) => {
@@ -150,6 +156,14 @@ describe('Main App Functions', () => {
   })
 })
 
+const LocationSpyGlobal = ({ onLocationChange }: { onLocationChange: (pathname: string) => void }) => {
+  const location = useLocation()
+  React.useEffect(() => {
+    onLocationChange(location.pathname)
+  }, [location, onLocationChange])
+  return null
+}
+
 describe('post-sign-in bootstrap', () => {
   const renderApp = () =>
     render(
@@ -190,14 +204,50 @@ describe('post-sign-in bootstrap', () => {
     await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
   })
 
-  it('does not bootstrap when the stored profile already matches the session identity', async () => {
+  it('hydrates (not bootstraps) when the stored profile already matches the session identity', async () => {
     vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(duosUser as never)
-    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: duosUser as never })
+    const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    const freshUser = { ...duosUser, roles: [{ userId: 2, roleId: 5, name: 'Researcher' }] }
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: freshUser as never })
 
     renderApp()
 
-    await waitFor(() => expect(document.querySelector('.main')).toBeInTheDocument())
+    // Same identity → the local profile refreshes from the probe's
+    // server-fetched user (roles/ToS can change between page loads)…
+    await waitFor(() => expect(setCurrentUser).toHaveBeenCalledWith(freshUser))
+    // …without the full bootstrap (no metrics, no cache reset, no navigation).
     expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('routes a hydrated user with explicitly rejected ToS to the acceptance gate', async () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(duosUser as never)
+    vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    const noTosUser = { ...duosUser, userStatusInfo: { tosAccepted: false } }
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: noTosUser as never })
+    const pageVisitStub = vi.fn()
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <LocationSpyGlobal onLocationChange={pageVisitStub} />
+        <App />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(pageVisitStub).toHaveBeenCalledWith('/tos_acceptance'))
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('bootstraps when a fresh probe reports an unregistered session over a stored identity (cross-tab switch)', async () => {
+    // Another tab switched the shared cookie to a brand-new account: this
+    // tab still stores user 7, but a FRESH probe reports authenticated with
+    // no user. That must re-bootstrap (reaching registration), not silently
+    // keep wearing user 7's identity under the new session.
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ ...duosUser, userId: 7 } as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    renderApp()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
   })
 
   it('does not bootstrap while signed out', async () => {

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -237,6 +237,21 @@ describe('post-sign-in bootstrap', () => {
     expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
   })
 
+  it('hides the header while reconciling so stale role tabs are never committed', async () => {
+    // Cross-tab switch shape with the bootstrap still in flight: the header
+    // derives role tabs from Storage.getCurrentUser() and must not render
+    // the previous identity's chrome while the identity is in question.
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ ...duosUser, userId: 7 } as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+    vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
+
+    renderApp()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalled())
+    expect(screen.queryByText('Contact Us')).not.toBeInTheDocument()
+    expect(screen.queryByText('Data Use Oversight System')).not.toBeInTheDocument()
+  })
+
   it('bootstraps when a fresh probe reports an unregistered session over a stored identity (cross-tab switch)', async () => {
     // Another tab switched the shared cookie to a brand-new account: this
     // tab still stores user 7, but a FRESH probe reports authenticated with

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -174,7 +174,7 @@ describe('post-sign-in bootstrap', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(completeSignIn).mockResolvedValue(undefined)
+    vi.mocked(completeSignIn).mockResolvedValue('completed')
   })
 
   afterEach(() => {
@@ -284,6 +284,7 @@ describe('post-sign-in bootstrap', () => {
     vi.mocked(completeSignIn).mockImplementation(async () => {
       // What registerAndRedirectNewUser -> setUserRoleStatuses does.
       Storage.setCurrentUser(duosUser as never)
+      return 'completed'
     })
 
     renderApp()

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -97,6 +97,9 @@ describe('Main App Functions', () => {
   })
 
   it('should render main layout components on the home page', async () => {
+    // A resolved signed-out probe: while the probe is in flight the app
+    // deliberately shows only the reconciliation spinner (no layout chrome).
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
     render(
       <MemoryRouter initialEntries={['/']}>
         <App />

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -208,4 +208,25 @@ describe('post-sign-in bootstrap', () => {
     await waitFor(() => expect(document.querySelector('.main')).toBeInTheDocument())
     expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
   })
+
+  it('unlocks the routes after registration even while the cached session still has no user', async () => {
+    // The probe's cached answer predates the registration for the rest of the
+    // page load: authenticated, no user. That must not read as an identity
+    // mismatch once completeSignIn persists the new nonzero profile — doing so
+    // re-armed the bootstrap into a run the once-per-identity guard blocks,
+    // pinning the app on the spinner forever.
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+    vi.mocked(completeSignIn).mockImplementation(async () => {
+      // What registerAndRedirectNewUser -> setUserRoleStatuses does.
+      Storage.setCurrentUser(duosUser as never)
+    })
+
+    renderApp()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    // The routes must come out from behind the bootstrap spinner…
+    await waitFor(() => expect(screen.getByText('Data Use Oversight System')).toBeInTheDocument())
+    // …and the bootstrap must not have re-armed into a second run.
+    expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()
+  })
 })

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -291,7 +291,7 @@ describe('post-sign-in bootstrap', () => {
 
     await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
     // The routes must come out from behind the bootstrap spinner…
-    await waitFor(() => expect(screen.getByText('Data Use Oversight System')).toBeInTheDocument())
+    expect(await screen.findByText('Data Use Oversight System')).toBeInTheDocument()
     // …and the bootstrap must not have re-armed into a second run.
     expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()
   })

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -87,7 +87,7 @@ describe('SignInButton', () => {
 
     await userEvent.click(screen.getByRole('button'))
 
-    await waitFor(() => expect(screen.getByText(signInError)).toBeInTheDocument())
+    expect(await screen.findByText(signInError)).toBeInTheDocument()
     expect(vi.mocked(Redirect.to)).not.toHaveBeenCalled()
   })
 
@@ -128,7 +128,7 @@ describe('SignInButton', () => {
 
     await userEvent.click(screen.getByRole('button'))
 
-    await waitFor(() => expect(screen.getByText(signInError)).toBeInTheDocument())
+    expect(await screen.findByText(signInError)).toBeInTheDocument()
     expect(screen.getByText('Error')).toBeInTheDocument()
     expect(screen.queryByText(signInText)).not.toBeInTheDocument()
   })

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import SignInButton from 'src/components/SignInButton'
 import { Auth } from 'src/libs/auth/auth'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
+import type { OidcUser } from 'src/libs/auth/oidcBroker'
 
 /**
  * With the BFF, SignInButton is just the front door: clicking it calls
@@ -35,8 +36,9 @@ describe('SignInButton', () => {
     vi.mocked(ServiceStatus.isConsentHealthy).mockResolvedValue(true)
     vi.mocked(ServiceStatus.isSamHealthy).mockResolvedValue(true)
     // Auth.signIn normally never resolves in the browser (the page navigates
-    // away); resolving keeps the default happy-path tests simple.
-    vi.mocked(Auth.signIn).mockResolvedValue(undefined)
+    // away); resolving keeps the default happy-path tests simple. The button
+    // never reads the legacy OidcUser result, so the value itself is unused.
+    vi.mocked(Auth.signIn).mockResolvedValue(undefined as unknown as OidcUser)
   })
 
   afterEach(() => {

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import SignInButton from 'src/components/SignInButton'
 import { Auth, Redirect } from 'src/libs/auth/auth'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
+import { Storage } from 'src/libs/storage'
 import type { OidcUser } from 'src/libs/auth/oidcBroker'
 
 /**
@@ -25,6 +26,7 @@ vi.mock('src/libs/auth/auth', () => ({
   },
   Redirect: {
     to: vi.fn(),
+    reload: vi.fn(),
   },
 }))
 vi.mock('src/libs/ajax/ServiceStatus')
@@ -74,9 +76,10 @@ describe('SignInButton', () => {
 
     await userEvent.click(screen.getByRole('button'))
 
-    // Only the legacy flow resolves (BFF mode navigates away instead). The
-    // reload keeps the query string so App's bootstrap can finish the trip.
-    await waitFor(() => expect(vi.mocked(Redirect.to)).toHaveBeenCalledWith(globalThis.location.href))
+    // Only the legacy flow resolves (BFF mode navigates away instead). A real
+    // reload (not an href assignment, which is a no-op on #fragment URLs)
+    // keeps the query string so App's bootstrap can finish the trip.
+    await waitFor(() => expect(vi.mocked(Redirect.reload)).toHaveBeenCalled())
     expect(globalThis.location.search).toContain('redirectTo')
   })
 
@@ -88,7 +91,34 @@ describe('SignInButton', () => {
     await userEvent.click(screen.getByRole('button'))
 
     expect(await screen.findByText(signInError)).toBeInTheDocument()
-    expect(vi.mocked(Redirect.to)).not.toHaveBeenCalled()
+    expect(vi.mocked(Redirect.reload)).not.toHaveBeenCalled()
+  })
+
+  it('shows the cancel message when the user closes the legacy popup', async () => {
+    // oidc-client-ts PopupWindow rejects with exactly this error. Closing the
+    // window is a decision, not a failure — no scary generic error.
+    vi.mocked(Auth.signIn).mockRejectedValue(new Error('Popup closed by user'))
+    mountComponent()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    await userEvent.click(screen.getByRole('button'))
+
+    expect(await screen.findByText('Sign in cancelled')).toBeInTheDocument()
+    expect(screen.getByText('Sign in cancelled by closing the sign in window')).toBeInTheDocument()
+    expect(screen.queryByText(signInError)).not.toBeInTheDocument()
+  })
+
+  it('clears partial auth state from storage when sign-in fails', async () => {
+    // The abandoned popup can leave partial oidc state behind; the old
+    // onFailure always cleared storage and the rewrite must too.
+    const clearStorage = vi.spyOn(Storage, 'clearStorage')
+    vi.mocked(Auth.signIn).mockRejectedValue(new Error('login failed'))
+    mountComponent()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(clearStorage).toHaveBeenCalled())
   })
 
   it('does not send /home as a returnTo either', async () => {

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -3,106 +3,47 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { MemoryRouter, useLocation } from 'react-router'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import SignInButton from 'src/components/SignInButton'
 import { Auth } from 'src/libs/auth/auth'
-import { User } from 'src/libs/ajax/User'
-import { Metrics } from 'src/libs/ajax/Metrics'
-import { ErrorReporter } from 'src/libs/ErrorReporter'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
-import { Storage } from 'src/libs/storage'
-import { Navigation } from 'src/libs/utils'
-import { DuosUser, UserStatusInfo } from 'src/types/model'
-import { OidcUser } from 'src/libs/auth/oidcBroker'
 
-const mockOidcUser: OidcUser = {
-  access_token: '',
-  session_state: null,
-  state: undefined,
-  token_type: '',
-  get expires_in() { return undefined },
-  get expired() { return undefined },
-  get scopes() { return [] },
-  toStorageString() { return '' },
-  profile: { jti: undefined, nbf: undefined, sub: '', iss: '', aud: '', exp: 0, iat: 0 },
-}
+/**
+ * With the BFF, SignInButton is just the front door: clicking it calls
+ * Auth.signIn(returnTo?), which POSTs /auth/login and full-page-redirects to
+ * B2C. Everything that used to happen in the popup onSuccess handler (user
+ * fetch, registration, ToS routing) now lives in src/libs/auth/postSignIn.ts
+ * and is covered by test/libs/auth/postSignIn.spec.ts.
+ */
 
-vi.mock('src/libs/auth/auth')
-vi.mock('src/libs/ajax/User')
-vi.mock('src/libs/ajax/Metrics')
-vi.mock('src/libs/ErrorReporter')
+const signInError = 'Unexpected error, please contact customer support.'
+
+vi.mock('src/libs/auth/auth', () => ({
+  Auth: {
+    signIn: vi.fn(),
+    signInError: vi.fn(() => signInError),
+  },
+}))
 vi.mock('src/libs/ajax/ServiceStatus')
-vi.mock('src/libs/utils', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('src/libs/utils')>()
-  return { ...actual, Navigation: { ...actual.Navigation, console: vi.fn() } }
-})
 
 const signInText = 'Sign In'
 
-const duosUser = {
-  displayName: 'display name',
-  email: 'test@user.com',
-  emailPreference: true,
-  eraCommonsId: 'eraCommonsId',
-  institutionId: 1,
-  isAdmin: true,
-  isAlumni: false,
-  isChairPerson: false,
-  isDataSubmitter: false,
-  isMember: false,
-  isResearcher: false,
-  isSigningOfficial: false,
-  isServiceAccount: false,
-  roles: [{ name: 'Admin' }],
-} as unknown as DuosUser
+const mountComponent = () => render(<SignInButton />)
 
-const userStatus: UserStatusInfo = {
-  adminEnabled: true,
-  enabled: true,
-  userSubjectId: '1234',
-  userEmail: 'test@user.com',
-  tosAccepted: true,
-}
-
-const consentStatus = {
-  ok: true,
-  degraded: false,
-  systems: {
-    sam: { details: { ok: true } },
-  },
-}
-
-// Helper: renders SignInButton inside a MemoryRouter and exposes the current location
-const LocationDisplay = () => {
-  const { pathname, search } = useLocation()
-  return <div data-testid="location">{pathname + search}</div>
-}
-
-const mountComponent = () =>
-  render(
-    <QueryClientProvider client={new QueryClient()}>
-      <MemoryRouter>
-        <SignInButton />
-        <LocationDisplay />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  )
-
-describe('Sign In: Component Loads', () => {
+describe('SignInButton', () => {
   beforeEach(() => {
     globalThis.history.replaceState({}, '', '/')
-    vi.mocked(ServiceStatus.getConsentStatus).mockResolvedValue(consentStatus as never)
     vi.mocked(ServiceStatus.isConsentHealthy).mockResolvedValue(true)
     vi.mocked(ServiceStatus.isSamHealthy).mockResolvedValue(true)
+    // Auth.signIn normally never resolves in the browser (the page navigates
+    // away); resolving keeps the default happy-path tests simple.
+    vi.mocked(Auth.signIn).mockResolvedValue(undefined)
   })
 
   afterEach(() => {
-    vi.restoreAllMocks()
-    Storage.clearStorage()
+    vi.clearAllMocks()
   })
 
-  it('Sign In Button Loads', async () => {
+  it('renders an enabled Sign In button', async () => {
     mountComponent()
     await waitFor(() => expect(screen.getByText(signInText)).toBeInTheDocument())
     const button = screen.getByRole('button')
@@ -112,102 +53,66 @@ describe('Sign In: Component Loads', () => {
     expect(button).toHaveStyle({ border: '2px solid rgb(255, 255, 255)' })
   })
 
-  it('Sign In: On Success', async () => {
-    const tosAcceptedUser = { userStatusInfo: userStatus, ...duosUser }
-    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
-    vi.mocked(ErrorReporter.report).mockResolvedValue(undefined)
-    vi.mocked(Metrics.identify).mockResolvedValue(undefined as never)
-    vi.mocked(Metrics.syncProfile).mockResolvedValue(undefined as never)
-    vi.mocked(Metrics.captureEvent).mockResolvedValue(undefined as never)
-    vi.mocked(Navigation.console).mockResolvedValue(undefined)
+  it('starts the BFF login flow without a returnTo from the landing page', async () => {
     mountComponent()
     await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
     await userEvent.click(screen.getByRole('button'))
-    await waitFor(() => expect(vi.mocked(User.getMe)).toHaveBeenCalled())
-    expect(Storage.getCurrentUser()).toEqual(tosAcceptedUser)
-    expect(Storage.getAnonymousId()).not.toBeNull()
-    expect(vi.mocked(ErrorReporter.report)).not.toHaveBeenCalled()
-    expect(vi.mocked(Metrics.identify)).toHaveBeenCalled()
-    expect(vi.mocked(Metrics.syncProfile)).toHaveBeenCalled()
-    expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalled()
+
+    await waitFor(() => expect(vi.mocked(Auth.signIn)).toHaveBeenCalledWith(undefined))
   })
 
-  it('Sign In: Preserves a redirectTo query parameter added outside the router', async () => {
-    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(User.getMe).mockResolvedValue(duosUser as never)
+  it('does not send /home as a returnTo either', async () => {
+    globalThis.history.replaceState({}, '', '/home')
     mountComponent()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(vi.mocked(Auth.signIn)).toHaveBeenCalledWith(undefined))
+  })
+
+  it('passes the current pathname as returnTo from any other page', async () => {
+    globalThis.history.replaceState({}, '', '/datalibrary')
+    mountComponent()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(vi.mocked(Auth.signIn)).toHaveBeenCalledWith('/datalibrary'))
+  })
+
+  it('prefers a redirectTo query parameter over the current pathname', async () => {
     globalThis.history.replaceState({}, '', '/?redirectTo=/datalibrary')
-
-    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
-    await userEvent.click(screen.getByRole('button'))
-
-    await waitFor(() =>
-      expect(screen.getByTestId('location').textContent).toBe('/tos_acceptance?redirectTo=/datalibrary'),
-    )
-  })
-
-  it('Sign In: No Roles Error Reporter Is Called', async () => {
-    const bareUser = { email: 'test@user.com' }
-    const tosAcceptedUser = { userStatusInfo: userStatus, ...bareUser }
-    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
-    vi.mocked(ErrorReporter.report).mockResolvedValue(undefined)
-    vi.mocked(Navigation.console).mockResolvedValue(undefined)
     mountComponent()
     await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
     await userEvent.click(screen.getByRole('button'))
-    await waitFor(() => expect(vi.mocked(ErrorReporter.report)).toHaveBeenCalled())
+
+    await waitFor(() => expect(vi.mocked(Auth.signIn)).toHaveBeenCalledWith('/datalibrary'))
   })
 
-  it('Sign In: Redirects to ToS if not accepted', async () => {
-    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(User.getMe).mockResolvedValue(duosUser as never)
+  it('shows an error alert when the login request fails', async () => {
+    vi.mocked(Auth.signIn).mockRejectedValue(new Error(signInError))
     mountComponent()
     await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
     await userEvent.click(screen.getByRole('button'))
-    await waitFor(() =>
-      expect(screen.getByTestId('location').textContent).toBe('/tos_acceptance'),
-    )
+
+    await waitFor(() => expect(screen.getByText(signInError)).toBeInTheDocument())
+    expect(screen.getByText('Error')).toBeInTheDocument()
+    expect(screen.queryByText(signInText)).not.toBeInTheDocument()
   })
 
-  it('Sign In: Registers user if not found and redirects to ToS', async () => {
-    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
-    vi.mocked(User.registerUser).mockResolvedValue(duosUser)
-    mountComponent()
-    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
-    await userEvent.click(screen.getByRole('button'))
-    await waitFor(() => expect(vi.mocked(User.registerUser)).toHaveBeenCalled())
-    await waitFor(() =>
-      expect(screen.getByTestId('location').textContent).toBe('/tos_acceptance'),
-    )
-  })
-
-  it('Sign In: Button is disabled when SAM is unhealthy', async () => {
+  it('is disabled when SAM is unhealthy', async () => {
     vi.mocked(ServiceStatus.isSamHealthy).mockResolvedValue(false)
     mountComponent()
     await waitFor(() => expect(screen.getByRole('button')).toBeDisabled())
   })
 
-  it('Sign In: Button is disabled when Consent is unhealthy', async () => {
+  it('is disabled when Consent is unhealthy', async () => {
     vi.mocked(ServiceStatus.isConsentHealthy).mockResolvedValue(false)
     mountComponent()
     await waitFor(() => expect(screen.getByRole('button')).toBeDisabled())
-  })
-
-  it('Sign In: Handles AzureB2C authentication error', async () => {
-    vi.mocked(Auth.signIn).mockResolvedValue(mockOidcUser)
-    vi.mocked(Auth.signOut).mockResolvedValue(undefined as never)
-    vi.mocked(User.getMe).mockRejectedValue(
-      new Error('AzureB2C authentication error'),
-    )
-    mountComponent()
-    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
-    await userEvent.click(screen.getByRole('button'))
-    await waitFor(() => expect(vi.mocked(Auth.signOut)).toHaveBeenCalled())
-    await waitFor(() =>
-      expect(screen.getByText('AzureB2C authentication error')).toBeInTheDocument(),
-    )
   })
 })

--- a/test/components/SignInButton.spec.tsx
+++ b/test/components/SignInButton.spec.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import SignInButton from 'src/components/SignInButton'
-import { Auth } from 'src/libs/auth/auth'
+import { Auth, Redirect } from 'src/libs/auth/auth'
 import { ServiceStatus } from 'src/libs/ajax/ServiceStatus'
 import type { OidcUser } from 'src/libs/auth/oidcBroker'
 
@@ -22,6 +22,9 @@ vi.mock('src/libs/auth/auth', () => ({
   Auth: {
     signIn: vi.fn(),
     signInError: vi.fn(() => signInError),
+  },
+  Redirect: {
+    to: vi.fn(),
   },
 }))
 vi.mock('src/libs/ajax/ServiceStatus')
@@ -62,6 +65,30 @@ describe('SignInButton', () => {
     await userEvent.click(screen.getByRole('button'))
 
     await waitFor(() => expect(vi.mocked(Auth.signIn)).toHaveBeenCalledWith(undefined))
+  })
+
+  it('reloads in place when Auth.signIn resolves (legacy popup flow)', async () => {
+    globalThis.history.replaceState({}, '', '/?redirectTo=/datalibrary')
+    mountComponent()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    await userEvent.click(screen.getByRole('button'))
+
+    // Only the legacy flow resolves (BFF mode navigates away instead). The
+    // reload keeps the query string so App's bootstrap can finish the trip.
+    await waitFor(() => expect(vi.mocked(Redirect.to)).toHaveBeenCalledWith(globalThis.location.href))
+    expect(globalThis.location.search).toContain('redirectTo')
+  })
+
+  it('does not reload when the login request fails', async () => {
+    vi.mocked(Auth.signIn).mockRejectedValue(new Error('login failed'))
+    mountComponent()
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    await userEvent.click(screen.getByRole('button'))
+
+    await waitFor(() => expect(screen.getByText(signInError)).toBeInTheDocument())
+    expect(vi.mocked(Redirect.to)).not.toHaveBeenCalled()
   })
 
   it('does not send /home as a returnTo either', async () => {

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -103,6 +103,23 @@ describe('useSessionReconciler', () => {
     renderReconciler()
 
     await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    // The legacy probe carries a user (the storage mirror), so it never
+    // reports "no profile" — the bootstrap's getMe must run as usual.
+    expect(vi.mocked(completeSignIn).mock.calls[0][0].sessionReportsNoProfile).toBe(false)
+  })
+
+  it('tells the bootstrap the probe reported no profile, so it skips the session-destroying getMe', async () => {
+    // Only the BFF probe answers authenticated-without-user (an unregistered
+    // session). completeSignIn must go straight to registration: its usual
+    // getMe would repeat the upstream 401 the probe just saw, and the
+    // /duos-api proxy answers that by destroying the session registerUser
+    // is about to need.
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    renderReconciler()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    expect(vi.mocked(completeSignIn).mock.calls[0][0].sessionReportsNoProfile).toBe(true)
   })
 
   it('reloads on identity reversal — a probe naming the pre-run stored user does not join', async () => {

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -28,7 +28,7 @@ const renderReconciler = () => renderHook(() => useSessionReconciler(queryClient
 
 describe('useSessionReconciler', () => {
   beforeEach(() => {
-    vi.mocked(completeSignIn).mockResolvedValue(undefined)
+    vi.mocked(completeSignIn).mockResolvedValue('completed')
   })
 
   afterEach(() => {
@@ -150,8 +150,8 @@ describe('useSessionReconciler', () => {
   it('joins an in-flight bootstrap instead of starting a concurrent one for the same identity', async () => {
     // completeSignIn hangs, as a slow registration would.
     let resolveBootstrap!: () => void
-    vi.mocked(completeSignIn).mockReturnValue(new Promise<void>((resolve) => {
-      resolveBootstrap = () => resolve()
+    vi.mocked(completeSignIn).mockReturnValue(new Promise((resolve) => {
+      resolveBootstrap = () => resolve('completed')
     }))
     const probe1: SessionInfo = { authenticated: true }
     vi.mocked(useSessionInfo).mockReturnValue(probe1)
@@ -245,8 +245,8 @@ describe('useSessionReconciler', () => {
     // swallow that profile — it is applied at run completion, after the
     // run's own (older) write.
     let resolveBootstrap!: () => void
-    vi.mocked(completeSignIn).mockReturnValue(new Promise<void>((resolve) => {
-      resolveBootstrap = () => resolve()
+    vi.mocked(completeSignIn).mockReturnValue(new Promise((resolve) => {
+      resolveBootstrap = () => resolve('completed')
     }))
     const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
     const user9 = { userId: 9, displayName: 'Nine', roles: [] } as unknown as DuosUser
@@ -267,6 +267,32 @@ describe('useSessionReconciler', () => {
 
     expect(setCurrentUser).toHaveBeenCalledWith(user9Promoted)
     expect(result.current.reconciling).toBe(false)
+  })
+
+  it('discards pending hydration when the run ends signed-out', async () => {
+    // The run failed and completeSignIn signed the session out, clearing
+    // storage. Applying the joined profile afterwards would resurrect a
+    // stale identity that survives the sign-out reload.
+    let resolveBootstrap!: (outcome: 'signed-out') => void
+    vi.mocked(completeSignIn).mockReturnValue(new Promise((resolve) => {
+      resolveBootstrap = resolve
+    }))
+    const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    const user9 = { userId: 9, displayName: 'Nine', roles: [] } as unknown as DuosUser
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: user9 as never })
+
+    const { rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+
+    // A same-user probe joins mid-run, supplying pending hydration.
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: { ...user9 } as never })
+    rerender()
+
+    await act(async () => {
+      resolveBootstrap('signed-out')
+    })
+
+    expect(setCurrentUser).not.toHaveBeenCalled()
   })
 
   it('cancels the in-flight bootstrap on unmount', async () => {

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -45,20 +45,84 @@ describe('useSessionReconciler', () => {
     expect(result.current.reconciling).toBe(true)
   })
 
-  it('hydrates without hiding the routes, recording classification in state', async () => {
+  it('hydrates without hiding the routes when auth-relevant fields match', async () => {
     vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
     const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
-    const freshProfile = { ...storedUser, roles: [{ name: 'Admin' }] }
+    // Cosmetic change only — same identity, same roles, same ToS state.
+    const freshProfile = { ...storedUser, displayName: 'Renamed User' }
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: freshProfile as never })
 
     const { result } = renderReconciler()
 
-    // Same identity — no blanking of the screen on a routine revalidation…
+    // No blanking of the screen on a routine revalidation…
     expect(result.current.reconciling).toBe(false)
     // …but the refreshed profile lands in storage and the classification is
     // recorded in state (which re-renders consumers off the new profile).
     await waitFor(() => expect(setCurrentUser).toHaveBeenCalledWith(freshProfile))
     expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('hides identity-bearing UI when the same user returns with changed roles or ToS state', async () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
+    const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    // Same identity, but the server revoked/added roles — committing the
+    // mounted UI off stale storage would render the old permissions.
+    const freshProfile = { ...storedUser, roles: [{ name: 'Admin' }] }
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: freshProfile as never })
+
+    // Capture every render's value: classification happens in an effect right
+    // after the first commit, so result.current alone can't see that commit.
+    const reconcilingPerRender: boolean[] = []
+    const { result } = renderHook(() => {
+      const reconciliation = useSessionReconciler(queryClient)
+      reconcilingPerRender.push(reconciliation.reconciling)
+      return reconciliation
+    }, { wrapper })
+
+    // The commit that received the fresh probe hid the identity-bearing UI…
+    expect(reconcilingPerRender[0]).toBe(true)
+    // …then hydration classified it and re-rendered off the fresh profile.
+    await waitFor(() => expect(setCurrentUser).toHaveBeenCalledWith(freshProfile))
+    expect(result.current.reconciling).toBe(false)
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('bootstraps (not hydrates) a legacy probe whose user is the empty default', async () => {
+    // The legacy popup flow reloads with CurrentUser still the default
+    // (userId 0) and the legacy probe mirrors storage — that is "no local
+    // identity", not a match: completeSignIn must run to finish sign-in.
+    vi.mocked(useSessionInfo).mockReturnValue({
+      authenticated: true,
+      user: { userId: 0, displayName: '', roles: [] } as never,
+    })
+
+    renderReconciler()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+  })
+
+  it('supersedes on identity reversal — a probe naming the pre-run stored user does not join', async () => {
+    // Storage holds user 7. A bootstrap for user 9 is in flight. The session
+    // switches BACK to user 7: the probe matches storage, but 9's run did not
+    // produce that state — joining would let 9's fetch overwrite storage.
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
+    vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
+    const otherUser = { userId: 9, displayName: 'Other', roles: [] } as unknown as DuosUser
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: otherUser as never })
+
+    const { rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    const firstRunOptions = vi.mocked(completeSignIn).mock.calls[0][0]
+    expect(firstRunOptions.isCancelled?.()).toBe(false)
+
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: storedUser as never })
+    rerender()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledTimes(2))
+    // The superseded run's token is cancelled, so its remaining side effects
+    // (persisting user 9, metrics, navigation) are suppressed inside
+    // completeSignIn.
+    expect(firstRunOptions.isCancelled?.()).toBe(true)
   })
 
   it('joins an in-flight bootstrap instead of starting a concurrent one for the same identity', async () => {

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -15,7 +15,7 @@ vi.mock('src/hooks/useSession', () => ({ useSessionInfo: vi.fn() }))
 vi.mock('src/libs/auth/postSignIn', () => ({ completeSignIn: vi.fn() }))
 // The hard-reload seam: identity conflicts under an in-flight bootstrap
 // reload the page instead of reconciling in place (see the scope policy).
-vi.mock('src/libs/auth/auth', () => ({ Redirect: { to: vi.fn() } }))
+vi.mock('src/libs/auth/auth', () => ({ Redirect: { to: vi.fn(), reload: vi.fn() } }))
 
 const queryClient = { clear: vi.fn() } as unknown as QueryClient
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -29,6 +29,7 @@ const renderReconciler = () => renderHook(() => useSessionReconciler(queryClient
 describe('useSessionReconciler', () => {
   beforeEach(() => {
     vi.mocked(completeSignIn).mockResolvedValue('completed')
+    vi.mocked(queryClient.clear).mockClear()
   })
 
   afterEach(() => {
@@ -122,6 +123,41 @@ describe('useSessionReconciler', () => {
     expect(vi.mocked(completeSignIn).mock.calls[0][0].sessionReportsNoProfile).toBe(true)
   })
 
+  it('clears the per-tab query cache when storage changed under us (cross-tab account switch)', async () => {
+    // This tab mounted (and filled its QueryClient) as user 7. Another tab
+    // then switched the shared cookie AND shared storage to user 9. This
+    // tab's next probe names 9 and MATCHES storage — an ordinary-looking
+    // hydrate — but the per-tab cache still holds 7's role-scoped results.
+    const user9 = { userId: 9, displayName: 'Nine', roles: [] } as unknown as DuosUser
+    const getCurrentUser = vi.spyOn(Storage, 'getCurrentUser')
+    vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    // Mount-time cache identity: user 7.
+    getCurrentUser.mockReturnValue(storedUser as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: { ...storedUser } as never })
+
+    const { rerender } = renderReconciler()
+    expect(queryClient.clear).not.toHaveBeenCalled()
+
+    // The other tab's switch: storage now names 9, and so does the probe.
+    getCurrentUser.mockReturnValue(user9 as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: user9 as never })
+    rerender()
+
+    await waitFor(() => expect(queryClient.clear).toHaveBeenCalled())
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('does not clear the query cache on a routine same-user hydrate', async () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
+    vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: { ...storedUser } as never })
+
+    renderReconciler()
+
+    await waitFor(() => expect(vi.mocked(useSessionInfo)).toHaveBeenCalled())
+    expect(queryClient.clear).not.toHaveBeenCalled()
+  })
+
   it('reloads on identity reversal — a probe naming the pre-run stored user does not join', async () => {
     // Storage holds user 7. A bootstrap for user 9 is in flight. The session
     // switches BACK to user 7: the probe matches storage, but 9's run did not
@@ -140,7 +176,7 @@ describe('useSessionReconciler', () => {
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: storedUser as never })
     rerender()
 
-    await waitFor(() => expect(vi.mocked(Redirect.to)).toHaveBeenCalledWith(globalThis.location.href))
+    await waitFor(() => expect(vi.mocked(Redirect.reload)).toHaveBeenCalled())
     expect(firstRunOptions.isCancelled?.()).toBe(true)
     expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()
   })
@@ -209,7 +245,7 @@ describe('useSessionReconciler', () => {
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: otherUser as never })
     rerender()
 
-    await waitFor(() => expect(vi.mocked(Redirect.to)).toHaveBeenCalledWith(globalThis.location.href))
+    await waitFor(() => expect(vi.mocked(Redirect.reload)).toHaveBeenCalled())
     expect(firstRunOptions.isCancelled?.()).toBe(true)
     // No second in-place bootstrap — the reload owns reconciliation now.
     expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -6,12 +6,16 @@ import type { QueryClient } from '@tanstack/react-query'
 import { useSessionReconciler } from 'src/hooks/useSessionReconciler'
 import { useSessionInfo } from 'src/hooks/useSession'
 import { completeSignIn } from 'src/libs/auth/postSignIn'
+import { Redirect } from 'src/libs/auth/auth'
 import { Storage } from 'src/libs/storage'
 import type { SessionInfo } from 'src/libs/auth/session'
 import type { DuosUser } from 'src/types/model'
 
 vi.mock('src/hooks/useSession', () => ({ useSessionInfo: vi.fn() }))
 vi.mock('src/libs/auth/postSignIn', () => ({ completeSignIn: vi.fn() }))
+// The hard-reload seam: identity conflicts under an in-flight bootstrap
+// reload the page instead of reconciling in place (see the scope policy).
+vi.mock('src/libs/auth/auth', () => ({ Redirect: { to: vi.fn() } }))
 
 const queryClient = { clear: vi.fn() } as unknown as QueryClient
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -101,10 +105,11 @@ describe('useSessionReconciler', () => {
     await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
   })
 
-  it('supersedes on identity reversal — a probe naming the pre-run stored user does not join', async () => {
+  it('reloads on identity reversal — a probe naming the pre-run stored user does not join', async () => {
     // Storage holds user 7. A bootstrap for user 9 is in flight. The session
     // switches BACK to user 7: the probe matches storage, but 9's run did not
     // produce that state — joining would let 9's fetch overwrite storage.
+    // Only an unsupported cross-tab switch produces this: cancel and reload.
     vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
     vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
     const otherUser = { userId: 9, displayName: 'Other', roles: [] } as unknown as DuosUser
@@ -118,11 +123,28 @@ describe('useSessionReconciler', () => {
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: storedUser as never })
     rerender()
 
-    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledTimes(2))
-    // The superseded run's token is cancelled, so its remaining side effects
-    // (persisting user 9, metrics, navigation) are suppressed inside
-    // completeSignIn.
+    await waitFor(() => expect(vi.mocked(Redirect.to)).toHaveBeenCalledWith(globalThis.location.href))
     expect(firstRunOptions.isCancelled?.()).toBe(true)
+    expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()
+  })
+
+  it('hides identity-bearing UI when the same user returns with a changed DAC assignment', () => {
+    // Same role names, different DAC scope — DACDatasets/ManageDac authorize
+    // by dacId, so this must not commit off stale storage.
+    const chairOfDac1 = { ...storedUser, roles: [{ name: 'Chairperson', dacId: 1 }] }
+    const chairOfDac2 = { ...storedUser, roles: [{ name: 'Chairperson', dacId: 2 }] }
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(chairOfDac1 as never)
+    vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: chairOfDac2 as never })
+
+    const reconcilingPerRender: boolean[] = []
+    renderHook(() => {
+      const reconciliation = useSessionReconciler(queryClient)
+      reconcilingPerRender.push(reconciliation.reconciling)
+      return reconciliation
+    }, { wrapper })
+
+    expect(reconcilingPerRender[0]).toBe(true)
   })
 
   it('joins an in-flight bootstrap instead of starting a concurrent one for the same identity', async () => {
@@ -153,35 +175,57 @@ describe('useSessionReconciler', () => {
     expect(result.current.reconciling).toBe(false)
   })
 
-  it('supersedes an in-flight bootstrap for a different identity — the older completion cannot unlock the routes', async () => {
-    const resolvers: Array<() => void> = []
-    vi.mocked(completeSignIn).mockImplementation(() => new Promise<void>((resolve) => {
-      resolvers.push(() => resolve())
-    }))
+  it('cancels and hard-reloads when a different identity appears under an in-flight bootstrap', async () => {
+    // Cross-tab account switching is unsupported (scope policy): the stale
+    // tab reloads instead of reconciling in place, and the obsolete run is
+    // cancelled so it cannot act before the page unloads.
+    vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
     // First probe: unregistered session (target 0).
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    const { rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    const firstRunOptions = vi.mocked(completeSignIn).mock.calls[0][0]
+    expect(firstRunOptions.isCancelled?.()).toBe(false)
+
+    const otherUser = { userId: 9, displayName: 'Other', roles: [] } as unknown as DuosUser
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: otherUser as never })
+    rerender()
+
+    await waitFor(() => expect(vi.mocked(Redirect.to)).toHaveBeenCalledWith(globalThis.location.href))
+    expect(firstRunOptions.isCancelled?.()).toBe(true)
+    // No second in-place bootstrap — the reload owns reconciliation now.
+    expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()
+  })
+
+  it('cancels the in-flight bootstrap when the session disappears', async () => {
+    vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
 
     const { result, rerender } = renderReconciler()
     await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    const runOptions = vi.mocked(completeSignIn).mock.calls[0][0]
 
-    // A fresh probe now names a different registered user (cross-tab switch
-    // landed mid-bootstrap) → a new bootstrap supersedes the first.
-    const otherUser = { userId: 9, displayName: 'Other', roles: [] } as unknown as DuosUser
-    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: otherUser as never })
+    // Sign-out in another tab (or expiry): the probe flips unauthenticated.
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
     rerender()
-    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledTimes(2))
 
-    // The SUPERSEDED run finishing must not reveal the routes…
-    await act(async () => {
-      resolvers[0]()
-    })
-    expect(result.current.reconciling).toBe(true)
-
-    // …only the active generation's completion may.
-    await act(async () => {
-      resolvers[1]()
-    })
+    expect(runOptions.isCancelled?.()).toBe(true)
+    // Signed out → nothing to reconcile; the UI renders the signed-out state.
     expect(result.current.reconciling).toBe(false)
+  })
+
+  it('cancels the in-flight bootstrap on unmount', async () => {
+    vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    const { unmount } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+    const runOptions = vi.mocked(completeSignIn).mock.calls[0][0]
+
+    unmount()
+
+    expect(runOptions.isCancelled?.()).toBe(true)
   })
 
   it('does nothing while signed out', async () => {

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -361,6 +361,18 @@ describe('useSessionReconciler', () => {
     expect(runOptions.isCancelled?.()).toBe(true)
   })
 
+  it('reconciles while the first probe is in flight — no anonymous chrome for a signed-in user', () => {
+    // On a hard load the probe has not answered yet. Rendering the signed-out
+    // header and routes in that window invites a click that starts a sign-in
+    // flow, and bounces deep links.
+    vi.mocked(useSessionInfo).mockReturnValue(undefined)
+
+    const { result } = renderReconciler()
+
+    expect(result.current.reconciling).toBe(true)
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
   it('does nothing while signed out', async () => {
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
 

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import type { QueryClient } from '@tanstack/react-query'
+import { useSessionReconciler } from 'src/hooks/useSessionReconciler'
+import { useSessionInfo } from 'src/hooks/useSession'
+import { completeSignIn } from 'src/libs/auth/postSignIn'
+import { Storage } from 'src/libs/storage'
+import type { SessionInfo } from 'src/libs/auth/session'
+import type { DuosUser } from 'src/types/model'
+
+vi.mock('src/hooks/useSession', () => ({ useSessionInfo: vi.fn() }))
+vi.mock('src/libs/auth/postSignIn', () => ({ completeSignIn: vi.fn() }))
+
+const queryClient = { clear: vi.fn() } as unknown as QueryClient
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter>{children}</MemoryRouter>
+)
+
+const storedUser = { userId: 7, displayName: 'Stored User', roles: [] } as unknown as DuosUser
+
+const renderReconciler = () => renderHook(() => useSessionReconciler(queryClient), { wrapper })
+
+describe('useSessionReconciler', () => {
+  beforeEach(() => {
+    vi.mocked(completeSignIn).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(useSessionInfo).mockReset()
+    vi.mocked(completeSignIn).mockReset()
+    localStorage.clear()
+  })
+
+  it('hides the routes from the first render when a fresh probe could change the identity', () => {
+    // Cross-tab switch shape: stored user 7, fresh probe reports an
+    // unregistered session. The stale identity must never be committed.
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    const { result } = renderReconciler()
+
+    expect(result.current.reconciling).toBe(true)
+  })
+
+  it('hydrates without hiding the routes, recording classification in state', async () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(storedUser as never)
+    const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    const freshProfile = { ...storedUser, roles: [{ name: 'Admin' }] }
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: freshProfile as never })
+
+    const { result } = renderReconciler()
+
+    // Same identity — no blanking of the screen on a routine revalidation…
+    expect(result.current.reconciling).toBe(false)
+    // …but the refreshed profile lands in storage and the classification is
+    // recorded in state (which re-renders consumers off the new profile).
+    await waitFor(() => expect(setCurrentUser).toHaveBeenCalledWith(freshProfile))
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+
+  it('joins an in-flight bootstrap instead of starting a concurrent one for the same identity', async () => {
+    // completeSignIn hangs, as a slow registration would.
+    let resolveBootstrap!: () => void
+    vi.mocked(completeSignIn).mockReturnValue(new Promise<void>((resolve) => {
+      resolveBootstrap = () => resolve()
+    }))
+    const probe1: SessionInfo = { authenticated: true }
+    vi.mocked(useSessionInfo).mockReturnValue(probe1)
+
+    const { result, rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+
+    // A focus revalidation publishes a NEW no-user result mid-registration.
+    const probe2: SessionInfo = { authenticated: true }
+    vi.mocked(useSessionInfo).mockReturnValue(probe2)
+    rerender()
+
+    // Same target identity → joins the in-flight run; no duplicate
+    // registration, metrics, or routing.
+    expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce()
+    expect(result.current.reconciling).toBe(true)
+
+    await act(async () => {
+      resolveBootstrap()
+    })
+    expect(result.current.reconciling).toBe(false)
+  })
+
+  it('supersedes an in-flight bootstrap for a different identity — the older completion cannot unlock the routes', async () => {
+    const resolvers: Array<() => void> = []
+    vi.mocked(completeSignIn).mockImplementation(() => new Promise<void>((resolve) => {
+      resolvers.push(() => resolve())
+    }))
+    // First probe: unregistered session (target 0).
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    const { result, rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+
+    // A fresh probe now names a different registered user (cross-tab switch
+    // landed mid-bootstrap) → a new bootstrap supersedes the first.
+    const otherUser = { userId: 9, displayName: 'Other', roles: [] } as unknown as DuosUser
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: otherUser as never })
+    rerender()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledTimes(2))
+
+    // The SUPERSEDED run finishing must not reveal the routes…
+    await act(async () => {
+      resolvers[0]()
+    })
+    expect(result.current.reconciling).toBe(true)
+
+    // …only the active generation's completion may.
+    await act(async () => {
+      resolvers[1]()
+    })
+    expect(result.current.reconciling).toBe(false)
+  })
+
+  it('does nothing while signed out', async () => {
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
+
+    const { result } = renderReconciler()
+
+    expect(result.current.reconciling).toBe(false)
+    expect(result.current.isLoggedIn).toBe(false)
+    expect(vi.mocked(completeSignIn)).not.toHaveBeenCalled()
+  })
+})

--- a/test/hooks/useSessionReconciler.spec.tsx
+++ b/test/hooks/useSessionReconciler.spec.tsx
@@ -215,6 +215,60 @@ describe('useSessionReconciler', () => {
     expect(result.current.reconciling).toBe(false)
   })
 
+  it('retires a cancelled run — the next authenticated probe starts fresh instead of joining it', async () => {
+    // /auth/me reports { authenticated: false } for transient failures too,
+    // so a network blip mid-bootstrap must not leave a dead token that the
+    // recovered probe would join (hanging the spinner or unlocking empty).
+    vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+
+    const { result, rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+
+    // Transient blip: probe flips unauthenticated…
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
+    rerender()
+    expect(result.current.reconciling).toBe(false)
+
+    // …then recovers with a fresh unauthenticated-session probe (same shape,
+    // NEW object). It must start a second bootstrap, not join the dead one.
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+    rerender()
+
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledTimes(2))
+    expect(result.current.reconciling).toBe(true)
+  })
+
+  it('applies the freshest joined profile when the run completes', async () => {
+    // A named-user bootstrap has an older getMe in flight when focus
+    // revalidation returns the SAME user with newer roles. The join must not
+    // swallow that profile — it is applied at run completion, after the
+    // run's own (older) write.
+    let resolveBootstrap!: () => void
+    vi.mocked(completeSignIn).mockReturnValue(new Promise<void>((resolve) => {
+      resolveBootstrap = () => resolve()
+    }))
+    const setCurrentUser = vi.spyOn(Storage, 'setCurrentUser').mockImplementation(() => {})
+    const user9 = { userId: 9, displayName: 'Nine', roles: [] } as unknown as DuosUser
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: user9 as never })
+
+    const { result, rerender } = renderReconciler()
+    await waitFor(() => expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce())
+
+    // Same user, newer authorization state, mid-run.
+    const user9Promoted = { ...user9, roles: [{ name: 'Admin' }] }
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, user: user9Promoted as never })
+    rerender()
+    expect(vi.mocked(completeSignIn)).toHaveBeenCalledOnce() // joined, not restarted
+
+    await act(async () => {
+      resolveBootstrap()
+    })
+
+    expect(setCurrentUser).toHaveBeenCalledWith(user9Promoted)
+    expect(result.current.reconciling).toBe(false)
+  })
+
   it('cancels the in-flight bootstrap on unmount', async () => {
     vi.mocked(completeSignIn).mockReturnValue(new Promise(() => {}))
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })

--- a/test/libs/ajax/Metrics.spec.ts
+++ b/test/libs/ajax/Metrics.spec.ts
@@ -110,5 +110,24 @@ describe('Metrics Tests', () => {
         expect.any(Object),
       )
     })
+
+    it('treats a persisted registered profile as signed in — the legacy token check is always false under the BFF', async () => {
+      // The legacy oidc keys are purged in BFF mode, so userIsLogged() is
+      // false for every signed-in BFF user. The stored profile is the
+      // identity: the event must post identified (proxy URL, no anonymous
+      // distinct_id), matching identify/syncProfile in the same flow.
+      vi.spyOn(Storage, 'userIsLogged').mockReturnValue(false)
+      vi.spyOn(Storage, 'getCurrentUser').mockReturnValue({ userId: 7 } as ReturnType<typeof Storage.getCurrentUser>)
+
+      await Metrics.captureEvent(Object.keys(eventList)[0] as MetricsEventName)
+
+      expect(retryFetchPost).toHaveBeenCalledWith(
+        '/bard-api/api/event',
+        expect.objectContaining({
+          properties: expect.objectContaining({ distinct_id: undefined }),
+        }),
+        expect.any(Object),
+      )
+    })
   })
 })

--- a/test/libs/auth/auth.spec.ts
+++ b/test/libs/auth/auth.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { OidcBroker } from 'src/libs/auth/oidcBroker'
 import { Auth, Redirect, redirectOnLogout } from 'src/libs/auth/auth'
+import { getSessionInfo, resetSessionProbeState } from 'src/libs/auth/session'
 import { Storage } from 'src/libs/storage'
 import { Config } from 'src/libs/config'
 import { v4 as uuid } from 'uuid'
@@ -62,8 +63,6 @@ describe('Auth Success', () => {
     await Auth.signIn()
     expect(Storage.getOidcUser().access_token).toBe(mockOidcUser.access_token)
     expect(Storage.userIsLogged()).toBe(true)
-    // Legacy isAuthenticated falls back to localStorage token expiry
-    expect(await Auth.isAuthenticated()).toBe(true)
   })
 
   it('Sign Out Clears the session when called', async () => {
@@ -245,15 +244,28 @@ describe('Auth (BFF mode)', () => {
     expect(redirectSpy).toHaveBeenCalledWith('/')
   })
 
-  it.each([
-    [true, 200],
-    [false, 401],
-  ])('isAuthenticated returns %s when /auth/me responds %i', async (expected, status) => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: expected, status })
+  it('signOut drops the cached session answer before redirecting', async () => {
+    // DuosHeader navigates before Auth.signOut's redirect unloads the page;
+    // a re-render in that window must re-probe rather than serve the cached
+    // pre-logout "authenticated" — which painted a signed-in header around
+    // the just-cleared empty user.
+    resetSessionProbeState()
+    const fetchMock = vi.fn()
+      // 1: session probe → cached authenticated answer
+      .mockResolvedValueOnce(new Response(JSON.stringify({ authenticated: true }), { status: 200 }))
+      // 2: CSRF token, 3: logout
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ token: 'csrf-123' }) } as never)
+      .mockResolvedValueOnce({ ok: true, status: 204 } as never)
+      // 4: the post-signOut ask must reach the network again
+      .mockResolvedValueOnce(new Response(JSON.stringify({ authenticated: false }), { status: 401 }))
     vi.stubGlobal('fetch', fetchMock)
+    vi.spyOn(Redirect, 'to').mockImplementation(() => {})
 
-    expect(await Auth.isAuthenticated()).toBe(expected)
-    expect(fetchMock).toHaveBeenCalledWith('/auth/me', { credentials: 'include' })
+    await expect(getSessionInfo()).resolves.toMatchObject({ authenticated: true })
+    await Auth.signOut()
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/auth/me', { credentials: 'include' })
   })
 
   it('redirectOnLogout signs out with the /home redirect target', async () => {

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -74,6 +74,10 @@ describe('completeSignIn', () => {
   })
 
   describe('existing user', () => {
+    beforeEach(() => {
+      globalThis.history.replaceState({}, '', '/')
+    })
+
     it('persists the user, clears the query cache, and routes ToS-accepted users to their console', async () => {
       const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
       vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
@@ -91,15 +95,28 @@ describe('completeSignIn', () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
-    it('leaves a ToS-accepted user in place when the callback landed on a destination page', async () => {
+    it('leaves a ToS-accepted user in place when the callback landed on the destination page', async () => {
       const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
       vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
+      // The BFF /auth/callback redirect already put the browser on /datalibrary.
+      globalThis.history.replaceState({}, '', '/datalibrary')
 
       await run('/datalibrary')
 
-      // The /auth/callback redirect already put the browser on /datalibrary.
       expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
       expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('navigates a ToS-accepted user to the destination when not already there (legacy reload)', async () => {
+      const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
+
+      // The legacy popup flow reloads on the landing page ('/'), with the
+      // destination carried in ?redirectTo= — the bootstrap must finish the trip.
+      await run('/datalibrary')
+
+      expect(navigate).toHaveBeenCalledWith('/datalibrary')
+      expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
     })
 
     it('routes a user who has not accepted the ToS to /tos_acceptance', async () => {
@@ -161,25 +178,44 @@ describe('completeSignIn', () => {
       expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=/datalibrary')
     })
 
-    it('treats a 409 from registration as an already-registered sign-in', async () => {
-      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+    it('treats a 409 from registration as an already-registered sign-in, re-fetching the user', async () => {
+      const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
+      // getMe fails first (that's how we reached registration), the register
+      // 409 proves the user exists, and the re-fetch succeeds.
+      vi.mocked(User.getMe)
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce(tosAcceptedUser as never)
       vi.mocked(User.registerUser).mockRejectedValue({ status: 409 })
-      // The 409 path routes off the locally stored user's ToS status.
-      Storage.setCurrentUser({ ...duosUser, userStatusInfo: tosAcceptedStatus })
 
       await run('/')
 
-      expect(vi.mocked(Navigation.console)).toHaveBeenCalledWith(expect.objectContaining({ userId: 1 }), navigate)
+      // The full sign-in completion runs off the fresh fetch, not stale storage.
+      expect(Storage.getCurrentUser()).toEqual(tosAcceptedUser)
+      expect(queryClient.clear).toHaveBeenCalled()
+      expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:signin')
+      expect(vi.mocked(Navigation.console)).toHaveBeenCalledWith(tosAcceptedUser, navigate)
       expect(vi.mocked(Notifications.showError)).not.toHaveBeenCalled()
     })
 
     it('sends a 409 user who has not accepted the ToS to /tos_acceptance', async () => {
-      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+      vi.mocked(User.getMe)
+        .mockRejectedValueOnce(new Error('not found'))
+        .mockResolvedValueOnce(duosUser as never)
       vi.mocked(User.registerUser).mockRejectedValue({ response: { status: 409 } })
 
       await run('/')
 
       expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
+    })
+
+    it('signs out when the post-409 user fetch fails too', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('still failing'))
+      vi.mocked(User.registerUser).mockRejectedValue({ status: 409 })
+
+      await run('/')
+
+      expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
+      expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
     })
 
     it('shows a registration error for any other failure', async () => {

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -93,7 +93,7 @@ describe('completeSignIn', () => {
       const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
       vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
 
-      await run('/')
+      await expect(run('/')).resolves.toBe('completed')
 
       expect(Storage.getCurrentUser()).toEqual(tosAcceptedUser)
       expect(Storage.getAnonymousId()).not.toBeNull()
@@ -172,7 +172,7 @@ describe('completeSignIn', () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
       vi.mocked(User.registerUser).mockResolvedValue(duosUser)
 
-      await run('/')
+      await expect(run('/')).resolves.toBe('completed')
 
       expect(vi.mocked(User.registerUser)).toHaveBeenCalled()
       expect(queryClient.clear).toHaveBeenCalled()
@@ -227,7 +227,7 @@ describe('completeSignIn', () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('still failing'))
       vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(409))
 
-      await run('/')
+      await expect(run('/')).resolves.toBe('signed-out')
 
       expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
       expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
@@ -237,7 +237,7 @@ describe('completeSignIn', () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
       vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(500, 'boom'))
 
-      await run('/')
+      await expect(run('/')).resolves.toBe('signed-out')
 
       expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith(expect.objectContaining({
         description: 'There was an error completing your registration. Please try again.',
@@ -261,7 +261,7 @@ describe('completeSignIn', () => {
       // A newer reconciliation supersedes this run while its getMe is in flight.
       cancelledFlag = true
       resolveGetMe({ ...duosUser, userStatusInfo: tosAcceptedStatus })
-      await run
+      await expect(run).resolves.toBe('cancelled')
 
       // The obsolete run must not persist, clear caches, emit metrics, or route.
       expect(Storage.getCurrentUser().userId).toBe(0)
@@ -292,7 +292,9 @@ describe('completeSignIn', () => {
     it('does not sign out or toast when a cancelled run fails', async () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
 
-      await completeSignIn({ navigate, queryClient, redirectPath: '/', isCancelled: () => true })
+      await expect(
+        completeSignIn({ navigate, queryClient, redirectPath: '/', isCancelled: () => true }),
+      ).resolves.toBe('cancelled')
 
       // The newer run owns the session — a superseded failure must not
       // destroy it or surface stale errors.
@@ -306,7 +308,7 @@ describe('completeSignIn', () => {
     it('shows the error and signs the user out', async () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('AzureB2C authentication error: bad tenant'))
 
-      await run('/')
+      await expect(run('/')).resolves.toBe('signed-out')
 
       expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith({ text: 'AzureB2C authentication error: bad tenant' })
       expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -58,7 +58,8 @@ const duosUser = {
 const navigate = vi.fn()
 const queryClient = { clear: vi.fn() } as unknown as QueryClient
 
-const run = (redirectPath = '/') => completeSignIn({ navigate, queryClient, redirectPath })
+const run = (redirectPath = '/', options: { sessionReportsNoProfile?: boolean } = {}) =>
+  completeSignIn({ navigate, queryClient, redirectPath, ...options })
 
 // The exact shape fetchAdapter throws for an HTTP error: the axios-like
 // { response: { status } } error is re-wrapped by the adapter's outer catch,
@@ -246,6 +247,46 @@ describe('completeSignIn', () => {
       // routes — destroy the session instead so the user lands signed out.
       expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
       expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('unregistered session probe (BFF)', () => {
+    // The regression Kevin traced: /auth/me reports the upstream 401 on
+    // /api/user/me as "authenticated, no profile", but repeating getMe through
+    // /duos-api hits the same 401 — which the proxy treats as an authoritative
+    // token rejection and destroys the session, so the registerUser that
+    // follows arrives unauthenticated. The probe's answer must route straight
+    // to registration with the session intact.
+    it('registers without calling getMe when the probe already reported no profile', async () => {
+      // What the doomed getMe would produce: the proxy destroys the session
+      // and answers 401 session_expired. If completeSignIn regresses into
+      // calling it, registration fails and this test routes to sign-out.
+      vi.mocked(User.getMe).mockRejectedValue(adapterHttpError(401, 'session_expired'))
+      vi.mocked(User.registerUser).mockResolvedValue(duosUser)
+
+      await expect(run('/', { sessionReportsNoProfile: true })).resolves.toBe('completed')
+
+      expect(vi.mocked(User.getMe)).not.toHaveBeenCalled()
+      expect(vi.mocked(User.registerUser)).toHaveBeenCalled()
+      expect(vi.mocked(Auth.signOut)).not.toHaveBeenCalled()
+      expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:register')
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
+    })
+
+    it('recovers through the 409 branch when the no-profile answer was stale', async () => {
+      // The user registered in another tab after the probe answered: the
+      // register 409 proves it, and the re-fetch (now safe — a registered
+      // user's getMe succeeds) completes the sign-in.
+      const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
+      vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(409))
+
+      await expect(run('/', { sessionReportsNoProfile: true })).resolves.toBe('completed')
+
+      expect(vi.mocked(User.getMe)).toHaveBeenCalledOnce()
+      expect(Storage.getCurrentUser()).toEqual(tosAcceptedUser)
+      expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:signin')
+      expect(vi.mocked(Notifications.showError)).not.toHaveBeenCalled()
     })
   })
 

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -249,6 +249,41 @@ describe('completeSignIn', () => {
     })
   })
 
+  describe('cancellation (superseded runs)', () => {
+    it('performs no side effects once cancelled mid-flight', async () => {
+      let resolveGetMe!: (user: unknown) => void
+      vi.mocked(User.getMe).mockReturnValue(new Promise((resolve) => {
+        resolveGetMe = resolve
+      }) as never)
+      let cancelledFlag = false
+
+      const run = completeSignIn({ navigate, queryClient, redirectPath: '/', isCancelled: () => cancelledFlag })
+      // A newer reconciliation supersedes this run while its getMe is in flight.
+      cancelledFlag = true
+      resolveGetMe({ ...duosUser, userStatusInfo: tosAcceptedStatus })
+      await run
+
+      // The obsolete run must not persist, clear caches, emit metrics, or route.
+      expect(Storage.getCurrentUser().userId).toBe(0)
+      expect(queryClient.clear).not.toHaveBeenCalled()
+      expect(vi.mocked(Metrics.captureEvent)).not.toHaveBeenCalled()
+      expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('does not sign out or toast when a cancelled run fails', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+
+      await completeSignIn({ navigate, queryClient, redirectPath: '/', isCancelled: () => true })
+
+      // The newer run owns the session — a superseded failure must not
+      // destroy it or surface stale errors.
+      expect(vi.mocked(Auth.signOut)).not.toHaveBeenCalled()
+      expect(vi.mocked(Notifications.showError)).not.toHaveBeenCalled()
+      expect(vi.mocked(User.registerUser)).not.toHaveBeenCalled()
+    })
+  })
+
   describe('AzureB2C errors from Sam', () => {
     it('shows the error and signs the user out', async () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('AzureB2C authentication error: bad tenant'))

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -58,6 +58,15 @@ const queryClient = { clear: vi.fn() } as unknown as QueryClient
 
 const run = (redirectPath = '/') => completeSignIn({ navigate, queryClient, redirectPath })
 
+// The exact shape fetchAdapter throws for an HTTP error: the axios-like
+// { response: { status } } error is re-wrapped by the adapter's outer catch,
+// so the status lives on Error.cause, not on the thrown error itself.
+const adapterHttpError = (status: number, message = `Request failed with status ${status}`): Error => {
+  const inner = new Error(message) as Error & { response: { status: number, data: object } }
+  inner.response = { status, data: { message } }
+  return new Error(`${message} Please contact the help desk.`, { cause: inner })
+}
+
 describe('completeSignIn', () => {
   beforeEach(() => {
     Storage.clearStorage()
@@ -185,7 +194,7 @@ describe('completeSignIn', () => {
       vi.mocked(User.getMe)
         .mockRejectedValueOnce(new Error('not found'))
         .mockResolvedValueOnce(tosAcceptedUser as never)
-      vi.mocked(User.registerUser).mockRejectedValue({ status: 409 })
+      vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(409))
 
       await run('/')
 
@@ -201,7 +210,7 @@ describe('completeSignIn', () => {
       vi.mocked(User.getMe)
         .mockRejectedValueOnce(new Error('not found'))
         .mockResolvedValueOnce(duosUser as never)
-      vi.mocked(User.registerUser).mockRejectedValue({ response: { status: 409 } })
+      vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(409))
 
       await run('/')
 
@@ -210,7 +219,7 @@ describe('completeSignIn', () => {
 
     it('signs out when the post-409 user fetch fails too', async () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('still failing'))
-      vi.mocked(User.registerUser).mockRejectedValue({ status: 409 })
+      vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(409))
 
       await run('/')
 
@@ -218,15 +227,18 @@ describe('completeSignIn', () => {
       expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
     })
 
-    it('shows a registration error for any other failure', async () => {
+    it('shows a registration error and signs out for any other failure', async () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
-      vi.mocked(User.registerUser).mockRejectedValue({ status: 500, message: 'boom' })
+      vi.mocked(User.registerUser).mockRejectedValue(adapterHttpError(500, 'boom'))
 
       await run('/')
 
       expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith(expect.objectContaining({
         description: 'There was an error completing your registration. Please try again.',
       }))
+      // Resolving with an empty CurrentUser would unlock the authenticated
+      // routes — destroy the session instead so the user lands signed out.
+      expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
       expect(navigate).not.toHaveBeenCalled()
     })
   })

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -271,6 +271,32 @@ describe('completeSignIn', () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
+    it('resamples the joined profile after the missing-roles report and routes off the fresher state', async () => {
+      // The roles-missing report is the one await between the profile sample
+      // and routing: a fresher same-user profile joining during it must reach
+      // metrics/ToS routing, or an accepted user gets routed to the ToS gate
+      // — a navigation the reconciler's post-completion apply cannot repair.
+      const rolelessUser = { userId: 1, email: 'test@user.com' }
+      const acceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(rolelessUser as never)
+      let joined: DuosUser | undefined
+      vi.mocked(ErrorReporter.report).mockImplementation(async () => {
+        joined = acceptedUser
+      })
+
+      await expect(completeSignIn({
+        navigate,
+        queryClient,
+        redirectPath: '/',
+        latestJoinedProfile: () => joined,
+      })).resolves.toBe('completed')
+
+      // Routed as the accepted user, not the pre-report roleless one.
+      expect(Storage.getCurrentUser()).toEqual(acceptedUser)
+      expect(vi.mocked(Navigation.console)).toHaveBeenCalledWith(acceptedUser, navigate)
+      expect(navigate).not.toHaveBeenCalledWith('/tos_acceptance')
+    })
+
     it('stops before metrics and routing when superseded during the missing-roles report', async () => {
       // ErrorReporter.report awaits env lookup + delivery — long enough to be
       // superseded mid-call. The run must not resume with metrics/navigation.

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -145,7 +145,19 @@ describe('completeSignIn', () => {
 
       await run('/datalibrary')
 
-      expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=/datalibrary')
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=%2Fdatalibrary')
+    })
+
+    it('encodes a destination that carries its own query string', async () => {
+      // Unencoded, '/datalibrary?filter=a&b=c' splits at the '&' and the tail
+      // becomes sibling params of the ToS page — accepting the ToS then drops
+      // the user on the wrong page. URLSearchParams on the reading side decodes.
+      vi.mocked(User.getMe).mockResolvedValue(duosUser as never)
+
+      await run('/datalibrary?filter=a&b=c')
+
+      const url = vi.mocked(navigate).mock.calls[0][0] as string
+      expect(new URLSearchParams(url.split('?')[1]).get('redirectTo')).toBe('/datalibrary?filter=a&b=c')
     })
 
     it('reports missing roles to the error reporter', async () => {
@@ -190,7 +202,7 @@ describe('completeSignIn', () => {
 
       await run('/datalibrary')
 
-      expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=/datalibrary')
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=%2Fdatalibrary')
     })
 
     it('treats a 409 from registration as an already-registered sign-in, re-fetching the user', async () => {

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -5,6 +5,7 @@ import { User } from 'src/libs/ajax/User'
 import { Metrics } from 'src/libs/ajax/Metrics'
 import { Storage } from 'src/libs/storage'
 import { Auth } from 'src/libs/auth/auth'
+import { resetSessionCache } from 'src/libs/auth/session'
 import { Navigation, Notifications } from 'src/libs/utils'
 import { ErrorReporter } from 'src/libs/ErrorReporter'
 import { DuosUser, UserStatusInfo } from 'src/types/model'
@@ -12,6 +13,7 @@ import { DuosUser, UserStatusInfo } from 'src/types/model'
 vi.mock('src/libs/ajax/User')
 vi.mock('src/libs/ajax/Metrics')
 vi.mock('src/libs/ErrorReporter')
+vi.mock('src/libs/auth/session', () => ({ resetSessionCache: vi.fn() }))
 vi.mock('src/libs/auth/auth', () => ({
   Auth: {
     signOut: vi.fn().mockResolvedValue(undefined),
@@ -174,6 +176,9 @@ describe('completeSignIn', () => {
 
       expect(vi.mocked(User.registerUser)).toHaveBeenCalled()
       expect(queryClient.clear).toHaveBeenCalled()
+      // The cached /auth/me answer predates the registration — it must be
+      // dropped or the app deadlocks on a stale authenticated-no-user session.
+      expect(vi.mocked(resetSessionCache)).toHaveBeenCalled()
       expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:register')
       expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
     })
@@ -201,6 +206,7 @@ describe('completeSignIn', () => {
       // The full sign-in completion runs off the fresh fetch, not stale storage.
       expect(Storage.getCurrentUser()).toEqual(tosAcceptedUser)
       expect(queryClient.clear).toHaveBeenCalled()
+      expect(vi.mocked(resetSessionCache)).toHaveBeenCalled()
       expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:signin')
       expect(vi.mocked(Navigation.console)).toHaveBeenCalledWith(tosAcceptedUser, navigate)
       expect(vi.mocked(Notifications.showError)).not.toHaveBeenCalled()

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -271,6 +271,24 @@ describe('completeSignIn', () => {
       expect(navigate).not.toHaveBeenCalled()
     })
 
+    it('stops before metrics and routing when superseded during the missing-roles report', async () => {
+      // ErrorReporter.report awaits env lookup + delivery — long enough to be
+      // superseded mid-call. The run must not resume with metrics/navigation.
+      let cancelledFlag = false
+      const rolelessUser = { email: 'test@user.com', userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(rolelessUser as never)
+      vi.mocked(ErrorReporter.report).mockImplementation(async () => {
+        cancelledFlag = true
+      })
+
+      await completeSignIn({ navigate, queryClient, redirectPath: '/', isCancelled: () => cancelledFlag })
+
+      expect(vi.mocked(ErrorReporter.report)).toHaveBeenCalled()
+      expect(vi.mocked(Metrics.captureEvent)).not.toHaveBeenCalled()
+      expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
     it('does not sign out or toast when a cancelled run fails', async () => {
       vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
 

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { QueryClient } from '@tanstack/react-query'
+import { completeSignIn } from 'src/libs/auth/postSignIn'
+import { User } from 'src/libs/ajax/User'
+import { Metrics } from 'src/libs/ajax/Metrics'
+import { Storage } from 'src/libs/storage'
+import { Auth } from 'src/libs/auth/auth'
+import { Navigation, Notifications } from 'src/libs/utils'
+import { ErrorReporter } from 'src/libs/ErrorReporter'
+import { DuosUser, UserStatusInfo } from 'src/types/model'
+
+vi.mock('src/libs/ajax/User')
+vi.mock('src/libs/ajax/Metrics')
+vi.mock('src/libs/ErrorReporter')
+vi.mock('src/libs/auth/auth', () => ({
+  Auth: {
+    signOut: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+vi.mock('src/libs/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('src/libs/utils')>()
+  return {
+    ...actual,
+    Navigation: { ...actual.Navigation, console: vi.fn() },
+    Notifications: { showError: vi.fn(), showSuccess: vi.fn() },
+    setUserRoleStatuses: vi.fn((user) => {
+      Storage.setCurrentUser(user)
+      return user
+    }),
+  }
+})
+
+const tosAcceptedStatus: UserStatusInfo = {
+  adminEnabled: false,
+  enabled: true,
+  userSubjectId: '1234',
+  userEmail: 'test@user.com',
+  tosAccepted: true,
+}
+
+const duosUser = {
+  displayName: 'display name',
+  email: 'test@user.com',
+  emailPreference: true,
+  isAdmin: true,
+  isAlumni: false,
+  isChairPerson: false,
+  isDataSubmitter: false,
+  isMember: false,
+  isResearcher: false,
+  isSigningOfficial: false,
+  roles: [{ name: 'Admin' }],
+  userId: 1,
+} as unknown as DuosUser
+
+const navigate = vi.fn()
+const queryClient = { clear: vi.fn() } as unknown as QueryClient
+
+const run = (redirectPath = '/') => completeSignIn({ navigate, queryClient, redirectPath })
+
+describe('completeSignIn', () => {
+  beforeEach(() => {
+    Storage.clearStorage()
+    vi.mocked(Metrics.identify).mockResolvedValue(undefined as never)
+    vi.mocked(Metrics.syncProfile).mockResolvedValue(undefined as never)
+    vi.mocked(Metrics.captureEvent).mockResolvedValue(undefined as never)
+    vi.mocked(ErrorReporter.report).mockResolvedValue(undefined)
+    vi.mocked(Navigation.console).mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    Storage.clearStorage()
+  })
+
+  describe('existing user', () => {
+    it('persists the user, clears the query cache, and routes ToS-accepted users to their console', async () => {
+      const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
+
+      await run('/')
+
+      expect(Storage.getCurrentUser()).toEqual(tosAcceptedUser)
+      expect(Storage.getAnonymousId()).not.toBeNull()
+      expect(queryClient.clear).toHaveBeenCalled()
+      expect(vi.mocked(Metrics.identify)).toHaveBeenCalled()
+      expect(vi.mocked(Metrics.syncProfile)).toHaveBeenCalled()
+      expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:signin')
+      expect(vi.mocked(ErrorReporter.report)).not.toHaveBeenCalled()
+      expect(vi.mocked(Navigation.console)).toHaveBeenCalledWith(tosAcceptedUser, navigate)
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('leaves a ToS-accepted user in place when the callback landed on a destination page', async () => {
+      const tosAcceptedUser = { ...duosUser, userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(tosAcceptedUser as never)
+
+      await run('/datalibrary')
+
+      // The /auth/callback redirect already put the browser on /datalibrary.
+      expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
+      expect(navigate).not.toHaveBeenCalled()
+    })
+
+    it('routes a user who has not accepted the ToS to /tos_acceptance', async () => {
+      vi.mocked(User.getMe).mockResolvedValue(duosUser as never)
+
+      await run('/')
+
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
+      expect(vi.mocked(Navigation.console)).not.toHaveBeenCalled()
+    })
+
+    it('carries the destination through the ToS gate as redirectTo', async () => {
+      vi.mocked(User.getMe).mockResolvedValue(duosUser as never)
+
+      await run('/datalibrary')
+
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=/datalibrary')
+    })
+
+    it('reports missing roles to the error reporter', async () => {
+      const bareUser = { email: 'test@user.com', userStatusInfo: tosAcceptedStatus }
+      vi.mocked(User.getMe).mockResolvedValue(bareUser as never)
+
+      await run('/')
+
+      expect(vi.mocked(ErrorReporter.report)).toHaveBeenCalledWith('roles not found for user: test@user.com')
+    })
+  })
+
+  describe('registration fallback', () => {
+    it('registers a new user when getMe returns no user', async () => {
+      vi.mocked(User.getMe).mockResolvedValue(undefined as never)
+      vi.mocked(User.registerUser).mockResolvedValue(duosUser)
+
+      await run('/')
+
+      expect(vi.mocked(User.registerUser)).toHaveBeenCalled()
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
+    })
+
+    it('registers a new user when getMe fails and routes to /tos_acceptance', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+      vi.mocked(User.registerUser).mockResolvedValue(duosUser)
+
+      await run('/')
+
+      expect(vi.mocked(User.registerUser)).toHaveBeenCalled()
+      expect(queryClient.clear).toHaveBeenCalled()
+      expect(vi.mocked(Metrics.captureEvent)).toHaveBeenCalledWith('user:register')
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
+    })
+
+    it('preserves the destination when registering with a redirect path', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+      vi.mocked(User.registerUser).mockResolvedValue(duosUser)
+
+      await run('/datalibrary')
+
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance?redirectTo=/datalibrary')
+    })
+
+    it('treats a 409 from registration as an already-registered sign-in', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+      vi.mocked(User.registerUser).mockRejectedValue({ status: 409 })
+      // The 409 path routes off the locally stored user's ToS status.
+      Storage.setCurrentUser({ ...duosUser, userStatusInfo: tosAcceptedStatus })
+
+      await run('/')
+
+      expect(vi.mocked(Navigation.console)).toHaveBeenCalledWith(expect.objectContaining({ userId: 1 }), navigate)
+      expect(vi.mocked(Notifications.showError)).not.toHaveBeenCalled()
+    })
+
+    it('sends a 409 user who has not accepted the ToS to /tos_acceptance', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+      vi.mocked(User.registerUser).mockRejectedValue({ response: { status: 409 } })
+
+      await run('/')
+
+      expect(navigate).toHaveBeenCalledWith('/tos_acceptance')
+    })
+
+    it('shows a registration error for any other failure', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('not found'))
+      vi.mocked(User.registerUser).mockRejectedValue({ status: 500, message: 'boom' })
+
+      await run('/')
+
+      expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith(expect.objectContaining({
+        description: 'There was an error completing your registration. Please try again.',
+      }))
+      expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('AzureB2C errors from Sam', () => {
+    it('shows the error and signs the user out', async () => {
+      vi.mocked(User.getMe).mockRejectedValue(new Error('AzureB2C authentication error: bad tenant'))
+
+      await run('/')
+
+      expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith({ text: 'AzureB2C authentication error: bad tenant' })
+      expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
+      expect(vi.mocked(User.registerUser)).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> Part of the BFF Phase 4 stack: #3861 → #3862 → #3863 → #3864 → #3869 (#3855 merged to develop). This PR's diff is against #3862; review bottom-up. New to the stack? Start with the [review guide & retrospective](https://github.com/DataBiosphere/duos-ui/blob/claude/epic-4-signout-redirect-cleanup/docs/plans/epic-4-stack-review-guide.md).

### Addresses
https://broadworkbench.atlassian.net/browse/DT-3609 (BFF Phase 4, story 4-G)

### Summary
Sign-in through the BFF is a full-page redirect (`POST /auth/login` → B2C → `/auth/callback` → back here), so the popup `onSuccess` handler that used to fetch/register the user can no longer live in `SignInButton`:

- **New `src/libs/auth/postSignIn.ts`**: `completeSignIn()` owns everything the popup callbacks used to — `User.getMe()`, persist + role statuses, query-cache reset (pre-sign-in cached results were built with the anonymous user's visibility clauses), sign-in metrics, the ToS gate, registration with 409-means-already-registered, and the AzureB2C-error-from-Sam path (which signs the session back out).
- **`App.tsx`** detects the post-redirect state — a session exists but `CurrentUser` is empty — and runs `completeSignIn` exactly once, keeping the routes behind the spinner until it resolves.
- **`SignInButton.tsx`** shrinks to a single button calling `Auth.signIn(redirectTo?)` — no provider selection (that's the B2C page's job) and no BFF/legacy branching in the component (that already lives inside `Auth.signIn()` from #3849). `ServiceStatus` health gating, the tooltip, and `?redirectTo=` handling are preserved.

- **Bootstrap triggers**: App keys the bootstrap off `useSessionInfo` — it runs for a session with no local user (post-callback), for an authenticated session with no DUOS profile (unregistered — reaches `registerUser()`), and on identity mismatch between the session user and stored `CurrentUser` (cross-tab account switch / re-login after expiry), re-arming if the mismatch appears after completion. A non-409 registration failure signs the session out rather than unlocking the routes with an empty user; `errorStatus()` unwraps `Error.cause` to match the fetch adapter's real wrapped error shape.

- **Session reconciliation (`src/hooks/useSessionReconciler.ts` + [ADR-011](../blob/HEAD/docs/plans/bff_adrs/ADR-011-single-identity-per-browser.md))**: every fresh `/auth/me` result is classified once — hydrate (same identity; auth-equivalence covers role `{name, dacId}` pairs, `enabled`/`adminEnabled`, ToS), full bootstrap (no local identity / different user / no profile), or — per ADR-011's scope decision that cross-tab account switching is unsupported — a conflict under an in-flight bootstrap cancels the run (`completeSignIn` polls a cancellation token before every side effect) and hard-reloads the tab. Identity-bearing UI (routes AND header) hides while reconciling.

**Reviewer note (behavior change)**: errors from the moved registration/AzureB2C paths now surface via `Notifications.showError` instead of the button's inline `Alert`, since the button is no longer on screen when they occur.

### Testing
New `test/libs/auth/postSignIn.spec.ts` (happy path, redirect preservation, ToS gate, 409, registration failure, AzureB2C error). `SignInButton.spec.tsx` rewritten for the single-button contract (redirect capture from `/`, `/home`, deep links, `?redirectTo=` preference, error alert). Legacy flow: with `bffEnabled: false`, `Auth.signIn()` still runs the OidcBroker popup, and `completeSignIn` never triggers because the legacy flow persists `CurrentUser` itself before any reload.

Similarly to the first PR in this stack, https://github.com/DataBiosphere/duos-ui/pull/3855, `bffEnabled: true` is not plainly testable. With `bffEnabled: false`, there should be no regressions in existing functionality.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)




