### PR TITLE
[DT-3995] Condense data library filter spacing

### DIFF
--- a/src/components/data_library/LibraryFilters.tsx
+++ b/src/components/data_library/LibraryFilters.tsx
@@ -160,10 +160,13 @@ const DateFilterField: React.FC<DateFilterFieldProps> = ({ label, value, error, 
 
   // Adopt values that changed upstream (Clear, a removed chip, a tab switch)
   // without clobbering a date the user is part-way through typing: while the
-  // date is incomplete `value` does not change, so this does not fire.
-  React.useEffect(() => {
+  // date is incomplete `value` does not change, so this does not fire. Adjusted
+  // during render rather than in an effect so the stale draft is never painted.
+  const [prevValue, setPrevValue] = React.useState(value)
+  if (value !== prevValue) {
+    setPrevValue(value)
     setDraft(value)
-  }, [value])
+  }
 
   return (
     <TextField

--- a/src/components/data_library/LibraryFilters.tsx
+++ b/src/components/data_library/LibraryFilters.tsx
@@ -47,6 +47,28 @@ type CheckboxFilterKey = (typeof CHECKBOX_FILTER_KEYS)[number]
 const isCheckboxFilterKey = (key: FilterKey): key is CheckboxFilterKey =>
   (CHECKBOX_FILTER_KEYS as readonly string[]).includes(key)
 
+const COMPACT_ACCORDION_SX = {
+  '&:before': { display: 'none' },
+}
+
+const COMPACT_SUMMARY_SX = {
+  'minHeight': 40,
+  'px': 1,
+  '&.Mui-expanded': { minHeight: 40 },
+  '& .MuiAccordionSummary-content': { my: 1 },
+}
+
+const COMPACT_DETAILS_SX = {
+  px: 1,
+  py: 1,
+}
+
+const SECTION_LABEL_SX = { fontWeight: 400, fontSize: '1.4rem' }
+
+const COMPACT_OPTION_ROW_SX = { my: 0 }
+const COMPACT_OPTION_CHECKBOX_SX = { p: 0.5 }
+const COMPACT_OPTION_LABEL_SX = { fontSize: '1.2rem' }
+
 // Yes/No/Any radio groups. A registered key claimed by neither this list nor
 // CHECKBOX_FILTER_KEYS renders nothing at all.
 const BOOLEAN_FILTER_KEYS = [
@@ -133,17 +155,28 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
   const activeFilterCount = activeSectionCount + externalFilterCount
   const hasActiveFilters = activeFilterCount > 0
 
+  const renderSectionLabel = (key: FilterKey, label: string) => (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, overflow: 'hidden' }}>
+      <Typography variant="subtitle2" sx={SECTION_LABEL_SX} noWrap>{label}</Typography>
+      {isFilterActive(key, filters) && (
+        <Box component="span" sx={{ ...COUNT_BADGE_SX, fontWeight: 'bold', lineHeight: 1 }}>
+          •
+        </Box>
+      )}
+    </Box>
+  )
+
   const renderCheckboxSection = (section: LibraryFilterSection) => {
     const { key, label, options = [] } = section
     if (!isCheckboxFilterKey(key)) {
       return null
     }
     return (
-      <Accordion key={key} defaultExpanded={key === 'accessManagement'}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{label}</Typography>
+      <Accordion key={key} disableGutters defaultExpanded={key === 'accessManagement'} sx={COMPACT_ACCORDION_SX}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={COMPACT_SUMMARY_SX}>
+          {renderSectionLabel(key, label)}
         </AccordionSummary>
-        <AccordionDetails>
+        <AccordionDetails sx={COMPACT_DETAILS_SX}>
           {options.length === 0
             ? (
                 <Typography variant="body2" color="text.secondary">
@@ -155,15 +188,17 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
                   {options.map(option => (
                     <FormControlLabel
                       key={option.value}
+                      sx={COMPACT_OPTION_ROW_SX}
                       control={(
                         <Checkbox
                           checked={(filters[key]).includes(option.value)}
                           onChange={() => handleFilterToggle(key, option.value)}
                           size="small"
+                          sx={COMPACT_OPTION_CHECKBOX_SX}
                         />
                       )}
                       label={(
-                        <Typography variant="body2">
+                        <Typography variant="body2" sx={COMPACT_OPTION_LABEL_SX}>
                           {option.label}
                           {option.count !== undefined && ` (${option.count})`}
                         </Typography>
@@ -178,16 +213,17 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
   }
 
   const renderParticipantSection = (label: string) => (
-    <Accordion key="participantCount">
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{label}</Typography>
+    <Accordion key="participantCount" disableGutters sx={COMPACT_ACCORDION_SX}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={COMPACT_SUMMARY_SX}>
+        {renderSectionLabel('participantCount', label)}
       </AccordionSummary>
-      <AccordionDetails>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      <AccordionDetails sx={COMPACT_DETAILS_SX}>
+        <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1 }}>
           <TextField
             type="number"
             label="Minimum"
             size="small"
+            sx={{ flex: 1, minWidth: 0 }}
             value={filters.participantCount.min ?? ''}
             onChange={e => handleParticipantChange('min', e.target.value)}
             slotProps={{
@@ -201,6 +237,7 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
             type="number"
             label="Maximum"
             size="small"
+            sx={{ flex: 1, minWidth: 0 }}
             value={filters.participantCount.max ?? ''}
             onChange={e => handleParticipantChange('max', e.target.value)}
             slotProps={{
@@ -216,38 +253,42 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
   )
 
   const renderPostMortemIntervalSection = (section: LibraryFilterSection) => (
-    <Accordion key="biospecimenPostMortemInterval">
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{section.label}</Typography>
+    <Accordion key="biospecimenPostMortemInterval" disableGutters sx={COMPACT_ACCORDION_SX}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={COMPACT_SUMMARY_SX}>
+        {renderSectionLabel('biospecimenPostMortemInterval', section.label)}
       </AccordionSummary>
-      <AccordionDetails>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            type="number"
-            label="Minimum"
-            size="small"
-            value={filters.biospecimenPostMortemInterval.min ?? ''}
-            onChange={e => handlePostMortemIntervalChange('min', e.target.value)}
-            slotProps={{
-              htmlInput: {
-                min: section.range?.min,
-                max: section.range?.max,
-              },
-            }}
-          />
-          <TextField
-            type="number"
-            label="Maximum"
-            size="small"
-            value={filters.biospecimenPostMortemInterval.max ?? ''}
-            onChange={e => handlePostMortemIntervalChange('max', e.target.value)}
-            slotProps={{
-              htmlInput: {
-                min: section.range?.min,
-                max: section.range?.max,
-              },
-            }}
-          />
+      <AccordionDetails sx={COMPACT_DETAILS_SX}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1 }}>
+            <TextField
+              type="number"
+              label="Minimum"
+              size="small"
+              sx={{ flex: 1, minWidth: 0 }}
+              value={filters.biospecimenPostMortemInterval.min ?? ''}
+              onChange={e => handlePostMortemIntervalChange('min', e.target.value)}
+              slotProps={{
+                htmlInput: {
+                  min: section.range?.min,
+                  max: section.range?.max,
+                },
+              }}
+            />
+            <TextField
+              type="number"
+              label="Maximum"
+              size="small"
+              sx={{ flex: 1, minWidth: 0 }}
+              value={filters.biospecimenPostMortemInterval.max ?? ''}
+              onChange={e => handlePostMortemIntervalChange('max', e.target.value)}
+              slotProps={{
+                htmlInput: {
+                  min: section.range?.min,
+                  max: section.range?.max,
+                },
+              }}
+            />
+          </Box>
           {hasPostMortemIntervalWithoutUnit && (
             <Typography color="warning.main" variant="body2">
               Select a post-mortem interval unit to avoid ambiguous results.
@@ -284,18 +325,19 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
     const dateFields = dateFieldsBySection[key]
 
     return (
-      <Accordion key={key}>
-        <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-          <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{label}</Typography>
+      <Accordion key={key} disableGutters sx={COMPACT_ACCORDION_SX}>
+        <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={COMPACT_SUMMARY_SX}>
+          {renderSectionLabel(key, label)}
         </AccordionSummary>
-        <AccordionDetails>
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <AccordionDetails sx={COMPACT_DETAILS_SX}>
+          <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1 }}>
             {dateFields.map(dateField => (
               <TextField
                 key={dateField.stateKey}
                 type="date"
                 label={dateField.label}
                 size="small"
+                sx={{ flex: 1, minWidth: 0 }}
                 slotProps={{
                   inputLabel: { shrink: true },
                 }}
@@ -324,11 +366,11 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
   }
 
   const renderBooleanSection = (key: BooleanFilterKey, label: string) => (
-    <Accordion key={key}>
-      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>{label}</Typography>
+    <Accordion key={key} disableGutters sx={COMPACT_ACCORDION_SX}>
+      <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={COMPACT_SUMMARY_SX}>
+        {renderSectionLabel(key, label)}
       </AccordionSummary>
-      <AccordionDetails>
+      <AccordionDetails sx={COMPACT_DETAILS_SX}>
         <FormControl>
           <RadioGroup
             aria-label={label}
@@ -367,7 +409,7 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          mb: 2,
+          mb: 1,
         }}
       >
         <Box
@@ -385,7 +427,7 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
               </IconButton>
             </Tooltip>
           )}
-          {isOpen && <Typography variant="h6">Filters</Typography>}
+          {isOpen && <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>Filters</Typography>}
           {!isOpen && onToggle && (
             <>
               {activeFilterCount > 0 && (

--- a/src/components/data_library/LibraryFilters.tsx
+++ b/src/components/data_library/LibraryFilters.tsx
@@ -22,8 +22,9 @@ import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { FilterKey, LibraryFilterSection, LibraryFiltersProps } from 'src/types/library'
-import { COUNT_BADGE_SX } from 'src/components/data_library/countBadgeStyles'
-import { isFilterActive } from 'src/components/data_library/filterRegistry'
+import { COUNT_BADGE_COLOR, COUNT_BADGE_SX } from 'src/components/data_library/countBadgeStyles'
+import { isFilterActive, isInvertedDateRange } from 'src/components/data_library/filterRegistry'
+import { muiCheckboxFix, muiTextFieldFix } from 'src/libs/muiThemeFix'
 
 const CHECKBOX_FILTER_KEYS = [
   'accessManagement',
@@ -54,7 +55,6 @@ const COMPACT_ACCORDION_SX = {
 const COMPACT_SUMMARY_SX = {
   'minHeight': 40,
   'px': 1,
-  '&.Mui-expanded': { minHeight: 40 },
   '& .MuiAccordionSummary-content': { my: 1 },
 }
 
@@ -63,11 +63,137 @@ const COMPACT_DETAILS_SX = {
   py: 1,
 }
 
-const SECTION_LABEL_SX = { fontWeight: 400, fontSize: '1.4rem' }
+// Weight is the only cue left that a section label is a heading: `::before` is
+// hidden above and `subtitle2` already resolves to 14px against 12px options.
+const SECTION_LABEL_SX = { fontWeight: 600 }
+
+// A dot rather than a number — the count badge pill is sized for digits.
+const ACTIVE_DOT_SX = {
+  width: 6,
+  height: 6,
+  flexShrink: 0,
+  borderRadius: '50%',
+  backgroundColor: COUNT_BADGE_COLOR,
+}
 
 const COMPACT_OPTION_ROW_SX = { my: 0 }
-const COMPACT_OPTION_CHECKBOX_SX = { p: 0.5 }
+const COMPACT_OPTION_CONTROL_SX = { ...muiCheckboxFix, p: 0.5 }
 const COMPACT_OPTION_LABEL_SX = { fontSize: '1.2rem' }
+
+const COMPACT_RANGE_FIELD_SX = { flex: 1, minWidth: 0 }
+
+// Two `type="date"` inputs share ~248px here, so Chrome's ~20px picker
+// indicator does not fit alongside `mm/dd/yyyy` and would be clipped by the
+// sidebar's `overflowX: 'hidden'`. Hidden; the fields stay typeable.
+const COMPACT_DATE_FIELD_SX = {
+  'flex': 1,
+  'minWidth': 0,
+  '& input::-webkit-calendar-picker-indicator': { display: 'none' },
+}
+
+// `inputLabel` collides with muiTextFieldFix's own, so merge rather than spread.
+const DATE_FIELD_SLOT_PROPS = {
+  ...muiTextFieldFix,
+  inputLabel: { ...muiTextFieldFix.inputLabel, shrink: true },
+}
+
+// The two fields each date section renders, plus the message shown when their
+// bounds cross. The inversion rule itself lives in isInvertedDateRange so the
+// panel, the active-filter indicator and the query cannot disagree.
+const DATE_SECTION_CONFIG = {
+  clinicalTrialDates: {
+    fields: [
+      { stateKey: 'startDate', label: 'Start Date' },
+      { stateKey: 'endDate', label: 'End Date' },
+    ],
+    invertedMessage: 'Start Date cannot be after End Date',
+  },
+  biospecimenCollectionDate: {
+    fields: [
+      { stateKey: 'before', label: 'Collected Before' },
+      { stateKey: 'after', label: 'Collected After' },
+    ],
+    invertedMessage: 'Collected After cannot be later than Collected Before',
+  },
+  ipFiledDate: {
+    fields: [
+      { stateKey: 'before', label: 'Filed Before' },
+      { stateKey: 'after', label: 'Filed After' },
+    ],
+    invertedMessage: 'Filed After cannot be later than Filed Before',
+  },
+  fundingDate: {
+    fields: [
+      { stateKey: 'startDate', label: 'Start Date' },
+      { stateKey: 'endDate', label: 'End Date' },
+    ],
+    invertedMessage: 'Start Date cannot be after End Date',
+  },
+} as const
+
+type DateFilterSectionKey = keyof typeof DATE_SECTION_CONFIG
+
+// Native date inputs report an empty value both when explicitly cleared and
+// while an existing date is being edited. Keep that ambiguous empty value local
+// until blur; every complete value still commits immediately.
+const isCompleteDate = (value: string) => value === '' || /^\d{4}-\d{2}-\d{2}$/.test(value)
+
+interface DateFilterFieldProps {
+  label: string
+  value: string
+  error: boolean
+  errorId?: string
+  onCommit: (value: string | undefined) => void
+}
+
+/**
+ * A `type="date"` filter input that keeps in-progress dates local: while typing
+ * it commits every date that reads as finished, including years below 1000,
+ * and on blur it commits any complete value not already applied. The draft
+ * state is not optional: React
+ * restores a controlled input's DOM value after a change event that leaves the
+ * rendered value untouched, so suppressing the commit alone would wipe every
+ * segment the moment a date became complete.
+ */
+const DateFilterField: React.FC<DateFilterFieldProps> = ({ label, value, error, errorId, onCommit }) => {
+  const [draft, setDraft] = React.useState(value)
+
+  // Adopt values that changed upstream (Clear, a removed chip, a tab switch)
+  // without clobbering a date the user is part-way through typing: while the
+  // date is incomplete `value` does not change, so this does not fire.
+  React.useEffect(() => {
+    setDraft(value)
+  }, [value])
+
+  return (
+    <TextField
+      type="date"
+      label={label}
+      size="small"
+      sx={COMPACT_DATE_FIELD_SX}
+      slotProps={{
+        ...DATE_FIELD_SLOT_PROPS,
+        htmlInput: { 'aria-describedby': errorId },
+      }}
+      value={draft}
+      error={error}
+      onChange={(event) => {
+        const next = event.target.value
+        setDraft(next)
+        if (next !== '' && isCompleteDate(next) && next !== value) {
+          onCommit(next || undefined)
+        }
+      }}
+      // Blur resolves an empty draft as an intentional clear and also remains
+      // a fallback for browsers that defer completed-date change events.
+      onBlur={() => {
+        if (isCompleteDate(draft) && draft !== value) {
+          onCommit(draft || undefined)
+        }
+      }}
+    />
+  )
+}
 
 // Yes/No/Any radio groups. A registered key claimed by neither this list nor
 // CHECKBOX_FILTER_KEYS renders nothing at all.
@@ -127,12 +253,6 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
     })
   }
 
-  const hasInvalidClinicalTrialDateRange = !!(
-    filters.clinicalTrialDates.startDate
-    && filters.clinicalTrialDates.endDate
-    && filters.clinicalTrialDates.startDate > filters.clinicalTrialDates.endDate
-  )
-
   const hasPostMortemIntervalValue = (
     filters.biospecimenPostMortemInterval.min !== undefined
     || filters.biospecimenPostMortemInterval.max !== undefined
@@ -157,11 +277,9 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
 
   const renderSectionLabel = (key: FilterKey, label: string) => (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, overflow: 'hidden' }}>
-      <Typography variant="subtitle2" sx={SECTION_LABEL_SX} noWrap>{label}</Typography>
+      <Typography variant="subtitle2" sx={SECTION_LABEL_SX} title={label} noWrap>{label}</Typography>
       {isFilterActive(key, filters) && (
-        <Box component="span" sx={{ ...COUNT_BADGE_SX, fontWeight: 'bold', lineHeight: 1 }}>
-          •
-        </Box>
+        <Box component="span" role="img" aria-label="Filter active" sx={ACTIVE_DOT_SX} />
       )}
     </Box>
   )
@@ -194,7 +312,7 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
                           checked={(filters[key]).includes(option.value)}
                           onChange={() => handleFilterToggle(key, option.value)}
                           size="small"
-                          sx={COMPACT_OPTION_CHECKBOX_SX}
+                          sx={COMPACT_OPTION_CONTROL_SX}
                         />
                       )}
                       label={(
@@ -212,10 +330,10 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
     )
   }
 
-  const renderParticipantSection = (label: string) => (
+  const renderParticipantSection = (section: LibraryFilterSection) => (
     <Accordion key="participantCount" disableGutters sx={COMPACT_ACCORDION_SX}>
       <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={COMPACT_SUMMARY_SX}>
-        {renderSectionLabel('participantCount', label)}
+        {renderSectionLabel('participantCount', section.label)}
       </AccordionSummary>
       <AccordionDetails sx={COMPACT_DETAILS_SX}>
         <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1 }}>
@@ -223,13 +341,14 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
             type="number"
             label="Minimum"
             size="small"
-            sx={{ flex: 1, minWidth: 0 }}
+            sx={COMPACT_RANGE_FIELD_SX}
             value={filters.participantCount.min ?? ''}
             onChange={e => handleParticipantChange('min', e.target.value)}
             slotProps={{
+              ...muiTextFieldFix,
               htmlInput: {
-                min: sections.find(section => section.key === 'participantCount')?.range?.min,
-                max: sections.find(section => section.key === 'participantCount')?.range?.max,
+                min: section.range?.min,
+                max: section.range?.max,
               },
             }}
           />
@@ -237,13 +356,14 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
             type="number"
             label="Maximum"
             size="small"
-            sx={{ flex: 1, minWidth: 0 }}
+            sx={COMPACT_RANGE_FIELD_SX}
             value={filters.participantCount.max ?? ''}
             onChange={e => handleParticipantChange('max', e.target.value)}
             slotProps={{
+              ...muiTextFieldFix,
               htmlInput: {
-                min: sections.find(section => section.key === 'participantCount')?.range?.min,
-                max: sections.find(section => section.key === 'participantCount')?.range?.max,
+                min: section.range?.min,
+                max: section.range?.max,
               },
             }}
           />
@@ -264,10 +384,11 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
               type="number"
               label="Minimum"
               size="small"
-              sx={{ flex: 1, minWidth: 0 }}
+              sx={COMPACT_RANGE_FIELD_SX}
               value={filters.biospecimenPostMortemInterval.min ?? ''}
               onChange={e => handlePostMortemIntervalChange('min', e.target.value)}
               slotProps={{
+                ...muiTextFieldFix,
                 htmlInput: {
                   min: section.range?.min,
                   max: section.range?.max,
@@ -278,10 +399,11 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
               type="number"
               label="Maximum"
               size="small"
-              sx={{ flex: 1, minWidth: 0 }}
+              sx={COMPACT_RANGE_FIELD_SX}
               value={filters.biospecimenPostMortemInterval.max ?? ''}
               onChange={e => handlePostMortemIntervalChange('max', e.target.value)}
               slotProps={{
+                ...muiTextFieldFix,
                 htmlInput: {
                   min: section.range?.min,
                   max: section.range?.max,
@@ -290,7 +412,7 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
             />
           </Box>
           {hasPostMortemIntervalWithoutUnit && (
-            <Typography color="warning.main" variant="body2">
+            <Typography color="warning.main" variant="body2" sx={COMPACT_OPTION_LABEL_SX}>
               Select a post-mortem interval unit to avoid ambiguous results.
             </Typography>
           )}
@@ -299,30 +421,12 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
     </Accordion>
   )
 
-  const renderDateSection = (
-    key: 'clinicalTrialDates' | 'biospecimenCollectionDate' | 'ipFiledDate' | 'fundingDate',
-    label: string,
-  ) => {
-    const dateFieldsBySection = {
-      clinicalTrialDates: [
-        { stateKey: 'startDate', label: 'Start Date' },
-        { stateKey: 'endDate', label: 'End Date' },
-      ],
-      biospecimenCollectionDate: [
-        { stateKey: 'before', label: 'Collected Before' },
-        { stateKey: 'after', label: 'Collected After' },
-      ],
-      ipFiledDate: [
-        { stateKey: 'before', label: 'Filed Before' },
-        { stateKey: 'after', label: 'Filed After' },
-      ],
-      fundingDate: [
-        { stateKey: 'startDate', label: 'Start Date' },
-        { stateKey: 'endDate', label: 'End Date' },
-      ],
-    } as const
-
-    const dateFields = dateFieldsBySection[key]
+  const renderDateSection = (key: DateFilterSectionKey, label: string) => {
+    const { fields, invertedMessage } = DATE_SECTION_CONFIG[key]
+    const hasDateRangeError = isInvertedDateRange(key, filters)
+    // The error moved out of `helperText`, so wire aria-describedby by hand —
+    // otherwise the fields are aria-invalid with no reachable explanation.
+    const dateRangeErrorId = hasDateRangeError ? `${key}-date-range-error` : undefined
 
     return (
       <Accordion key={key} disableGutters sx={COMPACT_ACCORDION_SX}>
@@ -330,35 +434,33 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
           {renderSectionLabel(key, label)}
         </AccordionSummary>
         <AccordionDetails sx={COMPACT_DETAILS_SX}>
-          <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1 }}>
-            {dateFields.map(dateField => (
-              <TextField
-                key={dateField.stateKey}
-                type="date"
-                label={dateField.label}
-                size="small"
-                sx={{ flex: 1, minWidth: 0 }}
-                slotProps={{
-                  inputLabel: { shrink: true },
-                }}
-                value={(filters[key] as Record<string, string | undefined>)[dateField.stateKey] || ''}
-                onChange={(event) => {
-                  onChange({
-                    ...filters,
-                    [key]: {
-                      ...(filters[key] as Record<string, string | undefined>),
-                      [dateField.stateKey]: event.target.value || undefined,
-                    },
-                  })
-                }}
-                error={key === 'clinicalTrialDates' && hasInvalidClinicalTrialDateRange}
-                helperText={
-                  key === 'clinicalTrialDates' && dateField.stateKey === 'endDate' && hasInvalidClinicalTrialDateRange
-                    ? 'Start Date cannot be after End Date'
-                    : undefined
-                }
-              />
-            ))}
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'row', gap: 1 }}>
+              {fields.map(dateField => (
+                <DateFilterField
+                  key={dateField.stateKey}
+                  label={dateField.label}
+                  value={(filters[key] as Record<string, string | undefined>)[dateField.stateKey] || ''}
+                  error={hasDateRangeError}
+                  errorId={dateRangeErrorId}
+                  onCommit={(nextValue) => {
+                    onChange({
+                      ...filters,
+                      [key]: {
+                        ...(filters[key] as Record<string, string | undefined>),
+                        [dateField.stateKey]: nextValue,
+                      },
+                    })
+                  }}
+                />
+              ))}
+            </Box>
+            {/* Full width below the row: as helperText it wraps to 4-5 lines. */}
+            {hasDateRangeError && (
+              <Typography id={dateRangeErrorId} color="error" variant="body2" sx={COMPACT_OPTION_LABEL_SX}>
+                {invertedMessage}
+              </Typography>
+            )}
           </Box>
         </AccordionDetails>
       </Accordion>
@@ -387,14 +489,16 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
               <FormControlLabel
                 key={option.value}
                 value={option.value}
-                control={<Radio size="small" />}
-                label={option.label}
+                sx={COMPACT_OPTION_ROW_SX}
+                control={<Radio size="small" sx={COMPACT_OPTION_CONTROL_SX} />}
+                label={<Typography variant="body2" sx={COMPACT_OPTION_LABEL_SX}>{option.label}</Typography>}
               />
             ))}
             <FormControlLabel
               value=""
-              control={<Radio size="small" />}
-              label="Any"
+              sx={COMPACT_OPTION_ROW_SX}
+              control={<Radio size="small" sx={COMPACT_OPTION_CONTROL_SX} />}
+              label={<Typography variant="body2" sx={COMPACT_OPTION_LABEL_SX}>Any</Typography>}
             />
           </RadioGroup>
         </FormControl>
@@ -471,8 +575,8 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
       </Box>
 
       {isOpen && externalFilters.length > 0 && (
-        <Box sx={{ mb: 2 }}>
-          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 1 }}>
+        <Box sx={{ mb: 1 }}>
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 0.5 }}>
             Filters from other views
           </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
@@ -492,16 +596,16 @@ export const LibraryFilters: React.FC<LibraryFiltersProps> = React.memo(({
       {isOpen && (loading
         ? (
             <>
-              <Skeleton height={60} />
-              <Skeleton height={60} />
-              <Skeleton height={60} />
+              <Skeleton height={40} />
+              <Skeleton height={40} />
+              <Skeleton height={40} />
             </>
           )
         : (
             <>
               {sections.map((section) => {
                 if (section.key === 'participantCount') {
-                  return renderParticipantSection(section.label)
+                  return renderParticipantSection(section)
                 }
 
                 if (section.key === 'biospecimenPostMortemInterval') {

--- a/src/components/data_library/assets/biospecimenAsset.ts
+++ b/src/components/data_library/assets/biospecimenAsset.ts
@@ -15,6 +15,38 @@ const includesIgnoreCase = (source: string | undefined, values: string[]) => {
   return values.some(value => normalizedSource.includes(value.toLowerCase()))
 }
 
+const matchesCollectionDate = (biospecimen: BiospecimenAsset, filters: FilterState) => {
+  // Inverted bounds build no ES clause, so they must not narrow rows here
+  // either — otherwise the grid empties while the panel flags the range.
+  if (!isFilterActive('biospecimenCollectionDate', filters)) {
+    return true
+  }
+
+  const { after, before } = filters.biospecimenCollectionDate
+  const collectionDate = biospecimen.dateOfCollection || ''
+  if (after && collectionDate < after) {
+    return false
+  }
+  return !(before && collectionDate > before)
+}
+
+const matchesPostMortemInterval = (biospecimen: BiospecimenAsset, filters: FilterState) => {
+  const interval = biospecimen.postMortemInterval
+  if (
+    filters.biospecimenPostMortemIntervalUnit.length > 0
+    && !filters.biospecimenPostMortemIntervalUnit.includes(interval?.unit || '')
+  ) {
+    return false
+  }
+
+  const { min, max } = filters.biospecimenPostMortemInterval
+  const value = interval?.value
+  if (min !== undefined && (value === undefined || value < min)) {
+    return false
+  }
+  return !(max !== undefined && (value === undefined || value > max))
+}
+
 const matchesBiospecimenFilters = (biospecimen: BiospecimenAsset, filters?: FilterState) => {
   if (!filters) {
     return true
@@ -28,39 +60,7 @@ const matchesBiospecimenFilters = (biospecimen: BiospecimenAsset, filters?: Filt
     return false
   }
 
-  // Inverted bounds build no ES clause, so they must not narrow rows here
-  // either — otherwise the grid empties while the panel flags the range.
-  if (isFilterActive('biospecimenCollectionDate', filters)) {
-    const collectionDate = biospecimen.dateOfCollection || ''
-    if (filters.biospecimenCollectionDate.after && collectionDate < filters.biospecimenCollectionDate.after) {
-      return false
-    }
-    if (filters.biospecimenCollectionDate.before && collectionDate > filters.biospecimenCollectionDate.before) {
-      return false
-    }
-  }
-
-  if (
-    filters.biospecimenPostMortemIntervalUnit.length > 0
-    && !filters.biospecimenPostMortemIntervalUnit.includes(biospecimen.postMortemInterval?.unit || '')
-  ) {
-    return false
-  }
-
-  const postMortemValue = biospecimen.postMortemInterval?.value
-  const belowMinPostMortemInterval = (
-    filters.biospecimenPostMortemInterval.min !== undefined
-    && (postMortemValue === undefined || postMortemValue < filters.biospecimenPostMortemInterval.min)
-  )
-  if (belowMinPostMortemInterval) {
-    return false
-  }
-
-  const aboveMaxPostMortemInterval = (
-    filters.biospecimenPostMortemInterval.max !== undefined
-    && (postMortemValue === undefined || postMortemValue > filters.biospecimenPostMortemInterval.max)
-  )
-  return !aboveMaxPostMortemInterval
+  return matchesCollectionDate(biospecimen, filters) && matchesPostMortemInterval(biospecimen, filters)
 }
 
 export const biospecimenAsset: AssetDefinition = {

--- a/src/components/data_library/assets/biospecimenAsset.ts
+++ b/src/components/data_library/assets/biospecimenAsset.ts
@@ -4,6 +4,7 @@ import { BiospecimenAsset, FilterState, PaginationState, SortState } from 'src/t
 import { makeBiospecimenColumns } from 'src/components/data_library/columns/biospecimenColumns'
 import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow, STUDIES_AGG } from 'src/components/data_library/assets/definition'
 import { BioSpecimenPreservationMethod, BioSpecimenType, PostMortemIntervalUnit, Sex } from 'src/types/model'
+import { isFilterActive } from 'src/components/data_library/filterRegistry'
 
 const includesIgnoreCase = (source: string | undefined, values: string[]) => {
   if (values.length === 0) {
@@ -27,12 +28,16 @@ const matchesBiospecimenFilters = (biospecimen: BiospecimenAsset, filters?: Filt
     return false
   }
 
-  const collectionDate = biospecimen.dateOfCollection || ''
-  if (filters.biospecimenCollectionDate.after && collectionDate < filters.biospecimenCollectionDate.after) {
-    return false
-  }
-  if (filters.biospecimenCollectionDate.before && collectionDate > filters.biospecimenCollectionDate.before) {
-    return false
+  // Inverted bounds build no ES clause, so they must not narrow rows here
+  // either — otherwise the grid empties while the panel flags the range.
+  if (isFilterActive('biospecimenCollectionDate', filters)) {
+    const collectionDate = biospecimen.dateOfCollection || ''
+    if (filters.biospecimenCollectionDate.after && collectionDate < filters.biospecimenCollectionDate.after) {
+      return false
+    }
+    if (filters.biospecimenCollectionDate.before && collectionDate > filters.biospecimenCollectionDate.before) {
+      return false
+    }
   }
 
   if (

--- a/src/components/data_library/assets/fundingResourceAsset.ts
+++ b/src/components/data_library/assets/fundingResourceAsset.ts
@@ -3,6 +3,7 @@ import { FundingResourceStudyAggregationResponse, ElasticsearchQuery, Elasticsea
 import { FilterState, FundingResourceAsset, PaginationState, SortState } from 'src/types/library'
 import { makeFundingResourceColumns } from 'src/components/data_library/columns/fundingResourceColumns'
 import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow, STUDIES_AGG } from 'src/components/data_library/assets/definition'
+import { isFilterActive } from 'src/components/data_library/filterRegistry'
 
 // The Elasticsearch clause for fundingDate only decides which *studies* enter
 // the shared aggregation; every funding resource of a qualifying study comes
@@ -12,6 +13,12 @@ import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow, STUDIES_AGG } f
 // endDate filter → resource ends on/before it.
 const matchesFundingResourceFilters = (funding: FundingResourceAsset, filters?: FilterState) => {
   if (!filters) {
+    return true
+  }
+
+  // Inverted bounds build no ES clause, so they must not narrow rows here
+  // either — otherwise the grid empties while the panel flags the range.
+  if (!isFilterActive('fundingDate', filters)) {
     return true
   }
 

--- a/src/components/data_library/assets/intellectualPropertyAsset.ts
+++ b/src/components/data_library/assets/intellectualPropertyAsset.ts
@@ -3,6 +3,7 @@ import { ElasticsearchQuery, ElasticsearchResponse, IntellectualPropertyStudyAgg
 import { FilterState, IntellectualPropertyAsset, PaginationState, SortState } from 'src/types/library'
 import { makeIntellectualPropertyColumns } from 'src/components/data_library/columns/intellectualPropertyColumns'
 import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow, STUDIES_AGG } from 'src/components/data_library/assets/definition'
+import { isFilterActive } from 'src/components/data_library/filterRegistry'
 
 // The Elasticsearch clause for ipFiledDate only decides which *studies* enter
 // the shared aggregation; every IP asset of a qualifying study comes back, so
@@ -10,6 +11,12 @@ import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow, STUDIES_AGG } f
 // from this same function) includes assets filed outside the requested range.
 const matchesIntellectualPropertyFilters = (ip: IntellectualPropertyAsset, filters?: FilterState) => {
   if (!filters) {
+    return true
+  }
+
+  // Inverted bounds build no ES clause, so they must not narrow rows here
+  // either — otherwise the grid empties while the panel flags the range.
+  if (!isFilterActive('ipFiledDate', filters)) {
     return true
   }
 

--- a/src/components/data_library/countBadgeStyles.ts
+++ b/src/components/data_library/countBadgeStyles.ts
@@ -1,6 +1,12 @@
 import { SxProps, Theme } from '@mui/material'
 
 /**
+ * Brand color shared by the count badges and the per-section active-filter dot
+ * in `LibraryFilters`.
+ */
+export const COUNT_BADGE_COLOR = '#00609f'
+
+/**
  * Shared pill style for the small numeric count badges in the Data Library
  * (tab item counts in `LibraryTabs`, active-filter count in `LibraryFilters`).
  * Kept in one place so the badge shape and brand color stay in sync; callers
@@ -9,7 +15,7 @@ import { SxProps, Theme } from '@mui/material'
 export const COUNT_BADGE_SX: SxProps<Theme> = {
   fontSize: '12px',
   lineHeight: 1,
-  color: '#00609f',
+  color: COUNT_BADGE_COLOR,
   backgroundColor: 'rgba(0, 96, 159, 0.1)',
   borderRadius: '10px',
   padding: '2px 8px',

--- a/src/components/data_library/filterRegistry.ts
+++ b/src/components/data_library/filterRegistry.ts
@@ -129,6 +129,39 @@ export const EMPTY_FILTERS: FilterState = {
  * also count as inactive everywhere; encoding that once here keeps the badge, the
  * chips, and the query in lockstep.
  */
+/**
+ * The two bounds of each date-range filter, lower bound first. A range whose
+ * bounds cross can match nothing (both bounds are ANDed, and for the start/end
+ * pairs an asset would have to end before it starts), so it builds no clause
+ * and must read as inactive everywhere — see isFilterActive.
+ */
+const DATE_RANGE_BOUNDS = {
+  clinicalTrialDates: ['startDate', 'endDate'],
+  fundingDate: ['startDate', 'endDate'],
+  biospecimenCollectionDate: ['after', 'before'],
+  ipFiledDate: ['after', 'before'],
+} as const
+
+/**
+ * True when both bounds of a date-range filter are set and crossed. The single
+ * encoding of the rule: the filter panel's validation message, isFilterActive
+ * (and through it the badge, the chips and the query clause), and the
+ * client-side row filters in the funding/IP/biospecimen transforms all use it.
+ */
+export const isInvertedDateRange = (key: FilterKey, filters: FilterState): boolean => {
+  const bounds = DATE_RANGE_BOUNDS[key as keyof typeof DATE_RANGE_BOUNDS]
+  if (!bounds) {
+    return false
+  }
+
+  const [lowerKey, upperKey] = bounds
+  const value = filters[key] as Record<string, string | undefined>
+  const lower = value[lowerKey]
+  const upper = value[upperKey]
+
+  return !!lower && !!upper && lower > upper
+}
+
 export const isFilterActive = (key: FilterKey, filters: FilterState): boolean => {
   switch (key) {
     // Multi-select (array) filters are active once any value is selected.
@@ -159,21 +192,21 @@ export const isFilterActive = (key: FilterKey, filters: FilterState): boolean =>
     case 'biospecimenPostMortemInterval':
       return filters[key].min !== undefined || filters[key].max !== undefined
 
-    case 'clinicalTrialDates': {
-      const { startDate, endDate } = filters.clinicalTrialDates
-      // An inverted range builds no clause (see buildClause), so it is inactive.
-      if (startDate && endDate && startDate > endDate) {
+    // An inverted range builds no clause (see buildClause), so it is inactive.
+    case 'clinicalTrialDates':
+    case 'fundingDate': {
+      if (isInvertedDateRange(key, filters)) {
         return false
       }
-      return !!startDate || !!endDate
-    }
-    case 'fundingDate': {
-      const { startDate, endDate } = filters.fundingDate
+      const { startDate, endDate } = filters[key]
       return !!startDate || !!endDate
     }
 
     case 'biospecimenCollectionDate':
     case 'ipFiledDate': {
+      if (isInvertedDateRange(key, filters)) {
+        return false
+      }
       const { after, before } = filters[key]
       return !!after || !!before
     }
@@ -493,10 +526,10 @@ const FILTER_DEFINITIONS: Record<FilterKey, FilterDefinition> = {
   biospecimenCollectionDate: {
     label: 'Collection Date',
     buildClause: (filters) => {
-      const { after, before } = filters.biospecimenCollectionDate
-      if (!after && !before) {
+      if (!isFilterActive('biospecimenCollectionDate', filters)) {
         return undefined
       }
+      const { after, before } = filters.biospecimenCollectionDate
 
       return {
         range: {
@@ -538,10 +571,10 @@ const FILTER_DEFINITIONS: Record<FilterKey, FilterDefinition> = {
   ipFiledDate: {
     label: 'Filed Date',
     buildClause: (filters) => {
-      const { after, before } = filters.ipFiledDate
-      if (!after && !before) {
+      if (!isFilterActive('ipFiledDate', filters)) {
         return undefined
       }
+      const { after, before } = filters.ipFiledDate
 
       return {
         range: {
@@ -556,10 +589,10 @@ const FILTER_DEFINITIONS: Record<FilterKey, FilterDefinition> = {
   fundingDate: {
     label: 'Funding Dates',
     buildClause: (filters) => {
-      const { startDate, endDate } = filters.fundingDate
-      if (!startDate && !endDate) {
+      if (!isFilterActive('fundingDate', filters)) {
         return undefined
       }
+      const { startDate, endDate } = filters.fundingDate
 
       const clauses: QueryClause[] = []
       if (startDate) {

--- a/test/components/data_library/LibraryFilters.spec.tsx
+++ b/test/components/data_library/LibraryFilters.spec.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import LibraryFilters from 'src/components/data_library/LibraryFilters'
 import { AvailableFilters, AssetType, FilterState, LibraryFiltersProps } from 'src/types/library'
@@ -53,7 +53,7 @@ const availableFilters: AvailableFilters = {
   participantCountRange: { min: 0, max: 1000 },
 }
 
-const LibraryFiltersWrapper = ({ filters: initialFilters = EMPTY_FILTERS, onChange: externalOnChange, onClear: externalOnClear, loading = false }: Partial<LibraryFiltersProps>) => {
+const LibraryFiltersWrapper = ({ filters: initialFilters = EMPTY_FILTERS, onChange: externalOnChange, onClear: externalOnClear, loading = false, assetType = AssetType.DATASETS }: Partial<LibraryFiltersProps> & { assetType?: AssetType }) => {
   const [filters, setFilters] = useState(initialFilters)
 
   const handleOnChange = (newFilters: FilterState) => {
@@ -71,7 +71,7 @@ const LibraryFiltersWrapper = ({ filters: initialFilters = EMPTY_FILTERS, onChan
       filters={filters}
       onChange={handleOnChange}
       onClear={handleOnClear}
-      sections={getFilterSectionsForAsset(AssetType.DATASETS, availableFilters)}
+      sections={getFilterSectionsForAsset(assetType, availableFilters)}
       loading={loading}
     />
   )
@@ -364,6 +364,226 @@ describe('LibraryFilters — collapseable panel', () => {
     )
     expect(screen.queryByLabelText('Collapse filters')).not.toBeInTheDocument()
     expect(screen.queryByLabelText('Show filters')).not.toBeInTheDocument()
+  })
+
+  it('marks only the section whose filter is active with a dot', () => {
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, accessManagement: ['controlled'] }}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.DATASETS, availableFilters)}
+      />,
+    )
+    const dots = screen.getAllByLabelText('Filter active')
+    expect(dots).toHaveLength(1)
+    expect(dots[0].closest('.MuiAccordionSummary-root')).toHaveTextContent('Access Request Process')
+  })
+
+  it('shows no section dots when nothing is active', () => {
+    render(
+      <LibraryFilters
+        filters={EMPTY_FILTERS}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.DATASETS, availableFilters)}
+      />,
+    )
+    expect(screen.queryByLabelText('Filter active')).not.toBeInTheDocument()
+  })
+
+  it('marks the post-mortem interval range section, not its unit section', () => {
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, biospecimenPostMortemInterval: { min: 5 } }}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.BIOSPECIMENS, availableFilters)}
+      />,
+    )
+    const dots = screen.getAllByLabelText('Filter active')
+    expect(dots).toHaveLength(1)
+    // 'Post-mortem Interval' and 'Post-mortem Interval Unit' are separate
+    // sections, so an exact match guards against the dot landing on the unit.
+    expect(dots[0].closest('.MuiAccordionSummary-root')?.textContent).toBe('Post-mortem Interval')
+  })
+
+  it('runs the filter for every complete date reported while editing the year', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <LibraryFilters
+        filters={EMPTY_FILTERS}
+        onChange={onChange}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.CLINICAL_TRIALS, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Clinical Trial Dates'))
+    const startDate = screen.getByLabelText('Start Date')
+
+    // Native date inputs can report each intermediate year as a complete,
+    // valid date. Each one must update the search, including years below 1000.
+    fireEvent.change(startDate, { target: { value: '0002-05-13' } })
+    fireEvent.change(startDate, { target: { value: '0020-05-13' } })
+    fireEvent.change(startDate, { target: { value: '0202-05-13' } })
+    expect(onChange).toHaveBeenCalledTimes(3)
+    expect(onChange).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      clinicalTrialDates: { startDate: '0002-05-13' },
+    }))
+    expect(onChange).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      clinicalTrialDates: { startDate: '0020-05-13' },
+    }))
+    expect(onChange).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      clinicalTrialDates: { startDate: '0202-05-13' },
+    }))
+    expect(startDate).toHaveValue('0202-05-13')
+
+    fireEvent.change(startDate, { target: { value: '2024-05-13' } })
+    expect(onChange).toHaveBeenCalledTimes(4)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      clinicalTrialDates: { startDate: '2024-05-13' },
+    }))
+  })
+
+  it('runs the filter on blur when a date is cleared', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, clinicalTrialDates: { startDate: '2024-05-13' } }}
+        onChange={onChange}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.CLINICAL_TRIALS, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Clinical Trial Dates'))
+    const startDate = screen.getByLabelText('Start Date')
+    fireEvent.change(startDate, { target: { value: '' } })
+    expect(onChange).not.toHaveBeenCalled()
+    fireEvent.blur(startDate)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      clinicalTrialDates: { startDate: undefined },
+    }))
+  })
+
+  it('does not clear an existing filter while its date is being replaced', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, clinicalTrialDates: { startDate: '2023-05-13' } }}
+        onChange={onChange}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.CLINICAL_TRIALS, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Clinical Trial Dates'))
+    const startDate = screen.getByLabelText('Start Date')
+
+    // The browser emits an empty value while the date is incomplete.
+    fireEvent.change(startDate, { target: { value: '' } })
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.change(startDate, { target: { value: '2024-05-13' } })
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      clinicalTrialDates: { startDate: '2024-05-13' },
+    }))
+  })
+
+  it('does not re-run the filter while an empty date field is being filled in', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <LibraryFilters
+        filters={EMPTY_FILTERS}
+        onChange={onChange}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.CLINICAL_TRIALS, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Clinical Trial Dates'))
+    // An incomplete date reads as an empty value, which is already the state.
+    fireEvent.change(screen.getByLabelText('Start Date'), { target: { value: '' } })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('applies a date with an early year immediately', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <LibraryFilters
+        filters={EMPTY_FILTERS}
+        onChange={onChange}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.CLINICAL_TRIALS, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Clinical Trial Dates'))
+    const startDate = screen.getByLabelText('Start Date')
+
+    fireEvent.change(startDate, { target: { value: '0007-01-01' } })
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({
+      clinicalTrialDates: { startDate: '0007-01-01' },
+    }))
+  })
+
+  it('flags an inverted clinical-trial range entered with early years', async () => {
+    const user = userEvent.setup()
+    render(<LibraryFiltersWrapper assetType={AssetType.CLINICAL_TRIALS} />)
+    await user.click(screen.getByText('Clinical Trial Dates'))
+
+    const startDate = screen.getByLabelText('Start Date')
+    fireEvent.change(startDate, { target: { value: '0007-01-01' } })
+    fireEvent.blur(startDate)
+    const endDate = screen.getByLabelText('End Date')
+    fireEvent.change(endDate, { target: { value: '0004-01-01' } })
+    fireEvent.blur(endDate)
+
+    expect(screen.getByText('Start Date cannot be after End Date')).toBeInTheDocument()
+  })
+
+  it('flags an inverted funding date range', async () => {
+    const user = userEvent.setup()
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, fundingDate: { startDate: '2024-01-01', endDate: '2023-01-01' } }}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.FUNDING_RESOURCES, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Funding Dates'))
+    expect(screen.getByText('Start Date cannot be after End Date')).toBeInTheDocument()
+  })
+
+  it('flags an inverted before/after range with wording that matches its fields', async () => {
+    const user = userEvent.setup()
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, biospecimenCollectionDate: { after: '2024-01-01', before: '2020-01-01' } }}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.BIOSPECIMENS, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Collection Date'))
+    expect(screen.getByText('Collected After cannot be later than Collected Before')).toBeInTheDocument()
+  })
+
+  it('does not flag a date range that is only half filled in', async () => {
+    const user = userEvent.setup()
+    render(
+      <LibraryFilters
+        filters={{ ...EMPTY_FILTERS, fundingDate: { startDate: '2024-01-01' } }}
+        onChange={vi.fn()}
+        onClear={vi.fn()}
+        sections={getFilterSectionsForAsset(AssetType.FUNDING_RESOURCES, availableFilters)}
+      />,
+    )
+    await user.click(screen.getByText('Funding Dates'))
+    expect(screen.queryByText('Start Date cannot be after End Date')).not.toBeInTheDocument()
   })
 
   it('does not show Clear button when closed even with active filters', () => {

--- a/test/components/data_library/assets/fundingResourceAsset.spec.ts
+++ b/test/components/data_library/assets/fundingResourceAsset.spec.ts
@@ -268,6 +268,24 @@ describe('fundingResourceAsset — transformResponse', () => {
     expect(result.total).toBe(1)
     expect((result.items[0] as FundingResourceRow).fundingId).toBe('f-in-range')
   })
+
+  // An inverted range builds no ES clause, so it must not narrow rows here
+  // either — otherwise the grid empties while the panel flags the range.
+  it('ignores an inverted fundingDate range instead of filtering everything out', () => {
+    const response = makeResponse([
+      makeBucket('1', [
+        { fundingId: 'f-1', startDate: '2018-01-01', endDate: '2019-01-01' },
+        { fundingId: 'f-2', startDate: '2021-01-01', endDate: '2022-06-30' },
+      ]),
+    ])
+
+    const result = fundingResourceAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      fundingDate: { startDate: '2024-01-01', endDate: '2023-01-01' },
+    })
+
+    expect(result.total).toBe(2)
+  })
 })
 
 describe('fundingResourceAsset — getRowId', () => {

--- a/test/components/data_library/assets/intellectualPropertyAsset.spec.ts
+++ b/test/components/data_library/assets/intellectualPropertyAsset.spec.ts
@@ -251,6 +251,24 @@ describe('intellectualPropertyAsset — transformResponse', () => {
     expect((result.items[0] as IntellectualPropertyAsset).ipId).toBe('ip-in-range')
   })
 
+  // An inverted range builds no ES clause, so it must not narrow rows here
+  // either — otherwise the grid empties while the panel flags the range.
+  it('ignores an inverted ipFiledDate range instead of filtering everything out', () => {
+    const response = makeResponse([
+      makeBucket(1, [
+        { ipId: 'ip-old', filingDate: '2019-05-01' },
+        { ipId: 'ip-new', filingDate: '2025-01-01' },
+      ]),
+    ])
+
+    const result = intellectualPropertyAsset.transformResponse(response, pagination, {
+      ...EMPTY_FILTERS,
+      ipFiledDate: { after: '2024-01-01', before: '2020-01-01' },
+    })
+
+    expect(result.total).toBe(2)
+  })
+
   it('handles studies with no intellectualProperties assets', () => {
     const response = makeResponse([makeBucket(7, [])])
     const result = intellectualPropertyAsset.transformResponse(response, pagination)

--- a/test/components/data_library/filterRegistry.spec.ts
+++ b/test/components/data_library/filterRegistry.spec.ts
@@ -137,6 +137,25 @@ describe('filterRegistry', () => {
       expect(beforeOnly).toContainEqual({ key: 'ipFiledDate', sectionLabel: 'Filed Date', valueLabel: 'Until 2019-12-31' })
     })
 
+    it('does not surface any inverted date range (builds no clause, so no chip)', () => {
+      const inverted: FilterState = {
+        ...EMPTY_FILTERS,
+        fundingDate: { startDate: '2024-01-01', endDate: '2023-01-01' },
+        biospecimenCollectionDate: { after: '2024-01-01', before: '2020-01-01' },
+        ipFiledDate: { after: '2024-01-01', before: '2020-01-01' },
+      }
+      const chips = getExternalActiveFilters(AssetType.MODELS, inverted, availableFilters)
+      const chipKeys = chips.map(chip => chip.key)
+      expect(chipKeys).not.toContain('fundingDate')
+      expect(chipKeys).not.toContain('biospecimenCollectionDate')
+      expect(chipKeys).not.toContain('ipFiledDate')
+
+      const clauses = JSON.stringify(buildActiveFilterClauses(inverted))
+      expect(clauses).not.toContain('funding.startDate')
+      expect(clauses).not.toContain('dateOfCollection')
+      expect(clauses).not.toContain('filingDate')
+    })
+
     it('omits date filters that hold no active value', () => {
       const chips = getExternalActiveFilters(AssetType.MODELS, EMPTY_FILTERS, availableFilters)
       const dateKeys = ['fundingDate', 'biospecimenCollectionDate', 'ipFiledDate', 'clinicalTrialDates']


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-3995](https://broadworkbench.atlassian.net/browse/DT-3995)

### Summary

- Updates the data library filter to use less space in the layout.
- Changes the behavior of the calendar control used in some filters to hide the traditional calendar picker UI icon and makes the input text only so that they use less space.

Before:

<img width="966" height="584" alt="image" src="https://github.com/user-attachments/assets/e47ee588-ed22-4703-a80c-48d90da2e801" />

After:

<img width="1676" height="415" alt="image" src="https://github.com/user-attachments/assets/7f4bc8fc-322c-4777-80c5-5c57c5e35b1c" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
