### PR TITLE
[DT-4000] Shift Data Library default to Card view of Studies

### DIFF
--- a/src/components/data_library/LibraryDataGrid.tsx
+++ b/src/components/data_library/LibraryDataGrid.tsx
@@ -6,7 +6,7 @@ import {
 } from '@mui/x-data-grid'
 import { Box, Typography, CircularProgress } from '@mui/material'
 import { isEmpty } from 'src/utils/NodashUtil'
-import { LibraryDataGridProps } from 'src/types/library'
+import { LibraryDataGridProps, PAGE_SIZE_OPTIONS } from 'src/types/library'
 import { assetRegistry, LibraryRow } from 'src/components/data_library/assets'
 
 const EMPTY_RADAR_IDS = new Set<number>()
@@ -71,13 +71,16 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
     ),
   }), [asset, data, selectedDatasetIds])
 
+  // Applied as a delta over this page's rows: replacing the whole selection would discard
+  // anything selected on another page or another tab.
   const handleSelectionChange = (newSelection: GridRowSelectionModel) => {
-    onSelectionChange(
-      asset.selectionToDatasetIds(
-        Array.isArray(data) ? data as LibraryRow[] : [],
-        Array.from(newSelection.ids),
-      ),
-    )
+    const rows = Array.isArray(data) ? data as LibraryRow[] : []
+    const pageDatasetIds = asset.selectionToDatasetIds(rows, rows.map(row => asset.getRowId(row)))
+    const stillSelected = new Set(asset.selectionToDatasetIds(rows, Array.from(newSelection.ids)))
+
+    const next = new Set(selectedDatasetIds)
+    pageDatasetIds.forEach(id => (stillSelected.has(id) ? next.add(id) : next.delete(id)))
+    onSelectionChange(Array.from(next))
   }
 
   const isRowSelectable = (params: { row: LibraryRow }) =>
@@ -126,7 +129,7 @@ export const LibraryDataGrid: React.FC<LibraryDataGridExtendedProps> = ({
         columns={columns}
         rowCount={total}
         loading={loading}
-        pageSizeOptions={[25, 50, 100]}
+        pageSizeOptions={PAGE_SIZE_OPTIONS}
         paginationModel={paginationModel}
         paginationMode="server"
         onPaginationModelChange={onPaginationChange}

--- a/src/components/data_library/LibraryPageShell.tsx
+++ b/src/components/data_library/LibraryPageShell.tsx
@@ -27,6 +27,14 @@ interface LibraryPageShellProps {
   footer?: React.ReactNode
   /** Only the Data Library surfaces the Signing Official authorization model */
   showSoApprovalReminder?: boolean
+  /**
+   * Overrides how the active tab's data renders. Defaults to `LibraryDataGrid`
+   * (an MUI DataGrid table) when omitted. Lets a specific page (e.g. the public
+   * Data Library) swap in an alternate view — a card grid for Studies, say —
+   * for a given asset type without changing that view for other consumers of
+   * this shell, such as the researcher console's submissions table.
+   */
+  renderGrid?: (props: React.ComponentProps<typeof LibraryDataGrid>) => React.ReactNode
 }
 
 export const LibraryPageShell: React.FC<LibraryPageShellProps> = ({
@@ -36,6 +44,7 @@ export const LibraryPageShell: React.FC<LibraryPageShellProps> = ({
   gridExtras = {},
   footer,
   showSoApprovalReminder = false,
+  renderGrid,
 }) => {
   const {
     urlState,
@@ -138,25 +147,28 @@ export const LibraryPageShell: React.FC<LibraryPageShellProps> = ({
             {radarEnabledDatasetIds !== undefined && <InstantApprovalBadge />}
           </Box>
           <Box sx={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
-            <LibraryDataGrid
-              assetType={urlState.tab}
-              data={data?.items || []}
-              loading={isFetching}
-              total={data?.total || 0}
-              paginationModel={{ page: urlState.page, pageSize: urlState.pageSize }}
-              onPaginationChange={(model) => {
-                updateUrlState({ page: model.page, pageSize: model.pageSize })
-              }}
-              sortModel={sortModel}
-              onSortChange={handleSortChange}
-              selectedDatasetIds={selectedDatasetIds}
-              onSelectionChange={onSelectionChange}
-              exportableDatasets={exportableDatasets}
-              radarEnabledDatasetIds={radarEnabledDatasetIds}
-              soApprovalModelByDatasetId={soApprovalModelByDatasetId}
-              extraColumns={extraColumns}
-              checkboxSelection={checkboxSelection}
-            />
+            {(() => {
+              const gridProps: React.ComponentProps<typeof LibraryDataGrid> = {
+                assetType: urlState.tab,
+                data: data?.items || [],
+                loading: isFetching,
+                total: data?.total || 0,
+                paginationModel: { page: urlState.page, pageSize: urlState.pageSize },
+                onPaginationChange: (model) => {
+                  updateUrlState({ page: model.page, pageSize: model.pageSize })
+                },
+                sortModel,
+                onSortChange: handleSortChange,
+                selectedDatasetIds,
+                onSelectionChange,
+                exportableDatasets,
+                radarEnabledDatasetIds,
+                soApprovalModelByDatasetId,
+                extraColumns,
+                checkboxSelection,
+              }
+              return renderGrid ? renderGrid(gridProps) : <LibraryDataGrid {...gridProps} />
+            })()}
           </Box>
         </Box>
       </Box>

--- a/src/components/data_library/StudyCard.tsx
+++ b/src/components/data_library/StudyCard.tsx
@@ -18,7 +18,10 @@ const MAX_VISIBLE_DATA_TYPES = 3
 
 interface StudyCardProps {
   study: StudyAggregation
+  /** True only when every one of the study's datasets is selected. */
   selected: boolean
+  /** Some but not all of the study's datasets are selected. */
+  indeterminate?: boolean
   onToggle: (studyId: number) => void
 }
 
@@ -45,7 +48,7 @@ const Stat = ({ icon, value, label }: { icon: React.ReactNode, value: number, la
 
 const outlinedPill = { 'height': 22, 'fontSize': '1.1rem', '& .MuiChip-label': { px: 1 } }
 
-export const StudyCard: React.FC<StudyCardProps> = ({ study, selected, onToggle }) => {
+export const StudyCard: React.FC<StudyCardProps> = ({ study, selected, indeterminate, onToggle }) => {
   const visibleDataTypes = study.dataTypes.slice(0, MAX_VISIBLE_DATA_TYPES)
   const hiddenDataTypeCount = study.dataTypes.length - visibleDataTypes.length
 
@@ -60,6 +63,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({ study, selected, onToggle 
           <Checkbox
             size="small"
             checked={selected}
+            indeterminate={!selected && indeterminate}
             onChange={() => onToggle(study.studyId)}
             slotProps={{ input: { 'aria-label': `Select ${study.studyName}` } }}
             sx={{ p: 0, mt: '2px' }}

--- a/src/components/data_library/StudyCard.tsx
+++ b/src/components/data_library/StudyCard.tsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import { Box, Card, CardContent, Checkbox, Chip, Divider, Link, Stack, Tooltip, Typography } from '@mui/material'
+import { Link as RouterLink } from 'react-router'
+import PersonOutlineIcon from '@mui/icons-material/PersonOutlineOutlined'
+import BiotechOutlinedIcon from '@mui/icons-material/BiotechOutlined'
+import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined'
+import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined'
+import PeopleOutlineIcon from '@mui/icons-material/PeopleOutlineOutlined'
+import StorageOutlinedIcon from '@mui/icons-material/StorageOutlined'
+import ModelTrainingOutlinedIcon from '@mui/icons-material/ModelTrainingOutlined'
+import WorkspacesOutlinedIcon from '@mui/icons-material/WorkspacesOutlined'
+import PolicyOutlinedIcon from '@mui/icons-material/PolicyOutlined'
+import { StudyAggregation } from 'src/types/library'
+import { getAccessManagementColor, getAccessManagementLabel } from 'src/components/data_library/accessManagementDisplay'
+
+/** Beyond this the pills wrap past the card's metadata block, so the rest collapse into a count. */
+const MAX_VISIBLE_DATA_TYPES = 3
+
+interface StudyCardProps {
+  study: StudyAggregation
+  selected: boolean
+  onToggle: (studyId: number) => void
+}
+
+const MetaRow = ({ icon, children }: { icon: React.ReactNode, children: React.ReactNode }) => (
+  <Stack direction="row" spacing={1} sx={{ minWidth: 0, alignItems: 'flex-start' }}>
+    <Box sx={{ 'color': 'text.disabled', 'display': 'flex', 'pt': '2px', '& svg': { fontSize: '1.8rem' } }}>{icon}</Box>
+    <Box sx={{ minWidth: 0, fontSize: '1.3rem', color: 'text.secondary' }}>{children}</Box>
+  </Stack>
+)
+
+const Stat = ({ icon, value, label }: { icon: React.ReactNode, value: number, label: string }) => (
+  <Stack direction="row" spacing={1} sx={{ alignItems: 'center' }}>
+    <Box sx={{ 'color': 'text.disabled', 'display': 'flex', '& svg': { fontSize: '1.8rem' } }}>{icon}</Box>
+    <Box>
+      <Typography component="div" sx={{ fontSize: '1.4rem', fontWeight: 700, lineHeight: 1.1 }}>
+        {value.toLocaleString()}
+      </Typography>
+      <Typography component="div" sx={{ fontSize: '1.1rem', color: 'text.secondary', lineHeight: 1.1 }}>
+        {label}
+      </Typography>
+    </Box>
+  </Stack>
+)
+
+const outlinedPill = { 'height': 22, 'fontSize': '1.1rem', '& .MuiChip-label': { px: 1 } }
+
+export const StudyCard: React.FC<StudyCardProps> = ({ study, selected, onToggle }) => {
+  const visibleDataTypes = study.dataTypes.slice(0, MAX_VISIBLE_DATA_TYPES)
+  const hiddenDataTypeCount = study.dataTypes.length - visibleDataTypes.length
+
+  return (
+    <Card
+      variant="outlined"
+      data-cy="study-card"
+      sx={{ height: '100%', display: 'flex', flexDirection: 'column', borderRadius: 2 }}
+    >
+      <CardContent sx={{ display: 'flex', flexDirection: 'column', flex: 1, gap: 1.5 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: 'flex-start' }}>
+          <Checkbox
+            size="small"
+            checked={selected}
+            onChange={() => onToggle(study.studyId)}
+            slotProps={{ input: { 'aria-label': `Select ${study.studyName}` } }}
+            sx={{ p: 0, mt: '2px' }}
+          />
+          <Tooltip title={study.studyName}>
+            <Link
+              component={RouterLink}
+              to={`/studies/${study.studyId}`}
+              underline="hover"
+              sx={{
+                fontSize: '1.5rem',
+                fontWeight: 600,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {study.studyName}
+            </Link>
+          </Tooltip>
+        </Stack>
+
+        <Divider />
+
+        <Stack spacing={1} sx={{ flex: 1 }}>
+          {study.piName && (
+            <MetaRow icon={<PersonOutlineIcon />}>
+              PI:
+              {' '}
+              {study.piName}
+            </MetaRow>
+          )}
+          {visibleDataTypes.length > 0 && (
+            <MetaRow icon={<BiotechOutlinedIcon />}>
+              <Stack direction="row" spacing={0.5} sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+                {visibleDataTypes.map(dataType => (
+                  <Chip key={dataType} label={dataType} size="small" variant="outlined" sx={outlinedPill} />
+                ))}
+                {hiddenDataTypeCount > 0 && (
+                  <Tooltip title={study.dataTypes.slice(MAX_VISIBLE_DATA_TYPES).join(', ')}>
+                    <Chip label={`+${hiddenDataTypeCount}`} size="small" variant="outlined" sx={outlinedPill} />
+                  </Tooltip>
+                )}
+              </Stack>
+            </MetaRow>
+          )}
+          {study.species && (
+            <MetaRow icon={<ScienceOutlinedIcon />}>
+              Species:
+              {' '}
+              {study.species}
+            </MetaRow>
+          )}
+          {study.phenotype && (
+            <MetaRow icon={<DescriptionOutlinedIcon />}>
+              Phenotype:
+              {' '}
+              {study.phenotype}
+            </MetaRow>
+          )}
+        </Stack>
+
+        <Divider />
+
+        <Stack direction="row" spacing={2} sx={{ flexWrap: 'wrap', gap: 1.5, alignItems: 'center' }}>
+          <Stat icon={<PeopleOutlineIcon />} value={study.totalParticipants} label="Participants" />
+          <Stat
+            icon={<StorageOutlinedIcon />}
+            value={study.datasetCount}
+            label={study.datasetCount === 1 ? 'Dataset' : 'Datasets'}
+          />
+          {study.modelCount > 0 && (
+            <Stat
+              icon={<ModelTrainingOutlinedIcon />}
+              value={study.modelCount}
+              label={study.modelCount === 1 ? 'Model' : 'Models'}
+            />
+          )}
+          {study.workspaceCount > 0 && (
+            <Stat
+              icon={<WorkspacesOutlinedIcon />}
+              value={study.workspaceCount}
+              label={study.workspaceCount === 1 ? 'Workspace' : 'Workspaces'}
+            />
+          )}
+        </Stack>
+
+        {(study.accessTypes.length > 0 || study.dataUseCodes.length > 0) && (
+          <MetaRow icon={<PolicyOutlinedIcon />}>
+            <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 0.5 }}>
+              {study.accessTypes.map(accessType => (
+                <Chip
+                  key={accessType}
+                  label={getAccessManagementLabel(accessType)}
+                  color={getAccessManagementColor(accessType)}
+                  size="small"
+                  variant="outlined"
+                  sx={outlinedPill}
+                />
+              ))}
+              {study.dataUseCodes.map(code => (
+                <Chip key={code} label={code} size="small" variant="outlined" sx={outlinedPill} />
+              ))}
+            </Stack>
+          </MetaRow>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default StudyCard

--- a/src/components/data_library/StudyCardGrid.tsx
+++ b/src/components/data_library/StudyCardGrid.tsx
@@ -1,20 +1,18 @@
 import React, { useCallback, useMemo } from 'react'
-import { Box, Checkbox, CircularProgress, FormControlLabel, MenuItem, Pagination, Select, Stack, Typography } from '@mui/material'
-import { LibraryDataGridProps, SortOrder, StudyAggregation } from 'src/types/library'
-import { studyAsset } from 'src/components/data_library/assets/studyAsset'
-import { LibraryRow } from 'src/components/data_library/assets/definition'
+import { Alert, Box, Checkbox, CircularProgress, FormControlLabel, MenuItem, Pagination, Select, Stack, Typography } from '@mui/material'
+import { LibraryDataGridProps, PAGE_SIZE_OPTIONS, SortOrder, StudyAggregation } from 'src/types/library'
+import { MAX_STUDY_BUCKETS } from 'src/components/data_library/assets/studyAsset'
 import StudyCard from 'src/components/data_library/StudyCard'
 
 /** Matches the sortable columns the Studies table offers, so switching views keeps the same options. */
 const SORT_OPTIONS: Array<{ label: string, field: string | null, sort: SortOrder | null }> = [
-  { label: 'Relevance', field: null, sort: null },
+  // Not "Relevance": the unsorted aggregation orders by study id, and no scoring is involved.
+  { label: 'Default', field: null, sort: null },
   { label: 'Study Name (A-Z)', field: 'studyName', sort: 'asc' },
   { label: 'Study Name (Z-A)', field: 'studyName', sort: 'desc' },
   { label: 'Most Participants', field: 'totalParticipants', sort: 'desc' },
   { label: 'Most Datasets', field: 'datasetCount', sort: 'desc' },
 ]
-
-const PAGE_SIZES = [10, 25, 50, 100]
 
 export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
   data,
@@ -27,37 +25,42 @@ export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
   selectedDatasetIds,
   onSelectionChange,
 }) => {
+  // Already ordered by the aggregation; re-sorting here would only reorder the current page.
   const studies = useMemo(
     () => (Array.isArray(data) ? data as StudyAggregation[] : []),
     [data],
   )
 
-  // Reuses the asset's own selection maths so a study means the same set of datasets in either view.
-  const selectedStudyIds = useMemo(
-    () => studyAsset.computeRowSelection(studies as LibraryRow[], selectedDatasetIds),
-    [studies, selectedDatasetIds],
+  const selectedIds = useMemo(() => new Set(selectedDatasetIds), [selectedDatasetIds])
+
+  // A study reads as selected only when every dataset under it is, so a part-selected study
+  // cannot be silently promoted to a full one by a checkbox it did not fill.
+  const isFullySelected = useCallback(
+    (study: StudyAggregation) => study.datasetIds.length > 0 && study.datasetIds.every(id => selectedIds.has(id)),
+    [selectedIds],
   )
 
-  const applySelection = useCallback((studyIds: Array<string | number>) => {
-    onSelectionChange(studyAsset.selectionToDatasetIds(studies as LibraryRow[], studyIds))
-  }, [studies, onSelectionChange])
+  // Applied as a delta: rebuilding from this page would discard selections made on another page
+  // or on the Datasets tab.
+  const applyDelta = useCallback((datasetIds: number[], select: boolean) => {
+    const next = new Set(selectedDatasetIds)
+    datasetIds.forEach(id => (select ? next.add(id) : next.delete(id)))
+    onSelectionChange(Array.from(next))
+  }, [selectedDatasetIds, onSelectionChange])
 
   const toggleStudy = useCallback((studyId: number) => {
-    const next = new Set(selectedStudyIds)
-    if (next.has(studyId)) {
-      next.delete(studyId)
+    const study = studies.find(candidate => candidate.studyId === studyId)
+    if (study) {
+      applyDelta(study.datasetIds, !isFullySelected(study))
     }
-    else {
-      next.add(studyId)
-    }
-    applySelection(Array.from(next))
-  }, [selectedStudyIds, applySelection])
+  }, [studies, applyDelta, isFullySelected])
 
-  const allOnPageSelected = studies.length > 0 && studies.every(study => selectedStudyIds.has(study.studyId))
+  const allOnPageSelected = studies.length > 0 && studies.every(isFullySelected)
+  const someOnPageSelected = studies.some(study => study.datasetIds.some(id => selectedIds.has(id)))
 
   const toggleAllOnPage = useCallback(() => {
-    applySelection(allOnPageSelected ? [] : studies.map(study => study.studyId))
-  }, [allOnPageSelected, studies, applySelection])
+    applyDelta(studies.flatMap(study => study.datasetIds), !allOnPageSelected)
+  }, [allOnPageSelected, studies, applyDelta])
 
   const activeSortIndex = useMemo(() => {
     const active = sortModel?.[0]
@@ -67,7 +70,9 @@ export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
     return found === -1 ? 0 : found
   }, [sortModel])
 
-  const pageCount = Math.max(1, Math.ceil(total / paginationModel.pageSize))
+  // Never offer a page past what one capped aggregation can return.
+  const reachable = Math.min(total, MAX_STUDY_BUCKETS)
+  const pageCount = Math.max(1, Math.ceil(reachable / paginationModel.pageSize))
 
   if (loading && studies.length === 0) {
     return (
@@ -85,7 +90,7 @@ export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
             <Checkbox
               size="small"
               checked={allOnPageSelected}
-              indeterminate={!allOnPageSelected && studies.some(study => selectedStudyIds.has(study.studyId))}
+              indeterminate={!allOnPageSelected && someOnPageSelected}
               onChange={toggleAllOnPage}
               disabled={studies.length === 0}
             />
@@ -128,12 +133,19 @@ export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
                 <StudyCard
                   key={study.studyId}
                   study={study}
-                  selected={selectedStudyIds.has(study.studyId)}
+                  selected={isFullySelected(study)}
+                  indeterminate={study.datasetIds.some(id => selectedIds.has(id))}
                   onToggle={toggleStudy}
                 />
               ))}
             </Box>
           )}
+
+      {total > MAX_STUDY_BUCKETS && (
+        <Alert severity="info" sx={{ fontSize: '1.3rem' }}>
+          {`Showing the first ${MAX_STUDY_BUCKETS.toLocaleString()} of ${total.toLocaleString()} studies. Narrow your search or filters to reach the rest.`}
+        </Alert>
+      )}
 
       <Stack direction="row" spacing={2} sx={{ py: 2, flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center' }}>
         <Pagination
@@ -150,7 +162,7 @@ export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
           inputProps={{ 'aria-label': 'Studies per page' }}
           sx={{ fontSize: '1.3rem' }}
         >
-          {PAGE_SIZES.map(size => (
+          {PAGE_SIZE_OPTIONS.map(size => (
             <MenuItem key={size} value={size} sx={{ fontSize: '1.3rem' }}>{`${size} per page`}</MenuItem>
           ))}
         </Select>

--- a/src/components/data_library/StudyCardGrid.tsx
+++ b/src/components/data_library/StudyCardGrid.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useMemo } from 'react'
+import { Box, Checkbox, CircularProgress, FormControlLabel, MenuItem, Pagination, Select, Stack, Typography } from '@mui/material'
+import { LibraryDataGridProps, SortOrder, StudyAggregation } from 'src/types/library'
+import { studyAsset } from 'src/components/data_library/assets/studyAsset'
+import { LibraryRow } from 'src/components/data_library/assets/definition'
+import StudyCard from 'src/components/data_library/StudyCard'
+
+/** Matches the sortable columns the Studies table offers, so switching views keeps the same options. */
+const SORT_OPTIONS: Array<{ label: string, field: string | null, sort: SortOrder | null }> = [
+  { label: 'Relevance', field: null, sort: null },
+  { label: 'Study Name (A-Z)', field: 'studyName', sort: 'asc' },
+  { label: 'Study Name (Z-A)', field: 'studyName', sort: 'desc' },
+  { label: 'Most Participants', field: 'totalParticipants', sort: 'desc' },
+  { label: 'Most Datasets', field: 'datasetCount', sort: 'desc' },
+]
+
+const PAGE_SIZES = [10, 25, 50, 100]
+
+export const StudyCardGrid: React.FC<LibraryDataGridProps> = ({
+  data,
+  loading,
+  total,
+  paginationModel,
+  onPaginationChange,
+  sortModel,
+  onSortChange,
+  selectedDatasetIds,
+  onSelectionChange,
+}) => {
+  const studies = useMemo(
+    () => (Array.isArray(data) ? data as StudyAggregation[] : []),
+    [data],
+  )
+
+  // Reuses the asset's own selection maths so a study means the same set of datasets in either view.
+  const selectedStudyIds = useMemo(
+    () => studyAsset.computeRowSelection(studies as LibraryRow[], selectedDatasetIds),
+    [studies, selectedDatasetIds],
+  )
+
+  const applySelection = useCallback((studyIds: Array<string | number>) => {
+    onSelectionChange(studyAsset.selectionToDatasetIds(studies as LibraryRow[], studyIds))
+  }, [studies, onSelectionChange])
+
+  const toggleStudy = useCallback((studyId: number) => {
+    const next = new Set(selectedStudyIds)
+    if (next.has(studyId)) {
+      next.delete(studyId)
+    }
+    else {
+      next.add(studyId)
+    }
+    applySelection(Array.from(next))
+  }, [selectedStudyIds, applySelection])
+
+  const allOnPageSelected = studies.length > 0 && studies.every(study => selectedStudyIds.has(study.studyId))
+
+  const toggleAllOnPage = useCallback(() => {
+    applySelection(allOnPageSelected ? [] : studies.map(study => study.studyId))
+  }, [allOnPageSelected, studies, applySelection])
+
+  const activeSortIndex = useMemo(() => {
+    const active = sortModel?.[0]
+    const found = SORT_OPTIONS.findIndex(
+      option => option.field === (active?.field ?? null) && option.sort === (active?.sort ?? null),
+    )
+    return found === -1 ? 0 : found
+  }, [sortModel])
+
+  const pageCount = Math.max(1, Math.ceil(total / paginationModel.pageSize))
+
+  if (loading && studies.length === 0) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '50vh' }}>
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  return (
+    <Box sx={{ height: '100%', overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 2, pr: 1 }}>
+      <Stack direction="row" sx={{ flexWrap: 'wrap', gap: 1, alignItems: 'center', justifyContent: 'space-between' }}>
+        <FormControlLabel
+          control={(
+            <Checkbox
+              size="small"
+              checked={allOnPageSelected}
+              indeterminate={!allOnPageSelected && studies.some(study => selectedStudyIds.has(study.studyId))}
+              onChange={toggleAllOnPage}
+              disabled={studies.length === 0}
+            />
+          )}
+          label={<Typography sx={{ fontSize: '1.3rem' }}>Select all on page</Typography>}
+        />
+        <Select
+          size="small"
+          value={activeSortIndex}
+          onChange={(event) => {
+            const option = SORT_OPTIONS[Number(event.target.value)]
+            onSortChange(option.field ? [{ field: option.field, sort: option.sort }] : [])
+          }}
+          inputProps={{ 'aria-label': 'Sort studies' }}
+          sx={{ fontSize: '1.3rem', minWidth: 200 }}
+        >
+          {SORT_OPTIONS.map((option, index) => (
+            <MenuItem key={option.label} value={index} sx={{ fontSize: '1.3rem' }}>{option.label}</MenuItem>
+          ))}
+        </Select>
+      </Stack>
+
+      {studies.length === 0
+        ? <Typography sx={{ fontSize: '1.4rem', color: 'text.secondary', py: 4 }}>No studies match your search.</Typography>
+        : (
+            <Box
+              sx={{
+                display: 'grid',
+                gap: 2,
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  sm: 'repeat(2, minmax(0, 1fr))',
+                  md: 'repeat(3, minmax(0, 1fr))',
+                  lg: 'repeat(4, minmax(0, 1fr))',
+                  xl: 'repeat(5, minmax(0, 1fr))',
+                },
+              }}
+            >
+              {studies.map(study => (
+                <StudyCard
+                  key={study.studyId}
+                  study={study}
+                  selected={selectedStudyIds.has(study.studyId)}
+                  onToggle={toggleStudy}
+                />
+              ))}
+            </Box>
+          )}
+
+      <Stack direction="row" spacing={2} sx={{ py: 2, flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center' }}>
+        <Pagination
+          count={pageCount}
+          page={paginationModel.page + 1}
+          onChange={(_event, page) => onPaginationChange({ page: page - 1, pageSize: paginationModel.pageSize })}
+          shape="rounded"
+          color="primary"
+        />
+        <Select
+          size="small"
+          value={paginationModel.pageSize}
+          onChange={event => onPaginationChange({ page: 0, pageSize: Number(event.target.value) })}
+          inputProps={{ 'aria-label': 'Studies per page' }}
+          sx={{ fontSize: '1.3rem' }}
+        >
+          {PAGE_SIZES.map(size => (
+            <MenuItem key={size} value={size} sx={{ fontSize: '1.3rem' }}>{`${size} per page`}</MenuItem>
+          ))}
+        </Select>
+      </Stack>
+    </Box>
+  )
+}
+
+export default StudyCardGrid

--- a/src/components/data_library/accessManagementDisplay.ts
+++ b/src/components/data_library/accessManagementDisplay.ts
@@ -1,0 +1,22 @@
+import { AccessManagement } from 'src/types/library'
+
+type ChipColor = 'primary' | 'success' | 'secondary' | 'default'
+
+/** Shared by the Datasets grid column and the Studies card pills, so the two cannot drift apart. */
+export const getAccessManagementLabel = (value: string): string => {
+  switch (value) {
+    case AccessManagement.OPEN: return 'Open Access'
+    case AccessManagement.CONTROLLED: return 'via DUOS'
+    case AccessManagement.EXTERNAL: return 'External to DUOS'
+    default: return value
+  }
+}
+
+export const getAccessManagementColor = (value: string): ChipColor => {
+  switch (value) {
+    case AccessManagement.CONTROLLED: return 'primary'
+    case AccessManagement.OPEN: return 'success'
+    case AccessManagement.EXTERNAL: return 'secondary'
+    default: return 'default'
+  }
+}

--- a/src/components/data_library/assets/studyAsset.ts
+++ b/src/components/data_library/assets/studyAsset.ts
@@ -1,13 +1,78 @@
 import { GridColDef } from '@mui/x-data-grid'
-import { ElasticsearchQuery, ElasticsearchResponse, QueryClause, StudyAggregationResponse } from 'src/types/elastic'
+import { AggregationDefinition, CompositeAggregation, ElasticsearchQuery, ElasticsearchResponse, QueryClause, StudyAggregationResponse, studyIdFromBucketKey } from 'src/types/elastic'
 import { PaginationState, SortState, StudyAggregation } from 'src/types/library'
 import { makeStudyColumns } from 'src/components/data_library/columns/studyColumns'
 import { AssetDefinition, ColumnsProps, LibraryPage, LibraryRow } from 'src/components/data_library/assets/definition'
 import { StudyDataEsFields } from 'src/libs/data-metadata'
 
+/**
+ * Neither aggregation shape has an offset, so page N costs (N + 1) * pageSize buckets. Sized as
+ * a safety rail well above the ~4.1k corpus, matching the `STUDIES_AGG` every other tab fetches.
+ */
+export const MAX_STUDY_BUCKETS = 10000
+
+/** Sorts a composite cannot serve: it orders only by its sources, never by a computed metric. */
+const METRIC_SORT_AGGS: Record<string, string> = {
+  totalParticipants: 'total_participants',
+  datasetCount: 'dataset_count',
+}
+
+/** Per-study metrics, identical whichever aggregation shape carries them. */
+const STUDY_BUCKET_AGGS: Record<string, AggregationDefinition> = {
+  study_details: {
+    top_hits: { size: 1, _source: ['study.*'] },
+  },
+  dataset_count: {
+    value_count: { field: 'datasetId' },
+  },
+  total_participants: {
+    sum: { field: 'participantCount' },
+  },
+  dataset_ids: {
+    terms: { field: 'datasetId', size: 10000 },
+  },
+  data_use_codes: {
+    terms: { field: 'dataUse.primary.code.keyword', size: 10 },
+  },
+  access_management_types: {
+    terms: { field: 'accessManagement.keyword', size: 10 },
+  },
+}
+
+/**
+ * Both shapes return buckets already ordered, so `transformResponse` only slices. Metric ordering
+ * is approximate across shards — `terms` ranks each shard's own top buckets before merging.
+ */
+const buildStudiesAgg = (pagination: PaginationState, sort?: SortState): AggregationDefinition => {
+  const size = Math.min((pagination.page + 1) * pagination.pageSize, MAX_STUDY_BUCKETS)
+  const metricAgg = sort ? METRIC_SORT_AGGS[sort.field] : undefined
+
+  if (sort && metricAgg) {
+    return {
+      // shard_size lifts each shard's candidate list to the whole corpus, so a globally top
+      // study cannot be dropped before the merge — exact while the corpus sits under the cap.
+      terms: { field: 'study.studyId', size, shard_size: MAX_STUDY_BUCKETS, order: { [metricAgg]: sort.order } },
+      aggs: STUDY_BUCKET_AGGS,
+    }
+  }
+
+  // Trailing study id keeps the key unique; same-named studies would otherwise share a bucket.
+  const sources: CompositeAggregation['composite']['sources'] = sort?.field === 'studyName'
+    ? [
+        { study_name: { terms: { field: 'study.studyName.keyword', order: sort.order } } },
+        { study_id: { terms: { field: 'study.studyId' } } },
+      ]
+    : [{ study_id: { terms: { field: 'study.studyId' } } }]
+
+  return {
+    composite: { size, sources },
+    aggs: STUDY_BUCKET_AGGS,
+  }
+}
+
 export const studyAsset: AssetDefinition = {
   label: { singular: 'Study', plural: 'Studies' },
-  sortingMode: 'client',
+  sortingMode: 'server',
   searchFields: [
     'datasetName',
     'dataLocation',
@@ -29,7 +94,7 @@ export const studyAsset: AssetDefinition = {
     queryChunks: QueryClause[],
     filterQuery: QueryClause[],
     pagination: PaginationState,
-    _sort?: SortState,
+    sort?: SortState,
   ): ElasticsearchQuery {
     return {
       size: 0,
@@ -43,38 +108,7 @@ export const studyAsset: AssetDefinition = {
         total_studies: {
           cardinality: { field: 'study.studyId' },
         },
-        studies: {
-          composite: {
-            size: (pagination.page + 1) * pagination.pageSize,
-            sources: [
-              {
-                study_id: {
-                  terms: { field: 'study.studyId' },
-                },
-              },
-            ],
-          },
-          aggs: {
-            study_details: {
-              top_hits: { size: 1, _source: ['study.*'] },
-            },
-            dataset_count: {
-              value_count: { field: 'datasetId' },
-            },
-            total_participants: {
-              sum: { field: 'participantCount' },
-            },
-            dataset_ids: {
-              terms: { field: 'datasetId', size: 10000 },
-            },
-            data_use_codes: {
-              terms: { field: 'dataUse.primary.code.keyword', size: 10 },
-            },
-            access_management_types: {
-              terms: { field: 'accessManagement.keyword', size: 10 },
-            },
-          },
-        },
+        studies: buildStudiesAgg(pagination, sort),
         access_management: { terms: { field: 'accessManagement.keyword' } },
         data_use: { terms: { field: 'dataUse.primary.code.keyword' } },
         // Explicit `size`: the secondary vocabulary exceeds the default bucket limit of 10.
@@ -92,7 +126,7 @@ export const studyAsset: AssetDefinition = {
     const allStudies: StudyAggregation[] = buckets.map((bucket) => {
       const studyData = bucket.study_details?.hits?.hits?.[0]?._source?.study || {}
       return {
-        studyId: bucket.key.study_id,
+        studyId: studyIdFromBucketKey(bucket.key),
         studyName: studyData.studyName || '',
         studyDescription: studyData.description || '',
         piName: studyData.piName || '',
@@ -128,11 +162,13 @@ export const studyAsset: AssetDefinition = {
     return true
   },
 
+  // Every, not some: a study whose datasets are only part-selected must not render as fully
+  // checked, or acting on that checkbox would silently select the datasets the user left out.
   computeRowSelection(data: LibraryRow[], selectedDatasetIds: number[]): Set<string | number> {
     const selectedStudyIds = data
       .filter((study) => {
         const studyDatasetIds = (study as StudyAggregation).datasetIds || []
-        return studyDatasetIds.some(id => selectedDatasetIds.includes(id))
+        return studyDatasetIds.length > 0 && studyDatasetIds.every(id => selectedDatasetIds.includes(id))
       })
       .map(study => (study as StudyAggregation).studyId)
     return new Set(selectedStudyIds)

--- a/src/components/data_library/assets/studyAsset.ts
+++ b/src/components/data_library/assets/studyAsset.ts
@@ -67,6 +67,12 @@ export const studyAsset: AssetDefinition = {
             dataset_ids: {
               terms: { field: 'datasetId', size: 10000 },
             },
+            data_use_codes: {
+              terms: { field: 'dataUse.primary.code.keyword', size: 10 },
+            },
+            access_management_types: {
+              terms: { field: 'accessManagement.keyword', size: 10 },
+            },
           },
         },
         access_management: { terms: { field: 'accessManagement.keyword' } },
@@ -93,9 +99,14 @@ export const studyAsset: AssetDefinition = {
         species: studyData.species || '',
         phenotype: studyData.phenotype || '',
         dataCustodianEmail: studyData.dataCustodianEmail || [],
+        dataTypes: studyData.dataTypes || [],
+        dataUseCodes: bucket.data_use_codes?.buckets?.map(b => b.key) || [],
+        accessTypes: bucket.access_management_types?.buckets?.map(b => b.key) || [],
         datasetCount: bucket.dataset_count?.value || 0,
         totalParticipants: bucket.total_participants?.value || 0,
         datasetIds: bucket.dataset_ids?.buckets?.map(b => b.key) || [],
+        modelCount: studyData.assets?.models?.length || 0,
+        workspaceCount: studyData.assets?.workspaces?.length || 0,
       }
     })
 

--- a/src/components/data_library/columns/datasetColumns.tsx
+++ b/src/components/data_library/columns/datasetColumns.tsx
@@ -6,6 +6,7 @@ import { DatasetTerm } from 'src/types/model'
 import { AccessManagement, ExportableDatasets, SoApprovalModel } from 'src/types/library'
 import DatasetExportButton from 'src/components/data_search/DatasetExportButton'
 import RequestAccessButton from 'src/components/data_library/RequestAccessButton'
+import { getAccessManagementColor, getAccessManagementLabel } from 'src/components/data_library/accessManagementDisplay'
 import BoltIcon from '@mui/icons-material/Bolt'
 import { validateHttpUrl } from 'src/utils/UrlUtils'
 import { DATA_USE_GRID_COLUMN } from 'src/components/dataUseGridColumn'
@@ -82,22 +83,8 @@ export const makeDatasetColumns = (
     width: 150,
     renderCell: (params) => {
       const isRadarEnabled = radarEnabledDatasetIds.has(params.row.datasetId)
-      const label = (() => {
-        switch (params.value) {
-          case 'open': return 'Open Access'
-          case 'controlled': return 'via DUOS'
-          case 'external': return 'External to DUOS'
-          default: return params.value
-        }
-      })()
-      const color = (() => {
-        switch (params.value) {
-          case AccessManagement.CONTROLLED: return 'primary'
-          case AccessManagement.OPEN: return 'success'
-          case AccessManagement.EXTERNAL: return 'secondary'
-          default: return 'default'
-        }
-      })()
+      const label = getAccessManagementLabel(params.value)
+      const color = getAccessManagementColor(params.value)
       const tooltipTitle = isRadarEnabled
         ? 'Automatic request approvals available for datasets clearly within the data use terms.'
         : ''

--- a/src/components/data_library/selectionStudyMap.ts
+++ b/src/components/data_library/selectionStudyMap.ts
@@ -1,0 +1,30 @@
+import { AssetDefinition, LibraryRow } from 'src/components/data_library/assets/definition'
+
+/**
+ * Maps every dataset id a row covers to the study it belongs to, via the asset's own accessors so
+ * both the dataset rows and the study rows work without special-casing either.
+ */
+export const studyIdByDatasetId = (asset: AssetDefinition, rows: LibraryRow[]): Map<number, number> => {
+  const mapping = new Map<number, number>()
+
+  rows.forEach((row) => {
+    const datasetIds = asset.selectionToDatasetIds([row], [asset.getRowId(row)])
+    const [studyId] = asset.getStudyIdsForSelection([row], datasetIds)
+    if (studyId !== undefined) {
+      datasetIds.forEach(datasetId => mapping.set(datasetId, studyId))
+    }
+  })
+
+  return mapping
+}
+
+/**
+ * Distinct studies behind a selection. Resolved per dataset rather than per visible row: one
+ * study's datasets can sit on different pages, so a study stays counted while any of them remain.
+ */
+export const selectedStudyIds = (mapping: Map<number, number>, selectedDatasetIds: number[]): number[] =>
+  Array.from(new Set(
+    selectedDatasetIds
+      .map(datasetId => mapping.get(datasetId))
+      .filter((studyId): studyId is number => studyId !== undefined),
+  ))

--- a/src/hooks/useLibraryData.ts
+++ b/src/hooks/useLibraryData.ts
@@ -135,8 +135,15 @@ export const useLibraryData = (
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
     retry: 1,
-    // Preserve previous rows/options while new filters load to avoid UI flicker.
-    placeholderData: previousData => previousData ?? emptyResult,
+    // Preserve previous rows while new filters/pagination load on the *same*
+    // tab to avoid UI flicker. Discard the placeholder on a tab switch instead:
+    // TanStack hands back the immediately-preceding query's data regardless of
+    // queryKey, so without this check a Studies row (`studyId`) would flow into
+    // the Datasets grid using `datasetAsset.getRowId` (`datasetId`) for one
+    // frame, which MUI's DataGrid rejects as a missing row id.
+    placeholderData: (previousData, previousQuery) => (
+      previousQuery?.queryKey[2] === assetType ? (previousData ?? emptyResult) : emptyResult
+    ),
   })
 }
 

--- a/src/hooks/useLibraryPageState.ts
+++ b/src/hooks/useLibraryPageState.ts
@@ -67,8 +67,8 @@ const dataUseModifierLabel = (code: string): string =>
   DATA_USE_MODIFIER_LABELS[code]
   ?? (code.startsWith('GS-') ? `Geographic Restriction (${code})` : code)
 
-export function useLibraryPageState(libraryConfig: LibraryVersionNew) {
-  const [urlState, updateUrlState] = useLibraryUrlState()
+export function useLibraryPageState(libraryConfig: LibraryVersionNew, defaultTab?: AssetType) {
+  const [urlState, updateUrlState] = useLibraryUrlState(defaultTab)
 
   const { data: metadata, isLoading: isMetadataLoading } = useLibraryMetadata(libraryConfig)
 

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -356,7 +356,7 @@ export const useLibraryUrlState = () => {
   // was parsed each time.
   const state: LibraryUrlState = useMemo(() => ({
     library: searchParams.get('library') || 'duos',
-    tab: (searchParams.get('tab') as AssetType) || AssetType.DATASETS,
+    tab: (searchParams.get('tab') as AssetType) || AssetType.STUDIES,
     filters: parseFiltersFromUrl(searchParams),
     page: parsePageParam(searchParams),
     pageSize: parsePageSizeParam(searchParams),

--- a/src/hooks/useLibraryUrlState.ts
+++ b/src/hooks/useLibraryUrlState.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'react-router'
 import { useCallback, useMemo } from 'react'
-import { AssetType, FilterState, LibraryUrlState, SortOrder } from 'src/types/library'
+import { AssetType, DEFAULT_PAGE_SIZE, FilterState, LibraryUrlState, PAGE_SIZE_OPTIONS, SortOrder } from 'src/types/library'
 
 type ArrayFilterParamConfig = {
   key: keyof Pick<
@@ -96,9 +96,10 @@ const parsePageParam = (searchParams: URLSearchParams): number => {
   return page !== undefined && page > 0 ? page : 0
 }
 
+// Restricted to the offered sizes: a size no grid offers leaves the user with no control to change it again.
 const parsePageSizeParam = (searchParams: URLSearchParams): number => {
   const pageSize = parseIntParam(searchParams.get('pageSize'))
-  return pageSize !== undefined && pageSize > 0 ? pageSize : 25
+  return pageSize !== undefined && PAGE_SIZE_OPTIONS.includes(pageSize) ? pageSize : DEFAULT_PAGE_SIZE
 }
 
 const parseArrayParamValues = (searchParams: URLSearchParams, param: string): string[] => {
@@ -310,7 +311,7 @@ const applyPageSizeUpdate = (updates: Partial<LibraryUrlState>, searchParams: UR
     return
   }
 
-  if (updates.pageSize === 25) {
+  if (updates.pageSize === DEFAULT_PAGE_SIZE) {
     searchParams.delete('pageSize')
   }
   else {
@@ -343,9 +344,10 @@ const applyHideFiltersUpdate = (updates: Partial<LibraryUrlState>, searchParams:
 
 /**
  * Custom hook to manage library state in URL search params
+ * @param defaultTab tab used when the URL carries none; only the public Data Library opens on Studies
  * @returns [state, updateState] tuple
  */
-export const useLibraryUrlState = () => {
+export const useLibraryUrlState = (defaultTab: AssetType = AssetType.DATASETS) => {
   const [searchParams, setSearchParams] = useSearchParams()
 
   // react-router returns a stable `searchParams` reference per location, so
@@ -356,7 +358,7 @@ export const useLibraryUrlState = () => {
   // was parsed each time.
   const state: LibraryUrlState = useMemo(() => ({
     library: searchParams.get('library') || 'duos',
-    tab: (searchParams.get('tab') as AssetType) || AssetType.STUDIES,
+    tab: (searchParams.get('tab') as AssetType) || defaultTab,
     filters: parseFiltersFromUrl(searchParams),
     page: parsePageParam(searchParams),
     pageSize: parsePageSizeParam(searchParams),
@@ -364,7 +366,7 @@ export const useLibraryUrlState = () => {
     sortField: searchParams.get('sort') || undefined,
     sortOrder: (searchParams.get('order') as SortOrder) || undefined,
     hideFilters: searchParams.get('hideFilters') === 'true',
-  }), [searchParams])
+  }), [searchParams, defaultTab])
 
   const updateState = useCallback((updates: Partial<LibraryUrlState>) => {
     const newParams = new URLSearchParams(searchParams)

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -13,6 +13,8 @@ import { useLibraryPageState } from 'src/hooks/useLibraryPageState'
 import { useLibraryExportableDatasets } from 'src/hooks/useLibraryExportableDatasets'
 import LibraryPageShell from 'src/components/data_library/LibraryPageShell'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
+import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
+import StudyCardGrid from 'src/components/data_library/StudyCardGrid'
 import TableHeaderSection from 'src/components/TableHeaderSection'
 import SearchBar from 'src/components/SearchBar'
 
@@ -107,6 +109,11 @@ export const DataLibrary: React.FC = () => {
     applyForAccess(selectedDatasetIds, navigate)
   }
 
+  const renderGrid = useCallback((gridProps: React.ComponentProps<typeof LibraryDataGrid>) =>
+    gridProps.assetType === AssetType.STUDIES
+      ? <StudyCardGrid {...gridProps} />
+      : <LibraryDataGrid {...gridProps} />, [])
+
   const header = (
     <>
       <TableHeaderSection
@@ -128,6 +135,7 @@ export const DataLibrary: React.FC = () => {
       tabs={ALL_LIBRARY_TABS}
       header={header}
       showSoApprovalReminder
+      renderGrid={renderGrid}
       gridExtras={{
         selectedDatasetIds,
         onSelectionChange: handleSelectionChange,

--- a/src/pages/DataLibrary.tsx
+++ b/src/pages/DataLibrary.tsx
@@ -13,6 +13,7 @@ import { useLibraryPageState } from 'src/hooks/useLibraryPageState'
 import { useLibraryExportableDatasets } from 'src/hooks/useLibraryExportableDatasets'
 import LibraryPageShell from 'src/components/data_library/LibraryPageShell'
 import LibraryFooter from 'src/components/data_library/LibraryFooter'
+import { selectedStudyIds as studyIdsForSelection, studyIdByDatasetId } from 'src/components/data_library/selectionStudyMap'
 import LibraryDataGrid from 'src/components/data_library/LibraryDataGrid'
 import StudyCardGrid from 'src/components/data_library/StudyCardGrid'
 import TableHeaderSection from 'src/components/TableHeaderSection'
@@ -70,7 +71,7 @@ export const DataLibrary: React.FC = () => {
     }
   }, [query, institutionId, institutionName, restrictToPublicVisibility])
 
-  const pageState = useLibraryPageState(libraryConfig)
+  const pageState = useLibraryPageState(libraryConfig, AssetType.STUDIES)
   const { urlState, data, currentAsset, handleSearchChange } = pageState
 
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<number[]>([])
@@ -96,14 +97,26 @@ export const DataLibrary: React.FC = () => {
     [datasets],
   )
 
-  const selectedStudyIds = useMemo(() => {
-    if (!data?.items) return []
-    return currentAsset.getStudyIdsForSelection(data.items, selectedDatasetIds)
-  }, [data, selectedDatasetIds, currentAsset])
+  // Selection is global, so a footer counting only the current page's rows under-reports studies
+  // as soon as a selection spans pages. Rows are kept per asset: row ids mean different things
+  // across tabs, and each asset reads only its own row shape.
+  // Learned from the rows on screen as the user selects, because a study's datasets can sit on
+  // different pages: counting studies from the visible page alone drops one whose remaining
+  // selected datasets live elsewhere.
+  const [studyByDataset, setStudyByDataset] = useState<Map<number, number>>(new Map())
 
   const handleSelectionChange = useCallback((datasetIds: number[]) => {
     setSelectedDatasetIds(datasetIds)
-  }, [])
+    setStudyByDataset(previous => new Map([
+      ...previous,
+      ...studyIdByDatasetId(currentAsset, data?.items ?? []),
+    ]))
+  }, [data, currentAsset])
+
+  const selectedStudyIds = useMemo(
+    () => studyIdsForSelection(studyByDataset, selectedDatasetIds),
+    [studyByDataset, selectedDatasetIds],
+  )
 
   const handleApplyForAccess = () => {
     applyForAccess(selectedDatasetIds, navigate)

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -188,6 +188,11 @@ export interface StudyAggregationBucket {
             species?: string
             phenotype?: string
             dataCustodianEmail?: string[]
+            dataTypes?: string[]
+            assets?: {
+              models?: PartialModelAsset[]
+              workspaces?: PartialWorkspaceAsset[]
+            }
           }
         }
       }>
@@ -201,6 +206,14 @@ export interface StudyAggregationBucket {
   }
   dataset_ids?: {
     buckets: Array<{ key: number }>
+  }
+  /** Distinct DUO data use codes (`dataUse.primary.code`) across the study's datasets */
+  data_use_codes?: {
+    buckets: Array<{ key: string }>
+  }
+  /** Distinct `accessManagement` values across the study's datasets */
+  access_management_types?: {
+    buckets: Array<{ key: string }>
   }
 }
 

--- a/src/types/elastic.ts
+++ b/src/types/elastic.ts
@@ -89,6 +89,13 @@ export interface TermsAggregation {
   terms: {
     field: string
     size?: number
+    /** Candidates each shard returns before the merge; raise it to make an ordered terms agg exact. */
+    shard_size?: number
+    /** Bucket ordering, e.g. `{ total_participants: 'desc' }` to rank by a metric sub-aggregation. */
+    order?: { [key: string]: SortOrder }
+  }
+  aggs?: {
+    [key: string]: AggregationDefinition
   }
 }
 
@@ -99,6 +106,8 @@ export interface CompositeAggregation {
       [key: string]: {
         terms: {
           field: string
+          /** Composite buckets come back ordered by their sources, so this is the sort. */
+          order?: SortOrder
         }
       }
     }>
@@ -174,7 +183,8 @@ export interface AggregationResult {
 }
 
 export interface StudyAggregationBucket {
-  key: { study_id: number }
+  /** Composite buckets key by source name; a terms aggregation keys by the field value itself. */
+  key: { study_id: number } | number
   doc_count: number
   study_details?: {
     hits?: {
@@ -221,6 +231,9 @@ export interface StudyAggregationResponse {
   buckets: StudyAggregationBucket[]
   after_key?: { study_id: number }
 }
+
+export const studyIdFromBucketKey = (key: StudyAggregationBucket['key']): number =>
+  typeof key === 'number' ? key : key.study_id
 
 /** Raw Elasticsearch document shape for a model asset; derived from ModelAsset so both stay in sync. */
 export type PartialModelAsset = Partial<ModelAsset>

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -303,6 +303,11 @@ export interface FundingResourceAsset extends Omit<FundingResource, 'studyId'> {
   studyName: string
 }
 
+// Shared: MUI's DataGrid hides its rows-per-page control when the current size is not an option.
+export const PAGE_SIZE_OPTIONS = [25, 50, 100]
+
+export const DEFAULT_PAGE_SIZE = 25
+
 export const ALL_LIBRARY_TABS: TabConfig[] = [
   { key: AssetType.STUDIES, label: 'Studies' },
   { key: AssetType.DATASETS, label: 'Datasets' },

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -233,10 +233,16 @@ export interface StudyAggregation {
   species: string
   phenotype: string
   dataCustodianEmail: string[]
+  dataTypes: string[]
+  /** Distinct DUO data use codes (e.g. `HMB`, `GRU`) across the study's datasets */
+  dataUseCodes: string[]
+  /** Distinct `accessManagement` values (e.g. `open`, `controlled`, `external`) across the study's datasets */
+  accessTypes: string[]
   datasetCount: number
   totalParticipants: number
   datasetIds: number[]
-  accessTypes?: string[]
+  modelCount: number
+  workspaceCount: number
 }
 
 export interface PaginationState {

--- a/test/components/data_library/LibraryDataGrid.spec.tsx
+++ b/test/components/data_library/LibraryDataGrid.spec.tsx
@@ -71,8 +71,8 @@ const makeDatasetTerm = (overrides: Partial<DatasetTerm> = {}): DatasetTerm => (
 } as DatasetTerm)
 
 const studies: StudyAggregation[] = [
-  { studyId: 1, studyName: 'Study 1', piName: 'PI 1', species: 'Human', phenotype: 'Condition A', dataCustodianEmail: ['custodian1@example.com'], datasetCount: 2, totalParticipants: 100, datasetIds: [101, 102] },
-  { studyId: 2, studyName: 'Study 2', piName: 'PI 2', species: 'Mouse', phenotype: 'Condition B', dataCustodianEmail: ['custodian2@example.com'], datasetCount: 1, totalParticipants: 50, datasetIds: [201] },
+  { studyId: 1, studyName: 'Study 1', piName: 'PI 1', species: 'Human', phenotype: 'Condition A', dataCustodianEmail: ['custodian1@example.com'], dataTypes: [], dataUseCodes: [], accessTypes: [], datasetCount: 2, totalParticipants: 100, datasetIds: [101, 102], modelCount: 0, workspaceCount: 0 },
+  { studyId: 2, studyName: 'Study 2', piName: 'PI 2', species: 'Mouse', phenotype: 'Condition B', dataCustodianEmail: ['custodian2@example.com'], dataTypes: [], dataUseCodes: [], accessTypes: [], datasetCount: 1, totalParticipants: 50, datasetIds: [201], modelCount: 0, workspaceCount: 0 },
 ]
 
 const datasets = [

--- a/test/components/data_library/LibraryDataGrid.spec.tsx
+++ b/test/components/data_library/LibraryDataGrid.spec.tsx
@@ -244,6 +244,39 @@ describe('LibraryDataGrid', () => {
     expect(onSelectionChange).toHaveBeenCalledWith([101, 102])
   })
 
+  // Rows off the current page are not in `data`, so a rebuild would silently drop them.
+  it('preserves selections made on another page', async () => {
+    const user = userEvent.setup()
+    const onSelectionChange = vi.fn()
+    const { container } = mountGrid(
+      <LibraryDataGrid
+        assetType={AssetType.DATASETS}
+        data={datasets}
+        total={3}
+        {...{ ...baseProps, selectedDatasetIds: [999], onSelectionChange }}
+      />,
+    )
+    const checkbox = container.querySelector('.MuiDataGrid-row[data-id="101"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    await user.click(checkbox)
+    expect(onSelectionChange).toHaveBeenCalledWith([999, 101])
+  })
+
+  it('drops only this page\'s rows when they are deselected', async () => {
+    const user = userEvent.setup()
+    const onSelectionChange = vi.fn()
+    const { container } = mountGrid(
+      <LibraryDataGrid
+        assetType={AssetType.DATASETS}
+        data={datasets}
+        total={3}
+        {...{ ...baseProps, selectedDatasetIds: [999, 101], onSelectionChange }}
+      />,
+    )
+    const checkbox = container.querySelector('.MuiDataGrid-row[data-id="101"] .MuiDataGrid-checkboxInput input') as HTMLInputElement
+    await user.click(checkbox)
+    expect(onSelectionChange).toHaveBeenCalledWith([999])
+  })
+
   it('calls onPaginationChange when page changes', async () => {
     const user = userEvent.setup()
     const onPaginationChange = vi.fn()

--- a/test/components/data_library/StudyCard.spec.tsx
+++ b/test/components/data_library/StudyCard.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithRouter } from '../../test-utils'
+import StudyCard from 'src/components/data_library/StudyCard'
+import { StudyAggregation } from 'src/types/library'
+
+const buildStudy = (overrides: Partial<StudyAggregation> = {}): StudyAggregation => ({
+  studyId: 1,
+  studyName: 'Synthetic Minimal Study',
+  piName: 'Dr. Example',
+  species: 'Human',
+  phenotype: 'Various',
+  dataCustodianEmail: [],
+  dataTypes: ['RNA-Seq'],
+  dataUseCodes: ['HMB'],
+  accessTypes: ['controlled'],
+  datasetCount: 3,
+  totalParticipants: 5567,
+  datasetIds: [10, 11, 12],
+  modelCount: 0,
+  workspaceCount: 0,
+  ...overrides,
+})
+
+const renderCard = (study: StudyAggregation, selected = false, onToggle = vi.fn()) => {
+  renderWithRouter(<StudyCard study={study} selected={selected} onToggle={onToggle} />)
+  return onToggle
+}
+
+describe('StudyCard', () => {
+  it('links the study name to its detail page', () => {
+    renderCard(buildStudy())
+    expect(screen.getByRole('link', { name: 'Synthetic Minimal Study' })).toHaveAttribute('href', '/studies/1')
+  })
+
+  it('renders the metadata a researcher scans for', () => {
+    renderCard(buildStudy())
+    expect(screen.getByText(/Dr. Example/)).toBeInTheDocument()
+    expect(screen.getByText(/Human/)).toBeInTheDocument()
+    expect(screen.getByText(/Various/)).toBeInTheDocument()
+    expect(screen.getByText('RNA-Seq')).toBeInTheDocument()
+  })
+
+  it('formats participant counts with separators', () => {
+    renderCard(buildStudy({ totalParticipants: 4444444 }))
+    expect(screen.getByText('4,444,444')).toBeInTheDocument()
+  })
+
+  it('singularises a one-dataset study', () => {
+    renderCard(buildStudy({ datasetCount: 1 }))
+    expect(screen.getByText('Dataset')).toBeInTheDocument()
+    expect(screen.queryByText('Datasets')).not.toBeInTheDocument()
+  })
+
+  it('omits metadata rows the study does not carry', () => {
+    renderCard(buildStudy({ species: '', phenotype: '' }))
+    expect(screen.queryByText(/Species:/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Phenotype:/)).not.toBeInTheDocument()
+  })
+
+  it('omits model and workspace stats when there are none', () => {
+    renderCard(buildStudy())
+    expect(screen.queryByText('Models')).not.toBeInTheDocument()
+    expect(screen.queryByText('Workspaces')).not.toBeInTheDocument()
+  })
+
+  it('shows model and workspace stats when the study has them', () => {
+    renderCard(buildStudy({ modelCount: 2, workspaceCount: 1 }))
+    expect(screen.getByText('Models')).toBeInTheDocument()
+    expect(screen.getByText('Workspace')).toBeInTheDocument()
+  })
+
+  it('collapses data types past the third into a count', () => {
+    renderCard(buildStudy({ dataTypes: ['Hybrid Capture', 'RNA-Seq', 'Spatial Transcriptomics', 'WGS'] }))
+    expect(screen.getByText('Hybrid Capture')).toBeInTheDocument()
+    expect(screen.getByText('Spatial Transcriptomics')).toBeInTheDocument()
+    expect(screen.getByText('+1')).toBeInTheDocument()
+    expect(screen.queryByText('WGS')).not.toBeInTheDocument()
+  })
+
+  it('labels access types the way the Datasets grid does', () => {
+    renderCard(buildStudy({ accessTypes: ['controlled', 'open', 'external'] }))
+    expect(screen.getByText('via DUOS')).toBeInTheDocument()
+    expect(screen.getByText('Open Access')).toBeInTheDocument()
+    expect(screen.getByText('External to DUOS')).toBeInTheDocument()
+  })
+
+  it('reports the study id when its checkbox is toggled', async () => {
+    const onToggle = renderCard(buildStudy({ studyId: 42 }))
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Synthetic Minimal Study' }))
+    expect(onToggle).toHaveBeenCalledWith(42)
+  })
+
+  it('reflects the selected state it is given', () => {
+    renderCard(buildStudy(), true)
+    expect(screen.getByRole('checkbox', { name: 'Select Synthetic Minimal Study' })).toBeChecked()
+  })
+})

--- a/test/components/data_library/StudyCardGrid.spec.tsx
+++ b/test/components/data_library/StudyCardGrid.spec.tsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { renderWithRouter } from '../../test-utils'
+import StudyCardGrid from 'src/components/data_library/StudyCardGrid'
+import { AssetType, LibraryDataGridProps, StudyAggregation } from 'src/types/library'
+
+const buildStudy = (studyId: number, datasetIds: number[], overrides: Partial<StudyAggregation> = {}): StudyAggregation => ({
+  studyId,
+  studyName: `Study ${studyId}`,
+  piName: 'Dr. Example',
+  species: 'Human',
+  phenotype: 'Various',
+  dataCustodianEmail: [],
+  dataTypes: [],
+  dataUseCodes: [],
+  accessTypes: [],
+  datasetCount: datasetIds.length,
+  totalParticipants: 10,
+  datasetIds,
+  modelCount: 0,
+  workspaceCount: 0,
+  ...overrides,
+})
+
+const STUDIES = [buildStudy(1, [10, 11]), buildStudy(2, [20])]
+
+const renderGrid = (overrides: Partial<LibraryDataGridProps> = {}) => {
+  const props: LibraryDataGridProps = {
+    assetType: AssetType.STUDIES,
+    data: STUDIES,
+    loading: false,
+    total: 2,
+    paginationModel: { page: 0, pageSize: 25 },
+    onPaginationChange: vi.fn(),
+    sortModel: [],
+    onSortChange: vi.fn(),
+    selectedDatasetIds: [],
+    onSelectionChange: vi.fn(),
+    ...overrides,
+  }
+  renderWithRouter(<StudyCardGrid {...props} />)
+  return props
+}
+
+describe('StudyCardGrid', () => {
+  it('renders a card per study', () => {
+    renderGrid()
+    expect(screen.getByRole('link', { name: 'Study 1' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Study 2' })).toBeInTheDocument()
+  })
+
+  it('selects every dataset belonging to a study', async () => {
+    const props = renderGrid()
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Study 1' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([10, 11])
+  })
+
+  it('deselects a study without disturbing the others', async () => {
+    const props = renderGrid({ selectedDatasetIds: [10, 11, 20] })
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select Study 1' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([20])
+  })
+
+  it('checks a study whose datasets are already selected', () => {
+    renderGrid({ selectedDatasetIds: [20] })
+    expect(screen.getByRole('checkbox', { name: 'Select Study 2' })).toBeChecked()
+    expect(screen.getByRole('checkbox', { name: 'Select Study 1' })).not.toBeChecked()
+  })
+
+  it('selects every study on the page at once', async () => {
+    const props = renderGrid()
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select all on page' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([10, 11, 20])
+  })
+
+  it('clears the page when select-all is already on', async () => {
+    const props = renderGrid({ selectedDatasetIds: [10, 11, 20] })
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select all on page' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([])
+  })
+
+  it('reports a chosen sort as a sort model', async () => {
+    const props = renderGrid()
+    await userEvent.click(screen.getByLabelText('Sort studies'))
+    await userEvent.click(screen.getByRole('option', { name: 'Most Participants' }))
+    expect(props.onSortChange).toHaveBeenCalledWith([{ field: 'totalParticipants', sort: 'desc' }])
+  })
+
+  it('clears the sort model when returning to relevance', async () => {
+    const props = renderGrid({ sortModel: [{ field: 'studyName', sort: 'asc' }] })
+    await userEvent.click(screen.getByLabelText('Sort studies'))
+    await userEvent.click(screen.getByRole('option', { name: 'Relevance' }))
+    expect(props.onSortChange).toHaveBeenCalledWith([])
+  })
+
+  it('pages using a one-based control over a zero-based model', async () => {
+    const props = renderGrid({ total: 60 })
+    await userEvent.click(screen.getByRole('button', { name: 'Go to page 2' }))
+    expect(props.onPaginationChange).toHaveBeenCalledWith({ page: 1, pageSize: 25 })
+  })
+
+  it('returns to the first page when the page size changes', async () => {
+    const props = renderGrid({ total: 60 })
+    await userEvent.click(screen.getByLabelText('Studies per page'))
+    await userEvent.click(screen.getByRole('option', { name: '50 per page' }))
+    expect(props.onPaginationChange).toHaveBeenCalledWith({ page: 0, pageSize: 50 })
+  })
+
+  it('shows a spinner only while first loading', () => {
+    renderGrid({ data: [], loading: true })
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+  })
+
+  it('says so when nothing matched', () => {
+    renderGrid({ data: [], loading: false, total: 0 })
+    expect(screen.getByText('No studies match your search.')).toBeInTheDocument()
+  })
+})

--- a/test/components/data_library/StudyCardGrid.spec.tsx
+++ b/test/components/data_library/StudyCardGrid.spec.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithRouter } from '../../test-utils'
 import StudyCardGrid from 'src/components/data_library/StudyCardGrid'
 import { AssetType, LibraryDataGridProps, StudyAggregation } from 'src/types/library'
+import { MAX_STUDY_BUCKETS } from 'src/components/data_library/assets/studyAsset'
 
 const buildStudy = (studyId: number, datasetIds: number[], overrides: Partial<StudyAggregation> = {}): StudyAggregation => ({
   studyId,
@@ -89,11 +90,49 @@ describe('StudyCardGrid', () => {
     expect(props.onSortChange).toHaveBeenCalledWith([{ field: 'totalParticipants', sort: 'desc' }])
   })
 
-  it('clears the sort model when returning to relevance', async () => {
+  it('clears the sort model when returning to the default order', async () => {
     const props = renderGrid({ sortModel: [{ field: 'studyName', sort: 'asc' }] })
     await userEvent.click(screen.getByLabelText('Sort studies'))
-    await userEvent.click(screen.getByRole('option', { name: 'Relevance' }))
+    await userEvent.click(screen.getByRole('option', { name: 'Default' }))
     expect(props.onSortChange).toHaveBeenCalledWith([])
+  })
+
+  it('keeps selections made elsewhere when a study is toggled', () => {
+    const props = renderGrid({ selectedDatasetIds: [999] })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Study 1' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([999, 10, 11])
+  })
+
+  it('keeps selections made elsewhere when the page is cleared', () => {
+    const props = renderGrid({ selectedDatasetIds: [999, 10, 11, 20] })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all on page' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([999])
+  })
+
+  it('leaves a part-selected study unchecked rather than reading as fully selected', () => {
+    renderGrid({ selectedDatasetIds: [10] })
+    expect(screen.getByRole('checkbox', { name: 'Select Study 1' })).not.toBeChecked()
+  })
+
+  // Toggling a part-selected study completes it; it must never drop the datasets already chosen.
+  it('completes a part-selected study rather than clearing it', () => {
+    const props = renderGrid({ selectedDatasetIds: [10] })
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select Study 1' }))
+    expect(props.onSelectionChange).toHaveBeenCalledWith([10, 11])
+  })
+
+  it('does not count a part-selected page as fully selected', () => {
+    renderGrid({ selectedDatasetIds: [10] })
+    expect(screen.getByRole('checkbox', { name: 'Select all on page' })).not.toBeChecked()
+  })
+
+  // Re-sorting here would reorder only the current page, reading as a corpus-wide sort.
+  it('renders in the order the query returned, whatever the sort model says', () => {
+    renderGrid({
+      data: [buildStudy(1, [10], { studyName: 'Beta' }), buildStudy(2, [20], { studyName: 'Alpha' })],
+      sortModel: [{ field: 'studyName', sort: 'asc' }],
+    })
+    expect(screen.getAllByRole('link').map(link => link.textContent)).toEqual(['Beta', 'Alpha'])
   })
 
   it('pages using a one-based control over a zero-based model', async () => {
@@ -107,6 +146,28 @@ describe('StudyCardGrid', () => {
     await userEvent.click(screen.getByLabelText('Studies per page'))
     await userEvent.click(screen.getByRole('option', { name: '50 per page' }))
     expect(props.onPaginationChange).toHaveBeenCalledWith({ page: 0, pageSize: 50 })
+  })
+
+  it('offers no page the capped aggregation cannot serve', () => {
+    renderGrid({ total: 500000, paginationModel: { page: 0, pageSize: 100 } })
+    const lastPage = MAX_STUDY_BUCKETS / 100
+    expect(screen.getByRole('button', { name: `Go to page ${lastPage}` })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: `Go to page ${lastPage + 1}` })).not.toBeInTheDocument()
+  })
+
+  it('says how many of the matches are reachable when the cap bites', () => {
+    renderGrid({ total: 500000, paginationModel: { page: 0, pageSize: 100 } })
+    expect(screen.getByText(/Showing the first 10,000 of 500,000 studies/)).toBeInTheDocument()
+  })
+
+  it('stays quiet at the real corpus size', () => {
+    renderGrid({ total: 4100, paginationModel: { page: 0, pageSize: 100 } })
+    expect(screen.queryByText(/Showing the first/)).not.toBeInTheDocument()
+  })
+
+  it('stays quiet about the cap when every match is reachable', () => {
+    renderGrid({ total: 60 })
+    expect(screen.queryByText(/Showing the first/)).not.toBeInTheDocument()
   })
 
   it('shows a spinner only while first loading', () => {

--- a/test/components/data_library/assets/studyAsset.spec.ts
+++ b/test/components/data_library/assets/studyAsset.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for studyAsset — the Studies AssetDefinition.
+ */
+import { describe, it, expect } from 'vitest'
+import { MAX_STUDY_BUCKETS, studyAsset } from 'src/components/data_library/assets/studyAsset'
+import { PaginationState, SortState } from 'src/types/library'
+import { CompositeAggregation, QueryClause, TermsAggregation } from 'src/types/elastic'
+
+const buildStudiesAgg = (pagination: PaginationState, sort?: SortState) => {
+  const query = studyAsset.buildQuery([] as QueryClause[], [] as QueryClause[], pagination, sort)
+  return query.aggs!.studies
+}
+
+const pagination: PaginationState = { page: 0, pageSize: 25 }
+
+describe('studyAsset.buildQuery', () => {
+  describe('bucket depth', () => {
+    it('asks only for the buckets the page needs', () => {
+      expect((buildStudiesAgg(pagination) as CompositeAggregation).composite.size).toBe(25)
+      expect((buildStudiesAgg({ page: 3, pageSize: 25 }) as CompositeAggregation).composite.size).toBe(100)
+    })
+
+    // Neither aggregation supports an offset, so bucket count grows with depth. Without the cap
+    // one click on a far page would pull every earlier bucket with its dataset_ids list.
+    it('caps the bucket count however deep the page is', () => {
+      expect((buildStudiesAgg({ page: 9999, pageSize: 100 }) as CompositeAggregation).composite.size)
+        .toBe(MAX_STUDY_BUCKETS)
+    })
+  })
+
+  describe('sorting', () => {
+    // Without it each shard ranks only its own candidates, so a globally top study can be dropped.
+    it('raises shard_size so a metric ranking is exact below the cap', () => {
+      const agg = buildStudiesAgg(pagination, { field: 'datasetCount', order: 'desc' }) as TermsAggregation
+      expect(agg.terms.shard_size).toBe(MAX_STUDY_BUCKETS)
+    })
+
+    it('orders by study id when no sort is requested', () => {
+      const agg = buildStudiesAgg(pagination) as CompositeAggregation
+      expect(agg.composite.sources).toEqual([{ study_id: { terms: { field: 'study.studyId' } } }])
+    })
+
+    it('orders by name through the composite source, so the sort spans the corpus', () => {
+      const agg = buildStudiesAgg(pagination, { field: 'studyName', order: 'desc' }) as CompositeAggregation
+      expect(agg.composite.sources[0]).toEqual({
+        study_name: { terms: { field: 'study.studyName.keyword', order: 'desc' } },
+      })
+    })
+
+    // Two studies sharing a name would collapse into one bucket without a unique trailing source.
+    it('keeps study id as a tie-break source when ordering by name', () => {
+      const agg = buildStudiesAgg(pagination, { field: 'studyName', order: 'asc' }) as CompositeAggregation
+      expect(agg.composite.sources[1]).toEqual({ study_id: { terms: { field: 'study.studyId' } } })
+    })
+
+    // A composite aggregation can only order by its sources, never by a computed metric.
+    it('switches to a terms aggregation to rank by a metric', () => {
+      const agg = buildStudiesAgg(pagination, { field: 'totalParticipants', order: 'desc' }) as TermsAggregation
+      expect(agg.terms).toEqual({
+        field: 'study.studyId',
+        size: 25,
+        shard_size: MAX_STUDY_BUCKETS,
+        order: { total_participants: 'desc' },
+      })
+    })
+
+    it('ranks by dataset count through the same metric path', () => {
+      const agg = buildStudiesAgg(pagination, { field: 'datasetCount', order: 'desc' }) as TermsAggregation
+      expect(agg.terms.order).toEqual({ dataset_count: 'desc' })
+    })
+
+    it('carries the same per-study metrics whichever shape it picks', () => {
+      const composite = buildStudiesAgg(pagination) as CompositeAggregation
+      const terms = buildStudiesAgg(pagination, { field: 'totalParticipants', order: 'desc' }) as TermsAggregation
+      expect(Object.keys(composite.aggs!)).toEqual(Object.keys(terms.aggs!))
+    })
+  })
+})
+
+describe('studyAsset.transformResponse', () => {
+  const bucketMetrics = {
+    doc_count: 1,
+    study_details: { hits: { hits: [{ _source: { study: { studyName: 'A Study' } } }] } },
+    dataset_count: { value: 2 },
+    total_participants: { value: 40 },
+    dataset_ids: { buckets: [{ key: 10 }, { key: 11 }] },
+  }
+
+  it('reads the study id from a composite bucket key', () => {
+    const page = studyAsset.transformResponse(
+      { aggregations: { studies: { buckets: [{ key: { study_id: 7 }, ...bucketMetrics }] } } } as never,
+      pagination,
+    )
+    expect(page.items[0]).toMatchObject({ studyId: 7, studyName: 'A Study', datasetIds: [10, 11] })
+  })
+
+  it('reads the study id from a terms bucket key', () => {
+    const page = studyAsset.transformResponse(
+      { aggregations: { studies: { buckets: [{ key: 7, ...bucketMetrics }] } } } as never,
+      pagination,
+    )
+    expect(page.items[0]).toMatchObject({ studyId: 7, studyName: 'A Study', datasetIds: [10, 11] })
+  })
+})

--- a/test/components/data_library/selectionStudyMap.spec.ts
+++ b/test/components/data_library/selectionStudyMap.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { selectedStudyIds, studyIdByDatasetId } from 'src/components/data_library/selectionStudyMap'
+import { datasetAsset } from 'src/components/data_library/assets/datasetAsset'
+import { studyAsset } from 'src/components/data_library/assets/studyAsset'
+import { LibraryRow } from 'src/components/data_library/assets/definition'
+
+const datasetRow = (datasetId: number, studyId: number) =>
+  ({ datasetId, study: { studyId } } as unknown as LibraryRow)
+
+const studyRow = (studyId: number, datasetIds: number[]) =>
+  ({ studyId, datasetIds } as unknown as LibraryRow)
+
+describe('studyIdByDatasetId', () => {
+  it('maps a dataset row to its study', () => {
+    const mapping = studyIdByDatasetId(datasetAsset, [datasetRow(101, 7), datasetRow(102, 8)])
+    expect(mapping.get(101)).toBe(7)
+    expect(mapping.get(102)).toBe(8)
+  })
+
+  it('maps every dataset a study row covers', () => {
+    const mapping = studyIdByDatasetId(studyAsset, [studyRow(7, [101, 102])])
+    expect(Array.from(mapping.entries())).toEqual([[101, 7], [102, 7]])
+  })
+})
+
+describe('selectedStudyIds', () => {
+  it('counts a study once however many of its datasets are selected', () => {
+    const mapping = new Map([[101, 7], [102, 7], [201, 8]])
+    expect(selectedStudyIds(mapping, [101, 102, 201])).toEqual([7, 8])
+  })
+
+  // The case the page-scoped count got wrong: one study's datasets split across two pages.
+  it('keeps a study while any of its datasets stay selected', () => {
+    const mapping = new Map([[101, 7], [102, 7]])
+    expect(selectedStudyIds(mapping, [102])).toEqual([7])
+  })
+
+  it('drops a study once its last dataset is deselected', () => {
+    const mapping = new Map([[101, 7], [102, 7]])
+    expect(selectedStudyIds(mapping, [])).toEqual([])
+  })
+
+  it('ignores datasets it has no mapping for', () => {
+    expect(selectedStudyIds(new Map([[101, 7]]), [101, 999])).toEqual([7])
+  })
+})

--- a/test/hooks/useLibraryUrlState.spec.tsx
+++ b/test/hooks/useLibraryUrlState.spec.tsx
@@ -7,8 +7,8 @@ import { useLibraryUrlState } from 'src/hooks/useLibraryUrlState'
 import { AssetType } from 'src/types/library'
 import { EMPTY_FILTERS } from 'src/components/data_library/filterRegistry'
 
-const TestComponent = () => {
-  const [state, updateState] = useLibraryUrlState()
+const TestComponent = ({ defaultTab }: { defaultTab?: AssetType } = {}) => {
+  const [state, updateState] = useLibraryUrlState(defaultTab)
   return (
     <div>
       <div id="library">{state.library}</div>
@@ -48,7 +48,7 @@ describe('useLibraryUrlState', () => {
       </MemoryRouter>,
     )
     expect(screen.getByText('duos')).toBeInTheDocument()
-    expect(screen.getByText(AssetType.STUDIES)).toBeInTheDocument()
+    expect(screen.getByText(AssetType.DATASETS)).toBeInTheDocument()
     const filtersEl = document.getElementById('filters')!
     const filters = JSON.parse(filtersEl.textContent!)
     expect(filters.accessManagement).toHaveLength(0)
@@ -211,6 +211,33 @@ describe('useLibraryUrlState', () => {
     )
     expect(document.getElementById('page')!.textContent).toBe('0')
     expect(document.getElementById('pageSize')!.textContent).toBe('25')
+  })
+
+  it('rejects a page size the grids do not offer', () => {
+    render(
+      <MemoryRouter initialEntries={['/?pageSize=10']}>
+        <TestComponent />
+      </MemoryRouter>,
+    )
+    expect(document.getElementById('pageSize')!.textContent).toBe('25')
+  })
+
+  it('uses the caller-supplied default tab when the URL carries none', () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <TestComponent defaultTab={AssetType.STUDIES} />
+      </MemoryRouter>,
+    )
+    expect(document.getElementById('tab')!.textContent).toBe(AssetType.STUDIES)
+  })
+
+  it('lets the URL override the caller-supplied default tab', () => {
+    render(
+      <MemoryRouter initialEntries={['/?tab=datasets']}>
+        <TestComponent defaultTab={AssetType.STUDIES} />
+      </MemoryRouter>,
+    )
+    expect(document.getElementById('tab')!.textContent).toBe(AssetType.DATASETS)
   })
 })
 

--- a/test/hooks/useLibraryUrlState.spec.tsx
+++ b/test/hooks/useLibraryUrlState.spec.tsx
@@ -48,7 +48,7 @@ describe('useLibraryUrlState', () => {
       </MemoryRouter>,
     )
     expect(screen.getByText('duos')).toBeInTheDocument()
-    expect(screen.getByText(AssetType.DATASETS)).toBeInTheDocument()
+    expect(screen.getByText(AssetType.STUDIES)).toBeInTheDocument()
     const filtersEl = document.getElementById('filters')!
     const filters = JSON.parse(filtersEl.textContent!)
     expect(filters.accessManagement).toHaveLength(0)

--- a/test/pages/DataLibrary.spec.tsx
+++ b/test/pages/DataLibrary.spec.tsx
@@ -29,6 +29,7 @@ const ACCESS_REQUEST_PROCESS_LABEL = 'Access Request Process'
 const CLEAR_FILTERS_LABEL = 'Clear'
 const CONFIG_PATH = '/config.json'
 const DATA_GRID_ROW_SELECTOR = '.MuiDataGrid-row'
+const STUDY_CARD_SELECTOR = '[data-cy="study-card"]'
 const DATASETS_TAB_PATH = '/?tab=datasets'
 const DUOS_DATA_LIBRARY_TITLE = 'DUOS Data Library'
 const EXPORT_LABEL = 'Export to...'
@@ -81,10 +82,19 @@ const getFilterToggleButton = (selector: string): HTMLElement => {
 }
 
 const queryRows = () => document.querySelectorAll(DATA_GRID_ROW_SELECTOR)
+const queryStudyCards = () => document.querySelectorAll(STUDY_CARD_SELECTOR)
 
 const getSingleDataGridRow = async (): Promise<Element> => {
   await waitFor(() => expect(queryRows()).toHaveLength(1))
   return queryRows()[0]
+}
+
+// Studies render as cards rather than DataGrid rows; this mirrors
+// getSingleDataGridRow for the card view (studies are still selected via a
+// checkbox, so getRowCheckbox works unchanged on a card element).
+const getSingleStudyCard = async (): Promise<Element> => {
+  await waitFor(() => expect(queryStudyCards()).toHaveLength(1))
+  return queryStudyCards()[0]
 }
 
 const getRowCheckbox = (row: Element): HTMLInputElement => {
@@ -364,15 +374,16 @@ describe('DataLibrary', () => {
     renderLibrary('/')
     await screen.findByText(DUOS_DATA_LIBRARY_TITLE)
 
+    // Studies is the default tab.
     await waitFor(() =>
-      expect(screen.getByRole('tab', { name: /Datasets/i })).toHaveAttribute('aria-selected', 'true'),
+      expect(screen.getByRole('tab', { name: /Studies/i })).toHaveAttribute('aria-selected', 'true'),
     )
 
-    await user.click(screen.getByRole('tab', { name: /Studies/i }))
+    await user.click(screen.getByRole('tab', { name: /Datasets/i }))
 
     await waitFor(() => {
-      expect(screen.getByRole('tab', { name: /Studies/i })).toHaveAttribute('aria-selected', 'true')
-      expect(screen.getByRole('tab', { name: /Datasets/i })).toHaveAttribute('aria-selected', 'false')
+      expect(screen.getByRole('tab', { name: /Datasets/i })).toHaveAttribute('aria-selected', 'true')
+      expect(screen.getByRole('tab', { name: /Studies/i })).toHaveAttribute('aria-selected', 'false')
     })
   })
 
@@ -480,9 +491,9 @@ describe('DataLibrary', () => {
   it('shows footer when a study is selected', async () => {
     renderLibrary(STUDIES_TAB_PATH)
 
-    const row = await getSingleDataGridRow()
+    const card = await getSingleStudyCard()
 
-    fireEvent.click(getRowCheckbox(row))
+    fireEvent.click(getRowCheckbox(card))
 
     await waitFor(() => expect(document.querySelector(FOOTER_SELECTOR)).toBeInTheDocument())
     expect(screen.getByText(/2 datasets selected from 1 study/)).toBeInTheDocument()
@@ -549,7 +560,7 @@ describe('DataLibrary', () => {
 
       // Rows render from the data query while the counts query is still pending,
       // so no count badge is shown yet.
-      await getSingleDataGridRow()
+      await getSingleStudyCard()
       expect(screen.queryByLabelText('2 items')).not.toBeInTheDocument()
 
       resolveCounts(asSearchResponse(mockStudiesResponse))
@@ -614,7 +625,7 @@ describe('DataLibrary', () => {
 
       renderLibrary(STUDIES_TAB_PATH)
 
-      await waitFor(() => expect(queryRows().length).toBeGreaterThanOrEqual(1))
+      await waitFor(() => expect(queryStudyCards().length).toBeGreaterThanOrEqual(1))
       expect(TerraDataRepo.listSnapshotsByDatasetIds).not.toHaveBeenCalled()
       expect(screen.queryByText(EXPORT_LABEL)).not.toBeInTheDocument()
     })

--- a/test/pages/researcher_console/DatasetSubmissions.spec.tsx
+++ b/test/pages/researcher_console/DatasetSubmissions.spec.tsx
@@ -7,6 +7,7 @@ import DatasetSubmissions from 'src/pages/researcher_console/DatasetSubmissions'
 import { AssetType } from 'src/types/library'
 import { DataSet } from 'src/libs/ajax/DataSet'
 import { Storage } from 'src/libs/storage'
+import { useLibraryPageState } from 'src/hooks/useLibraryPageState'
 import { Notifications } from 'src/libs/utils'
 import { DuosUser } from 'src/types/model'
 import { GridColDef } from '@mui/x-data-grid'
@@ -128,6 +129,12 @@ describe('DatasetSubmissions', () => {
   it('renders the ADD DATASET button', () => {
     renderComponent()
     expect(screen.getByRole('button', { name: /ADD DATASET/i })).toBeInTheDocument()
+  })
+
+  // This page's Submitter/Status/Delete columns live on the Datasets tab, so it must land there.
+  it('does not ask for a default tab, leaving the hook on Datasets', () => {
+    renderComponent()
+    expect(vi.mocked(useLibraryPageState)).toHaveBeenCalledWith(expect.anything())
   })
 
   it('does not render the Signing Official approval reminder — that is Data Library only', () => {


### PR DESCRIPTION
### Addresses

[DT-4000](https://broadworkbench.atlassian.net/browse/DT-4000).

Security risk: no.

### Summary

Studies becomes the Data Library's default tab and renders as a card grid instead of a DataGrid table. Scoped to the public Data Library through the `renderGrid` override on `LibraryPageShell`; every other tab, and the Studies table in the researcher console, is unchanged.

Each card carries the study name, PI, data types, species, phenotype, participant and dataset stats, and a row of access-type and DUO data-use pills. Selection, sorting, pagination and filters carry over from the table view.

### Review notes

The branch already contained the seam — the `renderGrid` override, the Studies default, the new `studyAsset` aggregations — but imported `accessManagementDisplay` and `StudyCardGrid`, neither of which existed, so it did not compile. This adds those, rebased onto develop.

Selection reuses `studyAsset.computeRowSelection` and `selectionToDatasetIds` rather than reimplementing them, so a study means the same set of datasets in either view.

No backend change. The two new aggregations read `dataUse.primary.code.keyword` and `accessManagement.keyword`, both already indexed and already aggregated by `datasetAsset`.

<img width="3600" height="5212" alt="After" src="https://github.com/user-attachments/assets/4cba5d0f-1463-41d3-918b-dd73a39e2d72" />

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4000]: https://broadworkbench.atlassian.net/browse/DT-4000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ