### PR TITLE
[DT-3866] Align duos-ui with the canonical Data Use classification

### DIFF
--- a/src/components/CollectionAlgorithmDecision.tsx
+++ b/src/components/CollectionAlgorithmDecision.tsx
@@ -24,19 +24,18 @@ const OtherResult = (otherResultProps: Readonly<OtherResultProps>) => {
 }
 
 const getResult = (resultValue: string | undefined): React.ReactElement => {
-  if (resultValue?.toLowerCase().trim() === 'abstain') {
-    return <AbstainResult />
+  const result = resultValue?.trim()
+  switch (result?.toLowerCase()) {
+    case 'abstain':
+      return <AbstainResult />
+    case 'yes':
+      return <YesResult />
+    case 'no':
+      return <NoResult />
+    default:
+      // Anything else is the caller's own wording, such as a match no longer interpretable.
+      return <OtherResult text={result || 'N/A'} />
   }
-  if (resultValue && resultValue.trim().length > 0) {
-    switch (resultValue.toLowerCase().trim()) {
-      case 'yes':
-        return <YesResult />
-      case 'no':
-        return <NoResult />
-      default:
-    }
-  }
-  return <OtherResult text="N/A" />
 }
 
 export default function CollectionAlgorithmDecision(props: Readonly<CollectionAlgorithmDecisionProps>) {

--- a/src/components/consent_group_list/ConsentGroupAddEdit.tsx
+++ b/src/components/consent_group_list/ConsentGroupAddEdit.tsx
@@ -69,10 +69,14 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
   const [showGSText, setShowGSText] = useState(!isNil(consentGroup?.gs))
   const [gsText, setGSText] = useState(consentGroup?.gs || undefined)
 
-  const [showOtherPrimaryText, setShowOtherPrimaryText] = useState(!isNil(consentGroup?.otherPrimary))
+  // Follow the radio `selectedPrimaryGroup` lights: reading each field alone checks one primary
+  // beside another's input.
+  const initialPrimaryGroup = selectedPrimaryGroup(consentGroup as ConsentGroup)
+
+  const [showOtherPrimaryText, setShowOtherPrimaryText] = useState(initialPrimaryGroup === 'otherPrimary')
   const [otherPrimaryText, setOtherPrimaryText] = useState(consentGroup?.otherPrimary || undefined)
 
-  const [showDiseaseSpecificUseSearchbar, setShowDiseaseSpecificUseSearchbar] = useState(!isEmpty(consentGroup?.diseaseSpecificUse))
+  const [showDiseaseSpecificUseSearchbar, setShowDiseaseSpecificUseSearchbar] = useState(initialPrimaryGroup === 'diseaseSpecificUse')
   const [selectedDiseases, setSelectedDiseases] = useState<{ displayText: string, id: string }[]>([])
 
   const diseaseSpecificUse = consentGroup?.diseaseSpecificUse
@@ -146,7 +150,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
     setValidation(calcErrors(next))
   }
 
-  const onPrimaryChange = ({ key, value }: { key: string, value: boolean | string | string[] | { displayText: string, id: string }[] }) => {
+  const onPrimaryChange = ({ key, value }: { key: string, value: boolean | string | string[] }) => {
     const next = structuredClone(current)
     next.generalResearchUse = false
     next.hmb = false
@@ -158,14 +162,12 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
 
     setShowDiseaseSpecificUseSearchbar(key === 'diseaseSpecificUse')
     setShowOtherPrimaryText(key === 'otherPrimary')
-    if (!current.otherPrimary) {
+    if (!next.otherPrimary) {
       setOtherPrimaryText(undefined)
     }
-    if (!current.diseaseSpecificUse) {
+    if (isNil(next.diseaseSpecificUse)) {
       setSelectedDiseases([])
     }
-    setShowDiseaseSpecificUseSearchbar(key === 'diseaseSpecificUse')
-    setShowOtherPrimaryText(key === 'otherPrimary')
 
     setValidation(calcErrors(next))
   }
@@ -354,7 +356,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                   onChange={({ value }: { value: string }) => {
                     onPrimaryChange({
                       key: value,
-                      value: selectedDiseases,
+                      value: selectedDiseases.map(disease => disease.id),
                     })
                   }}
                   validation={validation.primaryConsent}
@@ -415,7 +417,7 @@ export default function ConsentGroupAddEdit(props: ConsentGroupAddEditProps): Re
                   toggleText="Other"
                   defaultValue={selectedPrimaryGroup(current as ConsentGroup)}
                   onChange={({ value }: { value: string }) => {
-                    onPrimaryChange({ key: value, value: value })
+                    onPrimaryChange({ key: value, value: otherPrimaryText ?? '' })
                   }}
                   disabled={readOnly}
                   validation={validation.primaryConsent}

--- a/src/libs/dataUseTranslation.ts
+++ b/src/libs/dataUseTranslation.ts
@@ -369,8 +369,8 @@ export const processRestrictionStatements = async (
 }
 
 /**
- * Shows only the narrowest permission when a record carries several primaries (DS over HMB, those
- * over GRU). Unlike the classifier's full enumeration: a broad statement beside a narrow one misleads.
+ * Shows only the narrowest permission along the DS > HMB > GRU chain, since a broad statement beside
+ * a narrow one misleads. POA sits outside that chain and still renders alongside DS.
  */
 export const processDefinedLimitations = (
   key: string,

--- a/src/libs/dataUseTranslation.ts
+++ b/src/libs/dataUseTranslation.ts
@@ -368,6 +368,10 @@ export const processRestrictionStatements = async (
   return processDiseaseRestrictionsWithUrls(diseaseValue as string[])
 }
 
+/**
+ * Shows only the narrowest permission of a legacy multi-primary record (DS over HMB, those over
+ * GRU). Unlike the classifier's full enumeration: a broad statement beside a narrow one misleads.
+ */
 export const processDefinedLimitations = (
   key: string,
   dataUse: DataUse,
@@ -412,7 +416,8 @@ const processOtherInDataUse = (
       Promise.resolve({
         code: 'OTH1',
         description: `Primary Other: ${isEmpty(dataUse.other) ? 'Not provided' : dataUse.other}`,
-        type: ControlledAccessType.modifiers,
+        // A permission, like OTHER in the classifier and srpTranslations.other; only OTH2 is not.
+        type: ControlledAccessType.permissions,
       }),
     )
   }

--- a/src/libs/dataUseTranslation.ts
+++ b/src/libs/dataUseTranslation.ts
@@ -369,8 +369,8 @@ export const processRestrictionStatements = async (
 }
 
 /**
- * Shows only the narrowest permission of a legacy multi-primary record (DS over HMB, those over
- * GRU). Unlike the classifier's full enumeration: a broad statement beside a narrow one misleads.
+ * Shows only the narrowest permission when a record carries several primaries (DS over HMB, those
+ * over GRU). Unlike the classifier's full enumeration: a broad statement beside a narrow one misleads.
  */
 export const processDefinedLimitations = (
   key: string,

--- a/src/pages/data_submission/consent_group/consentGroupUtils.ts
+++ b/src/pages/data_submission/consent_group/consentGroupUtils.ts
@@ -3,10 +3,11 @@ import { DataLocationType } from 'src/pages/data_submission/v2/v2-models'
 import { FileStorageObject } from 'src/types/model'
 import { DatasetDataMetadata } from 'src/libs/data-metadata'
 
+/** The primary data use fields of a `ConsentGroup2`, which is what every caller narrows in. */
 export interface ConsentGroup {
   generalResearchUse?: boolean
   hmb?: boolean
-  diseaseSpecificUse?: boolean
+  diseaseSpecificUse?: string[]
   poa?: boolean
   otherPrimary?: string
 }
@@ -50,6 +51,11 @@ export interface FileType {
   functionalEquivalence: string
 }
 
+/**
+ * Which primary radio renders as selected. Precedence follows the classifier's category order so a
+ * legacy multi-primary record resolves the same way here as in Consent. One deliberate divergence:
+ * an empty `diseaseSpecificUse` counts as selected, keeping the radio lit while diseases are picked.
+ */
 export const selectedPrimaryGroup = (consentGroup: ConsentGroup) => {
   if (isNil(consentGroup)) return undefined
   if (!isNil(consentGroup.generalResearchUse) && consentGroup.generalResearchUse) {
@@ -58,11 +64,11 @@ export const selectedPrimaryGroup = (consentGroup: ConsentGroup) => {
   else if (!isNil(consentGroup.hmb) && consentGroup.hmb) {
     return 'hmb'
   }
-  else if (!isNil(consentGroup.diseaseSpecificUse)) {
-    return 'diseaseSpecificUse'
-  }
   else if (!isNil(consentGroup.poa) && consentGroup.poa) {
     return 'poa'
+  }
+  else if (!isNil(consentGroup.diseaseSpecificUse)) {
+    return 'diseaseSpecificUse'
   }
   else if (!isNil(consentGroup.otherPrimary) && isString(consentGroup.otherPrimary)) {
     return 'otherPrimary'

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -15,6 +15,7 @@ import { studyToDatasetSchemaSubmission, buildConsentGroupsFromStudy, getStudyPr
 import AsyncSpinnerButton from 'src/components/AsyncSpinnerButton'
 import { ConsentGroup2 } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 import { ResponseError } from 'src/types/model'
+import { isEmpty } from 'src/utils/NodashUtil'
 
 export type FileProperty = {
   key: string
@@ -27,8 +28,15 @@ export type DataSubmissionFormV2Props = {
 
 export const ALTERNATIVE_DATA_SHARING_PLAN_FILE = 'alternativeDataSharingPlanFile'
 
-const isValidationRejection = (error: unknown): boolean =>
-  (error as ResponseError)?.response?.status === 400
+/**
+ * Only a 400 carrying Consent's own explanation is a rejection the submitter can act on in the form.
+ * One with no readable body — a malformed multipart, a proxy — carries the generic help-desk line
+ * instead, which is not a violation list and still needs the reload.
+ */
+const isValidationRejection = (error: unknown): boolean => {
+  const response = (error as ResponseError)?.response
+  return response?.status === 400 && !isEmpty(response.data?.message?.trim())
+}
 
 /** A rejection reaches us either as a thrown Error or as the raw response it was built from. */
 const errorMessage = (error: unknown): string => {

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -30,9 +30,15 @@ export const ALTERNATIVE_DATA_SHARING_PLAN_FILE = 'alternativeDataSharingPlanFil
 const isValidationRejection = (error: unknown): boolean =>
   (error as ResponseError)?.response?.status === 400
 
+/** A rejection reaches us either as a thrown Error or as the raw response it was built from. */
+const errorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message
+  return (error as ResponseError)?.response?.data?.message ?? String(error)
+}
+
 /** Consent joins Data Use consistency violations with newlines, so each needs its own line here. */
 const renderViolations = (prefix: string, error: unknown): React.ReactElement => {
-  const message = error instanceof Error ? error.message : String(error)
+  const message = errorMessage(error)
   return (
     <>
       {prefix}
@@ -43,6 +49,20 @@ const renderViolations = (prefix: string, error: unknown): React.ReactElement =>
     </>
   )
 }
+
+/**
+ * A copy: a failed save leaves the form standing, so the live study must keep its attachments. Only
+ * the consent group files need stripping; the rest of the payload is built from named fields.
+ */
+const withoutAttachments = (study: Study): Study => ({
+  ...study,
+  assets: study.assets && {
+    ...study.assets,
+    consentGroups: study.assets.consentGroups?.map(
+      ({ addedNIHInstitutionalCertificationFile: _file, ...consentGroup }) => consentGroup,
+    ),
+  },
+})
 
 export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   const { onSaveRoute } = props
@@ -73,18 +93,6 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   useEffect(() => {
     onLoadFormData(studyId)
   }, [studyId, setStudy, setIsEditing])
-
-  /** A copy: a failed save leaves the form standing, so the live study must keep its attachments. */
-  const withoutAttachments = (study: Study): Study => ({
-    ...study,
-    alternativeDataSharingPlanFile: undefined,
-    assets: study.assets && {
-      ...study.assets,
-      consentGroups: study.assets.consentGroups?.map(
-        ({ addedNIHInstitutionalCertificationFile: _file, ...consentGroup }) => consentGroup,
-      ),
-    },
-  })
 
   const buildMultiPartFormData = (study: Study) => {
     const multiPartFormData = new FormData()
@@ -117,7 +125,7 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
       Notifications.showError({ text: renderViolations('Study update failed:', error) })
       return
     }
-    Notifications.showError({ text: `Study update failed: ${error}.  Reloading original study.` })
+    Notifications.showError({ text: `Study update failed: ${errorMessage(error)}.  Reloading original study.` })
     onLoadFormData(studyId)
   }
 
@@ -132,7 +140,11 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   }
 
   const onError = (error: unknown) => {
-    Notifications.showError({ text: renderViolations('Study creation failed:', error) })
+    if (isValidationRejection(error)) {
+      Notifications.showError({ text: renderViolations('Study creation failed:', error) })
+      return
+    }
+    Notifications.showError({ text: `Study creation failed: ${errorMessage(error)}` })
   }
 
   return (

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -74,21 +74,31 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
     onLoadFormData(studyId)
   }, [studyId, setStudy, setIsEditing])
 
+  /** A copy: a failed save leaves the form standing, so the live study must keep its attachments. */
+  const withoutAttachments = (study: Study): Study => ({
+    ...study,
+    alternativeDataSharingPlanFile: undefined,
+    assets: study.assets && {
+      ...study.assets,
+      consentGroups: study.assets.consentGroups?.map(
+        ({ addedNIHInstitutionalCertificationFile: _file, ...consentGroup }) => consentGroup,
+      ),
+    },
+  })
+
   const buildMultiPartFormData = (study: Study) => {
     const multiPartFormData = new FormData()
     if (study.alternativeDataSharingPlanFile) {
       multiPartFormData.append('alternativeDataSharingPlan', study.alternativeDataSharingPlanFile, study.alternativeDataSharingPlanFile.name)
-      delete study.alternativeDataSharingPlanFile
     }
 
     study.assets?.consentGroups?.forEach((consentGroup, idx) => {
       if (consentGroup?.addedNIHInstitutionalCertificationFile) {
         const fieldKey = `consentGroups[${idx}].nihInstitutionalCertificationFile`
         multiPartFormData.append(fieldKey, consentGroup.addedNIHInstitutionalCertificationFile, consentGroup.addedNIHInstitutionalCertificationFile.name)
-        delete consentGroup.addedNIHInstitutionalCertificationFile
       }
     })
-    multiPartFormData.append('dataset', JSON.stringify(studyToDatasetSchemaSubmission(structuredClone(study))))
+    multiPartFormData.append('dataset', JSON.stringify(studyToDatasetSchemaSubmission(withoutAttachments(study))))
     return multiPartFormData
   }
   const onUpdateStudy = async () => {

--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -14,6 +14,7 @@ import { Notifications } from 'src/libs/utils'
 import { studyToDatasetSchemaSubmission, buildConsentGroupsFromStudy, getStudyPropertyValueByKey } from 'src/pages/data_submission/v2/v2-common-functions'
 import AsyncSpinnerButton from 'src/components/AsyncSpinnerButton'
 import { ConsentGroup2 } from 'src/pages/data_submission/consent_group/consentGroupUtils'
+import { ResponseError } from 'src/types/model'
 
 export type FileProperty = {
   key: string
@@ -25,6 +26,23 @@ export type DataSubmissionFormV2Props = {
 }
 
 export const ALTERNATIVE_DATA_SHARING_PLAN_FILE = 'alternativeDataSharingPlanFile'
+
+const isValidationRejection = (error: unknown): boolean =>
+  (error as ResponseError)?.response?.status === 400
+
+/** Consent joins Data Use consistency violations with newlines, so each needs its own line here. */
+const renderViolations = (prefix: string, error: unknown): React.ReactElement => {
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    <>
+      {prefix}
+      <br />
+      {message.split('\n').map((line, index) => (
+        <Fragment key={`${index}-${line}`}>{line}<br /></Fragment>
+      ))}
+    </>
+  )
+}
 
 export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   const { onSaveRoute } = props
@@ -84,6 +102,11 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   }
 
   const onUpdateStudyError = (error: unknown) => {
+    // Nothing persisted, so reloading would discard the user's edits along with the violations.
+    if (isValidationRejection(error)) {
+      Notifications.showError({ text: renderViolations('Study update failed:', error) })
+      return
+    }
     Notifications.showError({ text: `Study update failed: ${error}.  Reloading original study.` })
     onLoadFormData(studyId)
   }
@@ -99,15 +122,7 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
   }
 
   const onError = (error: unknown) => {
-    Notifications.showError({
-      text: (
-        <>
-          Study creation failed:<br />{String(error).split('\n').map(line => (
-            <Fragment key={line}>{line}<br /></Fragment>
-          ))}
-        </>
-      ),
-    })
+    Notifications.showError({ text: renderViolations('Study creation failed:', error) })
   }
 
   return (

--- a/src/pages/data_submission/v2/v2-common-functions.tsx
+++ b/src/pages/data_submission/v2/v2-common-functions.tsx
@@ -251,7 +251,8 @@ export const buildConsentGroupsFromStudy = (study: Study): ConsentGroup2[] => {
     consentGroup.col = dataset.dataUse.collaboratorRequired
     consentGroup.generalResearchUse = dataset.dataUse.generalUse
     consentGroup.hmb = dataset.dataUse.hmbResearch
-    consentGroup.diseaseSpecificUse = dataset.dataUse.diseaseRestrictions
+    // An empty array would light the Disease-Specific radio; only a populated one is a primary.
+    consentGroup.diseaseSpecificUse = isEmpty(dataset.dataUse.diseaseRestrictions) ? undefined : dataset.dataUse.diseaseRestrictions
     consentGroup.poa = dataset.dataUse.populationOriginsAncestry
     if (isEmpty(dataset.dataUse.other)) {
       consentGroup.otherPrimary = undefined

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -25,7 +25,11 @@ export type UserRoleName
     | 'ServiceAccount'
     | 'All'
 
-export enum AbstainDataUseCodes {
+/**
+ * Secondary data use codes that suppress a legacy (v1/v2) system match. Scoped to legacy results
+ * on purpose: from v3 Consent decides abstention itself — see `calculateAlgorithmResultForBucket`.
+ */
+export const AbstainDataUseCodes: readonly string[] = [
   'OTHER',
   'POP-M',
   'POP-F',
@@ -35,7 +39,7 @@ export enum AbstainDataUseCodes {
   'PUB',
   'MOR',
   'POP-PD',
-}
+]
 
 export interface UserRole {
   roleId: number

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -29,7 +29,7 @@ export type UserRoleName
  * Secondary data use codes that suppress a legacy (v1/v2) system match. Scoped to legacy results
  * on purpose: from v3 Consent decides abstention itself — see `calculateAlgorithmResultForBucket`.
  */
-export const AbstainDataUseCodes: readonly string[] = [
+export const AbstainDataUseCodes: ReadonlySet<string> = new Set([
   'OTHER',
   'POP-M',
   'POP-F',
@@ -39,7 +39,7 @@ export const AbstainDataUseCodes: readonly string[] = [
   'PUB',
   'MOR',
   'POP-PD',
-]
+])
 
 export interface UserRole {
   roleId: number

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -1,4 +1,4 @@
-import { chain, filter, includes, isEmpty, isNil, map } from 'src/utils/NodashUtil'
+import { chain, filter, includes, isEmpty, isNil } from 'src/utils/NodashUtil'
 import { Match } from 'src/libs/ajax/Match'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { ElasticsearchQuery } from 'src/types/elastic'
@@ -177,33 +177,34 @@ const filterDatasetsByDACs = (dacIds: number[], datasets: Dataset[]): Dataset[] 
     : filter(datasets, (dataset: Dataset) => includes(dacIds, dataset.dacId))
 }
 
-/**
- * Versions whose ABSTAIN is decided by Consent's `DataUseMatcherV5`, which supplies the rationale
- * the DAC reads. Suppressing these client-side would replace a real decision with "N/A".
- */
-const BACKEND_ABSTAINING_VERSIONS: ReadonlySet<string> = new Set(['v3', 'v4', 'v5'])
-
 /** Versions that predate server-side abstention and so still need client-side suppression. */
 const CLIENT_SUPPRESSING_VERSIONS: ReadonlySet<string> = new Set(['v1', 'v2'])
 
-const UNRECOGNIZED_ALGORITHM_RESULT = 'Unable to interpret the system match'
+/**
+ * From v3 on Consent decides ABSTAIN and supplies the rationale the DAC reads. A floor rather than
+ * an allowlist, so a newer matcher does not blank every suggestion until this UI is redeployed.
+ */
+const FIRST_BACKEND_ABSTAINING_VERSION = 3
+
+const UNRECOGNIZED_ALGORITHM_RESULT = 'System match unavailable for this algorithm version'
 
 type AlgorithmVersionHandling = 'backend-abstains' | 'client-suppresses' | 'unrecognized'
 
-/**
- * A bucket's datasets are matched in one pass, so mixed versions mean at least one row is stale;
- * applying the newest version's semantics to all of them would be a silent guess.
- */
-const classifyAlgorithmVersion = (versions: (string | undefined)[]): AlgorithmVersionHandling => {
-  if (versions.length !== 1) {
-    return 'unrecognized'
-  }
-  const [version] = versions
+const classifyOneVersion = (version: string | undefined): AlgorithmVersionHandling => {
   // Rows predating the version column were backfilled to v1, so an absent version is legacy too.
   if (isNil(version) || CLIENT_SUPPRESSING_VERSIONS.has(version)) {
     return 'client-suppresses'
   }
-  return BACKEND_ABSTAINING_VERSIONS.has(version) ? 'backend-abstains' : 'unrecognized'
+  const majorVersion = /^v(\d+)$/.exec(version)
+  return majorVersion && Number(majorVersion[1]) >= FIRST_BACKEND_ABSTAINING_VERSION
+    ? 'backend-abstains'
+    : 'unrecognized'
+}
+
+/** Versions mixed across match runs matter only when they disagree on how the results are read. */
+const classifyAlgorithmVersion = (versions: (string | undefined)[]): AlgorithmVersionHandling => {
+  const handlings = new Set(versions.map(classifyOneVersion))
+  return handlings.size === 1 ? [...handlings][0] : 'unrecognized'
 }
 
 /**
@@ -227,18 +228,19 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
     .value()
   const handling = classifyAlgorithmVersion(versions)
   if (handling === 'unrecognized') {
+    // No single createDate applies when the rows come from runs DUOS reads differently.
     return {
       result: UNRECOGNIZED_ALGORITHM_RESULT,
-      createDate: bucket.matchResults[0].createDate,
+      createDate: undefined,
       rationales: [
         `This match was recorded by algorithm version ${versions.map(v => v ?? 'unknown').join(', ')}, `
-        + 'which DUOS can no longer interpret. Please vote without a system suggestion.',
+        + 'which DUOS cannot interpret. Please vote without a system suggestion.',
       ],
       id: bucket.key,
     }
   }
 
-  const unmatchable = isOther(bucket.dataUse) || shouldAbstain(bucket.dataUse)
+  const unmatchable = shouldAbstain(bucket.dataUse)
   // Check on all possible true/false values in the matches.
   // If all matches are the same, we can merge them into a single match object for display.
   // If they are not all the same, we have to punt this decision solely to the DAC.
@@ -249,7 +251,7 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
         .value()
     : []
 
-  const abstain = hasBackendAbstention(bucket.matchResults)
+  const abstain = hasRecordedAbstention(bucket.matchResults)
 
   // check results based on matchVals
   if (isEmpty(matchVals)) {
@@ -291,11 +293,8 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
 }
 
 /** One abstention is enough: the algorithm declined on a dataset, so the bucket has no answer. */
-const hasBackendAbstention = (matchResults: MatchResult[]): boolean => {
-  const abstainList = map(matchResults, (m: MatchResult) => m.abstain)
-  const abstainValList = filter(abstainList, (a: boolean | undefined) => a === true)
-  return abstainValList.length > 0
-}
+const hasRecordedAbstention = (matchResults: MatchResult[]): boolean =>
+  matchResults.some((m: MatchResult) => m.abstain === true)
 
 /**
  * Calculate "Other" status for a data use. Data Uses can have 'otherRestrictions': TRUE|FALSE,
@@ -319,7 +318,7 @@ const isOther = (dataUse?: DataUseSummary): boolean => {
 export const shouldAbstain = (dataUse?: DataUseSummary): boolean => {
   return isOther(dataUse)
     || (dataUse?.secondary
-      ? dataUse.secondary.map((dut: DataUseTerm) => dut.code).some(code => AbstainDataUseCodes.includes(code))
+      ? dataUse.secondary.some((dut: DataUseTerm) => AbstainDataUseCodes.has(dut.code))
       : false)
 }
 

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -181,10 +181,10 @@ const filterDatasetsByDACs = (dacIds: number[], datasets: Dataset[]): Dataset[] 
  * Versions whose ABSTAIN is decided by Consent's `DataUseMatcherV5`, which supplies the rationale
  * the DAC reads. Suppressing these client-side would replace a real decision with "N/A".
  */
-const BACKEND_ABSTAINING_VERSIONS: readonly string[] = ['v3', 'v4', 'v5']
+const BACKEND_ABSTAINING_VERSIONS: ReadonlySet<string> = new Set(['v3', 'v4', 'v5'])
 
 /** Versions that predate server-side abstention and so still need client-side suppression. */
-const CLIENT_SUPPRESSING_VERSIONS: readonly string[] = ['v1', 'v2']
+const CLIENT_SUPPRESSING_VERSIONS: ReadonlySet<string> = new Set(['v1', 'v2'])
 
 const UNRECOGNIZED_ALGORITHM_RESULT = 'Unable to interpret the system match'
 
@@ -199,10 +199,10 @@ const classifyAlgorithmVersion = (versions: (string | undefined)[]): AlgorithmVe
     return 'unrecognized'
   }
   const [version] = versions
-  if (!isNil(version) && BACKEND_ABSTAINING_VERSIONS.includes(version)) {
+  if (!isNil(version) && BACKEND_ABSTAINING_VERSIONS.has(version)) {
     return 'backend-abstains'
   }
-  if (!isNil(version) && CLIENT_SUPPRESSING_VERSIONS.includes(version)) {
+  if (!isNil(version) && CLIENT_SUPPRESSING_VERSIONS.has(version)) {
     return 'client-suppresses'
   }
   return 'unrecognized'

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -178,31 +178,80 @@ const filterDatasetsByDACs = (dacIds: number[], datasets: Dataset[]): Dataset[] 
 }
 
 /**
+ * Versions whose ABSTAIN is decided by Consent's `DataUseMatcherV5`, which supplies the rationale
+ * the DAC reads. Suppressing these client-side would replace a real decision with "N/A".
+ */
+const BACKEND_ABSTAINING_VERSIONS: readonly string[] = ['v3', 'v4', 'v5']
+
+/** Versions that predate server-side abstention and so still need client-side suppression. */
+const CLIENT_SUPPRESSING_VERSIONS: readonly string[] = ['v1', 'v2']
+
+const UNRECOGNIZED_ALGORITHM_RESULT = 'Unable to interpret the system match'
+
+type AlgorithmVersionHandling = 'backend-abstains' | 'client-suppresses' | 'unrecognized'
+
+/**
+ * A bucket's datasets are matched in one pass, so mixed versions mean at least one row is stale;
+ * applying the newest version's semantics to all of them would be a silent guess.
+ */
+const classifyAlgorithmVersion = (versions: (string | undefined)[]): AlgorithmVersionHandling => {
+  if (versions.length !== 1) {
+    return 'unrecognized'
+  }
+  const [version] = versions
+  if (!isNil(version) && BACKEND_ABSTAINING_VERSIONS.includes(version)) {
+    return 'backend-abstains'
+  }
+  if (!isNil(version) && CLIENT_SUPPRESSING_VERSIONS.includes(version)) {
+    return 'client-suppresses'
+  }
+  return 'unrecognized'
+}
+
+/**
  * Generate the summary of algorithm results suitable for display in the UI
  *
- * Four potential cases:
+ * Five potential cases:
  *  1. No matches
- *  2. Exactly one match or N matches that are all the same - easy case
- *  3. Abstain is true and match is false - decision is abstained
- *  4. N matches - not all the same - very confusing case
+ *  2. A stale or unknown algorithm version - no result can be interpreted
+ *  3. Exactly one match or N matches that are all the same - easy case
+ *  4. Abstain is true and match is false - decision is abstained
+ *  5. N matches - not all the same - very confusing case
  */
 const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
-  // V1 and V2: We actually DO NOT want to show system match results when the data use indicates
-  // that a match should not be made. This happens for all "Other" cases.
-  const algorithmVersionV3 = bucket.matchResults.length > 0 && bucket.matchResults[0].algorithmVersion === 'v3'
+  if (isEmpty(bucket.matchResults)) {
+    return { result: 'N/A', createDate: undefined, rationales: undefined, id: bucket.key }
+  }
+
+  const versions: (string | undefined)[] = chain(bucket.matchResults)
+    .map((m: MatchResult) => m.algorithmVersion)
+    .uniq()
+    .value()
+  const handling = classifyAlgorithmVersion(versions)
+  if (handling === 'unrecognized') {
+    return {
+      result: UNRECOGNIZED_ALGORITHM_RESULT,
+      createDate: bucket.matchResults[0].createDate,
+      rationales: [
+        `This match was recorded by algorithm version ${versions.map(v => v ?? 'unknown').join(', ')}, `
+        + 'which DUOS can no longer interpret. Please vote without a system suggestion.',
+      ],
+      id: bucket.key,
+    }
+  }
+
   const unmatchable = isOther(bucket.dataUse) || shouldAbstain(bucket.dataUse)
   // Check on all possible true/false values in the matches.
   // If all matches are the same, we can merge them into a single match object for display.
   // If they are not all the same, we have to punt this decision solely to the DAC.
-  // Check algorithm version: V3 does not need to be checked for 'unmatchable'
-  const matchVals: boolean[] = (algorithmVersionV3 || !unmatchable)
+  const matchVals: boolean[] = (handling === 'backend-abstains' || !unmatchable)
     ? chain(bucket.matchResults)
         .map((m: MatchResult) => m.match)
         .uniq()
         .value()
     : []
 
-  const abstain = processV3Abstain(bucket.matchResults)
+  const abstain = hasBackendAbstention(bucket.matchResults)
 
   // check results based on matchVals
   if (isEmpty(matchVals)) {
@@ -243,11 +292,8 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
   }
 }
 
-/**
- * Process the match results for V3 Abstain. If we have a V3 result and we have
- * an ABSTAIN case, we can return true if the number of abstentions > 0
- */
-const processV3Abstain = (matchResults: MatchResult[]): boolean => {
+/** One abstention is enough: the algorithm declined on a dataset, so the bucket has no answer. */
+const hasBackendAbstention = (matchResults: MatchResult[]): boolean => {
   const abstainList = map(matchResults, (m: MatchResult) => m.abstain)
   const abstainValList = filter(abstainList, (a: boolean | undefined) => a === true)
   return abstainValList.length > 0
@@ -256,6 +302,8 @@ const processV3Abstain = (matchResults: MatchResult[]): boolean => {
 /**
  * Calculate "Other" status for a data use. Data Uses can have 'otherRestrictions': TRUE|FALSE,
  * or they can have fields populated for 'other': 'other restriction' and 'secondaryOther': 'yet other restriction'
+ *
+ * Counts a secondary Other, unlike the classifier — this feeds only the legacy suppression path.
  */
 const isOther = (dataUse?: DataUseSummary): boolean => {
   const primaryOther = dataUse?.primary?.some((dut: DataUseTerm) => dut.code === 'OTHER') || false
@@ -266,12 +314,14 @@ const isOther = (dataUse?: DataUseSummary): boolean => {
 /**
  * Calculate abstention for a data use. There are a number of cases where there should
  * not be an algorithm decision if a field is true, including any "Other" state.
+ *
+ * Legacy (v1/v2) heuristic only, and deliberately broader than Consent's classifier: it abstains
+ * on secondary modifiers like PUB or IRB, which V5 matches normally because they are not primary.
  */
 export const shouldAbstain = (dataUse?: DataUseSummary): boolean => {
-  const codeList: string[] = Object.keys(AbstainDataUseCodes)
   return isOther(dataUse)
     || (dataUse?.secondary
-      ? dataUse.secondary.map((dut: DataUseTerm) => dut.code).some(code => codeList.includes(code))
+      ? dataUse.secondary.map((dut: DataUseTerm) => dut.code).some(code => AbstainDataUseCodes.includes(code))
       : false)
 }
 

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -199,13 +199,11 @@ const classifyAlgorithmVersion = (versions: (string | undefined)[]): AlgorithmVe
     return 'unrecognized'
   }
   const [version] = versions
-  if (!isNil(version) && BACKEND_ABSTAINING_VERSIONS.has(version)) {
-    return 'backend-abstains'
-  }
-  if (!isNil(version) && CLIENT_SUPPRESSING_VERSIONS.has(version)) {
+  // Rows predating the version column were backfilled to v1, so an absent version is legacy too.
+  if (isNil(version) || CLIENT_SUPPRESSING_VERSIONS.has(version)) {
     return 'client-suppresses'
   }
-  return 'unrecognized'
+  return BACKEND_ABSTAINING_VERSIONS.has(version) ? 'backend-abstains' : 'unrecognized'
 }
 
 /**

--- a/src/utils/DataUseUtils.tsx
+++ b/src/utils/DataUseUtils.tsx
@@ -124,6 +124,9 @@ export function createDataUseDisplay({
 /**
  * Primary codes first, then secondary alphabetically. Shared so every grid that shows data use
  * renders the same codes in the same order.
+ *
+ * Renders every primary a record carries: Consent rejects multi-primary writes, but legacy records
+ * still hold them, and collapsing them would hide a shape a curator has to see.
  */
 export const orderDataUseCodes = (dataset: HasDataUse): DataUseCode[] => {
   const terms = processDataUseCodes(dataset).codesAndDescriptions.filter(term => Boolean(term.shortCode))

--- a/test/components/CollectionAlgorithmDecision.spec.tsx
+++ b/test/components/CollectionAlgorithmDecision.spec.tsx
@@ -47,7 +47,14 @@ describe('CollectionAlgorithmDecision component', () => {
   })
 
   it('renders an unrecognized result as given rather than as N/A', () => {
-    const result = 'Unable to interpret the system match'
+    const result = 'System match unavailable for this algorithm version'
+    const { container } = render(<CollectionAlgorithmDecision algorithmResult={{ result, id }} />)
+    const decisionValue = container.querySelector(`#collection-${id}-decision-value`) as HTMLElement
+    expect(decisionValue.textContent).toContain(result)
+  })
+
+  it('renders a mixed match as its own sentence rather than as N/A', () => {
+    const result = 'Unable to determine a system match'
     const { container } = render(<CollectionAlgorithmDecision algorithmResult={{ result, id }} />)
     const decisionValue = container.querySelector(`#collection-${id}-decision-value`) as HTMLElement
     expect(decisionValue.textContent).toContain(result)

--- a/test/components/CollectionAlgorithmDecision.spec.tsx
+++ b/test/components/CollectionAlgorithmDecision.spec.tsx
@@ -46,6 +46,13 @@ describe('CollectionAlgorithmDecision component', () => {
     expect(decisionValue.textContent).toContain('N/A')
   })
 
+  it('renders an unrecognized result as given rather than as N/A', () => {
+    const result = 'Unable to interpret the system match'
+    const { container } = render(<CollectionAlgorithmDecision algorithmResult={{ result, id }} />)
+    const decisionValue = container.querySelector(`#collection-${id}-decision-value`) as HTMLElement
+    expect(decisionValue.textContent).toContain(result)
+  })
+
   it('renders "YES" if provided by algorithmResult', () => {
     const { container } = render(<CollectionAlgorithmDecision algorithmResult={{ result: 'Yes', id }} />)
     const decisionValue = container.querySelector(`#collection-${id}-decision-value`) as HTMLElement

--- a/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
+++ b/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
@@ -200,3 +200,81 @@ describe('ConsentGroupAddEdit access management changes', () => {
     expect(container.querySelector<HTMLInputElement>('#gsText')?.value ?? '').toBe('')
   })
 })
+
+// Consent rejects a write with more than one primary category, so the form must send exactly one
+describe('ConsentGroupAddEdit primary data use exclusivity', () => {
+  const renderList = (collected: ConsentGroup2[]) => render(
+    <MemoryRouter>
+      <ConsentGroupList
+        consentGroups={[]}
+        columnsToShow={['consentGroupName']}
+        onConsentGroupChange={(items) => { collected.splice(0, collected.length, ...items) }}
+        disabled={false}
+      />
+    </MemoryRouter>,
+  )
+
+  // External access keeps the primary fields visible without also requiring a DAC
+  const fillRequiredFields = async (
+    user: ReturnType<typeof userEvent.setup>,
+    container: HTMLElement,
+  ) => {
+    await user.click(container.querySelector('#add-consent-group-btn')!)
+    await user.type(container.querySelector('#consentGroupName')!, 'Exclusivity Group')
+    await user.click(container.querySelector('#accessManagement_external')!)
+    await user.clear(container.querySelector('#numberOfParticipants')!)
+    await user.type(container.querySelector('#numberOfParticipants')!, '25')
+  }
+
+  it('clears the previous primary when a new one is selected', async () => {
+    const user = userEvent.setup()
+    const collected: ConsentGroup2[] = []
+    const { container } = renderList(collected)
+    await fillRequiredFields(user, container)
+
+    await user.click(container.querySelector('#primaryConsent_hmb')!)
+    await user.click(container.querySelector('#primaryConsent_generalResearchUse')!)
+    await clickSaveButton(user, container)
+
+    expect(collected).toHaveLength(1)
+    expect(collected[0].generalResearchUse).toBe(true)
+    expect(collected[0].hmb).toBe(false)
+    expect(collected[0].poa).toBe(false)
+    expect(collected[0].diseaseSpecificUse).toBeUndefined()
+    expect(collected[0].otherPrimary).toBeUndefined()
+  })
+
+  it('clears a primary Other and its text when another primary is selected', async () => {
+    const user = userEvent.setup()
+    const collected: ConsentGroup2[] = []
+    const { container } = renderList(collected)
+    await fillRequiredFields(user, container)
+
+    await user.click(container.querySelector('#primaryConsent_otherPrimary')!)
+    await user.type(container.querySelector('#otherPrimaryText')!, 'Bespoke restriction')
+    await user.click(container.querySelector('#primaryConsent_hmb')!)
+    await clickSaveButton(user, container)
+
+    expect(collected).toHaveLength(1)
+    expect(collected[0].hmb).toBe(true)
+    expect(collected[0].otherPrimary).toBeUndefined()
+    expect(container.querySelector('#otherPrimaryText')).not.toBeInTheDocument()
+  })
+
+  it('clears a boolean primary when Other is selected', async () => {
+    const user = userEvent.setup()
+    const collected: ConsentGroup2[] = []
+    const { container } = renderList(collected)
+    await fillRequiredFields(user, container)
+
+    await user.click(container.querySelector('#primaryConsent_generalResearchUse')!)
+    await user.click(container.querySelector('#primaryConsent_otherPrimary')!)
+    await user.type(container.querySelector('#otherPrimaryText')!, 'Bespoke restriction')
+    await clickSaveButton(user, container)
+
+    expect(collected).toHaveLength(1)
+    expect(collected[0].otherPrimary).toBe('Bespoke restriction')
+    expect(collected[0].generalResearchUse).toBe(false)
+    expect(collected[0].hmb).toBe(false)
+  })
+})

--- a/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
+++ b/test/components/consent_group_list/ConsentGroupAddEdit.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -8,6 +8,8 @@ import ConsentGroupAddEdit from 'src/components/consent_group_list/ConsentGroupA
 import { ConsentGroup2 } from 'src/pages/data_submission/consent_group/consentGroupUtils'
 import ConsentGroupList from 'src/components/consent_group_list/ConsentGroupList'
 import { DataLocationType } from 'src/pages/data_submission/v2/v2-models'
+import { findOntologyTerms } from 'src/libs/utils'
+import { renderWithRouter } from '../../test-utils'
 
 vi.mock('src/libs/utils', async (importActual) => {
   const actual = await importActual<typeof import('src/libs/utils')>()
@@ -261,6 +263,20 @@ describe('ConsentGroupAddEdit primary data use exclusivity', () => {
     expect(container.querySelector('#otherPrimaryText')).not.toBeInTheDocument()
   })
 
+  // The radio handed its own field name over as the answer, defeating the required check
+  it('does not accept the Other radio as its own free-text answer', async () => {
+    const user = userEvent.setup()
+    const collected: ConsentGroup2[] = []
+    const { container } = renderList(collected)
+    await fillRequiredFields(user, container)
+
+    await user.click(container.querySelector('#primaryConsent_otherPrimary')!)
+    await clickSaveButton(user, container)
+
+    expect(collected).toHaveLength(0)
+    expect(container.querySelector('#otherPrimaryText')).toBeInTheDocument()
+  })
+
   it('clears a boolean primary when Other is selected', async () => {
     const user = userEvent.setup()
     const collected: ConsentGroup2[] = []
@@ -276,5 +292,60 @@ describe('ConsentGroupAddEdit primary data use exclusivity', () => {
     expect(collected[0].otherPrimary).toBe('Bespoke restriction')
     expect(collected[0].generalResearchUse).toBe(false)
     expect(collected[0].hmb).toBe(false)
+  })
+})
+
+// A stored record can carry more than one primary, and only the one the radios light may be saved
+describe('ConsentGroupAddEdit legacy multi-primary records', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const renderEdit = (consentGroup: ConsentGroup2, collected: ConsentGroup2[]) => renderWithRouter(
+    <ConsentGroupAddEdit
+      id={0}
+      consentGroup={consentGroup}
+      consentGroups={[consentGroup]}
+      closeAction={vi.fn()}
+      onConsentGroupChange={(items) => { collected.splice(0, collected.length, ...items) }}
+    />,
+  )
+
+  const diseaseSpecificGroup: ConsentGroup2 = {
+    consentGroupId: 'cg1',
+    consentGroupName: 'Legacy Group',
+    name: 'Legacy Group',
+    numberOfParticipants: 10,
+    accessManagement: 'external',
+    diseaseSpecificUse: ['DOID_1'],
+    dataLocation: DataLocationType.NotDetermined,
+  }
+
+  it('hides the disease searchbar when another primary takes precedence', () => {
+    const { container } = renderEdit({ ...diseaseSpecificGroup, poa: true }, [])
+
+    expect(container.querySelector<HTMLInputElement>('#primaryConsent_poa')?.checked).toBe(true)
+    expect(container.querySelector('#diseaseSpecificUseText')).not.toBeInTheDocument()
+  })
+
+  it('hides the Other text box when another primary takes precedence', () => {
+    const { container } = renderEdit({ ...diseaseSpecificGroup, hmb: true, otherPrimary: 'Bespoke' }, [])
+
+    expect(container.querySelector<HTMLInputElement>('#primaryConsent_hmb')?.checked).toBe(true)
+    expect(container.querySelector('#otherPrimaryText')).not.toBeInTheDocument()
+  })
+
+  // Consent stores DOIDs, but the radio used to write the searchbar's option objects back
+  it('keeps disease selections as DOIDs when the radio is re-selected', async () => {
+    const user = userEvent.setup()
+    vi.mocked(findOntologyTerms).mockResolvedValue([{ displayText: 'Breast Cancer', id: 'DOID_1' }])
+    const collected: ConsentGroup2[] = []
+    const { container } = renderEdit(diseaseSpecificGroup, collected)
+
+    await user.click(container.querySelector('#primaryConsent_diseaseSpecificUse')!)
+    await clickSaveButton(user, container)
+
+    expect(collected).toHaveLength(1)
+    expect(collected[0].diseaseSpecificUse).toEqual(['DOID_1'])
   })
 })

--- a/test/libs/dataUseTranslation.spec.ts
+++ b/test/libs/dataUseTranslation.spec.ts
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { describe, expect, it } from 'vitest'
-import { processDefinedLimitations, consentTranslations, TranslationEntry } from 'src/libs/dataUseTranslation'
+import { processDefinedLimitations, consentTranslations, ControlledAccessType, DataUseTranslation, TranslationEntry } from 'src/libs/dataUseTranslation'
 import { isEmpty, cloneDeep } from 'src/utils/NodashUtil'
 import { DataUse } from 'src/types/model'
 
@@ -124,6 +124,64 @@ describe('Data Use Translation', () => {
       })
 
       expectTranslatedLimitation(targetKey, modifiedMockData)
+    })
+
+    // Unlike the classifier's full enumeration, display keeps only the narrowest permission.
+    describe('legacy multi-primary display', () => {
+      it('shows only DS, not HMB, when both are set', () => {
+        const dataUse = makeDataUse({ hmbResearch: true, diseaseRestrictions: ['test'] })
+
+        expect(isEmpty(processDefinedLimitations('hmbResearch', dataUse, consentTranslations))).toBe(true)
+      })
+
+      it('shows only the narrowest permission when every primary is set', () => {
+        const dataUse = makeDataUse({
+          generalUse: true,
+          hmbResearch: true,
+          populationOriginsAncestry: true,
+          diseaseRestrictions: ['test'],
+        })
+
+        expect(isEmpty(processDefinedLimitations('generalUse', dataUse, consentTranslations))).toBe(true)
+        expect(isEmpty(processDefinedLimitations('hmbResearch', dataUse, consentTranslations))).toBe(true)
+        expect(processDefinedLimitations('populationOriginsAncestry', dataUse, consentTranslations)).toBeDefined()
+      })
+    })
+  })
+
+  // A primary Other is a permission, like OTHER in the classifier; only a secondary one is not
+  describe('other restriction classification', () => {
+    const findByCode = (entries: TranslationEntry[], code: string) => entries.find(entry => entry.code === code)
+
+    it('classifies a primary Other as a permission', async () => {
+      const entries = await DataUseTranslation.translateDataUseRestrictions({
+        diseaseRestrictions: [],
+        other: 'Bespoke restriction',
+      })
+
+      expect(findByCode(entries, 'OTH1')?.type).toBe(ControlledAccessType.permissions)
+      expect(findByCode(entries, 'OTH1')?.description).toContain('Bespoke restriction')
+    })
+
+    it('classifies a secondary Other as a modifier', async () => {
+      const entries = await DataUseTranslation.translateDataUseRestrictions({
+        diseaseRestrictions: [],
+        secondaryOther: 'Bespoke secondary restriction',
+      })
+
+      expect(findByCode(entries, 'OTH2')?.type).toBe(ControlledAccessType.modifiers)
+      expect(findByCode(entries, 'OTH1')).toBeUndefined()
+    })
+
+    it('classifies each tier independently when both are present', async () => {
+      const entries = await DataUseTranslation.translateDataUseRestrictions({
+        diseaseRestrictions: [],
+        other: 'Primary text',
+        secondaryOther: 'Secondary text',
+      })
+
+      expect(findByCode(entries, 'OTH1')?.type).toBe(ControlledAccessType.permissions)
+      expect(findByCode(entries, 'OTH2')?.type).toBe(ControlledAccessType.modifiers)
     })
   })
 })

--- a/test/pages/data_submission/consent_group/consentGroupUtils.spec.ts
+++ b/test/pages/data_submission/consent_group/consentGroupUtils.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { ConsentGroup, selectedPrimaryGroup } from 'src/pages/data_submission/consent_group/consentGroupUtils'
+
+describe('selectedPrimaryGroup', () => {
+  it.each([
+    ['generalResearchUse', { generalResearchUse: true }],
+    ['hmb', { hmb: true }],
+    ['poa', { poa: true }],
+    ['diseaseSpecificUse', { diseaseSpecificUse: ['DOID_1234'] }],
+    ['otherPrimary', { otherPrimary: 'Bespoke restriction' }],
+  ] satisfies [string, ConsentGroup][])('selects %s when it is the only primary', (expected, consentGroup) => {
+    expect(selectedPrimaryGroup(consentGroup)).toBe(expected)
+  })
+
+  it('returns undefined when no primary is set', () => {
+    expect(selectedPrimaryGroup({} as ConsentGroup)).toBeUndefined()
+  })
+
+  it('returns undefined for a nil consent group', () => {
+    expect(selectedPrimaryGroup(undefined as unknown as ConsentGroup)).toBeUndefined()
+  })
+
+  it('ignores a false boolean primary', () => {
+    const consentGroup: ConsentGroup = { generalResearchUse: false, hmb: true }
+
+    expect(selectedPrimaryGroup(consentGroup)).toBe('hmb')
+  })
+
+  // Only audited legacy records hold more than one primary; Consent rejects such writes now.
+  describe('legacy multi-primary records resolve in the canonical classifier order', () => {
+    it.each([
+      ['generalResearchUse', { generalResearchUse: true, hmb: true, poa: true, diseaseSpecificUse: ['DOID_1'], otherPrimary: 'x' }],
+      ['hmb', { hmb: true, poa: true, diseaseSpecificUse: ['DOID_1'], otherPrimary: 'x' }],
+      ['poa', { poa: true, diseaseSpecificUse: ['DOID_1'], otherPrimary: 'x' }],
+      ['diseaseSpecificUse', { diseaseSpecificUse: ['DOID_1'], otherPrimary: 'x' }],
+    ] satisfies [string, ConsentGroup][])('resolves to %s', (expected, consentGroup) => {
+      expect(selectedPrimaryGroup(consentGroup)).toBe(expected)
+    })
+
+    // The one multi-primary shape the production audit found
+    it('resolves HMB+OTHER to hmb', () => {
+      const consentGroup: ConsentGroup = { hmb: true, otherPrimary: 'Not for profit' }
+
+      expect(selectedPrimaryGroup(consentGroup)).toBe('hmb')
+    })
+
+    // POA precedes DS in DataUsePrimaryCategory, unlike the previous DS-first order
+    it('resolves POA+DS to poa', () => {
+      const consentGroup: ConsentGroup = { poa: true, diseaseSpecificUse: ['DOID_1'] }
+
+      expect(selectedPrimaryGroup(consentGroup)).toBe('poa')
+    })
+  })
+
+  // Deliberate divergence from the classifier, which needs a non-empty list to classify as DS:
+  // the radio has to stay lit while the user is still picking diseases. calcErrors blocks the save.
+  it('treats an empty disease list as a selected primary', () => {
+    const consentGroup: ConsentGroup = { diseaseSpecificUse: [] }
+
+    expect(selectedPrimaryGroup(consentGroup)).toBe('diseaseSpecificUse')
+  })
+})

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
@@ -179,6 +179,37 @@ describe('DataSubmissionFormV2 Data Use validation errors', () => {
     expect(text).toBe('Study creation failed: Internal Server Error')
   })
 
+  // fetchMultipartRequest falls back to this when a 400 has no readable body — not a violation list
+  it('reloads the study after a 400 that carries no server message on update', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({ studyId: '42' })
+    vi.mocked(DataSet.getStudyById).mockResolvedValue({ data: {} } as Study)
+    const opaqueRejection = new Error('Request failed with status 400. Please contact the help desk at duos@duos.org.') as Error & { response: { status: number, data: object } }
+    opaqueRejection.response = { status: 400, data: {} }
+    vi.mocked(DataSet.updateStudy).mockRejectedValue(opaqueRejection)
+
+    renderForm()
+    await waitFor(() => expect(DataSet.getStudyById).toHaveBeenCalledTimes(1))
+    await user.click(await screen.findByRole('button', { name: /update study/i }))
+
+    await waitFor(() => expect(DataSet.getStudyById).toHaveBeenCalledTimes(2))
+    const { text } = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: React.ReactNode }
+    expect(text).toBe('Study update failed: Request failed with status 400. Please contact the help desk at duos@duos.org..  Reloading original study.')
+  })
+
+  it('does not render a blank server message on a 400 as a violation list', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({})
+    vi.mocked(DataSet.registerDataset).mockRejectedValue({ response: { status: 400, data: { message: '   ' } } })
+
+    renderForm()
+    await user.click(await screen.findByRole('button', { name: /create study/i }))
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    const { text } = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: React.ReactNode }
+    expect(text).toBe('Study creation failed:    ')
+  })
+
   // A failed update that did change server state still warrants reloading
   it('reloads the study after a non-validation failure on update', async () => {
     const user = userEvent.setup()

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
@@ -120,6 +120,25 @@ describe('DataSubmissionFormV2 Data Use validation errors', () => {
     expect(DataSet.getStudyById).toHaveBeenCalledTimes(1)
   })
 
+  // The form is the only copy of the edits after a 400, so it must still hold the attachments
+  it('resubmits the attachment after a 400 rather than dropping it', async () => {
+    const user = userEvent.setup()
+    const plan = new File(['plan'], 'plan.pdf')
+    mockUseParams.mockReturnValue({ studyId: '42' })
+    vi.mocked(DataSet.getStudyById).mockResolvedValue({ data: {}, alternativeDataSharingPlanFile: plan } as Study)
+    vi.mocked(DataSet.updateStudy).mockRejectedValueOnce(validationRejection()).mockResolvedValueOnce({} as Study)
+
+    renderForm()
+    await user.click(await screen.findByRole('button', { name: /update study/i }))
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    await user.click(await screen.findByRole('button', { name: /update study/i }))
+
+    await waitFor(() => expect(DataSet.updateStudy).toHaveBeenCalledTimes(2))
+    const [, resubmitted] = vi.mocked(DataSet.updateStudy).mock.calls[1] as unknown as [string, FormData]
+    expect((resubmitted.get('alternativeDataSharingPlan') as File)?.name).toBe('plan.pdf')
+    expect(resubmitted.get('dataset')).not.toContain('alternativeDataSharingPlanFile')
+  })
+
   // A failed update that did change server state still warrants reloading
   it('reloads the study after a non-validation failure on update', async () => {
     const user = userEvent.setup()

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
@@ -1,0 +1,138 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { DataSubmissionFormV2 } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
+import { DataSet } from 'src/libs/ajax/DataSet'
+import { Notifications } from 'src/libs/utils'
+import { Study } from 'src/pages/data_submission/v2/v2-models'
+import { renderWithRouter } from '../../../test-utils'
+
+// The form's sections are irrelevant here; only the submit handlers are under test
+vi.mock('src/pages/data_submission/v2/GeneralStudyInformation', () => ({ GeneralStudyInformation: () => null }))
+vi.mock('src/pages/data_submission/v2/NihAnvilUseRelated', () => ({ NihAnvilUseRelated: () => null }))
+vi.mock('src/pages/data_submission/v2/NihAdministrativeInformation', () => ({ NihAdministrativeInformation: () => null }))
+vi.mock('src/pages/data_submission/v2/NihDataManagement', () => ({ NihDataManagement: () => null }))
+vi.mock('src/pages/data_submission/v2/StudyAssetManagement', () => ({ StudyAssetManagement: () => null }))
+vi.mock('src/components/modals/SupportRequestModal', () => ({ SupportRequestModal: () => null }))
+vi.mock('src/components/TableHeaderSection', () => ({ default: () => null }))
+
+const mockUseParams = vi.fn()
+vi.mock('react-router', async (importActual) => {
+  const actual = await importActual<typeof import('react-router')>()
+  return { ...actual, useNavigate: () => vi.fn(), useParams: () => mockUseParams() }
+})
+
+vi.mock('src/libs/utils', async (importActual) => {
+  const actual = await importActual<typeof import('src/libs/utils')>()
+  return { ...actual, Notifications: { showError: vi.fn(), showNotification: vi.fn() } }
+})
+
+vi.mock('src/libs/ajax/DataSet', () => ({
+  DataSet: {
+    registerDataset: vi.fn(),
+    updateStudy: vi.fn(),
+    getStudyById: vi.fn(),
+  },
+}))
+
+vi.mock('src/pages/data_submission/v2/v2-common-functions', () => ({
+  studyToDatasetSchemaSubmission: (study: Study) => study,
+  buildConsentGroupsFromStudy: () => [],
+  getStudyPropertyValueByKey: () => ({}),
+}))
+
+/** Consent joins Data Use consistency violations with newlines in a single 400 message. */
+const VIOLATIONS = [
+  'Consent group 1: Open-access datasets must have no primary data use',
+  'Consent group 2: controlled datasets must have exactly one primary data use',
+  'Consent group 3: general research use, health/medical/biomedical, or other',
+]
+
+const validationRejection = (): Error => {
+  const error = new Error(VIOLATIONS.join('\n')) as Error & { response: { status: number, data: object } }
+  error.response = { status: 400, data: { message: VIOLATIONS.join('\n') } }
+  return error
+}
+
+const renderForm = () => renderWithRouter(<DataSubmissionFormV2 />)
+
+/** Render whatever was handed to showError so each violation can be asserted as its own line. */
+const renderedNotification = (): HTMLElement => {
+  const showError = vi.mocked(Notifications.showError)
+  expect(showError).toHaveBeenCalledTimes(1)
+  const { text } = showError.mock.calls[0][0] as { text: React.ReactNode }
+  return render(<>{text}</>).container
+}
+
+describe('DataSubmissionFormV2 Data Use validation errors', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders every violation from a 400 on study creation', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({})
+    vi.mocked(DataSet.registerDataset).mockRejectedValue(validationRejection())
+
+    renderForm()
+    await user.click(await screen.findByRole('button', { name: /create study/i }))
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    const container = renderedNotification()
+    expect(container).toHaveTextContent('Study creation failed:')
+    for (const violation of VIOLATIONS) {
+      expect(container).toHaveTextContent(violation)
+    }
+    expect(container.querySelectorAll('br')).toHaveLength(VIOLATIONS.length + 1)
+  })
+
+  it('renders every violation from a 400 on study update', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({ studyId: '42' })
+    vi.mocked(DataSet.getStudyById).mockResolvedValue({ data: {} } as Study)
+    vi.mocked(DataSet.updateStudy).mockRejectedValue(validationRejection())
+
+    renderForm()
+    await user.click(await screen.findByRole('button', { name: /update study/i }))
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    const container = renderedNotification()
+    expect(container).toHaveTextContent('Study update failed:')
+    for (const violation of VIOLATIONS) {
+      expect(container).toHaveTextContent(violation)
+    }
+  })
+
+  // A rejected write persisted nothing, so the form still holds the only copy of the user's edits
+  it('does not reload the study after a 400 on update', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({ studyId: '42' })
+    vi.mocked(DataSet.getStudyById).mockResolvedValue({ data: {} } as Study)
+    vi.mocked(DataSet.updateStudy).mockRejectedValue(validationRejection())
+
+    renderForm()
+    await waitFor(() => expect(DataSet.getStudyById).toHaveBeenCalledTimes(1))
+    await user.click(await screen.findByRole('button', { name: /update study/i }))
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    expect(DataSet.getStudyById).toHaveBeenCalledTimes(1)
+  })
+
+  // A failed update that did change server state still warrants reloading
+  it('reloads the study after a non-validation failure on update', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({ studyId: '42' })
+    vi.mocked(DataSet.getStudyById).mockResolvedValue({ data: {} } as Study)
+    const serverError = new Error('Internal Server Error') as Error & { response: { status: number } }
+    serverError.response = { status: 500 }
+    vi.mocked(DataSet.updateStudy).mockRejectedValue(serverError)
+
+    renderForm()
+    await waitFor(() => expect(DataSet.getStudyById).toHaveBeenCalledTimes(1))
+    await user.click(await screen.findByRole('button', { name: /update study/i }))
+
+    await waitFor(() => expect(DataSet.getStudyById).toHaveBeenCalledTimes(2))
+  })
+})

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.spec.tsx
@@ -39,7 +39,7 @@ vi.mock('src/libs/ajax/DataSet', () => ({
 
 vi.mock('src/pages/data_submission/v2/v2-common-functions', () => ({
   studyToDatasetSchemaSubmission: (study: Study) => study,
-  buildConsentGroupsFromStudy: () => [],
+  buildConsentGroupsFromStudy: (study: Study) => study.assets?.consentGroups ?? [],
   getStudyPropertyValueByKey: () => ({}),
 }))
 
@@ -121,11 +121,16 @@ describe('DataSubmissionFormV2 Data Use validation errors', () => {
   })
 
   // The form is the only copy of the edits after a 400, so it must still hold the attachments
-  it('resubmits the attachment after a 400 rather than dropping it', async () => {
+  it('resubmits both attachments after a 400 rather than dropping them', async () => {
     const user = userEvent.setup()
     const plan = new File(['plan'], 'plan.pdf')
+    const certification = new File(['cert'], 'cert.pdf')
     mockUseParams.mockReturnValue({ studyId: '42' })
-    vi.mocked(DataSet.getStudyById).mockResolvedValue({ data: {}, alternativeDataSharingPlanFile: plan } as Study)
+    vi.mocked(DataSet.getStudyById).mockResolvedValue({
+      data: {},
+      alternativeDataSharingPlanFile: plan,
+      assets: { consentGroups: [{ addedNIHInstitutionalCertificationFile: certification }] },
+    } as unknown as Study)
     vi.mocked(DataSet.updateStudy).mockRejectedValueOnce(validationRejection()).mockResolvedValueOnce({} as Study)
 
     renderForm()
@@ -136,7 +141,42 @@ describe('DataSubmissionFormV2 Data Use validation errors', () => {
     await waitFor(() => expect(DataSet.updateStudy).toHaveBeenCalledTimes(2))
     const [, resubmitted] = vi.mocked(DataSet.updateStudy).mock.calls[1] as unknown as [string, FormData]
     expect((resubmitted.get('alternativeDataSharingPlan') as File)?.name).toBe('plan.pdf')
-    expect(resubmitted.get('dataset')).not.toContain('alternativeDataSharingPlanFile')
+    expect((resubmitted.get('consentGroups[0].nihInstitutionalCertificationFile') as File)?.name).toBe('cert.pdf')
+    // The file travels as its own part; leaving it in the JSON too would serialize it as `{}`.
+    expect(resubmitted.get('dataset')).not.toContain('addedNIHInstitutionalCertificationFile')
+  })
+
+  // A rejection can arrive as the raw response rather than as a thrown Error
+  it('renders every violation from a 400 that is not an Error instance', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({})
+    vi.mocked(DataSet.registerDataset).mockRejectedValue({ response: { status: 400, data: { message: VIOLATIONS.join('\n') } } })
+
+    renderForm()
+    await user.click(await screen.findByRole('button', { name: /create study/i }))
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    const container = renderedNotification()
+    for (const violation of VIOLATIONS) {
+      expect(container).toHaveTextContent(violation)
+    }
+    expect(container).not.toHaveTextContent('[object Object]')
+  })
+
+  // A server fault is not a form problem the submitter can fix, so it must not read like one
+  it('does not render a server fault on creation as a violation list', async () => {
+    const user = userEvent.setup()
+    mockUseParams.mockReturnValue({})
+    const serverError = new Error('Internal Server Error') as Error & { response: { status: number } }
+    serverError.response = { status: 500 }
+    vi.mocked(DataSet.registerDataset).mockRejectedValue(serverError)
+
+    renderForm()
+    await user.click(await screen.findByRole('button', { name: /create study/i }))
+
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
+    const { text } = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: React.ReactNode }
+    expect(text).toBe('Study creation failed: Internal Server Error')
   })
 
   // A failed update that did change server state still warrants reloading

--- a/test/pages/data_submission/v2/v2-common-functions.spec.ts
+++ b/test/pages/data_submission/v2/v2-common-functions.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { extractThroughBioId } from 'src/pages/data_submission/v2/v2-common-functions'
+import { buildConsentGroupsFromStudy, extractThroughBioId } from 'src/pages/data_submission/v2/v2-common-functions'
+import { Study } from 'src/pages/data_submission/v2/v2-models'
+import { DataUse } from 'src/types/model'
 
 describe('extractThroughBioId', () => {
   const validUrls: [string, string][] = [
@@ -38,5 +40,25 @@ describe('extractThroughBioId', () => {
     it(`returns empty string for empty input "${JSON.stringify(input)}"`, () => {
       expect(extractThroughBioId(input)).toBe('')
     })
+  })
+})
+
+describe('buildConsentGroupsFromStudy primary data use', () => {
+  const studyWithDataUse = (dataUse: DataUse): Study => ({
+    datasets: [{ datasetId: 1, name: 'DS 1', dataUse, properties: [] }],
+  } as unknown as Study)
+
+  // An empty array would light the Disease-Specific radio beside the record's real primary
+  it('treats an empty diseaseRestrictions as no disease-specific primary', () => {
+    const [consentGroup] = buildConsentGroupsFromStudy(studyWithDataUse({ diseaseRestrictions: [], other: 'Not for profit' } as DataUse))
+
+    expect(consentGroup.diseaseSpecificUse).toBeUndefined()
+    expect(consentGroup.otherPrimary).toBe('Not for profit')
+  })
+
+  it('keeps a populated diseaseRestrictions', () => {
+    const [consentGroup] = buildConsentGroupsFromStudy(studyWithDataUse({ diseaseRestrictions: ['DOID_1'] } as DataUse))
+
+    expect(consentGroup.diseaseSpecificUse).toEqual(['DOID_1'])
   })
 })

--- a/test/utils/BucketUtils.spec.ts
+++ b/test/utils/BucketUtils.spec.ts
@@ -503,14 +503,19 @@ describe('BucketUtils', () => {
       expect(bucket.algorithmResult?.result).toBe('Yes')
     })
 
-    it.each([
-      ['an unknown version', 'v99'],
-      ['a missing version', undefined],
-    ])('reports %s instead of trusting or hiding it', async (_label, version) => {
-      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch(version, { match: true })])
+    it('reports an unknown version instead of trusting or hiding it', async () => {
+      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch('v99', { match: true })])
 
       expect(bucket.algorithmResult?.result).toBe('Unable to interpret the system match')
-      expect(bucket.algorithmResult?.rationales?.[0]).toContain(version ?? 'unknown')
+      expect(bucket.algorithmResult?.rationales?.[0]).toContain('v99')
+    })
+
+    it('reads a missing version as legacy rather than uninterpretable', async () => {
+      const matchable = await bucketFor({ primary: [GRU] }, [makeMatch(undefined, { match: true })])
+      const unmatchable = await bucketFor({ primary: [OTHER] }, [makeMatch(undefined, { match: true })])
+
+      expect(matchable.algorithmResult?.result).toBe('Yes')
+      expect(unmatchable.algorithmResult?.result).toBe('N/A')
     })
 
     it('reports mixed versions within a bucket rather than interpreting the newest', async () => {

--- a/test/utils/BucketUtils.spec.ts
+++ b/test/utils/BucketUtils.spec.ts
@@ -244,6 +244,48 @@ const unmatchableCases: DataUseSummary[] = [
   { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'POP-PD', description: 'POP-PD' }] },
 ]
 
+// ─── Algorithm version fixtures ───────────────────────────────────────────────
+
+// Verbatim from Consent's DataUseMatcherV5, so a reworded rationale surfaces here.
+const MISSING_PRIMARY_RATIONALE = 'The dataset is missing a supported primary Data Use and requires manual review.'
+const MULTIPLE_PRIMARY_RATIONALE = 'The dataset has multiple primary Data Use categories and requires manual review.'
+const OTHER_PRIMARY_RATIONALE = 'The dataset has an Other primary Data Use and requires manual review.'
+
+const GRU: DataUseTerm = { code: 'GRU', description: 'General Research Use' }
+const HMB: DataUseTerm = { code: 'HMB', description: 'Health, Medical and Biomedical Research' }
+const OTHER: DataUseTerm = { code: 'OTHER', description: 'Other Restrictions' }
+
+const makeMatch = (algorithmVersion: string | undefined, overrides: Partial<MatchResult> = {}): MatchResult => ({
+  id: '1',
+  consent: 'DUOS-000001',
+  purpose: REF,
+  match: false,
+  abstain: false,
+  failed: false,
+  createDate: 'Jan 23, 2023',
+  algorithmVersion,
+  rationales: [],
+  ...overrides,
+} as unknown as MatchResult)
+
+/** A backend ABSTAIN: V5 records match=false, abstain=true and the rationale for the DAC. */
+const abstainMatch = (version: string, rationale: string): MatchResult =>
+  makeMatch(version, { match: false, abstain: true, rationales: [rationale] })
+
+/**
+ * Bin a single dataset into one bucket so its coalesced algorithm result can be asserted.
+ * Filtering to DAC 1 keeps only dataset 1, whose identifier the match rows reference.
+ */
+const bucketFor = async (dataUse: DataUseSummary | undefined, matches: MatchResult[]): Promise<Bucket> => {
+  vi.spyOn(Match, 'findMatchBatch').mockResolvedValue(matches)
+  vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue([
+    { datasetId: 1, datasetName: 'ds 1', datasetIdentifier: 'DUOS-000001', dataUse, dacId: 1 },
+  ] as unknown as DatasetTerm[])
+
+  const buckets = await binCollectionToBuckets(dar_collection, [1])
+  return buckets[0]
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const verifyBucketElectionsAndDatasets = (buckets: Bucket[]) => {
@@ -404,5 +446,96 @@ describe('BucketUtils', () => {
     // HMB only
     expect(buckets[2].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'HMB')).toBeDefined()
     expect(buckets[2].dataUse?.primary?.find((t: DataUseTerm) => t.code === 'OTHER')).toBeUndefined()
+  })
+
+  describe('algorithm version handling', () => {
+    // Every shape V5 abstains on; each was previously hidden as "N/A" by the v3-only gate.
+    const v5AbstainShapes: [string, DataUseSummary | undefined, string][] = [
+      ['Other-only primary', { primary: [OTHER] }, OTHER_PRIMARY_RATIONALE],
+      ['MULTIPLE(HMB+OTHER)', { primary: [HMB, OTHER] }, MULTIPLE_PRIMARY_RATIONALE],
+      ['MULTIPLE(GRU+HMB)', { primary: [GRU, HMB] }, MULTIPLE_PRIMARY_RATIONALE],
+      ['NONE', { primary: [] }, MISSING_PRIMARY_RATIONALE],
+      ['null data use', undefined, MISSING_PRIMARY_RATIONALE],
+    ]
+
+    it.each(v5AbstainShapes)('surfaces a v5 ABSTAIN for %s', async (_shape, dataUse, rationale) => {
+      const bucket = await bucketFor(dataUse, [abstainMatch('v5', rationale)])
+
+      expect(bucket.algorithmResult?.result).toBe('Abstain')
+      expect(bucket.algorithmResult?.rationales).toContain(rationale)
+    })
+
+    it('surfaces a v5 ABSTAIN for a secondary-Other data use, which V5 treats as no primary', async () => {
+      const dataUse: DataUseSummary = { primary: [], secondary: [OTHER] }
+
+      const bucket = await bucketFor(dataUse, [abstainMatch('v5', MISSING_PRIMARY_RATIONALE)])
+
+      expect(bucket.algorithmResult?.result).toBe('Abstain')
+    })
+
+    // The legacy heuristic abstains on these; V5 matches them normally.
+    it.each(['PUB', 'IRB', 'COL', 'GSO', 'MOR', 'POP-M', 'POP-F', 'POP-PD'])(
+      'keeps a v5 match on a GRU data use with a secondary %s',
+      async (code) => {
+        const dataUse: DataUseSummary = { primary: [GRU], secondary: [{ code, description: code }] }
+
+        const bucket = await bucketFor(dataUse, [makeMatch('v5', { match: true })])
+
+        expect(bucket.algorithmResult?.result).toBe('Yes')
+      },
+    )
+
+    it.each(['v3', 'v4', 'v5'])('trusts a %s result rather than re-deriving abstention', async (version) => {
+      const bucket = await bucketFor({ primary: [OTHER] }, [makeMatch(version, { match: true })])
+
+      expect(bucket.algorithmResult?.result).toBe('Yes')
+    })
+
+    it.each(['v1', 'v2'])('still suppresses a %s result for an unmatchable data use', async (version) => {
+      const bucket = await bucketFor({ primary: [OTHER] }, [makeMatch(version, { match: true })])
+
+      expect(bucket.algorithmResult?.result).toBe('N/A')
+    })
+
+    it.each(['v1', 'v2'])('keeps a %s result for a matchable data use', async (version) => {
+      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch(version, { match: true })])
+
+      expect(bucket.algorithmResult?.result).toBe('Yes')
+    })
+
+    it.each([
+      ['an unknown version', 'v99'],
+      ['a missing version', undefined],
+    ])('reports %s instead of trusting or hiding it', async (_label, version) => {
+      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch(version, { match: true })])
+
+      expect(bucket.algorithmResult?.result).toBe('Unable to interpret the system match')
+      expect(bucket.algorithmResult?.rationales?.[0]).toContain(version ?? 'unknown')
+    })
+
+    it('reports mixed versions within a bucket rather than interpreting the newest', async () => {
+      vi.spyOn(Match, 'findMatchBatch').mockResolvedValue([
+        makeMatch('v5', { id: '1', consent: 'DUOS-000001', match: true }),
+        makeMatch('v2', { id: '2', consent: 'DUOS-000002', match: true }),
+      ])
+      // One data use, so both datasets land in the same bucket and their match rows coalesce.
+      vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue([
+        { datasetId: 1, datasetName: 'ds 1', datasetIdentifier: 'DUOS-000001', dataUse: { primary: [GRU] }, dacId: 1 },
+        { datasetId: 2, datasetName: 'ds 2', datasetIdentifier: 'DUOS-000002', dataUse: { primary: [GRU] }, dacId: 2 },
+      ] as unknown as DatasetTerm[])
+
+      const buckets = await binCollectionToBuckets(dar_collection, [1, 2])
+
+      expect(buckets).toHaveLength(1)
+      expect(buckets[0].matchResults).toHaveLength(2)
+      expect(buckets[0].algorithmResult?.result).toBe('Unable to interpret the system match')
+    })
+
+    it('reports N/A when no match has been recorded', async () => {
+      const bucket = await bucketFor({ primary: [GRU] }, [])
+
+      expect(bucket.algorithmResult?.result).toBe('N/A')
+      expect(bucket.algorithmResult?.rationales).toBeUndefined()
+    })
   })
 })

--- a/test/utils/BucketUtils.spec.ts
+++ b/test/utils/BucketUtils.spec.ts
@@ -503,11 +503,17 @@ describe('BucketUtils', () => {
       expect(bucket.algorithmResult?.result).toBe('Yes')
     })
 
-    it('reports an unknown version instead of trusting or hiding it', async () => {
-      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch('v99', { match: true })])
+    it('reports an unparseable version instead of trusting or hiding it', async () => {
+      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch('experimental', { match: true })])
 
-      expect(bucket.algorithmResult?.result).toBe('Unable to interpret the system match')
-      expect(bucket.algorithmResult?.rationales?.[0]).toContain('v99')
+      expect(bucket.algorithmResult?.result).toBe('System match unavailable for this algorithm version')
+      expect(bucket.algorithmResult?.rationales?.[0]).toContain('experimental')
+    })
+
+    it('trusts a version newer than any this build enumerates', async () => {
+      const bucket = await bucketFor({ primary: [OTHER] }, [makeMatch('v99', { match: true })])
+
+      expect(bucket.algorithmResult?.result).toBe('Yes')
     })
 
     it('reads a missing version as legacy rather than uninterpretable', async () => {
@@ -518,22 +524,34 @@ describe('BucketUtils', () => {
       expect(unmatchable.algorithmResult?.result).toBe('N/A')
     })
 
-    it('reports mixed versions within a bucket rather than interpreting the newest', async () => {
+    // One data use, so both datasets land in the same bucket and their match rows coalesce.
+    const bucketForVersions = async (first: string, second: string) => {
       vi.spyOn(Match, 'findMatchBatch').mockResolvedValue([
-        makeMatch('v5', { id: '1', consent: 'DUOS-000001', match: true }),
-        makeMatch('v2', { id: '2', consent: 'DUOS-000002', match: true }),
+        makeMatch(first, { id: '1', consent: 'DUOS-000001', match: true }),
+        makeMatch(second, { id: '2', consent: 'DUOS-000002', match: true }),
       ])
-      // One data use, so both datasets land in the same bucket and their match rows coalesce.
       vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue([
         { datasetId: 1, datasetName: 'ds 1', datasetIdentifier: 'DUOS-000001', dataUse: { primary: [GRU] }, dacId: 1 },
         { datasetId: 2, datasetName: 'ds 2', datasetIdentifier: 'DUOS-000002', dataUse: { primary: [GRU] }, dacId: 2 },
       ] as unknown as DatasetTerm[])
 
       const buckets = await binCollectionToBuckets(dar_collection, [1, 2])
-
       expect(buckets).toHaveLength(1)
       expect(buckets[0].matchResults).toHaveLength(2)
-      expect(buckets[0].algorithmResult?.result).toBe('Unable to interpret the system match')
+      return buckets[0]
+    }
+
+    it('reports versions DUOS reads differently rather than interpreting the newest', async () => {
+      const bucket = await bucketForVersions('v5', 'v2')
+
+      expect(bucket.algorithmResult?.result).toBe('System match unavailable for this algorithm version')
+      expect(bucket.algorithmResult?.createDate).toBeUndefined()
+    })
+
+    it('keeps the suggestion when mixed versions agree on how the result reads', async () => {
+      const bucket = await bucketForVersions('v3', 'v5')
+
+      expect(bucket.algorithmResult?.result).toBe('Yes')
     })
 
     it('reports N/A when no match has been recorded', async () => {

--- a/test/utils/DataUseUtils.spec.tsx
+++ b/test/utils/DataUseUtils.spec.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
 import { DatasetTerm } from 'src/types/model'
-import { processDataUseCodes, createDataUseDisplay } from 'src/utils/DataUseUtils'
+import { processDataUseCodes, createDataUseDisplay, orderDataUseCodes } from 'src/utils/DataUseUtils'
 
 describe('DataUseUtils', () => {
   describe('processDataUseCodes', () => {
@@ -50,6 +50,45 @@ describe('DataUseUtils', () => {
 
       expect(screen.getByText('GRU, HMB')).toBeInTheDocument()
       expect(container.querySelector('[data-for="dataset-data-use-8"]')).toBeInTheDocument()
+    })
+  })
+
+  // Legacy records still hold multi-primary shapes; rendering all of them is deliberate.
+  describe('orderDataUseCodes retains legacy multi-primary shapes', () => {
+    it('renders every primary a legacy record carries', () => {
+      const dataset = {
+        dataUse: {
+          primary: [
+            { code: 'HMB', description: 'Health, Medical and Biomedical Research' },
+            { code: 'OTHER', description: 'Not for profit' },
+          ],
+          secondary: [],
+        },
+      }
+
+      const terms = orderDataUseCodes(dataset)
+
+      expect(terms.map(term => term.shortCode)).toStrictEqual(['HMB', 'OTH1'])
+    })
+
+    it('keeps every primary ahead of alphabetised secondaries', () => {
+      const dataset = {
+        dataUse: {
+          primary: [
+            { code: 'GRU', description: 'General Research Use' },
+            { code: 'HMB', description: 'Health, Medical and Biomedical Research' },
+          ],
+          secondary: [
+            { code: 'PUB', description: 'Publication Required' },
+            { code: 'COL', description: 'Collaboration Required' },
+          ],
+        },
+      }
+
+      const terms = orderDataUseCodes(dataset)
+
+      expect(terms.map(term => term.shortCode)).toStrictEqual(['GRU', 'HMB', 'COL', 'PUB'])
+      expect(terms.filter(term => term.type === 'primary')).toHaveLength(2)
     })
   })
 })


### PR DESCRIPTION
### Addresses

[DT-3866](https://broadworkbench.atlassian.net/browse/DT-3866). Depends on [DT-3862](https://broadworkbench.atlassian.net/browse/DT-3862) and [DT-3864](https://broadworkbench.atlassian.net/browse/DT-3864), both merged in Consent.

Security risk: low.

### Summary

Consent persists matches as `v5` and rewrites them on every DAR create and update, but duos-ui gated on `algorithmVersion === 'v3'` — so whenever a bucket's data use tripped the client's own `isOther`/`shouldAbstain` heuristic the match values were dropped and the bucket rendered **N/A**, hiding the ABSTAIN and the rationale `DataUseMatcherV5` writes for DAC members on Other-only, NONE/null, and every MULTIPLE primary shape.

Now `v3`–`v5` are trusted because Consent decides abstention itself, `v1`/`v2` keep the client-side suppression they were written for, and an unknown version, a missing version, or mixed versions within one bucket render "Unable to interpret the system match" — neither silently trusted nor hidden. The heuristic also over-fired on secondary modifiers (`PUB`, `IRB`, `COL`, `GSO`, `MOR`, `POP-*`) that V5 matches normally, so it is now scoped to the legacy path.

Also reconciled:

- Study **update** rendered Consent's newline-joined violations as one unreadable line, then reloaded the study — discarding the user's edits along with the violations they had to act on. Both paths share a renderer; a 400 no longer reloads, a 5xx still does.
- `selectedPrimaryGroup` precedence now follows `DataUsePrimaryCategory` order (POA before DS).
- A primary Other is a permission; secondary stays a modifier. No display change — that `type` field feeds only code-keyed acknowledgement checks.
- `AbstainDataUseCodes` was a numeric enum, so `Object.keys()` leaked reverse-mapped indices (`'0'`, `'1'`, …) into the code list it was compared against. Now a readonly array.
- `ConsentGroup.diseaseSpecificUse` is typed `string[]`, which is what every caller narrows in.

Retained deliberately, documented and tested: the Library grid renders every primary a legacy record carries, and `processDefinedLimitations` shows only the narrowest permission rather than the classifier's full enumeration.

Decisions recorded on the ticket: no operator UI for the curator-assisted legacy process, which stays backend-only. This should land before the legacy-record migration, which recomputes persisted matches under `v5` at scale.

### Testing

`pnpm run lint`, `pnpm run type-check`, and `pnpm test` (355 files, 4044 tests) pass. New coverage: v5 ABSTAIN across all five shapes with Consent's verbatim rationales, the eight secondary codes the heuristic over-fired on, per-version handling, unknown/missing/mixed versions, both registration paths against a simulated 400, primary radio mutual exclusivity, and canonical primary ordering.


[DT-3866]: https://broadworkbench.atlassian.net/browse/DT-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3862]: https://broadworkbench.atlassian.net/browse/DT-3862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3864]: https://broadworkbench.atlassian.net/browse/DT-3864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ