### PR TITLE
Claude suggested flaky test fixes.

### DIFF
--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,6 +4,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     include: ['test/**/*.{spec,test}.{js,ts}'],
     env: {
       FASTIFY_LOG_LEVEL: 'silent',

--- a/test/components/ai_models_list/AiModelAddEdit.spec.tsx
+++ b/test/components/ai_models_list/AiModelAddEdit.spec.tsx
@@ -79,9 +79,7 @@ describe('AiModelAddEdit component', () => {
   it('edits existing model and saves changes', async () => {
     const user = userEvent.setup()
     const models: AiModel[] = [sampleModel]
-    const onAiModelsChange = vi.fn((updated: AiModel[]) => {
-      expect(updated[0].name).toBe('Baseline Model Edited')
-    })
+    const onAiModelsChange = vi.fn()
     const { container } = render(
       <AiModelAddEdit
         id={0}
@@ -94,5 +92,9 @@ describe('AiModelAddEdit component', () => {
     await user.clear(container.querySelector('#name')!)
     await user.type(container.querySelector('#name')!, 'Baseline Model Edited')
     await user.click(container.querySelector('.collaborator-form-add-save-button')!)
+
+    expect(onAiModelsChange).toHaveBeenCalledTimes(1)
+    const [updated] = onAiModelsChange.mock.calls[0] as [AiModel[]]
+    expect(updated[0].name).toBe('Baseline Model Edited')
   })
 })

--- a/test/components/clinical_trial_list/ClinicalTrialAddEdit.spec.tsx
+++ b/test/components/clinical_trial_list/ClinicalTrialAddEdit.spec.tsx
@@ -82,10 +82,7 @@ describe('ClinicalTrialAddEdit component', () => {
   it('edits existing trial and saves changes', async () => {
     const user = userEvent.setup()
     const trials: ClinicalTrial[] = [sampleTrial]
-    const onChangeFn = vi.fn((updated: ClinicalTrial[]) => {
-      expect(updated[0].title).toBe('Baseline Trial Edited')
-      expect(updated[0].phase).toBe(ClinicalTrialPhase.PHASE2)
-    })
+    const onChangeFn = vi.fn()
     const { container } = render(
       <ClinicalTrialAddEdit
         id={0}
@@ -98,5 +95,10 @@ describe('ClinicalTrialAddEdit component', () => {
     await user.clear(container.querySelector('#title')!)
     await user.type(container.querySelector('#title')!, 'Baseline Trial Edited')
     await user.click(container.querySelector('.collaborator-form-add-save-button')!)
+
+    expect(onChangeFn).toHaveBeenCalledTimes(1)
+    const [updated] = onChangeFn.mock.calls[0] as [ClinicalTrial[]]
+    expect(updated[0].title).toBe('Baseline Trial Edited')
+    expect(updated[0].phase).toBe(ClinicalTrialPhase.PHASE2)
   })
 })

--- a/test/components/funding_resource_list/FundingResourceAddEdit.spec.tsx
+++ b/test/components/funding_resource_list/FundingResourceAddEdit.spec.tsx
@@ -50,9 +50,7 @@ describe('FundingResourceAddEdit component', () => {
   it('edits existing funding resource and saves changes', async () => {
     const user = userEvent.setup({ delay: null })
     const resources: FundingResource[] = [sampleFunding]
-    const onFundingResourcesChange = vi.fn((updated: FundingResource[]) => {
-      expect(updated[0].funderName).toBe('Funder A Edited')
-    })
+    const onFundingResourcesChange = vi.fn()
     const { container } = render(
       <FundingResourceAddEdit
         id={0}
@@ -65,5 +63,9 @@ describe('FundingResourceAddEdit component', () => {
     await user.clear(container.querySelector('#funderName')!)
     await user.type(container.querySelector('#funderName')!, 'Funder A Edited')
     await user.click(container.querySelector('.collaborator-form-add-save-button')!)
+
+    expect(onFundingResourcesChange).toHaveBeenCalledTimes(1)
+    const [updated] = onFundingResourcesChange.mock.calls[0] as [FundingResource[]]
+    expect(updated[0].funderName).toBe('Funder A Edited')
   }, 15000)
 })

--- a/test/components/workspaces_list/WorkspaceAddEdit.spec.tsx
+++ b/test/components/workspaces_list/WorkspaceAddEdit.spec.tsx
@@ -76,9 +76,7 @@ describe('WorkspaceAddEdit component', () => {
   it('edits existing workspace and saves changes', async () => {
     const user = userEvent.setup()
     const workspaces: Workspace[] = [sampleWorkspace]
-    const onWorkspaceChange = vi.fn((updated: Workspace[]) => {
-      expect(updated[0].name).toBe('Analysis Workspace Edited')
-    })
+    const onWorkspaceChange = vi.fn()
     const { container } = render(
       <WorkspaceAddEdit
         id={0}
@@ -91,5 +89,9 @@ describe('WorkspaceAddEdit component', () => {
     await user.clear(container.querySelector('#name')!)
     await user.type(container.querySelector('#name')!, 'Analysis Workspace Edited')
     await user.click(container.querySelector('.collaborator-form-add-save-button')!)
+
+    expect(onWorkspaceChange).toHaveBeenCalledTimes(1)
+    const [updated] = onWorkspaceChange.mock.calls[0] as [Workspace[]]
+    expect(updated[0].name).toBe('Analysis Workspace Edited')
   })
 })

--- a/test/libs/ajax/fetchAdapter.spec.ts
+++ b/test/libs/ajax/fetchAdapter.spec.ts
@@ -629,7 +629,7 @@ describe('fetchAdapter - Fetch methods', () => {
       )
 
       await fetchPost('/api/dar/v2', { data: 'test' }).catch(() => {})
-      await vi.waitFor(() => expect(ErrorReporter.report).toHaveBeenCalledOnce())
+      await vi.waitFor(() => expect(ErrorReporter.report).toHaveBeenCalledOnce(), { timeout: 5000 })
     })
   })
 })
@@ -1044,9 +1044,9 @@ describe('fetchAdapter - BFF mode', () => {
       .rejects.toThrow('csrf endpoint down Please contact the help desk')
 
     expect(fetchMock).not.toHaveBeenCalled()
-    // Give the fire-and-forget reportError chain time to complete
-    await new Promise(resolve => setTimeout(resolve, 0))
-    expect(ErrorReporter.report).toHaveBeenCalled()
+    // reportError is fire-and-forget, so poll for it rather than assuming it lands
+    // within a single macrotask.
+    await vi.waitFor(() => expect(ErrorReporter.report).toHaveBeenCalled(), { timeout: 5000 })
   })
 
   it('fetchMultipart - reports and wraps a CSRF token acquisition failure the same way', async () => {

--- a/test/libs/auth/auth.spec.ts
+++ b/test/libs/auth/auth.spec.ts
@@ -142,7 +142,10 @@ describe('Auth (BFF mode)', () => {
     // The BFF signIn promise never settles (full-page redirect), so don't await it
     void Auth.signIn()
 
-    await vi.waitFor(() => expect(redirectSpy).toHaveBeenCalledWith('https://b2c.example.com/authorize?state=xyz'))
+    await vi.waitFor(
+      () => expect(redirectSpy).toHaveBeenCalledWith('https://b2c.example.com/authorize?state=xyz'),
+      { timeout: 5000 },
+    )
     expect(fetchMock).toHaveBeenCalledWith('/auth/login', { method: 'POST', credentials: 'include' })
   })
 
@@ -156,7 +159,10 @@ describe('Auth (BFF mode)', () => {
 
     void Auth.signIn('/datalibrary?tab=all')
 
-    await vi.waitFor(() => expect(redirectSpy).toHaveBeenCalledWith('https://b2c.example.com/authorize'))
+    await vi.waitFor(
+      () => expect(redirectSpy).toHaveBeenCalledWith('https://b2c.example.com/authorize'),
+      { timeout: 5000 },
+    )
     expect(fetchMock).toHaveBeenCalledWith(
       `/auth/login?returnTo=${encodeURIComponent('/datalibrary?tab=all')}`,
       { method: 'POST', credentials: 'include' },

--- a/test/pages/dar_application/ResearcherInfo.spec.tsx
+++ b/test/pages/dar_application/ResearcherInfo.spec.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { screen, waitFor, within } from '@testing-library/react'
+import { act, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Modal from 'react-modal'
 import ResearcherInfo, { ResearcherInfoProps } from 'src/pages/dar_application/ResearcherInfo'
@@ -95,16 +95,25 @@ const fillCollaboratorForm = async (user: UserEventInstance, { name, eraCommonsI
   await user.type(emailInput!, email)
 }
 
-const AsyncResearcherWrapper = (componentProps: ResearcherInfoProps) => {
+// Models a researcher that arrives asynchronously. The arrival is driven by a promise
+// the test resolves explicitly rather than by a real timer, so "before the load
+// completes" is a state the test controls instead of a wall-clock race it has to win.
+type AsyncResearcherWrapperProps = ResearcherInfoProps & { researcherLoad: Promise<DuosUser> }
+
+const AsyncResearcherWrapper = ({ researcherLoad, ...componentProps }: AsyncResearcherWrapperProps) => {
   const [asyncResearcher, setAsyncResearcher] = useState<DuosUser>({} as DuosUser)
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setAsyncResearcher({ displayName: 'Sample Researcher', email: 'researcher@example.test' } as DuosUser)
-    }, 50)
+    let cancelled = false
 
-    return () => clearTimeout(timer)
-  }, [])
+    researcherLoad.then((loaded) => {
+      if (!cancelled) setAsyncResearcher(loaded)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [researcherLoad])
 
   return <ResearcherInfo {...componentProps} researcher={asyncResearcher} />
 }
@@ -127,13 +136,24 @@ describe('Researcher Info', () => {
   })
 
   it('does not show the library card warning before async researcher load completes', async () => {
-    renderWithRouter(<AsyncResearcherWrapper {...props} />)
+    let completeResearcherLoad: (researcher: DuosUser) => void = () => {}
+    const researcherLoad = new Promise<DuosUser>((resolve) => {
+      completeResearcherLoad = resolve
+    })
 
+    renderWithRouter(<AsyncResearcherWrapper {...props} researcherLoad={researcherLoad} />)
+
+    // The load is still outstanding, so this is not a race the test can lose.
     expect(document.querySelector('[data-cy="researcher-info-library-card-required"]')).toBeNull()
+
+    await act(async () => {
+      completeResearcherLoad({ displayName: 'Sample Researcher', email: 'researcher@example.test' } as DuosUser)
+      await researcherLoad
+    })
 
     await waitFor(() => {
       expect(document.querySelector('[data-cy="researcher-info-library-card-required"]')).not.toBeNull()
-    }, { timeout: 2000 })
+    })
   })
 
   it('renders the library card required alert when researcher has no library card', () => {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,8 @@
+import { configure } from '@testing-library/react'
+
+// Testing Library's default `asyncUtilTimeout` is 1000ms, which is the wall-clock
+// budget every bare `waitFor`/`findBy*` call gets. On a loaded CI machine a single
+// MUI DataGrid render can exceed that on its own, so the suite fails for lack of
+// time rather than for a real defect. Give async utilities a load-tolerant budget;
+// it costs nothing when the expectation resolves promptly.
+configure({ asyncUtilTimeout: 5000 })

--- a/vitest.browser.config.ts
+++ b/vitest.browser.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
   },
   test: {
     name: 'browser',
+    setupFiles: ['./test/setup.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     globals: true,
     include: ['test/browser/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     browser: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     pool: 'vmThreads',
+    setupFiles: ['./test/setup.ts'],
+    // Vitest's 5s default is a wall-clock budget. Under heavy CI load, render-heavy
+    // tests exhaust it and fail without any defect; worse, an abandoned test's pending
+    // userEvent keystrokes then bleed into the next test. Give tests real headroom.
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
     include: ['test/**/*.{spec,test}.{js,jsx,ts,tsx}'],
     exclude: ['test/browser/**', 'test/e2e/**', 'build/**', 'node_modules/**', 'server/**'],
     coverage: {


### PR DESCRIPTION
### Addresses

[https://broadworkbench.atlassian.net/browse/DT-4027](https://broadworkbench.atlassian.net/browse/DT-4027)

### Summary

44 tests across 19 files were flaky under CPU load. They looked like many unrelated
bugs but had **one root cause: wall-clock budget exhaustion** — Vitest's default 5 second
`testTimeout` and Testing Library's default 1 second `asyncUtilTimeout`. Fixed by raising
both globally, plus two genuine real-time races and four cascade-amplifiers.

All suites now pass under the same load that previously produced 79 failures.
Coverage is byte-identical.


| Run | Result |
|---|---|
| Baseline, idle | 369 files / 4341 tests — **all pass** |
| Under load, run 1 | **16 files / 37 tests fail** |
| Under load, run 2 | **18 files / 42 tests fail** |

79 failure instances total, 44 distinct tests. Different tests failed on each run —
the signature of a timing problem rather than a logic bug.

---

#### Root cause

All 79 failures trace to one thing: tests running out of wall-clock time, not
tests being wrong.

| Mechanism | Instances | Symptom |
|---|---|---|
| Vitest default **5 s `testTimeout`** | 68 / 79 | `Error: Test timed out in 5000ms` |
| RTL default **1 s `asyncUtilTimeout`** | 10 / 79 | `TestingLibraryElementError: Unable to find an element…` |
| **Cascade** from the above | ~5 / 79 | Scrambled-text uncaught exceptions (below) |

Measured under 10x load *after* the fix, the slowest tests take **4–10.5 s**. Under
the old 5 s ceiling they were guaranteed to fail; the work itself was always legitimate.

### The cascade (the part that hid the root cause)

When a test hits `testTimeout`, Vitest abandons it and starts the next one — but the
dead test's `userEvent` promise chain **keeps typing into the shared jsdom document**.

That produced assertion failures like:

```
AssertionError: expected 'ud woArnkaslpyascies  dWeosrckrsippat…'
              to be 'Analysis Workspace Edited'
```


#### Coverage is unchanged

| | Baseline | After |
|---|---|---|
| Files measured | 514 | 514 |
| **Per-file metric changes** | — | **0** |
| Lines / Statements / Functions / Branches | 89.36 / 88.74 / 86.07 / 81.56 | 89.36 / 88.74 / 86.07 / 81.56 |
| Server | 95.12 / 94.90 / 97.14 / 84.27 | 95.12 / 94.90 / 97.14 / 84.27 |

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
