### PR TITLE
[DT-4008] Remove the client-side legacy match suppression from duos-ui

### DIFF
--- a/src/hooks/useLibraryPageState.ts
+++ b/src/hooks/useLibraryPageState.ts
@@ -32,7 +32,7 @@ import { getFormattedName } from 'src/components/forms/SelectOptionInterface'
  * That class covers only the eight restrictions those forms collect, so the codes
  * below fill in the rest of the secondary vocabulary the corpus can hold: the
  * modifiers `consentTranslations` translates for the dataset views, plus the
- * `AbstainDataUseCodes` the voting flow recognizes. Without them a real, selectable
+ * population restrictions the index stores. Without them a real, selectable
  * checkbox would read as a bare abbreviation.
  *
  * `OTHER` is spelled out rather than taken from `SecondaryDataUseTerms.OTH`: the form's

--- a/src/libs/dataUseTranslation.ts
+++ b/src/libs/dataUseTranslation.ts
@@ -353,7 +353,7 @@ export const processRestrictionStatements = async (
   }
 
   if (key !== 'diseaseRestrictions') {
-    return processDefinedLimitations(key, dataUse, consentTranslations)
+    return processDefinedLimitations(key, consentTranslations)
   }
 
   const diseaseValue = value as (string | { label: string })[]
@@ -368,32 +368,13 @@ export const processRestrictionStatements = async (
   return processDiseaseRestrictionsWithUrls(diseaseValue as string[])
 }
 
-/**
- * Shows only the narrowest permission along the DS > HMB > GRU chain, since a broad statement beside
- * a narrow one misleads. POA sits outside that chain and still renders alongside DS.
- */
+/** Only `diseaseRestrictions` is function-valued, and it resolves through its own path. */
 export const processDefinedLimitations = (
   key: string,
-  dataUse: DataUse,
   translations: ConsentTranslationsMap,
 ): TranslationEntry | undefined => {
-  const targetKeys = ['hmbResearch', 'populationOriginsAncestry', 'generalUse']
-  const isHMBActive = !!dataUse.hmbResearch && isEmpty(dataUse.diseaseRestrictions)
-  const isPOAActive = !!dataUse.populationOriginsAncestry
-  const isGeneralUseActive = !!dataUse.generalUse && !isHMBActive && !isPOAActive && isEmpty(dataUse.diseaseRestrictions)
-  let statement: TranslationEntry | undefined
-  if (
-    !targetKeys.includes(key)
-    || (key === 'hmbResearch' && isHMBActive)
-    || (key === 'populationOriginsAncestry' && isPOAActive)
-    || (key === 'generalUse' && isGeneralUseActive)
-  ) {
-    const translation = translations[key]
-    if (translation && typeof translation !== 'function') {
-      statement = translation
-    }
-  }
-  return statement
+  const translation = translations[key]
+  return translation && typeof translation !== 'function' ? translation : undefined
 }
 
 // Extend DataUse to include otherRestrictions for runtime compatibility

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -25,22 +25,6 @@ export type UserRoleName
     | 'ServiceAccount'
     | 'All'
 
-/**
- * Secondary data use codes that suppress a legacy (v1/v2) system match. Scoped to legacy results
- * on purpose: from v3 Consent decides abstention itself — see `calculateAlgorithmResultForBucket`.
- */
-export const AbstainDataUseCodes: ReadonlySet<string> = new Set([
-  'OTHER',
-  'POP-M',
-  'POP-F',
-  'COL',
-  'IRB',
-  'GSO',
-  'PUB',
-  'MOR',
-  'POP-PD',
-])
-
 export interface UserRole {
   roleId: number
   name: UserRoleName

--- a/src/utils/BucketUtils.ts
+++ b/src/utils/BucketUtils.ts
@@ -5,7 +5,6 @@ import { ElasticsearchQuery } from 'src/types/elastic'
 import { processVotesForBucket } from './DarCollectionUtils'
 import { processMatchData } from './VoteUtils'
 import {
-  AbstainDataUseCodes,
   AlgorithmResult,
   DacTerm,
   DarCollection,
@@ -177,9 +176,6 @@ const filterDatasetsByDACs = (dacIds: number[], datasets: Dataset[]): Dataset[] 
     : filter(datasets, (dataset: Dataset) => includes(dacIds, dataset.dacId))
 }
 
-/** Versions that predate server-side abstention and so still need client-side suppression. */
-const CLIENT_SUPPRESSING_VERSIONS: ReadonlySet<string> = new Set(['v1', 'v2'])
-
 /**
  * From v3 on Consent decides ABSTAIN and supplies the rationale the DAC reads. A floor rather than
  * an allowlist, so a newer matcher does not blank every suggestion until this UI is redeployed.
@@ -188,14 +184,10 @@ const FIRST_BACKEND_ABSTAINING_VERSION = 3
 
 const UNRECOGNIZED_ALGORITHM_RESULT = 'System match unavailable for this algorithm version'
 
-type AlgorithmVersionHandling = 'backend-abstains' | 'client-suppresses' | 'unrecognized'
+type AlgorithmVersionHandling = 'backend-abstains' | 'unrecognized'
 
 const classifyOneVersion = (version: string | undefined): AlgorithmVersionHandling => {
-  // Rows predating the version column were backfilled to v1, so an absent version is legacy too.
-  if (isNil(version) || CLIENT_SUPPRESSING_VERSIONS.has(version)) {
-    return 'client-suppresses'
-  }
-  const majorVersion = /^v(\d+)$/.exec(version)
+  const majorVersion = isNil(version) ? null : /^v(\d+)$/.exec(version)
   return majorVersion && Number(majorVersion[1]) >= FIRST_BACKEND_ABSTAINING_VERSION
     ? 'backend-abstains'
     : 'unrecognized'
@@ -240,24 +232,17 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
     }
   }
 
-  const unmatchable = shouldAbstain(bucket.dataUse)
   // Check on all possible true/false values in the matches.
   // If all matches are the same, we can merge them into a single match object for display.
   // If they are not all the same, we have to punt this decision solely to the DAC.
-  const matchVals: boolean[] = (handling === 'backend-abstains' || !unmatchable)
-    ? chain(bucket.matchResults)
-        .map((m: MatchResult) => m.match)
-        .uniq()
-        .value()
-    : []
+  const matchVals: boolean[] = chain(bucket.matchResults)
+    .map((m: MatchResult) => m.match)
+    .uniq()
+    .value()
 
   const abstain = hasRecordedAbstention(bucket.matchResults)
 
-  // check results based on matchVals
-  if (isEmpty(matchVals)) {
-    return { result: 'N/A', createDate: undefined, rationales: undefined, id: bucket.key }
-  }
-  else if ((matchVals.length === 1)) {
+  if (matchVals.length === 1) {
     const rationales: string[] = chain(bucket.matchResults)
       .flatMap((match: MatchResult) => match.rationales)
       .uniq()
@@ -295,32 +280,6 @@ const calculateAlgorithmResultForBucket = (bucket: Bucket): AlgorithmResult => {
 /** One abstention is enough: the algorithm declined on a dataset, so the bucket has no answer. */
 const hasRecordedAbstention = (matchResults: MatchResult[]): boolean =>
   matchResults.some((m: MatchResult) => m.abstain === true)
-
-/**
- * Calculate "Other" status for a data use. Data Uses can have 'otherRestrictions': TRUE|FALSE,
- * or they can have fields populated for 'other': 'other restriction' and 'secondaryOther': 'yet other restriction'
- *
- * Counts a secondary Other, unlike the classifier — this feeds only the legacy suppression path.
- */
-const isOther = (dataUse?: DataUseSummary): boolean => {
-  const primaryOther = dataUse?.primary?.some((dut: DataUseTerm) => dut.code === 'OTHER') || false
-  const secondaryOther = dataUse?.secondary?.some((dut: DataUseTerm) => dut.code === 'OTHER') || false
-  return primaryOther || secondaryOther
-}
-
-/**
- * Calculate abstention for a data use. There are a number of cases where there should
- * not be an algorithm decision if a field is true, including any "Other" state.
- *
- * Legacy (v1/v2) heuristic only, and deliberately broader than Consent's classifier: it abstains
- * on secondary modifiers like PUB or IRB, which V5 matches normally because they are not primary.
- */
-export const shouldAbstain = (dataUse?: DataUseSummary): boolean => {
-  return isOther(dataUse)
-    || (dataUse?.secondary
-      ? dataUse.secondary.some((dut: DataUseTerm) => AbstainDataUseCodes.has(dut.code))
-      : false)
-}
 
 /**
  * Helper function to retrieve DatasetTerms for a list of datasets. This is primarily used to get the pre-processed

--- a/test/hooks/useLibraryPageState.spec.tsx
+++ b/test/hooks/useLibraryPageState.spec.tsx
@@ -212,8 +212,8 @@ describe('useLibraryPageState — data use modifier options', () => {
   })
 
   it('words the modifiers the submission forms do not collect', () => {
-    // These live in `consentTranslations` and `AbstainDataUseCodes` rather than in
-    // SecondaryDataUseTerms, and are as real as any code the forms do collect.
+    // These live in `consentTranslations` rather than in SecondaryDataUseTerms, and
+    // are as real as any code the forms do collect.
     const options = withModifierFacet(['NCTRL', 'NAGR', 'NCU', 'RS-G', 'RS-PD', 'POP-M', 'POP-F', 'POP-PD'])
     expect(options).toContainEqual({ value: 'NCTRL', label: 'No Control Set Use (NCTRL)' })
     expect(options).toContainEqual({ value: 'NAGR', label: 'No Aggregate-Level Data Use (NAGR)' })

--- a/test/libs/dataUseTranslation.spec.ts
+++ b/test/libs/dataUseTranslation.spec.ts
@@ -1,151 +1,24 @@
 import '@testing-library/jest-dom/vitest'
 import { describe, expect, it } from 'vitest'
 import { processDefinedLimitations, consentTranslations, ControlledAccessType, DataUseTranslation, TranslationEntry } from 'src/libs/dataUseTranslation'
-import { isEmpty, cloneDeep } from 'src/utils/NodashUtil'
-import { DataUse } from 'src/types/model'
-
-interface MockDataUse extends DataUse {
-  [key: string]: boolean | string | string[] | undefined
-}
-
-const mockDataUse: MockDataUse = {
-  diseaseRestrictions: [],
-}
-
-const makeDataUse = (overrides: Partial<MockDataUse>): MockDataUse => ({
-  ...cloneDeep(mockDataUse),
-  ...overrides,
-})
-
-const expectTranslatedLimitation = (targetKey: string, dataUse: MockDataUse) => {
-  const response = processDefinedLimitations(targetKey, dataUse, consentTranslations)
-  const targetTranslation = consentTranslations[targetKey] as TranslationEntry
-
-  expect(response).toBeDefined()
-  expect(Object.keys(response!)).not.toHaveLength(0)
-  expect(response?.code).toBe(targetTranslation.code)
-  expect(response?.description).toBe(targetTranslation.description)
-}
 
 describe('Data Use Translation', () => {
   describe('processDefinedLimitations()', () => {
-    it('translates Populations, Origins, and Ancestry (POA) if it has been marked in the data use', () => {
-      const targetKey = 'populationOriginsAncestry'
-      const modifiedMockData = makeDataUse({ diseaseRestrictions: [], populationOriginsAncestry: true })
+    // The caller guards on the key being set, so the lookup is all that remains.
+    it.each(['populationOriginsAncestry', 'hmbResearch', 'generalUse', 'pediatric', 'gender'])(
+      'translates %s',
+      (targetKey) => {
+        const response = processDefinedLimitations(targetKey, consentTranslations)
+        const targetTranslation = consentTranslations[targetKey] as TranslationEntry
 
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
+        expect(response).toBeDefined()
+        expect(response?.code).toBe(targetTranslation.code)
+        expect(response?.description).toBe(targetTranslation.description)
+      },
+    )
 
-    it('translates HMB if it\'s been marked in the data use', () => {
-      const targetKey = 'hmbResearch'
-      const modifiedMockData = makeDataUse({ [targetKey]: true, diseaseRestrictions: [] })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('translates HMB if diseaseRestrictions is an empty array', () => {
-      const targetKey = 'hmbResearch'
-      const modifiedMockData = makeDataUse({ diseaseRestrictions: [], [targetKey]: true })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('does not translate HMB if diseaseRestrictions is populated', () => {
-      const targetKey = 'hmbResearch'
-      const modifiedMockData = makeDataUse({
-        diseaseRestrictions: ['test'],
-        [targetKey]: true,
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('translates General Research Use (GRU) if selected', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        diseaseRestrictions: [],
-      })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('does not translate GRU if HMB is selected', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        hmbResearch: true,
-        diseaseRestrictions: [],
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('does not translate GRU if diseaseRestrictions is populated', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        diseaseRestrictions: ['test'],
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('does not translate GRU if POA is selected', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        populationOriginsAncestry: true,
-        diseaseRestrictions: [],
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('translates Pediatric Studies (PSO) if pediatric is selected', () => {
-      const targetKey = 'pediatric'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        diseaseRestrictions: [],
-      })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('translates Gender Studies (GSO) if gender is selected', () => {
-      const targetKey = 'gender'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: 'female',
-        diseaseRestrictions: [],
-      })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    // Unlike the classifier's full enumeration, display keeps only the narrowest permission.
-    describe('legacy multi-primary display', () => {
-      it('shows only DS, not HMB, when both are set', () => {
-        const dataUse = makeDataUse({ hmbResearch: true, diseaseRestrictions: ['test'] })
-
-        expect(isEmpty(processDefinedLimitations('hmbResearch', dataUse, consentTranslations))).toBe(true)
-      })
-
-      it('shows only the narrowest permission when every primary is set', () => {
-        const dataUse = makeDataUse({
-          generalUse: true,
-          hmbResearch: true,
-          populationOriginsAncestry: true,
-          diseaseRestrictions: ['test'],
-        })
-
-        expect(isEmpty(processDefinedLimitations('generalUse', dataUse, consentTranslations))).toBe(true)
-        expect(isEmpty(processDefinedLimitations('hmbResearch', dataUse, consentTranslations))).toBe(true)
-        expect(processDefinedLimitations('populationOriginsAncestry', dataUse, consentTranslations)).toBeDefined()
-      })
+    it('leaves an ontology-backed entry to the path that resolves it', () => {
+      expect(processDefinedLimitations('diseaseRestrictions', consentTranslations)).toBeUndefined()
     })
   })
 

--- a/test/pages/dar_collection_review/DarCollectionReview.spec.tsx
+++ b/test/pages/dar_collection_review/DarCollectionReview.spec.tsx
@@ -214,7 +214,7 @@ const matchResponse = [
     failed: false,
     abstain: false,
     createDate: 1668729600000,
-    algorithmVersion: 'v2',
+    algorithmVersion: 'v5',
     rationales: [],
   },
 ] as unknown as MatchResult[]

--- a/test/utils/BucketUtils.spec.ts
+++ b/test/utils/BucketUtils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { binCollectionToBuckets, Bucket, shouldAbstain } from 'src/utils/BucketUtils'
+import { binCollectionToBuckets, Bucket } from 'src/utils/BucketUtils'
 import { isUndefined } from 'src/utils/NodashUtil'
 import { Match } from 'src/libs/ajax/Match'
 import {
@@ -148,8 +148,8 @@ const dar_collection: DarCollection = {
 }
 
 const match_results = [
-  { id: '1', consent: 'DUOS-000001', purpose: REF, match: true, failed: false, abstain: false, createDate: 'Jan 23, 2023', algorithmVersion: 'v2', rationales: [] },
-  { id: '2', consent: 'DUOS-000002', purpose: REF, match: true, failed: false, abstain: false, createDate: 'Jan 23, 2023', algorithmVersion: 'v2', rationales: [] },
+  { id: '1', consent: 'DUOS-000001', purpose: REF, match: true, failed: false, abstain: false, createDate: 'Jan 23, 2023', algorithmVersion: 'v5', rationales: [] },
+  { id: '2', consent: 'DUOS-000002', purpose: REF, match: true, failed: false, abstain: false, createDate: 'Jan 23, 2023', algorithmVersion: 'v5', rationales: [] },
 ] as unknown as MatchResult[]
 
 const dataset_terms = [
@@ -223,26 +223,6 @@ const similar_data_use_terms = [
   { datasetId: 4, datasetName: 'ds 4', datasetIdentifier: 'DUOS-000004', dataUse: { primary: [{ code: 'GRU', description: 'General Research Use' }] }, dacId: 4 },
   { datasetId: 5, datasetName: 'ds 5', datasetIdentifier: 'DUOS-000005', dataUse: { primary: [{ code: 'HMB', description: 'Health, Medical and Biomedical Research' }] }, dacId: 5 },
 ] as unknown as DatasetTerm[]
-
-// ─── shouldAbstain cases ──────────────────────────────────────────────────────
-
-const matchableCases: DataUseSummary[] = [
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'NCU', description: 'NCU' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'NMDS', description: 'NMDS' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'NCTRL', description: 'NCTRL' }] },
-]
-
-const unmatchableCases: DataUseSummary[] = [
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'OTHER', description: 'OTHER' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'POP-M', description: 'POP-M' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'POP-F', description: 'POP-F' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'COL', description: 'COL' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'IRB', description: 'IRB' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'GSO', description: 'GSO' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'PUB', description: 'PUB' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'MOR', description: 'MOR' }] },
-  { primary: [{ code: 'GRU', description: 'GRU' }], secondary: [{ code: 'POP-PD', description: 'POP-PD' }] },
-]
 
 // ─── Algorithm version fixtures ───────────────────────────────────────────────
 
@@ -401,8 +381,8 @@ describe('BucketUtils', () => {
 
   it('match failures should be condensed for a bucket with two failing matches', async () => {
     const failing_matches = [
-      { id: '1', consent: 'DUOS-000001', purpose: REF, match: false, failed: false, abstain: true, createDate: 'Jan 23, 2023', algorithmVersion: 'v2', rationales: ['1', '2', '3'] },
-      { id: '2', consent: 'DUOS-000002', purpose: REF, match: false, failed: false, abstain: true, createDate: 'Jan 23, 2023', algorithmVersion: 'v2', rationales: ['1', '2', '3', '4', '5'] },
+      { id: '1', consent: 'DUOS-000001', purpose: REF, match: false, failed: false, abstain: true, createDate: 'Jan 23, 2023', algorithmVersion: 'v5', rationales: ['1', '2', '3'] },
+      { id: '2', consent: 'DUOS-000002', purpose: REF, match: false, failed: false, abstain: true, createDate: 'Jan 23, 2023', algorithmVersion: 'v5', rationales: ['1', '2', '3', '4', '5'] },
     ] as unknown as MatchResult[]
     vi.spyOn(Match, 'findMatchBatch').mockResolvedValue(failing_matches)
     vi.spyOn(DataSet, 'searchDatasetIndex').mockResolvedValue(dataset_terms)
@@ -419,14 +399,6 @@ describe('BucketUtils', () => {
       }
     }
     expect(rationaleCheck).toBe(true)
-  })
-
-  it.each(matchableCases)('correctly determines matchable data use: %j', (dataUse) => {
-    expect(shouldAbstain(dataUse)).toBe(false)
-  })
-
-  it.each(unmatchableCases)('correctly determines unmatchable data use: %j', (dataUse) => {
-    expect(shouldAbstain(dataUse)).toBe(true)
   })
 
   it('correctly buckets data uses when there are similar data use entries', async () => {
@@ -473,7 +445,7 @@ describe('BucketUtils', () => {
       expect(bucket.algorithmResult?.result).toBe('Abstain')
     })
 
-    // The legacy heuristic abstains on these; V5 matches them normally.
+    // V5 matches these normally: they are secondary modifiers, not primaries.
     it.each(['PUB', 'IRB', 'COL', 'GSO', 'MOR', 'POP-M', 'POP-F', 'POP-PD'])(
       'keeps a v5 match on a GRU data use with a secondary %s',
       async (code) => {
@@ -491,16 +463,11 @@ describe('BucketUtils', () => {
       expect(bucket.algorithmResult?.result).toBe('Yes')
     })
 
-    it.each(['v1', 'v2'])('still suppresses a %s result for an unmatchable data use', async (version) => {
+    it.each(['v1', 'v2'])('reports a %s result as uninterpretable rather than suppressing it', async (version) => {
       const bucket = await bucketFor({ primary: [OTHER] }, [makeMatch(version, { match: true })])
 
-      expect(bucket.algorithmResult?.result).toBe('N/A')
-    })
-
-    it.each(['v1', 'v2'])('keeps a %s result for a matchable data use', async (version) => {
-      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch(version, { match: true })])
-
-      expect(bucket.algorithmResult?.result).toBe('Yes')
+      expect(bucket.algorithmResult?.result).toBe('System match unavailable for this algorithm version')
+      expect(bucket.algorithmResult?.rationales?.[0]).toContain(version)
     })
 
     it('reports an unparseable version instead of trusting or hiding it', async () => {
@@ -516,12 +483,11 @@ describe('BucketUtils', () => {
       expect(bucket.algorithmResult?.result).toBe('Yes')
     })
 
-    it('reads a missing version as legacy rather than uninterpretable', async () => {
-      const matchable = await bucketFor({ primary: [GRU] }, [makeMatch(undefined, { match: true })])
-      const unmatchable = await bucketFor({ primary: [OTHER] }, [makeMatch(undefined, { match: true })])
+    it('reports a missing version as uninterpretable', async () => {
+      const bucket = await bucketFor({ primary: [GRU] }, [makeMatch(undefined, { match: true })])
 
-      expect(matchable.algorithmResult?.result).toBe('Yes')
-      expect(unmatchable.algorithmResult?.result).toBe('N/A')
+      expect(bucket.algorithmResult?.result).toBe('System match unavailable for this algorithm version')
+      expect(bucket.algorithmResult?.rationales?.[0]).toContain('unknown')
     })
 
     // One data use, so both datasets land in the same bucket and their match rows coalesce.


### PR DESCRIPTION
### Addresses

[DT-4008](https://broadworkbench.atlassian.net/browse/DT-4008). The duos-ui half of the same cleanup as [DT-4009](https://github.com/DataBiosphere/consent/pull/3038), which retires the backend migration surface. Neither depends on the other.

Security risk: no.

### Summary

duos-ui suppressed the system match client-side for rows computed before Consent decided abstention itself. [DT-3866](https://broadworkbench.atlassian.net/browse/DT-3866) scoped that suppression to legacy algorithm versions rather than removing it, since the [DT-3861](https://broadworkbench.atlassian.net/browse/DT-3861) production audit showed the rows were real.

Two commits, gated on different preconditions and revertible independently:

- **`4ff7d14d` — the match-version suppression.** Removes `CLIENT_SUPPRESSING_VERSIONS`, the `client-suppresses` arm of `AlgorithmVersionHandling`, the absent-version fallback, `shouldAbstain`, `isOther`, and `AbstainDataUseCodes`. Anything below the backend-abstaining floor is now `unrecognized`, so a legacy or missing version reports the uninterpretable result rather than a hidden one.
- **`96e4cd5f` — the multi-primary collapse** in `processDefinedLimitations`. The function stays; `processRestrictionStatements` calls it for every non-`diseaseRestrictions` key.

### Do not merge yet — and the first commit may not be mergeable at all

**Corrected 2026-08-27.** An earlier version of this PR said the first commit was waiting on DT-3863's production recompute. That was wrong, and the measurement is [recorded on the ticket](https://broadworkbench.atlassian.net/browse/DT-4008?focusedCommentId=116591).

`LegacyDataUseService.recomputeAbstainingMatches` selects on `abstainsWhenMatched() && darCount > 0`, so it only reaches DARs that include an abstaining dataset. Legacy rows on canonical datasets are never restamped — a property of the code, not of any environment's data. A complete zero-failure run in dev left 393 legacy rows standing.

Production, measured before DT-3863 ships: **529 legacy rows, 48% of the match corpus**, of which only **3** sit under an open DataAccess election. No null `algorithm_version` rows anywhere. And `v1` is exactly the unresolved-identifier population — 410 rows, a perfect overlap — so 78% of the legacy corpus is what [DT-3942](https://broadworkbench.atlassian.net/browse/DT-3942) exists to reconcile.

So `4ff7d14d` is blocked on DT-3942, as [the epic](https://broadworkbench.atlassian.net/browse/DT-3860) always said. There is a further catch: DT-3942's scope backfills `dataset_id` and preserves rationales but never touches `algorithm_version`, so those 410 rows would still read `v1` after it completes. An explicit recompute step has to be added somewhere, or this commit stays blocked indefinitely. Raised on DT-3942.

`96e4cd5f` is unaffected. Its precondition is that no persisted record carries multiple primaries, and production has exactly one such dataset, awaiting its domain-approved disposition.

### Review notes

Three places where the code did not match the ticket's instructions:

**`isOther` is removed entirely, not just its secondary-Other arm.** `shouldAbstain` was its only caller, so scoping the edit as written would have orphaned it.

**The `isEmpty(matchVals)` → `N/A` branch is gone.** That branch *was* the suppression — `matchVals` was only ever empty because the legacy-and-unmatchable path deliberately emptied it. Derived unconditionally from a non-empty `matchResults`, it cannot be empty, so the branch is unreachable rather than merely unused.

**`processDefinedLimitations` loses its `dataUse` parameter.** With the collapse gone it is a pure translation lookup, and `processRestrictionStatements` already guards on the key being set — which is what the collapse was reading. That collapsed the per-key specs into one `it.each`, since they had become the same assertion, and made the empty-`diseaseRestrictions` case an exact duplicate.

The ticket also refers to `BACKEND_ABSTAINING_VERSIONS`; DT-3866 replaced that set with the `FIRST_BACKEND_ABSTAINING_VERSION` floor, which is what the change is written against. The floor stays a floor, so a matcher newer than this build still reads as `backend-abstains`.

Legacy versions in general-purpose fixtures move to `v5` — after this change a `v2` fixture silently exercises the uninterpretable path, which is not what those tests are about.

### Verification

`pnpm run lint` 0 errors, `pnpm run type-check` 0 errors, full suite 369 files / 4,321 tests green. E2E is unaffected — the Playwright specs cover liveness, about, auth, status, and home, none of which reach this code.

Coverage percentages dip slightly on two files, which is arithmetic rather than a regression — deleting fully-covered code shrinks the denominator while the pre-existing uncovered code stays. Absolute uncovered counts are flat or better:

| file | uncovered lines | uncovered branches |
|---|---|---|
| `BucketUtils.ts` | 2 → 2 | 6 → 5 |
| `dataUseTranslation.ts` | 36 → 36 | 27 → 26 |

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4008]: https://broadworkbench.atlassian.net/browse/DT-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-4009]: https://broadworkbench.atlassian.net/browse/DT-4009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3866]: https://broadworkbench.atlassian.net/browse/DT-3866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3861]: https://broadworkbench.atlassian.net/browse/DT-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-3942]: https://broadworkbench.atlassian.net/browse/DT-3942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ