### PR TITLE
[DT-4016] Replace react-google-charts with a native SVG donut chart (BFF Phase 5, story 5-A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-dropzone": "20.1.0",
-    "react-google-charts": "5.2.1",
     "react-markdown": "10.1.0",
     "react-modal": "3.16.3",
     "react-paginating": "1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,9 +55,6 @@ importers:
       react-dropzone:
         specifier: 20.1.0
         version: 20.1.0(@types/react@19.2.17)(react@19.2.7)
-      react-google-charts:
-        specifier: 5.2.1
-        version: 5.2.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react-markdown:
         specifier: 10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -2753,12 +2750,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-google-charts@5.2.1:
-    resolution: {integrity: sha512-mCbPiObP8yWM5A9ogej7Qp3/HX4EzOwuEzUYvcfHtL98Xt4V/brD14KgfDzSNNtyD48MNXCpq5oVaYKt0ykQUQ==}
-    peerDependencies:
-      react: '>=16.3.0'
-      react-dom: '>=16.3.0'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5976,11 +5967,6 @@ snapshots:
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
-
-  react-google-charts@5.2.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   react-is@16.13.1: {}
 

--- a/src/App.css
+++ b/src/App.css
@@ -27,11 +27,4 @@
   to { transform: rotate(360deg); }
 }
 
-/*
-  Fix for tooltip flicker on mouseover for react-google-charts
-  See https://stackoverflow.com/questions/37902708/google-charts-tooltip-flickering
-  And https://github.com/google/google-visualization-issues/issues/2162
-*/
-svg > g > g:last-child { pointer-events: none }
-
 /*///////////////////////////////////////////////////////AUX STYLES FOR NAVIGATION*/

--- a/src/components/common/VotesPieChart.tsx
+++ b/src/components/common/VotesPieChart.tsx
@@ -2,8 +2,6 @@ import React, { useMemo } from 'react'
 import { isNil, isEmpty } from 'src/utils/NodashUtil'
 import { Vote } from 'src/types/model'
 
-// This chart must stay inline SVG with no chart library: the CSP allows
-// scripts from 'self' only, so it cannot load a remote chart loader at runtime.
 const VOTE_CATEGORIES = [
   { label: 'Yes', color: '#1FA371' },
   { label: 'No', color: '#DA000E' },

--- a/src/components/common/VotesPieChart.tsx
+++ b/src/components/common/VotesPieChart.tsx
@@ -109,12 +109,12 @@ export default function VotesPieChart({
 
   return (
     <div style={{ ...style, ...styleOverride }} className={`${keyString}-pie-chart`}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', width, height }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '2rem', padding: '1.5rem 1rem', width, height }}>
         <svg
           viewBox={`0 0 ${VIEW_BOX_SIZE} ${VIEW_BOX_SIZE}`}
           role="img"
           aria-label={`Vote summary: ${summary}`}
-          style={{ width: '45%', maxWidth: '180px', flex: '0 0 auto' }}
+          style={{ width: '40%', maxWidth: '150px', flex: '0 0 auto' }}
         >
           {slices.length === 1
             ? (
@@ -135,8 +135,6 @@ export default function VotesPieChart({
                     key={slice.label}
                     d={donutSlicePath(slice.start, slice.start + slice.fraction, innerRadius)}
                     fill={slice.color}
-                    stroke="#FFFFFF"
-                    strokeWidth="1"
                   >
                     <title>{sliceTitle(slice.label, slice.count, slice.fraction)}</title>
                   </path>
@@ -152,18 +150,25 @@ export default function VotesPieChart({
             flexDirection: 'column',
             gap: '0.25rem',
             fontFamily: 'Montserrat',
-            fontSize: 12,
+            fontSize: 13,
             fontWeight: 400,
-            color: '#333F52',
+            color: '#222222',
           }}
         >
-          {VOTE_CATEGORIES.map(({ label, color }) => (
+          {slices.map(({ label, color }) => (
             <li key={label} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
               <span
                 aria-hidden="true"
-                style={{ width: 12, height: 12, backgroundColor: color, display: 'inline-block', flex: '0 0 auto' }}
+                style={{
+                  width: 10,
+                  height: 10,
+                  borderRadius: '50%',
+                  backgroundColor: color,
+                  display: 'inline-block',
+                  flex: '0 0 auto',
+                }}
               />
-              <span>{`${label} (${counts[label]})`}</span>
+              <span>{label}</span>
             </li>
           ))}
         </ul>

--- a/src/components/common/VotesPieChart.tsx
+++ b/src/components/common/VotesPieChart.tsx
@@ -1,34 +1,76 @@
 import React, { useMemo } from 'react'
-import { Chart } from 'react-google-charts'
-import { isNil, isEmpty, map } from 'src/utils/NodashUtil'
+import { isNil, isEmpty } from 'src/utils/NodashUtil'
 import { Vote } from 'src/types/model'
 
-const pieSliceColors = {
-  0: { color: '#1FA371' },
-  1: { color: '#DA000E' },
-  2: { color: '#979797' },
-}
+// This chart must stay inline SVG with no chart library: the CSP allows
+// scripts from 'self' only, so it cannot load a remote chart loader at runtime.
+const VOTE_CATEGORIES = [
+  { label: 'Yes', color: '#1FA371' },
+  { label: 'No', color: '#DA000E' },
+  { label: 'Not Yet Voted', color: '#979797' },
+] as const
 
-const getVoteLabel = (vote: boolean | undefined): string => {
+type VoteLabel = (typeof VOTE_CATEGORIES)[number]['label']
+
+const VIEW_BOX_SIZE = 100
+const CENTER = VIEW_BOX_SIZE / 2
+const OUTER_RADIUS = CENTER
+
+const getVoteLabel = (vote: boolean | undefined): VoteLabel => {
   if (vote) return 'Yes'
   if (isNil(vote)) return 'Not Yet Voted'
   return 'No'
 }
 
-const processVotes = (votes: Vote[]) => {
-  const headerData = ['Vote', 'Total Votes']
-  const decisionMap: Record<string, number> = {
-    'Yes': 0,
-    'No': 0,
-    'Not Yet Voted': 0,
-  }
-
+const countVotes = (votes: Vote[]): Record<VoteLabel, number> => {
+  const counts: Record<VoteLabel, number> = { 'Yes': 0, 'No': 0, 'Not Yet Voted': 0 }
   votes.forEach((v) => {
-    decisionMap[getVoteLabel(v.vote)]++
+    counts[getVoteLabel(v.vote)]++
   })
-  const decisionDataArray = map(decisionMap, (count, key) => [key, count])
-  return [headerData, ...decisionDataArray]
+  return counts
 }
+
+interface PieSlice {
+  readonly label: VoteLabel
+  readonly color: string
+  readonly count: number
+  readonly fraction: number
+  readonly start: number
+}
+
+const toSlices = (counts: Record<VoteLabel, number>, total: number): PieSlice[] => {
+  let start = 0
+  return VOTE_CATEGORIES.flatMap(({ label, color }) => {
+    const count = counts[label]
+    if (count === 0) return []
+    const fraction = count / total
+    const slice = { label, color, count, fraction, start }
+    start += fraction
+    return [slice]
+  })
+}
+
+// A point on a circle around CENTER; fraction 0 is 12 o'clock, clockwise.
+const polarPoint = (radius: number, fraction: number): string => {
+  const angle = 2 * Math.PI * fraction
+  const x = CENTER + radius * Math.sin(angle)
+  const y = CENTER - radius * Math.cos(angle)
+  return `${x.toFixed(3)} ${y.toFixed(3)}`
+}
+
+const donutSlicePath = (start: number, end: number, innerRadius: number): string => {
+  const largeArc = end - start > 0.5 ? 1 : 0
+  return [
+    `M ${polarPoint(OUTER_RADIUS, start)}`,
+    `A ${OUTER_RADIUS} ${OUTER_RADIUS} 0 ${largeArc} 1 ${polarPoint(OUTER_RADIUS, end)}`,
+    `L ${polarPoint(innerRadius, end)}`,
+    `A ${innerRadius} ${innerRadius} 0 ${largeArc} 0 ${polarPoint(innerRadius, start)}`,
+    'Z',
+  ].join(' ')
+}
+
+const sliceTitle = (label: VoteLabel, count: number, fraction: number): string =>
+  `${label}: ${count} (${Math.round(fraction * 100)}%)`
 
 interface VotesPieChartProps {
   readonly votes?: Vote[]
@@ -49,14 +91,7 @@ export default function VotesPieChart({
   style = { width: '70%' },
   styleOverride,
 }: VotesPieChartProps) {
-  const processedVotes = useMemo(() => processVotes(votes), [votes])
-  const options = {
-    pieHole,
-    is3d: false,
-    fontName: 'Montserrat',
-    pieSliceText: 'none',
-    slices: pieSliceColors,
-  }
+  const counts = useMemo(() => countVotes(votes), [votes])
 
   if (isEmpty(votes)) {
     return (
@@ -67,15 +102,72 @@ export default function VotesPieChart({
       </div>
     )
   }
+
+  const slices = toSlices(counts, votes.length)
+  const innerRadius = OUTER_RADIUS * pieHole
+  const summary = VOTE_CATEGORIES.map(({ label }) => `${counts[label]} ${label}`).join(', ')
+
   return (
-    <div style={{ ...style, ...styleOverride }}>
-      <Chart
-        chartType="PieChart"
-        data={processedVotes}
-        options={options}
-        width={width}
-        height={height}
-      />
+    <div style={{ ...style, ...styleOverride }} className={`${keyString}-pie-chart`}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', width, height }}>
+        <svg
+          viewBox={`0 0 ${VIEW_BOX_SIZE} ${VIEW_BOX_SIZE}`}
+          role="img"
+          aria-label={`Vote summary: ${summary}`}
+          style={{ width: '45%', maxWidth: '180px', flex: '0 0 auto' }}
+        >
+          {slices.length === 1
+            ? (
+                <circle
+                  cx={CENTER}
+                  cy={CENTER}
+                  r={(OUTER_RADIUS + innerRadius) / 2}
+                  fill="none"
+                  stroke={slices[0].color}
+                  strokeWidth={OUTER_RADIUS - innerRadius}
+                >
+                  <title>{sliceTitle(slices[0].label, slices[0].count, 1)}</title>
+                </circle>
+              )
+            : (
+                slices.map(slice => (
+                  <path
+                    key={slice.label}
+                    d={donutSlicePath(slice.start, slice.start + slice.fraction, innerRadius)}
+                    fill={slice.color}
+                    stroke="#FFFFFF"
+                    strokeWidth="1"
+                  >
+                    <title>{sliceTitle(slice.label, slice.count, slice.fraction)}</title>
+                  </path>
+                ))
+              )}
+        </svg>
+        <ul
+          style={{
+            listStyle: 'none',
+            margin: 0,
+            padding: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '0.25rem',
+            fontFamily: 'Montserrat',
+            fontSize: 12,
+            fontWeight: 400,
+            color: '#333F52',
+          }}
+        >
+          {VOTE_CATEGORIES.map(({ label, color }) => (
+            <li key={label} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <span
+                aria-hidden="true"
+                style={{ width: 12, height: 12, backgroundColor: color, display: 'inline-block', flex: '0 0 auto' }}
+              />
+              <span>{`${label} (${counts[label]})`}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   )
 }

--- a/test/components/collection_voting_slab/MultiDatasetVoteSlab.spec.tsx
+++ b/test/components/collection_voting_slab/MultiDatasetVoteSlab.spec.tsx
@@ -27,7 +27,6 @@ vi.mock('src/libs/ajax/Email', () => ({
   Email: { sendReminderEmail: vi.fn() },
 }))
 
-// VotesPieChart uses react-google-charts which cannot render in jsdom
 vi.mock('src/components/common/VotesPieChart', () => ({
   default: () => <div data-testid="votes-pie-chart" />,
 }))

--- a/test/components/common/VotesPieChart.spec.tsx
+++ b/test/components/common/VotesPieChart.spec.tsx
@@ -41,20 +41,20 @@ describe('VotesPieChart', () => {
     expect(document.querySelector('.test-pie-chart-no-data')).not.toBeInTheDocument()
   })
 
-  it('shows every category with its count in the legend', () => {
+  it('shows a legend entry for every voted category', () => {
     render(<VotesPieChart keyString="test" votes={testVotes} />)
 
-    expect(screen.getByText('Yes (1)')).toBeInTheDocument()
-    expect(screen.getByText('No (1)')).toBeInTheDocument()
-    expect(screen.getByText('Not Yet Voted (1)')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+    expect(screen.getByText('No')).toBeInTheDocument()
+    expect(screen.getByText('Not Yet Voted')).toBeInTheDocument()
   })
 
-  it('omits the slice for a zero-count category but keeps it in the legend', () => {
+  it('omits a zero-count category from the pie and the legend', () => {
     const votes = [makeVote(1, true), makeVote(2, true), makeVote(3, false)]
     const { container } = render(<VotesPieChart keyString="test" votes={votes} />)
 
     expect(container.querySelectorAll('path')).toHaveLength(2)
-    expect(screen.getByText('Not Yet Voted (0)')).toBeInTheDocument()
+    expect(screen.queryByText('Not Yet Voted')).not.toBeInTheDocument()
   })
 
   it('labels each slice with its count and percentage', () => {

--- a/test/components/common/VotesPieChart.spec.tsx
+++ b/test/components/common/VotesPieChart.spec.tsx
@@ -1,24 +1,23 @@
 import React from 'react'
 import '@testing-library/jest-dom/vitest'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import VotesPieChart from 'src/components/common/VotesPieChart'
+import { Vote } from 'src/types/model'
 
-vi.mock('react-google-charts', () => ({
-  Chart: () => <div data-testid="pie-chart" />,
-}))
+const makeVote = (voteId: number, vote?: boolean): Vote => ({
+  voteId,
+  userId: voteId,
+  createDate: '',
+  electionId: 1,
+  displayName: `User ${voteId}`,
+  type: 'DAC',
+  vote,
+})
 
-const testVotes = [
-  { voteId: 1, userId: 1, createDate: '', electionId: 1, displayName: 'A', type: 'DAC', vote: true },
-  { voteId: 2, userId: 2, createDate: '', electionId: 1, displayName: 'B', type: 'DAC', vote: false },
-  { voteId: 3, userId: 3, createDate: '', electionId: 1, displayName: 'C', type: 'DAC', vote: undefined },
-]
+const testVotes = [makeVote(1, true), makeVote(2, false), makeVote(3, undefined)]
 
 describe('VotesPieChart', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
   it('renders the no-data div when votes is empty', () => {
     render(<VotesPieChart keyString="test" />)
 
@@ -33,11 +32,47 @@ describe('VotesPieChart', () => {
     expect(document.querySelector('.test-pie-chart-no-data')).toBeInTheDocument()
   })
 
-  it('renders the chart when votes are provided', () => {
+  it('renders an inline SVG chart with one slice per category', () => {
+    const { container } = render(<VotesPieChart keyString="test" votes={testVotes} />)
+
+    const svg = screen.getByRole('img', { name: 'Vote summary: 1 Yes, 1 No, 1 Not Yet Voted' })
+    expect(svg).toBeInTheDocument()
+    expect(container.querySelectorAll('path')).toHaveLength(3)
+    expect(document.querySelector('.test-pie-chart-no-data')).not.toBeInTheDocument()
+  })
+
+  it('shows every category with its count in the legend', () => {
     render(<VotesPieChart keyString="test" votes={testVotes} />)
 
-    expect(screen.getByTestId('pie-chart')).toBeInTheDocument()
-    expect(document.querySelector('.test-pie-chart-no-data')).not.toBeInTheDocument()
+    expect(screen.getByText('Yes (1)')).toBeInTheDocument()
+    expect(screen.getByText('No (1)')).toBeInTheDocument()
+    expect(screen.getByText('Not Yet Voted (1)')).toBeInTheDocument()
+  })
+
+  it('omits the slice for a zero-count category but keeps it in the legend', () => {
+    const votes = [makeVote(1, true), makeVote(2, true), makeVote(3, false)]
+    const { container } = render(<VotesPieChart keyString="test" votes={votes} />)
+
+    expect(container.querySelectorAll('path')).toHaveLength(2)
+    expect(screen.getByText('Not Yet Voted (0)')).toBeInTheDocument()
+  })
+
+  it('labels each slice with its count and percentage', () => {
+    const votes = [makeVote(1, true), makeVote(2, true), makeVote(3, false), makeVote(4, undefined)]
+    const { container } = render(<VotesPieChart keyString="test" votes={votes} />)
+
+    const titles = [...container.querySelectorAll('path > title')].map(t => t.textContent)
+    expect(titles).toEqual(['Yes: 2 (50%)', 'No: 1 (25%)', 'Not Yet Voted: 1 (25%)'])
+  })
+
+  it('renders a full ring when only one category has votes', () => {
+    const votes = [makeVote(1, true), makeVote(2, true)]
+    const { container } = render(<VotesPieChart keyString="test" votes={votes} />)
+
+    expect(container.querySelectorAll('path')).toHaveLength(0)
+    const ring = container.querySelector('circle')
+    expect(ring).toBeInTheDocument()
+    expect(ring?.querySelector('title')).toHaveTextContent('Yes: 2 (100%)')
   })
 
   it('applies styleOverride to the chart wrapper', () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-4016

Security risk: **low** — this change removes attack surface rather than adding it. `react-google-charts` injected the Google Charts loader from `https://www.gstatic.com/charts/loader.js` at runtime, and that loader chain-loads further unversioned Google-hosted scripts. SRI cannot pin an unversioned loader that fetches more scripts dynamically, so the story's decision was replace-or-allowlist. This PR takes the replace path: the app now loads zero external scripts, which lets the upcoming [CSP story (5-F)](https://broadworkbench.atlassian.net/browse/DT-4021) ship `scriptSrc: ["'self'"]` and removes the supply-chain exposure a replacement chart library would have kept.

### Summary

`VotesPieChart` (rendered by `ChairVoteInfo` on the collection voting slab) now draws its donut as inline SVG instead of delegating to Google Charts:

- **Visual parity with the old chart**: the same three colors in the same fixed order (Yes `#1FA371`, No `#DA000E`, Not Yet Voted `#979797`), slices starting at 12 o'clock clockwise, the same 0.3 pie hole, no text on slices, and a legend beside the chart. The props interface is unchanged, so `ChairVoteInfo.tsx` needed no edit.
- **Small accessibility gains over the old chart**: each slice carries a native `<title>` tooltip with count and percent, and the SVG has an accessible name summarizing all counts — so the numbers are one hover away even though the legend shows plain labels, and identity never depends on color alone.
- **Geometry details**: slices are annular-sector paths; a single non-zero category renders as a stroked ring, since one path cannot arc 360°; zero-count categories appear in neither the pie nor the legend, matching how the chart renders on dev today.
- **Commit 90019a3a adjusted the look after a local side-by-side comparison with dev**: plain legend labels with round markers, zero-count categories hidden, no separator strokes, and padding to match the chart area Google Charts reserved.
- **`react-google-charts` is removed from `package.json`** (and the lockfile). It was the component's only consumer.
- **The App.css tooltip-flicker workaround is removed.** It was a *global* `svg > g > g:last-child { pointer-events: none }` rule added for Google Charts — left in place, it could have silently disabled hover tooltips on this and any future inline SVG.

### Screens

New: 
<img width="1459" height="600" alt="Screenshot 2026-08-24 at 4 49 09 PM" src="https://github.com/user-attachments/assets/9bd4c3be-c256-4cb2-9e06-b531516b1e4d" />


Old:
<img width="1470" height="679" alt="Screenshot 2026-08-24 at 4 42 22 PM" src="https://github.com/user-attachments/assets/f61186b9-486b-4a9d-8860-32baf2486344" />



----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
