### PR TITLE
[DT-4017] Verify CSRF coverage end-to-end (BFF Phase 5, story 5-B)

### DIFF
--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -113,7 +113,7 @@ than 001 through 003: the numbers belong to this list, not to the directory.
 | [006](#adr-006--lazy-oidc-client-initialization-with-startup-warm-up) | Lazy OIDC client init with startup warm-up | 2 |
 | [007](#adr-007--idp-stored-in-session-as-sub-provider) | `idp` stored as sub-provider, from the B2C `id_token` claim | 2 |
 | [008](#adr-008--azure-b2c-as-single-oidc-entry-point) | Azure B2C as the single OIDC entry point | 0, 2 |
-| [009](#adr-009--state-changing-upstream-gets-are-proxied-not-blocked) | State-changing upstream GETs are proxied, not blocked | 3 |
+| [009](#adr-009--state-changing-upstream-gets-are-proxied-not-blocked) | State-changing upstream GETs are proxied, not blocked | 3, 5 |
 | [010](#adr-010--the-proxy-scope-declares-its-own-error-shape) | The proxy scope declares its own error shape | 3, 4 |
 
 ### ADR-001 — PostgreSQL-backed sessions via `@fastify/session`
@@ -207,8 +207,15 @@ changes `DUOS_AZURE_ISSUER_URL` and its siblings, not the BFF's structure.
 `SameSite=Lax` is required by the OAuth callback redirect and a CSRF token cannot
 guard a GET, which leaves two upstream endpoints that mutate state on GET
 forgeable by a plain link. Blocking either breaks the app — one is how the client
-learns who the user is — so the residual risk is accepted, documented, and the
-real fix (making the side effect a POST) belongs upstream in Consent.
+learns who the user is — so the residual risk was accepted and documented, and the
+real fix (making the side effect a POST) belongs upstream in Consent (DT-3945).
+
+Phase 5 (story 5-B) then closed the residual for modern browsers with Fetch
+Metadata enforcement: a positive allowlist requiring `Sec-Fetch-Site:
+same-origin` plus a `cors`/`same-origin` mode, applied to every proxy prefix
+and to `/auth/me` (`server/src/security/fetchMetadata.ts`). Requests without
+the headers — older browsers and non-browser clients — are allowed and remain
+covered only by the original accepted-risk analysis.
 
 ### ADR-010 — The proxy scope declares its own error shape
 

--- a/docs/plans/bff_adrs/ADR-009-state-changing-gets.md
+++ b/docs/plans/bff_adrs/ADR-009-state-changing-gets.md
@@ -67,14 +67,33 @@ change, out of scope for a duos-ui story — **raise it with the Consent API own
 as follow-up.** This ADR should be revisited, and can likely be retired, once
 that lands.
 
-### One BFF-side mitigation, deliberately deferred
+### One BFF-side mitigation, deliberately deferred — since implemented (Epic 5, story 5-B)
 
 Available without touching client or upstream: reject requests arriving with
 `Sec-Fetch-Mode: navigate` on the proxy, since no API call should ever be a
-top-level navigation and the header cannot be forged from JavaScript. It is
+top-level navigation and the header cannot be forged from JavaScript. It was
 **not** implemented here — it is a new request-rejection rule rather than part of
-this story, and it should be decided on its own merits. Worth considering for
-Epic 5 (security hardening).
+this story, and it should be decided on its own merits.
+
+**Update (2026-08-24, Epic 5, story 5-B):** implemented, and deliberately
+broader than the navigate-only rule sketched above — that rule would not have
+closed the gap. The dangerous requests here are same-**site** (a compromised
+`*.broadinstitute.org` sibling), and they come in three shapes — a top-level
+navigation, a `no-cors` subresource (`<img>`), and a credentialed `fetch()`
+whose read CORS blocks but whose GET still executes upstream. The enforced
+rule is a positive allowlist: when `Sec-Fetch-Site` is present, require
+`same-origin` AND `Sec-Fetch-Mode: cors`/`same-origin`; when the headers are
+absent (older browsers, non-browser clients), allow and rely on the
+CSRF/session controls. It is applied by the shared proxy machinery to every
+upstream prefix, and to `/auth/me` (which calls `GET /api/user/me`
+server-side); `/auth/login` and `/auth/callback` are exempt because the OAuth
+callback is a legitimate cross-site navigation. See
+`server/src/security/fetchMetadata.ts` for the rule and its rationale, and
+`server/test/fetchMetadata.test.ts` for the matrix.
+
+The residual risk above is therefore closed for modern browsers; the
+accepted-risk analysis continues to apply only to browsers that send no Fetch
+Metadata headers. The upstream fix (DT-3945) remains the real fix.
 
 ---
 
@@ -126,3 +145,17 @@ A false positive. The regex matched `Approved` inside
 The audit script is not checked in — it is 40 lines of throwaway Python and
 would rot against the Consent API's shape. Re-derive it when the upstream API
 changes materially, or when a new epic widens what the proxy forwards.
+
+### Re-run (2026-08-24, Epic 5, story 5-B)
+
+**Audited:** Consent API `origin/develop` at `001497ae1`, 2026-08-24, with the
+same method (brace-matched `@GET` bodies across the `*Resource.java` files,
+searched for mutation-verb calls): 37 resource files, 91 `@GET` methods.
+
+**Result: unchanged.** The same two endpoints are state-changing — 
+`GET /api/nih/sync` (`nihService.syncAccount`) and `GET /api/user/me`
+(`nihService.syncAccount` unconditionally, plus
+`samService.asyncPostRegistrationInfo` when the user has no Sam status) — and
+no new ones appeared. Every other candidate the verb regex surfaced was the
+`createExceptionResponse` error-path false positive. Both endpoints are now
+behind the Fetch Metadata guard described above; DT-3945 is still open.

--- a/docs/plans/bff_adrs/ADR-009-state-changing-gets.md
+++ b/docs/plans/bff_adrs/ADR-009-state-changing-gets.md
@@ -67,7 +67,7 @@ change, out of scope for a duos-ui story — **raise it with the Consent API own
 as follow-up.** This ADR should be revisited, and can likely be retired, once
 that lands.
 
-### One BFF-side mitigation, deliberately deferred — since implemented (Epic 5, story 5-B)
+### One BFF-side mitigation, deliberately deferred — since implemented (Phase 5, story 5-B)
 
 Available without touching client or upstream: reject requests arriving with
 `Sec-Fetch-Mode: navigate` on the proxy, since no API call should ever be a
@@ -75,7 +75,7 @@ top-level navigation and the header cannot be forged from JavaScript. It was
 **not** implemented here — it is a new request-rejection rule rather than part of
 this story, and it should be decided on its own merits.
 
-**Update (2026-08-24, Epic 5, story 5-B):** implemented, and deliberately
+**Update (2026-08-24, Phase 5, story 5-B):** implemented, and deliberately
 broader than the navigate-only rule sketched above — that rule would not have
 closed the gap. The dangerous requests here are same-**site** (a compromised
 `*.broadinstitute.org` sibling), and they come in three shapes — a top-level
@@ -144,9 +144,9 @@ A false positive. The regex matched `Approved` inside
 
 The audit script is not checked in — it is 40 lines of throwaway Python and
 would rot against the Consent API's shape. Re-derive it when the upstream API
-changes materially, or when a new epic widens what the proxy forwards.
+changes materially, or when a new phase widens what the proxy forwards.
 
-### Re-run (2026-08-24, Epic 5, story 5-B)
+### Re-run (2026-08-24, Phase 5, story 5-B)
 
 **Audited:** Consent API `origin/develop` at `001497ae1`, 2026-08-24, with the
 same method (brace-matched `@GET` bodies across the `*Resource.java` files,

--- a/server/src/auth/csrf.ts
+++ b/server/src/auth/csrf.ts
@@ -41,7 +41,7 @@ export const csrfPluginOptions = {
 } as const
 
 /**
- * GET /auth/csrf-token — gated on an authenticated session (Epic 5, story 5-B).
+ * GET /auth/csrf-token — gated on an authenticated session (Phase 5, story 5-B).
  *
  * The route always documented itself as a post-sign-in call, but nothing
  * enforced that: any same-origin request minted an anonymous session row (the

--- a/server/src/auth/csrf.ts
+++ b/server/src/auth/csrf.ts
@@ -1,4 +1,4 @@
-import type { FastifyRequest } from 'fastify'
+import type { FastifyReply, FastifyRequest } from 'fastify'
 
 /**
  * How the BFF registers `@fastify/csrf-protection` — one object, imported by
@@ -39,3 +39,43 @@ export const csrfPluginOptions = {
   getToken: (request: FastifyRequest): string | undefined =>
     request.headers[CSRF_HEADER] as string | undefined,
 } as const
+
+/**
+ * GET /auth/csrf-token — gated on an authenticated session (Epic 5, story 5-B).
+ *
+ * The route always documented itself as a post-sign-in call, but nothing
+ * enforced that: any same-origin request minted an anonymous session row (the
+ * secret `generateCsrf()` writes is what triggers the save) plus a token for
+ * it. The gate closes that: no user in the session means 401, and because the
+ * rejection happens before `generateCsrf()`, nothing is written and no row is
+ * created (`saveUninitialized: false`).
+ *
+ * `accessToken` is the authentication marker for the same reason the proxies
+ * and /auth/me key on it: it exists exactly from the OAuth callback until the
+ * session is destroyed. A pre-auth session (PKCE fields only) is rejected too
+ * — by design, since /auth/login is deliberately CSRF-exempt and nothing
+ * pre-auth needs a token.
+ *
+ * Shared here, like `csrfPluginOptions` above and for the same reason: the
+ * route existed in three copies (index.ts, proxyTestHarness.ts, auth.test.ts),
+ * so a gate added only in index.ts would leave every suite green while testing
+ * an ungated route production no longer has.
+ *
+ * The optional chain on `request.session` is for index.test.ts, which mocks
+ * @fastify/session away; everywhere real, the session plugin guarantees an
+ * object.
+ */
+export async function handleCsrfToken(request: FastifyRequest, reply: FastifyReply): Promise<void> {
+  if (!request.session?.accessToken) {
+    reply.status(401).send({ error: 'unauthenticated' })
+    return
+  }
+  const token = reply.generateCsrf()
+  // generateCsrf() writes the secret into the session on first use, so persist
+  // before replying — the same pre-response save as me.ts and callback.ts:
+  // with rolling off, an unsaved modification makes @fastify/session's async
+  // onSend save race Fastify's wrapThenable into a second reply.send()
+  // (ERR_HTTP_HEADERS_SENT — see index.ts on the session config).
+  await request.session.save()
+  reply.send({ token })
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -219,7 +219,7 @@ export async function buildApp(): Promise<AppInstance> {
     // The client fetches this after sign-in and echoes the token in an
     // X-CSRF-Token header on unsafe auth requests. Gated on an authenticated
     // session (story 5-B): an anonymous request gets 401 and mints no session
-    // row — see the handler in auth/csrf.ts. After session rotation (Epic 5,
+    // row — see the handler in auth/csrf.ts. After session rotation (Phase 5,
     // 5-C) the pre-auth secret is discarded, so the client must (re)fetch this
     // once login completes.
     fastify.get('/auth/csrf-token', handleCsrfToken)
@@ -238,7 +238,7 @@ export async function buildApp(): Promise<AppInstance> {
     // than alongside /health: it depends on @fastify/cookie, @fastify/session
     // and @fastify/csrf-protection, all of which are registered above only when
     // DUOS_DB_HOST is set. Gating it on bffEnabled too keeps it dark until
-    // cutover — the client does not call /duos-api until Epic 4 points
+    // cutover — the client does not call /duos-api until Phase 4 points
     // getApiUrl() at it — so a deployment running the legacy client-side flow
     // exposes no proxy route at all.
     await fastify.register(apiProxy)

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,7 +10,8 @@ import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
 import { createPgSessionStore } from './session/pgStore.js'
-import { csrfPluginOptions } from './auth/csrf.js'
+import { csrfPluginOptions, handleCsrfToken } from './auth/csrf.js'
+import { fetchMetadataGuard } from './security/fetchMetadata.js'
 import { getOidcConfig } from './auth/oidcClient.js'
 import { handleLogin } from './auth/login.js'
 import { handleCallback } from './auth/callback.js'
@@ -216,17 +217,22 @@ export async function buildApp(): Promise<AppInstance> {
     fastify.post('/auth/login', handleLogin)
     fastify.get('/auth/callback', handleCallback)
     // The client fetches this after sign-in and echoes the token in an
-    // X-CSRF-Token header on unsafe auth requests. The CSRF secret lives in the
-    // session, so calling this creates/updates a session row — the client
-    // should only call it once authenticated (see Epic 4, story 4-D). After
-    // session rotation (Epic 5, 5-D) the pre-auth secret is discarded, so the
-    // client must (re)fetch this once login completes.
-    fastify.get('/auth/csrf-token', async (_request, reply) => reply.send({ token: reply.generateCsrf() }))
-    // /auth/login is deliberately exempt: it is pre-authentication (no token to
-    // have fetched yet), and login CSRF is neutralized by the PKCE state binding
-    // the flow to the session. /auth/me is a safe GET. Only logout is guarded.
+    // X-CSRF-Token header on unsafe auth requests. Gated on an authenticated
+    // session (story 5-B): an anonymous request gets 401 and mints no session
+    // row — see the handler in auth/csrf.ts. After session rotation (Epic 5,
+    // 5-C) the pre-auth secret is discarded, so the client must (re)fetch this
+    // once login completes.
+    fastify.get('/auth/csrf-token', handleCsrfToken)
+    // /auth/login is deliberately exempt from CSRF: it is pre-authentication
+    // (no token to have fetched yet), and login CSRF is neutralized by the
+    // PKCE state binding the flow to the session. Only logout is guarded.
     fastify.post('/auth/logout', { onRequest: fastify.csrfProtection }, handleLogout)
-    fastify.get('/auth/me', getMe)
+    // /auth/me is a safe GET here, but it calls Consent's state-changing
+    // GET /api/user/me server-side, so it carries the Fetch Metadata guard the
+    // proxies get from their shared machinery (story 5-B; see
+    // security/fetchMetadata.ts). /auth/login and /auth/callback must NOT get
+    // it — the callback is a legitimate cross-site navigation from B2C.
+    fastify.get('/auth/me', { onRequest: fetchMetadataGuard }, getMe)
 
     // The API proxy (Phase 3). Registered here, inside both switches, rather
     // than alongside /health: it depends on @fastify/cookie, @fastify/session

--- a/server/src/proxy/upstreamProxy.ts
+++ b/server/src/proxy/upstreamProxy.ts
@@ -12,6 +12,7 @@ import type {
 import fastifyReplyFrom from '@fastify/reply-from'
 import { requireEnv } from '../auth/oidcClient.js'
 import { REFRESH_WINDOW_SECONDS, RefreshFailedError, refreshAccessToken } from '../auth/refresh.js'
+import { fetchMetadataGuard } from '../security/fetchMetadata.js'
 
 /**
  * The BFF upstream proxy machinery.
@@ -388,8 +389,14 @@ export async function registerUpstreamProxy(
     undici: { connections: options.undiciConnections ?? UPSTREAM_POOL_CONNECTIONS },
   })
 
+  // The Fetch Metadata guard runs first, on every method and every path under
+  // the prefix (allowlisted unauthenticated paths included — they are fetched
+  // same-origin by the client too), so a rejected request costs no CSRF work,
+  // no session read, no token refresh, and never reaches the upstream. Part of
+  // the shared machinery deliberately: like the CSRF hook, a new upstream
+  // cannot opt out of it. See security/fetchMetadata.ts for the rule.
   app.all(`${prefix}/*`, {
-    onRequest: csrfForUnsafeMethods,
+    onRequest: [fetchMetadataGuard, csrfForUnsafeMethods],
     preHandler: ensureUpstreamAuth,
   }, (request, reply) => {
     reply.from(pathFor(request.url), {

--- a/server/src/security/fetchMetadata.ts
+++ b/server/src/security/fetchMetadata.ts
@@ -25,13 +25,15 @@ import type { FastifyReply, FastifyRequest } from 'fastify'
  *   `same-origin`.** Anything else — including a missing or malformed
  *   `Sec-Fetch-Mode` alongside a present `Sec-Fetch-Site` — is rejected.
  *
- * When `Sec-Fetch-Site` is absent (older browsers, and non-browser clients
+ * When **both** headers are absent (older browsers, and non-browser clients
  * such as curl or the test injector), the request is **allowed** and the
  * CSRF/session controls carry the load alone — exactly the pre-guard posture.
  * That is a documented, deliberate choice: the headers are forbidden request
  * headers a browser sets itself, so an attacker-controlled *browser* request
  * cannot strip them, and a non-browser client holds no victim's cookie jar to
- * forge with.
+ * forge with. A request carrying only ONE of the pair is not a browser shape
+ * at all — browsers send both together or neither — so it is rejected as
+ * malformed rather than waved through as legacy.
  *
  * This is safe to apply bluntly because no legitimate flow navigates to or
  * subresource-loads a guarded path (verified 2026-08-24: every client download
@@ -60,7 +62,7 @@ const ALLOWED_MODES: ReadonlySet<string> = new Set(['cors', 'same-origin'])
  *
  * The header reads tolerate `string[]` (repeated headers): a repeated
  * `sec-fetch-site` fails the `=== 'same-origin'` comparison and is rejected —
- * malformed input fails closed, only a genuinely absent header is waved
+ * malformed input fails closed, only the genuinely absent PAIR is waved
  * through.
  */
 export async function fetchMetadataGuard(
@@ -68,11 +70,11 @@ export async function fetchMetadataGuard(
   reply: FastifyReply,
 ): Promise<FastifyReply | undefined> {
   const site = request.headers['sec-fetch-site']
-  if (site === undefined) {
+  const mode = request.headers['sec-fetch-mode']
+  if (site === undefined && mode === undefined) {
     return undefined
   }
 
-  const mode = request.headers['sec-fetch-mode']
   if (site === 'same-origin' && typeof mode === 'string' && ALLOWED_MODES.has(mode)) {
     return undefined
   }

--- a/server/src/security/fetchMetadata.ts
+++ b/server/src/security/fetchMetadata.ts
@@ -1,0 +1,85 @@
+import type { FastifyReply, FastifyRequest } from 'fastify'
+
+/**
+ * Fetch Metadata enforcement (Epic 5, story 5-B) — closes the ADR-009 residual.
+ *
+ * The residual risk recorded in docs/plans/bff_adrs/ADR-009-state-changing-gets.md
+ * is state-changing **GETs** (`/api/nih/sync`, and the sync side effect inside
+ * `/api/user/me`). CSRF tokens cannot apply to GET, and `SameSite=Lax` still
+ * sends the session cookie on **same-site** requests — in dev/staging the app
+ * shares the `broadinstitute.org` registrable domain with many sibling
+ * services, so a compromised sibling subdomain is same-site, not cross-site.
+ * The forgery has three shapes there, not one:
+ *
+ *   - a top-level navigation (`Sec-Fetch-Mode: navigate`),
+ *   - a subresource such as `<img>` (`no-cors`),
+ *   - a credentialed `fetch()` (`cors` — CORS blocks the *read*, but the
+ *     simple GET still executes upstream).
+ *
+ * All three arrive with `Sec-Fetch-Site: same-site`, so neither a
+ * cross-site-only rule nor a navigate-only rule (the mitigation ADR-009
+ * deferred) closes the gap. The rule is a positive allowlist instead:
+ *
+ *   **When the Fetch Metadata headers are present, require
+ *   `Sec-Fetch-Site: same-origin` AND `Sec-Fetch-Mode: cors` or
+ *   `same-origin`.** Anything else — including a missing or malformed
+ *   `Sec-Fetch-Mode` alongside a present `Sec-Fetch-Site` — is rejected.
+ *
+ * When `Sec-Fetch-Site` is absent (older browsers, and non-browser clients
+ * such as curl or the test injector), the request is **allowed** and the
+ * CSRF/session controls carry the load alone — exactly the pre-guard posture.
+ * That is a documented, deliberate choice: the headers are forbidden request
+ * headers a browser sets itself, so an attacker-controlled *browser* request
+ * cannot strip them, and a non-browser client holds no victim's cookie jar to
+ * forge with.
+ *
+ * This is safe to apply bluntly because no legitimate flow navigates to or
+ * subresource-loads a guarded path (verified 2026-08-24: every client download
+ * goes `fetch` → blob → `createObjectURL`, never a proxy-path navigation).
+ * Applied to every upstream proxy prefix (upstreamProxy.ts attaches it ahead
+ * of the CSRF hook, so a rejected request costs no session read, no token
+ * refresh, and no upstream call) and to `/auth/me`, which sits outside the
+ * prefixes but calls Consent's state-changing `GET /api/user/me` server-side.
+ * It must NOT be attached to `/auth/login` or `/auth/callback`: the OAuth
+ * callback is a legitimate cross-site top-level navigation from B2C.
+ */
+
+/**
+ * Like the CSRF rejection, a bare 403 would be ambiguous — upstreams deny
+ * writes with 403 too — so the body names the guard. No client branches on
+ * this: a legitimate same-origin caller can never trigger it.
+ */
+export const FETCH_METADATA_ERROR_CODE = 'cross_site_request_blocked'
+
+const ALLOWED_MODES: ReadonlySet<string> = new Set(['cors', 'same-origin'])
+
+/**
+ * An onRequest hook. Async, returning the reply on rejection, in the same
+ * style as the proxy's `ensureUpstreamAuth`: Fastify needs the reply returned
+ * from an async hook to know the response was already sent.
+ *
+ * The header reads tolerate `string[]` (repeated headers): a repeated
+ * `sec-fetch-site` fails the `=== 'same-origin'` comparison and is rejected —
+ * malformed input fails closed, only a genuinely absent header is waved
+ * through.
+ */
+export async function fetchMetadataGuard(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<FastifyReply | undefined> {
+  const site = request.headers['sec-fetch-site']
+  if (site === undefined) {
+    return undefined
+  }
+
+  const mode = request.headers['sec-fetch-mode']
+  if (site === 'same-origin' && typeof mode === 'string' && ALLOWED_MODES.has(mode)) {
+    return undefined
+  }
+
+  request.log.info(
+    { url: request.url, method: request.method, secFetchSite: site, secFetchMode: mode },
+    '[fetch-metadata] blocked a request whose Fetch Metadata is not same-origin cors/same-origin',
+  )
+  return reply.status(403).send({ error: FETCH_METADATA_ERROR_CODE })
+}

--- a/server/src/security/fetchMetadata.ts
+++ b/server/src/security/fetchMetadata.ts
@@ -1,7 +1,7 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
 
 /**
- * Fetch Metadata enforcement (Epic 5, story 5-B) — closes the ADR-009 residual.
+ * Fetch Metadata enforcement (Phase 5, story 5-B) — closes the ADR-009 residual.
  *
  * The residual risk recorded in docs/plans/bff_adrs/ADR-009-state-changing-gets.md
  * is state-changing **GETs** (`/api/nih/sync`, and the sync side effect inside

--- a/server/test/apiProxy.test.ts
+++ b/server/test/apiProxy.test.ts
@@ -228,6 +228,87 @@ describe('apiProxy', () => {
     })
   })
 
+  // The ADR-009 residual: CSRF tokens cannot guard GET, and SameSite=Lax still
+  // sends the cookie same-SITE — so a compromised sibling subdomain could drive
+  // the two state-changing upstream GETs. The positive allowlist closes all
+  // three forgery shapes (navigation, no-cors subresource, credentialed cors
+  // fetch). The full header matrix lives in fetchMetadata.test.ts; these pin
+  // that the shared proxy machinery wires the guard ahead of everything else.
+  describe('Fetch Metadata enforcement (story 5-B)', () => {
+    const BLOCKED = { error: 'cross_site_request_blocked' }
+
+    it.each([
+      ['a same-site credentialed cors fetch', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors' }],
+      ['a same-site no-cors subresource (<img src>)', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'no-cors' }],
+      ['a top-level navigation', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'navigate' }],
+    ])('rejects %s to a state-changing GET, without calling the upstream', async (_name, headers) => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/nih/sync`, headers })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual(BLOCKED)
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('rejects a cross-site request on an unsafe method before the CSRF guard runs', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors' },
+      })
+
+      expect(res.statusCode).toBe(403)
+      // The Fetch Metadata rejection, not the CSRF one — the guard is first.
+      expect(res.json()).toEqual(BLOCKED)
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    // The guard covers the allowlisted unauthenticated paths too: the client
+    // fetches those same-origin as well, and a same-site subresource load of
+    // /status has no legitimate caller either.
+    it('applies to allowlisted unauthenticated paths', async () => {
+      app = await buildProxyApp()
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/status`,
+        headers: { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'no-cors' },
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('passes a legitimate same-origin fetch through', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `${PROXY_PREFIX}/api/user/me`,
+        headers: { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'cors' },
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.received).toHaveLength(1)
+    })
+
+    // Older browsers send no Fetch Metadata; the request proceeds and the
+    // CSRF/session controls carry the load alone. Documented in
+    // security/fetchMetadata.ts — this is the pre-guard posture, kept
+    // deliberately rather than breaking those browsers.
+    it('allows a request without Fetch Metadata headers (older browsers)', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({ method: 'GET', url: `${PROXY_PREFIX}/api/user/me` })
+
+      expect(res.statusCode).toBe(200)
+      expect(upstream.received).toHaveLength(1)
+    })
+  })
+
   // The proxy turns every DUOS API write into a cookie-authenticated request,
   // so without this any site could drive them using a signed-in victim's cookie.
   describe('CSRF enforcement', () => {
@@ -249,6 +330,51 @@ describe('apiProxy', () => {
         expect(upstream.received).toHaveLength(0)
       },
     )
+
+    // The classic CSRF shape against a proxied mutation, end to end: an
+    // attacker page auto-submits a cross-origin form in a signed-in victim's
+    // browser. The cookie rides along (same-site siblings defeat Lax), the
+    // custom header cannot. Two variants, because two guards apply: a modern
+    // browser's form POST carries Fetch Metadata and dies at that guard; an
+    // older browser's carries none and dies at the CSRF check. Both must 403
+    // without touching the upstream.
+    it('rejects a forged cross-origin form POST (modern browser, Fetch Metadata present)', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'origin': 'https://evil.example.org',
+          'sec-fetch-site': 'cross-site',
+          'sec-fetch-mode': 'navigate',
+        },
+        payload: 'name=forged',
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: 'cross_site_request_blocked' })
+      expect(upstream.received).toHaveLength(0)
+    })
+
+    it('rejects a forged cross-origin form POST (older browser, no Fetch Metadata)', async () => {
+      app = await buildProxyApp(freshSession())
+
+      const res = await app.inject({
+        method: 'POST',
+        url: `${PROXY_PREFIX}/api/dataset/1`,
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          'origin': 'https://evil.example.org',
+        },
+        payload: 'name=forged',
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual(rejection(MISSING_SECRET))
+      expect(upstream.received).toHaveLength(0)
+    })
 
     // The case the four above do NOT cover: a real signed-in session that has a
     // secret, on a request that simply carries no token — a client that forgot

--- a/server/test/auth.test.ts
+++ b/server/test/auth.test.ts
@@ -6,7 +6,8 @@ import fastifyCsrf from '@fastify/csrf-protection'
 import type { PostgresDb } from '@fastify/postgres'
 import type { Configuration } from 'openid-client'
 import { createPgSessionStore } from '../src/session/pgStore.js'
-import { csrfPluginOptions } from '../src/auth/csrf.js'
+import { csrfPluginOptions, handleCsrfToken } from '../src/auth/csrf.js'
+import { fetchMetadataGuard } from '../src/security/fetchMetadata.js'
 import { handleLogin } from '../src/auth/login.js'
 import { handleCallback } from '../src/auth/callback.js'
 import { handleLogout } from '../src/auth/logout.js'
@@ -130,11 +131,14 @@ async function buildAuthApp(pg: PostgresDb, errorLog?: string[]): Promise<Fastif
   // the body or under three other header spellings that production rejects.
   await app.register(fastifyCsrf, csrfPluginOptions)
 
+  // Routes registered exactly as index.ts registers them — the shared
+  // handleCsrfToken (gated since 5-B) and the Fetch Metadata guard on
+  // /auth/me. Copies here would let the production wiring drift untested.
   app.post('/auth/login', handleLogin)
   app.get('/auth/callback', handleCallback)
-  app.get('/auth/csrf-token', async (_request, reply) => reply.send({ token: reply.generateCsrf() }))
+  app.get('/auth/csrf-token', handleCsrfToken)
   app.post('/auth/logout', { onRequest: app.csrfProtection }, handleLogout)
-  app.get('/auth/me', getMe)
+  app.get('/auth/me', { onRequest: fetchMetadataGuard }, getMe)
   return app
 }
 
@@ -435,6 +439,137 @@ describe('BFF OAuth flow (integration, openid-client mocked at the function boun
       })
 
       expect(res.statusCode).toBe(403)
+    })
+
+    // The classic CSRF shape, end to end: an attacker page auto-submits a
+    // <form action="https://duos/auth/logout" method="POST"> in the victim's
+    // browser. The session cookie rides along (same-site siblings defeat Lax
+    // — see index.ts), but no X-CSRF-Token can: a cross-origin form cannot
+    // set a custom header. Asserted with the exact headers a browser form
+    // POST carries, so this stays a faithful forgery even if the guard's
+    // internals change.
+    it('rejects a forged cross-origin form POST to /auth/logout, leaving the session intact', async () => {
+      const cookie = await authenticatedCookie()
+      expect(rows.size).toBe(1)
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/auth/logout',
+        headers: {
+          cookie,
+          'content-type': 'application/x-www-form-urlencoded',
+          'origin': 'https://evil.example.org',
+          'sec-fetch-site': 'cross-site',
+          'sec-fetch-mode': 'navigate',
+        },
+        payload: 'submit=Sign+out',
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(rows.size).toBe(1) // session survives
+      expect(auditUpdates).toHaveLength(0) // handler never ran
+    })
+  })
+
+  describe('/auth/csrf-token gate (story 5-B)', () => {
+    it('rejects an anonymous request with 401 and mints no session row', async () => {
+      const res = await app.inject({ method: 'GET', url: '/auth/csrf-token' })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'unauthenticated' })
+      // The pre-gate route wrote generateCsrf()'s secret into a fresh session,
+      // which persisted a row and set a cookie — an anonymous-session mint per
+      // caller. The gate answers before the secret exists.
+      expect(rows.size).toBe(0)
+      expect(res.cookies.find(c => c.name === 'sessionId')).toBeUndefined()
+      expect(res.body).not.toContain('token')
+    })
+
+    it('rejects a pre-auth session (login begun, callback not reached) with 401', async () => {
+      // login() persists PKCE material but no tokens — the session exists and
+      // is real, but holds no user yet. Nothing pre-auth needs a CSRF token:
+      // /auth/login itself is deliberately exempt.
+      const { cookie } = await login()
+      expect(rows.size).toBe(1)
+
+      const res = await app.inject({ method: 'GET', url: '/auth/csrf-token', headers: { cookie } })
+
+      expect(res.statusCode).toBe(401)
+      expect(res.json()).toEqual({ error: 'unauthenticated' })
+    })
+
+    it('issues a token to an authenticated session, persisted before the reply', async () => {
+      const { cookie } = await login()
+      await app.inject({ method: 'GET', url: '/auth/callback?code=c&state=s', headers: { cookie } })
+
+      const res = await app.inject({ method: 'GET', url: '/auth/csrf-token', headers: { cookie } })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.json().token).toEqual(expect.any(String))
+      // The secret must be in the STORED session by the time the reply lands,
+      // or a token could be handed out that the next request cannot verify.
+      const sess = [...rows.values()][0].sess as Record<string, unknown>
+      expect(sess._csrf).toEqual(expect.any(String))
+    })
+  })
+
+  describe('Fetch Metadata on /auth/me (story 5-B)', () => {
+    // /auth/me is a safe GET at the BFF, but it triggers Consent's
+    // state-changing GET /api/user/me server-side — the ADR-009 residual. The
+    // guard's full matrix lives in fetchMetadata.test.ts; these pin that
+    // /auth/me is wired with it, that rejected requests never reach the
+    // upstream, and that the legitimate shapes still work.
+    async function authenticatedCookie(): Promise<string> {
+      const { cookie } = await login()
+      await app.inject({ method: 'GET', url: '/auth/callback?code=c&state=s', headers: { cookie } })
+      return cookie
+    }
+
+    it.each([
+      ['a same-site credentialed fetch (compromised sibling subdomain)', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors' }],
+      ['a same-site no-cors subresource', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'no-cors' }],
+      ['a top-level navigation', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'navigate' }],
+    ])('rejects %s with 403, without calling the upstream', async (_name, headers) => {
+      const cookie = await authenticatedCookie()
+      const fetchSpy = vi.fn()
+      vi.stubGlobal('fetch', fetchSpy)
+
+      const res = await app.inject({ method: 'GET', url: '/auth/me', headers: { cookie, ...headers } })
+      vi.unstubAllGlobals()
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: 'cross_site_request_blocked' })
+      expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('serves a legitimate same-origin fetch', async () => {
+      const cookie = await authenticatedCookie()
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        status: 200, ok: true, json: async () => ({ email: 'user@example.com' }),
+      }))
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/auth/me',
+        headers: { cookie, 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'cors' },
+      })
+      vi.unstubAllGlobals()
+
+      expect(res.statusCode).toBe(200)
+      expect(res.json().authenticated).toBe(true)
+    })
+
+    it('serves a request without Fetch Metadata headers (older browsers) — documented allow', async () => {
+      const cookie = await authenticatedCookie()
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        status: 200, ok: true, json: async () => ({ email: 'user@example.com' }),
+      }))
+
+      const res = await app.inject({ method: 'GET', url: '/auth/me', headers: { cookie } })
+      vi.unstubAllGlobals()
+
+      expect(res.statusCode).toBe(200)
+      expect(res.json().authenticated).toBe(true)
     })
   })
 

--- a/server/test/bardProxy.test.ts
+++ b/server/test/bardProxy.test.ts
@@ -148,6 +148,24 @@ describe('bardProxy', () => {
     })
   })
 
+  // One representative case: the guard is shared machinery (fetchMetadata.test.ts
+  // owns the matrix); this pins that THIS prefix is covered by it.
+  describe('Fetch Metadata enforcement (story 5-B)', () => {
+    it('rejects a same-site cross-origin request without calling Bard', async () => {
+      app = await buildBardApp(freshSession())
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `${BARD_PROXY_PREFIX}/api/event`,
+        headers: { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors' },
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: 'cross_site_request_blocked' })
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
   describe('CSRF enforcement', () => {
     it('rejects a POST without a token before it reaches Bard', async () => {
       app = await buildBardApp(freshSession())

--- a/server/test/ecmProxy.test.ts
+++ b/server/test/ecmProxy.test.ts
@@ -138,6 +138,24 @@ describe('ecmProxy', () => {
     })
   })
 
+  // One representative case: the guard is shared machinery (fetchMetadata.test.ts
+  // owns the matrix); this pins that THIS prefix is covered by it.
+  describe('Fetch Metadata enforcement (story 5-B)', () => {
+    it('rejects a same-site cross-origin request without calling ECM', async () => {
+      app = await buildEcmApp(freshSession())
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `${ECM_PROXY_PREFIX}${AUTH_URL_PATH}`,
+        headers: { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors' },
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: 'cross_site_request_blocked' })
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
   describe('CSRF enforcement', () => {
     it('rejects a POST without a token before it reaches ECM', async () => {
       app = await buildEcmApp(freshSession())

--- a/server/test/fetchMetadata.test.ts
+++ b/server/test/fetchMetadata.test.ts
@@ -72,9 +72,11 @@ describe('fetchMetadataGuard', () => {
       ['a user-initiated navigation (site none)', { 'sec-fetch-site': 'none', 'sec-fetch-mode': 'navigate' }],
       ['a cross-site cors fetch', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors' }],
       ['a cross-site no-cors subresource', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'no-cors' }],
-      // Malformed shapes fail closed: only a genuinely ABSENT sec-fetch-site
-      // is waved through. A real browser always sends the pair together.
+      // Malformed shapes fail closed: only the genuinely absent PAIR is waved
+      // through. A real browser always sends both headers or neither, so a
+      // lone header in either direction is not a browser shape.
       ['a present site with a missing mode', { 'sec-fetch-site': 'same-origin' }],
+      ['a present mode with a missing site', { 'sec-fetch-mode': 'cors' }],
       ['a repeated sec-fetch-site header', { 'sec-fetch-site': ['same-origin', 'same-origin'], 'sec-fetch-mode': 'cors' }],
       ['a repeated sec-fetch-mode header', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': ['cors', 'cors'] }],
       ['an unknown mode value', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'websocket' }],

--- a/server/test/fetchMetadata.test.ts
+++ b/server/test/fetchMetadata.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import { FETCH_METADATA_ERROR_CODE, fetchMetadataGuard } from '../src/security/fetchMetadata.js'
+
+// ---------------------------------------------------------------------------
+// Story 5-B: the Fetch Metadata positive allowlist, exercised as a matrix on a
+// minimal app. The integration suites prove the guard is *wired* — on every
+// upstream proxy prefix (apiProxy/ecmProxy/tdrProxy/bardProxy.test.ts, via the
+// shared machinery) and on /auth/me (auth.test.ts, index.test.ts). This suite
+// owns the rule itself: exactly which (Sec-Fetch-Site, Sec-Fetch-Mode) pairs
+// pass, and that everything else — including the malformed shapes — fails
+// closed. The rule closes the ADR-009 residual, whose attack arrives as
+// same-SITE (a compromised *.broadinstitute.org sibling), so the same-site
+// rows are the load-bearing ones.
+// ---------------------------------------------------------------------------
+
+describe('fetchMetadataGuard', () => {
+  let app: FastifyInstance
+  let handlerCalls: number
+
+  beforeEach(async () => {
+    app = Fastify({ logger: false })
+    handlerCalls = 0
+    app.get('/guarded', { onRequest: fetchMetadataGuard }, async () => {
+      handlerCalls += 1
+      return { ok: true }
+    })
+  })
+
+  afterEach(async () => {
+    await app.close()
+  })
+
+  const get = (headers: Record<string, string | string[]> = {}) =>
+    app.inject({ method: 'GET', url: '/guarded', headers })
+
+  describe('allows', () => {
+    it.each([
+      ['a same-origin cors fetch (the SPA calling its own BFF)', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'cors' }],
+      ['a same-origin same-origin-mode request', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'same-origin' }],
+    ])('%s', async (_name, headers) => {
+      const res = await get(headers)
+
+      expect(res.statusCode).toBe(200)
+      expect(handlerCalls).toBe(1)
+    })
+
+    // Older browsers and non-browser clients send no Fetch Metadata at all.
+    // Allowed by design, documented in the module: the CSRF and session
+    // controls carry the load alone there, which is the pre-guard posture —
+    // and a request whose headers CAN be absent is one an attacker's browser
+    // cannot produce, since browsers set these forbidden headers themselves.
+    it('a request with no Fetch Metadata headers (older browsers) — documented', async () => {
+      const res = await get()
+
+      expect(res.statusCode).toBe(200)
+      expect(handlerCalls).toBe(1)
+    })
+  })
+
+  describe('rejects with 403 and the named error', () => {
+    it.each([
+      // The ADR-009 attack: everything a compromised sibling subdomain sends
+      // is same-SITE, in all three shapes.
+      ['a same-site credentialed cors fetch (compromised sibling subdomain)', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors' }],
+      ['a same-site no-cors subresource (<img src>)', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'no-cors' }],
+      ['a same-site top-level navigation', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'navigate' }],
+      // Navigations are rejected regardless of site — no legitimate flow
+      // navigates to a guarded path, and Lax sends the cookie on all of these.
+      ['a same-origin navigation', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'navigate' }],
+      ['a cross-site navigation', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'navigate' }],
+      ['a user-initiated navigation (site none)', { 'sec-fetch-site': 'none', 'sec-fetch-mode': 'navigate' }],
+      ['a cross-site cors fetch', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors' }],
+      ['a cross-site no-cors subresource', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'no-cors' }],
+      // Malformed shapes fail closed: only a genuinely ABSENT sec-fetch-site
+      // is waved through. A real browser always sends the pair together.
+      ['a present site with a missing mode', { 'sec-fetch-site': 'same-origin' }],
+      ['a repeated sec-fetch-site header', { 'sec-fetch-site': ['same-origin', 'same-origin'], 'sec-fetch-mode': 'cors' }],
+      ['a repeated sec-fetch-mode header', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': ['cors', 'cors'] }],
+      ['an unknown mode value', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'websocket' }],
+    ])('%s', async (_name, headers) => {
+      const res = await get(headers as Record<string, string | string[]>)
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: FETCH_METADATA_ERROR_CODE })
+      expect(handlerCalls).toBe(0)
+    })
+  })
+
+  it('applies to unsafe methods the same way', async () => {
+    app.post('/guarded-post', { onRequest: fetchMetadataGuard }, async () => {
+      handlerCalls += 1
+      return { ok: true }
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/guarded-post',
+      headers: { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors', 'content-type': 'application/json' },
+      payload: '{}',
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(handlerCalls).toBe(0)
+  })
+})

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -324,6 +324,44 @@ describe('BFF auth route registration', () => {
     await localApp.close()
   })
 
+  // buildApp() must wire the GATED /auth/csrf-token handler (story 5-B), not
+  // the pre-gate inline route. With @fastify/session mocked away there is no
+  // session at all, so the gate's 401 — rather than the mocked generateCsrf's
+  // 'test-csrf-token' — is proof the shared handler is the one registered.
+  it('registers the gated /auth/csrf-token handler: anonymous requests get 401, no token', async () => {
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const res = await localApp.inject({ method: 'GET', url: '/auth/csrf-token' })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json()).toEqual({ error: 'unauthenticated' })
+    expect(res.body).not.toContain('test-csrf-token')
+
+    await localApp.close()
+  })
+
+  // The Fetch Metadata guard (story 5-B) must sit on /auth/me — it fronts
+  // Consent's state-changing GET /api/user/me — and must NOT sit on
+  // /auth/callback, which is a legitimate cross-site navigation from B2C.
+  it('guards /auth/me with Fetch Metadata but leaves /auth/callback navigable', async () => {
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+
+    const { getMe } = await import('../src/auth/me.js')
+    const { handleCallback } = await import('../src/auth/callback.js')
+    const crossSite = { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'navigate' }
+
+    const me = await localApp.inject({ method: 'GET', url: '/auth/me', headers: crossSite })
+    expect(me.statusCode).toBe(403)
+    expect(me.json()).toEqual({ error: 'cross_site_request_blocked' })
+    expect(getMe).not.toHaveBeenCalled()
+
+    const callback = await localApp.inject({ method: 'GET', url: '/auth/callback', headers: crossSite })
+    expect(callback.statusCode).toBe(200)
+    expect(handleCallback).toHaveBeenCalled()
+
+    await localApp.close()
+  })
+
   // The app's setNotFoundHandler() serves the SPA shell (200) for any
   // unmatched route, so an unregistered /auth/* route can't be distinguished
   // from a registered one by status code alone — assert the handler itself

--- a/server/test/proxyTestHarness.ts
+++ b/server/test/proxyTestHarness.ts
@@ -5,7 +5,7 @@ import Fastify, { type FastifyInstance, type FastifyRequest, type Session } from
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
-import { csrfPluginOptions } from '../src/auth/csrf.js'
+import { csrfPluginOptions, handleCsrfToken } from '../src/auth/csrf.js'
 import { TRUST_PROXY } from '../src/config.js'
 
 /**
@@ -102,9 +102,11 @@ export async function buildAppShell(): Promise<FastifyInstance> {
     rolling: false,
   })
   await app.register(fastifyCsrf, csrfPluginOptions)
-  // Mirrors index.ts's /auth/csrf-token — the only way a client gets a token,
-  // and therefore the only way these tests can produce a valid one.
-  app.get('/auth/csrf-token', async (_request, reply) => reply.send({ token: reply.generateCsrf() }))
+  // The real /auth/csrf-token handler, not a copy — the only way a client gets
+  // a token, and therefore the only way these tests can produce a valid one.
+  // Since story 5-B it is gated on an authenticated session, so a suite that
+  // needs a token must seed one (seedSession applies to this route too).
+  app.get('/auth/csrf-token', handleCsrfToken)
   return app
 }
 

--- a/server/test/tdrProxy.test.ts
+++ b/server/test/tdrProxy.test.ts
@@ -140,6 +140,24 @@ describe('tdrProxy', () => {
     })
   })
 
+  // One representative case: the guard is shared machinery (fetchMetadata.test.ts
+  // owns the matrix); this pins that THIS prefix is covered by it.
+  describe('Fetch Metadata enforcement (story 5-B)', () => {
+    it('rejects a same-site cross-origin request without calling TDR', async () => {
+      app = await buildTdrApp(freshSession())
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `${TDR_PROXY_PREFIX}${SNAPSHOTS_PATH}`,
+        headers: { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors' },
+      })
+
+      expect(res.statusCode).toBe(403)
+      expect(res.json()).toEqual({ error: 'cross_site_request_blocked' })
+      expect(upstream.received).toHaveLength(0)
+    })
+  })
+
   describe('CSRF enforcement', () => {
     it('rejects a POST without a token before it reaches TDR', async () => {
       app = await buildTdrApp(freshSession())

--- a/src/libs/ajax/csrf.ts
+++ b/src/libs/ajax/csrf.ts
@@ -36,6 +36,22 @@ export const isCsrfRejection = async (res: Response): Promise<boolean> => {
   }
 }
 
+/**
+ * Thrown when /auth/csrf-token answers 401 — the endpoint is gated on an
+ * authenticated session (Epic 5, story 5-B), so its 401 means the BFF session
+ * is expired or signed out. Typed so the fetch adapter can run the normal
+ * session-expired handling (metric + redirectOnLogout) instead of surfacing a
+ * generic help-desk error for a request that never got sent. This signal comes
+ * from the BFF itself, so it is authoritative about the DUOS session no matter
+ * which upstream the blocked request was headed for.
+ */
+export class CsrfTokenSessionExpiredError extends Error {
+  constructor() {
+    super('The CSRF token request returned 401: the BFF session is expired or signed out')
+    this.name = 'CsrfTokenSessionExpiredError'
+  }
+}
+
 // A promise rather than the token itself, so concurrent unsafe requests share
 // one /auth/csrf-token round-trip instead of racing to fetch their own.
 let csrfTokenPromise: Promise<string> | null = null
@@ -43,6 +59,9 @@ let csrfTokenPromise: Promise<string> | null = null
 export const getCsrfToken = (): Promise<string> => {
   csrfTokenPromise ??= fetch('/auth/csrf-token', { credentials: 'include' })
     .then(async (res) => {
+      if (res.status === 401) {
+        throw new CsrfTokenSessionExpiredError()
+      }
       if (!res.ok) {
         throw new Error(`CSRF token request failed with status ${res.status}`)
       }

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -5,7 +5,7 @@ import { Storage } from 'src/libs/storage'
 import { ErrorReporter } from 'src/libs/ErrorReporter'
 import { shouldSkip401Redirect } from 'src/utils/AuthRedirectUtils'
 import { BFF_BARD_PREFIX, Config } from 'src/libs/config'
-import { getCsrfToken, isCsrfRejection, resetCsrfToken } from 'src/libs/ajax/csrf'
+import { CsrfTokenSessionExpiredError, getCsrfToken, isCsrfRejection, resetCsrfToken } from 'src/libs/ajax/csrf'
 
 export type ResponseType = 'blob' | 'json' | 'text'
 export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
@@ -116,6 +116,46 @@ function buildUrlWithParams(url: string, params?: Params): string {
   return query ? `${url}?${query}` : url
 }
 
+// Record relevant 401 logouts to Bard / Mixpanel, then start the sign-out
+// redirect. The metric gives systematic, empirical data to assess premature
+// logout issues. More context: https://github.com/DataBiosphere/duos-ui/pull/3389
+const recordAutoLogout401 = async (url: string): Promise<void> => {
+  const oidcUser = Storage.getOidcUser()
+  const expiresOn = oidcUser?.profile?.exp ?? null
+  const currentTime = Math.floor(Date.now() / 1000)
+  await Metrics.captureEvent(eventList.userAutoLogout401, {
+    expires_on: expiresOn,
+    current_time: currentTime,
+    time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
+    endpoint_url: url,
+  }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
+  redirectOnLogout()
+}
+
+/**
+ * The session-expired path for a 401 from /auth/csrf-token itself (the
+ * endpoint is gated on authentication — Epic 5, story 5-B). Runs the same
+ * telemetry + redirect as a real 401 response and throws the same axios-like
+ * shape, so callers cannot tell whether the session died before or after the
+ * request went out.
+ *
+ * Deliberately NOT routed through shouldSkip401Redirect: that util judges
+ * whether the TARGET upstream's 401 is authoritative about the DUOS session
+ * (an ECM 401 is not). This 401 comes from the BFF itself, so it is always
+ * authoritative — even when the blocked request was headed for a sibling
+ * proxy prefix. No redirect loop is possible: Auth.signOut calls
+ * getCsrfToken directly and consumes its own errors.
+ */
+const throwSessionExpired = async (url: string): Promise<never> => {
+  await recordAutoLogout401(url)
+  reportError(url, 401)
+  const error = new Error('Request failed with status 401') as Error & {
+    response: { status: number, data: { message?: string, code?: number } }
+  }
+  error.response = { status: 401, data: {} }
+  throw error
+}
+
 async function handleResponse<T>(
   res: Response,
   url: string,
@@ -125,19 +165,7 @@ async function handleResponse<T>(
   if (!res.ok) {
     const apiUrl = await Config.getApiUrl()
     if (res.status === 401 && !shouldSkip401Redirect(url, method, apiUrl)) {
-      // Record relevant 401 logouts to Bard / Mixpanel.
-      // This gives systematic, empirical data to assess premature logout issues.
-      // More context: https://github.com/DataBiosphere/duos-ui/pull/3389
-      const oidcUser = Storage.getOidcUser()
-      const expiresOn = oidcUser?.profile?.exp ?? null
-      const currentTime = Math.floor(Date.now() / 1000)
-      await Metrics.captureEvent(eventList.userAutoLogout401, {
-        expires_on: expiresOn,
-        current_time: currentTime,
-        time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
-        endpoint_url: url,
-      }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
-      redirectOnLogout()
+      await recordAutoLogout401(url)
     }
     reportError(url, res.status)
 
@@ -249,6 +277,11 @@ async function fetchRequest<T>(
     return handleResponse<T>(res, fullUrl, responseType, method)
   }
   catch (error) {
+    // The gated /auth/csrf-token said the session is gone — run the normal
+    // session-expired handling instead of wrapping this as a generic failure.
+    if (error instanceof CsrfTokenSessionExpiredError) {
+      return throwSessionExpired(fullUrl)
+    }
     // TypeError = network-level failure (offline, invalid URL, CORS, etc.) that never reached the server
     // DOMException (e.g. AbortError, NotAllowedError) = aborted request or blocked by permissions policy
     // Report with status 0 (no HTTP response) rather than 502 (bad gateway) to avoid misleading monitoring
@@ -308,6 +341,14 @@ async function fetchMultipartRequest<T>(
     res = await fetchFn(fullUrl, fetchOptions)
   }
   catch (error) {
+    // Same session-expired handling as fetchRequest — see throwSessionExpired.
+    // Note this makes multipart slightly BETTER than its pre-gate behavior
+    // (multipart's own error path never redirected on a real 401): the
+    // csrf-token 401 is an unambiguous dead-session signal, so redirecting is
+    // correct, not accidental.
+    if (error instanceof CsrfTokenSessionExpiredError) {
+      return throwSessionExpired(fullUrl)
+    }
     // TypeError = network-level failure (offline, invalid URL, CORS, etc.) that never reached the server
     // DOMException (e.g. AbortError, NotAllowedError) = aborted request or blocked by permissions policy
     // Report with status 0 (no HTTP response) rather than 502 (bad gateway) to avoid misleading monitoring

--- a/src/libs/ajax/fetchAdapter.ts
+++ b/src/libs/ajax/fetchAdapter.ts
@@ -116,20 +116,45 @@ function buildUrlWithParams(url: string, params?: Params): string {
   return query ? `${url}?${query}` : url
 }
 
+/**
+ * Guards the auto-logout handler against re-entering itself.
+ *
+ * The metric below is an identified event, so in BFF mode it posts to
+ * /bard-api — an unsafe same-origin request, which fetches a CSRF token from
+ * the gated /auth/csrf-token. The session is already gone, so that fetch
+ * answers 401, and the adapter routes a 401 there straight back into this
+ * handler. Unguarded, the outer `await` never resolves: redirectOnLogout()
+ * never runs and the token endpoint is hit again on every turn. (reportError
+ * above avoids the same loop for Bard URLs, one level further in.)
+ *
+ * The nested call returns without a metric and without a redirect; the
+ * outer call finishes both exactly once.
+ */
+let autoLogoutInFlight = false
+
 // Record relevant 401 logouts to Bard / Mixpanel, then start the sign-out
 // redirect. The metric gives systematic, empirical data to assess premature
 // logout issues. More context: https://github.com/DataBiosphere/duos-ui/pull/3389
 const recordAutoLogout401 = async (url: string): Promise<void> => {
+  if (autoLogoutInFlight) return
+  autoLogoutInFlight = true
   const oidcUser = Storage.getOidcUser()
   const expiresOn = oidcUser?.profile?.exp ?? null
   const currentTime = Math.floor(Date.now() / 1000)
-  await Metrics.captureEvent(eventList.userAutoLogout401, {
-    expires_on: expiresOn,
-    current_time: currentTime,
-    time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
-    endpoint_url: url,
-  }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
-  redirectOnLogout()
+  try {
+    await Metrics.captureEvent(eventList.userAutoLogout401, {
+      expires_on: expiresOn,
+      current_time: currentTime,
+      time_until_expires: expiresOn === null ? null : expiresOn - currentTime,
+      endpoint_url: url,
+    }, AbortSignal.timeout(1000)) // Wait <= 1s, abort if log slower
+  }
+  finally {
+    // The sign-out must start even if the metric throws, and the flag must
+    // clear so a later 401 in a page that did not navigate still records.
+    autoLogoutInFlight = false
+    redirectOnLogout()
+  }
 }
 
 /**
@@ -144,7 +169,8 @@ const recordAutoLogout401 = async (url: string): Promise<void> => {
  * (an ECM 401 is not). This 401 comes from the BFF itself, so it is always
  * authoritative — even when the blocked request was headed for a sibling
  * proxy prefix. No redirect loop is possible: Auth.signOut calls
- * getCsrfToken directly and consumes its own errors.
+ * getCsrfToken directly and consumes its own errors, and the telemetry
+ * below cannot re-enter this handler — see autoLogoutInFlight.
  */
 const throwSessionExpired = async (url: string): Promise<never> => {
   await recordAutoLogout401(url)

--- a/test/libs/ajax/csrf.spec.ts
+++ b/test/libs/ajax/csrf.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { CSRF_ERROR_CODE, getCsrfToken, isCsrfRejection, resetCsrfToken } from 'src/libs/ajax/csrf'
+import { CSRF_ERROR_CODE, CsrfTokenSessionExpiredError, getCsrfToken, isCsrfRejection, resetCsrfToken } from 'src/libs/ajax/csrf'
 
 describe('csrf', () => {
   let fetchMock: ReturnType<typeof vi.fn>
@@ -68,11 +68,32 @@ describe('csrf', () => {
 
   it('rejects on a non-ok response without caching it', async () => {
     fetchMock
-      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce({ ok: false, status: 500, json: () => Promise.resolve({}) })
+      .mockResolvedValueOnce(tokenResponse('csrf-after-recovery'))
+
+    await expect(getCsrfToken()).rejects.toThrow('500')
+    expect(await getCsrfToken()).toBe('csrf-after-recovery')
+  })
+
+  // /auth/csrf-token is gated on an authenticated session (story 5-B), so its
+  // 401 is a session-expired signal, not a generic failure — the adapter keys
+  // its redirect handling on this type.
+  it('throws the typed session-expired error on a 401, without caching it', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({ error: 'unauthenticated' }) })
       .mockResolvedValueOnce(tokenResponse('csrf-after-login'))
 
-    await expect(getCsrfToken()).rejects.toThrow('401')
+    await expect(getCsrfToken()).rejects.toBeInstanceOf(CsrfTokenSessionExpiredError)
     expect(await getCsrfToken()).toBe('csrf-after-login')
+  })
+
+  it('does not use the typed error for other non-ok statuses', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 502, json: () => Promise.resolve({}) })
+
+    const failure = await getCsrfToken().catch((e: unknown) => e)
+
+    expect(failure).toBeInstanceOf(Error)
+    expect(failure).not.toBeInstanceOf(CsrfTokenSessionExpiredError)
   })
 
   describe('isCsrfRejection', () => {

--- a/test/libs/ajax/csrfCrossTab.spec.ts
+++ b/test/libs/ajax/csrfCrossTab.spec.ts
@@ -16,7 +16,7 @@ import { Config } from 'src/libs/config'
 // full-page navigation, which resets the module cache — the freshly loaded
 // page cannot hold a stale token. A SECOND tab can: it keeps its module cache
 // across the first tab's re-login, and the session rotation at that login
-// (Epic 5, 5-C) discards the server-side secret its cached token was minted
+// (Phase 5, 5-C) discards the server-side secret its cached token was minted
 // against.
 // ---------------------------------------------------------------------------
 

--- a/test/libs/ajax/csrfCrossTab.spec.ts
+++ b/test/libs/ajax/csrfCrossTab.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { fetchPost } from 'src/libs/ajax/fetchAdapter'
 import { resetCsrfToken } from 'src/libs/ajax/csrf'
 import { Config } from 'src/libs/config'
+import { redirectOnLogout } from 'src/libs/auth/auth'
 
 // ---------------------------------------------------------------------------
 // Story 5-B: the cross-tab stale-token recovery, end to end.
@@ -56,6 +57,10 @@ function makeBffStub() {
     // What /auth/csrf-token hands out. Normally the same as serverToken;
     // split so a test can model a recovery whose fresh token STILL fails.
     issuedToken: null as string | null,
+    // Session destroyed/expired: /auth/csrf-token is gated on authentication
+    // (story 5-B) and answers 401; a POST finds no session secret and gets
+    // the missing_secret CSRF rejection.
+    sessionDead: false,
     tokenFetches: 0,
     postAttempts: [] as string[],
   }
@@ -63,6 +68,12 @@ function makeBffStub() {
   const fetchMock = vi.fn(async (url: string, init?: { headers?: Record<string, string> }) => {
     if (url === '/auth/csrf-token') {
       state.tokenFetches += 1
+      if (state.sessionDead) {
+        return new Response(JSON.stringify({ error: 'unauthenticated' }), {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
       return new Response(JSON.stringify({ token: state.issuedToken ?? state.serverToken }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
@@ -70,6 +81,12 @@ function makeBffStub() {
     }
     const sent = init?.headers?.['X-CSRF-Token'] ?? ''
     state.postAttempts.push(sent)
+    if (state.sessionDead) {
+      return new Response(
+        JSON.stringify({ error: 'csrf_validation_failed', reason: 'missing_secret' }),
+        { status: 403, headers: { 'content-type': 'application/json' } },
+      )
+    }
     if (sent !== state.serverToken) {
       return new Response(
         JSON.stringify({ error: 'csrf_validation_failed', reason: 'invalid_token' }),
@@ -87,6 +104,7 @@ function makeBffStub() {
 
 describe('cross-tab stale CSRF token recovery (real csrf module)', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     // The token cache is module-level state shared across tests — start cold.
     resetCsrfToken()
     vi.mocked(Config.isBffEnabled).mockResolvedValue(true)
@@ -153,5 +171,24 @@ describe('cross-tab stale CSRF token recovery (real csrf module)', () => {
 
     // Initial success + stale attempt + single retry: exactly three POSTs.
     expect(state.postAttempts).toHaveLength(3)
+  })
+
+  // The expired-session path end to end, with the REAL csrf module: warm
+  // token → session dies → stale POST gets the CSRF 403 → the retry refetches
+  // → the gated /auth/csrf-token answers 401 → the adapter runs the normal
+  // session-expired handling instead of a generic help-desk error.
+  it('redirects to sign-out when the session dies under a warm cache', async () => {
+    const { state, fetchMock } = makeBffStub()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchPost('/duos-api/api/dataset', { name: 'one' })
+    state.sessionDead = true
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'two' }))
+      .rejects.toMatchObject({ response: { status: 401 } })
+
+    expect(redirectOnLogout).toHaveBeenCalledOnce()
+    // The stale POST went out once; the refetch 401 stopped the retry POST.
+    expect(state.postAttempts).toHaveLength(2)
   })
 })

--- a/test/libs/ajax/csrfCrossTab.spec.ts
+++ b/test/libs/ajax/csrfCrossTab.spec.ts
@@ -1,0 +1,157 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchPost } from 'src/libs/ajax/fetchAdapter'
+import { resetCsrfToken } from 'src/libs/ajax/csrf'
+import { Config } from 'src/libs/config'
+
+// ---------------------------------------------------------------------------
+// Story 5-B: the cross-tab stale-token recovery, end to end.
+//
+// fetchAdapter.spec.ts mocks getCsrfToken/resetCsrfToken away, so its retry
+// tests prove the adapter's branching but not the real token cache's part in
+// it. This suite keeps src/libs/ajax/csrf REAL and fakes only the server, so
+// the whole loop runs: cache warm → server rotates → stale send → rejection →
+// cache reset → refetch → retry with the NEW token.
+//
+// Why cross-tab is the realistic stale-token path: a normal login is a
+// full-page navigation, which resets the module cache — the freshly loaded
+// page cannot hold a stale token. A SECOND tab can: it keeps its module cache
+// across the first tab's re-login, and the session rotation at that login
+// (Epic 5, 5-C) discards the server-side secret its cached token was minted
+// against.
+// ---------------------------------------------------------------------------
+
+vi.mock('src/libs/config', async importOriginal => ({
+  ...(await importOriginal<typeof import('src/libs/config')>()),
+  Config: {
+    getApiUrl: vi.fn(),
+    getBardApiUrl: vi.fn(),
+    isBffEnabled: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/ajax/Metrics', () => ({
+  Metrics: { captureEvent: vi.fn() },
+}))
+
+vi.mock('src/libs/storage', () => ({
+  Storage: { getOidcUser: vi.fn() },
+}))
+
+vi.mock('src/libs/auth/auth', () => ({
+  redirectOnLogout: vi.fn(),
+}))
+
+vi.mock('src/libs/ErrorReporter', () => ({
+  ErrorReporter: { report: vi.fn() },
+}))
+
+/**
+ * A stand-in BFF: hands out its current token on /auth/csrf-token and
+ * accepts a proxied POST only when X-CSRF-Token matches it. Rotating the
+ * session is one assignment to `serverToken`.
+ */
+function makeBffStub() {
+  const state = {
+    serverToken: 'token-a',
+    // What /auth/csrf-token hands out. Normally the same as serverToken;
+    // split so a test can model a recovery whose fresh token STILL fails.
+    issuedToken: null as string | null,
+    tokenFetches: 0,
+    postAttempts: [] as string[],
+  }
+
+  const fetchMock = vi.fn(async (url: string, init?: { headers?: Record<string, string> }) => {
+    if (url === '/auth/csrf-token') {
+      state.tokenFetches += 1
+      return new Response(JSON.stringify({ token: state.issuedToken ?? state.serverToken }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }
+    const sent = init?.headers?.['X-CSRF-Token'] ?? ''
+    state.postAttempts.push(sent)
+    if (sent !== state.serverToken) {
+      return new Response(
+        JSON.stringify({ error: 'csrf_validation_failed', reason: 'invalid_token' }),
+        { status: 403, headers: { 'content-type': 'application/json' } },
+      )
+    }
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  })
+
+  return { state, fetchMock }
+}
+
+describe('cross-tab stale CSRF token recovery (real csrf module)', () => {
+  beforeEach(() => {
+    // The token cache is module-level state shared across tests — start cold.
+    resetCsrfToken()
+    vi.mocked(Config.isBffEnabled).mockResolvedValue(true)
+    vi.mocked(Config.getApiUrl).mockResolvedValue('/duos-api')
+    vi.mocked(Config.getBardApiUrl).mockResolvedValue('https://bard.example.org')
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetCsrfToken()
+  })
+
+  it('recovers when the session rotates under a warm cache: rejection → refetch → retry with the new token', async () => {
+    const { state, fetchMock } = makeBffStub()
+    vi.stubGlobal('fetch', fetchMock)
+
+    // This tab warms its cache and uses token-a successfully.
+    const first = await fetchPost<{ ok: boolean }>('/duos-api/api/dataset', { name: 'one' })
+    expect(first.data).toEqual({ ok: true })
+    expect(state.tokenFetches).toBe(1)
+    expect(state.postAttempts).toEqual(['token-a'])
+
+    // Another tab re-authenticates; session rotation discards the old secret
+    // and the server now only honors the new session's token.
+    state.serverToken = 'token-b'
+
+    // This tab's next write sends the stale cached token, gets the CSRF
+    // rejection, refetches ONCE, and retries with the new token — invisibly
+    // to the caller.
+    const second = await fetchPost<{ ok: boolean }>('/duos-api/api/dataset', { name: 'two' })
+
+    expect(second.data).toEqual({ ok: true })
+    expect(state.postAttempts).toEqual(['token-a', 'token-a', 'token-b'])
+    expect(state.tokenFetches).toBe(2) // one warm-up, one recovery — no extra churn
+  })
+
+  it('caches the recovered token: the next write reuses it without another fetch', async () => {
+    const { state, fetchMock } = makeBffStub()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchPost('/duos-api/api/dataset', { name: 'one' })
+    state.serverToken = 'token-b'
+    await fetchPost('/duos-api/api/dataset', { name: 'two' })
+
+    const third = await fetchPost<{ ok: boolean }>('/duos-api/api/dataset', { name: 'three' })
+
+    expect(third.data).toEqual({ ok: true })
+    expect(state.postAttempts.at(-1)).toBe('token-b')
+    expect(state.tokenFetches).toBe(2) // still two — token-b came from the cache
+  })
+
+  it('surfaces the failure (bounded retry) when the refetched token is rejected too', async () => {
+    const { state, fetchMock } = makeBffStub()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await fetchPost('/duos-api/api/dataset', { name: 'one' })
+    // A server that rejects even the refetched token — e.g. the session died
+    // entirely, so nothing this tab can mint verifies. The adapter must stop
+    // after ONE retry rather than loop.
+    state.serverToken = 'never-issued'
+    state.issuedToken = 'token-b'
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'two' })).rejects.toThrow()
+
+    // Initial success + stale attempt + single retry: exactly three POSTs.
+    expect(state.postAttempts).toHaveLength(3)
+  })
+})

--- a/test/libs/ajax/csrfSessionExpiredMetric.spec.ts
+++ b/test/libs/ajax/csrfSessionExpiredMetric.spec.ts
@@ -1,0 +1,162 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchGet, fetchPost } from 'src/libs/ajax/fetchAdapter'
+import { resetCsrfToken } from 'src/libs/ajax/csrf'
+import { Config, Token } from 'src/libs/config'
+import { Storage } from 'src/libs/storage'
+import { redirectOnLogout } from 'src/libs/auth/auth'
+
+// ---------------------------------------------------------------------------
+// Story 5-B: the session-expired handler must not re-enter itself.
+//
+// The other suites mock src/libs/ajax/Metrics away, so the auto-logout metric
+// is a no-op in them. It is not a no-op in the browser: an identified event
+// posts to /bard-api, an unsafe same-origin request that fetches its own CSRF
+// token — from the same gated endpoint whose 401 starts the handler. This
+// suite keeps BOTH the csrf module and Metrics REAL, so the metric really
+// tries to go out and the loop is either bounded or the test fails.
+//
+// Two entry points reach the loop, and both are covered below:
+//   1. the token fetch for an unsafe request answers 401;
+//   2. a DUOS API response is a 401 and the token cache is cold, so the
+//      metric's own token fetch answers 401.
+// ---------------------------------------------------------------------------
+
+vi.mock('src/libs/config', async importOriginal => ({
+  ...(await importOriginal<typeof import('src/libs/config')>()),
+  Config: {
+    getApiUrl: vi.fn(),
+    getBardApiUrl: vi.fn(),
+    isBffEnabled: vi.fn(),
+  },
+  Token: { getToken: vi.fn() },
+}))
+
+vi.mock('src/libs/storage', () => ({
+  Storage: {
+    getOidcUser: vi.fn(),
+    userIsLogged: vi.fn(),
+    getCurrentUser: vi.fn(),
+    getAnonymousId: vi.fn(),
+    setAnonymousId: vi.fn(),
+  },
+}))
+
+vi.mock('src/libs/auth/auth', () => ({
+  redirectOnLogout: vi.fn(),
+}))
+
+vi.mock('src/libs/ErrorReporter', () => ({
+  ErrorReporter: { report: vi.fn() },
+}))
+
+vi.mock('@databiosphere/bard-client', () => ({
+  getDefaultProperties: vi.fn().mockReturnValue({}),
+}))
+
+// The hard cap turns a recursion regression into a failed assertion instead
+// of a test run that hangs.
+const CALL_CAP = 12
+
+/**
+ * A dead-session BFF: /auth/csrf-token is gated and answers 401, the
+ * /bard-api proxy holds no session token and answers 401, and the DUOS API
+ * answers with `apiStatus`.
+ */
+function makeDeadSessionBff(apiStatus: number = 200) {
+  const state = { tokenFetches: 0, metricPosts: 0, apiCalls: 0, calls: 0 }
+
+  const unauthenticated = () => new Response(JSON.stringify({ error: 'unauthenticated' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' },
+  })
+
+  const fetchMock = vi.fn(async (url: string) => {
+    state.calls += 1
+    if (state.calls > CALL_CAP) {
+      throw new Error(`the session-expired handler looped: more than ${CALL_CAP} requests`)
+    }
+    if (url === '/auth/csrf-token') {
+      state.tokenFetches += 1
+      return unauthenticated()
+    }
+    if (url.startsWith('/bard-api/')) {
+      state.metricPosts += 1
+      return unauthenticated()
+    }
+    state.apiCalls += 1
+    return new Response(JSON.stringify({ ok: true }), {
+      status: apiStatus,
+      headers: { 'content-type': 'application/json' },
+    })
+  })
+
+  return { state, fetchMock }
+}
+
+describe('session-expired handling with the real Metrics path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetCsrfToken()
+    vi.mocked(Config.isBffEnabled).mockResolvedValue(true)
+    vi.mocked(Config.getApiUrl).mockResolvedValue('/duos-api')
+    vi.mocked(Config.getBardApiUrl).mockResolvedValue('https://bard.example.org')
+    vi.mocked(Token.getToken).mockReturnValue(undefined)
+    // A registered user: this is what makes the metric identified, so it
+    // rides /bard-api instead of the cross-origin (token-free) Bard URL.
+    vi.mocked(Storage.userIsLogged).mockReturnValue(true)
+    vi.mocked(Storage.getCurrentUser).mockReturnValue({ userId: 42 } as ReturnType<typeof Storage.getCurrentUser>)
+    vi.mocked(Storage.getAnonymousId).mockReturnValue('anon-id')
+    vi.mocked(Storage.getOidcUser).mockReturnValue({} as ReturnType<typeof Storage.getOidcUser>)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    resetCsrfToken()
+  })
+
+  it('redirects once and stops when the token fetch for a write answers 401', async () => {
+    const { state, fetchMock } = makeDeadSessionBff()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'two' }))
+      .rejects.toMatchObject({ response: { status: 401 } })
+
+    expect(redirectOnLogout).toHaveBeenCalledOnce()
+    expect(state.apiCalls).toBe(0) // the write itself never went out
+    // One token fetch for the write, one for the metric that the handler
+    // then tries to send. The metric dies at its token fetch, so it never
+    // reaches /bard-api — and it never starts a third round.
+    expect(state.tokenFetches).toBe(2)
+    expect(state.metricPosts).toBe(0)
+  })
+
+  it('redirects once and stops when a DUOS API 401 meets a cold token cache', async () => {
+    const { state, fetchMock } = makeDeadSessionBff(401)
+    vi.stubGlobal('fetch', fetchMock)
+
+    // A GET needs no token of its own, so the FIRST token fetch here is the
+    // metric's. Its 401 lands back in the handler that sent it.
+    await expect(fetchGet('/duos-api/api/dataset/1'))
+      .rejects.toMatchObject({ response: { status: 401 } })
+
+    expect(redirectOnLogout).toHaveBeenCalledOnce()
+    expect(state.apiCalls).toBe(1)
+    expect(state.tokenFetches).toBe(1)
+    expect(state.metricPosts).toBe(0)
+  })
+
+  // The guard must not become a one-shot latch: it clears when the handler
+  // finishes, so a page that has not navigated yet still records the next one.
+  it('records again after the first handler finishes', async () => {
+    const { state, fetchMock } = makeDeadSessionBff()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'one' })).rejects.toThrow()
+    const afterFirst = state.tokenFetches
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'two' })).rejects.toThrow()
+
+    expect(redirectOnLogout).toHaveBeenCalledTimes(2)
+    expect(state.tokenFetches).toBeGreaterThan(afterFirst)
+  })
+})

--- a/test/libs/ajax/fetchAdapter.spec.ts
+++ b/test/libs/ajax/fetchAdapter.spec.ts
@@ -14,7 +14,7 @@ import { Metrics } from 'src/libs/ajax/Metrics'
 import { Storage } from 'src/libs/storage'
 import { Config } from 'src/libs/config'
 import { redirectOnLogout } from 'src/libs/auth/auth'
-import { getCsrfToken, resetCsrfToken } from 'src/libs/ajax/csrf'
+import { CsrfTokenSessionExpiredError, getCsrfToken, resetCsrfToken } from 'src/libs/ajax/csrf'
 import type { OidcUser } from 'src/libs/auth/oidcBroker'
 import { ErrorReporter } from 'src/libs/ErrorReporter'
 import eventList from 'src/libs/events'
@@ -1058,6 +1058,58 @@ describe('fetchAdapter - BFF mode', () => {
       .rejects.toThrow('csrf endpoint down Please contact the help desk')
 
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  // The gated /auth/csrf-token 401s on a dead session (story 5-B). That
+  // signal must run the SAME session-expired handling as a real 401 response
+  // — metric, redirectOnLogout, and the axios-like 401 shape — or an expired
+  // session on a write surfaces as a help-desk error and the UI stays stale.
+  it('runs the session-expired flow when the CSRF token fetch returns 401', async () => {
+    vi.mocked(getCsrfToken).mockRejectedValue(new CsrfTokenSessionExpiredError())
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'test' }))
+      .rejects.toMatchObject({ message: 'Request failed with status 401', response: { status: 401 } })
+
+    expect(fetchMock).not.toHaveBeenCalled() // the write itself was never sent
+    expect(redirectOnLogout).toHaveBeenCalledOnce()
+    expect(Metrics.captureEvent).toHaveBeenCalledWith(
+      eventList.userAutoLogout401,
+      expect.objectContaining({ endpoint_url: '/duos-api/api/dataset' }),
+      expect.anything(),
+    )
+  })
+
+  // shouldSkip401Redirect would skip an ECM 401 (a sibling upstream is not
+  // authoritative about the DUOS session) — but this 401 came from the BFF's
+  // own /auth/csrf-token, which always is. The redirect must fire regardless
+  // of where the blocked request was headed.
+  it('redirects even when the blocked request targeted a sibling upstream proxy', async () => {
+    vi.mocked(getCsrfToken).mockRejectedValue(new CsrfTokenSessionExpiredError())
+
+    await expect(fetchPost('/ecm-api/api/oidc/v1/ras/link', { code: 'x' }))
+      .rejects.toMatchObject({ response: { status: 401 } })
+
+    expect(redirectOnLogout).toHaveBeenCalledOnce()
+  })
+
+  it('does not run the session-expired flow for an ordinary token fetch failure', async () => {
+    vi.mocked(getCsrfToken).mockRejectedValue(new Error('csrf endpoint down'))
+
+    await expect(fetchPost('/duos-api/api/dataset', { name: 'test' })).rejects.toThrow('csrf endpoint down')
+
+    expect(redirectOnLogout).not.toHaveBeenCalled()
+  })
+
+  it('fetchMultipart - runs the session-expired flow when the token fetch returns 401', async () => {
+    vi.mocked(getCsrfToken).mockRejectedValue(new CsrfTokenSessionExpiredError())
+    const formData = new FormData()
+    formData.append('file', 'content')
+
+    await expect(fetchMultipart('/duos-api/api/upload', formData))
+      .rejects.toMatchObject({ response: { status: 401 } })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(redirectOnLogout).toHaveBeenCalledOnce()
   })
 
   it('fetchMultipart - does not attach X-CSRF-Token on cross-origin URLs', async () => {


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-4017

### Summary

Hardening-phase audit that the CSRF legs from Phases 2–4 compose correctly, plus the two new controls the audit called for. Security risk: low (adds request-rejection rules; no new surface).

**Gate `/auth/csrf-token` on an authenticated session.** Anonymous requests now get 401 and mint no session row (previously any same-origin request created an anonymous session row plus a token). The handler is shared (`server/src/auth/csrf.ts`) so `index.ts` and both test harnesses register the same route — the same anti-drift pattern as `csrfPluginOptions`. It saves the session before replying to avoid the documented `ERR_HTTP_HEADERS_SENT` double-send.

**Fetch Metadata enforcement (`server/src/security/fetchMetadata.ts`)** closing the ADR-009 residual (state-changing upstream GETs, reachable same-site where `SameSite=Lax` still sends the cookie). Positive allowlist: when `Sec-Fetch-Site` is present, require `same-origin` plus a `cors`/`same-origin` mode; absent headers (older browsers) are allowed and documented — the CSRF/session controls carry the load there. Wired first in the shared proxy machinery (all four prefixes, so a new upstream cannot opt out) and on `/auth/me` (it calls Consent's state-changing `GET /api/user/me` server-side). `/auth/login` and `/auth/callback` are exempt: the OAuth callback is a legitimate cross-site navigation from B2C.

**Route audit:** the only unsafe cookie-authenticated routes are `POST /auth/logout` (`csrfProtection`) and the proxy unsafe methods (`csrfForUnsafeMethods`, exemptions pinned). `POST /auth/login` stays deliberately exempt (pre-authentication; PKCE state binds the flow to the session). Health, config.json, and the SPA fallback are state-less.

**State-changing-GET audit re-run** against Consent `develop` (`001497ae1`, 2026-08-24): same two endpoints (`GET /api/nih/sync`, `GET /api/user/me`), no new ones among 91 `@GET` methods in 37 resource files. Recorded in `docs/plans/bff_adrs/ADR-009-state-changing-gets.md` along with the implemented mitigation; DT-3945 (the upstream fix) stays open.

### Test plan

- `server/test/fetchMetadata.test.ts` — the allowlist matrix, including the same-site shapes (credentialed `cors` fetch, `no-cors` subresource, navigation) and the fail-closed malformed shapes.
- `server/test/apiProxy.test.ts` — rejected requests never reach the upstream; forged cross-origin form POSTs in both browser generations (modern dies at Fetch Metadata, legacy dies at CSRF); allowlisted unauthenticated paths covered too.
- `server/test/ecmProxy.test.ts` / `tdrProxy.test.ts` / `bardProxy.test.ts` — one wiring case per prefix.
- `server/test/auth.test.ts` — token-gate cases (anonymous 401 + no session row, pre-auth 401, authenticated 200 with the secret persisted before the reply); the `/auth/me` matrix with the upstream fetch asserted uncalled; a forged form POST to `/auth/logout`.
- `server/test/index.test.ts` — `buildApp()` wires the gated handler and guards `/auth/me` while leaving `/auth/callback` navigable.
- `test/libs/ajax/csrfCrossTab.spec.ts` — cross-tab stale-token recovery driving the REAL csrf module: warm cache → rotation in another tab → 403 → one refetch → retry with the new token; plus the bounded-retry failure case.
- Full runs: 366 server tests, client suite, lint, both type-checks, and the server build all green.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)