### PR TITLE
[DT-3796] Admin DAA view.

### DIFF
--- a/src/components/DuosHeader.tsx
+++ b/src/components/DuosHeader.tsx
@@ -73,6 +73,7 @@ export const headerTabsConfig: Tab[] = [
       { label: 'Users', link: '/admin_manage_users' },
       { label: 'Institutions', link: '/admin_manage_institutions' },
       { label: 'Library Cards', link: '/admin_manage_lc' },
+      { label: 'DAA Associations', link: '/admin_daa_associations' },
     ],
     isRendered: user => user.isAdmin,
   },

--- a/src/pages/AdminDaaAssociations.tsx
+++ b/src/pages/AdminDaaAssociations.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+import { DaaAssociationsPage } from 'src/pages/signing_official_console/DAAAssignment'
+import { USER_ROLES } from 'src/libs/utils'
+
+const DESCRIPTION = 'Read-only view of DAA pre-authorization status for researchers across all '
+  + 'institutions. Pre-authorization is granted and revoked by each institution\'s Signing '
+  + 'Official.'
+
+/**
+ * Admin Console → DAA Associations.
+ *
+ * The SO Console page scoped to researchers at every institution and rendered
+ * read-only: admins observe pre-authorization status here, while granting and
+ * revoking remain a Signing Official responsibility.
+ */
+export const AdminDaaAssociations = function AdminDaaAssociations(): React.JSX.Element {
+  return (
+    <DaaAssociationsPage
+      title="DAA Associations"
+      description={DESCRIPTION}
+      scope={USER_ROLES.admin}
+      readOnly
+    />
+  )
+}
+
+export default AdminDaaAssociations

--- a/src/pages/signing_official_console/DAAAssignment/DAAAccordionRow.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAAccordionRow.tsx
@@ -12,8 +12,30 @@ import DAAResearcherSubtable from './DAAResearcherSubtable'
 import BulkActionButtons from './BulkActionButtons'
 import { DAAResearcherRowData } from './types'
 import { daaLabel, formatDateYYYYMMDD } from './researcherViewHelpers'
+import { accordionHeaderKeyboardProps } from './accordionHeaderKeyboard'
 
 const FONT = 'Montserrat'
+
+/**
+ * The recently-updated warning tells an SO to act on their own institution's
+ * researchers. An admin viewing the read-only, system-wide page has neither an
+ * institution nor the controls to act, so the same fact is stated without the
+ * call to action.
+ */
+const RECENTLY_UPDATED_TOOLTIP = {
+  managed: 'This DAA was updated within the last year. Review the agreement to ensure your '
+    + 'institution\'s researchers are operating under the most current terms.',
+  readOnly: 'This DAA was updated within the last year. Researchers pre-authorized before the '
+    + 'update may be operating under superseded terms.',
+} as const
+
+/** Body of the same warning as an in-panel banner, following the heading sentence. */
+const RECENTLY_UPDATED_BANNER = {
+  managed: ' Please review the agreement to ensure it reflects your institution\'s current data '
+    + 'governance expectations before authorizing new researchers.',
+  readOnly: ' Researchers pre-authorized before the update may be operating under superseded '
+    + 'terms.',
+} as const
 
 interface DAAAccordionRowProps {
   daa: DAAObject
@@ -29,6 +51,10 @@ interface DAAAccordionRowProps {
   onApproveAll: (researcherIds: number[]) => void
   /** Bulk "Remove All" — receives the ids of every currently-authorized researcher */
   onRemoveAll: (researcherIds: number[]) => void
+  /** Read-only mode (Admin Console): renders no bulk or per-row action buttons. */
+  readOnly?: boolean
+  /** Adds an Institution column to the researcher sub-table. */
+  showInstitution?: boolean
 }
 
 /**
@@ -41,6 +67,9 @@ interface DAAAccordionRowProps {
  * status and action buttons for this specific DAA.
  *
  * This is the DAA-first mirror of ResearcherAccordionRow.
+ *
+ * In read-only mode the bulk action buttons are omitted from the header and the
+ * sub-table drops its Action column, leaving status information only.
  */
 export default function DAAAccordionRow({
   daa,
@@ -54,6 +83,8 @@ export default function DAAAccordionRow({
   onRevoke,
   onApproveAll,
   onRemoveAll,
+  readOnly = false,
+  showInstitution = false,
 }: Readonly<DAAAccordionRowProps>) {
   const daaId = daa.daaId
   const label = daaLabel(daa)
@@ -86,6 +117,7 @@ export default function DAAAccordionRow({
         aria-controls={`daa-researcher-panel-${daaId}`}
         data-cy={`daa-accordion-toggle-${daaId}`}
         onClick={onToggle}
+        {...accordionHeaderKeyboardProps(onToggle)}
         sx={{
           'display': 'flex',
           'alignItems': 'center',
@@ -118,8 +150,7 @@ export default function DAAAccordionRow({
                 title={
                   (
                     <Typography sx={{ fontFamily: FONT, fontSize: 12, lineHeight: 1.6 }}>
-                      This DAA was updated within the last year. Review the agreement to ensure
-                      your institution&apos;s researchers are operating under the most current terms.
+                      {readOnly ? RECENTLY_UPDATED_TOOLTIP.readOnly : RECENTLY_UPDATED_TOOLTIP.managed}
                     </Typography>
                   )
                 }
@@ -149,13 +180,15 @@ export default function DAAAccordionRow({
 
         {/* Right: bulk actions + authorized count badge + chevron */}
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexShrink: 0, ml: 2 }}>
-          <BulkActionButtons
-            dataCyPrefix={`daa-${daaId}`}
-            approveAllDisabled={unauthorizedUserIds.length === 0}
-            removeAllDisabled={authorizedUserIds.length === 0}
-            onApproveAll={() => onApproveAll(unauthorizedUserIds)}
-            onRemoveAll={() => onRemoveAll(authorizedUserIds)}
-          />
+          {!readOnly && (
+            <BulkActionButtons
+              dataCyPrefix={`daa-${daaId}`}
+              approveAllDisabled={unauthorizedUserIds.length === 0}
+              removeAllDisabled={authorizedUserIds.length === 0}
+              onApproveAll={() => onApproveAll(unauthorizedUserIds)}
+              onRemoveAll={() => onRemoveAll(authorizedUserIds)}
+            />
+          )}
           {authorizedCount > 0 && (
             <Chip
               label={`${authorizedCount} pre-authorized`}
@@ -206,9 +239,8 @@ export default function DAAAccordionRow({
               <Typography
                 sx={{ fontFamily: FONT, fontSize: 13, color: '#e65100', lineHeight: 1.7 }}
               >
-                <strong>This DAA has been updated within the last year.</strong> Please review
-                the agreement to ensure it reflects your institution&apos;s current data
-                governance expectations before authorizing new researchers.
+                <strong>This DAA has been updated within the last year.</strong>
+                {readOnly ? RECENTLY_UPDATED_BANNER.readOnly : RECENTLY_UPDATED_BANNER.managed}
               </Typography>
             </Box>
           )}
@@ -216,6 +248,8 @@ export default function DAAAccordionRow({
             researcherRows={researcherRows}
             onAuthorize={onAuthorize}
             onRevoke={onRevoke}
+            readOnly={readOnly}
+            showInstitution={showInstitution}
           />
         </Box>
       </Collapse>

--- a/src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.tsx
@@ -10,6 +10,8 @@ import {
 import AuthStatusChip from './AuthStatusChip'
 import AuthActionButton from './AuthActionButton'
 import { AuthStatus, DAAResearcherRowData } from './types'
+import { ACTION_COLUMN, normalizedWidths, visibleColumns } from './subtableColumns'
+import { institutionLabel } from './researcherViewHelpers'
 
 const FONT = 'Montserrat'
 
@@ -41,17 +43,24 @@ function rowBorderColor(status: AuthStatus): string {
   return '1px solid #e5e7eb'
 }
 
+const INSTITUTION_COLUMN = 'Institution'
+
 const COLUMN_HEADERS = [
   'Researcher',
   'Email',
+  INSTITUTION_COLUMN,
   'Pre-Auth Status',
   'Pre-authorized By',
-  'Action',
+  ACTION_COLUMN,
 ] as const
 
-const COLUMN_WIDTHS: Record<(typeof COLUMN_HEADERS)[number], string> = {
+type ColumnHeader = (typeof COLUMN_HEADERS)[number]
+
+/** Relative weights, renormalized to 100% across whichever columns are shown. */
+const COLUMN_WIDTHS: Record<ColumnHeader, string> = {
   'Researcher': '23%',
   'Email': '25%',
+  'Institution': '20%',
   'Pre-Auth Status': '17%',
   'Pre-authorized By': '20%',
   'Action': '15%',
@@ -61,6 +70,13 @@ interface DAAResearcherSubtableProps {
   researcherRows: DAAResearcherRowData[]
   onAuthorize: (researcherId: number) => void
   onRevoke: (researcherId: number) => void
+  /** Read-only mode (Admin Console): drops the Action column entirely. */
+  readOnly?: boolean
+  /**
+   * Adds the Institution column. Only meaningful when the list spans more than
+   * one institution, which is the Admin Console's cross-institution scope.
+   */
+  showInstitution?: boolean
 }
 
 /**
@@ -71,19 +87,29 @@ interface DAAResearcherSubtableProps {
  *
  * This is the mirror of ResearcherDAASubtable — researcher-first instead of
  * DAA-first.
+ *
+ * In read-only mode the Action column — header and cells — is not rendered, so
+ * the same table serves the Admin Console's observe-only view; that view also
+ * adds an Institution column, since its rows span institutions.
  */
 export default function DAAResearcherSubtable({
   researcherRows,
   onAuthorize,
   onRevoke,
+  readOnly = false,
+  showInstitution = false,
 }: Readonly<DAAResearcherSubtableProps>) {
+  const columnHeaders = visibleColumns(COLUMN_HEADERS, readOnly)
+    .filter(column => showInstitution || column !== INSTITUTION_COLUMN)
+  const columnWidths = normalizedWidths(columnHeaders, COLUMN_WIDTHS)
+
   return (
     <Box sx={{ bgcolor: '#fafafa' }} data-cy="daa-researcher-subtable">
       <Table size="small">
         <TableHead>
           <TableRow sx={{ bgcolor: '#f0f0f0' }}>
-            {COLUMN_HEADERS.map(col => (
-              <TableCell key={col} sx={{ ...tableCellHeadSx, width: COLUMN_WIDTHS[col] }}>
+            {columnHeaders.map(col => (
+              <TableCell key={col} sx={{ ...tableCellHeadSx, width: columnWidths[col] }}>
                 {col}
               </TableCell>
             ))}
@@ -106,34 +132,44 @@ export default function DAAResearcherSubtable({
               <TableCell sx={tableCellBodySx}>
                 {researcher.email}
               </TableCell>
-              <TableCell sx={{ width: COLUMN_WIDTHS['Pre-Auth Status'] }}>
+              {showInstitution && (
+                <TableCell
+                  sx={{ ...tableCellBodySx, width: columnWidths[INSTITUTION_COLUMN] }}
+                  data-cy={`daa-researcher-institution-${researcher.userId}`}
+                >
+                  {institutionLabel(researcher)}
+                </TableCell>
+              )}
+              <TableCell sx={{ width: columnWidths['Pre-Auth Status'] }}>
                 <AuthStatusChip status={status} />
               </TableCell>
               <TableCell
-                sx={{ ...tableCellBodySx, width: COLUMN_WIDTHS['Pre-authorized By'] }}
+                sx={{ ...tableCellBodySx, width: columnWidths['Pre-authorized By'] }}
                 data-cy={`daa-authorized-by-${researcher.userId}`}
               >
                 {authorizedBy ?? '—'}
               </TableCell>
-              <TableCell
-                sx={{
-                  width: COLUMN_WIDTHS.Action,
-                  minWidth: 120,
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                <AuthActionButton
-                  status={status}
-                  onAuthorize={() => onAuthorize(researcher.userId)}
-                  onRevoke={() => onRevoke(researcher.userId)}
-                />
-              </TableCell>
+              {!readOnly && (
+                <TableCell
+                  sx={{
+                    width: COLUMN_WIDTHS.Action,
+                    minWidth: 120,
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  <AuthActionButton
+                    status={status}
+                    onAuthorize={() => onAuthorize(researcher.userId)}
+                    onRevoke={() => onRevoke(researcher.userId)}
+                  />
+                </TableCell>
+              )}
             </TableRow>
           ))}
           {researcherRows.length === 0 && (
             <TableRow>
               <TableCell
-                colSpan={COLUMN_HEADERS.length}
+                colSpan={columnHeaders.length}
                 sx={{ ...tableCellBodySx, textAlign: 'center', color: '#999', py: 4 }}
                 data-cy="daa-researcher-subtable-empty"
               >

--- a/src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.tsx
@@ -10,7 +10,7 @@ import {
 import AuthStatusChip from './AuthStatusChip'
 import AuthActionButton from './AuthActionButton'
 import { AuthStatus, DAAResearcherRowData } from './types'
-import { ACTION_COLUMN, normalizedWidths, visibleColumns } from './subtableColumns'
+import { ACTION_COLUMN, normalizedWidths, withoutActionColumn } from './subtableColumns'
 import { institutionLabel } from './researcherViewHelpers'
 
 const FONT = 'Montserrat'
@@ -99,7 +99,7 @@ export default function DAAResearcherSubtable({
   readOnly = false,
   showInstitution = false,
 }: Readonly<DAAResearcherSubtableProps>) {
-  const columnHeaders = visibleColumns(COLUMN_HEADERS, readOnly)
+  const columnHeaders = (readOnly ? withoutActionColumn(COLUMN_HEADERS) : COLUMN_HEADERS)
     .filter(column => showInstitution || column !== INSTITUTION_COLUMN)
   const columnWidths = normalizedWidths(columnHeaders, COLUMN_WIDTHS)
 

--- a/src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.tsx
@@ -152,7 +152,7 @@ export default function DAAResearcherSubtable({
               {!readOnly && (
                 <TableCell
                   sx={{
-                    width: COLUMN_WIDTHS.Action,
+                    width: columnWidths[ACTION_COLUMN],
                     minWidth: 120,
                     whiteSpace: 'nowrap',
                   }}

--- a/src/pages/signing_official_console/DAAAssignment/DAAView.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DAAView.tsx
@@ -18,7 +18,7 @@ import ResearcherViewConfirmDialog from './ResearcherViewConfirmDialog'
 import BulkActionConfirmDialog from './BulkActionConfirmDialog'
 import { buildDAAViewRows, daaLabel } from './researcherViewHelpers'
 import { useBulkPreAuthorization } from './useBulkPreAuthorization'
-import { BulkConfirmState, ConfirmDialogState, DAAAccordionData } from './types'
+import { BulkConfirmState, ConfirmDialogState, DAAAccordionData, UserListScope } from './types'
 
 const FONT = 'Montserrat'
 const BRAND_BLUE = '#0948b7'
@@ -40,6 +40,24 @@ export interface DAAViewProps {
   readonly daas: readonly DAAObject[]
   readonly isLoading: boolean
   readonly onResearchersRefresh: (updated: DuosUser[]) => void
+  /**
+   * Role scope to reload the user list with after a mutation. Must match the
+   * scope the page loaded with, or a refresh would silently swap the list for a
+   * differently-scoped one.
+   */
+  readonly scope?: UserListScope
+  /**
+   * Read-only mode (Admin Console). Suppresses every mutating control: the
+   * per-row action buttons, the bulk Approve All / Remove All buttons, and the
+   * confirmation dialogs those buttons open.
+   */
+  readonly readOnly?: boolean
+  /**
+   * Adds an Institution column to each DAA's researcher sub-table. Only
+   * meaningful when the list spans more than one institution, which is the Admin
+   * Console's cross-institution scope.
+   */
+  readonly showInstitution?: boolean
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -56,12 +74,19 @@ export interface DAAViewProps {
  *
  * Auth mutations (createDaaLcLink / deleteDaaLcLink) are the same APIs used
  * by the existing ManageResearcherDAAs page.
+ *
+ * With `readOnly` set, the same view becomes the Admin Console's observe-only
+ * list: identical layout, search, expand/collapse and legend, but no controls
+ * that can change a pre-authorization.
  */
 export default function DAAView({
   researchers,
   daas,
   isLoading,
   onResearchersRefresh,
+  scope = USER_ROLES.signingOfficial,
+  readOnly = false,
+  showInstitution = false,
 }: Readonly<DAAViewProps>) {
   const [search, setSearch] = useState('')
   const [expanded, setExpanded] = useState<Record<number, boolean>>({})
@@ -92,13 +117,13 @@ export default function DAAView({
 
   const refreshResearchers = useCallback(async () => {
     try {
-      const updated = await User.list(USER_ROLES.signingOfficial)
+      const updated = await User.list(scope)
       onResearchersRefresh(updated)
     }
     catch {
       Notifications.showError({ text: 'Failed to refresh researcher list' })
     }
-  }, [onResearchersRefresh])
+  }, [onResearchersRefresh, scope])
 
   const toggleRow = useCallback((daaId: number) => {
     setExpanded(prev => ({ ...prev, [daaId]: !prev[daaId] }))
@@ -276,7 +301,7 @@ export default function DAAView({
             researcherRows={row.researcherRows}
             authorizedCount={row.authorizedCount}
             isRecentlyUpdated={row.isRecentlyUpdated}
-            isExpanded={expanded[row.daa.daaId]}
+            isExpanded={expanded[row.daa.daaId] ?? false}
             onToggle={() => toggleRow(row.daa.daaId)}
             onAuthorize={researcherId => openAuthorizeDialog(
               row.daa.daaId,
@@ -304,9 +329,16 @@ export default function DAAView({
               'remove',
               userIds,
             )}
+            readOnly={readOnly}
+            showInstitution={showInstitution}
           />
         ))}
       </Box>
+
+      {/*
+        Both dialogs render nothing until their state is set, and read-only mode
+        renders no control that can set it — so they self-suppress there.
+      */}
 
       {/* Single-relationship confirmation dialog (shared with ResearcherView) */}
       <ResearcherViewConfirmDialog

--- a/src/pages/signing_official_console/DAAAssignment/DaaAssociationsPage.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/DaaAssociationsPage.tsx
@@ -1,0 +1,219 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { Tabs, Tab, Box } from '@mui/material'
+
+import ResearcherView from './ResearcherView'
+import DAAView from './DAAView'
+import { User } from 'src/libs/ajax/User'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
+import { DAA } from 'src/libs/ajax/DAA'
+import { DAAObject, DuosUser } from 'src/types/model'
+import { UserListScope } from './types'
+import { extractError } from 'src/utils/ErrorUtils'
+import TableHeaderSection from 'src/components/TableHeaderSection'
+import { usePageTitle } from 'src/hooks/usePageTitle'
+
+const TAB_SX = {
+  textTransform: 'none',
+  fontSize: '15px',
+  fontFamily: 'Montserrat, sans-serif',
+  color: '#00609f',
+  fontWeight: 'bold',
+  padding: '0 25px',
+} as const
+
+const TAB_PANEL_SX = {
+  backgroundColor: '#f5f5f5',
+  paddingLeft: '7rem',
+  paddingRight: '5rem',
+  paddingTop: '2rem',
+  paddingBottom: '2rem',
+} as const
+
+/**
+ * Whether a user from a list response holds the Researcher role.
+ *
+ * Reads `roles`, not the `isResearcher` convenience flag: that flag is derived
+ * by `setUserRoleStatuses` for the signed-in user only, so on a list response it
+ * is absent. `roles` is what the payload actually carries — the same field the
+ * admin user table reads via `formatUserRoles`.
+ */
+function isResearcher(user: DuosUser): boolean {
+  return (user.roles ?? []).some(role => role.name === USER_ROLES.researcher)
+}
+
+/**
+ * Narrows a loaded user list to the researchers the page is about.
+ *
+ * The `SigningOfficial` scope already returns only the researchers at the SO's
+ * institution, so it is passed through untouched. The `Admin` scope returns
+ * every user of every role — admins, DAC chairs, signing officials, service
+ * accounts — and pre-authorization applies to none of them, so those are
+ * dropped rather than listed as researcher cards with no pre-auth status.
+ */
+function scopeToResearchers(users: DuosUser[], scope: UserListScope): DuosUser[] {
+  return scope === USER_ROLES.admin ? users.filter(isResearcher) : users
+}
+
+export interface DaaAssociationsPageProps {
+  /** Page heading, also used as the document title. */
+  readonly title: string
+  readonly description: string
+  /**
+   * Which user list to load. `SigningOfficial` returns the researchers at the
+   * signed-in SO's institution; `Admin` returns users across every institution,
+   * narrowed to researchers by {@link scopeToResearchers}.
+   */
+  readonly scope: UserListScope
+  /**
+   * Renders the page without any control that can change a pre-authorization —
+   * no per-row or bulk action buttons, and no confirmation dialogs. Implied by
+   * the `Admin` scope, which is read-only by definition.
+   */
+  readonly readOnly?: boolean
+}
+
+/**
+ * The DAA Associations page, shared by the SO Console (manage) and the Admin
+ * Console (read-only, system-wide).
+ *
+ * Both consoles get the identical page structure — header section, Researcher
+ * View / DAA View tab bar, search, legend, expand/collapse-all and accordion
+ * lists. The only differences are which user list is loaded and whether the
+ * mutating controls are rendered.
+ */
+export default function DaaAssociationsPage({
+  title,
+  description,
+  scope,
+  readOnly = false,
+}: Readonly<DaaAssociationsPageProps>): React.JSX.Element {
+  usePageTitle(title)
+  const [researchers, setResearchers] = useState<DuosUser[]>([])
+  const [daas, setDaas] = useState<DAAObject[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState(0)
+
+  // Granting and revoking is a Signing Official responsibility, so the
+  // cross-institution scope cannot be paired with the mutating controls even by
+  // a caller that forgets to ask for read-only.
+  const isReadOnly = readOnly || scope === USER_ROLES.admin
+
+  // An SO's list is one institution, so naming it on every row would be noise.
+  // The admin list spans institutions, where it is the only way to tell two
+  // similarly-named researchers apart or to narrow the list to one institution.
+  const showInstitution = scope === USER_ROLES.admin
+
+  // Every path that sets the list — the initial load and any post-mutation
+  // refresh inside the views — funnels through the same narrowing.
+  const handleResearchersRefresh = useCallback(
+    (updated: DuosUser[]) => setResearchers(scopeToResearchers(updated, scope)),
+    [scope],
+  )
+
+  useEffect(() => {
+    // A scope change re-runs this effect; ignore whatever the superseded run
+    // returns so a slow response cannot overwrite the current scope's data.
+    let ignore = false
+
+    const init = async () => {
+      setIsLoading(true)
+      try {
+        // Independent requests: the page waits for the slower of the two, not both.
+        const [userList, daaList] = await Promise.all([User.list(scope), DAA.getDaas()])
+        if (ignore) return
+        setResearchers(scopeToResearchers(userList, scope))
+        // A DAA is always associated with the DAC that uploaded it, even when it is not that DAC's
+        // active agreement. Anything with no DAC at all is legacy data we can ignore.
+        setDaas(daaList.filter(daa => Array.isArray(daa.dacs) && daa.dacs.length > 0))
+      }
+      catch (error) {
+        if (ignore) return
+        console.error('Failed to load DAA associations page data', error)
+        Notifications.showError({
+          text: `Error: Unable to retrieve DAA association data from server: ${extractError(error)}`,
+        })
+      }
+      finally {
+        if (!ignore) setIsLoading(false)
+      }
+    }
+    init()
+
+    return () => {
+      ignore = true
+    }
+  }, [scope])
+
+  return (
+    <div>
+      <Box sx={{ paddingLeft: '4rem', maxWidth: '50%', marginBottom: '2rem' }}>
+        <TableHeaderSection
+          title={title}
+          description={description}
+        />
+      </Box>
+      <Box
+        sx={{
+          borderTop: 1,
+          borderBottom: 1,
+          borderColor: 'divider',
+          paddingLeft: '5rem',
+          paddingRight: '5rem',
+        }}
+      >
+        <Tabs
+          value={activeTab}
+          onChange={(_event, newValue) => setActiveTab(newValue)}
+          aria-label="DAA association views"
+          variant="scrollable"
+          scrollButtons="auto"
+          allowScrollButtonsMobile
+          slotProps={{
+            indicator: {
+              style: { backgroundColor: '#00609f' },
+            },
+          }}
+        >
+          <Tab
+            key="researcherView"
+            value={0}
+            label="Researcher View"
+            sx={{ ...TAB_SX, marginLeft: '2rem' }}
+          />
+          <Tab
+            key="daaView"
+            value={1}
+            label="DAA View"
+            sx={TAB_SX}
+          />
+        </Tabs>
+      </Box>
+      {activeTab === 0 && (
+        <Box sx={TAB_PANEL_SX}>
+          <ResearcherView
+            researchers={researchers}
+            daas={daas}
+            isLoading={isLoading}
+            onResearchersRefresh={handleResearchersRefresh}
+            scope={scope}
+            readOnly={isReadOnly}
+            showInstitution={showInstitution}
+          />
+        </Box>
+      )}
+      {activeTab === 1 && (
+        <Box sx={TAB_PANEL_SX}>
+          <DAAView
+            researchers={researchers}
+            daas={daas}
+            isLoading={isLoading}
+            onResearchersRefresh={handleResearchersRefresh}
+            scope={scope}
+            readOnly={isReadOnly}
+            showInstitution={showInstitution}
+          />
+        </Box>
+      )}
+    </div>
+  )
+}

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.tsx
@@ -10,6 +10,8 @@ import { DuosUser } from 'src/types/model'
 import ResearcherDAASubtable from './ResearcherDAASubtable'
 import BulkActionButtons from './BulkActionButtons'
 import { DAARowData } from './types'
+import { accordionHeaderKeyboardProps } from './accordionHeaderKeyboard'
+import { institutionLabel } from './researcherViewHelpers'
 
 const FONT = 'Montserrat'
 
@@ -25,6 +27,14 @@ interface ResearcherAccordionRowProps {
   onApproveAll: (daaIds: number[]) => void
   /** Bulk "Remove All" — receives the ids of every currently-authorized DAA */
   onRemoveAll: (daaIds: number[]) => void
+  /** Read-only mode (Admin Console): renders no bulk or per-row action buttons. */
+  readOnly?: boolean
+  /**
+   * Shows the researcher's institution in the card header. Only meaningful when
+   * the list spans more than one institution, which is the Admin Console's
+   * cross-institution scope.
+   */
+  showInstitution?: boolean
 }
 
 /**
@@ -32,6 +42,9 @@ interface ResearcherAccordionRowProps {
  *
  * The card header shows the researcher's name, email, and summary badge counts.
  * When expanded, a sub-table lists each DAA with its status and an action button.
+ *
+ * In read-only mode the bulk action buttons are omitted from the header and the
+ * sub-table drops its Action column, leaving status information only.
  */
 export default function ResearcherAccordionRow({
   researcher,
@@ -43,6 +56,8 @@ export default function ResearcherAccordionRow({
   onRevoke,
   onApproveAll,
   onRemoveAll,
+  readOnly = false,
+  showInstitution = false,
 }: Readonly<ResearcherAccordionRowProps>) {
   const researcherId = researcher.userId
 
@@ -73,6 +88,7 @@ export default function ResearcherAccordionRow({
         aria-controls={`researcher-daa-panel-${researcherId}`}
         data-cy={`researcher-row-toggle-${researcherId}`}
         onClick={onToggle}
+        {...accordionHeaderKeyboardProps(onToggle)}
         sx={{
           'display': 'flex',
           'alignItems': 'center',
@@ -108,6 +124,14 @@ export default function ResearcherAccordionRow({
             <Typography sx={{ fontFamily: FONT, fontSize: 12, color: '#888' }}>
               {researcher.email}
             </Typography>
+            {showInstitution && (
+              <Typography
+                data-cy={`researcher-institution-${researcherId}`}
+                sx={{ fontFamily: FONT, fontSize: 12, color: '#888' }}
+              >
+                {institutionLabel(researcher)}
+              </Typography>
+            )}
           </Box>
         </Box>
 
@@ -135,13 +159,15 @@ export default function ResearcherAccordionRow({
               No pre-auth status
             </Typography>
           )}
-          <BulkActionButtons
-            dataCyPrefix={`researcher-${researcherId}`}
-            approveAllDisabled={unauthorizedDaaIds.length === 0}
-            removeAllDisabled={authorizedDaaIds.length === 0}
-            onApproveAll={() => onApproveAll(unauthorizedDaaIds)}
-            onRemoveAll={() => onRemoveAll(authorizedDaaIds)}
-          />
+          {!readOnly && (
+            <BulkActionButtons
+              dataCyPrefix={`researcher-${researcherId}`}
+              approveAllDisabled={unauthorizedDaaIds.length === 0}
+              removeAllDisabled={authorizedDaaIds.length === 0}
+              onApproveAll={() => onApproveAll(unauthorizedDaaIds)}
+              onRemoveAll={() => onRemoveAll(authorizedDaaIds)}
+            />
+          )}
         </Box>
       </Box>
 
@@ -156,6 +182,7 @@ export default function ResearcherAccordionRow({
           daaRows={daaRows}
           onAuthorize={onAuthorize}
           onRevoke={onRevoke}
+          readOnly={readOnly}
         />
       </Collapse>
     </Paper>

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.tsx
@@ -11,7 +11,7 @@ import AuthStatusChip from './AuthStatusChip'
 import AuthActionButton from './AuthActionButton'
 import { AuthStatus, DAARowData } from './types'
 import { daaLabel, formatDateYYYYMMDD } from './researcherViewHelpers'
-import { ACTION_COLUMN, visibleColumns } from './subtableColumns'
+import { ACTION_COLUMN, withoutActionColumn } from './subtableColumns'
 
 const FONT = 'Montserrat'
 
@@ -67,7 +67,7 @@ export default function ResearcherDAASubtable({
   onRevoke,
   readOnly = false,
 }: Readonly<ResearcherDAASubtableProps>) {
-  const columnHeaders = visibleColumns(COLUMN_HEADERS, readOnly)
+  const columnHeaders = readOnly ? withoutActionColumn(COLUMN_HEADERS) : COLUMN_HEADERS
 
   return (
     <Box sx={{ bgcolor: '#fafafa' }} data-cy="daa-subtable">

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.tsx
@@ -11,6 +11,7 @@ import AuthStatusChip from './AuthStatusChip'
 import AuthActionButton from './AuthActionButton'
 import { AuthStatus, DAARowData } from './types'
 import { daaLabel, formatDateYYYYMMDD } from './researcherViewHelpers'
+import { ACTION_COLUMN, visibleColumns } from './subtableColumns'
 
 const FONT = 'Montserrat'
 
@@ -42,30 +43,38 @@ function rowBorderColor(status: AuthStatus): string {
   return '1px solid #e5e7eb'
 }
 
-const COLUMN_HEADERS = ['DAA', 'DAC', 'Effective Date', 'Status', 'Action'] as const
+const COLUMN_HEADERS = ['DAA', 'DAC', 'Effective Date', 'Status', ACTION_COLUMN] as const
 
 interface ResearcherDAASubtableProps {
   daaRows: DAARowData[]
   onAuthorize: (daaId: number) => void
   onRevoke: (daaId: number) => void
+  /** Read-only mode (Admin Console): drops the Action column entirely. */
+  readOnly?: boolean
 }
 
 /**
  * Sub-table rendered inside a researcher's expanded accordion row.
  * Lists every DAA the SO manages, showing the researcher's auth status
  * and an action button for each.
+ *
+ * In read-only mode the Action column — header and cells — is not rendered, so
+ * the same table serves the Admin Console's observe-only view.
  */
 export default function ResearcherDAASubtable({
   daaRows,
   onAuthorize,
   onRevoke,
+  readOnly = false,
 }: Readonly<ResearcherDAASubtableProps>) {
+  const columnHeaders = visibleColumns(COLUMN_HEADERS, readOnly)
+
   return (
     <Box sx={{ bgcolor: '#fafafa' }} data-cy="daa-subtable">
       <Table size="small">
         <TableHead>
           <TableRow sx={{ bgcolor: '#f0f0f0' }}>
-            {COLUMN_HEADERS.map(col => (
+            {columnHeaders.map(col => (
               <TableCell key={col} sx={tableCellHeadSx}>
                 {col}
               </TableCell>
@@ -94,13 +103,15 @@ export default function ResearcherDAASubtable({
               <TableCell>
                 <AuthStatusChip status={status} />
               </TableCell>
-              <TableCell>
-                <AuthActionButton
-                  status={status}
-                  onAuthorize={() => onAuthorize(daa.daaId)}
-                  onRevoke={() => onRevoke(daa.daaId)}
-                />
-              </TableCell>
+              {!readOnly && (
+                <TableCell>
+                  <AuthActionButton
+                    status={status}
+                    onAuthorize={() => onAuthorize(daa.daaId)}
+                    onRevoke={() => onRevoke(daa.daaId)}
+                  />
+                </TableCell>
+              )}
             </TableRow>
           ))}
         </TableBody>

--- a/src/pages/signing_official_console/DAAAssignment/ResearcherView.tsx
+++ b/src/pages/signing_official_console/DAAAssignment/ResearcherView.tsx
@@ -16,7 +16,7 @@ import ResearcherAccordionRow from './ResearcherAccordionRow'
 import ResearcherViewLegend from './ResearcherViewLegend'
 import ResearcherViewConfirmDialog from './ResearcherViewConfirmDialog'
 import BulkActionConfirmDialog from './BulkActionConfirmDialog'
-import { BulkConfirmState, ConfirmDialogState, DAARowData, ResearcherRowData } from './types'
+import { BulkConfirmState, ConfirmDialogState, DAARowData, ResearcherRowData, UserListScope } from './types'
 import { buildResearcherRows, daaLabel } from './researcherViewHelpers'
 import { useBulkPreAuthorization } from './useBulkPreAuthorization'
 
@@ -40,6 +40,24 @@ export interface ResearcherViewProps {
   readonly daas: readonly DAAObject[]
   readonly isLoading: boolean
   readonly onResearchersRefresh: (updated: DuosUser[]) => void
+  /**
+   * Role scope to reload the user list with after a mutation. Must match the
+   * scope the page loaded with, or a refresh would silently swap the list for a
+   * differently-scoped one.
+   */
+  readonly scope?: UserListScope
+  /**
+   * Read-only mode (Admin Console). Suppresses every mutating control: the
+   * per-row action buttons, the bulk Approve All / Remove All buttons, and the
+   * confirmation dialogs those buttons open.
+   */
+  readonly readOnly?: boolean
+  /**
+   * Shows each researcher's institution and makes it searchable. Only meaningful
+   * when the list spans more than one institution, which is the Admin Console's
+   * cross-institution scope.
+   */
+  readonly showInstitution?: boolean
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────
@@ -53,12 +71,19 @@ export interface ResearcherViewProps {
  *
  * Auth mutations (createDaaLcLink / deleteDaaLcLink) are the same APIs used
  * by the existing ManageResearcherDAAs page.
+ *
+ * With `readOnly` set, the same view becomes the Admin Console's observe-only
+ * list: identical layout, search, expand/collapse and legend, but no controls
+ * that can change a pre-authorization.
  */
 export default function ResearcherView({
   researchers,
   daas,
   isLoading,
   onResearchersRefresh,
+  scope = USER_ROLES.signingOfficial,
+  readOnly = false,
+  showInstitution = false,
 }: Readonly<ResearcherViewProps>) {
   const [search, setSearch] = useState('')
   const [expanded, setExpanded] = useState<Record<number, boolean>>({})
@@ -78,9 +103,12 @@ export default function ResearcherView({
     return researcherRows.filter(
       (row: ResearcherRowData) =>
         row.researcher.displayName?.toLowerCase().includes(term)
-        || row.researcher.email?.toLowerCase().includes(term),
+        || row.researcher.email?.toLowerCase().includes(term)
+        // Matched on the raw name, so the dash shown for a researcher with no
+        // institution is not itself a search hit.
+        || (showInstitution && !!row.researcher.institution?.name?.toLowerCase().includes(term)),
     )
-  }, [researcherRows, search])
+  }, [researcherRows, search, showInstitution])
 
   const allExpanded
     = filteredRows.length > 0
@@ -90,13 +118,13 @@ export default function ResearcherView({
 
   const refreshResearchers = useCallback(async () => {
     try {
-      const updated = await User.list(USER_ROLES.signingOfficial)
+      const updated = await User.list(scope)
       onResearchersRefresh(updated)
     }
     catch {
       Notifications.showError({ text: 'Failed to refresh researcher list' })
     }
-  }, [onResearchersRefresh])
+  }, [onResearchersRefresh, scope])
 
   const toggleRow = useCallback((userId: number) => {
     setExpanded(prev => ({ ...prev, [userId]: !prev[userId] }))
@@ -222,13 +250,14 @@ export default function ResearcherView({
         }}
       >
         <TextField
-          placeholder="Search researchers"
+          placeholder={showInstitution ? 'Search by researcher, email, or institution' : 'Search researchers'}
           value={search}
           onChange={e => setSearch(e.target.value)}
           size="small"
           data-cy="researcher-search"
           sx={{
-            'width': 280,
+            // Wide enough for the longer placeholder the institution search uses.
+            'width': showInstitution ? 360 : 280,
             '& .MuiOutlinedInput-root': { fontFamily: FONT, fontSize: 13 },
           }}
           slotProps={{
@@ -292,9 +321,16 @@ export default function ResearcherView({
             onRevoke={daaId => openRevokeDialog(row.researcher, daaId, row.daaRows)}
             onApproveAll={daaIds => openBulkDialog(row.researcher, 'approve', daaIds)}
             onRemoveAll={daaIds => openBulkDialog(row.researcher, 'remove', daaIds)}
+            readOnly={readOnly}
+            showInstitution={showInstitution}
           />
         ))}
       </Box>
+
+      {/*
+        Both dialogs render nothing until their state is set, and read-only mode
+        renders no control that can set it — so they self-suppress there.
+      */}
 
       {/* Single-relationship confirmation dialog */}
       <ResearcherViewConfirmDialog

--- a/src/pages/signing_official_console/DAAAssignment/accordionHeaderKeyboard.ts
+++ b/src/pages/signing_official_console/DAAAssignment/accordionHeaderKeyboard.ts
@@ -1,0 +1,26 @@
+import React from 'react'
+
+/**
+ * Keyboard activation for the accordion card headers, which are `role="button"`
+ * Boxes rather than real buttons.
+ *
+ * A native button handles Enter and Space for free; a div with `role="button"`
+ * does not, so it has to be put in the tab order and taught both keys. This
+ * matters most on the read-only Admin Console page, where expanding a row is the
+ * only interaction on the page — without it, none of the pre-authorization data
+ * is reachable without a mouse.
+ */
+export function accordionHeaderKeyboardProps(onToggle: () => void): {
+  tabIndex: number
+  onKeyDown: (event: React.KeyboardEvent) => void
+} {
+  return {
+    tabIndex: 0,
+    onKeyDown: (event: React.KeyboardEvent) => {
+      if (event.key !== 'Enter' && event.key !== ' ') return
+      // Space would otherwise scroll the page.
+      event.preventDefault()
+      onToggle()
+    },
+  }
+}

--- a/src/pages/signing_official_console/DAAAssignment/accordionHeaderKeyboard.ts
+++ b/src/pages/signing_official_console/DAAAssignment/accordionHeaderKeyboard.ts
@@ -17,6 +17,10 @@ export function accordionHeaderKeyboardProps(onToggle: () => void): {
   return {
     tabIndex: 0,
     onKeyDown: (event: React.KeyboardEvent) => {
+      // Only the header itself activates. Enter/Space on a nested control — the
+      // bulk Approve All / Remove All buttons — bubbles up here, and swallowing
+      // it would toggle the row and suppress the button's own activation.
+      if (event.target !== event.currentTarget) return
       if (event.key !== 'Enter' && event.key !== ' ') return
       // Space would otherwise scroll the page.
       event.preventDefault()

--- a/src/pages/signing_official_console/DAAAssignment/index.ts
+++ b/src/pages/signing_official_console/DAAAssignment/index.ts
@@ -1,5 +1,6 @@
 export { default } from './ResearcherView'
 export { default as DAAView } from './DAAView'
+export { default as DaaAssociationsPage } from './DaaAssociationsPage'
 export {
   buildDAARows,
   buildResearcherRows,
@@ -11,6 +12,7 @@ export {
 } from './researcherViewHelpers'
 export type { ResearcherViewProps } from './ResearcherView'
 export type { DAAViewProps } from './DAAView'
+export type { DaaAssociationsPageProps } from './DaaAssociationsPage'
 export type {
   AuthStatus,
   BulkConfirmState,
@@ -19,4 +21,5 @@ export type {
   DAAResearcherRowData,
   DAARowData,
   ResearcherRowData,
+  UserListScope,
 } from './types'

--- a/src/pages/signing_official_console/DAAAssignment/researcherViewHelpers.ts
+++ b/src/pages/signing_official_console/DAAAssignment/researcherViewHelpers.ts
@@ -58,14 +58,60 @@ function getAuthorizedDaaIdSet(researcher: DuosUser): Set<number> {
 }
 
 /**
+ * Maps each DAA the researcher is authorized for to the SO who granted it.
+ * On duplicate `daaId` entries the first wins.
+ */
+function buildAuthorizedByMap(researcher: DuosUser): Map<number, string | undefined> {
+  const authorizedByDaaId = new Map<number, string | undefined>()
+  const daaDetails = researcher.libraryCard?.daaDetails
+  if (!Array.isArray(daaDetails)) return authorizedByDaaId
+
+  daaDetails.forEach((detail) => {
+    if (!authorizedByDaaId.has(detail.daaId)) {
+      authorizedByDaaId.set(detail.daaId, detail.authorizedBy)
+    }
+  })
+  return authorizedByDaaId
+}
+
+/**
  * Returns the email address of the SO who authorized a researcher for a given
  * DAA, as recorded in the `daaDetails` array of their library card.
  */
 export function getAuthorizedBy(researcher: DuosUser, daaId: number): string | undefined {
-  const daaDetails = researcher.libraryCard?.daaDetails
-  if (!Array.isArray(daaDetails)) return undefined
+  return buildAuthorizedByMap(researcher).get(daaId)
+}
 
-  return daaDetails.find(detail => detail.daaId === daaId)?.authorizedBy
+/** The single definition of the researcher/DAA authorization rule. */
+function statusFromAuthorizedIds(authorizedDaaIds: ReadonlySet<number>, daaId: number): AuthStatus {
+  if (!daaId) return 'not_requested'
+  return authorizedDaaIds.has(daaId) ? 'authorized' : 'not_requested'
+}
+
+/**
+ * One researcher's library card flattened for repeated lookup.
+ *
+ * The DAA View asks the same two questions (is this researcher authorized for
+ * this DAA, and by whom) once per researcher/DAA pair, so building this index
+ * once per researcher keeps the grid linear instead of re-walking the library
+ * card for every cell — the Admin Console's system-wide list makes that
+ * difference material.
+ */
+interface ResearcherAuthIndex {
+  authorizedDaaIds: Set<number>
+  authorizedByDaaId: Map<number, string | undefined>
+}
+
+function buildAuthIndex(researcher: DuosUser): ResearcherAuthIndex {
+  return {
+    authorizedDaaIds: getAuthorizedDaaIdSet(researcher),
+    authorizedByDaaId: buildAuthorizedByMap(researcher),
+  }
+}
+
+/** API payloads can include duplicate DAA entries; daaId is the canonical key. */
+function dedupeDaas(daas: readonly DAAObject[]): DAAObject[] {
+  return Array.from(new Map(daas.map(daa => [daa.daaId, daa])).values())
 }
 
 /**
@@ -75,6 +121,17 @@ export function getAuthorizedBy(researcher: DuosUser, daaId: number): string | u
  */
 export function daaLabel(daa: DAAObject): string {
   return daa.file?.fileName ?? `DAA-${daa.daaId}`
+}
+
+/**
+ * Display name of a researcher's institution.
+ *
+ * Falls back to a dash rather than the users table's "N/A" so it matches the
+ * dash this folder's tables already use for missing values. Searching matches on
+ * the raw name, so the placeholder is never itself a search hit.
+ */
+export function institutionLabel(researcher: DuosUser): string {
+  return researcher.institution?.name || DASH
 }
 
 /**
@@ -94,25 +151,25 @@ export function getDacName(daa: DAAObject): string {
  * researcher's library card.
  */
 export function getAuthStatus(researcher: DuosUser, daaId: number): AuthStatus {
-  const normalizedDaaId = daaId
-  if (!normalizedDaaId) return 'not_requested'
+  return statusFromAuthorizedIds(getAuthorizedDaaIdSet(researcher), daaId)
+}
 
+/** buildDAARows against an already-deduplicated DAA list. */
+function buildDAARowsFor(researcher: DuosUser, uniqueDaas: readonly DAAObject[]): DAARowData[] {
   const authorizedDaaIds = getAuthorizedDaaIdSet(researcher)
-  return authorizedDaaIds.has(normalizedDaaId) ? 'authorized' : 'not_requested'
+
+  return uniqueDaas.map(daa => ({
+    daa,
+    dacName: getDacName(daa),
+    status: statusFromAuthorizedIds(authorizedDaaIds, daa.daaId),
+  }))
 }
 
 /**
  * Builds the full list of DAARowData for a single researcher across all DAAs.
  */
 export function buildDAARows(researcher: DuosUser, daas: readonly DAAObject[]): DAARowData[] {
-  // API payloads can include duplicate DAA entries; use daaId as the canonical key.
-  const uniqueDaas = Array.from(new Map(daas.map(daa => [daa.daaId, daa])).values())
-
-  return uniqueDaas.map(daa => ({
-    daa,
-    dacName: getDacName(daa),
-    status: getAuthStatus(researcher, daa.daaId),
-  }))
+  return buildDAARowsFor(researcher, dedupeDaas(daas))
 }
 
 /**
@@ -122,9 +179,12 @@ export function buildResearcherRows(
   researchers: readonly DuosUser[],
   daas: readonly DAAObject[],
 ): ResearcherRowData[] {
+  // Deduplicated once for the whole grid rather than once per researcher.
+  const uniqueDaas = dedupeDaas(daas)
+
   return researchers
     .map((researcher) => {
-      const daaRows = buildDAARows(researcher, daas)
+      const daaRows = buildDAARowsFor(researcher, uniqueDaas)
       const authorizedCount = daaRows.filter(r => r.status === 'authorized').length
       return { researcher, daaRows, authorizedCount }
     })
@@ -147,16 +207,24 @@ export function isRecentlyUpdated(daa: DAAObject): boolean {
 
 /**
  * Builds the per-researcher auth rows for a single DAA.
+ *
+ * `indexByUserId` lets a caller iterating many DAAs (see buildDAAViewRows) build
+ * each researcher's index once instead of once per DAA; without it, each row
+ * builds its own.
  */
 export function buildDAAResearcherRows(
   daa: DAAObject,
   researchers: readonly DuosUser[],
+  indexByUserId?: ReadonlyMap<number, ResearcherAuthIndex>,
 ): DAAResearcherRowData[] {
-  return researchers.map(researcher => ({
-    researcher,
-    status: getAuthStatus(researcher, daa.daaId),
-    authorizedBy: getAuthorizedBy(researcher, daa.daaId),
-  }))
+  return researchers.map((researcher) => {
+    const authIndex = indexByUserId?.get(researcher.userId) ?? buildAuthIndex(researcher)
+    return {
+      researcher,
+      status: statusFromAuthorizedIds(authIndex.authorizedDaaIds, daa.daaId),
+      authorizedBy: authIndex.authorizedByDaaId.get(daa.daaId),
+    }
+  })
 }
 
 /**
@@ -167,10 +235,14 @@ export function buildDAAViewRows(
   daas: readonly DAAObject[],
   researchers: readonly DuosUser[],
 ): DAAAccordionData[] {
-  const uniqueDaas = Array.from(new Map(daas.map(daa => [daa.daaId, daa])).values())
+  const uniqueDaas = dedupeDaas(daas)
+  // Built once per researcher rather than once per researcher/DAA pair.
+  const indexByUserId = new Map(
+    researchers.map(researcher => [researcher.userId, buildAuthIndex(researcher)]),
+  )
 
   return uniqueDaas.map((daa) => {
-    const researcherRows = buildDAAResearcherRows(daa, researchers)
+    const researcherRows = buildDAAResearcherRows(daa, researchers, indexByUserId)
     const authorizedCount = researcherRows.filter(r => r.status === 'authorized').length
     return {
       daa,

--- a/src/pages/signing_official_console/DAAAssignment/subtableColumns.ts
+++ b/src/pages/signing_official_console/DAAAssignment/subtableColumns.ts
@@ -10,13 +10,11 @@
 export const ACTION_COLUMN = 'Action'
 
 /**
- * The columns to render: every column normally, all but Action when read-only.
+ * `headers` without the Action column — what a read-only view renders.
+ * Views that can act on rows render their header list unchanged.
  */
-export function visibleColumns<T extends string>(
-  headers: readonly T[],
-  readOnly: boolean,
-): readonly T[] {
-  return readOnly ? headers.filter(header => header !== ACTION_COLUMN) : headers
+export function withoutActionColumn<T extends string>(headers: readonly T[]): readonly T[] {
+  return headers.filter(header => header !== ACTION_COLUMN)
 }
 
 /**

--- a/src/pages/signing_official_console/DAAAssignment/subtableColumns.ts
+++ b/src/pages/signing_official_console/DAAAssignment/subtableColumns.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared column handling for the two DAA-association sub-tables.
+ *
+ * Both tables end in an Action column that read-only mode drops, and the DAA
+ * table also gains an Institution column only on the cross-institution admin
+ * view. Header and body must drop or add a column together or the cell counts
+ * stop lining up, so the rules live here once.
+ */
+
+export const ACTION_COLUMN = 'Action'
+
+/**
+ * The columns to render: every column normally, all but Action when read-only.
+ */
+export function visibleColumns<T extends string>(
+  headers: readonly T[],
+  readOnly: boolean,
+): readonly T[] {
+  return readOnly ? headers.filter(header => header !== ACTION_COLUMN) : headers
+}
+
+/**
+ * Percentage widths for exactly `columns`, renormalized to total 100%.
+ *
+ * `widths` is read as relative weights rather than final percentages: whichever
+ * combination of columns a view renders, the declared widths are scaled to fill
+ * the table. Without this, a dropped column leaves the widths short of 100% and
+ * the browser apportions the shortfall by its own heuristic, so the same table
+ * ends up with different proportions in each console.
+ */
+export function normalizedWidths<T extends string>(
+  columns: readonly T[],
+  widths: Readonly<Record<T, string>>,
+): Record<string, string> {
+  const weights = columns.map(column => [column, Number.parseFloat(widths[column])] as const)
+  const total = weights.reduce((sum, [, weight]) => sum + weight, 0)
+  if (!total) return Object.fromEntries(columns.map(column => [column, 'auto']))
+
+  return Object.fromEntries(
+    weights.map(([column, weight]) => [column, `${((weight / total) * 100).toFixed(4)}%`]),
+  )
+}

--- a/src/pages/signing_official_console/DAAAssignment/types.ts
+++ b/src/pages/signing_official_console/DAAAssignment/types.ts
@@ -1,6 +1,14 @@
 import { DAAObject, DuosUser } from 'src/types/model'
+import type { User } from 'src/libs/ajax/User'
 
 export type AuthStatus = 'authorized' | 'not_requested' | 'revoked'
+
+/**
+ * Which user list the DAA association views work against: `SigningOfficial`
+ * scopes to the signed-in SO's institution, `Admin` spans every institution.
+ * Derived from `User.list` so the two cannot drift apart.
+ */
+export type UserListScope = Parameters<typeof User.list>[0]
 
 // ── Researcher View types ──────────────────────────────────────────────────────
 

--- a/src/pages/signing_official_console/ManageResearcherDAAs.tsx
+++ b/src/pages/signing_official_console/ManageResearcherDAAs.tsx
@@ -1,138 +1,25 @@
-import React, { useEffect, useState } from 'react'
-import { Tabs, Tab, Box } from '@mui/material'
+import React from 'react'
 
-import ResearcherView, { DAAView } from 'src/pages/signing_official_console/DAAAssignment'
-import { User } from 'src/libs/ajax/User'
-import { Notifications, USER_ROLES } from 'src/libs/utils'
-import { DAA } from 'src/libs/ajax/DAA'
-import { DAAObject, DuosUser } from 'src/types/model'
-import { extractError } from 'src/utils/ErrorUtils'
-import TableHeaderSection from 'src/components/TableHeaderSection'
+import { DaaAssociationsPage } from 'src/pages/signing_official_console/DAAAssignment'
+import { USER_ROLES } from 'src/libs/utils'
 
+const DESCRIPTION = 'Grant and revoke pre-authorization for researchers at your institution to '
+  + 'submit DARs directly to the DAC (without SO review of the individual DAR first) when '
+  + 'permitted by the DAC.'
+
+/**
+ * SO Console → DAA Associations. Scoped to the SO's own institution, with the
+ * pre-authorize / revoke controls enabled.
+ *
+ * The Admin Console renders the same page read-only and system-wide; see
+ * `src/pages/AdminDaaAssociations.tsx`.
+ */
 export default function ManageResearcherDAAs(): React.JSX.Element {
-  const [researchers, setResearchers] = useState<DuosUser[]>([])
-  const [daas, setDaas] = useState<DAAObject[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [activeTab, setActiveTab] = useState(0)
-
-  useEffect(() => {
-    const init = async () => {
-      setIsLoading(true)
-      try {
-        const researcherList = await User.list(USER_ROLES.signingOfficial)
-        setResearchers(researcherList)
-        const daaList: DAAObject[] = await DAA.getDaas()
-        // A DAA is always associated with the DAC that uploaded it, even when it is not that DAC's
-        // active agreement. Anything with no DAC at all is legacy data we can ignore.
-        const filteredDAAList = daaList.filter(daa => Array.isArray(daa.dacs) && daa.dacs.length > 0)
-        setDaas(filteredDAAList)
-      }
-      catch (error) {
-        console.error('Failed to load ManageResearcherDAAs page data', error)
-        Notifications.showError({
-          text: `Error: Unable to retrieve current user from server: ${extractError(error)}`,
-        })
-      }
-      finally {
-        setIsLoading(false)
-      }
-    }
-    init()
-  }, [])
-
   return (
-    <div>
-      <Box sx={{ paddingLeft: '4rem', maxWidth: '50%', marginBottom: '2rem' }}>
-        <TableHeaderSection
-          title="Pre-Authorize Researchers (DAAs)"
-          description="Grant and revoke pre-authorization for researchers at your institution to submit DARs directly to the DAC (without SO review of the individual DAR first) when permitted by the DAC."
-        />
-      </Box>
-      <Box
-        sx={{
-          borderTop: 1,
-          borderBottom: 1,
-          borderColor: 'divider',
-          paddingLeft: '5rem',
-          paddingRight: '5rem',
-        }}
-      >
-        <Tabs
-          value={activeTab}
-          onChange={(_event, newValue) => setActiveTab(newValue)}
-          aria-label="library view tabs"
-          variant="scrollable"
-          scrollButtons="auto"
-          allowScrollButtonsMobile
-          slotProps={{
-            indicator: {
-              style: { backgroundColor: '#00609f' },
-            },
-          }}
-        >
-          <Tab
-            key="researcherView"
-            value={0}
-            label="Researcher View"
-            sx={{
-              textTransform: 'none',
-              fontSize: '15px',
-              fontFamily: 'Montserrat, sans-serif',
-              color: '#00609f',
-              fontWeight: 'bold',
-              marginLeft: '2rem',
-              padding: '0 25px',
-            }}
-          />
-          <Tab
-            key="daaView"
-            value={1}
-            label="DAA View"
-            sx={{
-              textTransform: 'none',
-              fontSize: '15px',
-              fontFamily: 'Montserrat, sans-serif',
-              color: '#00609f',
-              fontWeight: 'bold',
-              padding: '0 25px',
-            }}
-          />
-        </Tabs>
-      </Box>
-      {activeTab === 0 && (
-        <Box sx={{
-          backgroundColor: '#f5f5f5',
-          paddingLeft: '7rem',
-          paddingRight: '5rem',
-          paddingTop: '2rem',
-          paddingBottom: '2rem',
-        }}
-        >
-          <ResearcherView
-            researchers={researchers}
-            daas={daas}
-            isLoading={isLoading}
-            onResearchersRefresh={setResearchers}
-          />
-        </Box>
-      )}
-      {activeTab === 1 && (
-        <Box sx={{
-          backgroundColor: '#f5f5f5',
-          paddingLeft: '7rem',
-          paddingRight: '5rem',
-          paddingTop: '2rem',
-          paddingBottom: '2rem',
-        }}
-        >
-          <DAAView
-            researchers={researchers}
-            daas={daas}
-            isLoading={isLoading}
-            onResearchersRefresh={setResearchers}
-          />
-        </Box>
-      )}
-    </div>
+    <DaaAssociationsPage
+      title="Pre-Authorize Researchers (DAAs)"
+      description={DESCRIPTION}
+      scope={USER_ROLES.signingOfficial}
+    />
   )
 }

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -30,6 +30,7 @@ import { InstitutionDetails } from 'src/components/institution_table/Institution
 import { FORM_MODES } from 'src/components/institution_table/InstitutionFormMode'
 import AdminManageInstitutions from 'src/pages/AdminManageInstitutions'
 import AdminManageLC from 'src/pages/AdminManageLC'
+import AdminDaaAssociations from 'src/pages/AdminDaaAssociations'
 import AdminManageDarCollections from 'src/pages/AdminManageDarCollections'
 import ManageDac from 'src/pages/manage_dac/ManageDac'
 import ManageRadar from 'src/pages/manage_dac/ManageRadar'
@@ -138,6 +139,7 @@ const AppRoutes = (props: AppRoutesProps) => {
           <Route path="/admin_manage_institutions/institutions/:institutionId" element={<InstitutionDetails formMode={FORM_MODES.editExisting} />} />
           <Route path="/admin_manage_institutions" element={<AdminManageInstitutions />} />
           <Route path="/admin_manage_lc/" element={<AdminManageLC />} />
+          <Route path="/admin_daa_associations" element={<AdminDaaAssociations />} />
           <Route path="/admin_manage_dar_collections/" element={<AdminManageDarCollections />} />
           <Route path="/manage_add_dac_daa" element={<EditDac />} />
         </Route>

--- a/test/components/DuosHeader.spec.tsx
+++ b/test/components/DuosHeader.spec.tsx
@@ -141,6 +141,23 @@ describe('DuosHeader', () => {
       await mountHeader('/admin_manage_dar_collections', { ...mockUser, isAdmin: true, isResearcher: false })
       expect(screen.getByRole('tab', { name: 'Admin Console' })).toBeInTheDocument()
     })
+
+    it('displays the DAA Associations subtab for an admin', async () => {
+      await mountHeader('/admin_manage_dar_collections', { ...mockUser, isAdmin: true, isResearcher: false })
+      expect(screen.getByRole('tab', { name: 'DAA Associations' })).toBeInTheDocument()
+    })
+
+    it('points the Admin Console DAA Associations subtab at the admin route', () => {
+      const adminConsole = headerTabsConfig.find(tab => tab.label === 'Admin Console')
+      const daaAssociations = adminConsole?.children?.find(subTab => subTab.label === 'DAA Associations')
+
+      expect(daaAssociations?.link).toEqual('/admin_daa_associations')
+    })
+
+    it('highlights Admin Console on /admin_daa_associations', async () => {
+      await mountHeader('/admin_daa_associations', { ...mockUser, isAdmin: true, isResearcher: false })
+      expect(screen.getByRole('tab', { name: 'Admin Console' })).toHaveClass('Mui-selected')
+    })
   })
 
   describe('Authenticated Signing Official', () => {

--- a/test/pages/AdminDaaAssociations.spec.tsx
+++ b/test/pages/AdminDaaAssociations.spec.tsx
@@ -1,0 +1,437 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AdminDaaAssociations from 'src/pages/AdminDaaAssociations'
+import { User } from 'src/libs/ajax/User'
+import { DAA } from 'src/libs/ajax/DAA'
+import { Notifications, ROLES, USER_ROLES } from 'src/libs/utils'
+import { DAAObject, DuosUser } from 'src/types/model'
+import { makeDaa, makeResearcher } from './signing_official_console/DAAAssignment/fixtures'
+
+const mockDaas: DAAObject[] = [
+  makeDaa({ daaId: 1, fileName: 'Default DUOS DAA', dacId: 10 }),
+  makeDaa({ daaId: 2, fileName: 'GTEx Access Agreement', dacId: 20 }),
+]
+
+// Researchers from two different institutions; the admin list is not institution-scoped.
+const mockResearchers: DuosUser[] = [
+  makeResearcher({
+    userId: 1,
+    displayName: 'Test User Alpha',
+    email: 'test.user.alpha@institution-a.org',
+    daaDetails: [{ daaId: 1, authorizedBy: 'so@institution-a.org' }],
+    institutionName: 'Institution Alpha',
+  }),
+  makeResearcher({
+    userId: 2,
+    displayName: 'Test User Beta',
+    email: 'test.user.beta@institution-b.org',
+    institutionName: 'Institution Beta',
+  }),
+  // Shaped like a real list response: the derived `isResearcher` flag is absent
+  // (only the signed-in user gets it), so `roles` is what identifies a researcher.
+  {
+    ...makeResearcher({
+      userId: 5,
+      displayName: 'Test User Epsilon',
+      email: 'test.user.epsilon@institution-c.org',
+    }),
+    isResearcher: false,
+  },
+]
+
+// The Admin user list returns every role, and pre-authorization applies to none
+// of these, so the page must drop them. Roles come from the payload's `roles`
+// array — a list response does not carry the derived `isResearcher` flag, so
+// these fixtures deliberately leave it false.
+const mockNonResearchers: DuosUser[] = [
+  makeResearcher({
+    userId: 3,
+    displayName: 'Test Admin Gamma',
+    email: 'admin.gamma@test.org',
+    roles: [{ roleId: ROLES.admin.roleId, name: USER_ROLES.admin, userId: 3 }],
+  }),
+  makeResearcher({
+    userId: 4,
+    displayName: 'Test SO Delta',
+    email: 'so.delta@institution-a.org',
+    roles: [{ roleId: ROLES.signingOfficial.roleId, name: USER_ROLES.signingOfficial, userId: 4 }],
+  }),
+]
+
+const mockUsers: DuosUser[] = [...mockResearchers, ...mockNonResearchers]
+
+const ACTION_SELECTORS = [
+  '[data-cy="auth-action-authorize"]',
+  '[data-cy="auth-action-revoke"]',
+  '[data-cy="auth-action-reauthorize"]',
+  '[data-cy^="bulk-approve-all-"]',
+  '[data-cy^="bulk-remove-all-"]',
+]
+
+// MUI Dialogs portal to document.body, so they are never inside the RTL container.
+const DIALOG_SELECTORS = [
+  '[data-cy="confirm-dialog"]',
+  '[data-cy="bulk-confirm-dialog"]',
+]
+
+const expectNoActionControls = (container: HTMLElement) => {
+  ACTION_SELECTORS.forEach((selector) => {
+    expect(container.querySelector(selector)).not.toBeInTheDocument()
+  })
+  DIALOG_SELECTORS.forEach((selector) => {
+    expect(document.body.querySelector(selector)).not.toBeInTheDocument()
+  })
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+}
+
+const mountPage = () => render(<AdminDaaAssociations />)
+
+const mountLoadedPage = async () => {
+  const rendered = mountPage()
+  await waitFor(() =>
+    expect(rendered.container.querySelector('[data-cy="researcher-view"]')).toBeInTheDocument())
+  return rendered
+}
+
+const openDaaViewTab = async (user: ReturnType<typeof userEvent.setup>, container: HTMLElement) => {
+  await user.click(await waitFor(() => {
+    const tab = container.querySelectorAll('[role="tab"]')[1] as HTMLElement
+    expect(tab).toHaveTextContent('DAA View')
+    return tab
+  }))
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('AdminDaaAssociations', () => {
+  beforeEach(() => {
+    vi.spyOn(Notifications, 'showError').mockImplementation(() => {})
+    vi.spyOn(User, 'list').mockResolvedValue(mockUsers)
+    vi.spyOn(DAA, 'getDaas').mockResolvedValue(mockDaas)
+  })
+
+  // ── Data scope ──────────────────────────────────────────────────────────────
+
+  it('loads the system-wide user list, not the institution-scoped one', async () => {
+    await mountLoadedPage()
+    expect(User.list).toHaveBeenCalledWith(USER_ROLES.admin)
+    expect(User.list).not.toHaveBeenCalledWith(USER_ROLES.signingOfficial)
+  })
+
+  it('lists researchers from every institution', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
+  })
+
+  // Guards the trap that `isResearcher` is derived for the signed-in user only,
+  // so filtering on it would empty this page against a real response.
+  it('identifies researchers by their roles, not the derived isResearcher flag', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="researcher-row-5"]')).toBeInTheDocument()
+  })
+
+  it('excludes users who are not researchers', async () => {
+    const { container } = await mountLoadedPage()
+    mockNonResearchers.forEach(({ userId }) => {
+      expect(container.querySelector(`[data-cy="researcher-row-${userId}"]`)).not.toBeInTheDocument()
+    })
+    // The header toggle shares the `researcher-row-` prefix, so exclude it from the count.
+    expect(container.querySelectorAll(
+      '[data-cy^="researcher-row-"]:not([data-cy^="researcher-row-toggle-"])',
+    )).toHaveLength(mockResearchers.length)
+  })
+
+  it('excludes non-researchers from the per-DAA researcher list too', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await user.click(await waitFor(() =>
+      container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement))
+
+    expect(container.querySelectorAll('[data-cy^="daa-researcher-row-"]')).toHaveLength(mockResearchers.length)
+    mockNonResearchers.forEach(({ userId }) => {
+      expect(container.querySelector(`[data-cy="daa-researcher-row-${userId}"]`)).not.toBeInTheDocument()
+    })
+  })
+
+  it('excludes DAAs with no DAC mapping', async () => {
+    vi.mocked(DAA.getDaas).mockResolvedValue([
+      makeDaa({ daaId: 1, mapped: true }),
+      makeDaa({ daaId: 2, mapped: false }),
+    ])
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    expect(container.querySelectorAll('[data-cy^="daa-row-"]')).toHaveLength(1)
+    expect(container.querySelector('[data-cy="daa-row-1"]')).toBeInTheDocument()
+  })
+
+  // ── Page structure ──────────────────────────────────────────────────────────
+
+  it('renders the DAA Associations header and both view tabs', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="table-header-title"]')).toHaveTextContent('DAA Associations')
+    const tabs = container.querySelectorAll('[role="tab"]')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0]).toHaveTextContent('Researcher View')
+    expect(tabs[1]).toHaveTextContent('DAA View')
+  })
+
+  it('sets the document title', async () => {
+    await mountLoadedPage()
+    expect(document.title).toEqual('DAA Associations | DUOS')
+  })
+
+  it('defaults to the Researcher View tab', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="researcher-view"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="daa-view"]')).not.toBeInTheDocument()
+  })
+
+  // ── Institution ─────────────────────────────────────────────────────────────
+
+  it('shows each researcher institution in the Researcher View', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="researcher-institution-1"]')).toHaveTextContent('Institution Alpha')
+    expect(container.querySelector('[data-cy="researcher-institution-2"]')).toHaveTextContent('Institution Beta')
+  })
+
+  it('shows a dash for a researcher with no institution', async () => {
+    const { container } = await mountLoadedPage()
+    // User 5 is built without an institution.
+    expect(container.querySelector('[data-cy="researcher-institution-5"]')).toHaveTextContent('—')
+  })
+
+  it('shows an Institution column in the per-DAA researcher sub-table', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await user.click(await waitFor(() =>
+      container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement))
+
+    const headers = Array.from(container.querySelectorAll('[data-cy="daa-researcher-subtable"] th'))
+      .map(th => th.textContent)
+    expect(headers).toEqual([
+      'Researcher',
+      'Email',
+      'Institution',
+      'Pre-Auth Status',
+      'Pre-authorized By',
+    ])
+    expect(container.querySelector('[data-cy="daa-researcher-institution-1"]')).toHaveTextContent('Institution Alpha')
+  })
+
+  it('filters researchers by institution', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.type(
+      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
+      'Institution Beta',
+    )
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
+  })
+
+  it('does not match the dash shown for researchers with no institution', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.type(
+      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
+      '—',
+    )
+    expect(container.querySelector('[data-cy="researcher-empty-message"]')).toBeInTheDocument()
+  })
+
+  it('advertises institution search in the search placeholder', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="researcher-search"] input'))
+      .toHaveAttribute('placeholder', 'Search by researcher, email, or institution')
+  })
+
+  it('renders the search bar, legend, and expand/collapse-all control', async () => {
+    const { container } = await mountLoadedPage()
+    expect(container.querySelector('[data-cy="researcher-search"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-view-legend"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="expand-collapse-all"]')).toBeInTheDocument()
+  })
+
+  it('shows a loading indicator while data is loading', () => {
+    vi.mocked(User.list).mockReturnValue(new Promise(() => {}))
+    const { container } = mountPage()
+    expect(container.querySelector('[data-cy="researcher-view-loading"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-list"]')).not.toBeInTheDocument()
+  })
+
+  it('shows an error notification when the initial data load fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(User.list).mockRejectedValue(new Error('network'))
+
+    mountPage()
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalledOnce())
+  })
+
+  // ── Read-only behavior ──────────────────────────────────────────────────────
+
+  it('renders no action controls in the Researcher View', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    expectNoActionControls(container)
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    expect(container.querySelector('[data-cy="daa-subtable"]')).toBeInTheDocument()
+    expectNoActionControls(container)
+  })
+
+  it('omits the Action column from the expanded researcher sub-table', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    const headers = Array.from(container.querySelectorAll('[data-cy="daa-subtable"] th'))
+      .map(th => th.textContent)
+    expect(headers).toEqual(['DAA', 'DAC', 'Effective Date', 'Status'])
+  })
+
+  it('renders no action controls in the DAA View', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await waitFor(() => expect(container.querySelector('[data-cy="daa-view"]')).toBeInTheDocument())
+
+    expect(container.querySelector('[data-cy="daa-accordion-row-1"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="daa-accordion-row-2"]')).toBeInTheDocument()
+    expectNoActionControls(container)
+
+    await user.click(container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement)
+    expect(container.querySelector('[data-cy="daa-researcher-subtable"]')).toBeInTheDocument()
+    expectNoActionControls(container)
+  })
+
+  it('omits the Action column from the expanded DAA sub-table', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await user.click(await waitFor(() =>
+      container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement))
+
+    const headers = Array.from(container.querySelectorAll('[data-cy="daa-researcher-subtable"] th'))
+      .map(th => th.textContent)
+    expect(headers).not.toContain('Action')
+  })
+
+  it('still shows pre-authorization status for all researchers under a DAA', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await user.click(await waitFor(() =>
+      container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement))
+
+    expect(container.querySelector('[data-cy="daa-researcher-row-1"] [data-cy="auth-status-chip-authorized"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="daa-researcher-row-2"] [data-cy="auth-status-chip-not_requested"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="daa-authorized-by-1"]')).toHaveTextContent('so@institution-a.org')
+  })
+
+  it('never calls a mutating DAA endpoint', async () => {
+    // Every DAA mutation the two views can reach: single-link, researcher-scoped
+    // bulk (ResearcherView) and DAA-scoped bulk (DAAView).
+    const mutations = [
+      'createDaaLcLink',
+      'deleteDaaLcLink',
+      'bulkAddDaasToUser',
+      'bulkRemoveDaasFromUser',
+      'bulkAddUsersToDaa',
+      'bulkRemoveUsersFromDaa',
+    ] as const
+    const spies = mutations.map(name => [name, vi.spyOn(DAA, name)] as const)
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    await openDaaViewTab(user, container)
+    await user.click(await waitFor(() =>
+      container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement))
+
+    spies.forEach(([name, spy]) => {
+      expect(spy, `DAA.${name} should not be called from a read-only page`).not.toHaveBeenCalled()
+    })
+  })
+
+  // ── Search ──────────────────────────────────────────────────────────────────
+
+  it('filters researchers by name', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.type(
+      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
+      'Alpha',
+    )
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).not.toBeInTheDocument()
+  })
+
+  it('filters researchers by email', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await user.type(
+      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
+      'institution-b',
+    )
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
+  })
+
+  it('filters DAAs by name in the DAA View', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await user.type(
+      await waitFor(() => container.querySelector('[data-cy="daa-search"] input') as HTMLElement),
+      'GTEx',
+    )
+    expect(container.querySelector('[data-cy="daa-accordion-row-2"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="daa-accordion-row-1"]')).not.toBeInTheDocument()
+  })
+
+  it('filters DAAs by DAC in the DAA View', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+
+    await openDaaViewTab(user, container)
+    await user.type(
+      await waitFor(() => container.querySelector('[data-cy="daa-search"] input') as HTMLElement),
+      'DAC-20',
+    )
+    expect(container.querySelector('[data-cy="daa-accordion-row-2"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="daa-accordion-row-1"]')).not.toBeInTheDocument()
+  })
+
+  // ── Expand / collapse all ───────────────────────────────────────────────────
+
+  it('expands and collapses every researcher row', async () => {
+    const user = userEvent.setup()
+    const { container } = await mountLoadedPage()
+    const toggleAll = container.querySelector('[data-cy="expand-collapse-all"]') as HTMLElement
+
+    await user.click(toggleAll)
+    expect(container.querySelectorAll('[data-cy="daa-subtable"]')).toHaveLength(mockResearchers.length)
+
+    await user.click(toggleAll)
+    await waitFor(() => expect(container.querySelector('[data-cy="daa-subtable"]')).not.toBeInTheDocument())
+  })
+})

--- a/test/pages/AdminDaaAssociations.spec.tsx
+++ b/test/pages/AdminDaaAssociations.spec.tsx
@@ -228,18 +228,6 @@ describe('AdminDaaAssociations', () => {
     expect(container.querySelector('[data-cy="daa-researcher-institution-1"]')).toHaveTextContent('Institution Alpha')
   })
 
-  it('filters researchers by institution', async () => {
-    const user = userEvent.setup()
-    const { container } = await mountLoadedPage()
-
-    await user.type(
-      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
-      'Institution Beta',
-    )
-    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
-  })
-
   it('does not match the dash shown for researchers with no institution', async () => {
     const user = userEvent.setup()
     const { container } = await mountLoadedPage()
@@ -371,51 +359,35 @@ describe('AdminDaaAssociations', () => {
 
   // ── Search ──────────────────────────────────────────────────────────────────
 
-  it('filters researchers by name', async () => {
+  // Institution is admin-only: this page's list spans institutions, so the
+  // search covers it alongside the fields the SO console already searched.
+  it.each([
+    { field: 'name', query: 'Alpha', kept: 1, dropped: 2 },
+    { field: 'email', query: 'institution-b', kept: 2, dropped: 1 },
+    { field: 'institution', query: 'Institution Beta', kept: 2, dropped: 1 },
+  ])('filters researchers by $field', async ({ query, kept, dropped }) => {
     const user = userEvent.setup()
     const { container } = await mountLoadedPage()
 
     await user.type(
       container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
-      'Alpha',
+      query,
     )
-    expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-cy="researcher-row-2"]')).not.toBeInTheDocument()
+    expect(container.querySelector(`[data-cy="researcher-row-${kept}"]`)).toBeInTheDocument()
+    expect(container.querySelector(`[data-cy="researcher-row-${dropped}"]`)).not.toBeInTheDocument()
   })
 
-  it('filters researchers by email', async () => {
-    const user = userEvent.setup()
-    const { container } = await mountLoadedPage()
-
-    await user.type(
-      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
-      'institution-b',
-    )
-    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
-  })
-
-  it('filters DAAs by name in the DAA View', async () => {
+  it.each([
+    { field: 'name', query: 'GTEx' },
+    { field: 'DAC', query: 'DAC-20' },
+  ])('filters DAAs by $field in the DAA View', async ({ query }) => {
     const user = userEvent.setup()
     const { container } = await mountLoadedPage()
 
     await openDaaViewTab(user, container)
     await user.type(
       await waitFor(() => container.querySelector('[data-cy="daa-search"] input') as HTMLElement),
-      'GTEx',
-    )
-    expect(container.querySelector('[data-cy="daa-accordion-row-2"]')).toBeInTheDocument()
-    expect(container.querySelector('[data-cy="daa-accordion-row-1"]')).not.toBeInTheDocument()
-  })
-
-  it('filters DAAs by DAC in the DAA View', async () => {
-    const user = userEvent.setup()
-    const { container } = await mountLoadedPage()
-
-    await openDaaViewTab(user, container)
-    await user.type(
-      await waitFor(() => container.querySelector('[data-cy="daa-search"] input') as HTMLElement),
-      'DAC-20',
+      query,
     )
     expect(container.querySelector('[data-cy="daa-accordion-row-2"]')).toBeInTheDocument()
     expect(container.querySelector('[data-cy="daa-accordion-row-1"]')).not.toBeInTheDocument()

--- a/test/pages/signing_official_console/DAAAssignment/DAAAccordionRow.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAAccordionRow.spec.tsx
@@ -191,6 +191,25 @@ describe('DAAAccordionRow', () => {
     expect(toggleSpy).not.toHaveBeenCalled()
   })
 
+  // Enter/Space on a bulk button bubbles to the header's keydown handler, which
+  // must leave it alone: the button activates itself and the card stays put.
+  it('activates a focused bulk button by keyboard, without toggling', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    const approveAll = container.querySelector('[data-cy="bulk-approve-all-daa-5"]') as HTMLElement
+
+    approveAll.focus()
+    await user.keyboard('{Enter}')
+    expect(approveAllSpy).toHaveBeenCalledWith([2])
+    expect(toggleSpy).not.toHaveBeenCalled()
+
+    const removeAll = container.querySelector('[data-cy="bulk-remove-all-daa-5"]') as HTMLElement
+    removeAll.focus()
+    await user.keyboard(' ')
+    expect(removeAllSpy).toHaveBeenCalledWith([1])
+    expect(toggleSpy).not.toHaveBeenCalled()
+  })
+
   it('disables Approve All when every researcher is already authorized', () => {
     const allAuthorized = mockRows.map(r => ({ ...r, status: 'authorized' as const }))
     const { container } = mount({ researcherRows: allAuthorized })

--- a/test/pages/signing_official_console/DAAAssignment/DAAAccordionRow.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAAccordionRow.spec.tsx
@@ -134,6 +134,23 @@ describe('DAAAccordionRow', () => {
     expect(toggleSpy).toHaveBeenCalledOnce()
   })
 
+  // The header is a role="button" Box, so keyboard support is not free — and on
+  // the read-only admin page it is the only control on the card.
+  it('is reachable by keyboard and toggles on Enter and Space', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    const header = container.querySelector('[data-cy="daa-accordion-toggle-5"]') as HTMLElement
+
+    expect(header).toHaveAttribute('tabindex', '0')
+    header.focus()
+    expect(header).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(toggleSpy).toHaveBeenCalledTimes(1)
+    await user.keyboard(' ')
+    expect(toggleSpy).toHaveBeenCalledTimes(2)
+  })
+
   it('does not render the researcher subtable when collapsed', () => {
     const { container } = mount({ isExpanded: false })
     expect(container.querySelector('[data-cy="daa-researcher-subtable"]')).not.toBeInTheDocument()
@@ -186,6 +203,70 @@ describe('DAAAccordionRow', () => {
     const { container } = mount({ researcherRows: noneAuthorized })
     expect(container.querySelector('[data-cy="bulk-remove-all-daa-5"]')).toBeDisabled()
     expect(container.querySelector('[data-cy="bulk-approve-all-daa-5"]')).not.toBeDisabled()
+  })
+
+  // ── Read-only mode ────────────────────────────────────────────────────────
+
+  describe('read-only mode', () => {
+    it('renders no bulk action buttons in the header', () => {
+      const { container } = mount({ readOnly: true })
+      expect(container.querySelector('[data-cy="bulk-approve-all-daa-5"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="bulk-remove-all-daa-5"]')).not.toBeInTheDocument()
+    })
+
+    it('still renders the header content and authorized count badge', () => {
+      const { container } = mount({ readOnly: true })
+      const row = container.querySelector('[data-cy="daa-accordion-row-5"]')
+      expect(row).toHaveTextContent('Default DUOS DAA')
+      expect(container.querySelector('[data-cy="daa-authorized-badge-5"]')).toHaveTextContent('1 pre-authorized')
+    })
+
+    it('renders the sub-table without action buttons when expanded', () => {
+      const { container } = mount({ readOnly: true, isExpanded: true })
+      expect(container.querySelector('[data-cy="daa-researcher-subtable"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-cy="daa-researcher-row-1"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-revoke"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-authorize"]')).not.toBeInTheDocument()
+    })
+
+    it('still toggles when the header is clicked', async () => {
+      const user = userEvent.setup()
+      const { container } = mount({ readOnly: true })
+      await user.click(container.querySelector('[data-cy="daa-accordion-toggle-5"]') as HTMLElement)
+      expect(toggleSpy).toHaveBeenCalledOnce()
+    })
+
+    // An admin has neither an institution nor the authorize control the SO copy
+    // tells them to use.
+    it('drops the authorize-oriented wording from the recently-updated banner', () => {
+      const { container } = mount({
+        daa: recentDaa,
+        isRecentlyUpdated: true,
+        isExpanded: true,
+        authorizedCount: 0,
+        readOnly: true,
+      })
+      const banner = container.querySelector('[data-cy="daa-recently-updated-banner-6"]') as HTMLElement
+      expect(banner).toHaveTextContent('This DAA has been updated within the last year.')
+      expect(banner).not.toHaveTextContent('before authorizing new researchers')
+      expect(banner).not.toHaveTextContent('your institution')
+    })
+
+    it('keeps the authorize-oriented banner wording when not read-only', () => {
+      const { container } = mount({
+        daa: recentDaa,
+        isRecentlyUpdated: true,
+        isExpanded: true,
+        authorizedCount: 0,
+      })
+      const banner = container.querySelector('[data-cy="daa-recently-updated-banner-6"]') as HTMLElement
+      expect(banner).toHaveTextContent('before authorizing new researchers')
+    })
+  })
+
+  it('exposes aria-expanded on the header from first render', () => {
+    const { container } = mount()
+    expect(container.querySelector('[data-cy="daa-accordion-toggle-5"]')).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('a disabled bulk button does nothing when clicked', async () => {

--- a/test/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable.spec.tsx
@@ -5,12 +5,22 @@ import { render, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DAAResearcherSubtable from 'src/pages/signing_official_console/DAAAssignment/DAAResearcherSubtable'
 import { DAAResearcherRowData } from 'src/pages/signing_official_console/DAAAssignment/types'
-import { DuosUser } from 'src/types/model'
+import { DuosUser, InstitutionInterface } from 'src/types/model'
 
-const makeResearcher = (userId: number, displayName: string, email: string): DuosUser => ({
+const makeResearcher = (
+  userId: number,
+  displayName: string,
+  email: string,
+  institution?: { id: number, name: string },
+): DuosUser => ({
   userId,
   displayName,
   email,
+  // Only the identifying fields, as a user payload's nested institution carries.
+  ...(institution && {
+    institutionId: institution.id,
+    institution: institution as unknown as InstitutionInterface,
+  }),
   createDate: new Date('2020-01-01'),
   emailPreference: true,
   isAdmin: false,
@@ -25,7 +35,10 @@ const makeResearcher = (userId: number, displayName: string, email: string): Duo
 
 const mockRows: DAAResearcherRowData[] = [
   {
-    researcher: makeResearcher(1, 'Test User Theta', 'test.user.theta@test.org'),
+    researcher: makeResearcher(1, 'Test User Theta', 'test.user.theta@test.org', {
+      id: 100,
+      name: 'Institution Theta',
+    }),
     status: 'authorized',
     authorizedBy: 'so@test.org',
   },
@@ -48,14 +61,19 @@ describe('DAAResearcherSubtable', () => {
     revokeSpy = vi.fn()
   })
 
-  const mount = (rows = mockRows) =>
+  const mount = (rows = mockRows, readOnly = false, showInstitution = false) =>
     render(
       <DAAResearcherSubtable
         researcherRows={rows}
         onAuthorize={authorizeSpy}
         onRevoke={revokeSpy}
+        readOnly={readOnly}
+        showInstitution={showInstitution}
       />,
     )
+
+  const columnHeaders = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('th')).map(th => th.textContent)
 
   it('renders all researcher rows', () => {
     const { container } = mount()
@@ -137,6 +155,75 @@ describe('DAAResearcherSubtable', () => {
     const { container } = mount()
     mockRows.forEach(({ researcher }) => {
       expect(container.querySelector(`[data-cy="daa-authorized-by-${researcher.userId}"]`)).toBeInTheDocument()
+    })
+  })
+
+  describe('read-only mode', () => {
+    it('omits the Action column header, keeping the other four', () => {
+      const { container } = mount(mockRows, true)
+      expect(columnHeaders(container)).toEqual([
+        'Researcher',
+        'Email',
+        'Pre-Auth Status',
+        'Pre-authorized By',
+      ])
+    })
+
+    it('renders no action buttons in any row', () => {
+      const { container } = mount(mockRows, true)
+      expect(container.querySelector('[data-cy="auth-action-revoke"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-authorize"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-reauthorize"]')).not.toBeInTheDocument()
+    })
+
+    it('still renders every row with its status chip and authorizedBy value', () => {
+      const { container } = mount(mockRows, true)
+      expect(container.querySelectorAll('[data-cy^="daa-researcher-row-"]')).toHaveLength(3)
+      expect(container.querySelector('[data-cy="daa-researcher-row-1"] [data-cy="auth-status-chip-authorized"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-cy="daa-authorized-by-1"]')).toHaveTextContent('so@test.org')
+    })
+
+    it('spans the empty-state cell across the remaining columns', () => {
+      const { container } = mount([], true)
+      const emptyCell = container.querySelector('[data-cy="daa-researcher-subtable-empty"]') as HTMLElement
+      expect(emptyCell).toHaveAttribute('colspan', '4')
+    })
+  })
+
+  describe('institution column', () => {
+    it('is absent by default', () => {
+      const { container } = mount()
+      expect(columnHeaders(container)).not.toContain('Institution')
+      expect(container.querySelector('[data-cy="daa-researcher-institution-1"]')).not.toBeInTheDocument()
+    })
+
+    it('is inserted after Email when asked', () => {
+      const { container } = mount(mockRows, true, true)
+      expect(columnHeaders(container)).toEqual([
+        'Researcher',
+        'Email',
+        'Institution',
+        'Pre-Auth Status',
+        'Pre-authorized By',
+      ])
+    })
+
+    it('shows each researcher institution, dashing the ones without', () => {
+      const { container } = mount(mockRows, true, true)
+      expect(container.querySelector('[data-cy="daa-researcher-institution-1"]')).toHaveTextContent('Institution Theta')
+      expect(container.querySelector('[data-cy="daa-researcher-institution-2"]')).toHaveTextContent('—')
+    })
+
+    it('keeps each row cell count aligned with the header', () => {
+      const { container } = mount(mockRows, true, true)
+      const row1 = container.querySelector('[data-cy="daa-researcher-row-1"]') as HTMLElement
+      expect(row1.querySelectorAll('td')).toHaveLength(columnHeaders(container).length)
+    })
+
+    it('spans the empty-state cell across all five columns', () => {
+      const { container } = mount([], true, true)
+      expect(container.querySelector('[data-cy="daa-researcher-subtable-empty"]'))
+        .toHaveAttribute('colspan', '5')
     })
   })
 })

--- a/test/pages/signing_official_console/DAAAssignment/DAAView.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DAAView.spec.tsx
@@ -10,7 +10,7 @@ import {
 } from 'src/pages/signing_official_console/DAAAssignment/researcherViewHelpers'
 import { DAA } from 'src/libs/ajax/DAA'
 import { User } from 'src/libs/ajax/User'
-import { Notifications } from 'src/libs/utils'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
 import { DuosUser, DAAObject, DaaBulkRelationResult } from 'src/types/model'
 import { makeDaa, makeResearcher } from './fixtures'
 
@@ -262,6 +262,38 @@ describe('DAAView', () => {
     await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
     await waitFor(() => expect(DAA.createDaaLcLink).toHaveBeenCalledWith(1, 2))
     await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  // `expanded` starts empty, so an unguarded lookup would pass undefined and React
+  // would omit the attribute entirely.
+  it('exposes aria-expanded on every DAA header before any row is toggled', () => {
+    const { container } = mount()
+    container.querySelectorAll('[data-cy^="daa-accordion-toggle-"]').forEach((header) => {
+      expect(header).toHaveAttribute('aria-expanded', 'false')
+    })
+  })
+
+  it('refreshes with the institution-scoped list by default', async () => {
+    vi.spyOn(DAA, 'createDaaLcLink').mockResolvedValue(undefined as unknown as DAAObject)
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement)
+    await user.click(container.querySelector('[data-cy="daa-researcher-row-2"] [data-cy="auth-action-authorize"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(User.list).toHaveBeenCalledWith(USER_ROLES.signingOfficial))
+  })
+
+  // The page owns the scope; a refresh must reload the same list it loaded, not
+  // a differently-scoped one.
+  it('refreshes with the scope it was given', async () => {
+    vi.spyOn(DAA, 'createDaaLcLink').mockResolvedValue(undefined as unknown as DAAObject)
+    const user = userEvent.setup()
+    const { container } = mount({ scope: USER_ROLES.admin })
+    await user.click(container.querySelector('[data-cy="daa-accordion-toggle-1"]') as HTMLElement)
+    await user.click(container.querySelector('[data-cy="daa-researcher-row-2"] [data-cy="auth-action-authorize"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(User.list).toHaveBeenCalledWith(USER_ROLES.admin))
+    expect(User.list).not.toHaveBeenCalledWith(USER_ROLES.signingOfficial)
   })
 
   it('opens revoke confirm dialog when Revoke is clicked for an authorized researcher', async () => {

--- a/test/pages/signing_official_console/DAAAssignment/DaaAssociationsPage.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/DaaAssociationsPage.spec.tsx
@@ -1,0 +1,140 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DaaAssociationsPage from 'src/pages/signing_official_console/DAAAssignment/DaaAssociationsPage'
+import { DAA } from 'src/libs/ajax/DAA'
+import { User } from 'src/libs/ajax/User'
+import { Notifications, ROLES, USER_ROLES } from 'src/libs/utils'
+import { DAAObject, DuosUser } from 'src/types/model'
+import { makeDaa, makeResearcher } from './fixtures'
+
+const mockDaas: DAAObject[] = [makeDaa({ daaId: 1, fileName: 'Default DUOS DAA', dacId: 10 })]
+
+const researcher: DuosUser = makeResearcher({
+  userId: 1,
+  displayName: 'Test User Alpha',
+  email: 'test.user.alpha@institution-a.org',
+})
+
+// Identified by `roles`, the field a list response actually carries.
+const nonResearcher: DuosUser = makeResearcher({
+  userId: 2,
+  displayName: 'Test Admin Beta',
+  email: 'admin.beta@test.org',
+  roles: [{ roleId: ROLES.admin.roleId, name: USER_ROLES.admin, userId: 2 }],
+})
+
+const mount = (scope: 'Admin' | 'SigningOfficial') =>
+  render(
+    <DaaAssociationsPage
+      title="DAA Associations"
+      description="Test description"
+      scope={scope}
+    />,
+  )
+
+const mountManaged = (scope: 'Admin' | 'SigningOfficial') =>
+  render(
+    <DaaAssociationsPage
+      title="DAA Associations"
+      description="Test description"
+      scope={scope}
+      readOnly={false}
+    />,
+  )
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('DaaAssociationsPage', () => {
+  beforeEach(() => {
+    vi.spyOn(Notifications, 'showError').mockImplementation(() => {})
+    vi.spyOn(Notifications, 'showSuccess').mockImplementation(() => {})
+    vi.spyOn(DAA, 'getDaas').mockResolvedValue(mockDaas)
+    vi.spyOn(User, 'list').mockResolvedValue([researcher, nonResearcher])
+  })
+
+  it('narrows the Admin list to researchers', async () => {
+    const { container } = mount(USER_ROLES.admin)
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument())
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).not.toBeInTheDocument()
+  })
+
+  // The SO endpoint is already institution-scoped to researchers, so the page
+  // must not second-guess what it returns.
+  it('passes the SigningOfficial list through unfiltered', async () => {
+    const { container } = mount(USER_ROLES.signingOfficial)
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument())
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
+  })
+
+  // Granting and revoking is an SO responsibility, so the cross-institution scope
+  // must not expose the controls even when a caller forgets to ask for read-only.
+  it('forces read-only for the Admin scope even when readOnly is false', async () => {
+    const user = userEvent.setup()
+    const { container } = mountManaged(USER_ROLES.admin)
+
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument())
+    expect(container.querySelector('[data-cy="bulk-approve-all-researcher-1"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-cy="bulk-remove-all-researcher-1"]')).not.toBeInTheDocument()
+
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    expect(container.querySelector('[data-cy="auth-action-authorize"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-cy="auth-action-revoke"]')).not.toBeInTheDocument()
+  })
+
+  it('keeps the action controls for the SigningOfficial scope', async () => {
+    const { container } = mountManaged(USER_ROLES.signingOfficial)
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument())
+    expect(container.querySelector('[data-cy="bulk-approve-all-researcher-1"]')).toBeInTheDocument()
+  })
+
+  // Independent requests: the DAA fetch must not wait on the user list, which is
+  // the slower of the two under the system-wide Admin scope.
+  it('loads the user list and the DAAs concurrently', async () => {
+    let resolveUsers: (users: DuosUser[]) => void = () => {}
+    vi.mocked(User.list).mockReturnValue(new Promise((resolve) => {
+      resolveUsers = resolve
+    }))
+
+    const { container } = mount(USER_ROLES.signingOfficial)
+
+    // Still waiting on the user list, yet the DAAs are already requested.
+    await waitFor(() => expect(DAA.getDaas).toHaveBeenCalledOnce())
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
+
+    resolveUsers([researcher])
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument())
+  })
+
+  it('leaves both lists unset when the DAA request fails', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.mocked(DAA.getDaas).mockRejectedValue(new Error('daa service down'))
+
+    const { container } = mount(USER_ROLES.signingOfficial)
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalledOnce())
+    // Not "this researcher has no DAAs" — nothing loaded at all.
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-empty-message"]')).toBeInTheDocument()
+  })
+
+  // The read-only Admin page cannot reach a refresh, but the narrowing must not
+  // depend on that: any future refresh has to land on the same filtered list.
+  it('keeps the Admin list narrowed after a post-mutation refresh', async () => {
+    vi.spyOn(DAA, 'createDaaLcLink').mockResolvedValue(undefined as unknown as DAAObject)
+    const user = userEvent.setup()
+    // readOnly is forced on for the Admin scope, so drive the refresh through the
+    // SO scope and assert the narrowing is applied to whatever comes back.
+    const { container } = mountManaged(USER_ROLES.signingOfficial)
+
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument())
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    await user.click(container.querySelector('[data-cy="daa-row-1"] [data-cy="auth-action-authorize"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
+
+    await waitFor(() => expect(User.list).toHaveBeenCalledTimes(2))
+    expect(User.list).toHaveBeenLastCalledWith(USER_ROLES.signingOfficial)
+  })
+})

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.spec.tsx
@@ -163,6 +163,25 @@ describe('ResearcherAccordionRow', () => {
     expect(toggleSpy).not.toHaveBeenCalled()
   })
 
+  // Enter/Space on a bulk button bubbles to the header's keydown handler, which
+  // must leave it alone: the button activates itself and the card stays put.
+  it('activates a focused bulk button by keyboard, without toggling', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    const approveAll = container.querySelector('[data-cy="bulk-approve-all-researcher-42"]') as HTMLElement
+
+    approveAll.focus()
+    await user.keyboard('{Enter}')
+    expect(approveAllSpy).toHaveBeenCalledWith([2])
+    expect(toggleSpy).not.toHaveBeenCalled()
+
+    const removeAll = container.querySelector('[data-cy="bulk-remove-all-researcher-42"]') as HTMLElement
+    removeAll.focus()
+    await user.keyboard(' ')
+    expect(removeAllSpy).toHaveBeenCalledWith([1])
+    expect(toggleSpy).not.toHaveBeenCalled()
+  })
+
   it('disables Approve All when every DAA is already authorized', () => {
     const allAuthorized = mockDaaRows.map(r => ({ ...r, status: 'authorized' as const }))
     const { container } = mount({ daaRows: allAuthorized })

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherAccordionRow.spec.tsx
@@ -13,6 +13,7 @@ const mockResearcher: DuosUser = makeResearcher({
   displayName: 'Test User Gamma',
   email: 'test.user.gamma@test.org',
   daaDetails: [{ daaId: 1 }],
+  institutionName: 'Institution Gamma',
 })
 
 const mockDaaRows: DAARowData[] = [
@@ -65,6 +66,29 @@ describe('ResearcherAccordionRow', () => {
     expect(container.querySelector('[data-cy="researcher-row-42"]')).toHaveTextContent('test.user.gamma@test.org')
   })
 
+  // ── Institution ───────────────────────────────────────────────────────────
+
+  it('does not show the institution by default', () => {
+    const { container } = mount()
+    expect(container.querySelector('[data-cy="researcher-institution-42"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-42"]')).not.toHaveTextContent('Institution Gamma')
+  })
+
+  it('shows the institution when asked', () => {
+    const { container } = mount({ showInstitution: true })
+    expect(container.querySelector('[data-cy="researcher-institution-42"]')).toHaveTextContent('Institution Gamma')
+  })
+
+  it('shows a dash when the researcher has no institution', () => {
+    const withoutInstitution = makeResearcher({
+      userId: 42,
+      displayName: 'Test User Gamma',
+      email: 'test.user.gamma@test.org',
+    })
+    const { container } = mount({ researcher: withoutInstitution, showInstitution: true })
+    expect(container.querySelector('[data-cy="researcher-institution-42"]')).toHaveTextContent('—')
+  })
+
   it('shows authorized badge when authorizedCount > 0', () => {
     const { container } = mount()
     expect(container.querySelector('[data-cy="researcher-authorized-badge-42"]')).toHaveTextContent('1 pre-authorized')
@@ -80,6 +104,33 @@ describe('ResearcherAccordionRow', () => {
     const { container } = mount()
     await user.click(container.querySelector('[data-cy="researcher-row-toggle-42"]') as HTMLElement)
     expect(toggleSpy).toHaveBeenCalledOnce()
+  })
+
+  // The header is a role="button" Box, so keyboard support is not free — and on
+  // the read-only admin page it is the only control on the card.
+  it('is reachable by keyboard and toggles on Enter and Space', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    const header = container.querySelector('[data-cy="researcher-row-toggle-42"]') as HTMLElement
+
+    expect(header).toHaveAttribute('tabindex', '0')
+    header.focus()
+    expect(header).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(toggleSpy).toHaveBeenCalledTimes(1)
+    await user.keyboard(' ')
+    expect(toggleSpy).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores other keys on the header', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    const header = container.querySelector('[data-cy="researcher-row-toggle-42"]') as HTMLElement
+    header.focus()
+
+    await user.keyboard('{Escape}a{ArrowDown}')
+    expect(toggleSpy).not.toHaveBeenCalled()
   })
 
   it('does not render the DAA subtable when collapsed', () => {
@@ -133,5 +184,36 @@ describe('ResearcherAccordionRow', () => {
     const { container } = mount({ daaRows: allAuthorized })
     await user.click(container.querySelector('[data-cy="bulk-approve-all-researcher-42"]') as HTMLElement)
     expect(approveAllSpy).not.toHaveBeenCalled()
+  })
+
+  // ── Read-only mode ────────────────────────────────────────────────────────
+
+  describe('read-only mode', () => {
+    it('renders no bulk action buttons in the header', () => {
+      const { container } = mount({ readOnly: true })
+      expect(container.querySelector('[data-cy="bulk-approve-all-researcher-42"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="bulk-remove-all-researcher-42"]')).not.toBeInTheDocument()
+    })
+
+    it('still renders the header content and authorized count badge', () => {
+      const { container } = mount({ readOnly: true })
+      expect(container.querySelector('[data-cy="researcher-row-42"]')).toHaveTextContent('Test User Gamma')
+      expect(container.querySelector('[data-cy="researcher-authorized-badge-42"]')).toHaveTextContent('1 pre-authorized')
+    })
+
+    it('renders the sub-table without action buttons when expanded', () => {
+      const { container } = mount({ readOnly: true, isExpanded: true })
+      expect(container.querySelector('[data-cy="daa-subtable"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-cy="daa-row-1"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-revoke"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-authorize"]')).not.toBeInTheDocument()
+    })
+
+    it('still toggles when the header is clicked', async () => {
+      const user = userEvent.setup()
+      const { container } = mount({ readOnly: true })
+      await user.click(container.querySelector('[data-cy="researcher-row-toggle-42"]') as HTMLElement)
+      expect(toggleSpy).toHaveBeenCalledOnce()
+    })
   })
 })

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherDAASubtable.spec.tsx
@@ -37,14 +37,18 @@ describe('ResearcherDAASubtable', () => {
     revokeSpy = vi.fn()
   })
 
-  const mount = (rows = mockDaaRows) =>
+  const mount = (rows = mockDaaRows, readOnly = false) =>
     render(
       <ResearcherDAASubtable
         daaRows={rows}
         onAuthorize={authorizeSpy}
         onRevoke={revokeSpy}
+        readOnly={readOnly}
       />,
     )
+
+  const columnHeaders = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll('th')).map(th => th.textContent)
 
   it('renders all DAA rows', () => {
     const { container } = mount()
@@ -98,5 +102,37 @@ describe('ResearcherDAASubtable', () => {
     const { container } = mount([])
     expect(container.querySelector('[data-cy="daa-subtable"]')).toBeInTheDocument()
     expect(container.querySelector('[data-cy^="daa-row-"]')).not.toBeInTheDocument()
+  })
+
+  it('renders the Action column by default', () => {
+    const { container } = mount()
+    expect(columnHeaders(container)).toEqual(['DAA', 'DAC', 'Effective Date', 'Status', 'Action'])
+  })
+
+  describe('read-only mode', () => {
+    it('omits the Action column header', () => {
+      const { container } = mount(mockDaaRows, true)
+      expect(columnHeaders(container)).toEqual(['DAA', 'DAC', 'Effective Date', 'Status'])
+    })
+
+    it('renders no action buttons in any row', () => {
+      const { container } = mount(mockDaaRows, true)
+      expect(container.querySelector('[data-cy="auth-action-revoke"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-authorize"]')).not.toBeInTheDocument()
+      expect(container.querySelector('[data-cy="auth-action-reauthorize"]')).not.toBeInTheDocument()
+    })
+
+    it('still renders every row with its status chip', () => {
+      const { container } = mount(mockDaaRows, true)
+      expect(container.querySelectorAll('[data-cy^="daa-row-"]')).toHaveLength(3)
+      expect(container.querySelector('[data-cy="daa-row-1"] [data-cy="auth-status-chip-authorized"]')).toBeInTheDocument()
+      expect(container.querySelector('[data-cy="daa-row-2"] [data-cy="auth-status-chip-not_requested"]')).toBeInTheDocument()
+    })
+
+    it('keeps each row cell count aligned with the header', () => {
+      const { container } = mount(mockDaaRows, true)
+      const row1 = container.querySelector('[data-cy="daa-row-1"]') as HTMLElement
+      expect(row1.querySelectorAll('td')).toHaveLength(columnHeaders(container).length)
+    })
   })
 })

--- a/test/pages/signing_official_console/DAAAssignment/ResearcherView.spec.tsx
+++ b/test/pages/signing_official_console/DAAAssignment/ResearcherView.spec.tsx
@@ -11,7 +11,7 @@ import {
 } from 'src/pages/signing_official_console/DAAAssignment/researcherViewHelpers'
 import { DAA } from 'src/libs/ajax/DAA'
 import { User } from 'src/libs/ajax/User'
-import { Notifications } from 'src/libs/utils'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
 import { DuosUser, DAAObject, DaaBulkRelationResult } from 'src/types/model'
 import { makeDaa, makeResearcher } from './fixtures'
 
@@ -33,11 +33,13 @@ const mockResearchers: DuosUser[] = [
     displayName: 'Test User Alpha',
     email: 'test.user.alpha@test.org',
     daaDetails: [{ daaId: 1 }],
+    institutionName: 'Institution Alpha',
   }),
   makeResearcher({
     userId: 2,
     displayName: 'Test User Beta',
     email: 'test.user.beta@test.org',
+    institutionName: 'Institution Beta',
   }),
 ]
 
@@ -155,6 +157,31 @@ describe('ResearcherView', () => {
     expect(container.querySelector('[data-cy="researcher-row-2"]')).not.toBeInTheDocument()
   })
 
+  // Institution search is opt-in: the SO list is one institution, so the term
+  // would only ever match everything or nothing there.
+  it('does not filter by institution unless showInstitution is set', async () => {
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.type(container.querySelector('[data-cy="researcher-search"] input') as HTMLElement, 'Institution Beta')
+    expect(container.querySelector('[data-cy="researcher-empty-message"]')).toBeInTheDocument()
+  })
+
+  it('filters researchers by institution when showInstitution is set', async () => {
+    const user = userEvent.setup()
+    const { container } = mount({ showInstitution: true })
+    await user.type(container.querySelector('[data-cy="researcher-search"] input') as HTMLElement, 'Institution Beta')
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toBeInTheDocument()
+  })
+
+  it('still filters by name and email when institution search is on', async () => {
+    const user = userEvent.setup()
+    const { container } = mount({ showInstitution: true })
+    await user.type(container.querySelector('[data-cy="researcher-search"] input') as HTMLElement, 'test.user.alpha')
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-2"]')).not.toBeInTheDocument()
+  })
+
   it('shows empty message when search has no matches', async () => {
     const user = userEvent.setup()
     const { container } = mount()
@@ -213,6 +240,29 @@ describe('ResearcherView', () => {
     await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
     await waitFor(() => expect(DAA.createDaaLcLink).toHaveBeenCalledOnce())
     await waitFor(() => expect(User.list).toHaveBeenCalled())
+  })
+
+  it('refreshes with the institution-scoped list by default', async () => {
+    vi.spyOn(DAA, 'createDaaLcLink').mockResolvedValue(undefined as unknown as DAAObject)
+    const user = userEvent.setup()
+    const { container } = mount()
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-2"]') as HTMLElement)
+    await user.click(container.querySelector('[data-cy="daa-row-1"] [data-cy="auth-action-authorize"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(User.list).toHaveBeenCalledWith(USER_ROLES.signingOfficial))
+  })
+
+  // The page owns the scope; a refresh must reload the same list it loaded, not
+  // a differently-scoped one.
+  it('refreshes with the scope it was given', async () => {
+    vi.spyOn(DAA, 'createDaaLcLink').mockResolvedValue(undefined as unknown as DAAObject)
+    const user = userEvent.setup()
+    const { container } = mount({ scope: USER_ROLES.admin })
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-2"]') as HTMLElement)
+    await user.click(container.querySelector('[data-cy="daa-row-1"] [data-cy="auth-action-authorize"]') as HTMLElement)
+    await user.click(document.body.querySelector('[data-cy="confirm-dialog-confirm"]') as HTMLElement)
+    await waitFor(() => expect(User.list).toHaveBeenCalledWith(USER_ROLES.admin))
+    expect(User.list).not.toHaveBeenCalledWith(USER_ROLES.signingOfficial)
   })
 
   it('opens revoke confirm dialog when Revoke is clicked', async () => {

--- a/test/pages/signing_official_console/DAAAssignment/fixtures.ts
+++ b/test/pages/signing_official_console/DAAAssignment/fixtures.ts
@@ -1,4 +1,5 @@
-import { DAAObject, DuosUser } from 'src/types/model'
+import { DAAObject, DuosUser, InstitutionInterface, UserRole } from 'src/types/model'
+import { ROLES, USER_ROLES } from 'src/libs/utils'
 
 interface DaaOptions {
   daaId: number
@@ -17,6 +18,15 @@ interface ResearcherOptions {
   displayName: string
   email: string
   daaDetails?: DaaDetailOption[]
+  /** Defaults to the Researcher role, as a list response would carry it. */
+  roles?: UserRole[]
+  /** Omitted by default, so tests must opt in to having an institution. */
+  institutionName?: string
+}
+
+/** The `roles` entry a list response carries for a researcher. */
+export function researcherRole(userId: number): UserRole {
+  return { roleId: ROLES.researcher.roleId, name: USER_ROLES.researcher, userId }
 }
 
 export function makeDaa({
@@ -50,6 +60,8 @@ export function makeResearcher({
   displayName,
   email,
   daaDetails,
+  roles,
+  institutionName,
 }: ResearcherOptions): DuosUser {
   return {
     userId,
@@ -64,7 +76,17 @@ export function makeResearcher({
     isMember: false,
     isResearcher: true,
     isSigningOfficial: false,
-    roles: [],
+    roles: roles ?? [researcherRole(userId)],
+    ...(institutionName && {
+      institutionId: userId * 100,
+      // Only the identifying fields, as a user payload's nested institution
+      // carries; InstitutionInterface also declares creation metadata that the
+      // views never read.
+      institution: {
+        id: userId * 100,
+        name: institutionName,
+      } as unknown as InstitutionInterface,
+    }),
     libraryCard: {
       id: userId * 10,
       userId,

--- a/test/pages/signing_official_console/DAAAssignment/subtableColumns.spec.ts
+++ b/test/pages/signing_official_console/DAAAssignment/subtableColumns.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   ACTION_COLUMN,
   normalizedWidths,
-  visibleColumns,
+  withoutActionColumn,
 } from 'src/pages/signing_official_console/DAAAssignment/subtableColumns'
 
 const HEADERS = [
@@ -33,18 +33,14 @@ const READ_ONLY_COLUMNS = HEADERS.filter(header => header !== ACTION_COLUMN)
 const sumOf = (widths: Record<string, string>): number =>
   Object.values(widths).reduce((sum, width) => sum + Number.parseFloat(width), 0)
 
-describe('visibleColumns', () => {
-  it('keeps every column when not read-only', () => {
-    expect(visibleColumns(HEADERS, false)).toEqual(HEADERS)
-  })
-
-  it('drops the Action column when read-only', () => {
-    expect(visibleColumns(HEADERS, true)).toEqual(READ_ONLY_COLUMNS)
+describe('withoutActionColumn', () => {
+  it('drops the Action column, keeping the others in order', () => {
+    expect(withoutActionColumn(HEADERS)).toEqual(READ_ONLY_COLUMNS)
   })
 
   it('is a no-op for a header list with no Action column', () => {
     const headers = ['DAA', 'DAC'] as const
-    expect(visibleColumns(headers, true)).toEqual(headers)
+    expect(withoutActionColumn(headers)).toEqual(headers)
   })
 })
 

--- a/test/pages/signing_official_console/DAAAssignment/subtableColumns.spec.ts
+++ b/test/pages/signing_official_console/DAAAssignment/subtableColumns.spec.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ACTION_COLUMN,
+  normalizedWidths,
+  visibleColumns,
+} from 'src/pages/signing_official_console/DAAAssignment/subtableColumns'
+
+const HEADERS = [
+  'Researcher',
+  'Email',
+  'Institution',
+  'Pre-Auth Status',
+  'Pre-authorized By',
+  ACTION_COLUMN,
+] as const
+
+type Header = (typeof HEADERS)[number]
+
+const WIDTHS: Record<Header, string> = {
+  'Researcher': '23%',
+  'Email': '25%',
+  'Institution': '20%',
+  'Pre-Auth Status': '17%',
+  'Pre-authorized By': '20%',
+  'Action': '15%',
+}
+
+// What the SO console renders: everything except Institution.
+const MANAGED_COLUMNS = HEADERS.filter(header => header !== 'Institution')
+// What the admin console renders: no Action, plus Institution.
+const READ_ONLY_COLUMNS = HEADERS.filter(header => header !== ACTION_COLUMN)
+
+const sumOf = (widths: Record<string, string>): number =>
+  Object.values(widths).reduce((sum, width) => sum + Number.parseFloat(width), 0)
+
+describe('visibleColumns', () => {
+  it('keeps every column when not read-only', () => {
+    expect(visibleColumns(HEADERS, false)).toEqual(HEADERS)
+  })
+
+  it('drops the Action column when read-only', () => {
+    expect(visibleColumns(HEADERS, true)).toEqual(READ_ONLY_COLUMNS)
+  })
+
+  it('is a no-op for a header list with no Action column', () => {
+    const headers = ['DAA', 'DAC'] as const
+    expect(visibleColumns(headers, true)).toEqual(headers)
+  })
+})
+
+describe('normalizedWidths', () => {
+  it('covers only the given columns', () => {
+    expect(Object.keys(normalizedWidths(READ_ONLY_COLUMNS, WIDTHS))).toEqual([...READ_ONLY_COLUMNS])
+  })
+
+  // The point of the normalization: no unclaimed width for the browser to
+  // apportion however it likes, whichever columns a view renders.
+  it('totals 100% for every column combination the two consoles render', () => {
+    expect(sumOf(normalizedWidths(MANAGED_COLUMNS, WIDTHS))).toBeCloseTo(100, 3)
+    expect(sumOf(normalizedWidths(READ_ONLY_COLUMNS, WIDTHS))).toBeCloseTo(100, 3)
+    expect(sumOf(normalizedWidths(HEADERS, WIDTHS))).toBeCloseTo(100, 3)
+  })
+
+  it('preserves the relative proportions of the given columns', () => {
+    const widths = normalizedWidths(READ_ONLY_COLUMNS, WIDTHS)
+    const ratio = (a: string, b: string) => Number.parseFloat(a) / Number.parseFloat(b)
+
+    expect(ratio(widths.Email, widths.Researcher))
+      .toBeCloseTo(ratio(WIDTHS.Email, WIDTHS.Researcher), 5)
+    expect(ratio(widths['Pre-authorized By'], widths['Pre-Auth Status']))
+      .toBeCloseTo(ratio(WIDTHS['Pre-authorized By'], WIDTHS['Pre-Auth Status']), 5)
+  })
+
+  it('falls back to auto widths rather than dividing by zero', () => {
+    expect(normalizedWidths(['Researcher'], { Researcher: '0%' }))
+      .toEqual({ Researcher: 'auto' })
+  })
+})

--- a/test/pages/signing_official_console/ManageResearcherDAAs.spec.tsx
+++ b/test/pages/signing_official_console/ManageResearcherDAAs.spec.tsx
@@ -6,8 +6,7 @@ import userEvent from '@testing-library/user-event'
 import ManageResearcherDAAs from 'src/pages/signing_official_console/ManageResearcherDAAs'
 import { User } from 'src/libs/ajax/User'
 import { DAA } from 'src/libs/ajax/DAA'
-import { Notifications } from 'src/libs/utils'
-import { USER_ROLES } from 'src/libs/utils'
+import { Notifications, USER_ROLES } from 'src/libs/utils'
 import { makeDaa, makeResearcher } from './DAAAssignment/fixtures'
 
 afterEach(() => vi.restoreAllMocks())

--- a/test/pages/signing_official_console/ManageResearcherDAAs.spec.tsx
+++ b/test/pages/signing_official_console/ManageResearcherDAAs.spec.tsx
@@ -7,6 +7,7 @@ import ManageResearcherDAAs from 'src/pages/signing_official_console/ManageResea
 import { User } from 'src/libs/ajax/User'
 import { DAA } from 'src/libs/ajax/DAA'
 import { Notifications } from 'src/libs/utils'
+import { USER_ROLES } from 'src/libs/utils'
 import { makeDaa, makeResearcher } from './DAAAssignment/fixtures'
 
 afterEach(() => vi.restoreAllMocks())
@@ -37,6 +38,65 @@ describe('ManageResearcherDAAs', () => {
     await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
     // The researcher holds DAAs 1 and 2, but 2 has no DAC mapping so only 1 is shown.
     expect(container.querySelectorAll('[data-cy^="daa-row-"]')).toHaveLength(1)
+  })
+
+  // The Admin Console renders the same page read-only, so the SO Console keeps an
+  // explicit guard that its institution scope and action controls are intact.
+  it('loads the institution-scoped researcher list and keeps the action controls', async () => {
+    vi.spyOn(User, 'list').mockResolvedValue([makeResearcher({
+      userId: 1,
+      displayName: 'Test User Eta',
+      email: 'test@test.com',
+      daaDetails: [{ daaId: 1 }],
+    })])
+    vi.spyOn(DAA, 'getDaas').mockResolvedValue([makeDaa({ daaId: 1, mapped: true })])
+
+    const { container } = render(<ManageResearcherDAAs />)
+
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-view"]')).toBeInTheDocument())
+    expect(User.list).toHaveBeenCalledWith(USER_ROLES.signingOfficial)
+    expect(container.querySelector('[data-cy="bulk-remove-all-researcher-1"]')).toBeInTheDocument()
+
+    const user = userEvent.setup()
+    await user.click(container.querySelector('[data-cy="researcher-row-toggle-1"]') as HTMLElement)
+    expect(container.querySelector('[data-cy="daa-row-1"] [data-cy="auth-action-revoke"]')).toBeInTheDocument()
+  })
+
+  // Institution is an Admin Console addition: an SO's list is one institution, so
+  // the SO page must look exactly as it did.
+  it('does not show institution or offer institution search', async () => {
+    vi.spyOn(User, 'list').mockResolvedValue([makeResearcher({
+      userId: 1,
+      displayName: 'Test User Eta',
+      email: 'test@test.com',
+      institutionName: 'Institution Eta',
+    })])
+    vi.spyOn(DAA, 'getDaas').mockResolvedValue([makeDaa({ daaId: 1, mapped: true })])
+
+    const { container } = render(<ManageResearcherDAAs />)
+
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-view"]')).toBeInTheDocument())
+    expect(container.querySelector('[data-cy="researcher-institution-1"]')).not.toBeInTheDocument()
+    expect(container.querySelector('[data-cy="researcher-row-1"]')).not.toHaveTextContent('Institution Eta')
+    expect(container.querySelector('[data-cy="researcher-search"] input'))
+      .toHaveAttribute('placeholder', 'Search researchers')
+
+    const user = userEvent.setup()
+    await user.type(
+      container.querySelector('[data-cy="researcher-search"] input') as HTMLElement,
+      'Institution Eta',
+    )
+    expect(container.querySelector('[data-cy="researcher-empty-message"]')).toBeInTheDocument()
+  })
+
+  it('sets the document title', async () => {
+    vi.spyOn(User, 'list').mockResolvedValue([])
+    vi.spyOn(DAA, 'getDaas').mockResolvedValue([])
+
+    const { container } = render(<ManageResearcherDAAs />)
+
+    await waitFor(() => expect(container.querySelector('[data-cy="researcher-view"]')).toBeInTheDocument())
+    expect(document.title).toEqual('Pre-Authorize Researchers (DAAs) | DUOS')
   })
 
   it('shows an error notification when initial data load fails', async () => {

--- a/test/routing/AppRoutes.spec.tsx
+++ b/test/routing/AppRoutes.spec.tsx
@@ -71,6 +71,7 @@ const roleBACRoutes: string[] = [
   '/admin_manage_institutions/institutions/1',
   '/admin_manage_institutions',
   '/admin_manage_lc/',
+  '/admin_daa_associations',
   '/admin_manage_dar_collections/',
   '/manage_add_dac_daa',
 ]


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3796](https://broadworkbench.atlassian.net/browse/DT-3796)

### Summary

Adds a DAA view to the Admin dashboard so that Admins can easily view DAA assignments.  Note: This view is read only.  Admins who also have the SO role need to navigate to the DAA console in the SO view to adjust DAA assignments.

After:
<img width="1974" height="481" alt="image" src="https://github.com/user-attachments/assets/811bdcde-2d8a-4c8d-a29d-3d32dfa6afa7" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
