### PR TITLE
[DT-4012] Handle the full consent /api/user/me contract and B2C authorization-response errors

### DIFF
--- a/server/src/auth/callback.ts
+++ b/server/src/auth/callback.ts
@@ -27,11 +27,13 @@ export async function handleCallback(request: FastifyRequest, reply: FastifyRepl
   catch (err: unknown) {
     if (err instanceof oidc.AuthorizationResponseError) {
       // B2C answered the authorization request with an error instead of a
-      // code — the user canceled on the B2C page (access_denied), or chose
-      // an identity the tenant's policy rejects. Land back in the
-      // SPA instead; a cancel is the user's own action and stays silent.
-      // A cancel is routine — info keeps it out of warn-based alerting;
-      // real provider errors stay at warn.
+      // code — the user canceled on the B2C page (access_denied), or B2C
+      // itself failed (error=server_error; observed as AADB2C90289 when a
+      // tenant's federation client secret to the upstream Microsoft provider
+      // expired, which fails EVERY Microsoft sign-in in that environment).
+      // Land back in the SPA instead; a cancel is the user's own action
+      // and stays silent. A cancel is also routine — info keeps it out of
+      // warn-based alerting; real provider errors stay at warn.
       const cancelled = err.error === 'access_denied'
       request.log[cancelled ? 'info' : 'warn']({ error: err.error, description: err.error_description }, '[auth] B2C authorization response is an error')
       reply.redirect(cancelled ? '/' : '/?signInError=provider')

--- a/server/src/auth/callback.ts
+++ b/server/src/auth/callback.ts
@@ -30,8 +30,11 @@ export async function handleCallback(request: FastifyRequest, reply: FastifyRepl
       // code — the user canceled on the B2C page (access_denied), or chose
       // an identity the tenant's policy rejects. Land back in the
       // SPA instead; a cancel is the user's own action and stays silent.
-      request.log.warn({ error: err.error, description: err.error_description }, '[auth] B2C authorization response is an error')
-      reply.redirect(err.error === 'access_denied' ? '/' : '/?signInError=provider')
+      // A cancel is routine — info keeps it out of warn-based alerting;
+      // real provider errors stay at warn.
+      const cancelled = err.error === 'access_denied'
+      request.log[cancelled ? 'info' : 'warn']({ error: err.error, description: err.error_description }, '[auth] B2C authorization response is an error')
+      reply.redirect(cancelled ? '/' : '/?signInError=provider')
       return
     }
     throw err

--- a/server/src/auth/callback.ts
+++ b/server/src/auth/callback.ts
@@ -17,10 +17,25 @@ export async function handleCallback(request: FastifyRequest, reply: FastifyRepl
   // inspected; DUOS_OAUTH_REDIRECT_URI supplies the base so it parses as an
   // absolute URL.
   const currentUrl = new URL(request.url, requireEnv('DUOS_OAUTH_REDIRECT_URI'))
-  const tokens = await oidc.authorizationCodeGrant(config, currentUrl, {
-    pkceCodeVerifier: request.session.pkceVerifier,
-    expectedState: request.session.pkceState,
-  })
+  let tokens: Awaited<ReturnType<typeof oidc.authorizationCodeGrant>>
+  try {
+    tokens = await oidc.authorizationCodeGrant(config, currentUrl, {
+      pkceCodeVerifier: request.session.pkceVerifier,
+      expectedState: request.session.pkceState,
+    })
+  }
+  catch (err: unknown) {
+    if (err instanceof oidc.AuthorizationResponseError) {
+      // B2C answered the authorization request with an error instead of a
+      // code — the user canceled on the B2C page (access_denied), or chose
+      // an identity the tenant's policy rejects. Land back in the
+      // SPA instead; a cancel is the user's own action and stays silent.
+      request.log.warn({ error: err.error, description: err.error_description }, '[auth] B2C authorization response is an error')
+      reply.redirect(err.error === 'access_denied' ? '/' : '/?signInError=provider')
+      return
+    }
+    throw err
+  }
 
   const claims = tokens.claims() // undefined when no id_token is present
 

--- a/server/src/auth/callback.ts
+++ b/server/src/auth/callback.ts
@@ -28,12 +28,9 @@ export async function handleCallback(request: FastifyRequest, reply: FastifyRepl
     if (err instanceof oidc.AuthorizationResponseError) {
       // B2C answered the authorization request with an error instead of a
       // code — the user canceled on the B2C page (access_denied), or B2C
-      // itself failed (error=server_error; observed as AADB2C90289 when a
-      // tenant's federation client secret to the upstream Microsoft provider
-      // expired, which fails EVERY Microsoft sign-in in that environment).
-      // Land back in the SPA instead; a cancel is the user's own action
-      // and stays silent. A cancel is also routine — info keeps it out of
-      // warn-based alerting; real provider errors stay at warn.
+      // itself failed. Land back in the SPA instead; a cancel is the user's
+      // own action and stays silent. A cancel is also routine — info keeps
+      // it out of warn-based alerting; real provider errors stay at warn.
       const cancelled = err.error === 'access_denied'
       request.log[cancelled ? 'info' : 'warn']({ error: err.error, description: err.error_description }, '[auth] B2C authorization response is an error')
       reply.redirect(cancelled ? '/' : '/?signInError=provider')

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -147,9 +147,10 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   }
 
   if (!res.ok) {
-    // A non-4xx failure (5xx, upstream outage) says nothing about whether the
-    // token itself is still valid — don't destroy the session or parse an
-    // error body as if it were a user profile.
+    // An unmapped status — 5xx, an upstream outage, or a 4xx the contract
+    // does not define (400/403/429) — says nothing about whether the token
+    // itself is still valid: don't destroy the session or parse an error
+    // body as if it were a user profile. 502 tells the probe to retry.
     reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
     return
   }

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -5,41 +5,35 @@ import { REFRESH_WINDOW_SECONDS, RefreshFailedError, refreshAccessToken } from '
 const UPSTREAM_TIMEOUT_MS = 5000
 
 /**
- * Answers an upstream 401/404. The DUOS API conflates "bad token" with "no
- * DUOS profile for this email" (both 401 — DuosUserAuthenticator turns the
- * lookup's NotFoundException into an empty principal), so the session's
- * `profileSeen` flag is the disambiguator this endpoint controls.
+ * Shown when the upstream 409 arrives without a usable message — the client
+ * needs something actionable even if the body was empty or malformed.
  */
-async function answerNoProfile(request: FastifyRequest, reply: FastifyReply): Promise<void> {
-  if (request.session.profileSeen) {
-    // This session has served a profile before, so "no profile" cannot be
-    // the explanation. The upstream is rejecting the token itself — revoked
-    // mid-lifetime (before refresh-before-forward would touch it) or the
-    // account was disabled. The terminal 401 is the honest answer; leaving
-    // the session alive would send the client into re-registering an
-    // existing user.
-    try {
-      await request.session.destroy()
-    }
-    catch (err: unknown) {
-      request.log.error({ err }, '[auth] upstream rejected a profile-seen session but it could not be destroyed — returning 401 anyway')
-    }
-    reply.clearCookie('sessionId').status(401).send({ authenticated: false })
-    return
+const PROVIDER_CONFLICT_FALLBACK_MESSAGE
+  = 'You may have previously signed in with a different authentication provider (Google or Microsoft). Please sign in with that provider.'
+
+/**
+ * Ends a session the upstream has authoritatively rejected.
+ */
+async function destroySession(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  try {
+    await request.session.destroy()
   }
-  // Never seen a profile: authenticated but not yet registered. Treating
-  // this 401 as a dead session destroyed every brand-new user's session on
-  // their first probe and made registration unreachable. In the rare case
-  // of a token revoked before first contact, the client's registration
-  // attempt fails too, which signs the session out. (404 kept deliberately:
-  // DT-3997 restores the upstream's 404 for unregistered users.)
-  reply.send({ authenticated: true, idp: request.session.idp })
+  catch (err: unknown) {
+    request.log.error({ err }, '[auth] upstream rejected the session but it could not be destroyed — answering as signed out anyway')
+  }
+  reply.clearCookie('sessionId')
 }
 
 /**
  * Confirms the user is authenticated against the upstream Consent API.
  * Forwards the upstream user profile and the active sub-provider — never the
  * tokens themselves, which stay server-side in the session.
+ *
+ * The upstream /api/user/me contract:
+ * - 200 registered profile
+ * - 401 rejected token
+ * - 404 authenticated but unregistered
+ * - 409 Sam sub-provider conflict
  */
 export async function getMe(request: FastifyRequest, reply: FastifyReply): Promise<void> {
   // The answer is per-session and now gates the whole SPA: no intermediary
@@ -98,13 +92,46 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     return
   }
 
-  if (res.status === 401 || res.status === 404) {
-    await answerNoProfile(request, reply)
+  if (res.status === 401) {
+    // The upstream rejected the token itself — revoked mid-lifetime (before refresh-before-forward would
+    // touch it) or the account was disabled. The terminal 401 is final so the session must be destroyed.
+    // The client still needs to know it is signed out, so the reply goes out after the session is destroyed.
+    await destroySession(request, reply)
+    reply.status(401).send({ authenticated: false })
+    return
+  }
+
+  if (res.status === 404) {
+    // Authenticated but not yet registered — the session is valid, and the
+    // client's post-sign-in bootstrap needs authenticated:true (with user
+    // absent) to reach its registration flow.
+    reply.send({ authenticated: true, idp: request.session.idp })
+    return
+  }
+
+  if (res.status === 409) {
+    // Sam sub-provider conflict: the account exists under the other B2C sub-provider and Sam rejects it.
+    // Registration cannot succeed and the session cannot become usable, so end it — but forward the
+    // upstream's actionable message (sign in with the other provider, plus the support link) instead
+    // of a generic failure.
+    let message = PROVIDER_CONFLICT_FALLBACK_MESSAGE
+    try {
+      const body: unknown = await res.json()
+      const upstreamMessage = (body as { message?: unknown } | null)?.message
+      if (typeof upstreamMessage === 'string' && upstreamMessage.length > 0) {
+        message = upstreamMessage
+      }
+    }
+    catch {
+      // Unparseable body — the fallback message stands.
+    }
+    await destroySession(request, reply)
+    reply.status(409).send({ authenticated: false, error: 'provider_conflict', message })
     return
   }
 
   if (!res.ok) {
-    // A non-401 failure (5xx, upstream outage) says nothing about whether the
+    // A non-4xx failure (5xx, upstream outage) says nothing about whether the
     // token itself is still valid — don't destroy the session or parse an
     // error body as if it were a user profile.
     reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
@@ -118,15 +145,6 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
   catch {
     reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
     return
-  }
-
-  if (!request.session.profileSeen) {
-    request.session.profileSeen = true
-    // Saved explicitly before the reply, once per session (the flag never
-    // flips back): with rolling off, the onSend hook only skips its async
-    // save when the session is unmodified — see index.ts on the
-    // ERR_HTTP_HEADERS_SENT hazard a post-reply async save creates.
-    await request.session.save()
   }
 
   reply.send({

--- a/server/src/auth/me.ts
+++ b/server/src/auth/me.ts
@@ -25,6 +25,55 @@ async function destroySession(request: FastifyRequest, reply: FastifyReply): Pro
 }
 
 /**
+ * Refresh-before-forward, mirroring the API proxy: an idle tab can outlive
+ * the access token while the refresh token and session are still perfectly
+ * valid. Forwarding the expired token would 401 upstream and destroy a
+ * session that only needed a refresh — and the client's focus revalidation
+ * makes this exact path hot.
+ *
+ * Returns false when the refresh failed and the reply has already gone out.
+ */
+async function refreshedIfExpiring(request: FastifyRequest, reply: FastifyReply): Promise<boolean> {
+  const secondsRemaining = (request.session.tokenExpiry ?? 0) - Math.floor(Date.now() / 1000)
+  if (secondsRemaining >= REFRESH_WINDOW_SECONDS) return true
+  try {
+    await refreshAccessToken(request)
+    return true
+  }
+  catch (err: unknown) {
+    if (err instanceof RefreshFailedError) {
+      // Terminal: B2C rejected the refresh token and refreshAccessToken has
+      // already destroyed the session — clear the dead cookie.
+      reply.clearCookie('sessionId').status(401).send({ authenticated: false })
+      return false
+    }
+    // Transient (network blip, B2C 5xx, store error) — the session is
+    // intact, so this must not read as signed out permanently: 502 tells
+    // the client probe to retry on the next ask.
+    reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
+    return false
+  }
+}
+
+/**
+ * The actionable message from the upstream 409 body ({ message, code }), or
+ * the fallback when the body is empty, malformed, or not a string.
+ */
+async function providerConflictMessage(res: Response): Promise<string> {
+  try {
+    const body: unknown = await res.json()
+    const upstreamMessage = (body as { message?: unknown } | null)?.message
+    if (typeof upstreamMessage === 'string' && upstreamMessage.length > 0) {
+      return upstreamMessage
+    }
+  }
+  catch {
+    // Unparseable body — the fallback message stands.
+  }
+  return PROVIDER_CONFLICT_FALLBACK_MESSAGE
+}
+
+/**
  * Confirms the user is authenticated against the upstream Consent API.
  * Forwards the upstream user profile and the active sub-provider — never the
  * tokens themselves, which stay server-side in the session.
@@ -47,30 +96,7 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     return
   }
 
-  // Refresh-before-forward, mirroring the API proxy: an idle tab can outlive
-  // the access token while the refresh token and session are still perfectly
-  // valid. Forwarding the expired token would 401 upstream and destroy a
-  // session that only needed a refresh — and the client's focus revalidation
-  // makes this exact path hot.
-  const secondsRemaining = (request.session.tokenExpiry ?? 0) - Math.floor(Date.now() / 1000)
-  if (secondsRemaining < REFRESH_WINDOW_SECONDS) {
-    try {
-      await refreshAccessToken(request)
-    }
-    catch (err: unknown) {
-      if (err instanceof RefreshFailedError) {
-        // Terminal: B2C rejected the refresh token and refreshAccessToken has
-        // already destroyed the session — clear the dead cookie.
-        reply.clearCookie('sessionId').status(401).send({ authenticated: false })
-        return
-      }
-      // Transient (network blip, B2C 5xx, store error) — the session is
-      // intact, so this must not read as signed out permanently: 502 tells
-      // the client probe to retry on the next ask.
-      reply.status(502).send({ authenticated: false, error: 'upstream_unavailable' })
-      return
-    }
-  }
+  if (!(await refreshedIfExpiring(request, reply))) return
 
   const url = `${requireEnv('DUOS_API_URL')}/api/user/me`
 
@@ -114,17 +140,7 @@ export async function getMe(request: FastifyRequest, reply: FastifyReply): Promi
     // Registration cannot succeed and the session cannot become usable, so end it — but forward the
     // upstream's actionable message (sign in with the other provider, plus the support link) instead
     // of a generic failure.
-    let message = PROVIDER_CONFLICT_FALLBACK_MESSAGE
-    try {
-      const body: unknown = await res.json()
-      const upstreamMessage = (body as { message?: unknown } | null)?.message
-      if (typeof upstreamMessage === 'string' && upstreamMessage.length > 0) {
-        message = upstreamMessage
-      }
-    }
-    catch {
-      // Unparseable body — the fallback message stands.
-    }
+    const message = await providerConflictMessage(res)
     await destroySession(request, reply)
     reply.status(409).send({ authenticated: false, error: 'provider_conflict', message })
     return

--- a/server/src/types/session.ts
+++ b/server/src/types/session.ts
@@ -23,10 +23,5 @@ declare module 'fastify' {
     // regardless — this field exists for the audit trail and observability,
     // not client selection.
     idp?: 'google' | 'microsoft'
-    // Set once /auth/me has served a DUOS profile on this session. The
-    // upstream conflates "no profile" with "bad token" (both 401), and this
-    // is the disambiguator: a 401/404 on a profile-seen session cannot mean
-    // "unregistered", so it is treated as a terminal token verdict.
-    profileSeen?: boolean
   }
 }

--- a/server/test/authCrypto.test.ts
+++ b/server/test/authCrypto.test.ts
@@ -311,15 +311,16 @@ describe('B2C OAuth callback (real openid-client validation against a fake B2C)'
   })
 
   it('redirects to /?signInError=provider when B2C answers with an error instead of a code', async () => {
-    // Edge case: the user picked an identity the tenant's policy
-    // rejects (e.g. a personal Microsoft Live account). B2C redirects back
+    // Edge case: B2C cannot complete the federated sign-in (observed when a
+    // tenant's federation client secret to the upstream Microsoft provider
+    // has expired — every Microsoft account then fails). B2C redirects back
     // with error=server_error — the real authorizationCodeGrant throws
     // AuthorizationResponseError, which must land the browser in the SPA
     const { cookie, state } = await login()
 
     const res = await app.inject({
       method: 'GET',
-      url: `/auth/callback?error=server_error&error_description=AADB2C90085&state=${state}`,
+      url: `/auth/callback?error=server_error&error_description=AADB2C90289&state=${state}`,
       headers: { cookie },
     })
 

--- a/server/test/authCrypto.test.ts
+++ b/server/test/authCrypto.test.ts
@@ -310,6 +310,40 @@ describe('B2C OAuth callback (real openid-client validation against a fake B2C)'
     expect(res.statusCode).toBe(500)
   })
 
+  it('redirects to /?signInError=provider when B2C answers with an error instead of a code', async () => {
+    // Edge case: the user picked an identity the tenant's policy
+    // rejects (e.g. a personal Microsoft Live account). B2C redirects back
+    // with error=server_error — the real authorizationCodeGrant throws
+    // AuthorizationResponseError, which must land the browser in the SPA
+    const { cookie, state } = await login()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?error=server_error&error_description=AADB2C90085&state=${state}`,
+      headers: { cookie },
+    })
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe('/?signInError=provider')
+    const sess = [...rows.values()][0].sess as Record<string, unknown>
+    expect(sess.accessToken).toBeUndefined()
+  })
+
+  it('redirects home silently when the user cancels on the B2C page (access_denied)', async () => {
+    const { cookie, state } = await login()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/auth/callback?error=access_denied&error_description=AADB2C90091&state=${state}`,
+      headers: { cookie },
+    })
+
+    expect(res.statusCode).toBe(302)
+    expect(res.headers.location).toBe('/')
+    const sess = [...rows.values()][0].sess as Record<string, unknown>
+    expect(sess.accessToken).toBeUndefined()
+  })
+
   it('returns 400 token_missing_email_claim when a valid id_token has no email', async () => {
     // The token is cryptographically valid — the grant succeeds — so this
     // exercises the handler guard on top of real validation, not a crypto error.

--- a/server/test/me.test.ts
+++ b/server/test/me.test.ts
@@ -16,21 +16,18 @@ const ENV = { DUOS_API_URL: 'https://consent.dsde-dev.broadinstitute.org' }
 // tests exercise the forward path untouched.
 const FRESH_EXPIRY = () => Math.floor(Date.now() / 1000) + 3600
 
-function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft', tokenExpiry?: number, profileSeen?: boolean } = {}) {
+function makeRequest(overrides: { accessToken?: string, idp?: 'google' | 'microsoft', tokenExpiry?: number } = {}) {
   const destroy = vi.fn().mockResolvedValue(undefined)
-  const save = vi.fn().mockResolvedValue(undefined)
   const request = {
     session: {
       accessToken: overrides.accessToken,
       idp: overrides.idp,
       tokenExpiry: overrides.tokenExpiry ?? FRESH_EXPIRY(),
-      profileSeen: overrides.profileSeen,
       destroy,
-      save,
     },
     log: { error: vi.fn(), info: vi.fn() },
   }
-  return { request: request as unknown as FastifyRequest, destroy, save }
+  return { request: request as unknown as FastifyRequest, destroy }
 }
 
 function makeReply() {
@@ -106,38 +103,30 @@ describe('getMe', () => {
     })
   })
 
-  it('marks the session profile-seen on the first served profile, with an explicit pre-reply save', async () => {
-    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
-    const { request, save } = makeRequest({ accessToken: 'test-access-token' })
-
-    await getMe(request, makeReply())
-
-    expect(request.session.profileSeen).toBe(true)
-    expect(save).toHaveBeenCalledOnce()
-  })
-
-  it('does not re-save a session already marked profile-seen', async () => {
-    // Focus revalidation makes this path hot — the flag costs one DB write
-    // per session, not one per probe.
-    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(200, { email: 'user@example.com' }) as never)
-    const { request, save } = makeRequest({ accessToken: 'test-access-token', profileSeen: true })
-
-    await getMe(request, makeReply())
-
-    expect(save).not.toHaveBeenCalled()
-  })
-
-  it.each([401, 404])('destroys a profile-seen session on an upstream %i — "no profile" cannot explain it', async (status) => {
+  it('destroys the session on an upstream 401', async () => {
     // A registered user's token revoked mid-lifetime forwards (no refresh due)
     // and 401s. Answering "authenticated, no user" here sent the client into
     // re-registering an existing account; the terminal 401 is the honest end.
-    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(status, {}) as never)
-    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token', idp: 'google', profileSeen: true })
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(401, {}) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token', idp: 'google' })
     const reply = makeReply()
 
     await getMe(request, reply)
 
     expect(destroy).toHaveBeenCalledOnce()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(401)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
+  })
+
+  it('still answers 401 when the rejected session cannot be destroyed', async () => {
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(401, {}) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token' })
+    destroy.mockRejectedValue(new Error('store unavailable'))
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
     expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
     expect(reply.status).toHaveBeenCalledWith(401)
     expect(reply.send).toHaveBeenCalledWith({ authenticated: false })
@@ -163,20 +152,35 @@ describe('getMe', () => {
     expect(reply.header).toHaveBeenCalledWith('cache-control', 'no-store')
   })
 
-  it('reports authenticated with no user on an upstream 401 — DUOS conflates "no profile" with "bad token"', async () => {
-    // DuosUserAuthenticator turns an unregistered email's NotFoundException
-    // into an empty principal → Dropwizard 401. The token itself was just
-    // refreshed, so this must NOT destroy the session: it is a brand-new
-    // user who needs the registration bootstrap, not a dead session.
-    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(401, {}) as never)
-    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token', idp: 'google' })
+  it('forwards the upstream 409 message and destroys the session — a Sam sub-provider conflict cannot be registered through', async () => {
+    const message = 'Email: user@example.com. You may have previously signed in with a different authentication provider (Google or Microsoft). Please sign in with that provider.'
+    vi.mocked(fetch).mockResolvedValue(makeFetchResponse(409, { message, code: 409 }) as never)
+    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token', idp: 'microsoft' })
     const reply = makeReply()
 
     await getMe(request, reply)
 
-    expect(destroy).not.toHaveBeenCalled()
-    expect(reply.clearCookie).not.toHaveBeenCalled()
-    expect(reply.send).toHaveBeenCalledWith({ authenticated: true, idp: 'google' })
+    expect(destroy).toHaveBeenCalledOnce()
+    expect(reply.clearCookie).toHaveBeenCalledWith('sessionId')
+    expect(reply.status).toHaveBeenCalledWith(409)
+    expect(reply.send).toHaveBeenCalledWith({ authenticated: false, error: 'provider_conflict', message })
+  })
+
+  it('answers the 409 with a fallback message when the upstream body is unusable', async () => {
+    const badBody = { status: 409, ok: false, json: vi.fn().mockRejectedValue(new Error('invalid JSON')) }
+    vi.mocked(fetch).mockResolvedValue(badBody as never)
+    const { request, destroy } = makeRequest({ accessToken: 'fresh-access-token' })
+    const reply = makeReply()
+
+    await getMe(request, reply)
+
+    expect(destroy).toHaveBeenCalledOnce()
+    expect(reply.status).toHaveBeenCalledWith(409)
+    expect(reply.send).toHaveBeenCalledWith({
+      authenticated: false,
+      error: 'provider_conflict',
+      message: expect.stringContaining('different authentication provider'),
+    })
   })
 
   it('does not refresh when the access token is comfortably fresh', async () => {
@@ -248,7 +252,7 @@ describe('getMe', () => {
     expect(reply.send).toHaveBeenCalledWith({ authenticated: true, idp: 'microsoft' })
   })
 
-  it('returns 502 without destroying the session when the upstream API errors with a non-401 status', async () => {
+  it('returns 502 without destroying the session when the upstream API errors with an unmapped status', async () => {
     vi.mocked(fetch).mockResolvedValue(makeFetchResponse(503, {}) as never)
     const { request, destroy } = makeRequest({ accessToken: 'test-access-token' })
     const reply = makeReply()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ function App() {
     if (queryParams.get('signInError') === null) return
     Notifications.showError({
       text: 'Sign in could not be completed because the identity provider reported an error. '
-        + 'Please try again. If the problem continues, contact Terra support.',
+        + 'Please try again. If the problem continues, contact DUOS support.',
       // Long timeout: the message carries instructions the user must read.
       timeout: 30000,
     })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,15 +51,16 @@ function App() {
 
   /**
    * The BFF /auth/callback lands here with ?signInError=provider when B2C answered the authorization request with an
-   * error instead of a code. The known case is when Microsoft provides login options that use an unsupported client id
+   * error instead of a code. The known case is B2C failing to connect to the chosen Microsoft provider (an expired
+   * federation client secret in the tenant fails every Microsoft sign-in). The message stays generic because the
+   * cause is on the provider side — the server log carries the B2C error and description.
    */
   useEffect(() => {
     const queryParams = new URLSearchParams(location.search)
     if (queryParams.get('signInError') === null) return
     Notifications.showError({
       text: 'Sign in could not be completed because the identity provider reported an error. '
-        + 'If you chose a personal Microsoft account (such as an Outlook.com or Live account), that account type is not supported — '
-        + 'please sign in with Google or with a Microsoft work or school account.',
+        + 'Please try again. If the problem continues, contact Terra support.',
       // Long timeout: the message carries instructions the user must read.
       timeout: 30000,
     })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,24 @@ function App() {
   }, [])
 
   /**
+   * The BFF /auth/callback lands here with ?signInError=provider when B2C answered the authorization request with an
+   * error instead of a code. The known case is when Microsoft provides login options that use an unsupported client id
+   */
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search)
+    if (queryParams.get('signInError') === null) return
+    Notifications.showError({
+      text: 'Sign in could not be completed because the identity provider reported an error. '
+        + 'If you chose a personal Microsoft account (such as an Outlook.com or Live account), that account type is not supported — '
+        + 'please sign in with Google or with a Microsoft work or school account.',
+      // Long timeout: the message carries instructions the user must read.
+      timeout: 30000,
+    })
+    queryParams.delete('signInError')
+    navigate({ pathname: location.pathname, search: queryParams.toString() }, { replace: true })
+  }, [navigate, location.pathname, location.search])
+
+  /**
      * Check for RAS Authentication URL params. If we have a code and state, we will call ECM APIs to get redirect
      * information and user linkage information. With that, we can sync the users account linkage and then redirect the
      * user to the original page they authenticated from.

--- a/src/libs/auth/postSignIn.ts
+++ b/src/libs/auth/postSignIn.ts
@@ -232,10 +232,12 @@ export const completeSignIn = async ({ navigate, queryClient, redirectPath, isCa
   }
   catch (error) {
     if (cancelled()) return 'cancelled'
-    // Explicitly handle AzureB2C errors from Sam
     const errorMessage = extractError(error)
-    if (errorMessage.toLowerCase().includes('azureb2c authentication error')) {
-      Notifications.showError({ text: errorMessage })
+    // A 409 from getMe is the Sam sub-provider conflict the account lives under the other provider,
+    // so registration cannot succeed — surface the actionable message instead of attempting it.
+    if (errorStatus(error) === 409 || errorMessage.toLowerCase().includes('azureb2c authentication error')) {
+      // Long timeout: the message carries instructions and a support link.
+      Notifications.showError({ text: errorMessage, timeout: 30000 })
       await Auth.signOut()
       return 'signed-out'
     }

--- a/src/libs/auth/session.ts
+++ b/src/libs/auth/session.ts
@@ -1,5 +1,6 @@
 import { Config } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
+import { ToastNotifications } from 'src/libs/ToastNotifications'
 import { DuosUser } from 'src/types/model'
 
 /**
@@ -62,6 +63,25 @@ const probeBffSession = async (): Promise<SessionInfo> => {
     const res = await fetch('/auth/me', { credentials: 'include' })
     if (res.status === 401) {
       // A real answer — no session — worth caching for the page load.
+      lastAuthoritativeAnswer = { authenticated: false }
+      return lastAuthoritativeAnswer
+    }
+    if (res.status === 409) {
+      // Sam sub-provider conflict (the account lives under the other provider). The BFF has already destroyed
+      // the session, so this fires once per sign-in attempt. Show the upstream's actionable message (sign in
+      // with the other provider, plus the support link) instead of failing sign-in generically.
+      let message = 'You may have previously signed in with a different authentication provider (Google or Microsoft). Please sign in with that provider.'
+      try {
+        const body = await res.json() as { message?: string }
+        if (typeof body.message === 'string' && body.message.length > 0) {
+          message = body.message
+        }
+      }
+      catch {
+        // Unparseable body — the fallback message stands.
+      }
+      // Long timeout: the message carries instructions and a support link.
+      ToastNotifications.showError({ text: message, timeout: 30000 })
       lastAuthoritativeAnswer = { authenticated: false }
       return lastAuthoritativeAnswer
     }

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -133,6 +133,33 @@ describe('Main App Functions', () => {
     await waitFor(() => expect(document.querySelector('[data-cy="notification-alert"]')).toBeVisible())
   })
 
+  it('shows the sign-in error toast and strips the marker when the BFF callback lands with ?signInError', async () => {
+    // The BFF /auth/callback redirects here when B2C answers the
+    // authorization request with an error instead of a code (e.g. a
+    // rejected Microsoft authentication attempt).
+    vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
+    const searchSpy = vi.fn()
+    const SearchSpy = () => {
+      const location = useLocation()
+      React.useEffect(() => {
+        searchSpy(location.search)
+      }, [location])
+      return null
+    }
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/', search: '?signInError=provider' }]}>
+        <SearchSpy />
+        <App />
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(document.querySelector('[data-cy="notification-alert"]')).toBeVisible())
+    expect(document.querySelector('[data-cy="notification-alert"]')?.textContent).toContain('identity provider')
+    // Stripped so a reload or bookmark does not repeat the toast.
+    await waitFor(() => expect(searchSpy).toHaveBeenCalledWith(''))
+  })
+
   it('should process RAS query params (code, state) and navigate to the profile page when the parameter specifies it', async () => {
     vi.mocked(AuthenticateNIH.getECMProviderLinkInfo).mockResolvedValue(linkInfo as never)
     vi.mocked(AuthenticateNIH.getSyncedUser).mockResolvedValue(duosUser as never)

--- a/test/components/App.spec.tsx
+++ b/test/components/App.spec.tsx
@@ -135,8 +135,8 @@ describe('Main App Functions', () => {
 
   it('shows the sign-in error toast and strips the marker when the BFF callback lands with ?signInError', async () => {
     // The BFF /auth/callback redirects here when B2C answers the
-    // authorization request with an error instead of a code (e.g. a
-    // rejected Microsoft authentication attempt).
+    // authorization request with an error instead of a code (e.g. B2C could
+    // not complete a federated Microsoft sign-in).
     vi.mocked(useSessionInfo).mockReturnValue({ authenticated: false })
     const searchSpy = vi.fn()
     const SearchSpy = () => {

--- a/test/libs/auth/postSignIn.spec.ts
+++ b/test/libs/auth/postSignIn.spec.ts
@@ -383,13 +383,31 @@ describe('completeSignIn', () => {
     })
   })
 
-  describe('AzureB2C errors from Sam', () => {
-    it('shows the error and signs the user out', async () => {
+  describe('Sam sub-provider conflicts', () => {
+    it('shows the 409 conflict message and signs the user out instead of attempting registration', async () => {
+      // Consent DT-4011 answers the conflict with a 409 and an actionable
+      // message — registration cannot succeed, so it must not be attempted.
+      const message = 'Email: test@user.com. You may have previously signed in with a different authentication provider (Google or Microsoft). Please sign in with that provider.'
+      vi.mocked(User.getMe).mockRejectedValue(adapterHttpError(409, message))
+
+      await expect(run('/')).resolves.toBe('signed-out')
+
+      expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith(
+        expect.objectContaining({ text: expect.stringContaining('different authentication provider') }),
+      )
+      expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
+      expect(vi.mocked(User.registerUser)).not.toHaveBeenCalled()
+    })
+
+    it('still recognizes the legacy 500 "AzureB2C authentication error" message', async () => {
+      // Older consent builds answer the conflict with a 500 and this message.
       vi.mocked(User.getMe).mockRejectedValue(new Error('AzureB2C authentication error: bad tenant'))
 
       await expect(run('/')).resolves.toBe('signed-out')
 
-      expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith({ text: 'AzureB2C authentication error: bad tenant' })
+      expect(vi.mocked(Notifications.showError)).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'AzureB2C authentication error: bad tenant' }),
+      )
       expect(vi.mocked(Auth.signOut)).toHaveBeenCalled()
       expect(vi.mocked(User.registerUser)).not.toHaveBeenCalled()
     })

--- a/test/libs/auth/session.spec.ts
+++ b/test/libs/auth/session.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { getSessionInfo, resetSessionCache, resetSessionProbeState, revalidateSessionInfo, userIsLogged } from 'src/libs/auth/session'
 import { Config } from 'src/libs/config'
 import { Storage } from 'src/libs/storage'
+import { ToastNotifications } from 'src/libs/ToastNotifications'
 
 vi.mock('src/libs/config', async importOriginal => ({
   ...(await importOriginal<typeof import('src/libs/config')>()),
@@ -49,6 +50,57 @@ describe('session probe', () => {
     await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
     await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns unauthenticated on 409 and shows the provider-conflict message — a real answer, not a transient failure', async () => {
+    // The BFF forwards consent's Sam sub-provider conflict (DT-4012) as a 409
+    // with an actionable message, and has already destroyed the session.
+    const message = 'Email: user@example.com. You may have previously signed in with a different authentication provider (Google or Microsoft). Please sign in with that provider.'
+    const showError = vi.spyOn(ToastNotifications, 'showError').mockImplementation(() => undefined)
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ authenticated: false, error: 'provider_conflict', message }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      }),
+    )
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    expect(showError).toHaveBeenCalledWith(expect.objectContaining({ text: message }))
+    // Cached like any authoritative answer — one failed sign-in, one toast.
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(showError).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to a generic provider-conflict message when the 409 body is unusable', async () => {
+    const showError = vi.spyOn(ToastNotifications, 'showError').mockImplementation(() => undefined)
+    fetchMock.mockResolvedValue(new Response('not json', { status: 409 }))
+
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    expect(showError).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('different authentication provider'),
+    }))
+  })
+
+  it('lets an authoritative 409 overwrite the held signed-in answer', async () => {
+    vi.spyOn(ToastNotifications, 'showError').mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: true, idp: 'google' }), { status: 200 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false, error: 'provider_conflict', message: 'conflict' }), { status: 409 }),
+    )
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ authenticated: false, error: 'upstream_unavailable' }), { status: 502 }),
+    )
+
+    await expect(getSessionInfo()).resolves.toMatchObject({ authenticated: true })
+    resetSessionCache()
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
+    resetSessionCache()
+
+    // The later transient failure reports the 409 verdict, not the stale sign-in.
+    await expect(getSessionInfo()).resolves.toEqual({ authenticated: false })
   })
 
   it('returns unauthenticated on upstream outage (502) but retries on the next ask', async () => {


### PR DESCRIPTION
### Addresses

[DT-4012](https://broadworkbench.atlassian.net/browse/DT-4012)

Security risk: low — sign-in error paths change how a refusal is presented; no change to who is admitted.

### Summary

Consent now answers `GET /api/user/me` with distinct statuses ([DT-3997 #3021](https://github.com/DataBiosphere/consent/pull/3021), [DT-4011 #3032](https://github.com/DataBiosphere/consent/pull/3032)): **401** rejected token, **404** authenticated but unregistered, **409** Sam sub-provider conflict with an actionable message. The BFF and client now map that contract instead of the old conflated handling:

- `server/src/auth/me.ts`: 401 destroys the session (the `profileSeen` disambiguator is dead machinery and is removed, along with its once-per-session store write); 404 keeps the "authenticated, no user" answer that routes new users into registration; 409 forwards the upstream message as `{ error: 'provider_conflict', message }` after destroying the session — the account lives under the other provider, so the session cannot become usable.
- `src/libs/auth/session.ts`: the probe treats 409 as an authoritative signed-out answer and shows the message (sign in with the other provider, plus the support link) instead of failing sign-in generically.
- `src/libs/auth/postSignIn.ts`: a 409 from getMe signs the user out with the message instead of attempting a registration that cannot succeed. The legacy `"azureb2c authentication error"` substring check stays for older consent builds.

A second edge case is outside consent entirely: B2C can answer the authorization request itself with an error instead of a code — the user's own cancel, or a B2C-side failure. The observed case is `AADB2C90289`/`invalid_client`: the non-prod B2C tenant's federation client secret to the upstream Microsoft provider has expired, which fails every Microsoft sign-in in those environments (secret rotation is tracked separately). `authorizationCodeGrant` throws `AuthorizationResponseError`, and the resulting 500 answered the browser's top-level `/auth/callback` navigation with raw JSON, stranding the user:

- `server/src/auth/callback.ts`: catch `AuthorizationResponseError`; a cancel (`access_denied`) redirects home silently, anything else logs the B2C error and redirects to `/?signInError=provider`. State-mismatch and token-validation failures still throw.
- `src/App.tsx`: a fixed toast for the `signInError` marker, then the marker is stripped from the URL. The marker is a key, never reflected text, so the toast cannot echo attacker-supplied content.

**Deployment note:** the 401 tightening assumes every environment runs a consent build with both fixes above. An old consent behind this BFF would destroy a brand-new user's session on the first probe and block registration.

### Testing

`pnpm run lint`, `pnpm run type-check`, `pnpm test` (368 files, 4312 tests), and the server suite (327 tests) pass. New coverage: 401 destroys the session (including a failing session store); 409 forwards the upstream message, falls back on an unusable body, and overwrites the probe's held signed-in answer; the bootstrap signs out on a 409 without a registration attempt; the callback's authorization-error redirects run against the real `openid-client` grant (fake B2C), alongside the unchanged security rejections; the App toast renders once and the marker is stripped.

The Microsoft sign-in repro was observed manually and produced the exact error this PR handles.

### 404 User Not Found -> New User Registration Case
<img width="1442" height="1206" alt="Screenshot 2026-08-25 at 12 25 32 PM" src="https://github.com/user-attachments/assets/ef8cc7b3-0ad3-4b44-9413-0f5947a5f8d2" />


### 409 Sam AzureB2C Error Case
<img width="1444" height="1235" alt="Screenshot 2026-08-25 at 11 46 21 AM" src="https://github.com/user-attachments/assets/b7b85381-4079-4079-8c74-6e9364c71058" />

### 500 Auth Provider Error 
<img width="1442" height="1206" alt="Screenshot 2026-08-25 at 1 32 59 PM" src="https://github.com/user-attachments/assets/f726805d-2778-4914-8eb0-639f079b8113" />


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DT-4012]: https://broadworkbench.atlassian.net/browse/DT-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

