### PR TITLE
[DT-3316] Fix grid pagination write-back and link focus ring

### DIFF
--- a/src/components/manage_users_table/ManageUsersTable.tsx
+++ b/src/components/manage_users_table/ManageUsersTable.tsx
@@ -19,6 +19,12 @@ const DATAGRID_SX = {
     outline: `2px solid ${Theme.palette.link}`,
     outlineOffset: '-2px',
   },
+  // The link takes focus in its cell's place, and index.css drops link outlines with !important,
+  // so the ring has to be reinstated at the same weight to be seen at all.
+  '& .MuiDataGrid-cell a:focus-visible': {
+    outline: `2px solid ${Theme.palette.link} !important`,
+    outlineOffset: '2px',
+  },
 }
 
 // Left inset matches SearchBar's own margin, negative right mirrors the search and add button row.
@@ -69,6 +75,7 @@ const filterFn = getSearchFilterFunctions().users
 
 export const ManageUsersTable = function ManageUsersTable({ isLoading, userList, searchText }: ManageUsersTableProps) {
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({ page: 0, pageSize: PAGE_SIZE_OPTIONS[0] })
+  const [lastSearchText, setLastSearchText] = useState(searchText)
 
   // Filtering is derived, so a keystroke costs one render rather than a cascade of effects.
   const rows = useMemo(() => {
@@ -76,8 +83,18 @@ export const ManageUsersTable = function ManageUsersTable({ isLoading, userList,
     return terms.reduce((list, term) => filterFn(term, list), userList ?? []).map(toUserRow)
   }, [userList, searchText])
 
-  // Clamped during render so a narrower search cannot leave the grid on an empty page.
   const lastPage = Math.max(0, Math.ceil(rows.length / paginationModel.pageSize) - 1)
+
+  // Adjusted during render rather than clamped for the render alone, so widening the results again
+  // cannot restore the page the admin was already moved off.
+  if (searchText !== lastSearchText) {
+    setLastSearchText(searchText)
+    setPaginationModel(model => ({ ...model, page: 0 }))
+  }
+  else if (paginationModel.page > lastPage) {
+    setPaginationModel(model => ({ ...model, page: lastPage }))
+  }
+
   const page = Math.min(paginationModel.page, lastPage)
 
   return (

--- a/src/components/manage_users_table/ManageUsersTable.tsx
+++ b/src/components/manage_users_table/ManageUsersTable.tsx
@@ -19,10 +19,9 @@ const DATAGRID_SX = {
     outline: `2px solid ${Theme.palette.link}`,
     outlineOffset: '-2px',
   },
-  // The link takes focus in its cell's place, and index.css drops link outlines with !important,
-  // so the ring has to be reinstated at the same weight to be seen at all.
+  // The link takes focus in its cell's place, and index.css resets link outlines.
   '& .MuiDataGrid-cell a:focus-visible': {
-    outline: `2px solid ${Theme.palette.link} !important`,
+    outline: `2px solid ${Theme.palette.link}`,
     outlineOffset: '2px',
   },
 }

--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,7 @@ a {
 }
 
 a, input {
-  outline: 0 !important;
+  outline: 0;
   text-decoration: none !important;
 }
 

--- a/src/styles/bootstrap_replacement.css
+++ b/src/styles/bootstrap_replacement.css
@@ -1094,10 +1094,6 @@ a:focus {
     color: #23527c;
     text-decoration: underline;
 }
-a:focus {
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px;
-}
 figure {
     margin: 0;
 }
@@ -2621,12 +2617,6 @@ input[type="range"] {
 select[multiple],
 select[size] {
     height: auto;
-}
-input[type="file"]:focus,
-input[type="radio"]:focus,
-input[type="checkbox"]:focus {
-    outline: 5px auto -webkit-focus-ring-color;
-    outline-offset: -2px;
 }
 output {
     display: block;

--- a/test/components/manage_users_table/ManageUsersTable.spec.tsx
+++ b/test/components/manage_users_table/ManageUsersTable.spec.tsx
@@ -60,11 +60,18 @@ const renderTable = (props: Partial<ManageUsersTableProps> = {}) => renderWithRo
   <ManageUsersTable isLoading={false} userList={testUsers} searchText="" {...props} />,
 )
 
-const SearchHarness = ({ users }: { users: DuosUser[] }) => {
+const numberedUsers = (count: number): DuosUser[] => Array.from({ length: count }, (_, index) => makeUser({
+  userId: index + 10,
+  displayName: `User ${String(index).padStart(2, '0')}`,
+  email: `user${index}@test.com`,
+}))
+
+const SearchHarness = ({ users, term }: { users: DuosUser[], term: string }) => {
   const [searchText, setSearchText] = useState('')
   return (
     <>
-      <button type="button" onClick={() => setSearchText('user0@')}>Apply search</button>
+      <button type="button" onClick={() => setSearchText(term)}>Apply search</button>
+      <button type="button" onClick={() => setSearchText('')}>Clear search</button>
       <ManageUsersTable isLoading={false} userList={users} searchText={searchText} />
     </>
   )
@@ -83,6 +90,13 @@ const columnHeader = (label: string): HTMLElement =>
 const sortBy = (label: string): void => {
   fireEvent.click(columnHeader(label))
 }
+
+// jsdom cannot resolve :focus-visible, so the emitted rules are read instead.
+const emittedRules = (): string[] =>
+  Array.from(document.querySelectorAll('style'))
+    .map(style => style.textContent ?? '')
+    .join('')
+    .split('}')
 
 const rowFor = async (name: string): Promise<HTMLElement> => {
   const cell = await screen.findByText(name)
@@ -180,12 +194,7 @@ describe('ManageUsersTable', () => {
   })
 
   it('narrows to a page that still holds rows when the search shrinks the list', async () => {
-    const manyUsers = Array.from({ length: 12 }, (_, index) => makeUser({
-      userId: index + 10,
-      displayName: `User ${String(index).padStart(2, '0')}`,
-      email: `user${index}@test.com`,
-    }))
-    renderWithRouter(<SearchHarness users={manyUsers} />)
+    renderWithRouter(<SearchHarness users={numberedUsers(12)} term="user0@" />)
 
     fireEvent.click(await screen.findByRole('button', { name: /go to next page/i }))
     expect(userOrder()).toEqual(['User 10', 'User 11'])
@@ -195,6 +204,30 @@ describe('ManageUsersTable', () => {
 
     expect(userOrder()).toEqual(['User 00'])
     expect(screen.getByText('1–1 of 1')).toBeInTheDocument()
+  })
+
+  it('stays on the first page when a search that shrank the list is cleared', async () => {
+    renderWithRouter(<SearchHarness users={numberedUsers(12)} term="user0@" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /go to next page/i }))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply search' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }))
+
+    // The abandoned second page is not restored, because the narrowing was written back to state.
+    expect(screen.getByText('1–10 of 12')).toBeInTheDocument()
+    expect(userOrder()).toEqual(numberedUsers(12).slice(0, 10).map(user => user.displayName))
+  })
+
+  it('restarts at the first page when a new search is applied', async () => {
+    renderWithRouter(<SearchHarness users={numberedUsers(24)} term="test.com" />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /go to next page/i }))
+    expect(screen.getByText('11–20 of 24')).toBeInTheDocument()
+
+    // Every user matches, so the page count is unchanged and only the reset can move the grid.
+    fireEvent.click(screen.getByRole('button', { name: 'Apply search' }))
+
+    expect(screen.getByText('1–10 of 24')).toBeInTheDocument()
   })
 
   it('shows a loading indicator while users are being fetched', () => {
@@ -211,20 +244,24 @@ describe('ManageUsersTable', () => {
     expect(columnHeader('User Name')).toBeInTheDocument()
   })
 
-  // jsdom cannot resolve :focus-visible, so the emitted rules are read instead.
   it('keeps a visible focus ring for keyboard users', () => {
     renderTable()
 
-    const rules = Array.from(document.querySelectorAll('style'))
-      .map(style => style.textContent ?? '')
-      .join('')
-      .split('}')
-
     for (const selector of ['.MuiDataGrid-cell:focus-visible', '.MuiDataGrid-columnHeader:focus-visible']) {
       // Last rule wins, so the keyboard ring must outrank the suppressed :focus outline.
-      const matching = rules.filter(rule => rule.includes(selector))
+      const matching = emittedRules().filter(rule => rule.includes(selector))
       expect(matching.length).toBeGreaterThan(0)
       expect(matching.at(-1)).toContain('outline:2px solid #216fb4')
     }
+  })
+
+  it('rings a focused user link at a weight that survives the global link reset', () => {
+    renderTable()
+
+    const matching = emittedRules().filter(rule => rule.includes('.MuiDataGrid-cell a:focus-visible'))
+    expect(matching.length).toBeGreaterThan(0)
+    // index.css drops link outlines with !important, so nothing lighter would be painted.
+    expect(matching.at(-1)).toContain('outline:2px solid #216fb4')
+    expect(matching.at(-1)).toContain('!important')
   })
 })

--- a/test/components/manage_users_table/ManageUsersTable.spec.tsx
+++ b/test/components/manage_users_table/ManageUsersTable.spec.tsx
@@ -255,13 +255,13 @@ describe('ManageUsersTable', () => {
     }
   })
 
-  it('rings a focused user link at a weight that survives the global link reset', () => {
+  it('rings a focused user link', () => {
     renderTable()
 
     const matching = emittedRules().filter(rule => rule.includes('.MuiDataGrid-cell a:focus-visible'))
     expect(matching.length).toBeGreaterThan(0)
-    // index.css drops link outlines with !important, so nothing lighter would be painted.
+    // The rule outranks index.css's link outline reset on specificity alone.
     expect(matching.at(-1)).toContain('outline:2px solid #216fb4')
-    expect(matching.at(-1)).toContain('!important')
+    expect(matching.at(-1)).not.toContain('!important')
   })
 })


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-3316

Security risk: no

Follow-up to #3867, which merged before this review feedback landed.

### Summary

Two fixes to the Manage Users grid, both confined to `ManageUsersTable`.

**Pagination is written back, not just clamped.** The clamp added in #3867 shaped the render but never reached state, so the component rendered a valid page while `paginationModel.page` kept the abandoned one. MUI syncs a controlled `paginationModel` into its internal state without firing `onPaginationModelChange`, so nothing corrected it — clearing a search jumped the admin back to a page they had already been moved off. The page is now adjusted during render, and a new search restarts at the first page. This restores the pre-#3867 behaviour, where `recalculateVisibleTable` wrote the clamped page back through `setCurrentPage`.

**A focused user name link is visible again.** #3867 gave the link its cell's `tabIndex` so it joins the grid's roving focus, which makes the link the focus target inside the cell — but the cell's `:focus-within { outline: none }` and the global `a, input { outline: 0 !important }` in `index.css` between them left it with no indicator at all. The grid now rings a focused link at matching weight, so keyboard users can see what they are about to activate.

### Notes for review

Only this table needed either fix. `SigningOfficialTable` owns its `SearchBar` and already resets pagination in the handler, and has no links in cells; `ManageUsersTable` receives `searchText` as a prop, so it has to react during render instead.

Two other points from the same review were checked and deliberately not actioned:

- The search filter splitting on `' '` rather than `/\s|,/` is not a regression. This table previously used `searchOnFilteredList`, which splits on `' '` too; the `/\s|,/` variant lives in `tableSearchHandler`, which it never called. Behaviour is unchanged, and `filterUsers` lowercases internally.
- The duplicated focus `sx` is real but wider than this PR — the block is copy-pasted across six grids, four of which (`LibraryDataGrid`, `ManageDac`, `DacProfile`, `ControlledAccessGrants`) have no `:focus-visible` ring at all, and `ManageDac`/`DacProfile` carry the same invisible-link-focus bug fixed here. That is worth centralising in its own ticket rather than partially here, ideally before DT-3982 adds a seventh grid.

### Testing

Three tests added, each verified to fail against `develop`: clearing a search does not restore the abandoned page, a new search restarts at page 1, and the link ring is emitted at a weight that survives the global reset. Full suite green (3894 tests), lint and type-check clean.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
