### PR TITLE
[DT-3873] Cover template validation over a real request

### DIFF
--- a/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
+++ b/src/pages/data_submission/v2/DataSubmissionFormV2.tsx
@@ -11,6 +11,7 @@ import { Styles } from 'src/libs/theme'
 import { StudyAssetManagement } from 'src/pages/data_submission/v2/StudyAssetManagement'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import { Notifications } from 'src/libs/utils'
+import { ErrorReporter } from 'src/libs/ErrorReporter'
 import { studyToDatasetSchemaSubmission, buildConsentGroupsFromStudy, getStudyPropertyValueByKey } from 'src/pages/data_submission/v2/v2-common-functions'
 import { loadStudyDatasetDraft } from 'src/pages/data_submission/v2/studyDatasetDraft'
 import { Draft } from 'src/libs/ajax/Draft'
@@ -177,7 +178,9 @@ export const DataSubmissionFormV2 = (props: DataSubmissionFormV2Props) => {
     try {
       await Draft.deleteDraft(draftUuid)
     }
-    catch (_error) {
+    catch (error) {
+      // The toast is transient; a rising rate here is the only signal drafts are accumulating.
+      ErrorReporter.report(`study dataset draft cleanup failed for ${draftUuid}: ${errorMessage(error)}`)
       Notifications.showError({
         text: 'Your study was created, but the draft it came from could not be removed. It may still appear in your drafts.',
       })

--- a/test/e2e/studyTemplate.spec.ts
+++ b/test/e2e/studyTemplate.spec.ts
@@ -42,7 +42,11 @@ test.describe('study template validation', () => {
   test.beforeEach(async ({ page, signInAs }) => {
     await signInAs(ROLE)
     await page.goto(UPLOAD_PATH)
-    await expect(page.getByRole('heading', { name: 'Upload Study Template' })).toBeVisible()
+    // RoleBAC redirects rather than erroring, so a role that cannot reach the page shows up here
+    // as a changed URL rather than as a missing element further down.
+    await expect(page).toHaveURL(new RegExp(`${UPLOAD_PATH}$`))
+    // TableHeaderSection renders its title in a div, so the page's first real heading is this one.
+    await expect(page.getByRole('heading', { name: '1. Start from the blank template' })).toBeVisible()
   })
 
   test('reports the errors Consent found and creates no draft', async ({ page }) => {

--- a/test/e2e/studyTemplate.spec.ts
+++ b/test/e2e/studyTemplate.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from './support/auth'
+import type { Page } from '@playwright/test'
+
+/*
+ * The only coverage that crosses the HTTP boundary: StudyTemplateUpload.spec.tsx mocks the ajax
+ * layer. Stops at draft navigation because creating a study would leave a permanent record in dev
+ * on every run, and DataSubmissionFormV2.modes.spec.tsx already covers past that point.
+ */
+
+const FIXTURES = 'test/fixtures/study-template/v1'
+const UPLOAD_PATH = '/data_submission_template'
+const DRAFT_URL = /\/data_submission_form\/draft\/study-dataset\/([0-9a-f-]+)$/
+
+// CHAIR satisfies both the route's RoleBAC and the endpoint's @RolesAllowed.
+const ROLE = 'CHAIR' as const
+
+const chooseFile = async (page: Page, fixture: string) => {
+  await page.locator('#study-template-file').setInputFiles(`${FIXTURES}/${fixture}`)
+}
+
+const validate = async (page: Page) => {
+  await page.locator('#validate-template-btn').click()
+}
+
+/** Drafts persist in dev, so a run that creates one removes it rather than leaving it behind. */
+const deleteDraft = async (page: Page, draftUuid: string) => {
+  const status = await page.evaluate(async (uuid) => {
+    const stored = localStorage.getItem('OidcUser')
+    const user = stored ? JSON.parse(stored) : {}
+    const token = user?.profile?.idp_access_token ?? user?.id_token
+    const config = await (await fetch('/config.json')).json()
+    const response = await fetch(`${config.apiUrl}/api/draft/v1/${uuid}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    return response.status
+  }, draftUuid)
+  expect(status, `cleanup of draft ${draftUuid} failed`).toBeLessThan(400)
+}
+
+test.describe('study template validation', () => {
+  test.beforeEach(async ({ page, signInAs }) => {
+    await signInAs(ROLE)
+    await page.goto(UPLOAD_PATH)
+    await expect(page.getByRole('heading', { name: 'Upload Study Template' })).toBeVisible()
+  })
+
+  test('reports the errors Consent found and creates no draft', async ({ page }) => {
+    await chooseFile(page, 'invalid/unknown-field.csv')
+    await validate(page)
+
+    // The fixture's single error, per its .errors.json in consent: row 2, column field.
+    await expect(page.getByRole('heading', { name: 'Your template has 1 error' })).toBeVisible()
+    await expect(page.getByText('Unknown study field: studyColour')).toBeVisible()
+    await expect(page.getByText('Row 2, column field')).toBeVisible()
+
+    // An invalid template is a completed result, not a failure: the user stays here to fix it.
+    await expect(page).toHaveURL(new RegExp(`${UPLOAD_PATH}$`))
+    await expect(page.locator('#validate-template-btn')).toBeEnabled()
+  })
+
+  test('clears the errors when the rejected file is removed', async ({ page }) => {
+    await chooseFile(page, 'invalid/unknown-field.csv')
+    await validate(page)
+    await expect(page.getByText('Unknown study field: studyColour')).toBeVisible()
+
+    await page.getByRole('button', { name: 'Remove unknown-field.csv' }).click()
+
+    await expect(page.getByText('Unknown study field: studyColour')).toBeHidden()
+    await expect(page.locator('#validate-template-btn')).toBeDisabled()
+  })
+
+  test('creates a draft from a valid template and navigates to it', async ({ page }) => {
+    await chooseFile(page, 'valid/minimal-valid.csv')
+    await validate(page)
+
+    await expect(page).toHaveURL(DRAFT_URL)
+
+    const draftUuid = DRAFT_URL.exec(page.url())?.[1]
+    expect(draftUuid, 'draft UUID missing from the URL').toBeTruthy()
+
+    await deleteDraft(page, draftUuid!)
+  })
+
+  test('validates a replacement after a rejection without reloading', async ({ page }) => {
+    await chooseFile(page, 'invalid/unknown-field.csv')
+    await validate(page)
+    await expect(page.getByText('Unknown study field: studyColour')).toBeVisible()
+
+    await chooseFile(page, 'valid/minimal-valid.csv')
+    await validate(page)
+
+    await expect(page).toHaveURL(DRAFT_URL)
+
+    const draftUuid = DRAFT_URL.exec(page.url())?.[1]
+    expect(draftUuid, 'draft UUID missing from the URL').toBeTruthy()
+
+    await deleteDraft(page, draftUuid!)
+  })
+})

--- a/test/e2e/studyTemplate.spec.ts
+++ b/test/e2e/studyTemplate.spec.ts
@@ -2,17 +2,15 @@ import { test, expect } from './support/auth'
 import type { Page } from '@playwright/test'
 
 /*
- * The only coverage that crosses the HTTP boundary: StudyTemplateUpload.spec.tsx mocks the ajax
- * layer. Stops at draft navigation because creating a study would leave a permanent record in dev
- * on every run, and DataSubmissionFormV2.modes.spec.tsx already covers past that point.
+ * The only coverage crossing the HTTP boundary; StudyTemplateUpload.spec.tsx mocks the ajax layer.
+ * Stops at draft navigation: a created study cannot be removed from dev afterwards.
  */
 
 const FIXTURES = 'test/fixtures/study-template/v1'
 const UPLOAD_PATH = '/data_submission_template'
 const DRAFT_URL = /\/data_submission_form\/draft\/study-dataset\/([0-9a-f-]+)$/
 
-// No automation account holds DataSubmitter, the real persona here. CHAIR holds Chairperson, which
-// both the route's RoleBAC and the endpoint's @RolesAllowed admit.
+// No automation account holds DataSubmitter, the real persona; Chairperson is also admitted.
 const ROLE = 'CHAIR' as const
 
 const chooseFile = async (page: Page, fixture: string) => {
@@ -43,8 +41,7 @@ test.describe('study template validation', () => {
   test.beforeEach(async ({ page, signInAs }) => {
     await signInAs(ROLE)
     await page.goto(UPLOAD_PATH)
-    // RoleBAC redirects rather than erroring, so a role that cannot reach the page shows up here
-    // as a changed URL rather than as a missing element further down.
+    // The app renders other pages at this URL when it gates the route, so check both.
     await expect(page).toHaveURL(new RegExp(`${UPLOAD_PATH}$`))
     // TableHeaderSection renders its title in a div, so the page's first real heading is this one.
     await expect(page.getByRole('heading', { name: '1. Start from the blank template' })).toBeVisible()
@@ -59,7 +56,6 @@ test.describe('study template validation', () => {
     await expect(page.getByText('Unknown study field: studyColour')).toBeVisible()
     await expect(page.getByText('Row 2, column field')).toBeVisible()
 
-    // An invalid template is a completed result, not a failure: the user stays here to fix it.
     await expect(page).toHaveURL(new RegExp(`${UPLOAD_PATH}$`))
     await expect(page.locator('#validate-template-btn')).toBeEnabled()
   })

--- a/test/e2e/studyTemplate.spec.ts
+++ b/test/e2e/studyTemplate.spec.ts
@@ -11,8 +11,9 @@ const FIXTURES = 'test/fixtures/study-template/v1'
 const UPLOAD_PATH = '/data_submission_template'
 const DRAFT_URL = /\/data_submission_form\/draft\/study-dataset\/([0-9a-f-]+)$/
 
-// CHAIR satisfies both the route's RoleBAC and the endpoint's @RolesAllowed.
-const ROLE = 'CHAIR' as const
+// ADMIN, not CHAIR: the auth spec proves Admin (its console renders on isAdmin alone) where DAC
+// Console renders for Member too. RoleBAC denies by rendering NotFound at the same URL.
+const ROLE = 'ADMIN' as const
 
 const chooseFile = async (page: Page, fixture: string) => {
   await page.locator('#study-template-file').setInputFiles(`${FIXTURES}/${fixture}`)

--- a/test/e2e/studyTemplate.spec.ts
+++ b/test/e2e/studyTemplate.spec.ts
@@ -11,9 +11,9 @@ const FIXTURES = 'test/fixtures/study-template/v1'
 const UPLOAD_PATH = '/data_submission_template'
 const DRAFT_URL = /\/data_submission_form\/draft\/study-dataset\/([0-9a-f-]+)$/
 
-// ADMIN, not CHAIR: the auth spec proves Admin (its console renders on isAdmin alone) where DAC
-// Console renders for Member too. RoleBAC denies by rendering NotFound at the same URL.
-const ROLE = 'ADMIN' as const
+// No automation account holds DataSubmitter, the real persona here. CHAIR holds Chairperson, which
+// both the route's RoleBAC and the endpoint's @RolesAllowed admit.
+const ROLE = 'CHAIR' as const
 
 const chooseFile = async (page: Page, fixture: string) => {
   await page.locator('#study-template-file').setInputFiles(`${FIXTURES}/${fixture}`)

--- a/test/fixtures/study-template/v1/README.md
+++ b/test/fixtures/study-template/v1/README.md
@@ -12,9 +12,12 @@ the test is that the generated blank template lines up with what Consent actuall
 |---|---|---|
 | `valid/minimal-valid.csv` | `.../v1/valid/minimal-valid.csv` | `3731e0ee` |
 | `valid/multi-consent-group-valid.csv` | `.../v1/valid/multi-consent-group-valid.csv` | `3731e0ee` |
+| `invalid/unknown-field.csv` | `.../v1/invalid/unknown-field.csv` | `3731e0ee` |
 
-Only the two valid fixtures are copied; the invalid ones exercise the parser, which does not run in
-this repository.
+The valid fixtures are copied for the round-trip spec, and one invalid fixture for the end-to-end
+spec, which needs a template Consent will reject. `unknown-field.csv` is the smallest: exactly one
+error, so the assertion does not depend on ordering. The rest exercise the parser, which does not
+run here.
 
 Keep these byte-identical to their source. If the contract changes, re-copy rather than edit — and
 note that provenance cannot be recorded inside the CSVs themselves, since v1 requires the canonical

--- a/test/fixtures/study-template/v1/invalid/unknown-field.csv
+++ b/test/fixtures/study-template/v1/invalid/unknown-field.csv
@@ -1,0 +1,2 @@
+templateVersion,recordType,recordId,parentRecordId,field,value
+1,study,study,,studyColour,ultraviolet

--- a/test/pages/data_submission/v2/DataSubmissionFormV2.modes.spec.tsx
+++ b/test/pages/data_submission/v2/DataSubmissionFormV2.modes.spec.tsx
@@ -7,6 +7,7 @@ import { fireEvent, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { DataSubmissionFormV2 } from 'src/pages/data_submission/v2/DataSubmissionFormV2'
 import { Draft } from 'src/libs/ajax/Draft'
+import { ErrorReporter } from 'src/libs/ErrorReporter'
 import { Notifications } from 'src/libs/utils'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { Study } from 'src/pages/data_submission/v2/v2-models'
@@ -14,6 +15,7 @@ import { DraftDetail } from 'src/types/draft'
 import { renderWithRouter } from '../../../test-utils'
 
 vi.mock('src/libs/ajax/Draft', () => ({ Draft: { getDraft: vi.fn(), deleteDraft: vi.fn() } }))
+vi.mock('src/libs/ErrorReporter', () => ({ ErrorReporter: { report: vi.fn() } }))
 vi.mock('src/libs/ajax/DataSet', () => ({ DataSet: { getStudyById: vi.fn(), registerDataset: vi.fn(), updateStudy: vi.fn() } }))
 vi.mock('src/libs/utils', async () => {
   const actual = await vi.importActual<typeof import('src/libs/utils')>('src/libs/utils')
@@ -290,6 +292,8 @@ describe('creating a study from a draft', () => {
     expect(Notifications.showError).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringContaining('could not be removed') }),
     )
+    // The toast is transient; the rate of these is only measurable if it is also reported.
+    expect(ErrorReporter.report).toHaveBeenCalledWith(expect.stringContaining(DRAFT_ID))
   })
 
   it('does not retry a failed cleanup', async () => {


### PR DESCRIPTION
### Addresses

[DT-3873](https://broadworkbench.atlassian.net/browse/DT-3873).

Security risk: no.

### Summary

`StudyTemplateUpload.spec.tsx` mocks the ajax layer, so nothing proved a real multipart upload reaches Consent and comes back in the shape the page expects. Adds an e2e covering a rejected template, its errors clearing on remove, a valid template creating a draft, and a replacement after a rejection.

It stops at draft navigation and deletes the draft it creates. A study cannot be un-created, so going further would leave a permanent record in dev on every run, and `DataSubmissionFormV2.modes.spec.tsx` already covers past that point.

Also reports a failed source-draft cleanup through `ErrorReporter`. It showed a toast only, which is transient, so the rate of these was not measurable.

### What was blocking it

The automation accounts had never accepted the DUOS Terms of Service. `useSessionReconciler` redirects a user with `tosAccepted === false`, so the app rendered the ToS page at the requested URL — which presents as a missing element, not a redirect. ADMIN and CHAIR have now accepted it in dev; MEMBER, RESEARCHER and SIGNING_OFFICIAL have not.

Worth knowing separately: `auth.spec.ts` asserts the `Admin Console` / `DAC Console` tab is visible, and those are nav chrome that render on the ToS page too. It passed throughout, so it never proved the app was usable past sign-in. Tightening it to assert something only the destination page renders would catch this class of drift.

CHAIR is used because no automation account holds `DataSubmitter`, the real persona here. Chairperson is admitted by both the route's `RoleBAC` and the endpoint's `@RolesAllowed`.

### Note

The invalid fixture is copied from consent byte-identical with a provenance row added, as the fixture README requires.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-3873]: https://broadworkbench.atlassian.net/browse/DT-3873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ