### PR TITLE
[DT-3994] Update DAC profile page to User profile style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 @import './styles/buttons.css';
 @import './styles/display.css';
+@import './styles/profile-card.css';
 @import './styles/typography.css';
 
 html, body, .body, #root {

--- a/src/pages/manage_dac/DacProfile.tsx
+++ b/src/pages/manage_dac/DacProfile.tsx
@@ -15,23 +15,9 @@ import { validateHttpUrl } from 'src/utils/UrlUtils'
 import type { DacObject, Dataset, DatasetProperty } from 'src/types/model'
 import backArrowIcon from 'src/images/back_arrow.svg'
 import editDACIcon from 'src/images/dac_icon.svg'
+import './DacProfile.css'
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50]
-
-const SECTION_DIVIDER: React.CSSProperties = {
-  border: 'none',
-  borderTop: '1px solid #e0e0e0',
-  margin: '3rem 0 0 0',
-}
-
-const SECTION_TITLE_SX = {
-  fontFamily: 'Montserrat',
-  fontWeight: 600,
-  fontSize: '2rem',
-  color: '#1f3b50',
-  mt: 3,
-  mb: 2,
-}
 
 const DATAGRID_SX = {
   '& .MuiDataGrid-cell:focus': { outline: 'none' },
@@ -252,14 +238,16 @@ export const DacProfile: React.FC = () => {
       )}
 
       {/* ── Rule Automation for DARs (RADAR) ── */}
-      <hr style={SECTION_DIVIDER} />
-      <Typography sx={SECTION_TITLE_SX}>Rule Automation for DARs (RADAR)</Typography>
-      {dacId !== undefined && <DACBotComponent dacId={dacId} />}
+      <section className="dac-profile-section dac-profile-card">
+        <h1 className="dac-profile-section-heading">Rule Automation for DARs (RADAR)</h1>
+        {dacId !== undefined && <DACBotComponent dacId={dacId} />}
+      </section>
 
       {/* ── Datasets Managed by this DAC ── */}
-      <hr style={SECTION_DIVIDER} />
-      <Typography sx={SECTION_TITLE_SX}>Datasets Managed by this DAC</Typography>
-      {datasetsContent}
+      <section className="dac-profile-section dac-profile-card">
+        <h1 className="dac-profile-section-heading">Datasets Managed by this DAC</h1>
+        {datasetsContent}
+      </section>
     </div>
   )
 }

--- a/src/pages/manage_dac/DacProfile.tsx
+++ b/src/pages/manage_dac/DacProfile.tsx
@@ -11,11 +11,11 @@ import TableHeaderSection from 'src/components/TableHeaderSection'
 import { Spinner } from 'src/components/Spinner'
 import EditDac from 'src/pages/manage_dac/EditDac'
 import { DACBotComponent } from 'src/components/dac_bot/DACBotComponent'
+import { DacProfileSection } from 'src/pages/manage_dac/DacProfileSection'
 import { validateHttpUrl } from 'src/utils/UrlUtils'
 import type { DacObject, Dataset, DatasetProperty } from 'src/types/model'
 import backArrowIcon from 'src/images/back_arrow.svg'
 import editDACIcon from 'src/images/dac_icon.svg'
-import './DacProfile.css'
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50]
 
@@ -237,17 +237,13 @@ export const DacProfile: React.FC = () => {
         />
       )}
 
-      {/* ── Rule Automation for DARs (RADAR) ── */}
-      <section className="dac-profile-section dac-profile-card">
-        <h1 className="dac-profile-section-heading">Rule Automation for DARs (RADAR)</h1>
+      <DacProfileSection title="Rule Automation for DARs (RADAR)">
         {dacId !== undefined && <DACBotComponent dacId={dacId} />}
-      </section>
+      </DacProfileSection>
 
-      {/* ── Datasets Managed by this DAC ── */}
-      <section className="dac-profile-section dac-profile-card">
-        <h1 className="dac-profile-section-heading">Datasets Managed by this DAC</h1>
+      <DacProfileSection title="Datasets Managed by this DAC">
         {datasetsContent}
-      </section>
+      </DacProfileSection>
     </div>
   )
 }

--- a/src/pages/manage_dac/DacProfileSection.tsx
+++ b/src/pages/manage_dac/DacProfileSection.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Paper, Typography } from '@mui/material'
+
+// Values mirror .user-profile-card so the DAC and user profile pages share one card style.
+const CARD_SX = {
+  mt: '48px',
+  p: { xs: '20px', sm: '28px 32px 32px' },
+  border: '1px solid #d9e4f2',
+  borderRadius: '16px',
+  boxShadow: '0 10px 24px rgb(34 74 120 / 5%)',
+}
+
+const HEADING_SX = {
+  m: '0 0 24px',
+  color: '#01549f',
+  fontSize: '20px',
+  fontWeight: 600,
+}
+
+interface DacProfileSectionProps {
+  title: string
+  children?: React.ReactNode
+}
+
+export const DacProfileSection: React.FC<DacProfileSectionProps> = ({ title, children }) => {
+  const headingId = `dac-profile-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`
+
+  return (
+    <Paper component="section" elevation={0} aria-labelledby={headingId} sx={CARD_SX}>
+      <Typography id={headingId} component="h1" sx={HEADING_SX}>{title}</Typography>
+      {children}
+    </Paper>
+  )
+}

--- a/src/pages/manage_dac/DacProfileSection.tsx
+++ b/src/pages/manage_dac/DacProfileSection.tsx
@@ -1,21 +1,4 @@
-import React from 'react'
-import { Paper, Typography } from '@mui/material'
-
-// Values mirror .user-profile-card so the DAC and user profile pages share one card style.
-const CARD_SX = {
-  mt: '48px',
-  p: { xs: '20px', sm: '28px 32px 32px' },
-  border: '1px solid #d9e4f2',
-  borderRadius: '16px',
-  boxShadow: '0 10px 24px rgb(34 74 120 / 5%)',
-}
-
-const HEADING_SX = {
-  m: '0 0 24px',
-  color: '#01549f',
-  fontSize: '20px',
-  fontWeight: 600,
-}
+import React, { useId } from 'react'
 
 interface DacProfileSectionProps {
   title: string
@@ -23,12 +6,12 @@ interface DacProfileSectionProps {
 }
 
 export const DacProfileSection: React.FC<DacProfileSectionProps> = ({ title, children }) => {
-  const headingId = `dac-profile-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`
+  const headingId = useId()
 
   return (
-    <Paper component="section" elevation={0} aria-labelledby={headingId} sx={CARD_SX}>
-      <Typography id={headingId} component="h1" sx={HEADING_SX}>{title}</Typography>
+    <section className="profile-card" aria-labelledby={headingId}>
+      <h1 id={headingId} className="profile-card-heading">{title}</h1>
       {children}
-    </Paper>
+    </section>
   )
 }

--- a/src/pages/manage_dac/EditDac.tsx
+++ b/src/pages/manage_dac/EditDac.tsx
@@ -13,7 +13,6 @@ import backArrowIcon from 'src/images/back_arrow.svg'
 import { Spinner } from 'src/components/Spinner'
 import { Styles } from 'src/libs/theme'
 import PublishIcon from '@mui/icons-material/Publish'
-import { Typography } from '@mui/material'
 import { UploadDaaModal } from 'src/components/modals/UploadDaaModal'
 import { CreateDacUserModal } from 'src/components/modals/CreateDacUserModal'
 import { Storage } from 'src/libs/storage'
@@ -28,23 +27,10 @@ import {
   sortDaasByCreationDate,
 } from 'src/libs/daaHelpers'
 
+import './DacProfile.css'
+
 export const CHAIR = 'chair'
 export const MEMBER = 'member'
-
-const PROFILE_SECTION_DIVIDER: React.CSSProperties = {
-  border: 'none',
-  borderTop: '1px solid #e0e0e0',
-  margin: '3rem 0 0 0',
-}
-
-const PROFILE_SECTION_TITLE_SX = {
-  fontFamily: 'Montserrat',
-  fontWeight: 600,
-  fontSize: '2rem',
-  color: '#1f3b50',
-  mt: 3,
-  mb: 2,
-}
 
 interface EditDacProps {
   dacId?: number
@@ -1041,30 +1027,33 @@ export default function EditDac({ dacId: dacIdProp, onClose, hideHeader = false,
   const formContent = profileMode
     ? (
         <>
-          <hr style={PROFILE_SECTION_DIVIDER} />
-          <Typography sx={PROFILE_SECTION_TITLE_SX}>DAC Membership</Typography>
-          <div className="form-horizontal css-form" style={{ maxWidth: '1200px', marginTop: '1rem' }}>
-            {dacMembersJSX}
-            {chairSelectJSX}
-            {memberSelectJSX}
-          </div>
-          {profileSaveButtons}
-          <hr style={PROFILE_SECTION_DIVIDER} />
-          <Typography sx={PROFILE_SECTION_TITLE_SX}>DAC Info</Typography>
-          <form
-            className="form-horizontal css-form"
-            name="dacForm"
-            noValidate
-            encType="multipart/form-data"
-            style={{ maxWidth: '1200px', marginTop: '1rem' }}
-          >
-            {basicFieldsJSX}
-          </form>
-          {errorAlertJSX}
-          {profileSaveButtons}
-          <hr style={PROFILE_SECTION_DIVIDER} />
-          <Typography sx={PROFILE_SECTION_TITLE_SX}>Select a Data Access Agreement</Typography>
-          {daaContentJSX}
+          <section className="dac-profile-section dac-profile-card">
+            <h1 className="dac-profile-section-heading">DAC Membership</h1>
+            <div className="form-horizontal css-form" style={{ maxWidth: '1200px', marginTop: '1rem' }}>
+              {dacMembersJSX}
+              {chairSelectJSX}
+              {memberSelectJSX}
+            </div>
+            {profileSaveButtons}
+          </section>
+          <section className="dac-profile-section dac-profile-card">
+            <h1 className="dac-profile-section-heading">DAC Info</h1>
+            <form
+              className="form-horizontal css-form"
+              name="dacForm"
+              noValidate
+              encType="multipart/form-data"
+              style={{ maxWidth: '1200px', marginTop: '1rem' }}
+            >
+              {basicFieldsJSX}
+            </form>
+            {errorAlertJSX}
+            {profileSaveButtons}
+          </section>
+          <section className="dac-profile-section dac-profile-card">
+            <h1 className="dac-profile-section-heading">Select a Data Access Agreement</h1>
+            {daaContentJSX}
+          </section>
         </>
       )
     : (

--- a/src/pages/manage_dac/EditDac.tsx
+++ b/src/pages/manage_dac/EditDac.tsx
@@ -19,6 +19,7 @@ import { Storage } from 'src/libs/storage'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import type { DAAObject, DacObject, DuosUser, SimplifiedDuosUser } from 'src/types/model'
 import { DaaTabs } from 'src/components/DaaTabs'
+import { DacProfileSection } from './DacProfileSection'
 import {
   getOwnedDaas,
   getSharedDaas,
@@ -26,8 +27,6 @@ import {
   getDefaultTabForDac,
   sortDaasByCreationDate,
 } from 'src/libs/daaHelpers'
-
-import './DacProfile.css'
 
 export const CHAIR = 'chair'
 export const MEMBER = 'member'
@@ -1027,33 +1026,30 @@ export default function EditDac({ dacId: dacIdProp, onClose, hideHeader = false,
   const formContent = profileMode
     ? (
         <>
-          <section className="dac-profile-section dac-profile-card">
-            <h1 className="dac-profile-section-heading">DAC Membership</h1>
-            <div className="form-horizontal css-form" style={{ maxWidth: '1200px', marginTop: '1rem' }}>
+          <DacProfileSection title="DAC Membership">
+            <div className="form-horizontal css-form" style={{ maxWidth: '1200px' }}>
               {dacMembersJSX}
               {chairSelectJSX}
               {memberSelectJSX}
             </div>
             {profileSaveButtons}
-          </section>
-          <section className="dac-profile-section dac-profile-card">
-            <h1 className="dac-profile-section-heading">DAC Info</h1>
+          </DacProfileSection>
+          <DacProfileSection title="DAC Info">
             <form
               className="form-horizontal css-form"
               name="dacForm"
               noValidate
               encType="multipart/form-data"
-              style={{ maxWidth: '1200px', marginTop: '1rem' }}
+              style={{ maxWidth: '1200px' }}
             >
               {basicFieldsJSX}
             </form>
             {errorAlertJSX}
             {profileSaveButtons}
-          </section>
-          <section className="dac-profile-section dac-profile-card">
-            <h1 className="dac-profile-section-heading">Select a Data Access Agreement</h1>
+          </DacProfileSection>
+          <DacProfileSection title="Select a Data Access Agreement">
             {daaContentJSX}
-          </section>
+          </DacProfileSection>
         </>
       )
     : (

--- a/src/pages/user_profile/AcceptedAcknowledgements.tsx
+++ b/src/pages/user_profile/AcceptedAcknowledgements.tsx
@@ -45,7 +45,7 @@ export default function AcceptedAcknowledgements() {
 
   return (
     <div className="accepted-acknowledgements">
-      <h1 className="user-profile-section-heading">Accepted Terms & Policies</h1>
+      <h1 className="profile-card-heading">Accepted Terms & Policies</h1>
       {acceptedAcknowledgements.length === 0
         ? <p>No Accepted Terms & Policies Found</p>
         : (

--- a/src/pages/user_profile/AffiliationAndRoles.tsx
+++ b/src/pages/user_profile/AffiliationAndRoles.tsx
@@ -39,7 +39,7 @@ export default function AffiliationAndRole(props: AffiliationAndRoleProps) {
 
   return (
     <div className="affiliation-and-roles">
-      <h1 className="user-profile-section-heading">Affiliation & Role</h1>
+      <h1 className="profile-card-heading">Affiliation & Role</h1>
       <div>
         <p className="user-profile-subheading">My Institution</p>
         {institution

--- a/src/pages/user_profile/ExternalProfile.tsx
+++ b/src/pages/user_profile/ExternalProfile.tsx
@@ -252,7 +252,7 @@ export default function ExternalProfile(props: ExternalProfileProps) {
     : (
         <div className="external-profile">
           <div className="header-container">
-            <h1 className="user-profile-section-heading">
+            <h1 className="profile-card-heading">
               External Profiles
             </h1>
           </div>

--- a/src/pages/user_profile/ResearcherStatus.tsx
+++ b/src/pages/user_profile/ResearcherStatus.tsx
@@ -65,7 +65,7 @@ const ResearcherStatus: React.FC<ResearcherStatusProps> = (props) => {
 
   return (
     <>
-      <h1 className="user-profile-section-heading">Researcher Status</h1>
+      <h1 className="profile-card-heading">Researcher Status</h1>
       <p className="user-profile-subheading">Requestor Status</p>
       <Alert severity={hasCard ? 'success' : 'info'} sx={{ mb: 2 }}>
         {hasCard

--- a/src/pages/user_profile/UserProfile.css
+++ b/src/pages/user_profile/UserProfile.css
@@ -4,24 +4,6 @@
   padding: 50px clamp(24px, 10vw, 140px) 70px;
 }
 
-.user-profile-section {
-  margin-top: 48px;
-}
-
-.user-profile-card {
-  padding: 28px 32px 32px;
-  border: 1px solid #d9e4f2;
-  border-radius: 16px;
-  box-shadow: 0 10px 24px rgb(34 74 120 / 5%);
-}
-
-.user-profile-section-heading {
-  margin: 0 0 24px;
-  color: #01549f;
-  font-size: 20px;
-  font-weight: 600;
-}
-
 .user-profile-subheading {
   margin: 24px 0 12px;
   color: #000;
@@ -82,10 +64,6 @@
 @media (max-width: 700px) {
   .user-profile-page {
     padding-inline: 20px;
-  }
-
-  .user-profile-card {
-    padding: 20px;
   }
 
   .user-profile-name-row {

--- a/src/pages/user_profile/UserProfile.tsx
+++ b/src/pages/user_profile/UserProfile.tsx
@@ -115,8 +115,8 @@ export default function UserProfile() {
         description="Review and update the information DUOS holds about you"
         iconSize="none"
       />
-      <section className="user-profile-section user-profile-card">
-        <h1 className="user-profile-section-heading">Full Name</h1>
+      <section className="profile-card">
+        <h1 className="profile-card-heading">Full Name</h1>
         <div className="user-profile-name-row">
           <FormField
             type={FormFieldTypes.TEXT}
@@ -161,22 +161,22 @@ export default function UserProfile() {
           />
         </div>
       </section>
-      <section className="user-profile-section user-profile-card">
+      <section className="profile-card">
         <ExternalProfile
           readonly={false}
         />
       </section>
-      <section className="user-profile-section user-profile-card">
+      <section className="profile-card">
         <AffiliationAndRoles
           user={user as DuosUser}
         />
       </section>
-      <section className="user-profile-section user-profile-card">
+      <section className="profile-card">
         <ResearcherStatus
           user={user as DuosUser}
         />
       </section>
-      <section className="user-profile-section user-profile-card">
+      <section className="profile-card">
         <AcceptedAcknowledgements />
       </section>
     </main>

--- a/src/styles/profile-card.css
+++ b/src/styles/profile-card.css
@@ -1,0 +1,20 @@
+.profile-card {
+  margin-top: 48px;
+  padding: 28px 32px 32px;
+  border: 1px solid #d9e4f2;
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgb(34 74 120 / 5%);
+}
+
+.profile-card-heading {
+  margin: 0 0 24px;
+  color: #01549f;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+@media (max-width: 700px) {
+  .profile-card {
+    padding: 20px;
+  }
+}

--- a/test/pages/manage_dac/DacProfile.spec.tsx
+++ b/test/pages/manage_dac/DacProfile.spec.tsx
@@ -139,7 +139,21 @@ describe('DacProfile', () => {
 
     await renderDacProfile()
 
-    expect(screen.getByText('No datasets are associated with this DAC.')).toBeTruthy()
+    const datasetsSection = screen.getByRole('region', { name: 'Datasets Managed by this DAC' })
+    expect(datasetsSection.textContent).toContain('No datasets are associated with this DAC.')
+  })
+
+  it.each([
+    'Rule Automation for DARs (RADAR)',
+    'Datasets Managed by this DAC',
+  ])('renders the %s section as its own card', async (title) => {
+    vi.mocked(DAC.get).mockResolvedValue(existingDac)
+    vi.mocked(DAC.datasets).mockResolvedValue([])
+
+    await renderDacProfile()
+
+    const section = screen.getByRole('region', { name: title })
+    expect(section.contains(screen.getByRole('heading', { name: title }))).toBe(true)
   })
 
   it('does not show a spinner and makes no API calls for an invalid dacId', async () => {

--- a/test/pages/manage_dac/DacProfileSection.spec.tsx
+++ b/test/pages/manage_dac/DacProfileSection.spec.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { DacProfileSection } from 'src/pages/manage_dac/DacProfileSection'
+
+describe('DacProfileSection', () => {
+  it('labels the section with its heading', () => {
+    render(
+      <DacProfileSection title="Rule Automation for DARs (RADAR)">
+        <p>Section body</p>
+      </DacProfileSection>,
+    )
+
+    const section = screen.getByRole('region', { name: 'Rule Automation for DARs (RADAR)' })
+    const heading = screen.getByRole('heading', { name: 'Rule Automation for DARs (RADAR)' })
+
+    expect(section).toContainElement(heading)
+    expect(section).toHaveAttribute('aria-labelledby', heading.id)
+  })
+
+  it('renders its children inside the card', () => {
+    render(
+      <DacProfileSection title="DAC Info">
+        <p>Section body</p>
+      </DacProfileSection>,
+    )
+
+    expect(screen.getByRole('region', { name: 'DAC Info' })).toContainElement(screen.getByText('Section body'))
+  })
+
+  it('renders a card with no children', () => {
+    render(<DacProfileSection title="Datasets Managed by this DAC" />)
+
+    expect(screen.getByRole('region', { name: 'Datasets Managed by this DAC' })).toBeInTheDocument()
+  })
+})

--- a/test/pages/manage_dac/EditDac.spec.tsx
+++ b/test/pages/manage_dac/EditDac.spec.tsx
@@ -12,6 +12,7 @@ import { Institution } from 'src/libs/ajax/Institution'
 import { Storage } from 'src/libs/storage'
 import { Notifications } from 'src/libs/utils'
 import type { DAAObject, DacObject, DuosUser } from 'src/types/model'
+import { renderWithRouter } from '../../test-utils'
 
 vi.mock('src/libs/ajax/DAC')
 vi.mock('src/libs/ajax/DAA')
@@ -264,6 +265,9 @@ const mountExistingEditDac = (dacId: number) =>
       </Routes>
     </MemoryRouter>,
   )
+
+const mountProfileEditDac = (dacId: number) =>
+  renderWithRouter(<EditDac dacId={dacId} hideHeader profileMode />, { route: `/dac_profile/${dacId}` })
 
 const fillForm = (
   container: HTMLElement,
@@ -914,5 +918,34 @@ describe('EditDAC Tests - No DAAs Configured', () => {
     })
 
     expect(container.querySelector('[data-cy="daa_upload_button"]')).toBeEnabled()
+  })
+})
+
+describe('EditDAC Tests - Profile Mode Sections', () => {
+  it.each([
+    'DAC Membership',
+    'DAC Info',
+    'Select a Data Access Agreement',
+  ])('renders the %s section as its own card', async (title) => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(adminUser)
+    vi.mocked(DAC.get).mockResolvedValue(existingDac as never)
+    vi.mocked(DAA.getDaas).mockResolvedValue([])
+    mountProfileEditDac(existingDac.dacId as number)
+
+    const section = await screen.findByRole('region', { name: title })
+    expect(section).toContainElement(screen.getByRole('heading', { name: title }))
+  })
+
+  it('renders no section cards outside profile mode', async () => {
+    vi.mocked(Storage.getCurrentUser).mockReturnValue(adminUser)
+    vi.mocked(DAC.get).mockResolvedValue(existingDac as never)
+    vi.mocked(DAA.getDaas).mockResolvedValue([])
+    const { container } = mountExistingEditDac(existingDac.dacId as number)
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-cy="dac_name"]')).toBeInTheDocument()
+    })
+
+    expect(screen.queryAllByRole('region')).toHaveLength(0)
   })
 })


### PR DESCRIPTION
### Addresses

[DT-3994](https://broadworkbench.atlassian.net/browse/DT-3994)

Security risk: no

### Summary

Restyles the five DAC profile page sections as cards matching the user profile chrome from DT-3809, replacing the old `<hr>` divider and 2rem navy heading. New `DacProfileSection` (MUI `Paper` + `Typography` via `sx`) is shared by `DacProfile` and `EditDac`'s profile-mode branch.

`EditDac` outside profile mode, the page header, and page width are unchanged.

<img width="3600" height="6742" alt="After" src="https://github.com/user-attachments/assets/fabdb527-e31e-4e5f-9d5e-8e7e253a05b4" />

[DT-3994]: https://broadworkbench.atlassian.net/browse/DT-3994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ