### PR TITLE
[DT-4008] Drop the multi-primary collapse from the Data Use translation

### DIFF
--- a/src/libs/dataUseTranslation.ts
+++ b/src/libs/dataUseTranslation.ts
@@ -353,7 +353,7 @@ export const processRestrictionStatements = async (
   }
 
   if (key !== 'diseaseRestrictions') {
-    return processDefinedLimitations(key, dataUse, consentTranslations)
+    return processDefinedLimitations(key, consentTranslations)
   }
 
   const diseaseValue = value as (string | { label: string })[]
@@ -368,32 +368,13 @@ export const processRestrictionStatements = async (
   return processDiseaseRestrictionsWithUrls(diseaseValue as string[])
 }
 
-/**
- * Shows only the narrowest permission along the DS > HMB > GRU chain, since a broad statement beside
- * a narrow one misleads. POA sits outside that chain and still renders alongside DS.
- */
+/** Only `diseaseRestrictions` is function-valued, and it resolves through its own path. */
 export const processDefinedLimitations = (
   key: string,
-  dataUse: DataUse,
   translations: ConsentTranslationsMap,
 ): TranslationEntry | undefined => {
-  const targetKeys = ['hmbResearch', 'populationOriginsAncestry', 'generalUse']
-  const isHMBActive = !!dataUse.hmbResearch && isEmpty(dataUse.diseaseRestrictions)
-  const isPOAActive = !!dataUse.populationOriginsAncestry
-  const isGeneralUseActive = !!dataUse.generalUse && !isHMBActive && !isPOAActive && isEmpty(dataUse.diseaseRestrictions)
-  let statement: TranslationEntry | undefined
-  if (
-    !targetKeys.includes(key)
-    || (key === 'hmbResearch' && isHMBActive)
-    || (key === 'populationOriginsAncestry' && isPOAActive)
-    || (key === 'generalUse' && isGeneralUseActive)
-  ) {
-    const translation = translations[key]
-    if (translation && typeof translation !== 'function') {
-      statement = translation
-    }
-  }
-  return statement
+  const translation = translations[key]
+  return translation && typeof translation !== 'function' ? translation : undefined
 }
 
 // Extend DataUse to include otherRestrictions for runtime compatibility

--- a/test/libs/dataUseTranslation.spec.ts
+++ b/test/libs/dataUseTranslation.spec.ts
@@ -1,151 +1,24 @@
 import '@testing-library/jest-dom/vitest'
 import { describe, expect, it } from 'vitest'
 import { processDefinedLimitations, consentTranslations, ControlledAccessType, DataUseTranslation, TranslationEntry } from 'src/libs/dataUseTranslation'
-import { isEmpty, cloneDeep } from 'src/utils/NodashUtil'
-import { DataUse } from 'src/types/model'
-
-interface MockDataUse extends DataUse {
-  [key: string]: boolean | string | string[] | undefined
-}
-
-const mockDataUse: MockDataUse = {
-  diseaseRestrictions: [],
-}
-
-const makeDataUse = (overrides: Partial<MockDataUse>): MockDataUse => ({
-  ...cloneDeep(mockDataUse),
-  ...overrides,
-})
-
-const expectTranslatedLimitation = (targetKey: string, dataUse: MockDataUse) => {
-  const response = processDefinedLimitations(targetKey, dataUse, consentTranslations)
-  const targetTranslation = consentTranslations[targetKey] as TranslationEntry
-
-  expect(response).toBeDefined()
-  expect(Object.keys(response!)).not.toHaveLength(0)
-  expect(response?.code).toBe(targetTranslation.code)
-  expect(response?.description).toBe(targetTranslation.description)
-}
 
 describe('Data Use Translation', () => {
   describe('processDefinedLimitations()', () => {
-    it('translates Populations, Origins, and Ancestry (POA) if it has been marked in the data use', () => {
-      const targetKey = 'populationOriginsAncestry'
-      const modifiedMockData = makeDataUse({ diseaseRestrictions: [], populationOriginsAncestry: true })
+    // The caller guards on the key being set, so the lookup is all that remains.
+    it.each(['populationOriginsAncestry', 'hmbResearch', 'generalUse', 'pediatric', 'gender'])(
+      'translates %s',
+      (targetKey) => {
+        const response = processDefinedLimitations(targetKey, consentTranslations)
+        const targetTranslation = consentTranslations[targetKey] as TranslationEntry
 
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
+        expect(response).toBeDefined()
+        expect(response?.code).toBe(targetTranslation.code)
+        expect(response?.description).toBe(targetTranslation.description)
+      },
+    )
 
-    it('translates HMB if it\'s been marked in the data use', () => {
-      const targetKey = 'hmbResearch'
-      const modifiedMockData = makeDataUse({ [targetKey]: true, diseaseRestrictions: [] })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('translates HMB if diseaseRestrictions is an empty array', () => {
-      const targetKey = 'hmbResearch'
-      const modifiedMockData = makeDataUse({ diseaseRestrictions: [], [targetKey]: true })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('does not translate HMB if diseaseRestrictions is populated', () => {
-      const targetKey = 'hmbResearch'
-      const modifiedMockData = makeDataUse({
-        diseaseRestrictions: ['test'],
-        [targetKey]: true,
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('translates General Research Use (GRU) if selected', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        diseaseRestrictions: [],
-      })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('does not translate GRU if HMB is selected', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        hmbResearch: true,
-        diseaseRestrictions: [],
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('does not translate GRU if diseaseRestrictions is populated', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        diseaseRestrictions: ['test'],
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('does not translate GRU if POA is selected', () => {
-      const targetKey = 'generalUse'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        populationOriginsAncestry: true,
-        diseaseRestrictions: [],
-      })
-      const response = processDefinedLimitations(targetKey, modifiedMockData, consentTranslations)
-
-      expect(isEmpty(response)).toBe(true)
-    })
-
-    it('translates Pediatric Studies (PSO) if pediatric is selected', () => {
-      const targetKey = 'pediatric'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: true,
-        diseaseRestrictions: [],
-      })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    it('translates Gender Studies (GSO) if gender is selected', () => {
-      const targetKey = 'gender'
-      const modifiedMockData = makeDataUse({
-        [targetKey]: 'female',
-        diseaseRestrictions: [],
-      })
-
-      expectTranslatedLimitation(targetKey, modifiedMockData)
-    })
-
-    // Unlike the classifier's full enumeration, display keeps only the narrowest permission.
-    describe('legacy multi-primary display', () => {
-      it('shows only DS, not HMB, when both are set', () => {
-        const dataUse = makeDataUse({ hmbResearch: true, diseaseRestrictions: ['test'] })
-
-        expect(isEmpty(processDefinedLimitations('hmbResearch', dataUse, consentTranslations))).toBe(true)
-      })
-
-      it('shows only the narrowest permission when every primary is set', () => {
-        const dataUse = makeDataUse({
-          generalUse: true,
-          hmbResearch: true,
-          populationOriginsAncestry: true,
-          diseaseRestrictions: ['test'],
-        })
-
-        expect(isEmpty(processDefinedLimitations('generalUse', dataUse, consentTranslations))).toBe(true)
-        expect(isEmpty(processDefinedLimitations('hmbResearch', dataUse, consentTranslations))).toBe(true)
-        expect(processDefinedLimitations('populationOriginsAncestry', dataUse, consentTranslations)).toBeDefined()
-      })
+    it('leaves an ontology-backed entry to the path that resolves it', () => {
+      expect(processDefinedLimitations('diseaseRestrictions', consentTranslations)).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
### Addresses

[DT-4008](https://broadworkbench.atlassian.net/browse/DT-4008).

Security risk: no.

### Summary

`processDefinedLimitations` hid a broader primary whenever a narrower one was set, along the DS > HMB > GRU chain. That only ever mattered for records carrying more than one primary, and production now has none — verified: datasets carrying more than one of GRU, HMB, POA, non-empty DS, or nonblank Other returns 0. The collapse can now only disagree with what Consent classifies.

The function stays, since `processRestrictionStatements` calls it for every non-`diseaseRestrictions` key, but it reduces to the translation lookup and no longer takes the data use — the caller already guards on the key being set, which is what the collapse was reading.

The per-key specs collapse into one `it.each`: with the branch gone they were the same assertion, and the empty-`diseaseRestrictions` case became a duplicate. A case for the function-valued entry is added, since that guard is the function's remaining behaviour.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4008]: https://broadworkbench.atlassian.net/browse/DT-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ