### PR TITLE
[DT-1854] Download a blank study template, then upload, validate, and replace a filled-in one

### DIFF
--- a/docs/plans/study-template-validation-workflow.md
+++ b/docs/plans/study-template-validation-workflow.md
@@ -98,7 +98,7 @@ sequenceDiagram
     else Template is valid
         API->>DB: Create typed Draft (StudyDatasetSubmissionV1)
         DB-->>API: draft UUID and draftType
-        API-->>UI: 200 { valid: true, draft: { id, draftType } }
+        API-->>UI: 201 Location /api/draft/v1/:id { valid: true, draft: { id, draftType } }
         UI->>UI: Navigate to /data_submission_form/draft/study-dataset/:draftUuid
         UI->>API: GET /api/draft/v1/:draftUuid
         API-->>UI: Draft document and typed metadata
@@ -125,9 +125,9 @@ registration. Add `Chairperson` to the existing draft endpoints as well so all t
 create, resume, update, attach files to, and delete their authorized drafts. Existing ownership and
 administrator authorization checks remain unchanged.
 
-Validation errors are a completed, expected result and should return HTTP 200. Authentication, authorization, malformed multipart requests, size-limit violations, and unexpected server failures should use appropriate non-2xx responses.
+Validation errors are a completed, expected result and should return HTTP 200; a valid template creates a draft and returns HTTP 201 at its location. Authentication, authorization, malformed multipart requests, size-limit violations, and unexpected server failures should use appropriate non-2xx responses.
 
-Ticket 3 settled where the boundary falls: the 5 MiB limit is enforced at the resource and answered with `413`, while an empty, non-UTF-8, or malformed file stays a `valid: false` result, since only the latter is something the producer edits.
+Ticket 3 settled where the boundary falls: the 5 MiB limit is enforced by the validator and answered with `413`, while an empty, non-UTF-8, or malformed file stays a `valid: false` result, since only the latter is something the producer edits.
 
 Invalid template response:
 
@@ -583,8 +583,9 @@ and authentication requirements.
 - Unauthorized and unauthenticated callers receive the existing standard responses.
 - Missing, multiple, empty, and oversized file parts are rejected without draft creation.
 - Template validation errors return HTTP 200 with `valid: false` and structured errors.
-- Successful validation returns HTTP 200 with `valid: true`, an empty error list, and a reference
-  containing both the draft UUID and `StudyDatasetSubmissionV1` type.
+- Successful validation returns HTTP 201, a `Location` header for the created draft, and a body
+  with `valid: true`, an empty error list, and a reference containing both the draft UUID and
+  `StudyDatasetSubmissionV1` type.
 - Exactly one draft with type `StudyDatasetSubmissionV1`, owned by the caller, is created for a valid
   request.
 - The existing authorized draft endpoint returns the persisted registration-shaped document.
@@ -834,7 +835,7 @@ observation is recorded in full because no ticket owns it.
 | --- | --- | --- |
 | The `draft` table is the only JSON write in this area without the NUL guard the DAR tables already have. A U+0000 escape survives the parser and `jsonb` rejects it, so a valid template can 500 on insert. | Tickets 2 and 3 | Ticket 2 rejects U+0000 during parsing so the producer is told; Ticket 3 applies the existing `regexp_replace` idiom to `DraftDAO.insert` and `updateDraftByDraftUUID`. |
 | `StudyTemplateValidationResult.truncated` has no counterpart in the response type documented in this plan or in the v1 contract. | Ticket 3 | Settled: it reaches the wire. duos-ui already renders a notice when it is true, and OpenAPI, the v1 contract, and this plan now document it. |
-| The service reports the 5 MiB and UTF-8 failures as `valid: false` rather than as request failures, contradicting this plan and the contract. | Ticket 3 | Settled: the resource rejects an oversized upload with `413` before the service reads it, and encoding stays a `valid: false` result. See the note under "Validate a template" above. |
+| The service reports the 5 MiB and UTF-8 failures as `valid: false` rather than as request failures, contradicting this plan and the contract. | Ticket 3 | Settled: an oversized upload is refused by the validator that reads it and answered `413`, and encoding stays a `valid: false` result. See the note under "Validate a template" above. |
 
 Chairperson access to the draft endpoints was already specified in Ticket 3 and needed no change.
 

--- a/docs/plans/study-template-validation-workflow.md
+++ b/docs/plans/study-template-validation-workflow.md
@@ -127,13 +127,14 @@ administrator authorization checks remain unchanged.
 
 Validation errors are a completed, expected result and should return HTTP 200. Authentication, authorization, malformed multipart requests, size-limit violations, and unexpected server failures should use appropriate non-2xx responses.
 
-Note: the Ticket 2 service currently reports the size-limit and encoding failures as `valid: false` results instead. Ticket 3 reconciles the two — see "Findings from implementation" below.
+Ticket 3 settled where the boundary falls: the 5 MiB limit is enforced at the resource and answered with `413`, while an empty, non-UTF-8, or malformed file stays a `valid: false` result, since only the latter is something the producer edits.
 
 Invalid template response:
 
 ```json
 {
   "valid": false,
+  "truncated": false,
   "errors": [
     {
       "row": 3,
@@ -149,6 +150,7 @@ Valid template response:
 ```json
 {
   "valid": true,
+  "truncated": false,
   "draft": {
     "id": "c2e4583a-20b9-4705-8280-e6a5753f10c9",
     "draftType": "StudyDatasetSubmissionV1"
@@ -172,9 +174,12 @@ interface StudyDatasetDraftReference {
 }
 
 type TemplateValidationResponse =
-  | { valid: false, errors: TemplateValidationError[] }
-  | { valid: true, errors: TemplateValidationError[], draft: StudyDatasetDraftReference }
+  | { valid: false, errors: TemplateValidationError[], truncated: boolean }
+  | { valid: true, errors: TemplateValidationError[], truncated: false, draft: StudyDatasetDraftReference }
 ```
+
+`truncated` reports that the 100-error cap was reached. The last error says so as well, so a client
+that ignores the flag still tells the producer that errors were omitted.
 
 Both branches use `TemplateValidationError[]` so callers can pass `errors` through uniformly. The
 success branch is identified by `valid` and includes a typed draft reference.
@@ -821,15 +826,15 @@ adding template-only cleanup behavior here.
 ## Findings from implementation
 
 Two kinds of thing came out of building Ticket 4 (DT-1854) against the Consent DTOs and the Ticket 2
-parser. The actionable ones are now carried by the tickets that own them, following the same pattern
-as "Contract outcomes" above, so they are summarised here rather than specified here. The design
+parser. The actionable ones were carried by the tickets that own them, following the same pattern as
+"Contract outcomes" above, and are summarised here with what each was settled as. The design
 observation is recorded in full because no ticket owns it.
 
 | Finding | Recorded in | Outcome |
 | --- | --- | --- |
 | The `draft` table is the only JSON write in this area without the NUL guard the DAR tables already have. A U+0000 escape survives the parser and `jsonb` rejects it, so a valid template can 500 on insert. | Tickets 2 and 3 | Ticket 2 rejects U+0000 during parsing so the producer is told; Ticket 3 applies the existing `regexp_replace` idiom to `DraftDAO.insert` and `updateDraftByDraftUUID`. |
-| `StudyTemplateValidationResult.truncated` has no counterpart in the response type documented in this plan or in the v1 contract. | Ticket 3 | Ticket 3 decides whether it reaches the wire and makes OpenAPI and both documents agree. duos-ui types it as optional, so either choice works. |
-| The service reports the 5 MiB and UTF-8 failures as `valid: false` rather than as request failures, contradicting this plan and the contract. | Ticket 3 | Ticket 3 either rejects oversize at the resource layer or amends both documents. See the note under "Validate a template" above. |
+| `StudyTemplateValidationResult.truncated` has no counterpart in the response type documented in this plan or in the v1 contract. | Ticket 3 | Settled: it reaches the wire. duos-ui already renders a notice when it is true, and OpenAPI, the v1 contract, and this plan now document it. |
+| The service reports the 5 MiB and UTF-8 failures as `valid: false` rather than as request failures, contradicting this plan and the contract. | Ticket 3 | Settled: the resource rejects an oversized upload with `413` before the service reads it, and encoding stays a `valid: false` result. See the note under "Validate a template" above. |
 
 Chairperson access to the draft endpoints was already specified in Ticket 3 and needed no change.
 

--- a/docs/plans/study-template-validation-workflow.md
+++ b/docs/plans/study-template-validation-workflow.md
@@ -127,6 +127,8 @@ administrator authorization checks remain unchanged.
 
 Validation errors are a completed, expected result and should return HTTP 200. Authentication, authorization, malformed multipart requests, size-limit violations, and unexpected server failures should use appropriate non-2xx responses.
 
+Note: the Ticket 2 service currently reports the size-limit and encoding failures as `valid: false` results instead. Ticket 3 reconciles the two — see "Findings from implementation" below.
+
 Invalid template response:
 
 ```json
@@ -813,3 +815,34 @@ adding template-only cleanup behavior here.
 - A new platform-wide retention implementation.
 - Supporting template v2.
 - Performance testing beyond the documented 5 MiB request limit.
+
+---
+
+## Findings from implementation
+
+Two kinds of thing came out of building Ticket 4 (DT-1854) against the Consent DTOs and the Ticket 2
+parser. The actionable ones are now carried by the tickets that own them, following the same pattern
+as "Contract outcomes" above, so they are summarised here rather than specified here. The design
+observation is recorded in full because no ticket owns it.
+
+| Finding | Recorded in | Outcome |
+| --- | --- | --- |
+| The `draft` table is the only JSON write in this area without the NUL guard the DAR tables already have. A U+0000 escape survives the parser and `jsonb` rejects it, so a valid template can 500 on insert. | Tickets 2 and 3 | Ticket 2 rejects U+0000 during parsing so the producer is told; Ticket 3 applies the existing `regexp_replace` idiom to `DraftDAO.insert` and `updateDraftByDraftUUID`. |
+| `StudyTemplateValidationResult.truncated` has no counterpart in the response type documented in this plan or in the v1 contract. | Ticket 3 | Ticket 3 decides whether it reaches the wire and makes OpenAPI and both documents agree. duos-ui types it as optional, so either choice works. |
+| The service reports the 5 MiB and UTF-8 failures as `valid: false` rather than as request failures, contradicting this plan and the contract. | Ticket 3 | Ticket 3 either rejects oversize at the resource layer or amends both documents. See the note under "Validate a template" above. |
+
+Chairperson access to the draft endpoints was already specified in Ticket 3 and needed no change.
+
+### The supported field set is derivable, not prose
+
+Worth recording because it is a property of the contract rather than a task. The v1 field catalogue is
+exactly a slice of declared wire order: items 1–27 of `StudyRegistrationRequest`'s
+`@JsonPropertyOrder` (of 41), items 2–23 of `ConsentGroupRequest`'s (of 25), and both
+`FileTypeObject` properties. That is 51 fields, and it is why the blank template is 51 rows. The
+duos-ui manifest (`src/libs/studyTemplate/studyTemplateV1Manifest.ts`) is ordered to match, so it can
+be diffed against those annotations rather than against this document, and
+`test/libs/studyTemplate/studyTemplateV1Manifest.spec.ts` enforces that no field Consent lists in
+`StudyTemplateV1Fields.UNSUPPORTED_*` is ever offered — Consent rejects those by name, so offering one
+would produce a template that cannot validate.
+
+Ticket 5 should expect the same slice when mapping a draft document back into the UI `Study` model.

--- a/docs/plans/study-template-validation-workflow.md
+++ b/docs/plans/study-template-validation-workflow.md
@@ -99,8 +99,8 @@ sequenceDiagram
         API->>DB: Create typed Draft (StudyDatasetSubmissionV1)
         DB-->>API: draft UUID and draftType
         API-->>UI: 200 { valid: true, draft: { id, draftType } }
-        UI->>UI: Navigate to /data_submission_form/draft/study-dataset/:draftId
-        UI->>API: GET /api/draft/v1/:draftId
+        UI->>UI: Navigate to /data_submission_form/draft/study-dataset/:draftUuid
+        UI->>API: GET /api/draft/v1/:draftUuid
         API-->>UI: Draft document and typed metadata
         UI->>UI: Verify meta.draftType is StudyDatasetSubmissionV1
         UI-->>U: Render populated Draft Study Registration Form
@@ -277,14 +277,14 @@ Add a typed multipart method to `src/libs/ajax/DataSet.ts` or a dedicated draft 
 Add an explicit route so a draft UUID cannot be confused with an existing numeric study ID:
 
 ```text
-/data_submission_form/draft/study-dataset/:draftId
+/data_submission_form/draft/study-dataset/:draftUuid
 ```
 
 Update `DataSubmissionFormV2` to support three explicit modes:
 
 1. Blank study creation.
 2. Existing study editing by `studyId`.
-3. Draft study creation by `draftId`.
+3. Draft study creation by `draftUuid`.
 
 Draft mode should:
 
@@ -648,7 +648,7 @@ class is reserved for non-download secondary actions.
 
 The selected file remains visible after validation errors. Users can remove it, select a replacement,
 and retry without leaving the page. A valid response navigates to
-`/data_submission_form/draft/study-dataset/:draftId` using the returned typed reference.
+`/data_submission_form/draft/study-dataset/:draftUuid` using the returned typed reference.
 
 **Acceptance criteria**
 
@@ -710,7 +710,7 @@ Add draft mode to the study registration form and populate it from a validated t
 
 **Description**
 
-Add the explicit `/data_submission_form/draft/study-dataset/:draftId` route and a typed client for
+Add the explicit `/data_submission_form/draft/study-dataset/:draftUuid` route and a typed client for
 the existing generic draft read and delete endpoints. Extend `DataSubmissionFormV2` with an
 explicit draft mode instead of treating a UUID as a persisted study ID. After loading, require
 `meta.draftType === 'StudyDatasetSubmissionV1'` before mapping the registration-shaped document

--- a/src/libs/ajax/Draft.ts
+++ b/src/libs/ajax/Draft.ts
@@ -1,5 +1,6 @@
 import { Config } from 'src/libs/config'
-import { fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { fetchDelete, fetchGet, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { DraftDetail } from 'src/types/draft'
 import { TemplateValidationResponse } from 'src/types/studyTemplate'
 
 export const Draft = {
@@ -18,5 +19,25 @@ export const Draft = {
     formData.append('file', file)
     const res = await fetchMultipart<TemplateValidationResponse>(url, formData, Config.multiPartOpts())
     return res.data
+  },
+
+  /**
+   * Load a draft's document and metadata. The endpoint is generic across draft types, so a caller
+   * must check `meta.draftType` before mapping the document.
+   * @returns Promise resolving to the draft document and its metadata
+   */
+  getDraft: async (draftUuid: string): Promise<DraftDetail> => {
+    const url = `${await Config.getApiUrl()}/api/draft/v1/${draftUuid}`
+    const res = await fetchGet<DraftDetail>(url, Config.authOpts())
+    return res.data
+  },
+
+  /**
+   * Delete a draft and its attachments. Used after the study it seeded has been created, so a
+   * failure here leaves a study that exists and a draft that outlived its purpose.
+   */
+  deleteDraft: async (draftUuid: string): Promise<void> => {
+    const url = `${await Config.getApiUrl()}/api/draft/v1/${draftUuid}`
+    await fetchDelete<void>(url, Config.authOpts())
   },
 }

--- a/src/libs/ajax/Draft.ts
+++ b/src/libs/ajax/Draft.ts
@@ -1,0 +1,22 @@
+import { Config } from 'src/libs/config'
+import { fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { TemplateValidationResponse } from 'src/types/studyTemplate'
+
+export const Draft = {
+  /**
+   * Validate a filled-in study/dataset template. A valid template creates a
+   * `StudyDatasetSubmissionV1` draft and the response carries its typed reference.
+   *
+   * Validation failures are a completed result, not a request failure: the endpoint answers 200 with
+   * `valid: false`, so callers get them as data and must render them separately from a thrown error.
+   * @param file The CSV template to validate
+   * @returns Promise resolving to the discriminated validation response
+   */
+  validateStudyDatasetTemplate: async (file: File): Promise<TemplateValidationResponse> => {
+    const url = `${await Config.getApiUrl()}/api/draft/v1/study-dataset/template-validation`
+    const formData = new FormData()
+    formData.append('file', file)
+    const res = await fetchMultipart<TemplateValidationResponse>(url, formData, Config.multiPartOpts())
+    return res.data
+  },
+}

--- a/src/libs/ajax/Draft.ts
+++ b/src/libs/ajax/Draft.ts
@@ -6,10 +6,12 @@ import { TemplateValidationResponse } from 'src/types/studyTemplate'
 export const Draft = {
   /**
    * Validate a filled-in study/dataset template. A valid template creates a
-   * `StudyDatasetSubmissionV1` draft and the response carries its typed reference.
+   * `StudyDatasetSubmissionV1` draft, answered 201 at its location, and the response body carries
+   * its typed reference.
    *
    * Validation failures are a completed result, not a request failure: the endpoint answers 200 with
    * `valid: false`, so callers get them as data and must render them separately from a thrown error.
+   * Both are 2xx, so branch on `valid` rather than on the status.
    * @param file The CSV template to validate
    * @returns Promise resolving to the discriminated validation response
    */

--- a/src/libs/studyTemplate/studyTemplateV1Csv.ts
+++ b/src/libs/studyTemplate/studyTemplateV1Csv.ts
@@ -1,0 +1,61 @@
+import {
+  CONSENT_GROUP_FIELDS,
+  FILE_TYPE_FIELDS,
+  RECORD_TYPE,
+  SCAFFOLD_RECORD_ID,
+  STUDY_FIELDS,
+  TEMPLATE_HEADER,
+  TEMPLATE_VERSION,
+} from 'src/libs/studyTemplate/studyTemplateV1Manifest'
+
+export const BLANK_TEMPLATE_FILENAME = 'duos-study-template-v1.csv'
+export const BLANK_TEMPLATE_MIME = 'text/csv'
+
+/** Bytes Consent accepts for one template; it reports the same limit with this wording. */
+export const MAX_TEMPLATE_BYTES = 5 * 1024 * 1024
+export const MAX_TEMPLATE_SIZE_MESSAGE = 'Template file must be no larger than 5 MiB'
+
+const FORMULA_PREFIXES = new Set(['=', '+', '-', '@'])
+
+/**
+ * Renders one cell: neutralizes a spreadsheet formula prefix, then quotes per RFC 4180.
+ *
+ * No cell this module currently emits starts with a formula prefix — the manifest is field names and
+ * record ids, and every `value` is empty. The guard is applied to every cell anyway so that adding a
+ * field or emitting example values later cannot silently turn the download into a CSV-injection
+ * vector in the producer's spreadsheet.
+ */
+export const escapeCsvCell = (value: string): string => {
+  const neutralized = FORMULA_PREFIXES.has(value.trimStart().charAt(0)) ? `'${value}` : value
+  return /["\r\n,]/.test(neutralized) ? `"${neutralized.replaceAll('"', '""')}"` : neutralized
+}
+
+const buildRow = (
+  recordType: string,
+  recordId: string,
+  parentRecordId: string,
+  field: string,
+): string => [TEMPLATE_VERSION, recordType, recordId, parentRecordId, field, '']
+  .map(escapeCsvCell)
+  .join(',')
+
+/**
+ * Builds the blank v1 template: the canonical header, then one row per offered field with `value`
+ * left empty. Scaffolds a single record of each type; a producer adds datasets by copying the
+ * `consentGroup` block under a new `recordId`, and array items by repeating a field's row.
+ *
+ * CRLF and no BOM: CRLF is the RFC 4180 separator and Excel's default, and every cell emitted here
+ * is ASCII, so a BOM would buy nothing.
+ */
+export const buildBlankStudyTemplateV1 = (): string => {
+  const rows = [
+    TEMPLATE_HEADER.map(escapeCsvCell).join(','),
+    ...STUDY_FIELDS.map(field =>
+      buildRow(RECORD_TYPE.study, SCAFFOLD_RECORD_ID.study, '', field)),
+    ...CONSENT_GROUP_FIELDS.map(field =>
+      buildRow(RECORD_TYPE.consentGroup, SCAFFOLD_RECORD_ID.consentGroup, SCAFFOLD_RECORD_ID.study, field)),
+    ...FILE_TYPE_FIELDS.map(field =>
+      buildRow(RECORD_TYPE.fileType, SCAFFOLD_RECORD_ID.fileType, SCAFFOLD_RECORD_ID.consentGroup, field)),
+  ]
+  return `${rows.join('\r\n')}\r\n`
+}

--- a/src/libs/studyTemplate/studyTemplateV1Manifest.ts
+++ b/src/libs/studyTemplate/studyTemplateV1Manifest.ts
@@ -1,0 +1,129 @@
+/**
+ * The study-template CSV v1 field catalogue.
+ *
+ * Canonical contract: `docs/study-template-v1.md` in the `consent` repository. Field order here is
+ * the declared wire order of `StudyRegistrationRequest`, `ConsentGroupRequest`, and
+ * `FileTypeObject`, so a reviewer can diff this manifest against those DTOs' `@JsonPropertyOrder`
+ * rather than against prose.
+ *
+ * v1 carries no JSON: every structured wire value is a row. The free-form `assets` and `data` maps,
+ * the file-backed `alternativeDataSharingPlan*` group, and integration-owned identifiers are
+ * therefore excluded — Consent rejects them by name, so emitting one would produce a template that
+ * cannot validate.
+ */
+
+export const TEMPLATE_VERSION = '1'
+
+export const TEMPLATE_HEADER = [
+  'templateVersion',
+  'recordType',
+  'recordId',
+  'parentRecordId',
+  'field',
+  'value',
+] as const
+
+export const RECORD_TYPE = {
+  study: 'study',
+  consentGroup: 'consentGroup',
+  fileType: 'fileType',
+} as const
+
+/**
+ * Scaffold record ids. `study` is fixed by the contract; the other two are template-only grouping
+ * keys that never reach the wire, so a producer may rename them or add sibling records freely.
+ */
+export const SCAFFOLD_RECORD_ID = {
+  study: 'study',
+  consentGroup: 'consentGroup-1',
+  fileType: 'fileType-1',
+} as const
+
+/** Wire order items 1–27 of `StudyRegistrationRequest`. */
+export const STUDY_FIELDS = [
+  'studyName',
+  'studyType',
+  'studyDescription',
+  'dataTypes',
+  'phenotypeIndication',
+  'species',
+  'piName',
+  'piEmail',
+  'dataCustodianEmail',
+  'publicVisibility',
+  'throughBioId',
+  'nihAnvilUse',
+  'submittingToAnvil',
+  'dbGaPPhsID',
+  'dbGaPStudyRegistrationName',
+  'embargoReleaseDate',
+  'sequencingCenter',
+  'piInstitution',
+  'nihGrantContractNumber',
+  'nihICsSupportingStudy',
+  'nihProgramOfficerName',
+  'nihInstitutionCenterSubmission',
+  'nihGenomicProgramAdministratorName',
+  'multiCenterStudy',
+  'collaboratingSites',
+  'controlledAccessRequiredForGenomicSummaryResultsGSR',
+  'controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation',
+] as const
+
+/** Wire order items 2–23 of `ConsentGroupRequest`; `fileTypes` is a record type, not a field. */
+export const CONSENT_GROUP_FIELDS = [
+  'consentGroupName',
+  'accessManagement',
+  'generalResearchUse',
+  'hmb',
+  'diseaseSpecificUse',
+  'poa',
+  'otherPrimary',
+  'nmds',
+  'gso',
+  'pub',
+  'col',
+  'irb',
+  'gs',
+  'mor',
+  'morDate',
+  'npu',
+  'otherSecondary',
+  'dataAccessCommitteeId',
+  'dataLocation',
+  'url',
+  'requestLocation',
+  'numberOfParticipants',
+] as const
+
+export const FILE_TYPE_FIELDS = [
+  'fileType',
+  'functionalEquivalence',
+] as const
+
+/**
+ * Wire properties Consent reports as excluded rather than unknown, so a producer who names one is
+ * told it belongs on the draft form. Mirrors `StudyTemplateV1Fields.UNSUPPORTED_STUDY_FIELDS`.
+ */
+export const EXCLUDED_STUDY_FIELDS = [
+  'alternativeDataSharingPlan',
+  'alternativeDataSharingPlanReasons',
+  'alternativeDataSharingPlanExplanation',
+  'alternativeDataSharingPlanFileName',
+  'alternativeDataSharingPlanFile',
+  'alternativeDataSharingPlanDataSubmitted',
+  'alternativeDataSharingPlanDataReleased',
+  'alternativeDataSharingPlanTargetDeliveryDate',
+  'alternativeDataSharingPlanTargetPublicReleaseDate',
+  'alternativeDataSharingPlanAccessManagement',
+  'nihInstitutionalCertificationFile',
+  'assets',
+  'data',
+  'externalIdentifier',
+  'externalIdentifierType',
+] as const
+
+export const EXCLUDED_CONSENT_GROUP_FIELDS = [
+  'datasetId',
+  'data',
+] as const

--- a/src/pages/data_submission/StudyTemplateUpload.tsx
+++ b/src/pages/data_submission/StudyTemplateUpload.tsx
@@ -30,6 +30,14 @@ export const StudyTemplateUpload = (): React.JSX.Element => {
   const [file, setFile] = useState<File | null>(null)
   const [validationErrors, setValidationErrors] = useState<TemplateValidationError[]>([])
   const [truncated, setTruncated] = useState(false)
+  // The picker and Remove stay live while a validation is in flight, so the handler needs the
+  // current selection at the moment its response arrives, not the one captured when it started.
+  const selectedFileRef = useRef<File | null>(null)
+
+  const selectFile = useCallback((selected: File | null) => {
+    selectedFileRef.current = selected
+    setFile(selected)
+  }, [])
 
   // Failures are toasts, matching the rest of the app. Validation errors are not failures: they are a
   // completed result the user works through while editing their file, so they stay on the page.
@@ -46,38 +54,40 @@ export const StudyTemplateUpload = (): React.JSX.Element => {
     const selected = event.currentTarget.files?.[0] ?? null
     clearResults()
     if (!selected) {
-      setFile(null)
+      selectFile(null)
       return
     }
     // Pre-checks the two limits Consent enforces, so a doomed 5 MiB upload never leaves the browser.
     // Wording matches the server's so the two layers cannot appear to disagree.
     if (!selected.name.toLowerCase().endsWith('.csv')) {
-      setFile(null)
+      selectFile(null)
       Notifications.showError({ text: 'Template file must be a .csv file' })
       return
     }
     if (selected.size > MAX_TEMPLATE_BYTES) {
-      setFile(null)
+      selectFile(null)
       Notifications.showError({ text: MAX_TEMPLATE_SIZE_MESSAGE })
       return
     }
-    setFile(selected)
-  }, [clearResults])
+    selectFile(selected)
+  }, [clearResults, selectFile])
 
   const handleRemove = useCallback(() => {
-    setFile(null)
+    selectFile(null)
     clearResults()
     // Resetting the element lets the user re-select the same filename and still get a change event.
     if (inputRef.current) {
       inputRef.current.value = ''
     }
-  }, [clearResults])
+  }, [clearResults, selectFile])
 
   const handleValidate = useCallback(async () => {
     if (!file) return
+    const validated = file
     clearResults()
     try {
-      const result = await Draft.validateStudyDatasetTemplate(file)
+      const result = await Draft.validateStudyDatasetTemplate(validated)
+      if (selectedFileRef.current !== validated) return
       if (!result.valid) {
         setValidationErrors(result.errors)
         setTruncated(result.truncated === true)
@@ -90,6 +100,7 @@ export const StudyTemplateUpload = (): React.JSX.Element => {
       navigate(`/data_submission_form/draft/study-dataset/${result.draft.id}`)
     }
     catch (error) {
+      if (selectedFileRef.current !== validated) return
       Notifications.showError({
         text: error instanceof Error ? error.message : 'The template could not be validated. Please try again.',
       })

--- a/src/pages/data_submission/StudyTemplateUpload.tsx
+++ b/src/pages/data_submission/StudyTemplateUpload.tsx
@@ -39,6 +39,14 @@ export const StudyTemplateUpload = (): React.JSX.Element => {
     setFile(selected)
   }, [])
 
+  // Resetting the element lets the user re-select the same filename and still get a change event.
+  const clearSelection = useCallback(() => {
+    selectFile(null)
+    if (inputRef.current) {
+      inputRef.current.value = ''
+    }
+  }, [selectFile])
+
   // Failures are toasts, matching the rest of the app. Validation errors are not failures: they are a
   // completed result the user works through while editing their file, so they stay on the page.
   const clearResults = useCallback(() => {
@@ -54,32 +62,28 @@ export const StudyTemplateUpload = (): React.JSX.Element => {
     const selected = event.currentTarget.files?.[0] ?? null
     clearResults()
     if (!selected) {
-      selectFile(null)
+      clearSelection()
       return
     }
     // Pre-checks the two limits Consent enforces, so a doomed 5 MiB upload never leaves the browser.
     // Wording matches the server's so the two layers cannot appear to disagree.
     if (!selected.name.toLowerCase().endsWith('.csv')) {
-      selectFile(null)
+      clearSelection()
       Notifications.showError({ text: 'Template file must be a .csv file' })
       return
     }
     if (selected.size > MAX_TEMPLATE_BYTES) {
-      selectFile(null)
+      clearSelection()
       Notifications.showError({ text: MAX_TEMPLATE_SIZE_MESSAGE })
       return
     }
     selectFile(selected)
-  }, [clearResults, selectFile])
+  }, [clearResults, clearSelection, selectFile])
 
   const handleRemove = useCallback(() => {
-    selectFile(null)
+    clearSelection()
     clearResults()
-    // Resetting the element lets the user re-select the same filename and still get a change event.
-    if (inputRef.current) {
-      inputRef.current.value = ''
-    }
-  }, [clearResults, selectFile])
+  }, [clearResults, clearSelection])
 
   const handleValidate = useCallback(async () => {
     if (!file) return

--- a/src/pages/data_submission/StudyTemplateUpload.tsx
+++ b/src/pages/data_submission/StudyTemplateUpload.tsx
@@ -1,0 +1,221 @@
+import React, { useCallback, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router'
+import { Styles, Theme } from 'src/libs/theme'
+import TableHeaderSection from 'src/components/TableHeaderSection'
+import { DownloadLink } from 'src/components/DownloadLink'
+import { AsyncSpinnerButton } from 'src/components/AsyncSpinnerButton'
+import { Draft } from 'src/libs/ajax/Draft'
+import { Notifications } from 'src/libs/utils'
+import { fileDownload } from 'src/utils/FileDownload'
+import {
+  BLANK_TEMPLATE_FILENAME,
+  BLANK_TEMPLATE_MIME,
+  MAX_TEMPLATE_BYTES,
+  MAX_TEMPLATE_SIZE_MESSAGE,
+  buildBlankStudyTemplateV1,
+} from 'src/libs/studyTemplate/studyTemplateV1Csv'
+import { STUDY_DATASET_DRAFT_TYPE, TemplateValidationError } from 'src/types/studyTemplate'
+
+const FILE_INPUT_ID = 'study-template-file'
+
+const describeLocation = (error: TemplateValidationError): string | null => {
+  if (error.row === undefined) return null
+  return error.column === undefined ? `Row ${error.row}` : `Row ${error.row}, column ${error.column}`
+}
+
+export const StudyTemplateUpload = (): React.JSX.Element => {
+  const navigate = useNavigate()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const [file, setFile] = useState<File | null>(null)
+  const [validationErrors, setValidationErrors] = useState<TemplateValidationError[]>([])
+  const [truncated, setTruncated] = useState(false)
+
+  // Failures are toasts, matching the rest of the app. Validation errors are not failures: they are a
+  // completed result the user works through while editing their file, so they stay on the page.
+  const clearResults = useCallback(() => {
+    setValidationErrors([])
+    setTruncated(false)
+  }, [])
+
+  const handleDownload = useCallback(() => {
+    fileDownload(buildBlankStudyTemplateV1(), BLANK_TEMPLATE_FILENAME, BLANK_TEMPLATE_MIME)
+  }, [])
+
+  const handleFileChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = event.currentTarget.files?.[0] ?? null
+    clearResults()
+    if (!selected) {
+      setFile(null)
+      return
+    }
+    // Pre-checks the two limits Consent enforces, so a doomed 5 MiB upload never leaves the browser.
+    // Wording matches the server's so the two layers cannot appear to disagree.
+    if (!selected.name.toLowerCase().endsWith('.csv')) {
+      setFile(null)
+      Notifications.showError({ text: 'Template file must be a .csv file' })
+      return
+    }
+    if (selected.size > MAX_TEMPLATE_BYTES) {
+      setFile(null)
+      Notifications.showError({ text: MAX_TEMPLATE_SIZE_MESSAGE })
+      return
+    }
+    setFile(selected)
+  }, [clearResults])
+
+  const handleRemove = useCallback(() => {
+    setFile(null)
+    clearResults()
+    // Resetting the element lets the user re-select the same filename and still get a change event.
+    if (inputRef.current) {
+      inputRef.current.value = ''
+    }
+  }, [clearResults])
+
+  const handleValidate = useCallback(async () => {
+    if (!file) return
+    clearResults()
+    try {
+      const result = await Draft.validateStudyDatasetTemplate(file)
+      if (!result.valid) {
+        setValidationErrors(result.errors)
+        setTruncated(result.truncated === true)
+        return
+      }
+      if (result.draft?.draftType !== STUDY_DATASET_DRAFT_TYPE || !result.draft.id) {
+        Notifications.showError({ text: 'The template validated but the response did not identify a study/dataset draft. Please try again or contact support.' })
+        return
+      }
+      navigate(`/data_submission_form/draft/study-dataset/${result.draft.id}`)
+    }
+    catch (error) {
+      Notifications.showError({
+        text: error instanceof Error ? error.message : 'The template could not be validated. Please try again.',
+      })
+    }
+  }, [file, clearResults, navigate])
+
+  return (
+    <div style={Styles.PAGE}>
+      <TableHeaderSection
+        title="Upload Study Template"
+        description="Validate a completed study/dataset template before registering it in DUOS."
+      />
+
+      <div style={{ margin: 'auto', maxWidth: 800, padding: '2rem 0' }}>
+        <section style={{ marginBottom: '2.5rem' }}>
+          <h2 style={{ fontSize: '2rem' }}>1. Start from the blank template</h2>
+          <p style={{ fontSize: '1.4rem' }}>
+            The template lists every field DUOS accepts, one per row. Fill in the
+            {' '}
+            <strong>value</strong>
+            {' '}
+            column and leave the other columns as they are. To register more than one dataset, copy
+            the
+            {' '}
+            <strong>consentGroup</strong>
+            {' '}
+            rows and give the copies a new <strong>recordId</strong>.
+          </p>
+          <DownloadLink label="Download blank template" onDownload={handleDownload} />
+        </section>
+
+        <section style={{ marginBottom: '2.5rem' }}>
+          <h2 style={{ fontSize: '2rem' }}>2. Upload your completed template</h2>
+          <p style={{ fontSize: '1.4rem' }}>
+            Comma-separated
+            {' '}
+            <strong>.csv</strong>
+            {' '}
+            files only, up to 5 MiB. Documents such as the NIH institutional certification are added
+            on the registration form after validation.
+          </p>
+
+          <label
+            htmlFor={FILE_INPUT_ID}
+            className="button button-white"
+            style={{ display: 'inline-flex', alignItems: 'center', cursor: 'pointer' }}
+          >
+            {file ? 'Choose a different file' : 'Choose CSV file'}
+          </label>
+          <input
+            ref={inputRef}
+            id={FILE_INPUT_ID}
+            type="file"
+            accept=".csv"
+            style={{ display: 'none' }}
+            onChange={handleFileChange}
+          />
+
+          {file && (
+            <div style={{ marginTop: '1rem', fontSize: '1.4rem' }}>
+              <span>
+                Selected file:
+                {' '}
+                <strong>{file.name}</strong>
+              </span>
+              <button
+                type="button"
+                className="button button-white"
+                aria-label={`Remove ${file.name}`}
+                onClick={handleRemove}
+                style={{ marginLeft: '1.5rem' }}
+              >
+                Remove
+              </button>
+            </div>
+          )}
+        </section>
+
+        <AsyncSpinnerButton
+          id="validate-template-btn"
+          className="button button-blue"
+          onClick={handleValidate}
+          disabled={!file}
+          // The button must survive its own success: a template with errors resolves normally, and
+          // the default hide-on-success would remove the control the user needs to retry with.
+          hideOnSuccess={false}
+        >
+          Validate
+        </AsyncSpinnerButton>
+
+        <div aria-live="polite" style={{ marginTop: '2rem' }}>
+          {validationErrors.length > 0 && (
+            <div style={{ fontSize: '1.4rem' }}>
+              <h2 style={{ fontSize: '2rem', color: Theme.palette.error }}>
+                {`Your template has ${validationErrors.length} ${validationErrors.length === 1 ? 'error' : 'errors'}`}
+              </h2>
+              <p>Correct them in your file, then upload it again.</p>
+              <ul>
+                {validationErrors.map((error, index) => {
+                  const location = describeLocation(error)
+                  return (
+                    <li key={`${error.row ?? 'none'}-${error.column ?? 'none'}-${index}`}>
+                      {location && (
+                        <>
+                          <strong>{location}</strong>
+                          {': '}
+                        </>
+                      )}
+                      <span>{error.message}</span>
+                    </li>
+                  )
+                })}
+              </ul>
+              {truncated && <p>Further errors were omitted. Fix these and validate again to see the rest.</p>}
+            </div>
+          )}
+        </div>
+
+        <p style={{ marginTop: '2.5rem', fontSize: '1.4rem' }}>
+          Would you rather fill in the form directly?
+          {' '}
+          <Link to="/data_submission_form">Register a study without a template</Link>.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default StudyTemplateUpload

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -12,7 +12,10 @@ import { StudyAssetManagement } from 'src/pages/data_submission/v2/StudyAssetMan
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { Notifications } from 'src/libs/utils'
 import { studyToDatasetSchemaSubmission, buildConsentGroupsFromStudy, getStudyPropertyValueByKey } from 'src/pages/data_submission/v2/v2-common-functions'
+import { loadStudyDatasetDraft } from 'src/pages/data_submission/v2/studyDatasetDraft'
+import { Draft } from 'src/libs/ajax/Draft'
 import AsyncSpinnerButton from 'src/components/AsyncSpinnerButton'
+import { Spinner } from 'src/components/Spinner'
 import { ConsentGroup2 } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 
 export type FileProperty = {
@@ -26,15 +29,33 @@ export type DataSubmissionFormV2Props = {
 
 export const ALTERNATIVE_DATA_SHARING_PLAN_FILE = 'alternativeDataSharingPlanFile'
 
+/** A draft id is not a study id: a draft has never been submitted, so it creates rather than updates. */
+export type FormMode = 'create' | 'edit' | 'draft'
+
+const resolveFormMode = (draftUuid?: string, studyId?: string): FormMode => {
+  if (draftUuid) {
+    return 'draft'
+  }
+  return studyId ? 'edit' : 'create'
+}
+
 export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   const { onSaveRoute } = props
-  const { studyId } = useParams()
+  const { studyId, draftUuid } = useParams()
+  const formMode: FormMode = resolveFormMode(draftUuid, studyId)
   const [isEditing, setIsEditing] = useState(false)
   const [study, setStudy] = useState({ data: {} } as Study)
   const [loadingError, setLoadingError] = useState(false)
+  const [loadedDraftUuid, setLoadedDraftUuid] = useState<string>()
   const [showContactModal, setShowContactModal] = useState(false)
 
   const navigate = useNavigate()
+
+  const onLoadFailure = () => {
+    setStudy({ data: {} } as Study)
+    setIsEditing(false)
+    setLoadingError(true)
+  }
 
   const onLoadFormData = (studyId: string | undefined) => {
     if (studyId) {
@@ -44,17 +65,25 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
         study.assets = { ...studyAssets, consentGroups: consentGroupAssets }
         setStudy(study)
         setIsEditing(true)
-      }).catch(() => {
-        setStudy({ data: {} } as Study)
-        setIsEditing(false)
-        setLoadingError(true)
-      })
+      }).catch(onLoadFailure)
     }
   }
 
+  // A draft stays a draft until the study is created from it, so isEditing remains false.
+  const onLoadDraft = (draftUuid: string) => {
+    loadStudyDatasetDraft(draftUuid).then((study) => {
+      setStudy(study)
+      setLoadingError(false)
+    }).catch(onLoadFailure).finally(() => setLoadedDraftUuid(draftUuid))
+  }
+
   useEffect(() => {
+    if (formMode === 'draft' && draftUuid) {
+      onLoadDraft(draftUuid)
+      return
+    }
     onLoadFormData(studyId)
-  }, [studyId, setStudy, setIsEditing])
+  }, [studyId, draftUuid, formMode, setStudy, setIsEditing])
 
   const buildMultiPartFormData = (study: Study) => {
     const multiPartFormData = new FormData()
@@ -88,9 +117,28 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
     onLoadFormData(studyId)
   }
 
+  /**
+   * Best effort, and only once the study exists: a study that was created is not a failure because
+   * the draft it came from outlived it, so a failure here is reported on its own and not retried.
+   */
+  const removeSourceDraft = async () => {
+    if (formMode !== 'draft' || !draftUuid) {
+      return
+    }
+    try {
+      await Draft.deleteDraft(draftUuid)
+    }
+    catch (_error) {
+      Notifications.showError({
+        text: 'Your study was created, but the draft it came from could not be removed. It may still appear in your drafts.',
+      })
+    }
+  }
+
   const onSubmitStudy = async () => {
     await DataSet.registerDataset(buildMultiPartFormData(study))
     Notifications.showNotification({ text: 'Study created successfully', type: 'success' })
+    await removeSourceDraft()
     if (onSaveRoute) {
       navigate(onSaveRoute)
       return
@@ -110,14 +158,47 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
     })
   }
 
+  // Submitting before the draft arrives would register an empty study and then delete the draft.
+  if (formMode === 'draft' && loadedDraftUuid !== draftUuid) {
+    return (
+      <div style={Styles.PAGE}>
+        <Spinner />
+      </div>
+    )
+  }
+
+  // Nothing to edit, so nothing to submit or delete: the form is not offered at all.
+  if (formMode === 'draft' && loadingError) {
+    return (
+      <div style={Styles.PAGE}>
+        <div style={{ marginLeft: '-1.5%' }}>
+          <TableHeaderSection
+            title="Draft could not be loaded"
+            description="This draft may have been removed, or it may belong to a different kind of submission. Nothing has been changed."
+          />
+        </div>
+        <button
+          type="button"
+          className="button button-white"
+          data-cy="draft-load-error-back"
+          onClick={() => navigate('/dataset_submissions')}
+        >
+          Back to My Data Submissions
+        </button>
+      </div>
+    )
+  }
+
   return (
     <>
       {loadingError && <div>Error Loading Page</div>}
       <div style={Styles.PAGE}>
         <div style={{ marginLeft: '-1.5%' }}>
           <TableHeaderSection
-            title="Study Registration Form"
-            description="Submit new datasets to DUOS"
+            title={formMode === 'draft' ? 'Study Registration Draft' : 'Study Registration Form'}
+            description={formMode === 'draft'
+              ? 'Review the values from your template, edit anything that needs it, then create the study.'
+              : 'Submit new datasets to DUOS'}
           />
         </div>
 

--- a/src/pages/data_submission/v2/studyDatasetDraft.ts
+++ b/src/pages/data_submission/v2/studyDatasetDraft.ts
@@ -1,0 +1,26 @@
+import { Draft } from 'src/libs/ajax/Draft'
+import { datasetSchemaSubmissionToStudy } from 'src/pages/data_submission/v2/v2-common-functions'
+import { DatasetRegistrationSchemaV1, Study } from 'src/pages/data_submission/v2/v2-models'
+import { isStudyDatasetDraft } from 'src/types/draft'
+
+/** A draft that belongs to another workflow. Loading it here is an error, not something to submit. */
+export class WrongDraftTypeError extends Error {
+  constructor(draftType: string | undefined) {
+    super(`Draft is of type ${draftType ?? 'unknown'}, not a study/dataset draft`)
+    this.name = 'WrongDraftTypeError'
+  }
+}
+
+/**
+ * Loads a draft and maps it into the form's model, refusing anything that is not a study/dataset
+ * draft: the read endpoint is generic, so the id says nothing about what the draft holds.
+ * @param draftUuid The draft UUID
+ * @returns Promise resolving to the study the form should edit
+ */
+export const loadStudyDatasetDraft = async (draftUuid: string): Promise<Study> => {
+  const draft = await Draft.getDraft(draftUuid)
+  if (!isStudyDatasetDraft(draft)) {
+    throw new WrongDraftTypeError(draft?.meta?.draftType)
+  }
+  return datasetSchemaSubmissionToStudy(draft.document as unknown as DatasetRegistrationSchemaV1)
+}

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {
   Study,
   StudyProperty,
+  StudyPropertyType,
   StringStudyProperty,
   DateStudyProperty, BooleanStudyProperty,
   DatasetRegistrationSchemaV1,
@@ -185,6 +186,12 @@ const convertDateEpochToString = (dateEpoch: unknown): string | undefined => {
   return undefined
 }
 
+/** `false` is a value the producer gave, so it must not fall through to undefined. */
+const getBooleanStudyPropertyValueByKey = (study: Study, key: string): boolean | undefined => {
+  const value = getStudyPropertyValueByKey(study, key)
+  return typeof value === 'boolean' ? value : undefined
+}
+
 export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistrationSchemaV1 => {
   const datasetSchema: DatasetRegistrationSchemaV1 = {
     studyName: study.name || '',
@@ -199,7 +206,7 @@ export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistratio
     publicVisibility: study.publicVisibility || false,
     throughBioId: getStudyPropertyValueByKey(study, ThroughBioId.key) as string || undefined,
     nihAnvilUse: getStudyPropertyValueByKey(study, NihAnvilUse.key) as NiHAnvilUseValues || undefined,
-    submittingToAnvil: getStudyPropertyValueByKey(study, SubmittingToAnvil.key) as boolean || undefined,
+    submittingToAnvil: getBooleanStudyPropertyValueByKey(study, SubmittingToAnvil.key),
     dbGaPPhsID: getStudyPropertyValueByKey(study, DbGaPPhsID.key) as string || undefined,
     dbGaPStudyRegistrationName: getStudyPropertyValueByKey(study, DbGaPStudyRegistrationName.key) as string || undefined,
     embargoReleaseDate: convertDateEpochToString(getStudyPropertyValueByKey(study, EmbargoReleaseDate.key) as string || undefined),
@@ -210,15 +217,15 @@ export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistratio
     nihProgramOfficerName: getStudyPropertyValueByKey(study, NihProgramOfficerName.key) as string || undefined,
     nihInstitutionCenterSubmission: getStudyPropertyValueByKey(study, NihInstitutionCenterSubmission.key) as NIHInstituteAndCenterAbbreviations || undefined,
     nihGenomicProgramAdministratorName: getStudyPropertyValueByKey(study, NihGenomicProgramAdministratorName.key) as string || undefined,
-    multiCenterStudy: getStudyPropertyValueByKey(study, MultiCenterStudy.key) as boolean || undefined,
+    multiCenterStudy: getBooleanStudyPropertyValueByKey(study, MultiCenterStudy.key),
     collaboratingSites: getStudyPropertyValueByKey(study, CollaboratingSites.key) as string[] || undefined,
-    controlledAccessRequiredForGenomicSummaryResultsGSR: getStudyPropertyValueByKey(study, ControlledAccessRequiredForGenomicSummaryResultsGSR.key) as boolean || undefined,
+    controlledAccessRequiredForGenomicSummaryResultsGSR: getBooleanStudyPropertyValueByKey(study, ControlledAccessRequiredForGenomicSummaryResultsGSR.key),
     controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation: getStudyPropertyValueByKey(study, ControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation.key) as string || undefined,
-    alternativeDataSharingPlan: getStudyPropertyValueByKey(study, AlternativeDataSharingPlan.key) as boolean || undefined,
+    alternativeDataSharingPlan: getBooleanStudyPropertyValueByKey(study, AlternativeDataSharingPlan.key),
     alternativeDataSharingPlanReasons: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanReasons.key) as Array<DataSharingPlanReasons> || undefined,
     alternativeDataSharingPlanExplanation: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanExplanation.key) as string || undefined,
     alternativeDataSharingPlanDataSubmitted: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanDataSubmitted.key) as AlternativeDataSharingPlanDataSubmittedValues || undefined,
-    alternativeDataSharingPlanDataReleased: getStudyPropertyValueByKey(study, AlternativeDataSharingPlanDataReleased.key) as boolean || undefined,
+    alternativeDataSharingPlanDataReleased: getBooleanStudyPropertyValueByKey(study, AlternativeDataSharingPlanDataReleased.key),
     alternativeDataSharingPlanTargetDeliveryDate: convertDateEpochToString(getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetDeliveryDate.key) as string || undefined),
     alternativeDataSharingPlanTargetPublicReleaseDate: convertDateEpochToString(getStudyPropertyValueByKey(study, AlternativeDataSharingPlanTargetPublicReleaseDate.key) as string || undefined),
     consentGroups: structuredClone(study.assets?.consentGroups) || [],
@@ -231,6 +238,71 @@ export const studyToDatasetSchemaSubmission = (study: Study): DatasetRegistratio
   datasetSchema.assets = assets
   return datasetSchema
 }
+/**
+ * The inverse of {@link studyToDatasetSchemaSubmission}: a registration-shaped document becomes the
+ * Study the form edits. A property is written only where the document carries a value — Consent
+ * serializes with NON_NULL, so an empty field is absent, and writing one would submit a value the
+ * producer never gave.
+ */
+export const datasetSchemaSubmissionToStudy = (schema: DatasetRegistrationSchemaV1): Study => {
+  const properties: StudyProperty[] = []
+  const addProperty = (key: string, type: StudyPropertyType, value: unknown) => {
+    if (value !== undefined && value !== null) {
+      properties.push(new StudyProperty(key, type, value))
+    }
+  }
+
+  addProperty(StudyTypeProperty.key, 'String', schema.studyType)
+  addProperty(PhenotypeIndication.key, 'String', schema.phenotypeIndication)
+  addProperty(Species.key, 'String', schema.species)
+  addProperty(DataCustodianEmail.key, 'Json', schema.dataCustodianEmail)
+  addProperty(ThroughBioId.key, 'String', schema.throughBioId)
+  addProperty(NihAnvilUse.key, 'String', schema.nihAnvilUse)
+  addProperty(SubmittingToAnvil.key, 'Boolean', schema.submittingToAnvil)
+  addProperty(DbGaPPhsID.key, 'String', schema.dbGaPPhsID)
+  addProperty(DbGaPStudyRegistrationName.key, 'String', schema.dbGaPStudyRegistrationName)
+  addProperty(EmbargoReleaseDate.key, 'Date', schema.embargoReleaseDate)
+  addProperty(SequencingCenter.key, 'String', schema.sequencingCenter)
+  addProperty(PiInstitution.key, 'Number', schema.piInstitution)
+  addProperty(NihGrantContractNumber.key, 'String', schema.nihGrantContractNumber)
+  addProperty(NihICsSupportingStudy.key, 'Json', schema.nihICsSupportingStudy)
+  addProperty(NihProgramOfficerName.key, 'String', schema.nihProgramOfficerName)
+  addProperty(NihInstitutionCenterSubmission.key, 'String', schema.nihInstitutionCenterSubmission)
+  addProperty(NihGenomicProgramAdministratorName.key, 'String', schema.nihGenomicProgramAdministratorName)
+  addProperty(MultiCenterStudy.key, 'Boolean', schema.multiCenterStudy)
+  addProperty(CollaboratingSites.key, 'Json', schema.collaboratingSites)
+  addProperty(ControlledAccessRequiredForGenomicSummaryResultsGSR.key, 'Boolean', schema.controlledAccessRequiredForGenomicSummaryResultsGSR)
+  addProperty(ControlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation.key, 'String', schema.controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation)
+  addProperty(AlternativeDataSharingPlan.key, 'Boolean', schema.alternativeDataSharingPlan)
+  addProperty(AlternativeDataSharingPlanReasons.key, 'Json', schema.alternativeDataSharingPlanReasons)
+  addProperty(AlternativeDataSharingPlanExplanation.key, 'String', schema.alternativeDataSharingPlanExplanation)
+  addProperty(AlternativeDataSharingPlanDataSubmitted.key, 'String', schema.alternativeDataSharingPlanDataSubmitted)
+  addProperty(AlternativeDataSharingPlanDataReleased.key, 'Boolean', schema.alternativeDataSharingPlanDataReleased)
+  addProperty(AlternativeDataSharingPlanTargetDeliveryDate.key, 'Date', schema.alternativeDataSharingPlanTargetDeliveryDate)
+  addProperty(AlternativeDataSharingPlanTargetPublicReleaseDate.key, 'Date', schema.alternativeDataSharingPlanTargetPublicReleaseDate)
+
+  const otherAssets = structuredClone(schema.assets ?? {}) as Record<string, unknown>
+  delete otherAssets.consentGroups
+
+  const study = {
+    name: schema.studyName,
+    description: schema.studyDescription,
+    dataTypes: schema.dataTypes,
+    publicVisibility: schema.publicVisibility,
+    properties,
+    assets: { ...otherAssets, consentGroups: structuredClone(schema.consentGroups ?? []) },
+    data: schema.data ?? {},
+  } as Study
+
+  if (schema.piName !== undefined) {
+    study.piName = schema.piName
+  }
+  if (schema.piEmail !== undefined) {
+    study.piEmail = schema.piEmail
+  }
+  return study
+}
+
 const getDatasetPropertyValueByKey = <T = unknown>(key: string, dataset: Dataset): T | undefined => {
   if (dataset.properties && Array.isArray(dataset.properties)) {
     const result = dataset.properties.find(entry => entry.propertyName === key)

--- a/src/pages/researcher_console/DatasetSubmissions.tsx
+++ b/src/pages/researcher_console/DatasetSubmissions.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { Box } from '@mui/material'
 import AddCircleOutlineOutlinedIcon from '@mui/icons-material/AddCircleOutlineOutlined'
+import UploadFileOutlinedIcon from '@mui/icons-material/UploadFileOutlined'
 import { Notifications } from 'src/libs/utils'
 import SearchBar from 'src/components/SearchBar'
 import { DataSet } from 'src/libs/ajax/DataSet'
@@ -74,6 +75,10 @@ export default function DatasetSubmissions() {
     () => buildSubmissionOwnershipQuery(user?.userId, user?.email),
     [user?.userId, user?.email],
   )
+
+  // Template upload matches the route's role guard rather than ADD DATASET's narrower
+  // data-submitter-only rule: chairpersons and admins register studies too.
+  const canUploadTemplate = Boolean(user?.isDataSubmitter || user?.isChairPerson || user?.isAdmin)
 
   const libraryConfig: LibraryVersionNew = useMemo(() => ({
     key: `submissions-${user?.userId ?? 'anonymous'}`,
@@ -148,14 +153,24 @@ export default function DatasetSubmissions() {
           handleSearchChange={handleSearchChange}
           initialValue={urlState.query ?? ''}
         />
-        <AddObjectButton
-          id="add-dataset-btn"
-          label="ADD DATASET"
-          onClick={() => navigate('/data_submission_form')}
-          icon={<AddCircleOutlineOutlinedIcon />}
-          className="button button-blue"
-          disabled={!user?.isDataSubmitter}
-        />
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+          <AddObjectButton
+            id="upload-template-btn"
+            label="UPLOAD TEMPLATE"
+            onClick={() => navigate('/data_submission_template')}
+            icon={<UploadFileOutlinedIcon />}
+            className="button button-white"
+            disabled={!canUploadTemplate}
+          />
+          <AddObjectButton
+            id="add-dataset-btn"
+            label="ADD DATASET"
+            onClick={() => navigate('/data_submission_form')}
+            icon={<AddCircleOutlineOutlinedIcon />}
+            className="button button-blue"
+            disabled={!user?.isDataSubmitter}
+          />
+        </Box>
       </Box>
     </>
   )

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -46,6 +46,7 @@ import SigningOfficialLibraryCards from 'src/pages/signing_official_console/Sign
 import SigningOfficialDarRequests from 'src/pages/signing_official_console/SigningOfficialDarRequests'
 import ManageResearcherDAAs from 'src/pages/signing_official_console/ManageResearcherDAAs'
 import { DataSubmissionFormV2 } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
+import { StudyTemplateUpload } from 'src/pages/data_submission/StudyTemplateUpload'
 import SigningOfficialDarApprovals from 'src/pages/signing_official_console/SigningOfficialDarApprovals'
 import { DataLibrary } from 'src/pages/DataLibrary'
 import { StudyNameSearch } from 'src/routing/StudyNameSearch'
@@ -91,6 +92,7 @@ const AppRoutes = (props: AppRoutesProps) => {
         </Route>
         <Route element={<RoleBAC rolesAllowed={[USER_ROLES.dataSubmitter, USER_ROLES.chairperson, USER_ROLES.admin]} />}>
           <Route path="/dataset_submissions" element={<DatasetSubmissions />} />
+          <Route path="/data_submission_template" element={<StudyTemplateUpload />} />
           <Route path="/data_submission_form" element={<DataSubmissionFormV2 />}>
             <Route path=":studyId" element={<DataSubmissionFormV2 />} />
           </Route>

--- a/src/routing/AppRoutes.tsx
+++ b/src/routing/AppRoutes.tsx
@@ -96,6 +96,7 @@ const AppRoutes = (props: AppRoutesProps) => {
           <Route path="/data_submission_form" element={<DataSubmissionFormV2 />}>
             <Route path=":studyId" element={<DataSubmissionFormV2 />} />
           </Route>
+          <Route path="/data_submission_form/draft/study-dataset/:draftUuid" element={<DataSubmissionFormV2 />} />
           <Route path="/study_update/:studyId" element={<DataSubmissionFormV2 onSaveRoute="/dataset_submissions" />} />
           <Route path="/dataset_update/:datasetId" element={<DatasetUpdateForm />} />
         </Route>

--- a/src/types/draft.ts
+++ b/src/types/draft.ts
@@ -1,0 +1,36 @@
+/**
+ * Wire types for the generic draft endpoints. `meta.draftType` is what a caller must check before
+ * mapping a document — never the id it was loaded by or the route that loaded it.
+ */
+
+import { STUDY_DATASET_DRAFT_TYPE } from 'src/types/studyTemplate'
+
+export interface DraftUser {
+  userId: number
+  email: string
+  displayName?: string
+  createDate?: number
+  emailPreference?: boolean
+}
+
+export interface DraftMeta {
+  uuid: string
+  name: string
+  draftType: string
+  createDate: number
+  updateDate: number
+  createUser: DraftUser
+  updateUser: DraftUser
+  storedFiles?: unknown[]
+}
+
+export interface DraftDetail<TDocument = unknown> {
+  document: TDocument
+  meta: DraftMeta
+}
+
+/** Whether a loaded draft is one this workflow may map. Another type is a load error, not a submission. */
+export const isStudyDatasetDraft = (
+  draft: DraftDetail,
+): draft is DraftDetail<Record<string, unknown>> =>
+  draft?.meta?.draftType === STUDY_DATASET_DRAFT_TYPE

--- a/src/types/studyTemplate.ts
+++ b/src/types/studyTemplate.ts
@@ -6,10 +6,10 @@
 export const STUDY_DATASET_DRAFT_TYPE = 'StudyDatasetSubmissionV1'
 
 /**
- * One independently actionable validation error. `row` is one-based and counts the CSV header as
- * row 1. Parser and conversion errors carry a row, and a column when a single cell is at fault;
- * registration-validator violations may carry neither, and their location must never be inferred
- * from the message text.
+ * One independently actionable validation error. `row` is the one-based physical line the record
+ * starts on — an ignored blank line still occupies one, and a multi-line value reports its first.
+ * A registration-validator violation may carry neither row nor column, and its location must never
+ * be inferred from the message text.
  */
 export interface TemplateValidationError {
   row?: number

--- a/src/types/studyTemplate.ts
+++ b/src/types/studyTemplate.ts
@@ -1,0 +1,31 @@
+/**
+ * Wire types for study-template validation. Canonical contract: `docs/study-template-v1.md` in the
+ * `consent` repository.
+ */
+
+export const STUDY_DATASET_DRAFT_TYPE = 'StudyDatasetSubmissionV1'
+
+/**
+ * One independently actionable validation error. `row` is one-based and counts the CSV header as
+ * row 1. Parser and conversion errors carry a row, and a column when a single cell is at fault;
+ * registration-validator violations may carry neither, and their location must never be inferred
+ * from the message text.
+ */
+export interface TemplateValidationError {
+  row?: number
+  column?: string
+  message: string
+}
+
+export interface StudyDatasetDraftReference {
+  id: string
+  draftType: typeof STUDY_DATASET_DRAFT_TYPE
+}
+
+/**
+ * `truncated` reports that the 100-error cap was reached. Consent also appends a trailing
+ * message-only error saying so, so it is optional here: the notice renders either way.
+ */
+export type TemplateValidationResponse
+  = | { valid: false, errors: TemplateValidationError[], truncated?: boolean }
+    | { valid: true, errors: TemplateValidationError[], truncated?: boolean, draft: StudyDatasetDraftReference }

--- a/test/fixtures/study-template/v1/README.md
+++ b/test/fixtures/study-template/v1/README.md
@@ -19,3 +19,14 @@ this repository.
 Keep these byte-identical to their source. If the contract changes, re-copy rather than edit — and
 note that provenance cannot be recorded inside the CSVs themselves, since v1 requires the canonical
 header as the first row and rejects any row it does not recognise.
+
+## `draft/minimal-valid-draft-detail.json`
+
+Not a copy: what `GET /api/draft/v1/{draftUUID}` returns after `valid/minimal-valid.csv` is validated,
+captured from Consent's own `DraftService.draftAsJson` running against a database, so the envelope and
+the document are the server's rather than a guess. What a hand-written version gets wrong is the
+omissions — Consent serializes the document with `NON_NULL`, so a field the producer left empty is
+absent rather than `null`, and hydration has to read absence as unset.
+
+Volatile values are normalized: the UUID, the timestamps, and the synthetic user the capture ran as.
+Everything else is verbatim.

--- a/test/fixtures/study-template/v1/README.md
+++ b/test/fixtures/study-template/v1/README.md
@@ -1,0 +1,21 @@
+# Study template v1 fixtures
+
+These CSVs are **copies**. The canonical fixtures live in the `consent` repository at
+`src/test/resources/fixtures/study-template/v1/`, alongside the contract they implement
+(`consent/docs/study-template-v1.md`), so the parser's own tests load them directly.
+
+They are duplicated here because vitest cannot reach another repository, and the study-template
+round-trip spec needs the real bytes rather than a hand-written approximation of them — the point of
+the test is that the generated blank template lines up with what Consent actually accepts.
+
+| File | Copied from | consent commit |
+|---|---|---|
+| `valid/minimal-valid.csv` | `.../v1/valid/minimal-valid.csv` | `3731e0ee` |
+| `valid/multi-consent-group-valid.csv` | `.../v1/valid/multi-consent-group-valid.csv` | `3731e0ee` |
+
+Only the two valid fixtures are copied; the invalid ones exercise the parser, which does not run in
+this repository.
+
+Keep these byte-identical to their source. If the contract changes, re-copy rather than edit — and
+note that provenance cannot be recorded inside the CSVs themselves, since v1 requires the canonical
+header as the first row and rejects any row it does not recognise.

--- a/test/fixtures/study-template/v1/draft/minimal-valid-draft-detail.json
+++ b/test/fixtures/study-template/v1/draft/minimal-valid-draft-detail.json
@@ -1,0 +1,40 @@
+{
+  "document": {
+    "piName": "Synthetic Investigator",
+    "dataTypes": [
+      "Genomic"
+    ],
+    "studyName": "Synthetic Minimal Study",
+    "nihAnvilUse": "I am not NHGRI funded and do not plan to store data in AnVIL",
+    "consentGroups": [
+      {
+        "accessManagement": "open",
+        "consentGroupName": "Synthetic Open Dataset",
+        "numberOfParticipants": 10
+      }
+    ],
+    "publicVisibility": true,
+    "studyDescription": "A synthetic study used only for contract tests."
+  },
+  "meta": {
+    "createDate": 1787184054319,
+    "updateDate": 1787184054319,
+    "name": "Synthetic Minimal Study",
+    "createUser": {
+      "userId": 1,
+      "email": "submitter@example.org",
+      "displayName": "Synthetic Submitter",
+      "createDate": 1787184054175,
+      "emailPreference": true
+    },
+    "updateUser": {
+      "userId": 1,
+      "email": "submitter@example.org",
+      "displayName": "Synthetic Submitter",
+      "createDate": 1787184054175,
+      "emailPreference": true
+    },
+    "uuid": "0393c587-343b-4c85-8969-e69e3f4f5aa8",
+    "draftType": "StudyDatasetSubmissionV1"
+  }
+}

--- a/test/fixtures/study-template/v1/valid/minimal-valid.csv
+++ b/test/fixtures/study-template/v1/valid/minimal-valid.csv
@@ -1,0 +1,10 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Minimal Study
+1,study,study,,studyDescription,A synthetic study used only for contract tests.
+1,study,study,,dataTypes,Genomic
+1,study,study,,publicVisibility,true
+1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
+1,study,study,,piName,Synthetic Investigator
+1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
+1,consentGroup,dataset-open,study,accessManagement,open
+1,consentGroup,dataset-open,study,numberOfParticipants,10

--- a/test/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
+++ b/test/fixtures/study-template/v1/valid/multi-consent-group-valid.csv
@@ -1,0 +1,33 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyName,Synthetic Multi-Dataset Study
+1,study,study,,studyType,Observational
+1,study,study,,studyDescription,"A synthetic study with multiple datasets, quoted values, and non-file assets."
+1,study,study,,dataTypes,Genomic
+1,study,study,,dataTypes,Phenotypic
+1,study,study,,phenotypeIndication,Synthetic condition
+1,study,study,,species,Homo sapiens
+1,study,study,,piName,Synthetic Investigator
+1,study,study,,piEmail,investigator@example.org
+1,study,study,,dataCustodianEmail,custodian.one@example.org
+1,study,study,,dataCustodianEmail,custodian.two@example.org
+1,study,study,,publicVisibility,false
+1,study,study,,nihAnvilUse,I am not NHGRI funded and do not plan to store data in AnVIL
+1,study,study,,submittingToAnvil,false
+1,study,study,,multiCenterStudy,true
+1,study,study,,collaboratingSites,Synthetic Site One
+1,study,study,,collaboratingSites,Synthetic Site Two
+1,study,study,,controlledAccessRequiredForGenomicSummaryResultsGSR,false
+1,consentGroup,dataset-open,study,consentGroupName,Synthetic Open Dataset
+1,consentGroup,dataset-open,study,accessManagement,open
+1,consentGroup,dataset-open,study,numberOfParticipants,20
+1,consentGroup,dataset-open,study,dataLocation,Terra Workspace
+1,consentGroup,dataset-open,study,url,https://example.org/data/synthetic-open
+1,consentGroup,dataset-controlled,study,consentGroupName,Synthetic Controlled Dataset
+1,consentGroup,dataset-controlled,study,accessManagement,controlled
+1,consentGroup,dataset-controlled,study,generalResearchUse,true
+1,consentGroup,dataset-controlled,study,npu,true
+1,consentGroup,dataset-controlled,study,dataAccessCommitteeId,1
+1,consentGroup,dataset-controlled,study,numberOfParticipants,30
+1,fileType,ft-genome,dataset-controlled,fileType,Genome
+1,fileType,ft-genome,dataset-controlled,functionalEquivalence,Synthetic reference build
+1,fileType,ft-phenotype,dataset-controlled,fileType,Phenotype

--- a/test/libs/ajax/Draft.spec.ts
+++ b/test/libs/ajax/Draft.spec.ts
@@ -1,19 +1,33 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
 import { Config } from 'src/libs/config'
-import { fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { fetchDelete, fetchGet, fetchMultipart } from 'src/libs/ajax/fetchAdapter'
 import { Draft } from 'src/libs/ajax/Draft'
+import { DraftDetail } from 'src/types/draft'
 import { TemplateValidationResponse } from 'src/types/studyTemplate'
 
 vi.mock('src/libs/config', () => ({
   Config: {
     getApiUrl: vi.fn(),
     multiPartOpts: vi.fn(),
+    authOpts: vi.fn(),
   },
 }))
 
 vi.mock('src/libs/ajax/fetchAdapter', () => ({
   fetchMultipart: vi.fn(),
+  fetchGet: vi.fn(),
+  fetchDelete: vi.fn(),
 }))
+
+const authHeaders = {
+  headers: {
+    'Authorization': 'Bearer token',
+    'Accept': 'application/json',
+    'X-App-ID': 'DUOS',
+  },
+}
 
 const multiPartHeaders = {
   headers: {
@@ -107,5 +121,79 @@ describe('Draft.validateStudyDatasetTemplate', () => {
 
     await expect(Draft.validateStudyDatasetTemplate(buildTemplateFile()))
       .rejects.toThrow('Request failed with status 413')
+  })
+})
+
+describe('Draft.getDraft', () => {
+  const DRAFT_ID = '0393c587-343b-4c85-8969-e69e3f4f5aa8'
+  const DRAFT_URL = `http://localhost/api/draft/v1/${DRAFT_ID}`
+
+  // The response Consent actually returns for a validated template, captured rather than written.
+  const draftDetail = (): DraftDetail => JSON.parse(readFileSync(
+    resolve(__dirname, '../../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+    'utf8',
+  ))
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Config.getApiUrl).mockResolvedValue('http://localhost')
+    vi.mocked(Config.authOpts).mockReturnValue(authHeaders)
+  })
+
+  it('gets the draft by id from the generic draft path', async () => {
+    vi.mocked(fetchGet).mockResolvedValue({ data: draftDetail() })
+
+    await Draft.getDraft(DRAFT_ID)
+
+    expect(fetchGet).toHaveBeenCalledWith(DRAFT_URL, authHeaders)
+  })
+
+  it('returns the document and the metadata that says what it is', async () => {
+    vi.mocked(fetchGet).mockResolvedValue({ data: draftDetail() })
+
+    const result = await Draft.getDraft(DRAFT_ID)
+
+    expect(result.meta.draftType).toBe('StudyDatasetSubmissionV1')
+    expect(result.meta.uuid).toBe(DRAFT_ID)
+    expect(result.document).toMatchObject({ studyName: 'Synthetic Minimal Study' })
+  })
+
+  it('leaves a field the producer left empty absent rather than null', async () => {
+    const document = draftDetail().document as Record<string, unknown>
+
+    // Consent serializes with NON_NULL, so hydration reads absence as unset. A mapper written
+    // against a hand-made fixture full of nulls would not notice the difference until runtime.
+    expect('piEmail' in document).toBe(false)
+    expect('embargoReleaseDate' in document).toBe(false)
+  })
+
+  it('propagates request failures', async () => {
+    vi.mocked(fetchGet).mockRejectedValue(new Error('Request failed with status 404'))
+
+    await expect(Draft.getDraft(DRAFT_ID)).rejects.toThrow('Request failed with status 404')
+  })
+})
+
+describe('Draft.deleteDraft', () => {
+  const DRAFT_ID = '0393c587-343b-4c85-8969-e69e3f4f5aa8'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Config.getApiUrl).mockResolvedValue('http://localhost')
+    vi.mocked(Config.authOpts).mockReturnValue(authHeaders)
+  })
+
+  it('deletes the draft by id', async () => {
+    vi.mocked(fetchDelete).mockResolvedValue({ data: undefined })
+
+    await Draft.deleteDraft(DRAFT_ID)
+
+    expect(fetchDelete).toHaveBeenCalledWith(`http://localhost/api/draft/v1/${DRAFT_ID}`, authHeaders)
+  })
+
+  it('propagates request failures so cleanup can be reported on its own', async () => {
+    vi.mocked(fetchDelete).mockRejectedValue(new Error('Request failed with status 500'))
+
+    await expect(Draft.deleteDraft(DRAFT_ID)).rejects.toThrow('Request failed with status 500')
   })
 })

--- a/test/libs/ajax/Draft.spec.ts
+++ b/test/libs/ajax/Draft.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Config } from 'src/libs/config'
+import { fetchMultipart } from 'src/libs/ajax/fetchAdapter'
+import { Draft } from 'src/libs/ajax/Draft'
+import { TemplateValidationResponse } from 'src/types/studyTemplate'
+
+vi.mock('src/libs/config', () => ({
+  Config: {
+    getApiUrl: vi.fn(),
+    multiPartOpts: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/ajax/fetchAdapter', () => ({
+  fetchMultipart: vi.fn(),
+}))
+
+const multiPartHeaders = {
+  headers: {
+    'Authorization': 'Bearer token',
+    'Content-Type': 'multipart/form-data',
+    'X-App-ID': 'DUOS',
+  },
+}
+
+const VALIDATION_URL = 'http://localhost/api/draft/v1/study-dataset/template-validation'
+
+const buildTemplateFile = (name = 'template.csv') =>
+  new File(['templateVersion,recordType,recordId,parentRecordId,field,value\r\n'], name, { type: 'text/csv' })
+
+describe('Draft.validateStudyDatasetTemplate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Config.getApiUrl).mockResolvedValue('http://localhost')
+    vi.mocked(Config.multiPartOpts).mockReturnValue(multiPartHeaders)
+  })
+
+  it('posts the file as multipart to the typed validation path', async () => {
+    vi.mocked(fetchMultipart).mockResolvedValue({ data: { valid: false, errors: [] } })
+
+    await Draft.validateStudyDatasetTemplate(buildTemplateFile())
+
+    expect(fetchMultipart).toHaveBeenCalledWith(
+      VALIDATION_URL,
+      expect.any(FormData),
+      multiPartHeaders,
+    )
+  })
+
+  it('sends the CSV under the "file" part name', async () => {
+    vi.mocked(fetchMultipart).mockResolvedValue({ data: { valid: false, errors: [] } })
+    const file = buildTemplateFile('my-study.csv')
+
+    await Draft.validateStudyDatasetTemplate(file)
+
+    const formData = vi.mocked(fetchMultipart).mock.calls[0][1]
+    expect(formData.get('file')).toBe(file)
+  })
+
+  it('returns structured validation errors rather than throwing', async () => {
+    const response: TemplateValidationResponse = {
+      valid: false,
+      errors: [
+        { row: 3, column: 'piEmail', message: 'Must be a valid email address.' },
+        { message: 'Study name is required.' },
+      ],
+    }
+    vi.mocked(fetchMultipart).mockResolvedValue({ data: response })
+
+    const result = await Draft.validateStudyDatasetTemplate(buildTemplateFile())
+
+    expect(result.valid).toBe(false)
+    expect(result.errors).toHaveLength(2)
+    expect(result.errors[0].row).toBe(3)
+    expect(result.errors[1].row).toBeUndefined()
+  })
+
+  it('returns the typed draft reference for a valid template', async () => {
+    const response: TemplateValidationResponse = {
+      valid: true,
+      errors: [],
+      draft: { id: 'c2e4583a-20b9-4705-8280-e6a5753f10c9', draftType: 'StudyDatasetSubmissionV1' },
+    }
+    vi.mocked(fetchMultipart).mockResolvedValue({ data: response })
+
+    const result = await Draft.validateStudyDatasetTemplate(buildTemplateFile())
+
+    expect(result.valid).toBe(true)
+    if (result.valid) {
+      expect(result.draft.id).toBe('c2e4583a-20b9-4705-8280-e6a5753f10c9')
+      expect(result.draft.draftType).toBe('StudyDatasetSubmissionV1')
+    }
+  })
+
+  it('surfaces the truncation flag when the error cap is reached', async () => {
+    vi.mocked(fetchMultipart).mockResolvedValue({
+      data: { valid: false, errors: [{ message: 'too many' }], truncated: true },
+    })
+
+    const result = await Draft.validateStudyDatasetTemplate(buildTemplateFile())
+
+    expect(result.truncated).toBe(true)
+  })
+
+  it('propagates request failures', async () => {
+    vi.mocked(fetchMultipart).mockRejectedValue(new Error('Request failed with status 413'))
+
+    await expect(Draft.validateStudyDatasetTemplate(buildTemplateFile()))
+      .rejects.toThrow('Request failed with status 413')
+  })
+})

--- a/test/libs/studyTemplate/csvTestParser.ts
+++ b/test/libs/studyTemplate/csvTestParser.ts
@@ -1,0 +1,71 @@
+/**
+ * A minimal RFC 4180 reader for the study-template specs. Deliberately not shipped in `src`: the UI
+ * never parses templates (that is Consent's job), but the specs need to read the generated file and
+ * the canonical fixtures back as records rather than assert on raw strings.
+ *
+ * Splits on physical lines, which is safe here because no v1 fixture puts a newline inside a quoted
+ * cell. It does handle quoted commas and doubled quotes, which the fixtures do use.
+ */
+
+export interface TemplateRow {
+  templateVersion: string
+  recordType: string
+  recordId: string
+  parentRecordId: string
+  field: string
+  value: string
+}
+
+export const splitCsvLine = (line: string): string[] => {
+  const cells: string[] = []
+  let cell = ''
+  let inQuotes = false
+  let index = 0
+  while (index < line.length) {
+    const char = line[index]
+    if (inQuotes) {
+      if (char !== '"') {
+        cell += char
+      }
+      else if (line[index + 1] === '"') {
+        cell += '"'
+        index++
+      }
+      else {
+        inQuotes = false
+      }
+    }
+    else if (char === '"') {
+      inQuotes = true
+    }
+    else if (char === ',') {
+      cells.push(cell)
+      cell = ''
+    }
+    else {
+      cell += char
+    }
+    index++
+  }
+  cells.push(cell)
+  return cells
+}
+
+export const parseTemplateCsv = (csv: string): { header: string[], rows: TemplateRow[] } => {
+  const lines = csv.replace(/^\uFEFF/, '').split(/\r\n|\n/).filter(line => line.trim() !== '')
+  const [headerLine, ...dataLines] = lines
+  return {
+    header: splitCsvLine(headerLine),
+    rows: dataLines.map((line) => {
+      const cells = splitCsvLine(line)
+      return {
+        templateVersion: cells[0] ?? '',
+        recordType: cells[1] ?? '',
+        recordId: cells[2] ?? '',
+        parentRecordId: cells[3] ?? '',
+        field: cells[4] ?? '',
+        value: cells[5] ?? '',
+      }
+    }),
+  }
+}

--- a/test/libs/studyTemplate/studyTemplateRoundTrip.spec.ts
+++ b/test/libs/studyTemplate/studyTemplateRoundTrip.spec.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, it, expect } from 'vitest'
+import { buildBlankStudyTemplateV1 } from 'src/libs/studyTemplate/studyTemplateV1Csv'
+import { SCAFFOLD_RECORD_ID } from 'src/libs/studyTemplate/studyTemplateV1Manifest'
+import { TemplateRow, parseTemplateCsv } from './csvTestParser'
+
+/**
+ * Asserts the structural claim behind the round-trip acceptance criterion: a producer can fill in the
+ * downloaded template and reach a file Consent accepts, without adding or rearranging structural
+ * columns. The Java validator cannot run here, so the canonical fixtures stand in as the expected
+ * shape — see `test/fixtures/study-template/v1/README.md` for their provenance.
+ */
+
+// Resolved from the project root rather than import.meta.url: under vitest's vmThreads pool the
+// module URL is rooted at the project, so a relative URL escapes the repository.
+const readFixture = (name: string): string =>
+  readFileSync(resolve(process.cwd(), 'test/fixtures/study-template/v1/valid', name), 'utf8')
+
+const minimalValid = parseTemplateCsv(readFixture('minimal-valid.csv'))
+const multiConsentGroupValid = parseTemplateCsv(readFixture('multi-consent-group-valid.csv'))
+
+const generated = buildBlankStudyTemplateV1()
+const scaffold = parseTemplateCsv(generated)
+
+const fieldKey = (row: TemplateRow): string => `${row.recordType}|${row.field}`
+const identity = (row: TemplateRow): string => `${row.recordType}|${row.field}|${row.value}`
+
+describe('blank template round trip', () => {
+  it('reads both canonical fixtures', () => {
+    expect(minimalValid.rows.length).toBeGreaterThan(0)
+    expect(multiConsentGroupValid.rows.length).toBeGreaterThan(0)
+  })
+
+  it.each([
+    ['minimal-valid.csv', minimalValid],
+    ['multi-consent-group-valid.csv', multiConsentGroupValid],
+  ])('shares its header with %s', (_name, fixture) => {
+    expect(scaffold.header).toEqual(fixture.header)
+  })
+
+  // If this fails, a producer filling in the download would have to hand-author a row — exactly the
+  // failure the download exists to prevent.
+  it.each([
+    ['minimal-valid.csv', minimalValid],
+    ['multi-consent-group-valid.csv', multiConsentGroupValid],
+  ])('offers every field %s uses', (_name, fixture) => {
+    const offered = new Set(scaffold.rows.map(fieldKey))
+    const missing = [...new Set(fixture.rows.map(fieldKey))].filter(key => !offered.has(key))
+    expect(missing).toEqual([])
+  })
+
+  describe('filling the scaffold from minimal-valid.csv', () => {
+    // The scaffold and the fixture each hold exactly one consent group, so mapping the scaffold's
+    // template-only recordId onto the fixture's is unambiguous. recordId never reaches the wire.
+    const recordIds = (rows: TemplateRow[], recordType: string): string[] =>
+      [...new Set(rows.filter(row => row.recordType === recordType).map(row => row.recordId))]
+
+    it('has one consent group on each side, so record ids map positionally', () => {
+      expect(recordIds(scaffold.rows, 'consentGroup')).toEqual([SCAFFOLD_RECORD_ID.consentGroup])
+      expect(recordIds(minimalValid.rows, 'consentGroup')).toEqual(['dataset-open'])
+    })
+
+    it('reproduces the fixture exactly once the value cells are filled in', () => {
+      const fixtureValues = new Map(minimalValid.rows.map(row => [fieldKey(row), row.value]))
+
+      const filled = scaffold.rows
+        .filter(row => fixtureValues.has(fieldKey(row)))
+        .map(row => ({ ...row, value: fixtureValues.get(fieldKey(row))! }))
+
+      expect(filled.map(identity).sort()).toEqual(minimalValid.rows.map(identity).sort())
+    })
+
+    it('keeps the structural columns untouched while filling values', () => {
+      const fixtureFields = new Set(minimalValid.rows.map(fieldKey))
+      const filled = scaffold.rows.filter(row => fixtureFields.has(fieldKey(row)))
+
+      expect(filled.every(row => row.templateVersion === '1')).toBe(true)
+      expect(filled.filter(row => row.recordType === 'study').every(row => row.parentRecordId === '')).toBe(true)
+      expect(filled.filter(row => row.recordType === 'consentGroup')
+        .every(row => row.parentRecordId === SCAFFOLD_RECORD_ID.study)).toBe(true)
+    })
+
+    it('leaves the unused optional rows for the producer to delete', () => {
+      const fixtureFields = new Set(minimalValid.rows.map(fieldKey))
+      const unused = scaffold.rows.filter(row => !fixtureFields.has(fieldKey(row)))
+
+      expect(unused).toHaveLength(scaffold.rows.length - minimalValid.rows.length)
+      expect(unused.every(row => row.value === '')).toBe(true)
+    })
+  })
+
+  /**
+   * multi-consent-group-valid.csv repeats rows for multi-item `dataTypes`/`dataCustodianEmail` and
+   * adds a second consent group. Both are row additions, which the contract documents as the expected
+   * producer edit, so this fixture backs the field-coverage assertion above rather than a strict
+   * row-for-row round trip. Asserting equality here would be asserting the scaffold pre-empts choices
+   * only the producer can make.
+   */
+  it('needs added rows, not new fields, for repeated values and extra datasets', () => {
+    const repeated = multiConsentGroupValid.rows.filter((row, _index, rows) =>
+      rows.filter(other => fieldKey(other) === fieldKey(row) && other.recordId === row.recordId).length > 1)
+    expect(repeated.length).toBeGreaterThan(0)
+
+    const consentGroupIds = new Set(multiConsentGroupValid.rows
+      .filter(row => row.recordType === 'consentGroup')
+      .map(row => row.recordId))
+    expect(consentGroupIds.size).toBeGreaterThan(1)
+
+    const offered = new Set(scaffold.rows.map(fieldKey))
+    expect([...new Set(multiConsentGroupValid.rows.map(fieldKey))].every(key => offered.has(key))).toBe(true)
+  })
+})

--- a/test/libs/studyTemplate/studyTemplateV1Csv.spec.ts
+++ b/test/libs/studyTemplate/studyTemplateV1Csv.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildBlankStudyTemplateV1,
+  escapeCsvCell,
+} from 'src/libs/studyTemplate/studyTemplateV1Csv'
+import {
+  CONSENT_GROUP_FIELDS,
+  FILE_TYPE_FIELDS,
+  SCAFFOLD_RECORD_ID,
+  STUDY_FIELDS,
+} from 'src/libs/studyTemplate/studyTemplateV1Manifest'
+import { parseTemplateCsv } from './csvTestParser'
+
+const CANONICAL_HEADER = 'templateVersion,recordType,recordId,parentRecordId,field,value'
+
+describe('escapeCsvCell', () => {
+  it.each([
+    ['=SUM(A1:A2)', '\'=SUM(A1:A2)'],
+    ['+1234', '\'+1234'],
+    ['-1234', '\'-1234'],
+    ['@example', '\'@example'],
+  ])('neutralizes the formula prefix in %s', (input, expected) => {
+    expect(escapeCsvCell(input)).toBe(expected)
+  })
+
+  it('neutralizes a formula prefix hidden behind leading whitespace', () => {
+    expect(escapeCsvCell('  =SUM(A1)')).toBe('\'  =SUM(A1)')
+  })
+
+  it.each([
+    ['plain text', 'plain text'],
+    ['', ''],
+    ['a-b', 'a-b'],
+    ['user@example.org', 'user@example.org'],
+  ])('leaves %s alone', (input, expected) => {
+    expect(escapeCsvCell(input)).toBe(expected)
+  })
+
+  it('quotes cells containing a comma', () => {
+    expect(escapeCsvCell('one, two')).toBe('"one, two"')
+  })
+
+  it('doubles and quotes embedded quotes', () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""')
+  })
+
+  it('quotes cells containing a newline', () => {
+    expect(escapeCsvCell('line one\nline two')).toBe('"line one\nline two"')
+  })
+
+  it('neutralizes and quotes when a cell needs both', () => {
+    expect(escapeCsvCell('=one, two')).toBe('"\'=one, two"')
+  })
+})
+
+describe('buildBlankStudyTemplateV1', () => {
+  const csv = buildBlankStudyTemplateV1()
+  const { header, rows } = parseTemplateCsv(csv)
+
+  it('starts with the canonical header, byte for byte', () => {
+    expect(csv.startsWith(`${CANONICAL_HEADER}\r\n`)).toBe(true)
+  })
+
+  it('parses the header back to the six contract columns', () => {
+    expect(header).toEqual(['templateVersion', 'recordType', 'recordId', 'parentRecordId', 'field', 'value'])
+  })
+
+  it('uses CRLF separators and no BOM', () => {
+    expect(csv.startsWith('\uFEFF')).toBe(false)
+    expect(csv).toContain('\r\n')
+    expect(csv.replaceAll('\r\n', '')).not.toContain('\n')
+  })
+
+  it('emits one row per offered field', () => {
+    expect(rows).toHaveLength(STUDY_FIELDS.length + CONSENT_GROUP_FIELDS.length + FILE_TYPE_FIELDS.length)
+    expect(rows).toHaveLength(51)
+  })
+
+  it('leaves every value cell empty', () => {
+    expect(rows.every(row => row.value === '')).toBe(true)
+  })
+
+  it('marks every row as major version 1', () => {
+    expect(new Set(rows.map(row => row.templateVersion))).toEqual(new Set(['1']))
+  })
+
+  it('scaffolds the study record with the required id and no parent', () => {
+    const studyRows = rows.filter(row => row.recordType === 'study')
+    expect(studyRows.map(row => row.field)).toEqual([...STUDY_FIELDS])
+    expect(studyRows.every(row => row.recordId === 'study')).toBe(true)
+    expect(studyRows.every(row => row.parentRecordId === '')).toBe(true)
+  })
+
+  it('parents the consent group to the study record', () => {
+    const consentGroupRows = rows.filter(row => row.recordType === 'consentGroup')
+    expect(consentGroupRows.map(row => row.field)).toEqual([...CONSENT_GROUP_FIELDS])
+    expect(consentGroupRows.every(row => row.recordId === SCAFFOLD_RECORD_ID.consentGroup)).toBe(true)
+    expect(consentGroupRows.every(row => row.parentRecordId === SCAFFOLD_RECORD_ID.study)).toBe(true)
+  })
+
+  it('parents the file type to the consent group record, not the study', () => {
+    const fileTypeRows = rows.filter(row => row.recordType === 'fileType')
+    expect(fileTypeRows.map(row => row.field)).toEqual([...FILE_TYPE_FIELDS])
+    expect(fileTypeRows.every(row => row.recordId === SCAFFOLD_RECORD_ID.fileType)).toBe(true)
+    expect(fileTypeRows.every(row => row.parentRecordId === SCAFFOLD_RECORD_ID.consentGroup)).toBe(true)
+  })
+
+  it('groups rows study, then consent group, then file type', () => {
+    const order = [...new Set(rows.map(row => row.recordType))]
+    expect(order).toEqual(['study', 'consentGroup', 'fileType'])
+  })
+
+  // The escape guard is applied to every cell, but nothing the manifest currently emits triggers it.
+  // If this fails, a newly offered field starts with =, +, - or @ and the generated file would carry
+  // a leading apostrophe the producer did not ask for.
+  it('needs no formula escaping for any cell it currently emits', () => {
+    expect(csv).not.toContain('\'')
+  })
+
+  it('offers no field Consent excludes from v1', () => {
+    const fields = new Set(rows.map(row => row.field))
+    for (const excluded of ['assets', 'data', 'consentGroups', 'fileTypes', 'datasetId', 'alternativeDataSharingPlanFileName']) {
+      expect(fields.has(excluded)).toBe(false)
+    }
+  })
+})

--- a/test/libs/studyTemplate/studyTemplateV1Manifest.spec.ts
+++ b/test/libs/studyTemplate/studyTemplateV1Manifest.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CONSENT_GROUP_FIELDS,
+  EXCLUDED_CONSENT_GROUP_FIELDS,
+  EXCLUDED_STUDY_FIELDS,
+  FILE_TYPE_FIELDS,
+  RECORD_TYPE,
+  SCAFFOLD_RECORD_ID,
+  STUDY_FIELDS,
+  TEMPLATE_HEADER,
+  TEMPLATE_VERSION,
+} from 'src/libs/studyTemplate/studyTemplateV1Manifest'
+
+describe('studyTemplateV1Manifest', () => {
+  it('declares the canonical header in contract order', () => {
+    expect([...TEMPLATE_HEADER]).toEqual([
+      'templateVersion',
+      'recordType',
+      'recordId',
+      'parentRecordId',
+      'field',
+      'value',
+    ])
+  })
+
+  it('declares major version 1', () => {
+    expect(TEMPLATE_VERSION).toBe('1')
+  })
+
+  it('offers every supported field and no more', () => {
+    expect(STUDY_FIELDS).toHaveLength(27)
+    expect(CONSENT_GROUP_FIELDS).toHaveLength(22)
+    expect(FILE_TYPE_FIELDS).toHaveLength(2)
+  })
+
+  it('lists study fields in StudyRegistrationRequest wire order', () => {
+    expect(STUDY_FIELDS[0]).toBe('studyName')
+    expect(STUDY_FIELDS[3]).toBe('dataTypes')
+    expect(STUDY_FIELDS[9]).toBe('publicVisibility')
+    expect(STUDY_FIELDS[26]).toBe('controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation')
+  })
+
+  it('lists consent-group fields in ConsentGroupRequest wire order', () => {
+    expect(CONSENT_GROUP_FIELDS[0]).toBe('consentGroupName')
+    expect(CONSENT_GROUP_FIELDS[1]).toBe('accessManagement')
+    expect(CONSENT_GROUP_FIELDS[21]).toBe('numberOfParticipants')
+  })
+
+  it('lists file-type fields in FileTypeObject wire order', () => {
+    expect([...FILE_TYPE_FIELDS]).toEqual(['fileType', 'functionalEquivalence'])
+  })
+
+  it.each([
+    ['study', STUDY_FIELDS],
+    ['consentGroup', CONSENT_GROUP_FIELDS],
+    ['fileType', FILE_TYPE_FIELDS],
+  ])('names each %s field once', (_recordType, fields) => {
+    expect(new Set(fields).size).toBe(fields.length)
+  })
+
+  // Consent rejects these by name rather than as unknown fields, so offering one would produce a
+  // template that cannot validate.
+  it('offers no study field excluded from v1', () => {
+    const excluded = new Set<string>(EXCLUDED_STUDY_FIELDS)
+    expect(STUDY_FIELDS.filter(field => excluded.has(field))).toEqual([])
+  })
+
+  it('offers no consent-group field excluded from v1', () => {
+    const excluded = new Set<string>(EXCLUDED_CONSENT_GROUP_FIELDS)
+    expect(CONSENT_GROUP_FIELDS.filter(field => excluded.has(field))).toEqual([])
+  })
+
+  it('excludes the free-form JSON wire properties', () => {
+    expect(EXCLUDED_STUDY_FIELDS).toContain('assets')
+    expect(EXCLUDED_STUDY_FIELDS).toContain('data')
+    expect(EXCLUDED_CONSENT_GROUP_FIELDS).toContain('data')
+  })
+
+  it('excludes the whole alternative-sharing-plan group, not just its filename', () => {
+    const alternativePlanFields = EXCLUDED_STUDY_FIELDS.filter(field =>
+      field.startsWith('alternativeDataSharingPlan'))
+    expect(alternativePlanFields).toHaveLength(10)
+  })
+
+  // consentGroups and fileTypes are record types, so they are neither offered as fields nor listed
+  // as excluded — a producer supplies them as rows of their own recordType.
+  it('treats nested wire arrays as record types rather than fields', () => {
+    expect(STUDY_FIELDS).not.toContain('consentGroups')
+    expect(CONSENT_GROUP_FIELDS).not.toContain('fileTypes')
+    expect(Object.values(RECORD_TYPE)).toEqual(['study', 'consentGroup', 'fileType'])
+  })
+
+  it('fixes the study record id, which the contract requires to be "study"', () => {
+    expect(SCAFFOLD_RECORD_ID.study).toBe('study')
+  })
+})

--- a/test/pages/data_submission/StudyTemplateUpload.spec.tsx
+++ b/test/pages/data_submission/StudyTemplateUpload.spec.tsx
@@ -178,6 +178,65 @@ describe('StudyTemplateUpload', () => {
     })
   })
 
+  describe('stale results', () => {
+    const pendingValidation = () => {
+      let settle: (value: TemplateValidationResponse) => void = () => {}
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockReturnValue(
+        new Promise<TemplateValidationResponse>((resolve) => { settle = resolve }),
+      )
+      return async (response: TemplateValidationResponse) => {
+        await act(async () => {
+          settle(response)
+        })
+      }
+    }
+
+    it('discards errors belonging to a file the user has replaced', async () => {
+      const settle = pendingValidation()
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('first.csv'))
+      await clickValidate()
+      await selectFile(buildCsv('second.csv'))
+
+      await settle({ valid: false, errors: [{ message: 'Study name is required.' }] })
+
+      expect(screen.queryByText('Study name is required.')).toBeNull()
+      expect(screen.getByText('second.csv')).toBeTruthy()
+    })
+
+    it('does not navigate to a draft built from a file the user has removed', async () => {
+      const settle = pendingValidation()
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+      await clickButton('Remove my-study.csv')
+
+      await settle(validResponse)
+
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('does not report a failure for a file the user has removed', async () => {
+      let reject: (error: unknown) => void = () => {}
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockReturnValue(
+        new Promise<TemplateValidationResponse>((_resolve, rejectPromise) => { reject = rejectPromise }),
+      )
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+      await clickButton('Remove my-study.csv')
+
+      await act(async () => {
+        reject(new Error('Service unavailable'))
+      })
+
+      expect(showError).not.toHaveBeenCalled()
+    })
+  })
+
   describe('validation errors', () => {
     const invalidResponse: TemplateValidationResponse = {
       valid: false,

--- a/test/pages/data_submission/StudyTemplateUpload.spec.tsx
+++ b/test/pages/data_submission/StudyTemplateUpload.spec.tsx
@@ -1,0 +1,441 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { StudyTemplateUpload } from 'src/pages/data_submission/StudyTemplateUpload'
+import { Draft } from 'src/libs/ajax/Draft'
+import { fileDownload } from 'src/utils/FileDownload'
+import { Notifications } from 'src/libs/utils'
+import { TemplateValidationResponse } from 'src/types/studyTemplate'
+import { renderWithRouter } from '../../test-utils'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router')
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock('src/libs/ajax/Draft', () => ({
+  Draft: {
+    validateStudyDatasetTemplate: vi.fn(),
+  },
+}))
+
+vi.mock('src/utils/FileDownload', () => ({
+  fileDownload: vi.fn(),
+}))
+
+const buildCsv = (name = 'my-study.csv', size?: number): File => {
+  const file = new File(['templateVersion,recordType,recordId,parentRecordId,field,value\r\n'], name, { type: 'text/csv' })
+  if (size !== undefined) {
+    Object.defineProperty(file, 'size', { value: size })
+  }
+  return file
+}
+
+const validResponse: TemplateValidationResponse = {
+  valid: true,
+  errors: [],
+  draft: { id: 'c2e4583a-20b9-4705-8280-e6a5753f10c9', draftType: 'StudyDatasetSubmissionV1' },
+}
+
+const fileInput = (): HTMLInputElement => screen.getByLabelText(/Choose (a different file|CSV file)/i) as HTMLInputElement
+
+// fireEvent wraps its own act(), so these only need to yield the microtask queue so an async click
+// handler's continuation lands before the next assertion.
+const selectFile = async (file: File) => {
+  fireEvent.change(fileInput(), { target: { files: [file] } })
+}
+
+const clickValidate = async () => {
+  fireEvent.click(screen.getByRole('button', { name: 'Validate' }))
+}
+
+const clickButton = async (name: string | RegExp) => {
+  fireEvent.click(screen.getByRole('button', { name }))
+}
+
+describe('StudyTemplateUpload', () => {
+  let showError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    showError = vi.spyOn(Notifications, 'showError').mockImplementation(() => undefined)
+  })
+
+  describe('idle state', () => {
+    it('disables Validate until a file is selected', () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      expect(screen.getByRole('button', { name: 'Validate' }).hasAttribute('disabled')).toBe(true)
+    })
+
+    it('asks the picker for CSV files', () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      expect(fileInput().getAttribute('accept')).toBe('.csv')
+    })
+
+    it('states the size limit before any upload', () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      expect(screen.getByText(/up to 5 MiB/)).toBeTruthy()
+    })
+
+    it('offers a link back to the manual registration form', () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      const link = screen.getByRole('link', { name: /Register a study without a template/ })
+      expect(link.getAttribute('href')).toBe('/data_submission_form')
+    })
+
+    it('exposes an aria-live region for results', () => {
+      const { container } = renderWithRouter(<StudyTemplateUpload />)
+      expect(container.querySelector('[aria-live="polite"]')).toBeTruthy()
+    })
+  })
+
+  describe('template download', () => {
+    it('downloads a generated v1 CSV', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+
+      await clickButton(/Download blank template/)
+
+      expect(fileDownload).toHaveBeenCalledTimes(1)
+      const [content, filename, mime] = vi.mocked(fileDownload).mock.calls[0]
+      expect(filename).toBe('duos-study-template-v1.csv')
+      expect(mime).toBe('text/csv')
+      expect(String(content)).toContain('templateVersion,recordType,recordId,parentRecordId,field,value')
+    })
+
+    it('does not call the validation endpoint to build the template', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+
+      await clickButton(/Download blank template/)
+
+      expect(Draft.validateStudyDatasetTemplate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('file selection', () => {
+    it('shows the selected filename and enables Validate', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+
+      expect(screen.getByText('my-study.csv')).toBeTruthy()
+      expect(screen.getByRole('button', { name: 'Validate' }).hasAttribute('disabled')).toBe(false)
+    })
+
+    it('names the file in the Remove control', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+
+      expect(screen.getByRole('button', { name: 'Remove my-study.csv' })).toBeTruthy()
+    })
+
+    it('rejects a non-CSV file without uploading it', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('notes.txt'))
+
+      expect(showError).toHaveBeenCalledWith({ text: 'Template file must be a .csv file' })
+      expect(screen.getByRole('button', { name: 'Validate' }).hasAttribute('disabled')).toBe(true)
+      expect(Draft.validateStudyDatasetTemplate).not.toHaveBeenCalled()
+    })
+
+    it('rejects a file over 5 MiB without uploading it', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('huge.csv', 5 * 1024 * 1024 + 1))
+
+      expect(showError).toHaveBeenCalledWith({ text: 'Template file must be no larger than 5 MiB' })
+      expect(Draft.validateStudyDatasetTemplate).not.toHaveBeenCalled()
+    })
+
+    it('accepts a file exactly at the limit', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('exact.csv', 5 * 1024 * 1024))
+
+      expect(screen.getByRole('button', { name: 'Validate' }).hasAttribute('disabled')).toBe(false)
+    })
+  })
+
+  describe('pending state', () => {
+    it('marks Validate busy and blocks duplicate requests while validating', async () => {
+      let resolveValidation: (value: TemplateValidationResponse) => void = () => {}
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockReturnValue(
+        new Promise<TemplateValidationResponse>((resolve) => { resolveValidation = resolve }),
+      )
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      const button = screen.getByRole('button', { name: 'Validate' })
+      expect(button.getAttribute('aria-busy')).toBe('true')
+      expect(button.hasAttribute('disabled')).toBe(true)
+
+      fireEvent.click(button)
+      expect(Draft.validateStudyDatasetTemplate).toHaveBeenCalledTimes(1)
+
+      await act(async () => {
+        resolveValidation({ valid: false, errors: [{ message: 'done' }] })
+      })
+    })
+  })
+
+  describe('validation errors', () => {
+    const invalidResponse: TemplateValidationResponse = {
+      valid: false,
+      errors: [
+        { row: 3, column: 'piEmail', message: 'Must be a valid email address.' },
+        { row: 7, message: 'Unknown field "piEmial".' },
+        { message: 'Study name is required.' },
+      ],
+    }
+
+    beforeEach(() => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue(invalidResponse)
+    })
+
+    it('renders row and column context when available', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      expect(await screen.findByText('Row 3, column piEmail')).toBeTruthy()
+      expect(screen.getByText('Must be a valid email address.')).toBeTruthy()
+    })
+
+    it('renders a row without a column when only the row is known', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      expect(await screen.findByText('Row 7')).toBeTruthy()
+    })
+
+    it('never fabricates a location for message-only violations', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      const item = (await screen.findByText('Study name is required.')).closest('li')
+      expect(item?.textContent).toBe('Study name is required.')
+    })
+
+    it('stays on the page and keeps the filename visible', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await screen.findByText(/3 errors/)
+      expect(mockNavigate).not.toHaveBeenCalled()
+      expect(screen.getByText('my-study.csv')).toBeTruthy()
+    })
+
+    it('keeps Validate available for a retry', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await screen.findByText(/3 errors/)
+      const button = screen.getByRole('button', { name: 'Validate' })
+      expect(button.hasAttribute('disabled')).toBe(false)
+      expect(button.getAttribute('aria-busy')).toBe('false')
+    })
+
+    it('reports omitted errors when the cap is reached', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue({
+        valid: false,
+        errors: [{ message: 'first of many' }],
+        truncated: true,
+      })
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      expect(await screen.findByText(/Further errors were omitted/)).toBeTruthy()
+    })
+
+    it('clears previous errors when validation is retried', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+      await screen.findByText(/3 errors/)
+
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue({
+        valid: false,
+        errors: [{ message: 'Study name is required.' }],
+      })
+      await clickValidate()
+
+      expect(await screen.findByText(/1 error$/)).toBeTruthy()
+      expect(screen.queryByText('Must be a valid email address.')).toBeNull()
+    })
+  })
+
+  describe('remove and replace', () => {
+    beforeEach(() => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue({
+        valid: false,
+        errors: [{ row: 3, message: 'Must be a valid email address.' }],
+      })
+    })
+
+    it('clears the file and its errors', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+      await screen.findByText('Must be a valid email address.')
+
+      await clickButton('Remove my-study.csv')
+
+      expect(screen.queryByText('my-study.csv')).toBeNull()
+      expect(screen.queryByText('Must be a valid email address.')).toBeNull()
+      expect(screen.getByRole('button', { name: 'Validate' }).hasAttribute('disabled')).toBe(true)
+    })
+
+    it('resets the input so the same filename can be reselected', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+
+      await clickButton('Remove my-study.csv')
+
+      expect(fileInput().value).toBe('')
+    })
+
+    it('validates a replacement file without remounting the page', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('first.csv'))
+      await clickValidate()
+      await screen.findByText('Must be a valid email address.')
+
+      await clickButton('Remove first.csv')
+      await selectFile(buildCsv('second.csv'))
+
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue(validResponse)
+      await clickValidate()
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/data_submission_form/draft/study-dataset/c2e4583a-20b9-4705-8280-e6a5753f10c9')
+      })
+      expect(Draft.validateStudyDatasetTemplate).toHaveBeenCalledTimes(2)
+    })
+
+    it('replaces the file without an explicit remove', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('first.csv'))
+      await clickValidate()
+      await screen.findByText('Must be a valid email address.')
+
+      await selectFile(buildCsv('second.csv'))
+
+      expect(screen.getByText('second.csv')).toBeTruthy()
+      expect(screen.queryByText('Must be a valid email address.')).toBeNull()
+    })
+  })
+
+  describe('request failures', () => {
+    it('stays on the page and shows the failure', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockRejectedValue(new Error('Request failed with status 500'))
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await waitFor(() => {
+        expect(showError).toHaveBeenCalledWith({ text: 'Request failed with status 500' })
+      })
+      expect(mockNavigate).not.toHaveBeenCalled()
+      expect(screen.getByText('my-study.csv')).toBeTruthy()
+    })
+
+    it('allows a retry that then succeeds', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockRejectedValueOnce(new Error('Network error'))
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+      await waitFor(() => expect(showError).toHaveBeenCalled())
+
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue(validResponse)
+      await clickValidate()
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/data_submission_form/draft/study-dataset/c2e4583a-20b9-4705-8280-e6a5753f10c9')
+      })
+    })
+  })
+
+  describe('successful validation', () => {
+    it('routes to the exact draft UUID Consent returned', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue(validResponse)
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/data_submission_form/draft/study-dataset/c2e4583a-20b9-4705-8280-e6a5753f10c9')
+      })
+    })
+
+    it('refuses to route when the draft type is not StudyDatasetSubmissionV1', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue({
+        valid: true,
+        errors: [],
+        draft: { id: 'c2e4583a-20b9-4705-8280-e6a5753f10c9', draftType: 'SomeOtherDraft' },
+      } as unknown as TemplateValidationResponse)
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await waitFor(() => {
+        expect(showError).toHaveBeenCalledWith({
+          text: expect.stringContaining('did not identify a study/dataset draft'),
+        })
+      })
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+
+    it('refuses to route when the draft reference is missing', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue({
+        valid: true,
+        errors: [],
+      } as unknown as TemplateValidationResponse)
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await waitFor(() => expect(showError).toHaveBeenCalled())
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('failure reporting', () => {
+    it('reports failures as toasts rather than inline, matching the rest of the app', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockRejectedValue(new Error('Network error'))
+
+      const { container } = renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      await waitFor(() => expect(showError).toHaveBeenCalled())
+      expect(container.querySelector('[role="alert"]')).toBeNull()
+    })
+
+    // Validation errors are a completed result the user works through while editing their file, not a
+    // failure: they need row and column context and must survive longer than a toast.
+    it('keeps structured validation errors on the page instead of toasting them', async () => {
+      vi.mocked(Draft.validateStudyDatasetTemplate).mockResolvedValue({
+        valid: false,
+        errors: [{ row: 3, column: 'piEmail', message: 'Must be a valid email address.' }],
+      })
+
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv())
+      await clickValidate()
+
+      expect(await screen.findByText('Must be a valid email address.')).toBeTruthy()
+      expect(showError).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/test/pages/data_submission/StudyTemplateUpload.spec.tsx
+++ b/test/pages/data_submission/StudyTemplateUpload.spec.tsx
@@ -146,6 +146,13 @@ describe('StudyTemplateUpload', () => {
       expect(Draft.validateStudyDatasetTemplate).not.toHaveBeenCalled()
     })
 
+    it('resets the input after a rejection so the same file can be re-picked', async () => {
+      renderWithRouter(<StudyTemplateUpload />)
+      await selectFile(buildCsv('notes.txt'))
+
+      expect(fileInput().value).toBe('')
+    })
+
     it('accepts a file exactly at the limit', async () => {
       renderWithRouter(<StudyTemplateUpload />)
       await selectFile(buildCsv('exact.csv', 5 * 1024 * 1024))

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.hydration.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.hydration.spec.tsx
@@ -1,0 +1,153 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { Route, Routes } from 'react-router'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { DataSubmissionFormV2 } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
+import { Draft } from 'src/libs/ajax/Draft'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { DatasetRegistrationSchemaV1 } from 'src/pages/data_submission/v2/v2-models'
+import { DraftDetail } from 'src/types/draft'
+import { renderWithRouter } from '../../../test-utils'
+
+vi.mock('src/libs/ajax/Draft', () => ({ Draft: { getDraft: vi.fn(), deleteDraft: vi.fn() } }))
+vi.mock('src/libs/ajax/DataSet', () => ({ DataSet: { getStudyById: vi.fn(), registerDataset: vi.fn(), updateStudy: vi.fn() } }))
+vi.mock('src/libs/storage', () => ({ Storage: { getCurrentUser: () => ({}), userIsLogged: () => false } }))
+
+// Swap MUI DatePicker for a plain input, as the section specs do.
+vi.mock('src/components/DuosDatePicker', () => ({
+  DuosDatePicker: ({ id }: { id: string }) => <input data-testid={`date-picker-${id}`} />,
+}))
+
+const DRAFT_ID = '0393c587-343b-4c85-8969-e69e3f4f5aa8'
+const DRAFT_ROUTE = `/data_submission_form/draft/study-dataset/${DRAFT_ID}`
+
+const baseDocument = (): DatasetRegistrationSchemaV1 => {
+  const detail: DraftDetail<DatasetRegistrationSchemaV1> = JSON.parse(readFileSync(
+    resolve(__dirname, '../../../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+    'utf8',
+  ))
+  return detail.document
+}
+
+/** A draft with something of every kind the form has to place: scalar, property, group, file type. */
+const richDocument = (): DatasetRegistrationSchemaV1 => ({
+  ...baseDocument(),
+  piEmail: 'investigator@example.org',
+  phenotypeIndication: 'Synthetic indication',
+  species: 'Homo sapiens',
+  alternativeDataSharingPlan: true,
+  alternativeDataSharingPlanExplanation: 'Synthetic explanation',
+  data: { someClientKey: 'kept as-is' },
+  // A draft carries only what the wire contract defines, which is a subset of the richer shape the
+  // form uses once a study is persisted.
+  consentGroups: [
+    {
+      consentGroupName: 'Synthetic Open Dataset',
+      accessManagement: 'open',
+      numberOfParticipants: 10,
+      fileTypes: [{ fileType: 'Genome', functionalEquivalence: 'Synthetic reference build' }],
+    },
+    {
+      consentGroupName: 'Synthetic Controlled Dataset',
+      accessManagement: 'controlled',
+      numberOfParticipants: 42,
+    },
+  ] as unknown as DatasetRegistrationSchemaV1['consentGroups'],
+} as DatasetRegistrationSchemaV1)
+
+const renderDraft = (document: DatasetRegistrationSchemaV1) => {
+  const detail = { ...JSON.parse(readFileSync(
+    resolve(__dirname, '../../../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+    'utf8',
+  )), document }
+  vi.mocked(Draft.getDraft).mockResolvedValue(detail)
+  return renderWithRouter(
+    <Routes>
+      <Route path="/data_submission_form/draft/study-dataset/:draftUuid" element={<DataSubmissionFormV2 />} />
+    </Routes>,
+    { route: DRAFT_ROUTE },
+  )
+}
+
+const inputValue = (id: string): string =>
+  (globalThis.document.getElementById(id) as HTMLInputElement)?.value
+
+const submittedPayload = (): DatasetRegistrationSchemaV1 => {
+  const formData = vi.mocked(DataSet.registerDataset).mock.calls[0][0] as FormData
+  return JSON.parse(formData.get('dataset') as string)
+}
+
+const createStudy = async () => {
+  fireEvent.click(screen.getByText('Create Study'))
+  await waitFor(() => expect(DataSet.registerDataset).toHaveBeenCalled())
+}
+
+describe('DataSubmissionFormV2 hydrating a draft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(DataSet.registerDataset).mockResolvedValue({} as never)
+    vi.mocked(Draft.deleteDraft).mockResolvedValue(undefined)
+  })
+
+  it('places the scalar fields in their controls', async () => {
+    renderDraft(richDocument())
+
+    await waitFor(() => expect(inputValue('name')).toBe('Synthetic Minimal Study'))
+    expect(inputValue('description')).toBe('A synthetic study used only for contract tests.')
+    expect(inputValue('piName')).toBe('Synthetic Investigator')
+    expect(inputValue('piEmail')).toBe('investigator@example.org')
+  })
+
+  it('places the fields that travel as study properties', async () => {
+    renderDraft(richDocument())
+
+    await waitFor(() => expect(inputValue('phenotypeIndication')).toBe('Synthetic indication'))
+    expect(inputValue('species')).toBe('Homo sapiens')
+  })
+
+  it('lists the consent groups in the order the document gave them', async () => {
+    renderDraft(richDocument())
+
+    expect(await screen.findByText('Synthetic Open Dataset')).toBeInTheDocument()
+    expect(screen.getByText('Synthetic Controlled Dataset')).toBeInTheDocument()
+  })
+
+  it('keeps consent groups, their file types, and the client metadata through submission', async () => {
+    renderDraft(richDocument())
+    expect(await screen.findByText('Create Study')).toBeInTheDocument()
+
+    await createStudy()
+
+    const submitted = submittedPayload()
+    expect(submitted.consentGroups.map(group => group.consentGroupName))
+      .toEqual(['Synthetic Open Dataset', 'Synthetic Controlled Dataset'])
+    expect(submitted.consentGroups[0].fileTypes)
+      .toEqual([{ fileType: 'Genome', functionalEquivalence: 'Synthetic reference build' }])
+    expect(submitted.data).toEqual({ someClientKey: 'kept as-is' })
+  })
+
+  it('leaves the file control empty and still able to take a file', async () => {
+    // The sharing-plan section, and its file control, only appear for an NIH-funded study.
+    renderDraft({
+      ...richDocument(),
+      nihAnvilUse: 'I am NHGRI funded and I have a dbGaP PHS ID already',
+    } as DatasetRegistrationSchemaV1)
+    // FileInput keeps its input hidden and unlabelled, so it is found the way its own spec finds it.
+    await waitFor(() => expect(globalThis.document.querySelector('input[type="file"]')).toBeInTheDocument())
+
+    const fileInput = globalThis.document.querySelector('input[type="file"]') as HTMLInputElement
+    expect(fileInput.files?.length ?? 0).toBe(0)
+
+    const plan = new File(['plan'], 'sharing-plan.txt', { type: 'text/plain' })
+    fireEvent.change(fileInput, { target: { files: [plan] } })
+    await createStudy()
+
+    // The form clones the study before submitting, so the file arrives as a copy rather than the
+    // same instance.
+    const formData = vi.mocked(DataSet.registerDataset).mock.calls[0][0] as FormData
+    expect((formData.get('alternativeDataSharingPlan') as File).name).toBe('sharing-plan.txt')
+  })
+})

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.modes.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.modes.spec.tsx
@@ -1,0 +1,305 @@
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { Route, Routes } from 'react-router'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { DataSubmissionFormV2 } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
+import { Draft } from 'src/libs/ajax/Draft'
+import { Notifications } from 'src/libs/utils'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { Study } from 'src/pages/data_submission/v2/v2-models'
+import { DraftDetail } from 'src/types/draft'
+import { renderWithRouter } from '../../../test-utils'
+
+vi.mock('src/libs/ajax/Draft', () => ({ Draft: { getDraft: vi.fn(), deleteDraft: vi.fn() } }))
+vi.mock('src/libs/ajax/DataSet', () => ({ DataSet: { getStudyById: vi.fn(), registerDataset: vi.fn(), updateStudy: vi.fn() } }))
+vi.mock('src/libs/utils', async () => {
+  const actual = await vi.importActual<typeof import('src/libs/utils')>('src/libs/utils')
+  return { ...actual, Notifications: { showNotification: vi.fn(), showError: vi.fn() } }
+})
+
+vi.mock('src/libs/storage', () => ({
+  Storage: {
+    getCurrentUser: () => ({}),
+    userIsLogged: () => false,
+  },
+}))
+
+// The form's sections are exercised by their own specs. Here one only has to show what the form
+// handed it, so the assertions are about which study was loaded rather than how it renders.
+vi.mock('src/pages/data_submission/v2/GeneralStudyInformation', () => ({
+  GeneralStudyInformation: ({ study }: { study: Study }) => <div data-testid="study-name">{study?.name}</div>,
+}))
+vi.mock('src/pages/data_submission/v2/NihAnvilUseRelated', () => ({ NihAnvilUseRelated: () => <div /> }))
+vi.mock('src/pages/data_submission/v2/NihAdministrativeInformation', () => ({ NihAdministrativeInformation: () => <div /> }))
+vi.mock('src/pages/data_submission/v2/NihDataManagement', () => ({ NihDataManagement: () => <div /> }))
+vi.mock('src/pages/data_submission/v2/StudyAssetManagement', () => ({ StudyAssetManagement: () => <div /> }))
+
+const DRAFT_ID = '0393c587-343b-4c85-8969-e69e3f4f5aa8'
+const DRAFT_ROUTE = `/data_submission_form/draft/study-dataset/${DRAFT_ID}`
+
+const draftDetail = (): DraftDetail => JSON.parse(readFileSync(
+  resolve(__dirname, '../../../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+  'utf8',
+))
+
+const renderDraftRoute = () => renderWithRouter(
+  <Routes>
+    <Route path="/data_submission_form/draft/study-dataset/:draftUuid" element={<DataSubmissionFormV2 />} />
+    <Route path="/data_submission_form" element={<DataSubmissionFormV2 />} />
+  </Routes>,
+  { route: DRAFT_ROUTE },
+)
+
+describe('DataSubmissionFormV2 in draft mode', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('loads the draft by id rather than treating it as a study id', async () => {
+    vi.mocked(Draft.getDraft).mockResolvedValue(draftDetail())
+
+    renderDraftRoute()
+
+    await waitFor(() => expect(Draft.getDraft).toHaveBeenCalledWith(DRAFT_ID))
+    expect(DataSet.getStudyById).not.toHaveBeenCalled()
+  })
+
+  it('populates the form from the draft document', async () => {
+    vi.mocked(Draft.getDraft).mockResolvedValue(draftDetail())
+
+    renderDraftRoute()
+
+    expect(await screen.findByTestId('study-name')).toHaveTextContent('Synthetic Minimal Study')
+  })
+
+  it('says the registration is a draft', async () => {
+    vi.mocked(Draft.getDraft).mockResolvedValue(draftDetail())
+
+    renderDraftRoute()
+
+    expect(await screen.findByText('Study Registration Draft')).toBeInTheDocument()
+  })
+
+  it('offers creation rather than update, since a draft was never submitted', async () => {
+    vi.mocked(Draft.getDraft).mockResolvedValue(draftDetail())
+
+    renderDraftRoute()
+
+    expect(await screen.findByText('Create Study')).toBeInTheDocument()
+    expect(screen.queryByText('Update Study')).not.toBeInTheDocument()
+  })
+
+  it('offers nothing to submit until the draft has loaded', async () => {
+    let resolveDraft: (detail: DraftDetail) => void = () => {}
+    vi.mocked(Draft.getDraft).mockReturnValue(new Promise((resolve) => {
+      resolveDraft = resolve
+    }))
+
+    renderDraftRoute()
+
+    expect(screen.queryByText('Create Study')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('study-name')).not.toBeInTheDocument()
+
+    resolveDraft(draftDetail())
+
+    expect(await screen.findByText('Create Study')).toBeInTheDocument()
+  })
+
+  it('refuses a draft of another type without offering the form', async () => {
+    const draft = draftDetail()
+    draft.meta.draftType = 'SomeOtherSubmissionV1'
+    vi.mocked(Draft.getDraft).mockResolvedValue(draft)
+
+    renderDraftRoute()
+
+    expect(await screen.findByText('Draft could not be loaded')).toBeInTheDocument()
+    expect(screen.queryByText('Create Study')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('study-name')).not.toBeInTheDocument()
+  })
+
+  it('reports a missing or unauthorized draft the same recoverable way', async () => {
+    vi.mocked(Draft.getDraft).mockRejectedValue(new Error('Request failed with status 404'))
+
+    renderDraftRoute()
+
+    expect(await screen.findByText('Draft could not be loaded')).toBeInTheDocument()
+    expect(screen.getByText('Back to My Data Submissions')).toBeInTheDocument()
+  })
+})
+
+describe('DataSubmissionFormV2 outside draft mode', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('still renders the blank create form, loading nothing', async () => {
+    renderWithRouter(
+      <Routes>
+        <Route path="/data_submission_form" element={<DataSubmissionFormV2 />} />
+      </Routes>,
+      { route: '/data_submission_form' },
+    )
+
+    expect(await screen.findByText('Study Registration Form')).toBeInTheDocument()
+    expect(Draft.getDraft).not.toHaveBeenCalled()
+    expect(DataSet.getStudyById).not.toHaveBeenCalled()
+    expect(screen.getByText('Create Study')).toBeInTheDocument()
+  })
+
+  it('deletes no draft when a study is created without one', async () => {
+    vi.mocked(DataSet.registerDataset).mockResolvedValue({} as never)
+
+    renderWithRouter(
+      <Routes>
+        <Route path="/data_submission_form" element={<DataSubmissionFormV2 />} />
+      </Routes>,
+      { route: '/data_submission_form' },
+    )
+    expect(await screen.findByText('Create Study')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Create Study'))
+
+    await waitFor(() => expect(Notifications.showNotification).toHaveBeenCalled())
+    expect(DataSet.registerDataset).toHaveBeenCalled()
+    expect(Draft.deleteDraft).not.toHaveBeenCalled()
+  })
+})
+
+describe('DataSubmissionFormV2 editing a persisted study', () => {
+  const STUDY_ID = '1'
+  const persistedStudy = () => ({
+    studyId: 1,
+    name: 'Persisted Study',
+    datasets: [],
+    properties: [],
+    data: {},
+  } as unknown as Study)
+
+  const renderStudyRoute = () => renderWithRouter(
+    <Routes>
+      <Route path="/data_submission_form/:studyId" element={<DataSubmissionFormV2 />} />
+    </Routes>,
+    { route: `/data_submission_form/${STUDY_ID}` },
+  )
+
+  beforeEach(() => vi.clearAllMocks())
+
+  it('still loads by study id, with no draft involved', async () => {
+    vi.mocked(DataSet.getStudyById).mockResolvedValue(persistedStudy())
+
+    renderStudyRoute()
+
+    expect(await screen.findByTestId('study-name')).toHaveTextContent('Persisted Study')
+    expect(DataSet.getStudyById).toHaveBeenCalledWith(STUDY_ID)
+    expect(Draft.getDraft).not.toHaveBeenCalled()
+    expect(screen.getByText('Study Registration Form')).toBeInTheDocument()
+  })
+
+  it('still offers update rather than creation', async () => {
+    vi.mocked(DataSet.getStudyById).mockResolvedValue(persistedStudy())
+
+    renderStudyRoute()
+
+    expect(await screen.findByText('Update Study')).toBeInTheDocument()
+    expect(screen.queryByText('Create Study')).not.toBeInTheDocument()
+  })
+
+  it('still updates the study it loaded, deleting no draft', async () => {
+    vi.mocked(DataSet.getStudyById).mockResolvedValue(persistedStudy())
+    vi.mocked(DataSet.updateStudy).mockResolvedValue({} as never)
+
+    renderStudyRoute()
+    expect(await screen.findByText('Update Study')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Update Study'))
+
+    expect(DataSet.updateStudy).toHaveBeenCalledWith(STUDY_ID, expect.any(FormData))
+    expect(Draft.deleteDraft).not.toHaveBeenCalled()
+  })
+
+  it('still reports a failed load inline, keeping the form on the page', async () => {
+    // Only the draft path replaces the form with an error page; this one is unchanged.
+    vi.mocked(DataSet.getStudyById).mockRejectedValue(new Error('Request failed with status 404'))
+
+    renderStudyRoute()
+
+    expect(await screen.findByText('Error Loading Page')).toBeInTheDocument()
+    expect(screen.queryByText('Draft could not be loaded')).not.toBeInTheDocument()
+    expect(screen.getByText('Create Study')).toBeInTheDocument()
+  })
+})
+
+describe('creating a study from a draft', () => {
+  // fireEvent wraps its own act(); the click handler is async, so its continuation is awaited
+  // through what it does rather than by wrapping the click again.
+  const createStudy = async () => {
+    expect(await screen.findByText('Create Study')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Create Study'))
+    await waitFor(() => expect(DataSet.registerDataset).toHaveBeenCalled())
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(Draft.getDraft).mockResolvedValue(draftDetail())
+  })
+
+  it('removes the source draft once the study exists', async () => {
+    vi.mocked(DataSet.registerDataset).mockResolvedValue({} as never)
+    vi.mocked(Draft.deleteDraft).mockResolvedValue(undefined)
+
+    renderDraftRoute()
+    await createStudy()
+
+    await waitFor(() => expect(Draft.deleteDraft).toHaveBeenCalledWith(DRAFT_ID))
+    expect(vi.mocked(DataSet.registerDataset).mock.invocationCallOrder[0])
+      .toBeLessThan(vi.mocked(Draft.deleteDraft).mock.invocationCallOrder[0])
+  })
+
+  it('submits what the form holds rather than the document it was loaded from', async () => {
+    vi.mocked(DataSet.registerDataset).mockResolvedValue({} as never)
+    vi.mocked(Draft.deleteDraft).mockResolvedValue(undefined)
+
+    renderDraftRoute()
+    await createStudy()
+
+    // Built from the Study the form edits, so an edit made before submitting is what gets sent.
+    const formData = vi.mocked(DataSet.registerDataset).mock.calls[0][0] as FormData
+    const submitted = JSON.parse(formData.get('dataset') as string)
+    expect(submitted.studyName).toBe('Synthetic Minimal Study')
+    expect(submitted.consentGroups).toHaveLength(1)
+  })
+
+  it('keeps the draft when creation fails, so it can be tried again', async () => {
+    vi.mocked(DataSet.registerDataset).mockRejectedValue(new Error('Study creation failed'))
+
+    renderDraftRoute()
+    await createStudy()
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    expect(Draft.deleteDraft).not.toHaveBeenCalled()
+  })
+
+  it('reports a failed cleanup without presenting the study as failed', async () => {
+    vi.mocked(DataSet.registerDataset).mockResolvedValue({} as never)
+    vi.mocked(Draft.deleteDraft).mockRejectedValue(new Error('Request failed with status 500'))
+
+    renderDraftRoute()
+    await createStudy()
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    expect(Notifications.showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Study created successfully', type: 'success' }),
+    )
+    expect(Notifications.showError).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining('could not be removed') }),
+    )
+  })
+
+  it('does not retry a failed cleanup', async () => {
+    vi.mocked(DataSet.registerDataset).mockResolvedValue({} as never)
+    vi.mocked(Draft.deleteDraft).mockRejectedValue(new Error('Request failed with status 500'))
+
+    renderDraftRoute()
+    await createStudy()
+
+    await waitFor(() => expect(Draft.deleteDraft).toHaveBeenCalled())
+    expect(Draft.deleteDraft).toHaveBeenCalledTimes(1)
+  })
+})

--- a/test/pages/data_submission/v2/studyDatasetDraft.spec.ts
+++ b/test/pages/data_submission/v2/studyDatasetDraft.spec.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { Draft } from 'src/libs/ajax/Draft'
+import { WrongDraftTypeError, loadStudyDatasetDraft } from 'src/pages/data_submission/v2/studyDatasetDraft'
+import { DraftDetail } from 'src/types/draft'
+
+vi.mock('src/libs/ajax/Draft', () => ({ Draft: { getDraft: vi.fn() } }))
+vi.mock('src/libs/storage', () => ({ Storage: { getCurrentUser: () => ({}) } }))
+
+const DRAFT_ID = '0393c587-343b-4c85-8969-e69e3f4f5aa8'
+
+const draftDetail = (): DraftDetail => JSON.parse(readFileSync(
+  resolve(__dirname, '../../../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+  'utf8',
+))
+
+describe('loadStudyDatasetDraft', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('maps a study/dataset draft into the form model', async () => {
+    vi.mocked(Draft.getDraft).mockResolvedValue(draftDetail())
+
+    const study = await loadStudyDatasetDraft(DRAFT_ID)
+
+    expect(study.name).toBe('Synthetic Minimal Study')
+    expect(study.assets?.consentGroups).toHaveLength(1)
+  })
+
+  it('refuses a draft belonging to another workflow', async () => {
+    const draft = draftDetail()
+    draft.meta.draftType = 'SomeOtherSubmissionV1'
+    vi.mocked(Draft.getDraft).mockResolvedValue(draft)
+
+    await expect(loadStudyDatasetDraft(DRAFT_ID)).rejects.toBeInstanceOf(WrongDraftTypeError)
+  })
+
+  it('refuses a draft that does not say what it is', async () => {
+    const draft = draftDetail()
+    delete (draft.meta as Partial<DraftDetail['meta']>).draftType
+    vi.mocked(Draft.getDraft).mockResolvedValue(draft)
+
+    await expect(loadStudyDatasetDraft(DRAFT_ID)).rejects.toBeInstanceOf(WrongDraftTypeError)
+  })
+
+  it('propagates a missing or unauthorized draft', async () => {
+    vi.mocked(Draft.getDraft).mockRejectedValue(new Error('Request failed with status 404'))
+
+    await expect(loadStudyDatasetDraft(DRAFT_ID)).rejects.toThrow('Request failed with status 404')
+  })
+})

--- a/test/pages/data_submission/v2/v2-common-functions.spec.ts
+++ b/test/pages/data_submission/v2/v2-common-functions.spec.ts
@@ -1,5 +1,30 @@
-import { describe, it, expect } from 'vitest'
-import { extractThroughBioId } from 'src/pages/data_submission/v2/v2-common-functions'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import {
+  datasetSchemaSubmissionToStudy,
+  extractThroughBioId,
+  getStudyPropertyValueByKey,
+  studyToDatasetSchemaSubmission,
+} from 'src/pages/data_submission/v2/v2-common-functions'
+import { DatasetRegistrationSchemaV1 } from 'src/pages/data_submission/v2/v2-models'
+import { DraftDetail } from 'src/types/draft'
+
+vi.mock('src/libs/storage', () => ({
+  Storage: {
+    // The form falls back to the submitter's institution when a document carries none. Held empty
+    // so a round trip shows what the document said rather than what the session would add.
+    getCurrentUser: () => ({}),
+  },
+}))
+
+const draftDocument = (): DatasetRegistrationSchemaV1 => {
+  const detail: DraftDetail<DatasetRegistrationSchemaV1> = JSON.parse(readFileSync(
+    resolve(__dirname, '../../../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+    'utf8',
+  ))
+  return detail.document
+}
 
 describe('extractThroughBioId', () => {
   const validUrls: [string, string][] = [
@@ -38,5 +63,127 @@ describe('extractThroughBioId', () => {
     it(`returns empty string for empty input "${JSON.stringify(input)}"`, () => {
       expect(extractThroughBioId(input)).toBe('')
     })
+  })
+})
+
+describe('datasetSchemaSubmissionToStudy', () => {
+  it('populates the scalar fields the form reads directly', () => {
+    const study = datasetSchemaSubmissionToStudy(draftDocument())
+
+    expect(study.name).toBe('Synthetic Minimal Study')
+    expect(study.description).toBe('A synthetic study used only for contract tests.')
+    expect(study.dataTypes).toEqual(['Genomic'])
+    expect(study.piName).toBe('Synthetic Investigator')
+    expect(study.publicVisibility).toBe(true)
+  })
+
+  it('populates the fields the form reads as study properties', () => {
+    const study = datasetSchemaSubmissionToStudy(draftDocument())
+
+    expect(getStudyPropertyValueByKey(study, 'nihAnvilUse'))
+      .toBe('I am not NHGRI funded and do not plan to store data in AnVIL')
+  })
+
+  it('carries consent groups as assets, with their ordering', () => {
+    const document = draftDocument()
+    document.consentGroups = [
+      { consentGroupName: 'First', accessManagement: 'open', numberOfParticipants: 1 },
+      { consentGroupName: 'Second', accessManagement: 'controlled', numberOfParticipants: 2 },
+    ] as DatasetRegistrationSchemaV1['consentGroups']
+
+    const study = datasetSchemaSubmissionToStudy(document)
+
+    expect(study.assets?.consentGroups?.map(group => group.consentGroupName))
+      .toEqual(['First', 'Second'])
+  })
+
+  it('writes no property for a field the document leaves out', () => {
+    // The document omits what the producer left empty, so a property written here would submit a
+    // value they never gave.
+    const study = datasetSchemaSubmissionToStudy(draftDocument())
+
+    expect(study.properties?.map(property => property.key)).not.toContain('embargoReleaseDate')
+    expect(study.properties?.map(property => property.key)).not.toContain('phenotypeIndication')
+    expect(study.piEmail).toBeUndefined()
+  })
+
+  it('does not share structure with the document it mapped', () => {
+    const document = draftDocument()
+
+    const study = datasetSchemaSubmissionToStudy(document)
+    study.assets!.consentGroups![0].consentGroupName = 'Edited in the form'
+
+    expect(document.consentGroups[0].consentGroupName).toBe('Synthetic Open Dataset')
+  })
+})
+
+describe('draft document round trip', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns every field the document carried', () => {
+    const document = draftDocument()
+
+    const submitted = studyToDatasetSchemaSubmission(datasetSchemaSubmissionToStudy(document))
+
+    Object.entries(document).forEach(([field, value]) => {
+      expect(submitted[field as keyof DatasetRegistrationSchemaV1]).toEqual(value)
+    })
+  })
+
+  it('invents nothing the document left out', () => {
+    const document = draftDocument()
+
+    const submitted = JSON.parse(JSON.stringify(
+      studyToDatasetSchemaSubmission(datasetSchemaSubmissionToStudy(document)),
+    ))
+
+    // Two additions, neither a value the producer gave: the form always carries the metadata bag,
+    // and the forward mapper always emits an assets object once consent groups are lifted out of
+    // it. Both are empty.
+    expect(Object.keys(submitted).sort())
+      .toEqual([...Object.keys(document), 'data', 'assets'].sort())
+    expect(submitted.data).toEqual({})
+    expect(submitted.assets).toEqual({})
+  })
+
+  it('round trips the optional fields a fuller document carries', () => {
+    const document: DatasetRegistrationSchemaV1 = {
+      ...draftDocument(),
+      piEmail: 'investigator@example.org',
+      phenotypeIndication: 'Synthetic indication',
+      species: 'Homo sapiens',
+      dataCustodianEmail: ['custodian@example.org'],
+      embargoReleaseDate: '2030-01-01',
+      piInstitution: 7,
+      multiCenterStudy: true,
+      collaboratingSites: ['Site A', 'Site B'],
+      alternativeDataSharingPlan: true,
+      alternativeDataSharingPlanExplanation: 'Synthetic explanation',
+    }
+
+    const submitted = studyToDatasetSchemaSubmission(datasetSchemaSubmissionToStudy(document))
+
+    Object.entries(document).forEach(([field, value]) => {
+      expect(submitted[field as keyof DatasetRegistrationSchemaV1]).toEqual(value)
+    })
+  })
+
+  it('round trips a boolean the document set to false', () => {
+    const document: DatasetRegistrationSchemaV1 = {
+      ...draftDocument(),
+      submittingToAnvil: false,
+      multiCenterStudy: false,
+      controlledAccessRequiredForGenomicSummaryResultsGSR: false,
+      alternativeDataSharingPlan: false,
+      alternativeDataSharingPlanDataReleased: false,
+    }
+
+    const submitted = studyToDatasetSchemaSubmission(datasetSchemaSubmissionToStudy(document))
+
+    expect(submitted.submittingToAnvil).toBe(false)
+    expect(submitted.multiCenterStudy).toBe(false)
+    expect(submitted.controlledAccessRequiredForGenomicSummaryResultsGSR).toBe(false)
+    expect(submitted.alternativeDataSharingPlan).toBe(false)
+    expect(submitted.alternativeDataSharingPlanDataReleased).toBe(false)
   })
 })

--- a/test/pages/researcher_console/DatasetSubmissions.spec.tsx
+++ b/test/pages/researcher_console/DatasetSubmissions.spec.tsx
@@ -162,6 +162,44 @@ describe('DatasetSubmissions', () => {
     expect(navigateMock).toHaveBeenCalledWith('/data_submission_form')
   })
 
+  // ── UPLOAD TEMPLATE button ─────────────────────────────────────────────────
+
+  it('renders the UPLOAD TEMPLATE button', () => {
+    renderComponent()
+    expect(screen.getByRole('button', { name: /UPLOAD TEMPLATE/i })).toBeInTheDocument()
+  })
+
+  // Deliberately wider than ADD DATASET's data-submitter-only rule: it matches the route's own
+  // RoleBAC guard, since chairpersons and admins register studies too.
+  it.each([
+    ['data submitter', { isDataSubmitter: true }],
+    ['chairperson', { isChairPerson: true }],
+    ['admin', { isAdmin: true }],
+  ])('UPLOAD TEMPLATE button is enabled for a %s', (_role, roleFlags) => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue({ ...baseUser, ...roleFlags })
+    renderComponent()
+    expect(screen.getByRole('button', { name: /UPLOAD TEMPLATE/i })).not.toBeDisabled()
+  })
+
+  it('UPLOAD TEMPLATE button is disabled for a user with none of those roles', () => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue({ ...baseUser, isResearcher: true })
+    renderComponent()
+    expect(screen.getByRole('button', { name: /UPLOAD TEMPLATE/i })).toBeDisabled()
+  })
+
+  it('clicking UPLOAD TEMPLATE navigates to /data_submission_template', () => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue({ ...baseUser, isDataSubmitter: true })
+    renderComponent()
+    fireEvent.click(screen.getByRole('button', { name: /UPLOAD TEMPLATE/i }))
+    expect(navigateMock).toHaveBeenCalledWith('/data_submission_template')
+  })
+
+  it('leaves the manual ADD DATASET path untouched for a chairperson', () => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue({ ...baseUser, isChairPerson: true })
+    renderComponent()
+    expect(screen.getByRole('button', { name: /ADD DATASET/i })).toBeDisabled()
+  })
+
   // ── Delete dialog ──────────────────────────────────────────────────────────
 
   it('delete dialog is not shown on initial render', () => {

--- a/test/routing/AppRoutes.spec.tsx
+++ b/test/routing/AppRoutes.spec.tsx
@@ -51,6 +51,7 @@ const roleBACRoutes: string[] = [
   '/dataset_submissions',
   '/data_submission_template',
   '/data_submission_form',
+  '/data_submission_form/draft/study-dataset/0393c587-343b-4c85-8969-e69e3f4f5aa8',
   '/study_update/1',
   '/dataset_update/1',
   '/dar_vote_review/1',
@@ -191,6 +192,45 @@ describe('AppRoutes — study template upload route', () => {
 
     expect(container.querySelector('[data-cy="not-found"]')).toBeInTheDocument()
     expect(queryByText('Upload Study Template')).not.toBeInTheDocument()
+  })
+})
+
+describe('AppRoutes — study/dataset draft route', () => {
+  const userWithRole = (roleName: string): DuosUser => ({
+    roles: [{ name: roleName }],
+  } as DuosUser)
+
+  const DRAFT_ROUTE = '/data_submission_form/draft/study-dataset/0393c587-343b-4c85-8969-e69e3f4f5aa8'
+
+  beforeEach(() => {
+    vi.spyOn(Storage, 'userIsLogged').mockReturnValue(true)
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('resolves the draft path to the registration form rather than the blank one', () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(userWithRole(USER_ROLES.dataSubmitter))
+
+    const { container } = render(
+      <MemoryRouter initialEntries={[DRAFT_ROUTE]}>
+        <AppRoutes isLogged={true} env="dev" />
+      </MemoryRouter>,
+    )
+
+    // Four segments deep, so it must not be mistaken for /data_submission_form/:studyId.
+    expect(container.querySelector('[data-cy="not-found"]')).not.toBeInTheDocument()
+  })
+
+  it('does not let a researcher through', () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(userWithRole(USER_ROLES.researcher))
+
+    const { container } = render(
+      <MemoryRouter initialEntries={[DRAFT_ROUTE]}>
+        <AppRoutes isLogged={true} env="dev" />
+      </MemoryRouter>,
+    )
+
+    expect(container.querySelector('[data-cy="not-found"]')).toBeInTheDocument()
   })
 })
 

--- a/test/routing/AppRoutes.spec.tsx
+++ b/test/routing/AppRoutes.spec.tsx
@@ -28,6 +28,10 @@ vi.mock('src/pages/manage_dac/ManageDac', () => ({
   default: () => <div>Manage DACs</div>,
 }))
 
+vi.mock('src/pages/data_submission/StudyTemplateUpload', () => ({
+  StudyTemplateUpload: () => <div>Upload Study Template</div>,
+}))
+
 const LocationSpy = ({ onLocationChange }: { onLocationChange: (loc: string) => void }) => {
   const location = useLocation()
   React.useEffect(() => {
@@ -45,6 +49,7 @@ const roleBACRoutes: string[] = [
   '/progress_report_application/1',
   '/dar_application/1',
   '/dataset_submissions',
+  '/data_submission_template',
   '/data_submission_form',
   '/study_update/1',
   '/dataset_update/1',
@@ -145,6 +150,47 @@ describe('AppRoutes — legacy DAC console redirects', () => {
     )
 
     expect(container.querySelector('[data-cy="not-found"]')).toBeInTheDocument()
+  })
+})
+
+describe('AppRoutes — study template upload route', () => {
+  const userWithRole = (roleName: string): DuosUser => ({
+    roles: [{ name: roleName }],
+  } as DuosUser)
+
+  beforeEach(() => {
+    vi.spyOn(Storage, 'userIsLogged').mockReturnValue(true)
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it.each([
+    USER_ROLES.dataSubmitter,
+    USER_ROLES.chairperson,
+    USER_ROLES.admin,
+  ])('renders the upload page for a %s', (roleName) => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(userWithRole(roleName))
+
+    const { getByText } = render(
+      <MemoryRouter initialEntries={['/data_submission_template']}>
+        <AppRoutes isLogged={true} env="dev" />
+      </MemoryRouter>,
+    )
+
+    expect(getByText('Upload Study Template')).toBeInTheDocument()
+  })
+
+  it('does not let a researcher through', () => {
+    vi.spyOn(Storage, 'getCurrentUser').mockReturnValue(userWithRole(USER_ROLES.researcher))
+
+    const { container, queryByText } = render(
+      <MemoryRouter initialEntries={['/data_submission_template']}>
+        <AppRoutes isLogged={true} env="dev" />
+      </MemoryRouter>,
+    )
+
+    expect(container.querySelector('[data-cy="not-found"]')).toBeInTheDocument()
+    expect(queryByText('Upload Study Template')).not.toBeInTheDocument()
   })
 })
 

--- a/test/types/draft.spec.ts
+++ b/test/types/draft.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { DraftDetail, isStudyDatasetDraft } from 'src/types/draft'
+
+const draftDetail = (): DraftDetail => JSON.parse(readFileSync(
+  resolve(__dirname, '../fixtures/study-template/v1/draft/minimal-valid-draft-detail.json'),
+  'utf8',
+))
+
+describe('isStudyDatasetDraft', () => {
+  it('accepts the draft a validated template produces', () => {
+    expect(isStudyDatasetDraft(draftDetail())).toBe(true)
+  })
+
+  it('rejects a draft of another type', () => {
+    const draft = draftDetail()
+    draft.meta.draftType = 'SomeOtherSubmissionV1'
+
+    expect(isStudyDatasetDraft(draft)).toBe(false)
+  })
+
+  it('rejects a draft whose type is missing rather than assuming this one', () => {
+    const draft = draftDetail()
+    delete (draft.meta as Partial<DraftDetail['meta']>).draftType
+
+    expect(isStudyDatasetDraft(draft)).toBe(false)
+  })
+})


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-1854

Security risk: **low** — the page accepts a user-supplied file but never parses it in the browser; parsing and validation stay server-side, and the endpoint it posts to is not deployed yet, so this adds no reachable state change. It adds a control rather than surface: every generated cell is escaped against spreadsheet formula injection. Consent's error strings render as React children rather than markup, and the new route reuses the existing `RoleBAC` guard.

### Summary

Ticket 4 of the study-template workflow planned in `docs/plans/study-template-validation-workflow.md`. Adds an **UPLOAD TEMPLATE** action beside **ADD DATASET** on My Data Submissions, routed to a new `/data_submission_template` page that downloads a blank v1 template, then uploads, validates, removes, and replaces a filled-in one without leaving the page. **ADD DATASET is untouched**, including its data-submitter-only disabled state.

- **The blank download is a v1 requirement, not a convenience.** The contract forbids JSON, so every structured wire value is a row — a hand-built file means keeping `recordType`, `recordId`, and `parentRecordId` consistent across 51 rows.
- **The field manifest is derivable rather than transcribed.** It follows the declared wire order of `StudyRegistrationRequest` (items 1–27 of 41), `ConsentGroupRequest` (items 2–23 of 25), and both `FileTypeObject` properties, so it can be diffed against those `@JsonPropertyOrder` annotations instead of against prose. It omits every field `StudyTemplateV1Fields.isExcludedFromV1()` rejects by name — the free-form `assets`/`data` maps, the `alternativeDataSharingPlan*` group, file-backed and integration-owned fields — because offering one would produce a template that cannot validate.
- **Every generated cell passes through the formula-prefix guard.** Nothing the manifest currently emits triggers it, which a test pins deliberately, so adding a field that starts with `=`, `+`, `-`, or `@` cannot silently introduce a CSV-injection vector into the producer's spreadsheet.
- **Validation failures are a completed result, not a request failure.** The client returns the discriminated response as data rather than throwing, and the page renders structured errors — with row and column context when Consent supplies it, and never fabricated when it doesn't. A request failure is different in kind and rendered differently: a 401, a 413, a 5xx, or Consent being unreachable becomes a dismissible toast, like every other failure in the app. Both leave the user on the page with the file still selected and VALIDATE still available, so a retry costs nothing.
- **Success requires both `valid: true` and a `StudyDatasetSubmissionV1` draft reference** before routing to `/data_submission_form/draft/study-dataset/:draftId`. A valid response with a missing or different type is treated as a request failure. Registering that route, and the `DataSubmissionFormV2` draft mode that gives it something to render, is [DT-3872](https://broadworkbench.atlassian.net/browse/DT-3872)'s first line of work; adding the route here without the hydration would resolve a validated template to the blank create form, as though the file had been discarded. The success path is unreachable until both that ticket and DT-3871 land — see Rollout below.
- The picker asks for `.csv` and pre-checks the 5 MiB limit in the browser using Consent's exact wording, so a doomed upload never leaves the page and the two layers cannot appear to disagree.
- **A validation result belongs to the file that produced it.** The picker and Remove stay live while a request is in flight, so a response that outlives its file is discarded rather than applied — otherwise A's errors could render beside B's filename, A's request failure could toast against an empty page, or A's draft could navigate away from B. Discarding the stale continuation is preferable to freezing the controls, since the user has already said they abandoned that file.

Worth a reviewer's eye:

- **`AsyncSpinnerButton` needed `hideOnSuccess={false}`.** It defaults to `true`, and a `valid: false` result resolves normally — the default would delete the Validate button at exactly the moment the user needs to retry.
- **The file picker is a plain `<input type="file">` rather than `FormField type={FormFieldTypes.FILE}`.** `FormField` keeps its own `formValue` state this page would duplicate and attaches a second label to the input, muddying the accessible name the ticket's a11y criteria require. `src/components/forms/FileInput.tsx` already establishes the bespoke-input pattern here. Happy to switch if you'd rather it match `IrbDocumentUpload.tsx`.
- **UPLOAD TEMPLATE is enabled for data submitters, chairpersons, and admins**, matching the route's own `RoleBAC` guard, while ADD DATASET stays data-submitter-only. That is per the ticket's acceptance criteria, but it does mean the two adjacent buttons behave differently for chairpersons and admins.
- **The canonical fixtures are duplicated from `consent`** into `test/fixtures/study-template/v1/` (provenance and commit recorded in a sibling README, since the parser rejects any unrecognised row and so cannot carry a comment). vitest can't reach another repository, and the round-trip spec needs real bytes rather than a hand-written approximation.

### What it looks like

**1. The entry point on My Data Submissions.** UPLOAD TEMPLATE sits beside ADD DATASET as a secondary action. ADD DATASET keeps its primary styling and its data-submitter-only disabled state.

<img width="3600" height="2376" alt="After-1" src="https://github.com/user-attachments/assets/68809722-8a97-4050-bcf2-c28128f38019" />

**2. The upload page, idle.** Download blank template renders through the shared `DownloadLink`, the picker states the `.csv` and 5 MiB limits before any upload, VALIDATE is disabled until a file is chosen, and there is a way back to the manual form. Shown here as an admin, one of the three roles the route admits.

<img width="3600" height="2042" alt="After-2" src="https://github.com/user-attachments/assets/40077e65-45c4-4daa-8db3-f0f38028cfb8" />

**3. A file selected.** The filename stays visible, Remove is offered alongside it, the picker relabels to "Choose a different file", and VALIDATE becomes available.

<img width="3600" height="2042" alt="After-3" src="https://github.com/user-attachments/assets/216d2b13-7e35-4cca-ab18-641390e7f174" />


The last two were captured with both dependencies present — [consent#3028](https://github.com/DataBiosphere/consent/pull/3028) running locally and the draft form from [#3875](https://github.com/DataBiosphere/duos-ui/pull/3875) — because that is the only state this page ships in: it cannot be released before either of them. The fixtures are the canonical ones from the `consent` repository.

**4. A template with errors.** `invalid/field-values.csv`, which is the fixture whose expected errors that repository pins in a sibling `.errors.json`. Each error renders with the location Consent supplies and none is invented: the first five carry a row and a column, and the last carries only a row, because no single cell is at fault for it. Note the third — "Unknown nihAnvilUse value" does not quote the offending cell, which is DT-3870's fix for echoing uploaded content back to the page.

<img width="1504" height="817" alt="validation-errors" src="https://github.com/user-attachments/assets/93d68933-e8d4-4ce2-8bc2-092b625a323c" />

**5. A valid template becomes a draft, and the draft becomes the form.** `valid/minimal-valid.csv` validates, Consent creates a `StudyDatasetSubmissionV1` draft owned by the caller, and the page routes to `/data_submission_form/draft/study-dataset/{id}`, which loads it: study name, description, and data types are the template's, and the dataset it described is a study asset. The route and the form mode behind it are [#3875](https://github.com/DataBiosphere/duos-ui/pull/3875)'s work — on this branch alone the same click reaches a route that does not exist yet, which is what the Rollout section below is about.

<img width="1504" height="817" alt="draft-hydrated-top" src="https://github.com/user-attachments/assets/ae6d87c1-18c8-43a0-a32f-682a92c0472f" />

<img width="1504" height="817" alt="draft-hydrated-datasets" src="https://github.com/user-attachments/assets/c92c0791-bb29-4e27-97b5-3855f67e5813" />

<details>
<summary><strong>The blank template it produces</strong> — 51 rows, 52 lines, 2,241 bytes, CRLF, every <code>value</code> cell empty</summary>

```csv
templateVersion,recordType,recordId,parentRecordId,field,value
1,study,study,,studyName,
1,study,study,,studyType,
1,study,study,,studyDescription,
1,study,study,,dataTypes,
1,study,study,,phenotypeIndication,
1,study,study,,species,
1,study,study,,piName,
1,study,study,,piEmail,
1,study,study,,dataCustodianEmail,
1,study,study,,publicVisibility,
1,study,study,,throughBioId,
1,study,study,,nihAnvilUse,
1,study,study,,submittingToAnvil,
1,study,study,,dbGaPPhsID,
1,study,study,,dbGaPStudyRegistrationName,
1,study,study,,embargoReleaseDate,
1,study,study,,sequencingCenter,
1,study,study,,piInstitution,
1,study,study,,nihGrantContractNumber,
1,study,study,,nihICsSupportingStudy,
1,study,study,,nihProgramOfficerName,
1,study,study,,nihInstitutionCenterSubmission,
1,study,study,,nihGenomicProgramAdministratorName,
1,study,study,,multiCenterStudy,
1,study,study,,collaboratingSites,
1,study,study,,controlledAccessRequiredForGenomicSummaryResultsGSR,
1,study,study,,controlledAccessRequiredForGenomicSummaryResultsGSRRequiredExplanation,
1,consentGroup,consentGroup-1,study,consentGroupName,
1,consentGroup,consentGroup-1,study,accessManagement,
1,consentGroup,consentGroup-1,study,generalResearchUse,
1,consentGroup,consentGroup-1,study,hmb,
1,consentGroup,consentGroup-1,study,diseaseSpecificUse,
1,consentGroup,consentGroup-1,study,poa,
1,consentGroup,consentGroup-1,study,otherPrimary,
1,consentGroup,consentGroup-1,study,nmds,
1,consentGroup,consentGroup-1,study,gso,
1,consentGroup,consentGroup-1,study,pub,
1,consentGroup,consentGroup-1,study,col,
1,consentGroup,consentGroup-1,study,irb,
1,consentGroup,consentGroup-1,study,gs,
1,consentGroup,consentGroup-1,study,mor,
1,consentGroup,consentGroup-1,study,morDate,
1,consentGroup,consentGroup-1,study,npu,
1,consentGroup,consentGroup-1,study,otherSecondary,
1,consentGroup,consentGroup-1,study,dataAccessCommitteeId,
1,consentGroup,consentGroup-1,study,dataLocation,
1,consentGroup,consentGroup-1,study,url,
1,consentGroup,consentGroup-1,study,requestLocation,
1,consentGroup,consentGroup-1,study,numberOfParticipants,
1,fileType,fileType-1,consentGroup-1,fileType,
1,fileType,fileType-1,consentGroup-1,functionalEquivalence,
```

</details>

### Rollout

**This must not be released before [DT-3871](https://broadworkbench.atlassian.net/browse/DT-3871).** That endpoint is written and in review at [consent#3028](https://github.com/DataBiosphere/consent/pull/3028) but not deployed, and deployed `DraftResource` is still `{ADMIN, DATASUBMITTER}` — a chairperson would get a 403. That ordering is the plan's staged-rollout decision (deploy Consent first, then expose the UI entry point) and is [DT-3873](https://broadworkbench.atlassian.net/browse/DT-3873)'s to sequence. Merging is safe; the page is simply unreachable value until then.

### Findings handed to other tickets

Three things surfaced while building against the Consent DTOs and the DT-3870 parser. None blocked this ticket, and all three have since been answered by the tickets that owned them — [DT-3870](https://broadworkbench.atlassian.net/browse/DT-3870) is merged and [DT-3871](https://broadworkbench.atlassian.net/browse/DT-3871) is in review at [consent#3028](https://github.com/DataBiosphere/consent/pull/3028):

- **The `draft` table is the only JSON write in this area without the NUL guard the DAR tables already have.** `jsonb` rejects a U+0000 escape, and U+0000 is valid UTF-8 and not whitespace, so it survives the parser's strict decode and its `isBlank()` check — a template Consent reports as valid can still 500 on insert. A known problem class here rather than a new one: a 2025 migration stripped it out of `data_access_request.data` and the go-forward guard now sits at five DAR call sites, but `DraftDAO.insert` and `updateDraftByDraftUUID` never got it. DT-3870 takes parse-time rejection so the producer is told; DT-3871 takes the write-time guard, which matters on update as much as insert since the draft is meant to be modified and saved.
- **Whether the truncation flag reaches the wire.** It does. DT-3871 serializes `truncated` and keeps the trailing message-only error as well, so the notice on this page renders from the flag while a client that ignores it still tells the producer. The type here stays optional, which is the forgiving side of that.
- **Whether oversize and encoding failures stay `valid: false`.** Split, in DT-3871: the 5 MiB limit is enforced by the validator that reads the upload and answered with `413` carrying the same wording this page pre-checks with, so both layers say the same thing in the same place; an empty, non-UTF-8, or malformed file stays a `valid: false` result, because that is what the producer edits and fixes here.

The plan doc keeps a summary table naming the owning ticket and what each was settled as, plus the one design observation no ticket owns — the supported field set being a derivable slice of declared wire order, which DT-3872 will want when mapping a draft back into the UI model. Its response models, examples, and its own claim about size limits now match what DT-3871 implemented.

### Testing

`pnpm run lint` and `pnpm run type-check` clean. `pnpm test` green at **356 files / 3993 tests**, including 95 new ones across five new specs — manifest fidelity, CSV generation and escaping, the round trip, the multipart client, and the page across idle, pending, validation-error, request-error, replacement, success, wrong-draft-type, stale-response, and accessibility states — plus role-visibility and routing additions to two existing specs. The three stale-response tests were each confirmed to fail without the guard.

The template shown above is the real browser download, and it is byte-identical to what the generator emits in tests: 2,241 bytes, 52 lines, every line CRLF.

The round-trip spec does real work rather than restating the generator: filling the generated scaffold's `value` cells from `minimal-valid.csv` reproduces that fixture exactly, so the download provably covers a known-valid file without hand-authored rows. `multi-consent-group-valid.csv` backs field coverage instead of strict equality, because repeated rows for multi-item arrays and a second consent group are row *additions* — the producer edit the contract documents.

`pnpm run test:e2e` is 6 passed / 5 failed locally; all five are `auth.spec.ts` throwing on missing `DUOS_AUTOMATION_*_SA` service-account credentials before any navigation. Pre-existing and environmental — no e2e spec touches this page or route.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DT-3871]: https://broadworkbench.atlassian.net/browse/DT-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




[DT-3872]: https://broadworkbench.atlassian.net/browse/DT-3872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ






