### PR TITLE
[DT-3609] Show the B2C sub-provider in the user menu (BFF Phase 4, story 4-H)

### DIFF
--- a/src/components/navigation/ProfileLinks.tsx
+++ b/src/components/navigation/ProfileLinks.tsx
@@ -3,6 +3,12 @@ import React from 'react'
 import { Box, Menu, MenuItem, PopoverOrigin, Typography } from '@mui/material'
 import { DuosUser } from 'src/types/model'
 import { Link } from 'react-router'
+import { useSessionInfo } from 'src/hooks/useSession'
+
+const IDP_LABELS: Record<string, string> = {
+  google: 'Google',
+  microsoft: 'Microsoft',
+}
 
 interface ProfileLinksProps {
   currentUser: DuosUser
@@ -14,6 +20,10 @@ interface ProfileLinksProps {
 
 export const ProfileLinks: React.FC<ProfileLinksProps> = (props) => {
   const { currentUser, onSubtabChange, signOut, orientation, menuWidth } = props
+  // /auth/me reports which sub-provider (Google or Microsoft) the user chose
+  // on the B2C login page — display only, nothing sensitive is stored.
+  const idp = useSessionInfo()?.idp
+  const idpLabel = idp ? IDP_LABELS[idp] : undefined
   const [anchorElUser, setAnchorElUser] = React.useState<null | HTMLElement>(null)
   const handleOpenUserMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorElUser(event.currentTarget)
@@ -73,6 +83,13 @@ export const ProfileLinks: React.FC<ProfileLinksProps> = (props) => {
         open={Boolean(anchorElUser)}
         onClose={handleCloseUserMenu}
       >
+        {idpLabel && (
+          <MenuItem key="idp" disabled sx={{ opacity: 1 }}>
+            <Typography sx={{ fontSize: 12, color: 'text.secondary' }}>
+              Signed in with {idpLabel}
+            </Typography>
+          </MenuItem>
+        )}
         <MenuItem key="profile" onClick={handleCloseUserMenu}>
           <Typography sx={{ fontSize: 12 }}>
             <Link id="link_profile" to="/profile" onClick={e => onSubtabChange(e, 0)}>Your Profile</Link>

--- a/src/components/navigation/ProfileLinks.tsx
+++ b/src/components/navigation/ProfileLinks.tsx
@@ -4,11 +4,14 @@ import { Box, Menu, MenuItem, PopoverOrigin, Typography } from '@mui/material'
 import { DuosUser } from 'src/types/model'
 import { Link } from 'react-router'
 import { useSessionInfo } from 'src/hooks/useSession'
+import type { SessionInfo } from 'src/libs/auth/session'
 
-const IDP_LABELS: Record<string, string> = {
+// Keyed off the SessionInfo union so adding a provider without a label (or
+// typo-ing one) is a compile error.
+const IDP_LABELS = {
   google: 'Google',
   microsoft: 'Microsoft',
-}
+} satisfies Record<NonNullable<SessionInfo['idp']>, string>
 
 interface ProfileLinksProps {
   currentUser: DuosUser

--- a/test/components/navigation/ProfileLinks.spec.tsx
+++ b/test/components/navigation/ProfileLinks.spec.tsx
@@ -32,7 +32,9 @@ const mockUser: DuosUser = {
 
 describe('ProfileLinks', () => {
   afterEach(() => {
-    vi.mocked(useSessionInfo).mockReturnValue(undefined)
+    // Clears call history and per-test mockReturnValue overrides, restoring
+    // the factory's default (undefined = probe in flight).
+    vi.mocked(useSessionInfo).mockReset()
   })
 
   const renderComponent = (propsOverride: Record<string, unknown> = {}) => {

--- a/test/components/navigation/ProfileLinks.spec.tsx
+++ b/test/components/navigation/ProfileLinks.spec.tsx
@@ -1,11 +1,18 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router'
 import { ProfileLinks } from 'src/components/navigation/ProfileLinks'
 import { DuosUser } from 'src/types/model'
+import { useSessionInfo } from 'src/hooks/useSession'
+
+// The session probe is mocked unresolved by default (undefined = in flight);
+// the sub-provider badge cases override it per test.
+vi.mock('src/hooks/useSession', () => ({
+  useSessionInfo: vi.fn(() => undefined),
+}))
 
 const mockUser: DuosUser = {
   createDate: new Date(),
@@ -24,6 +31,10 @@ const mockUser: DuosUser = {
 }
 
 describe('ProfileLinks', () => {
+  afterEach(() => {
+    vi.mocked(useSessionInfo).mockReturnValue(undefined)
+  })
+
   const renderComponent = (propsOverride: Record<string, unknown> = {}) => {
     const onSubtabChange = vi.fn()
     const signOut = vi.fn()
@@ -78,5 +89,28 @@ describe('ProfileLinks', () => {
     await user.click(screen.getByText(mockUser.displayName))
     expect(screen.getByText('Your Profile')).toBeVisible()
     expect(screen.getByText('Sign out')).toBeVisible()
+  })
+
+  it('shows the sub-provider badge when /auth/me reports an idp', async () => {
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true, idp: 'google' })
+    const user = userEvent.setup()
+    renderComponent()
+    await user.click(screen.getByText(mockUser.displayName))
+    expect(screen.getByText('Signed in with Google')).toBeVisible()
+  })
+
+  it('shows no badge while the session probe is in flight', async () => {
+    const user = userEvent.setup()
+    renderComponent()
+    await user.click(screen.getByText(mockUser.displayName))
+    expect(screen.queryByText(/Signed in with/)).not.toBeInTheDocument()
+  })
+
+  it('shows no badge when the session reports no idp (legacy flow)', async () => {
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: true })
+    const user = userEvent.setup()
+    renderComponent()
+    await user.click(screen.getByText(mockUser.displayName))
+    expect(screen.queryByText(/Signed in with/)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
> [!NOTE]
> Part of the BFF Phase 4 stack: #3861 → #3862 → #3863 → #3864 → #3869 (#3855 merged to develop). This PR's diff is against #3863; review bottom-up. New to the stack? Start with the [review guide & retrospective](https://github.com/DataBiosphere/duos-ui/blob/claude/epic-4-signout-redirect-cleanup/docs/plans/epic-4-stack-review-guide.md).

### Addresses
https://broadworkbench.atlassian.net/browse/DT-3609 (BFF Phase 4, story 4-H)

### Summary
`GET /auth/me` reports which sub-provider (Google or Microsoft) the user chose on the B2C login page. The user menu now shows a display-only, disabled "Signed in with Google/Microsoft" item above "Your Profile" — nothing sensitive is stored client-side. The badge is absent while the probe is in flight and in the legacy flow (no `idp` in the session info).

### Testing
`ProfileLinks.spec.tsx` gains three cases: badge shown for a reported idp, hidden while the probe is in flight, hidden when the session has no idp (legacy). Existing menu tests unchanged.

Similarly to the first PR in this stack, https://github.com/DataBiosphere/duos-ui/pull/3855, `bffEnabled: true` is not plainly testable. With `bffEnabled: false`, there should be no regressions in existing functionality.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


