### PR TITLE
[DT-400][DT-4054] Rename dependabot update groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,12 @@ updates:
     commit-message:
       prefix: "[DT-400-actions]"
     groups:
-      action-major-updates:
+      action-major:
         patterns:
           - "*"
         update-types:
           - "major"
-      action-other-updates:
+      action-minor-patch:
         update-types:
           - "minor"
           - "patch"
@@ -34,12 +34,12 @@ updates:
     commit-message:
       prefix: "[DT-400-pnpm]"
     groups:
-      pnpm-major-updates:
+      pnpm-major:
         patterns:
           - "*"
         update-types:
           - "major"
-      pnpm-other-updates:
+      pnpm-minor-patch:
         update-types:
           - "minor"
           - "patch"
@@ -57,12 +57,12 @@ updates:
     commit-message:
       prefix: "[DT-400-docker]"
     groups:
-      docker-major-updates:
+      docker-major:
         patterns:
           - "*"
         update-types:
           - "major"
-      docker-other-updates:
+      docker-minor-patch:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-400
https://broadworkbench.atlassian.net/browse/DT-4054

## Summary

Group names appear in every Dependabot PR title branch. `*-other-updates` was confusing naming:

- Renames each ecosystem's groups to `*-major` and `*-minor-patch`
- Config only: patterns and update-types are unchanged
- Open bump PRs under the old group names will be recreated on the next run

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment
