### PR TITLE
[DT-4019] Harden cookie attributes: Phase 5, story 5-D

### DIFF
--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -173,11 +173,6 @@ describe('plugin registration order', () => {
   })
 })
 
-// Story 5-D: the session cookie is configured in Epic 1; this block is the
-// hardening-phase verification that the PRODUCTION options are the strict set.
-// Asserted against the mocked @fastify/session registration because that is the
-// only place buildApp()'s own options are visible — session.test.ts and the load
-// harness stand the plugin up themselves and so cannot catch a drift here.
 describe('session cookie attributes', () => {
   async function sessionCookieOptions() {
     const { default: sessionPlugin } = await import('@fastify/session')
@@ -190,9 +185,6 @@ describe('session cookie attributes', () => {
   it('sets HttpOnly, SameSite=Lax and Path=/', async () => {
     const cookie = await sessionCookieOptions()
     expect(cookie.httpOnly).toBe(true)
-    // Lax, not Strict: Strict would strip the cookie from the top-level
-    // redirect B2C makes back to /auth/callback, which would arrive sessionless
-    // and lose the PKCE verifier and state.
     expect(cookie.sameSite).toBe('lax')
     expect(cookie.path).toBe('/')
   })

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -173,6 +173,58 @@ describe('plugin registration order', () => {
   })
 })
 
+// Story 5-D: the session cookie is configured in Epic 1; this block is the
+// hardening-phase verification that the PRODUCTION options are the strict set.
+// Asserted against the mocked @fastify/session registration because that is the
+// only place buildApp()'s own options are visible — session.test.ts and the load
+// harness stand the plugin up themselves and so cannot catch a drift here.
+describe('session cookie attributes', () => {
+  async function sessionCookieOptions() {
+    const { default: sessionPlugin } = await import('@fastify/session')
+    const calls = vi.mocked(sessionPlugin).mock.calls
+    expect(calls.length).toBeGreaterThan(0)
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    return (calls.at(-1)![1] as any).cookie as Record<string, unknown>
+  }
+
+  it('sets HttpOnly, SameSite=Lax and Path=/', async () => {
+    const cookie = await sessionCookieOptions()
+    expect(cookie.httpOnly).toBe(true)
+    // Lax, not Strict: Strict would strip the cookie from the top-level
+    // redirect B2C makes back to /auth/callback, which would arrive sessionless
+    // and lose the PKCE verifier and state.
+    expect(cookie.sameSite).toBe('lax')
+    expect(cookie.path).toBe('/')
+  })
+
+  it('sets Secure in production', async () => {
+    const previous = process.env.NODE_ENV
+    process.env.NODE_ENV = 'production'
+    vi.resetModules()
+    try {
+      const { resetConfigCache } = await import('../src/config.js')
+      resetConfigCache()
+      const { buildApp } = await import('../src/index.js')
+      const localApp = await buildApp()
+      const cookie = await sessionCookieOptions()
+      expect(cookie.secure).toBe(true)
+      expect(cookie.httpOnly).toBe(true)
+      expect(cookie.sameSite).toBe('lax')
+      expect(cookie.path).toBe('/')
+      await localApp.close()
+    }
+    finally {
+      process.env.NODE_ENV = previous
+      vi.resetModules()
+    }
+  })
+
+  it('leaves Secure off outside production so plain-HTTP dev keeps its session', async () => {
+    const cookie = await sessionCookieOptions()
+    expect(cookie.secure).toBe(false)
+  })
+})
+
 describe('GET /config.json', () => {
   let dir: string
 

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -190,10 +190,6 @@ describe('session cookie attributes', () => {
   })
 
   it('sets Secure in production', async () => {
-    // stubEnv, not a manual save/restore: assigning back an undefined `previous`
-    // would set NODE_ENV to the literal string 'undefined'. Vitest happens to
-    // set NODE_ENV=test, so that cannot bite today, but the test should not
-    // depend on knowing that.
     vi.stubEnv('NODE_ENV', 'production')
     vi.resetModules()
     try {

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -190,8 +190,11 @@ describe('session cookie attributes', () => {
   })
 
   it('sets Secure in production', async () => {
-    const previous = process.env.NODE_ENV
-    process.env.NODE_ENV = 'production'
+    // stubEnv, not a manual save/restore: assigning back an undefined `previous`
+    // would set NODE_ENV to the literal string 'undefined'. Vitest happens to
+    // set NODE_ENV=test, so that cannot bite today, but the test should not
+    // depend on knowing that.
+    vi.stubEnv('NODE_ENV', 'production')
     vi.resetModules()
     try {
       const { resetConfigCache } = await import('../src/config.js')
@@ -206,7 +209,7 @@ describe('session cookie attributes', () => {
       await localApp.close()
     }
     finally {
-      process.env.NODE_ENV = previous
+      vi.unstubAllEnvs()
       vi.resetModules()
     }
   })

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,6 +1,3 @@
-// Name of the GDPR cookie-banner preference cookie. The client reads it with
-// `document.cookie`, so HttpOnly cannot apply — the other hardening attributes
-// below are the full set available to it.
 const COOKIE_CONTROL = 'cookie_control'
 
 export const getCookiePairs = () => {
@@ -24,9 +21,7 @@ export const getAcknowledged = () => {
     return (control?.acknowledged === true)
   }
   catch {
-    // The value is user-controlled: anyone can hand-edit the cookie, and an
-    // older release wrote it unencoded. A corrupt value must read as "not
-    // acknowledged", not throw during render.
+    // Treat malformed or legacy values as unacknowledged.
     return false
   }
 }
@@ -36,13 +31,9 @@ export const setAcknowledged = () => {
   const control = { acknowledged: true, timestamp: Date.now() }
   // 400 - day cookie expiration (days * hours * minutes * seconds)
   const expiration = 400 * 24 * 60 * 60
-  // Strict, not Lax: this cookie takes no part in the OAuth callback, so
-  // nothing needs it on a cross-site navigation.
-  // Secure only over HTTPS — unconditional Secure would make plain-HTTP dev
-  // setups drop the cookie silently.
+  // Unlike the session cookie, this preference is not needed on cross-site redirects.
+  // Add Secure only when HTTPS is available; local development may use HTTP.
   const secure = window.location.protocol === 'https:' ? '; Secure' : ''
-  // The value is encoded because getCookiePairs() decodes. Raw JSON reads back
-  // unchanged today, but the two paths must agree.
   const value = encodeURIComponent(JSON.stringify(control))
   document.cookie = `${COOKIE_CONTROL}=${value}; path=/; max-age=${expiration}; SameSite=Strict${secure}`
 }

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,12 +1,24 @@
 const COOKIE_CONTROL = 'cookie_control'
 
+// decodeURIComponent throws URIError on a malformed sequence, and any cookie can
+// hold one (a raw '%', or a legacy unencoded value). Fall back to the raw text so
+// one bad cookie cannot break the whole document.cookie read.
+const decodeValue = (value: string) => {
+  try {
+    return decodeURIComponent(value)
+  }
+  catch {
+    return value
+  }
+}
+
 export const getCookiePairs = () => {
   const cookies = document.cookie
   const cookiePairs: Record<string, string> = {}
   for (const cookieStr of cookies
     .split(';')) {
     const [name, ...rest] = cookieStr.split('=')
-    cookiePairs[name.trim()] = decodeURIComponent(rest.join('=').trim())
+    cookiePairs[name.trim()] = decodeValue(rest.join('=').trim())
   }
   return cookiePairs
 }

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,3 +1,8 @@
+// Name of the GDPR cookie-banner preference cookie. The client reads it with
+// `document.cookie`, so HttpOnly cannot apply — the other hardening attributes
+// below are the full set available to it.
+const COOKIE_CONTROL = 'cookie_control'
+
 export const getCookiePairs = () => {
   const cookies = document.cookie
   const cookiePairs: Record<string, string> = {}
@@ -10,13 +15,20 @@ export const getCookiePairs = () => {
 }
 
 export const getAcknowledged = () => {
-  for (const [key, value] of Object.entries(getCookiePairs())) {
-    if (key === 'cookie_control') {
-      const control = JSON.parse(value)
-      return (control?.acknowledged === true)
-    }
+  const value = getCookiePairs()[COOKIE_CONTROL]
+  if (value === undefined) {
+    return false
   }
-  return false
+  try {
+    const control = JSON.parse(value)
+    return (control?.acknowledged === true)
+  }
+  catch {
+    // The value is user-controlled: anyone can hand-edit the cookie, and an
+    // older release wrote it unencoded. A corrupt value must read as "not
+    // acknowledged", not throw during render.
+    return false
+  }
 }
 
 export const setAcknowledged = () => {
@@ -24,7 +36,15 @@ export const setAcknowledged = () => {
   const control = { acknowledged: true, timestamp: Date.now() }
   // 400 - day cookie expiration (days * hours * minutes * seconds)
   const expiration = 400 * 24 * 60 * 60
-  document.cookie = `cookie_control=${JSON.stringify(control)}; path=/; max-age=` + expiration
+  // Strict, not Lax: this cookie takes no part in the OAuth callback, so
+  // nothing needs it on a cross-site navigation.
+  // Secure only over HTTPS — unconditional Secure would make plain-HTTP dev
+  // setups drop the cookie silently.
+  const secure = window.location.protocol === 'https:' ? '; Secure' : ''
+  // The value is encoded because getCookiePairs() decodes. Raw JSON reads back
+  // unchanged today, but the two paths must agree.
+  const value = encodeURIComponent(JSON.stringify(control))
+  document.cookie = `${COOKIE_CONTROL}=${value}; path=/; max-age=${expiration}; SameSite=Strict${secure}`
 }
 
 export const CookieUtils = {

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,8 +1,6 @@
 const COOKIE_CONTROL = 'cookie_control'
 
-// decodeURIComponent throws URIError on a malformed sequence, and any cookie can
-// hold one (a raw '%', or a legacy unencoded value). Fall back to the raw text so
-// one bad cookie cannot break the whole document.cookie read.
+// Preserve malformed values so one bad cookie cannot break the entire read.
 const decodeValue = (value: string) => {
   try {
     return decodeURIComponent(value)
@@ -39,9 +37,7 @@ export const getAcknowledged = () => {
 }
 
 export const setAcknowledged = () => {
-  // Base cookie control object
   const control = { acknowledged: true, timestamp: Date.now() }
-  // 400 - day cookie expiration (days * hours * minutes * seconds)
   const expiration = 400 * 24 * 60 * 60
   // Unlike the session cookie, this preference is not needed on cross-site redirects.
   // Add Secure only when HTTPS is available; local development may use HTTP.

--- a/test/utils/CookieUtils.spec.ts
+++ b/test/utils/CookieUtils.spec.ts
@@ -1,12 +1,21 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { CookieUtils } from 'src/utils/CookieUtils'
 
+// The stub below replaces `document.cookie` with a plain writable property, so
+// an assignment overwrites the whole string instead of appending one pair. That
+// is what makes the attribute assertions possible: the attributes a real
+// document.cookie setter consumes stay readable here.
 describe('CookieUtils', () => {
   beforeEach(() => {
     Object.defineProperty(document, 'cookie', {
       writable: true,
+      configurable: true,
       value: '',
     })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   describe('getCookiePairs', () => {
@@ -34,13 +43,54 @@ describe('CookieUtils', () => {
       document.cookie = 'foo=bar'
       expect(CookieUtils.getAcknowledged()).toBe(false)
     })
+
+    it('should return false, not throw, if the value is not valid JSON', () => {
+      document.cookie = 'cookie_control=not-json'
+      expect(() => CookieUtils.getAcknowledged()).not.toThrow()
+      expect(CookieUtils.getAcknowledged()).toBe(false)
+    })
+
+    it('should read back a value written by setAcknowledged', () => {
+      CookieUtils.setAcknowledged()
+      // Drop the attributes the browser would strip before a read.
+      document.cookie = document.cookie.split(';')[0]
+      expect(CookieUtils.getAcknowledged()).toBe(true)
+    })
   })
 
   describe('setAcknowledged', () => {
     it('should set cookie_control cookie when acknowledged', () => {
       CookieUtils.setAcknowledged()
       expect(document.cookie).toContain('cookie_control')
-      expect(document.cookie).toContain('"acknowledged":true')
+      expect(CookieUtils.getCookiePairs()['cookie_control']).toContain('"acknowledged":true')
+    })
+
+    it('should URL-encode the JSON value', () => {
+      CookieUtils.setAcknowledged()
+      const raw = document.cookie.split(';')[0].split('=').slice(1).join('=')
+      expect(raw).not.toContain('{')
+      expect(raw).toContain('%7B')
+      expect(JSON.parse(decodeURIComponent(raw)).acknowledged).toBe(true)
+    })
+
+    it('should set path, max-age and SameSite=Strict', () => {
+      CookieUtils.setAcknowledged()
+      expect(document.cookie).toContain('path=/')
+      expect(document.cookie).toContain(`max-age=${400 * 24 * 60 * 60}`)
+      // Strict, not Lax: nothing needs this cookie on a cross-site navigation.
+      expect(document.cookie).toContain('SameSite=Strict')
+    })
+
+    it('should omit Secure over plain HTTP so dev setups keep working', () => {
+      vi.stubGlobal('location', { ...window.location, protocol: 'http:' })
+      CookieUtils.setAcknowledged()
+      expect(document.cookie).not.toContain('Secure')
+    })
+
+    it('should add Secure over HTTPS', () => {
+      vi.stubGlobal('location', { ...window.location, protocol: 'https:' })
+      CookieUtils.setAcknowledged()
+      expect(document.cookie).toContain('; Secure')
     })
   })
 })

--- a/test/utils/CookieUtils.spec.ts
+++ b/test/utils/CookieUtils.spec.ts
@@ -21,6 +21,12 @@ describe('CookieUtils', () => {
       const pairs = CookieUtils.getCookiePairs()
       expect(pairs).toEqual({ foo: 'bar', baz: 'qux' })
     })
+
+    it('should fall back to the raw value when the encoding is malformed', () => {
+      document.cookie = 'discount=100%; foo=bar'
+      const pairs = CookieUtils.getCookiePairs()
+      expect(pairs).toEqual({ discount: '100%', foo: 'bar' })
+    })
   })
 
   describe('getAcknowledged', () => {
@@ -45,6 +51,18 @@ describe('CookieUtils', () => {
       document.cookie = 'cookie_control=not-json'
       expect(() => CookieUtils.getAcknowledged()).not.toThrow()
       expect(CookieUtils.getAcknowledged()).toBe(false)
+    })
+
+    it('should return false, not throw, if the value has malformed encoding', () => {
+      document.cookie = 'cookie_control=%'
+      expect(() => CookieUtils.getAcknowledged()).not.toThrow()
+      expect(CookieUtils.getAcknowledged()).toBe(false)
+    })
+
+    it('should still read cookie_control when an unrelated cookie is malformed', () => {
+      const control = { acknowledged: true }
+      document.cookie = `discount=100%; cookie_control=${encodeURIComponent(JSON.stringify(control))}`
+      expect(CookieUtils.getAcknowledged()).toBe(true)
     })
 
     it('should read back a value written by setAcknowledged', () => {

--- a/test/utils/CookieUtils.spec.ts
+++ b/test/utils/CookieUtils.spec.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { CookieUtils } from 'src/utils/CookieUtils'
 
-// The stub below replaces `document.cookie` with a plain writable property, so
-// an assignment overwrites the whole string instead of appending one pair. That
-// is what makes the attribute assertions possible: the attributes a real
-// document.cookie setter consumes stay readable here.
+// Keep assigned attributes observable; a real document.cookie setter consumes them.
 describe('CookieUtils', () => {
   beforeEach(() => {
     Object.defineProperty(document, 'cookie', {
@@ -52,7 +49,7 @@ describe('CookieUtils', () => {
 
     it('should read back a value written by setAcknowledged', () => {
       CookieUtils.setAcknowledged()
-      // Drop the attributes the browser would strip before a read.
+      // Simulate browser reads by dropping the consumed attributes.
       document.cookie = document.cookie.split(';')[0]
       expect(CookieUtils.getAcknowledged()).toBe(true)
     })
@@ -77,7 +74,6 @@ describe('CookieUtils', () => {
       CookieUtils.setAcknowledged()
       expect(document.cookie).toContain('path=/')
       expect(document.cookie).toContain(`max-age=${400 * 24 * 60 * 60}`)
-      // Strict, not Lax: nothing needs this cookie on a cross-site navigation.
       expect(document.cookie).toContain('SameSite=Strict')
     })
 


### PR DESCRIPTION
### Addresses

[DT-4019](https://broadworkbench.atlassian.net/browse/DT-4019) — Phase 5, story 5-D: verify strict cookie attributes on all cookies.

Security risk: low.

### Summary

The application sets exactly two cookies. This story hardens one and adds verification for the other.

**`cookie_control` (client, `src/utils/CookieUtils.ts`)** — the GDPR banner preference cookie. It was written with only `path` and `max-age`:

- Adds `SameSite=Strict`, not `Lax`. This cookie takes no part in the OAuth callback, so nothing needs it on a cross-site navigation.
- Adds `Secure` only when `location.protocol` is `https:`. Unconditional `Secure` would make plain-HTTP dev setups drop the cookie silently.
- URL-encodes the JSON value. `getCookiePairs()` already decodes, but production wrote raw JSON, so the read and write paths disagreed.
- Guards the `JSON.parse` in `getAcknowledged()`. The value is user-controlled and must not throw during render.

`HttpOnly` does not apply — the client reads this cookie with `document.cookie`.

**`sessionId` (server, `server/src/index.ts`)** — verification only. It already sets `HttpOnly`, `Secure` in production, `SameSite=Lax` and `Path=/`. Added tests in `server/test/index.test.ts` that assert the options `buildApp()` hands `@fastify/session`, including the production `Secure` branch. `session.test.ts` and the load harness stand the plugin up with their own options, so they cannot catch a drift in the production configuration.

Later hardening noted for Phase 6, out of scope here: migrate the session cookie to a `__Host-` prefixed name so the browser itself enforces `Secure`, host-only scope and `Path=/`.

### Test plan

- `pnpm --filter duos-server test` — 370 pass, 17 files.
- `pnpm exec vitest run test/utils/CookieUtils.spec.ts` — 11 pass. The spec now asserts the real attribute string: `path=/`, `max-age`, `SameSite=Strict`, `Secure` present over HTTPS and absent over HTTP, an encoded value, a round trip, and a corrupt value that reads `false` instead of throwing.
- `pnpm exec vitest run test/components/CookieBanner.spec.tsx test/components/DuosFooter.spec.tsx` — 6 pass (the two consumers).
- `tsc --noEmit` clean for client and server; `oxlint` and `eslint` clean on the changed files.
- Verified the new production-`Secure` test fails when the assertion is flipped, so it is not passing trivially.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4019]: https://broadworkbench.atlassian.net/browse/DT-4019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ