### PR TITLE
Visualize dat use modifiers in librry, add as filter options.

### DIFF
--- a/src/components/data_library/LibraryFilters.tsx
+++ b/src/components/data_library/LibraryFilters.tsx
@@ -28,6 +28,7 @@ import { isFilterActive } from 'src/components/data_library/filterRegistry'
 const CHECKBOX_FILTER_KEYS = [
   'accessManagement',
   'dataUse',
+  'dataUseModifiers',
   'dataType',
   'dac',
   'workspaceTools',

--- a/src/components/data_library/assets/datasetAsset.ts
+++ b/src/components/data_library/assets/datasetAsset.ts
@@ -17,6 +17,10 @@ const SORT_FIELD_MAP: Record<string, string> = {
 const FILTER_AGGS = {
   access_management: { terms: { field: 'accessManagement.keyword' } },
   data_use: { terms: { field: 'dataUse.primary.code.keyword' } },
+  // Drives the Data Use Modifiers filter's option list (not counts — it shows none).
+  // `size` is explicit because the secondary vocabulary is larger than Elasticsearch's
+  // default bucket limit of 10, and a dropped bucket is a code nobody can filter on.
+  data_use_modifiers: { terms: { field: 'dataUse.secondary.code.keyword', size: 50 } },
   data_type: { terms: { field: 'study.dataTypes.keyword' } },
   dac: { terms: { field: 'dac.dacName.keyword' } },
 }

--- a/src/components/data_library/assets/studyAsset.ts
+++ b/src/components/data_library/assets/studyAsset.ts
@@ -71,6 +71,8 @@ export const studyAsset: AssetDefinition = {
         },
         access_management: { terms: { field: 'accessManagement.keyword' } },
         data_use: { terms: { field: 'dataUse.primary.code.keyword' } },
+        // Explicit `size`: the secondary vocabulary exceeds the default bucket limit of 10.
+        data_use_modifiers: { terms: { field: 'dataUse.secondary.code.keyword', size: 50 } },
         data_type: { terms: { field: 'study.dataTypes.keyword' } },
         dac: { terms: { field: 'dac.dacName.keyword' } },
       },

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -8,6 +8,30 @@ import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
 import RequestAccessButton from 'src/components/data_library/RequestAccessButton'
 import BoltIcon from '@mui/icons-material/Bolt'
 import { validateHttpUrl } from 'src/utils/UrlUtils'
+import { DataUseCode, processDataUseCodes } from 'src/utils/DataUseUtils'
+
+/**
+ * A dataset's data use codes as one hyphenated string (`HMB-GSO-PUB`): the
+ * primary codes lead in the order the dataset declares them, then the secondary
+ * conditions alphabetically. Uses `shortCode` so a DS primary reads as `DS`
+ * rather than dragging its disease list into the middle of the sequence — the
+ * full text stays in the tooltip.
+ */
+const orderDataUseCodes = (dataset: DatasetTerm): DataUseCode[] => {
+  const terms = processDataUseCodes(dataset).codesAndDescriptions.filter(term => Boolean(term.shortCode))
+  return [
+    ...terms.filter(term => term.type === 'primary'),
+    ...terms
+      .filter(term => term.type === 'secondary')
+      .sort((a, b) => a.shortCode.localeCompare(b.shortCode)),
+  ]
+}
+
+// Codes alone are opaque; name the tier so a secondary condition isn't read as a primary use
+const dataUseTooltip = ({ code, description, type }: DataUseCode): string => {
+  const tier = type === 'primary' ? 'Primary' : 'Secondary'
+  return description ? `${tier} — ${code}: ${description}` : `${tier} — ${code}`
+}
 
 const makeSoApprovalColumn = (soApprovalModelByDatasetId: Map<number, SoApprovalModel>): GridColDef<DatasetTerm> => ({
   field: 'soApprovalModel',
@@ -151,22 +175,43 @@ export const makeDatasetColumns = (
   {
     field: 'dataUse',
     headerName: 'Data Use',
-    width: 150,
-    valueGetter: (_value, row) => row.dataUse?.primary?.[0]?.code || '',
+    width: 230,
+    // Keep the cell's value identical to what the chip shows, so the two cannot
+    // disagree if the grid ever gains export or quick-filter.
+    valueGetter: (_value, row) => orderDataUseCodes(row).map(term => term.shortCode).join('-'),
     renderCell: (params) => {
-      const codes = params.row.dataUse?.primary?.map(du => du.code).filter(Boolean) || []
-      if (codes.length === 0) return null
+      const terms = orderDataUseCodes(params.row)
+      if (terms.length === 0) return null
 
       return (
-        <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', alignItems: 'center', height: '100%' }}>
-          {codes.slice(0, 2).map(code => (
-            <Chip key={code} label={code} size="small" variant="outlined" />
-          ))}
-          {codes.length > 2 && (
-            <Tooltip title={codes.slice(2).join(', ')}>
-              <Chip label={`+${codes.length - 2}`} size="small" variant="outlined" />
-            </Tooltip>
-          )}
+        <Box sx={{ display: 'flex', alignItems: 'center', height: '100%', maxWidth: '100%' }}>
+          {/* One chip, so the tier of each code lives in the tooltip rather than in chip styling */}
+          <Tooltip
+            title={(
+              <Box component="ul" sx={{ m: 0, pl: 2 }}>
+                {terms.map((term, index) => (
+                  <li key={`${term.shortCode}-${index}`}>{dataUseTooltip(term)}</li>
+                ))}
+              </Box>
+            )}
+            describeChild
+          >
+            <Chip
+              // Derived here rather than read from params.value so the cell renders
+              // correctly on its own; valueGetter builds the identical string from the
+              // same helper. Both passes are a map over a handful of codes.
+              label={terms.map(term => term.shortCode).join('-')}
+              size="small"
+              variant="outlined"
+              color="primary"
+              // The tooltip is the only place the tier of each code and a DS primary's
+              // disease list appear, so it has to be reachable without a pointer. An
+              // unclickable Chip renders a plain div, which never receives focus.
+              tabIndex={0}
+              // A long sequence ellipsizes at the cell edge instead of overflowing it
+              sx={{ maxWidth: '100%' }}
+            />
+          </Tooltip>
         </Box>
       )
     },

--- a/src/components/data_library/filterRegistry.ts
+++ b/src/components/data_library/filterRegistry.ts
@@ -13,6 +13,7 @@ import { assetFilterRegistry } from 'src/libs/dataLibraryFilterConfig'
 type ArrayFilterKey
   = | 'accessManagement'
     | 'dataUse'
+    | 'dataUseModifiers'
     | 'dataType'
     | 'dac'
     | 'workspaceTools'
@@ -29,6 +30,7 @@ type ArrayFilterKey
 const ARRAY_FILTER_KEYS: ArrayFilterKey[] = [
   'accessManagement',
   'dataUse',
+  'dataUseModifiers',
   'dataType',
   'dac',
   'workspaceTools',
@@ -68,6 +70,7 @@ const BOOL_FILTER_KEYS: Array<'datasetsCited' | 'publicationsDatasetsCited' | 'i
 const FILTER_CONTROL_BY_KEY: Record<FilterKey, LibraryFilterSectionControl> = {
   accessManagement: 'checkbox',
   dataUse: 'checkbox',
+  dataUseModifiers: 'checkbox',
   dataType: 'checkbox',
   dac: 'checkbox',
   workspaceTools: 'checkbox',
@@ -94,6 +97,7 @@ const FILTER_CONTROL_BY_KEY: Record<FilterKey, LibraryFilterSectionControl> = {
 export const EMPTY_FILTERS: FilterState = {
   accessManagement: [],
   dataUse: [],
+  dataUseModifiers: [],
   dataType: [],
   dac: [],
   workspaceTools: [],
@@ -134,6 +138,7 @@ export const isFilterActive = (key: FilterKey, filters: FilterState): boolean =>
     // Multi-select (array) filters are active once any value is selected.
     case 'accessManagement':
     case 'dataUse':
+    case 'dataUseModifiers':
     case 'dataType':
     case 'dac':
     case 'workspaceTools':
@@ -187,6 +192,7 @@ const getFilterOptions = (key: FilterKey, availableFilters: AvailableFilters) =>
   switch (key) {
     case 'accessManagement':
     case 'dataUse':
+    case 'dataUseModifiers':
     case 'dataType':
     case 'dac':
     case 'workspaceTools':
@@ -327,6 +333,25 @@ const FILTER_DEFINITIONS: Record<FilterKey, FilterDefinition> = {
         },
       }
     },
+  },
+  /**
+   * Secondary data use conditions (DUO modifiers). This is a separate filter from
+   * `dataUse` rather than extra options within it: `buildActiveFilterClauses`
+   * combines clauses from different filters with AND, so selecting HMB here and
+   * NPU there means "HMB datasets that are also non-profit-only" — which a single
+   * OR'd checkbox list could not express.
+   */
+  dataUseModifiers: {
+    label: 'Data Use Modifiers',
+    // `matchAny` (match_phrase), not `match`: several modifier codes are hyphenated,
+    // and the analyzed field tokenizes them, so a plain `match` on `RS-G` — which ORs
+    // its tokens — would also return every `RS-PD` dataset. The primary `dataUse`
+    // filter above gets away with `match` only because every primary code is a
+    // single token.
+    buildClause: filters =>
+      filters.dataUseModifiers.length > 0
+        ? matchAny('dataUse.secondary.code', filters.dataUseModifiers)
+        : undefined,
   },
   dataType: {
     label: 'Data Type',

--- a/src/components/forms/SecondaryDataUseTerms.ts
+++ b/src/components/forms/SecondaryDataUseTerms.ts
@@ -31,10 +31,16 @@ export class SecondaryDataUseTerms {
     abbreviation: 'IRB',
   }
 
-  static readonly GSMINUS: SelectOptionWithKeyNameAndAbbreviation = {
-    key: 'GS-',
+  /**
+   * `GS`, not the `GS-` this previously carried: `consentTranslations` emits `GS` for
+   * `dataUse.geographicalRestrictions`, so `GS` is the code a dataset is indexed under.
+   * The dbGaP spelling appends the region (`GS-US`), which the data library still
+   * recognizes — see `dataUseModifierLabel` — but no plain `GS-` is ever stored.
+   */
+  static readonly GS: SelectOptionWithKeyNameAndAbbreviation = {
+    key: 'GS',
     name: 'Geographic Restriction',
-    abbreviation: 'GS-',
+    abbreviation: 'GS',
   }
 
   static readonly MOR: SelectOptionWithKeyNameAndAbbreviation = {
@@ -52,7 +58,7 @@ export class SecondaryDataUseTerms {
     SecondaryDataUseTerms.PUB,
     SecondaryDataUseTerms.COL,
     SecondaryDataUseTerms.IRB,
-    SecondaryDataUseTerms.GSMINUS,
+    SecondaryDataUseTerms.GS,
     SecondaryDataUseTerms.MOR,
     SecondaryDataUseTerms.NPU,
     SecondaryDataUseTerms.OTH,

--- a/src/hooks/useLibraryPageState.ts
+++ b/src/hooks/useLibraryPageState.ts
@@ -24,11 +24,16 @@ import { getFormattedName } from 'src/components/forms/SelectOptionInterface'
 /**
  * Panel wording for the secondary data use codes, keyed by the code the index stores.
  *
- * `SecondaryDataUseTerms` is the same list the dataset-submission and consent-group
- * forms render, so a restriction reads identically wherever it appears, and
- * `getFormattedName` supplies the app's existing `Name (ABBR)` format — the
- * abbreviation is what ties a checkbox to the grid's data use chip, which shows codes
- * only (`HMB-GSO-PUB`).
+ * `SecondaryDataUseTerms` carries the vocabulary the dataset-submission and
+ * consent-group forms are worded from, and `getFormattedName` supplies the app's
+ * existing `Name (ABBR)` format — the abbreviation is what ties a checkbox to the
+ * grid's data use chip, which shows codes only (`HMB-GSO-PUB`).
+ *
+ * That class covers only the eight restrictions those forms collect, so the codes
+ * below fill in the rest of the secondary vocabulary the corpus can hold: the
+ * modifiers `consentTranslations` translates for the dataset views, plus the
+ * `AbstainDataUseCodes` the voting flow recognizes. Without them a real, selectable
+ * checkbox would read as a bare abbreviation.
  *
  * `OTHER` is spelled out rather than taken from `SecondaryDataUseTerms.OTH`: the form's
  * key does not match what the index stores, and `OTH2` is a label this app synthesizes
@@ -41,8 +46,26 @@ const DATA_USE_MODIFIER_LABELS: Record<string, string> = {
       .filter(term => term.key !== SecondaryDataUseTerms.OTH.key)
       .map(term => [term.key, getFormattedName(term)]),
   ),
-  OTHER: 'Other Secondary Restriction (OTH2)',
+  'OTHER': 'Other Secondary Restriction (OTH2)',
+  'NCTRL': 'No Control Set Use (NCTRL)',
+  'NAGR': 'No Aggregate-Level Data Use (NAGR)',
+  'NCU': 'Non-Commercial Use Only (NCU)',
+  'RS-G': 'Gender-Specific Research (RS-G)',
+  'RS-PD': 'Pediatric Research Only (RS-PD)',
+  'POP-M': 'Male-Specific Research (POP-M)',
+  'POP-F': 'Female-Specific Research (POP-F)',
+  'POP-PD': 'Pediatric Research Only (POP-PD)',
 }
+
+/**
+ * A geographic restriction is the one modifier whose code is not fixed: dbGaP appends
+ * the permitted region to it (`GS-US`), so the exact code cannot be enumerated above.
+ * Match the family by prefix and keep the region visible — the alternative is the bare
+ * code, and the region is the whole substance of the restriction.
+ */
+const dataUseModifierLabel = (code: string): string =>
+  DATA_USE_MODIFIER_LABELS[code]
+  ?? (code.startsWith('GS-') ? `Geographic Restriction (${code})` : code)
 
 export function useLibraryPageState(libraryConfig: LibraryVersionNew) {
   const [urlState, updateUrlState] = useLibraryUrlState()
@@ -123,11 +146,12 @@ export function useLibraryPageState(libraryConfig: LibraryVersionNew) {
     // Type do, so no checkbox can match nothing and no indexed code is unfilterable —
     // the app's three hand-maintained lists of secondary codes disagree with each
     // other, and only the index settles which spelling is real. Counts are deliberately
-    // omitted; a code with no label falls back to its bare abbreviation.
+    // omitted; a code the label map has never heard of still lists, as its bare
+    // abbreviation, rather than being dropped from a filter the corpus supports.
     const dataUseModifierAgg = (metadata?.data_use_modifiers as AggregationResult)?.buckets || []
     const dataUseModifierOptions = dataUseModifierAgg
       .map(bucket => bucket.key as string)
-      .map(code => ({ value: code, label: DATA_USE_MODIFIER_LABELS[code] ?? code }))
+      .map(code => ({ value: code, label: dataUseModifierLabel(code) }))
       .sort((a, b) => a.label.localeCompare(b.label))
     const uniqueValues = (values: Array<string | undefined | null>) =>
       [...new Set(values.map(v => v?.trim()).filter(Boolean) as string[])]

--- a/src/hooks/useLibraryPageState.ts
+++ b/src/hooks/useLibraryPageState.ts
@@ -18,6 +18,31 @@ import {
   clinicalTrialPhaseSelectOptions,
   clinicalTrialStatusSelectOptions,
 } from 'src/utils/ClinicalTrialEnumUtils'
+import { SecondaryDataUseTerms } from 'src/components/forms/SecondaryDataUseTerms'
+import { getFormattedName } from 'src/components/forms/SelectOptionInterface'
+
+/**
+ * Panel wording for the secondary data use codes, keyed by the code the index stores.
+ *
+ * `SecondaryDataUseTerms` is the same list the dataset-submission and consent-group
+ * forms render, so a restriction reads identically wherever it appears, and
+ * `getFormattedName` supplies the app's existing `Name (ABBR)` format — the
+ * abbreviation is what ties a checkbox to the grid's data use chip, which shows codes
+ * only (`HMB-GSO-PUB`).
+ *
+ * `OTHER` is spelled out rather than taken from `SecondaryDataUseTerms.OTH`: the form's
+ * key does not match what the index stores, and `OTH2` is a label this app synthesizes
+ * at render time to tell a secondary other apart from a primary one (see
+ * `processDataUseCodes`).
+ */
+const DATA_USE_MODIFIER_LABELS: Record<string, string> = {
+  ...Object.fromEntries(
+    SecondaryDataUseTerms.VALUES
+      .filter(term => term.key !== SecondaryDataUseTerms.OTH.key)
+      .map(term => [term.key, getFormattedName(term)]),
+  ),
+  OTHER: 'Other Secondary Restriction (OTH2)',
+}
 
 export function useLibraryPageState(libraryConfig: LibraryVersionNew) {
   const [urlState, updateUrlState] = useLibraryUrlState()
@@ -94,6 +119,16 @@ export function useLibraryPageState(libraryConfig: LibraryVersionNew) {
     const dacAgg = (metadata?.dac as AggregationResult)?.buckets || []
     const dataTypeAgg = (metadata?.data_type as AggregationResult)?.buckets || []
 
+    // Options come from the codes the corpus actually contains, the way DAC and Data
+    // Type do, so no checkbox can match nothing and no indexed code is unfilterable —
+    // the app's three hand-maintained lists of secondary codes disagree with each
+    // other, and only the index settles which spelling is real. Counts are deliberately
+    // omitted; a code with no label falls back to its bare abbreviation.
+    const dataUseModifierAgg = (metadata?.data_use_modifiers as AggregationResult)?.buckets || []
+    const dataUseModifierOptions = dataUseModifierAgg
+      .map(bucket => bucket.key as string)
+      .map(code => ({ value: code, label: DATA_USE_MODIFIER_LABELS[code] ?? code }))
+      .sort((a, b) => a.label.localeCompare(b.label))
     const uniqueValues = (values: Array<string | undefined | null>) =>
       [...new Set(values.map(v => v?.trim()).filter(Boolean) as string[])]
         .sort((a, b) => a.localeCompare(b))
@@ -122,6 +157,7 @@ export function useLibraryPageState(libraryConfig: LibraryVersionNew) {
         { value: 'OTHER', label: 'Other Restriction' },
         { value: 'NRES', label: 'No Restrictions' },
       ],
+      dataUseModifiers: dataUseModifierOptions,
       dataType: dataTypeAgg
         .map(bucket => ({ value: bucket.key as string, label: bucket.key as string, count: bucket.doc_count }))
         .sort((a, b) => a.label.localeCompare(b.label)),

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -7,6 +7,7 @@ type ArrayFilterParamConfig = {
     FilterState,
     | 'accessManagement'
     | 'dataUse'
+    | 'dataUseModifiers'
     | 'dataType'
     | 'dac'
     | 'workspaceTools'
@@ -42,6 +43,7 @@ type DateFilterParamConfig = {
 const ARRAY_FILTER_PARAM_CONFIG: ArrayFilterParamConfig[] = [
   { key: 'accessManagement', param: 'access' },
   { key: 'dataUse', param: 'dataUse' },
+  { key: 'dataUseModifiers', param: 'dataUseModifiers' },
   { key: 'dataType', param: 'dataType' },
   { key: 'dac', param: 'dac' },
   { key: 'workspaceTools', param: 'workspaceTools' },

--- a/src/libs/dataLibraryFilterConfig.ts
+++ b/src/libs/dataLibraryFilterConfig.ts
@@ -2,12 +2,13 @@ import { AssetFilterConfig, AssetType } from 'src/types/library'
 
 export const assetFilterRegistry: Record<AssetType, AssetFilterConfig> = {
   [AssetType.STUDIES]: {
-    visibleFilters: ['accessManagement', 'dataUse', 'dataType', 'dac', 'participantCount'],
+    visibleFilters: ['accessManagement', 'dataUse', 'dataUseModifiers', 'dataType', 'dac', 'participantCount'],
   },
   [AssetType.DATASETS]: {
     visibleFilters: [
       'accessManagement',
       'dataUse',
+      'dataUseModifiers',
       'dataType',
       'dac',
       'participantCount',

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -42,6 +42,9 @@ export enum AccessManagement {
 export interface FilterState {
   accessManagement: string[]
   dataUse: string[]
+  // Secondary data use conditions (DUO modifiers, e.g. NPU/IRB/PUB). Kept
+  // separate from `dataUse` so a primary code and a modifier combine with AND.
+  dataUseModifiers: string[]
   dataType: string[]
   dac: string[]
   workspaceTools: string[]
@@ -112,6 +115,7 @@ export interface LibraryFilterSection {
 export interface AvailableFilters {
   accessManagement: FilterOption[]
   dataUse: FilterOption[]
+  dataUseModifiers: FilterOption[]
   dataType: FilterOption[]
   dac: FilterOption[]
   workspaceTools: FilterOption[]

--- a/src/utils/DataUseUtils.tsx
+++ b/src/utils/DataUseUtils.tsx
@@ -2,9 +2,18 @@ import React, { CSSProperties, ReactNode } from 'react'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
 import { DatasetTerm } from 'src/types/model'
 
-interface DataUseCode {
+export type DataUseCodeType = 'primary' | 'secondary'
+
+export interface DataUseCode {
   code: string
+  /**
+   * The bare DUO code, for displays too tight to carry `code` in full — `code`
+   * appends the disease list for DS (`DS (Breast Cancer)`), which does not fit
+   * where several codes are shown together.
+   */
+  shortCode: string
   description: string
+  type: DataUseCodeType
 }
 
 interface ProcessedDataUseCodes {
@@ -18,17 +27,22 @@ interface ProcessedDataUseCodes {
  * @returns {ProcessedDataUseCodes} - Object with processed data use information
  */
 export function processDataUseCodes(dataset: DatasetTerm): ProcessedDataUseCodes {
-  const codesAndDescriptions = dataset.dataUse?.primary
+  const codesAndDescriptions: DataUseCode[] = dataset.dataUse?.primary
     ? dataset.dataUse.primary.map((dataUse) => {
         if (dataUse.code === 'OTHER') {
-          return { code: `OTH1`, description: dataUse.description }
+          return { code: `OTH1`, shortCode: 'OTH1', description: dataUse.description, type: 'primary' }
         }
         else if (dataUse.code === 'DS') {
-          const disease = dataUse.description.substring(dataUse.description.indexOf(':') + 2)
-          return { code: `${dataUse.code} (${disease})`, description: dataUse.description }
+          // The diseases follow a "Disease specific: <list>" prefix. Guard the split:
+          // a description with no colon (or none at all) must still yield a usable
+          // code, since the library grid derives a whole row's cell value from this.
+          const separator = dataUse.description?.indexOf(':') ?? -1
+          const disease = separator >= 0 ? dataUse.description.substring(separator + 2) : dataUse.description
+          const code = disease ? `${dataUse.code} (${disease})` : dataUse.code
+          return { code, shortCode: dataUse.code, description: dataUse.description, type: 'primary' }
         }
         else {
-          return { code: dataUse.code, description: dataUse.description }
+          return { code: dataUse.code, shortCode: dataUse.code, description: dataUse.description, type: 'primary' }
         }
       })
     : []
@@ -36,10 +50,10 @@ export function processDataUseCodes(dataset: DatasetTerm): ProcessedDataUseCodes
   if (dataset.dataUse?.secondary) {
     dataset.dataUse.secondary.forEach((dataUse) => {
       if (dataUse.code === 'OTHER') {
-        codesAndDescriptions.push({ code: `OTH2`, description: dataUse.description })
+        codesAndDescriptions.push({ code: `OTH2`, shortCode: 'OTH2', description: dataUse.description, type: 'secondary' })
       }
       else {
-        codesAndDescriptions.push({ code: dataUse.code, description: dataUse.description })
+        codesAndDescriptions.push({ code: dataUse.code, shortCode: dataUse.code, description: dataUse.description, type: 'secondary' })
       }
     })
   }

--- a/test/components/dac_dataset_table/DACDatasetTableCellData.spec.tsx
+++ b/test/components/dac_dataset_table/DACDatasetTableCellData.spec.tsx
@@ -22,7 +22,12 @@ vi.mock('src/libs/ajax/DataSet', () => ({
 }))
 
 vi.mock('src/utils/DataUseUtils', () => ({
-  processDataUseCodes: vi.fn(() => ({ codeList: ['HMB'], codesAndDescriptions: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }] })),
+  processDataUseCodes: vi.fn(() => ({
+    codeList: ['HMB'],
+    // Mirrors the real DataUseCode shape (shortCode/type included) — vi.mock factories
+    // are not type-checked against the module, so this has to be kept in step by hand.
+    codesAndDescriptions: [{ code: 'HMB', shortCode: 'HMB', description: 'Health/Medical/Biomedical', type: 'primary' }],
+  })),
   createDataUseDisplay: vi.fn(() => <span>HMB</span>),
 }))
 

--- a/test/components/dac_dataset_table/DACDatasetsTable.spec.tsx
+++ b/test/components/dac_dataset_table/DACDatasetsTable.spec.tsx
@@ -30,7 +30,12 @@ vi.mock('src/utils/DataUseUtils', () => ({
   processDataUseCodes: vi.fn((dataset: DatasetTerm) => {
     const primary = (dataset.dataUse as { primary?: Array<{ code: string, description: string }> })?.primary ?? []
     const codeList = primary.map(p => p.code)
-    return { codeList, codesAndDescriptions: primary }
+    // Mirrors the real DataUseCode shape (shortCode/type included) — vi.mock factories
+    // are not type-checked against the module, so this has to be kept in step by hand.
+    return {
+      codeList,
+      codesAndDescriptions: primary.map(p => ({ ...p, shortCode: p.code, type: 'primary' })),
+    }
   }),
   createDataUseDisplay: vi.fn((opts: { dataset: DatasetTerm }) => {
     const primary = (opts.dataset.dataUse as { primary?: Array<{ code: string }> })?.primary ?? []

--- a/test/components/data_library/LibraryFilters.spec.tsx
+++ b/test/components/data_library/LibraryFilters.spec.tsx
@@ -16,6 +16,10 @@ const availableFilters: AvailableFilters = {
     { value: 'HMB', label: 'Health/Medical/Biomedical', count: 8 },
     { value: 'GRU', label: 'General Research Use', count: 3 },
   ],
+  dataUseModifiers: [
+    { value: 'NPU', label: 'Non-profit Use Only (NPU)' },
+    { value: 'IRB', label: 'Ethics Approval Required (IRB)' },
+  ],
   dataType: [
     { value: 'Phenotype', label: 'Phenotype', count: 7 },
     { value: 'Genomic', label: 'Genomic', count: 4 },
@@ -122,6 +126,22 @@ describe('LibraryFilters', () => {
     expect(onChange).toHaveBeenCalledWith({
       ...EMPTY_FILTERS,
       accessManagement: ['controlled'],
+    })
+  })
+
+  it('toggles a secondary data use condition independently of the primary codes', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<LibraryFiltersWrapper filters={{ ...EMPTY_FILTERS, dataUse: ['HMB'] }} onChange={onChange} />)
+
+    await user.click(screen.getByText('Data Use Modifiers'))
+    await user.click(screen.getByRole('checkbox', { name: 'Non-profit Use Only (NPU)' }))
+
+    // The primary selection survives, so the two combine rather than replace.
+    expect(onChange).toHaveBeenCalledWith({
+      ...EMPTY_FILTERS,
+      dataUse: ['HMB'],
+      dataUseModifiers: ['NPU'],
     })
   })
 

--- a/test/components/data_library/columns/datasetColumns.spec.tsx
+++ b/test/components/data_library/columns/datasetColumns.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { makeMockParams } from './columnTestUtils'
 import { makeDatasetColumns } from 'src/components/data_library/columns/datasetColumns'
@@ -151,6 +152,167 @@ describe('datasetColumns — SO Approval column', () => {
     expect(chip?.getAttribute('title')).toMatch(expectedText)
     // describeChild keeps the label, not the tooltip text, as the accessible name
     expect(chip).not.toHaveAttribute('aria-label')
+  })
+})
+
+describe('datasetColumns — Data Use column', () => {
+  const chipLabels = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('.MuiChip-label')).map(el => el.textContent)
+
+  // The tooltip content is a rendered list, not a string, so MUI does not mirror it
+  // into the native `title` attribute — it has to be hovered open.
+  const hoverTooltipText = async (container: HTMLElement) => {
+    await userEvent.hover(container.querySelector('.MuiChip-root')!)
+    return (await screen.findByRole('tooltip')).textContent
+  }
+
+  const dataUseValue = (row: Partial<DatasetTerm>) => {
+    const col = makeDatasetColumns().find(c => c.field === 'dataUse')!
+    return (col.valueGetter as (v: unknown, r: DatasetTerm) => string)(undefined, makeRow(row))
+  }
+
+  it('joins primary and secondary codes into one hyphenated chip', () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }],
+        secondary: [
+          { code: 'PUB', description: 'Publication Required' },
+          { code: 'GSO', description: 'Genetic Studies Only' },
+        ],
+      },
+    })
+    expect(chipLabels(container)).toEqual(['HMB-GSO-PUB'])
+  })
+
+  it('leads with the primary codes even when a secondary sorts ahead of them', () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }],
+        secondary: [{ code: 'COL', description: 'Collaboration Required' }],
+      },
+    })
+    expect(chipLabels(container)).toEqual(['HMB-COL'])
+  })
+
+  it('keeps multiple primary codes in declaration order, ahead of the secondaries', () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [
+          { code: 'HMB', description: 'Health/Medical/Biomedical' },
+          { code: 'POA', description: 'Population Origins or Ancestry' },
+        ],
+        secondary: [{ code: 'IRB', description: 'IRB Approval Required' }],
+      },
+    })
+    expect(chipLabels(container)).toEqual(['HMB-POA-IRB'])
+  })
+
+  it('sorts the secondary conditions alphabetically, whatever order they arrive in', () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'GRU', description: 'General Research Use' }],
+        secondary: [
+          { code: 'PUB', description: 'Publication Required' },
+          { code: 'IRB', description: 'IRB Approval Required' },
+          { code: 'COL', description: 'Collaboration Required' },
+          { code: 'NPU', description: 'Not for Profit Use Only' },
+        ],
+      },
+    })
+    expect(chipLabels(container)).toEqual(['GRU-COL-IRB-NPU-PUB'])
+  })
+
+  it('shortens a disease-specific primary to DS, keeping the diseases in the tooltip', async () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'DS', description: 'Disease specific: Breast Cancer' }],
+        secondary: [{ code: 'NPU', description: 'Not for Profit Use Only' }],
+      },
+    })
+    expect(chipLabels(container)).toEqual(['DS-NPU'])
+    expect(await hoverTooltipText(container)).toContain('DS (Breast Cancer)')
+  })
+
+  it('numbers the two "other" restrictions so they stay distinguishable', () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'OTHER', description: 'Primary Other: ask first' }],
+        secondary: [{ code: 'OTHER', description: 'Secondary Other: and again' }],
+      },
+    })
+    expect(chipLabels(container)).toEqual(['OTH1-OTH2'])
+  })
+
+  it('names each code and its tier in the tooltip', async () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }],
+        secondary: [{ code: 'NPU', description: 'Not for Profit Use Only' }],
+      },
+    })
+    const title = await hoverTooltipText(container)
+    expect(title).toContain('Primary — HMB: Health/Medical/Biomedical')
+    expect(title).toContain('Secondary — NPU: Not for Profit Use Only')
+    // describeChild keeps the code sequence as the accessible name, not the descriptions
+    expect(container.querySelector('.MuiChip-root')).not.toHaveAttribute('aria-label')
+  })
+
+  it('lists the primary alongside every secondary in the tooltip, primary first', async () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }],
+        secondary: [
+          { code: 'PUB', description: 'Publication Required' },
+          { code: 'GSO', description: 'Genetic Studies Only' },
+        ],
+      },
+    })
+    await userEvent.hover(container.querySelector('.MuiChip-root')!)
+    const lines = Array.from((await screen.findByRole('tooltip')).querySelectorAll('li'))
+      .map(li => li.textContent)
+
+    // One line per code in the chip, in the same order the chip shows them.
+    expect(lines).toEqual([
+      'Primary — HMB: Health/Medical/Biomedical',
+      'Secondary — GSO: Genetic Studies Only',
+      'Secondary — PUB: Publication Required',
+    ])
+  })
+
+  it('lists the primary in the tooltip even with no secondary conditions at all', async () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: { primary: [{ code: 'GRU', description: 'General Research Use' }], secondary: [] },
+    })
+    expect(await hoverTooltipText(container)).toContain('Primary — GRU: General Research Use')
+  })
+
+  it('puts the chip in the tab order, since the tooltip is the only place the tiers appear', () => {
+    const { container } = renderCell('dataUse', undefined, {
+      dataUse: {
+        primary: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }],
+        secondary: [{ code: 'NPU', description: 'Not for Profit Use Only' }],
+      },
+    })
+    expect(container.querySelector('.MuiChip-root')).toHaveAttribute('tabindex', '0')
+  })
+
+  it('renders nothing when the dataset has no data use codes', () => {
+    const { container } = renderCell('dataUse', undefined, { dataUse: { primary: [], secondary: [] } })
+    expect(container.textContent).toBe('')
+  })
+
+  it('gives the cell the same value the chip displays', () => {
+    expect(dataUseValue({
+      dataUse: {
+        primary: [{ code: 'HMB', description: 'Health/Medical/Biomedical' }],
+        secondary: [
+          { code: 'PUB', description: 'Publication Required' },
+          { code: 'GSO', description: 'Genetic Studies Only' },
+        ],
+      },
+    })).toBe('HMB-GSO-PUB')
+
+    expect(dataUseValue({ dataUse: { primary: [], secondary: [] } })).toBe('')
   })
 })
 

--- a/test/components/data_library/filterRegistry.spec.ts
+++ b/test/components/data_library/filterRegistry.spec.ts
@@ -4,6 +4,7 @@ import {
   EMPTY_FILTERS,
   getExternalActiveFilters,
   getFilterSectionsForAsset,
+  isFilterActive,
   removeFilterValue,
 } from 'src/components/data_library/filterRegistry'
 import { AssetType, AvailableFilters, FilterState } from 'src/types/library'
@@ -11,6 +12,7 @@ import { AssetType, AvailableFilters, FilterState } from 'src/types/library'
 const availableFilters: AvailableFilters = {
   accessManagement: [],
   dataUse: [],
+  dataUseModifiers: [],
   dataType: [],
   dac: [],
   workspaceTools: [],
@@ -64,6 +66,75 @@ describe('filterRegistry', () => {
     expect(serialized).toContain('study.dataTypes')
     expect(serialized).toContain('participantCount')
     expect(serialized).toContain('study.assets.presentations.citation')
+  })
+
+  describe('data use modifiers', () => {
+    it('is offered on the tabs that carry data use, right after the primary codes', () => {
+      for (const tab of [AssetType.DATASETS, AssetType.STUDIES]) {
+        const keys = getFilterSectionsForAsset(tab, availableFilters).map(section => section.key)
+        expect(keys).toContain('dataUseModifiers')
+        expect(keys.indexOf('dataUseModifiers')).toBe(keys.indexOf('dataUse') + 1)
+      }
+    })
+
+    it('matches the selected codes against the secondary data use field', () => {
+      const clauses = buildActiveFilterClauses({ ...EMPTY_FILTERS, dataUseModifiers: ['NPU', 'IRB'] })
+      expect(clauses).toEqual([{
+        bool: {
+          should: [
+            { match_phrase: { 'dataUse.secondary.code': 'NPU' } },
+            { match_phrase: { 'dataUse.secondary.code': 'IRB' } },
+          ],
+        },
+      }])
+    })
+
+    it('phrase-matches, so a hyphenated code cannot spill into its siblings', () => {
+      // `match` would OR the tokens of RS-G ([rs, g]) and so also hit RS-PD ([rs, pd]).
+      const clauses = buildActiveFilterClauses({ ...EMPTY_FILTERS, dataUseModifiers: ['RS-G'] })
+      expect(JSON.stringify(clauses)).not.toContain('"match"')
+      expect(clauses).toEqual([{
+        bool: { should: [{ match_phrase: { 'dataUse.secondary.code': 'RS-G' } }] },
+      }])
+    })
+
+    it('builds no clause when nothing is selected', () => {
+      const clauses = buildActiveFilterClauses(EMPTY_FILTERS)
+      expect(JSON.stringify(clauses)).not.toContain('dataUse.secondary.code')
+    })
+
+    it('combines with a primary code as AND — separate clauses, not one OR', () => {
+      const clauses = buildActiveFilterClauses({
+        ...EMPTY_FILTERS,
+        dataUse: ['HMB'],
+        dataUseModifiers: ['NPU'],
+      })
+      // Two clauses land in the query's `filter` array, so both must hold.
+      expect(clauses).toHaveLength(2)
+      expect(JSON.stringify(clauses)).toContain('dataUse.primary.code')
+      expect(JSON.stringify(clauses)).toContain('dataUse.secondary.code')
+    })
+
+    it('counts as active once a code is selected, and drops a single code on removal', () => {
+      const state: FilterState = { ...EMPTY_FILTERS, dataUseModifiers: ['NPU', 'IRB'] }
+      expect(isFilterActive('dataUseModifiers', state)).toBe(true)
+      expect(isFilterActive('dataUseModifiers', EMPTY_FILTERS)).toBe(false)
+      expect(removeFilterValue(state, 'dataUseModifiers', 'NPU').dataUseModifiers).toEqual(['IRB'])
+    })
+
+    it('surfaces as a removable chip when set from a tab that does not show it', () => {
+      const chips = getExternalActiveFilters(
+        AssetType.MODELS,
+        { ...EMPTY_FILTERS, dataUseModifiers: ['NPU'] },
+        { ...availableFilters, dataUseModifiers: [{ value: 'NPU', label: 'Non-Profit Use Only' }] },
+      )
+      expect(chips).toContainEqual({
+        key: 'dataUseModifiers',
+        sectionLabel: 'Data Use Modifiers',
+        valueLabel: 'Non-Profit Use Only',
+        value: 'NPU',
+      })
+    })
   })
 
   describe('getExternalActiveFilters', () => {

--- a/test/hooks/useLibraryData.spec.tsx
+++ b/test/hooks/useLibraryData.spec.tsx
@@ -141,6 +141,17 @@ describe('buildElasticsearchQuery', () => {
     expect(query.aggs).toHaveProperty('access_management')
   })
 
+  it('aggregates the secondary data use codes that drive the modifier filter options', () => {
+    for (const tab of [AssetType.DATASETS, AssetType.STUDIES]) {
+      const query = buildElasticsearchQuery(libraryConfig, tab, filters, '', pagination)
+      const agg = query.aggs!.data_use_modifiers as { terms: { field: string, size: number } }
+      expect(agg.terms.field).toEqual('dataUse.secondary.code.keyword')
+      // A dropped bucket is a code nobody can filter on, so the ES default of 10 is
+      // raised past the size of any plausible secondary vocabulary.
+      expect(agg.terms.size).toBeGreaterThan(20)
+    }
+  })
+
   it('adds search term to query', () => {
     const query = buildElasticsearchQuery(libraryConfig, AssetType.DATASETS, filters, 'breast cancer', pagination)
     expect(query.query?.bool.must).toHaveLength(2)

--- a/test/hooks/useLibraryPageState.spec.tsx
+++ b/test/hooks/useLibraryPageState.spec.tsx
@@ -199,10 +199,10 @@ describe('useLibraryPageState — data use modifier options', () => {
   })
 
   it('words each restriction the way the submission forms do, with its abbreviation', () => {
-    const options = withModifierFacet(['IRB', 'MOR', 'GS-', 'NPU'])
+    const options = withModifierFacet(['IRB', 'MOR', 'GS', 'NPU'])
     expect(options).toContainEqual({ value: 'IRB', label: 'Ethics Approval Required (IRB)' })
     expect(options).toContainEqual({ value: 'MOR', label: 'Publication Moratorium (MOR)' })
-    expect(options).toContainEqual({ value: 'GS-', label: 'Geographic Restriction (GS-)' })
+    expect(options).toContainEqual({ value: 'GS', label: 'Geographic Restriction (GS)' })
     expect(options).toContainEqual({ value: 'NPU', label: 'Non-profit Use Only (NPU)' })
   })
 
@@ -211,12 +211,33 @@ describe('useLibraryPageState — data use modifier options', () => {
     expect(options).toEqual([{ value: 'OTHER', label: 'Other Secondary Restriction (OTH2)' }])
   })
 
+  it('words the modifiers the submission forms do not collect', () => {
+    // These live in `consentTranslations` and `AbstainDataUseCodes` rather than in
+    // SecondaryDataUseTerms, and are as real as any code the forms do collect.
+    const options = withModifierFacet(['NCTRL', 'NAGR', 'NCU', 'RS-G', 'RS-PD', 'POP-M', 'POP-F', 'POP-PD'])
+    expect(options).toContainEqual({ value: 'NCTRL', label: 'No Control Set Use (NCTRL)' })
+    expect(options).toContainEqual({ value: 'NAGR', label: 'No Aggregate-Level Data Use (NAGR)' })
+    expect(options).toContainEqual({ value: 'NCU', label: 'Non-Commercial Use Only (NCU)' })
+    expect(options).toContainEqual({ value: 'RS-G', label: 'Gender-Specific Research (RS-G)' })
+    expect(options).toContainEqual({ value: 'RS-PD', label: 'Pediatric Research Only (RS-PD)' })
+    expect(options).toContainEqual({ value: 'POP-M', label: 'Male-Specific Research (POP-M)' })
+    expect(options).toContainEqual({ value: 'POP-F', label: 'Female-Specific Research (POP-F)' })
+    expect(options).toContainEqual({ value: 'POP-PD', label: 'Pediatric Research Only (POP-PD)' })
+  })
+
+  it('reads a region-qualified geographic restriction, and the legacy bare GS-', () => {
+    // dbGaP appends the permitted region to the code, so `GS-US` cannot be enumerated;
+    // `GS-` is what datasets indexed under the app's older spelling still carry.
+    const options = withModifierFacet(['GS-US', 'GS-'])
+    expect(options).toContainEqual({ value: 'GS-US', label: 'Geographic Restriction (GS-US)' })
+    expect(options).toContainEqual({ value: 'GS-', label: 'Geographic Restriction (GS-)' })
+  })
+
   it('keeps a code with no label, showing its bare abbreviation', () => {
-    // POP-M and NCTRL appear in the app's other secondary-code lists but not in
-    // SecondaryDataUseTerms; they must stay filterable rather than vanish.
-    const options = withModifierFacet(['POP-M', 'NCTRL', 'NPU'])
-    expect(options).toContainEqual({ value: 'POP-M', label: 'POP-M' })
-    expect(options).toContainEqual({ value: 'NCTRL', label: 'NCTRL' })
+    // An unrecognized code must stay filterable rather than vanish from a filter the
+    // corpus supports — the index, not this app's code lists, decides what exists.
+    const options = withModifierFacet(['XYZ', 'NPU'])
+    expect(options).toContainEqual({ value: 'XYZ', label: 'XYZ' })
   })
 
   it('lists options alphabetically by label', () => {

--- a/test/hooks/useLibraryPageState.spec.tsx
+++ b/test/hooks/useLibraryPageState.spec.tsx
@@ -181,3 +181,56 @@ describe('useLibraryPageState — filter handlers', () => {
     })
   })
 })
+
+describe('useLibraryPageState — data use modifier options', () => {
+  const withModifierFacet = (codes: string[]) => {
+    vi.mocked(useLibraryMetadata).mockReturnValue({
+      data: { data_use_modifiers: { buckets: codes.map(key => ({ key, doc_count: 3 })) } },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useLibraryMetadata>)
+    setup(AssetType.DATASETS)
+    const { result } = renderHook(() => useLibraryPageState(libraryConfig))
+    return result.current.availableFilters.dataUseModifiers
+  }
+
+  it('offers exactly the codes the index reports, so no checkbox matches nothing', () => {
+    const options = withModifierFacet(['NPU', 'IRB', 'MOR'])
+    expect(options.map(option => option.value).sort()).toEqual(['IRB', 'MOR', 'NPU'])
+  })
+
+  it('words each restriction the way the submission forms do, with its abbreviation', () => {
+    const options = withModifierFacet(['IRB', 'MOR', 'GS-', 'NPU'])
+    expect(options).toContainEqual({ value: 'IRB', label: 'Ethics Approval Required (IRB)' })
+    expect(options).toContainEqual({ value: 'MOR', label: 'Publication Moratorium (MOR)' })
+    expect(options).toContainEqual({ value: 'GS-', label: 'Geographic Restriction (GS-)' })
+    expect(options).toContainEqual({ value: 'NPU', label: 'Non-profit Use Only (NPU)' })
+  })
+
+  it('labels a secondary other-restriction OTH2 while still querying the indexed OTHER', () => {
+    const options = withModifierFacet(['OTHER'])
+    expect(options).toEqual([{ value: 'OTHER', label: 'Other Secondary Restriction (OTH2)' }])
+  })
+
+  it('keeps a code with no label, showing its bare abbreviation', () => {
+    // POP-M and NCTRL appear in the app's other secondary-code lists but not in
+    // SecondaryDataUseTerms; they must stay filterable rather than vanish.
+    const options = withModifierFacet(['POP-M', 'NCTRL', 'NPU'])
+    expect(options).toContainEqual({ value: 'POP-M', label: 'POP-M' })
+    expect(options).toContainEqual({ value: 'NCTRL', label: 'NCTRL' })
+  })
+
+  it('lists options alphabetically by label', () => {
+    const labels = withModifierFacet(['PUB', 'COL', 'IRB', 'OTHER', 'ZZZ']).map(option => option.label)
+    expect(labels).toEqual([...labels].sort((a, b) => a.localeCompare(b)))
+  })
+
+  it('carries no facet counts', () => {
+    expect(withModifierFacet(['NPU', 'IRB']).every(option => option.count === undefined)).toBe(true)
+  })
+
+  it('offers nothing when the aggregation is absent, rather than throwing', () => {
+    setup(AssetType.DATASETS)
+    const { result } = renderHook(() => useLibraryPageState(libraryConfig))
+    expect(result.current.availableFilters.dataUseModifiers).toEqual([])
+  })
+})

--- a/test/hooks/useLibraryUrlState.spec.tsx
+++ b/test/hooks/useLibraryUrlState.spec.tsx
@@ -68,6 +68,17 @@ describe('useLibraryUrlState', () => {
     expect(filters.participantCount.min).toBe(5)
   })
 
+  it('reads primary and secondary data use codes from their own params', () => {
+    render(
+      <MemoryRouter initialEntries={['/?dataUse=HMB&dataUseModifiers=NPU,IRB']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+    const filters = JSON.parse(document.getElementById('filters')!.textContent!)
+    expect(filters.dataUse).toEqual(['HMB'])
+    expect(filters.dataUseModifiers).toEqual(['NPU', 'IRB'])
+  })
+
   it('updates state via updateState', () => {
     render(
       <MemoryRouter initialEntries={['/']}>


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3807](https://broadworkbench.atlassian.net/browse/DT-3807)

### Summary

* Adds chips formatted with Primary first and secondary alpha sorted + hyphen separated.
* Adds new filter panel for Data Use Modifiers

<img width="1512" height="644" alt="image" src="https://github.com/user-attachments/assets/331ae4fa-12c4-471d-a29f-eb2238b793fd" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
