### PR TITLE
[DT-4021] Register @fastify/helmet for the non-CSP security headers (BFF Phase 5, story 5-F1)

### DIFF
--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -103,7 +103,7 @@ the migration plan and are summarised below; the ones that needed fuller
 treatment — because they were resolved during implementation, with alternatives
 and residual risk worth recording — have their own files under
 [`bff_adrs/`](bff_adrs/). That is why the directory holds 004 and 009 through
-012 rather than 001 through 003: the numbers belong to this list, not to the
+013 rather than 001 through 003: the numbers belong to this list, not to the
 directory.
 
 | ADR | Decision | Phase |
@@ -120,6 +120,7 @@ directory.
 | [010](#adr-010--the-proxy-scope-declares-its-own-error-shape) | The proxy scope declares its own error shape | 3, 4 |
 | [011](#adr-011--one-identity-per-browser-cross-tab-account-switching-reloads-the-stale-tab) | One identity per browser: cross-tab account switching reloads the stale tab | 4 |
 | [012](#adr-012--session-cookie-is-samesitelax-with-csrf-tokens-closing-the-gap) | Session cookie is `SameSite=Lax`, with CSRF tokens closing the gap | 1, 2–4 |
+| [013](#adr-013--security-headers-and-a-content-security-policy-derived-from-runtime-config) | Security headers, and a CSP derived from runtime config | 5 |
 
 ### ADR-001 — PostgreSQL-backed sessions via `@fastify/session`
 
@@ -287,6 +288,25 @@ CI.
 The options are defined once in `server/src/session/sessionOptions.ts` and
 imported by the server and all five test harnesses, so changing `sameSite` or
 `rolling` fails the suite.
+
+### ADR-013 — Security headers, and a Content Security Policy derived from runtime config
+
+**Full record:** [bff_adrs/ADR-013-content-security-policy.md](bff_adrs/ADR-013-content-security-policy.md)
+— written across the 5-F stack and growing with it.
+
+`@fastify/helmet` registers ahead of every route and outside both cutover
+switches: a legacy deployment needs these headers too. Two of its defaults would
+break flows this app depends on.
+
+`Cross-Origin-Opener-Policy` is **off entirely in legacy mode**.
+`same-origin-allow-popups` is not a safe middle ground, which was measured: on
+the return leg from B2C the popup's `window.opener` still goes null and
+`signinPopup()` never resolves. COOP is not part of the CSP and has no
+report-only mode, so that one breaks sign-in on the first deploy — which is why
+it ships on its own. `Cross-Origin-Embedder-Policy` stays off because the banner
+bucket and the two direct upstreams send no CORP header. HSTS is production-only.
+
+The Content Security Policy itself is explicitly off until story 5-F3.
 
 ### Decisions not tracked as ADRs
 

--- a/docs/plans/bff_adrs/ADR-013-content-security-policy.md
+++ b/docs/plans/bff_adrs/ADR-013-content-security-policy.md
@@ -12,9 +12,10 @@ itself (5-F3), and the sidecar change (5-F4) add their sections as they land.
 
 ## Context
 
-The server sent no security headers at all. Adding them is the last large
-control in Phase 5, and the risky one: a header that is one value wrong does
-not fail a test, it breaks sign-in for everybody or blanks a page for one user.
+The BFF server sent no security headers, those are being provided by the
+standard Terra proxy. Adding them is the last large control in Phase 5,
+and the risky one: a header that is one value wrong does not fail a test,
+it breaks sign-in for everybody or blanks a page for one user.
 
 The app also still runs in two modes. Under `bffEnabled` sign-in is a top-level
 redirect. A legacy deployment opens a popup, sends it to B2C, and reads the

--- a/docs/plans/bff_adrs/ADR-013-content-security-policy.md
+++ b/docs/plans/bff_adrs/ADR-013-content-security-policy.md
@@ -1,0 +1,84 @@
+# ADR-013 — Security headers, and a Content Security Policy derived from runtime config
+
+**Status:** Accepted (2026-08-31) &nbsp;|&nbsp; **Phase:** 5, story 5-F
+**Related:** [ADR-004](ADR-004-api-proxy-layer.md) (the proxies that make ECM and TDR same-origin)
+**Implemented by:** `server/src/security/` (duos-ui, DT-4021)
+
+This record is written across the 5-F stack and grows with it. Story 5-F1 —
+helmet's non-CSP headers — is recorded here. The report sink (5-F2), the policy
+itself (5-F3), and the sidecar change (5-F4) add their sections as they land.
+
+---
+
+## Context
+
+The server sent no security headers at all. Adding them is the last large
+control in Phase 5, and the risky one: a header that is one value wrong does
+not fail a test, it breaks sign-in for everybody or blanks a page for one user.
+
+The app also still runs in two modes. Under `bffEnabled` sign-in is a top-level
+redirect. A legacy deployment opens a popup, sends it to B2C, and reads the
+result back through `window.opener`. One set of header values cannot be correct
+for both.
+
+## Decision, part 1 — helmet's non-CSP defaults are set deliberately
+
+`@fastify/helmet` registers ahead of every route and outside both cutover
+switches, because a legacy deployment needs these headers just as much. Two of
+its defaults would break flows this app depends on.
+
+### `Cross-Origin-Opener-Policy` is off in legacy mode
+
+Not `same-origin`, and not `same-origin-allow-popups` either. `-allow-popups`
+reads like the safe middle ground for a popup sign-in and is not one. This was
+measured rather than assumed.
+
+The token spares a popup only on its **initial** navigation, and only while the
+popup's own document is `unsafe-none`. The return leg from B2C is a different
+comparison: the popup's current document is B2C's (`unsafe-none`) and the
+incoming one is ours (COOP set). That mismatches, so the browser swaps browsing
+context groups and `window.opener` becomes null. `oidc-client-ts` then throws on
+`postMessage`, the opener never hears back, and `signinPopup()` never resolves.
+
+Measured in Chromium across two local origins with a cross-origin hop between:
+
+```
+COOP on callback  : openerNull=true,  postMessage threw, opener saw nothing
+COOP off (control): openerNull=false, postMessage fine,  opener got the message
+```
+
+**COOP is not part of the CSP and has no report-only mode.** Nothing in 5-F3
+would have caught this. It breaks sign-in on the first deploy, in every
+environment, since none has `bffEnabled` on yet. That is why 5-F1 ships alone:
+it can be deployed and sign-in verified before anything else rides on it.
+
+Legacy deployments therefore get no COOP at all until Epic 6 retires that flow.
+Under `bffEnabled`, sign-in has no popup and no opener, so it keeps
+`same-origin-allow-popups`.
+
+### `Cross-Origin-Embedder-Policy` stays off
+
+COEP demands a CORP or CORS header on every cross-origin subresource. The banner
+bucket and the two direct upstreams send neither, so enabling it would block
+them. It stays off until those become same-origin (5-F6).
+
+### HSTS is production-only
+
+Gated on `NODE_ENV`, not on the transport, so `pnpm start:server` cannot pin a
+developer's browser to https for a year. A docker-compose stack runs as
+production and does send it; browsers ignore HSTS delivered over plain HTTP, so
+that costs nothing there.
+
+### The rest
+
+`Cross-Origin-Resource-Policy: same-origin`, `Referrer-Policy: no-referrer`, and
+`X-Frame-Options: DENY`. The deployed httpd sidecar also sets the last two, and
+its values win — ours are what a local or compose run gets, where there is no
+proxy at all.
+
+## Consequences so far
+
+- Sign-in is the thing to watch on the first deploy of 5-F1, in a **legacy**
+  environment. Every environment is legacy today.
+- `contentSecurityPolicy` is explicitly `false` until 5-F3. The tests assert its
+  absence, so the stack cannot quietly deliver half a policy.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,6 +176,9 @@ importers:
       '@fastify/csrf-protection':
         specifier: 8.0.1
         version: 8.0.1
+      '@fastify/helmet':
+        specifier: 13.1.1
+        version: 13.1.1
       '@fastify/postgres':
         specifier: 6.1.0
         version: 6.1.0(pg@8.22.0)
@@ -638,6 +641,9 @@ packages:
 
   '@fastify/forwarded@3.0.2':
     resolution: {integrity: sha512-NE8HgKLgYejV9lDpqkEFaDKMLYelJBVfHekhB0UKvX0ghagXRJqg68feg8er1NPXxG4N9i6vPxzt8E+3wHfcmA==}
+
+  '@fastify/helmet@13.1.1':
+    resolution: {integrity: sha512-bSat5DTq8geASv8G6P0KW1UbltZ+xGD/zyd9S72pT7ogAHehcsWL85GdjMRCjDsExJvaEvgEZ52qU/2HXirVCw==}
 
   '@fastify/merge-json-schemas@0.2.1':
     resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
@@ -2027,6 +2033,10 @@ packages:
 
   hdr-histogram-percentiles-obj@3.0.0:
     resolution: {integrity: sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==}
+
+  helmet@8.3.0:
+    resolution: {integrity: sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==}
+    engines: {node: '>=18.0.0'}
 
   history@5.3.0:
     resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
@@ -3752,6 +3762,11 @@ snapshots:
 
   '@fastify/forwarded@3.0.2': {}
 
+  '@fastify/helmet@13.1.1':
+    dependencies:
+      fastify-plugin: 6.0.0
+      helmet: 8.3.0
+
   '@fastify/merge-json-schemas@0.2.1':
     dependencies:
       dequal: 2.0.3
@@ -5175,6 +5190,8 @@ snapshots:
       pako: 1.0.11
 
   hdr-histogram-percentiles-obj@3.0.0: {}
+
+  helmet@8.3.0: {}
 
   history@5.3.0:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@fastify/cookie": "11.1.2",
     "@fastify/csrf-protection": "8.0.1",
+    "@fastify/helmet": "13.1.1",
     "@fastify/postgres": "6.1.0",
     "@fastify/reply-from": "12.6.4",
     "@fastify/session": "11.1.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -75,20 +75,12 @@ export async function buildApp(): Promise<AppInstance> {
   // Keep CSP construction and BFF route gating on the config served to the client.
   const clientConfig = await readConfig(configJsonPath, fastify.log)
 
-  // 1. Security response headers (Phase 5, story 5-F1). Registered first so
-  // its onRequest hook runs ahead of every route, and outside both switches
-  // below: the legacy client needs the same headers. The Content Security
-  // Policy is off here and lands in 5-F3 — COOP is the header that can break
-  // sign-in, and it ships on its own so a deploy can prove it did not.
+  // 1. Security response headers registered first. Registered first so
+  // its onRequest hook runs ahead of every route.
   await fastify.register(fastifyHelmet, helmetOptions(clientConfig, { isDev }))
 
   // 2. DB pool + session — registered only when the deployment provides the
-  // BFF database configuration. Session infrastructure is deployment config
-  // (env vars via helmfile/compose), not a runtime flag: every pod of a given
-  // deployment behaves identically, with no network dependency at boot.
-  // Directing users to the BFF sign-in flow is a separate switch — the
-  // boolean `bffEnabled` in config.json, checked at startup — see
-  // docs/plans/BFF_Overview.md.
+  // BFF database configuration.
   if (process.env.DUOS_DB_HOST) {
     fastify.log.info('[server] DUOS_DB_HOST is set — enabling BFF session infrastructure')
 
@@ -173,10 +165,7 @@ export async function buildApp(): Promise<AppInstance> {
   }
 
   // 3. BFF auth routes — the cutover switch. Read at startup from the same
-  // config object the /config.json route below serves, so the server and
-  // client agree on bffEnabled by construction. A missing key defaults to
-  // false and the routes stay dark — the fail-safe is the legacy
-  // client-side flow. See docs/plans/BFF_Overview.md § Rollout strategy.
+  // config object the /config.json route below serves.
   const { bffEnabled } = clientConfig
   if (bffEnabled === true) {
     // The two switches are meant to be independent (session infra can be on
@@ -186,42 +175,15 @@ export async function buildApp(): Promise<AppInstance> {
     if (!process.env.DUOS_DB_HOST) {
       throw new Error('bffEnabled is true in config.json but DUOS_DB_HOST is not set — the BFF auth routes require the session infrastructure to be configured')
     }
-    // Both /auth/me and the API proxy forward to this upstream, so a cutover
-    // without it is a deployment that boots, passes health checks, and then
-    // fails on the first user request. Checked here rather than left to the
-    // proxy's own requireEnv so the error arrives at startup, next to the
-    // switch that made it mandatory.
     if (!process.env.DUOS_API_URL) {
       throw new Error('bffEnabled is true in config.json but DUOS_API_URL is not set — /auth/me and the API proxy both forward to it')
     }
     fastify.log.info('[server] bffEnabled is true — registering BFF auth routes and the API proxy')
     fastify.post('/auth/login', handleLogin)
     fastify.get('/auth/callback', handleCallback)
-    // The client fetches this after sign-in and echoes the token in an
-    // X-CSRF-Token header on unsafe auth requests. Gated on an authenticated
-    // session (story 5-B): an anonymous request gets 401 and mints no session
-    // row — see the handler in auth/csrf.ts. After session rotation (Phase 5,
-    // 5-C) the pre-auth secret is discarded, so the client must (re)fetch this
-    // once login completes.
     fastify.get('/auth/csrf-token', handleCsrfToken)
-    // /auth/login is deliberately exempt from CSRF: it is pre-authentication
-    // (no token to have fetched yet), and login CSRF is neutralized by the
-    // PKCE state binding the flow to the session. Only logout is guarded.
     fastify.post('/auth/logout', { onRequest: fastify.csrfProtection }, handleLogout)
-    // /auth/me is a safe GET here, but it calls Consent's state-changing
-    // GET /api/user/me server-side, so it carries the Fetch Metadata guard the
-    // proxies get from their shared machinery (story 5-B; see
-    // security/fetchMetadata.ts). /auth/login and /auth/callback must NOT get
-    // it — the callback is a legitimate cross-site navigation from B2C.
     fastify.get('/auth/me', { onRequest: fetchMetadataGuard }, getMe)
-
-    // The API proxy (Phase 3). Registered here, inside both switches, rather
-    // than alongside /health: it depends on @fastify/cookie, @fastify/session
-    // and @fastify/csrf-protection, all of which are registered above only when
-    // DUOS_DB_HOST is set. Gating it on bffEnabled too keeps it dark until
-    // cutover — the client does not call /duos-api until Phase 4 points
-    // getApiUrl() at it — so a deployment running the legacy client-side flow
-    // exposes no proxy route at all.
     await fastify.register(apiProxy)
 
     // The single-feature upstream proxies. Same gates as the DUOS API proxy,
@@ -252,16 +214,7 @@ export async function buildApp(): Promise<AppInstance> {
   // Client config — intercepted via onRequest rather than a route, because
   // @fastify/vite's production static plugin (wildcard: false) walks build/
   // and registers its own explicit GET/HEAD route for every file it finds
-  // there, including config.json. A competing `fastify.get('/config.json', ...)`
-  // collides with that at startup (FST_ERR_DUPLICATED_ROUTE); onRequest fires
-  // before that nested route's handler regardless of which scope declared it,
-  // so this lets DUOS_API_URL override the static file's `apiUrl` without
-  // fighting Vite for the route — see config.ts for why.
-  // HEAD must be intercepted along with GET: the static plugin registers both,
-  // so a HEAD that fell through would describe the raw un-overridden file and
-  // disagree with GET's body (mismatched Content-Length for caches/validators).
-  // Node itself omits the body for HEAD responses; sending the same payload
-  // yields matching headers.
+  // there, including config.json.
   fastify.addHook('onRequest', async (request, reply) => {
     if ((request.method === 'GET' || request.method === 'HEAD')
       && (request.url === '/config.json' || request.url.startsWith('/config.json?'))) {
@@ -278,8 +231,7 @@ export async function buildApp(): Promise<AppInstance> {
 
   await fastify.vite.ready()
 
-  // SPA fallback — @fastify/vite sets up the Vite middleware and reply.html decorator
-  // but does not register routes; we wire the catch-all ourselves.
+  // SPA fallback
   fastify.setNotFoundHandler((_req, reply) => reply.html())
 
   // The encapsulated proxy declares its own error handler (ADR-010).

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -72,11 +72,7 @@ export async function buildApp(): Promise<AppInstance> {
   // (memoized) config.
   const configJsonPath = configPath(PROJECT_ROOT, isDev)
 
-  // Read once, here. Two things need it: the security headers below, whose
-  // COOP value differs by mode, and the `bffEnabled` cutover check further
-  // down. readConfig memoises for the life of the process, so a second call
-  // would return this same object — binding it makes that explicit and keeps
-  // the two in step.
+  // Keep CSP construction and BFF route gating on the config served to the client.
   const clientConfig = await readConfig(configJsonPath, fastify.log)
 
   // 1. Security response headers (Phase 5, story 5-F1). Registered first so

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,7 +9,9 @@ import fastifyPostgres from '@fastify/postgres'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
+import fastifyHelmet from '@fastify/helmet'
 import { createPgSessionStore } from './session/pgStore.js'
+import { helmetOptions } from './security/headers.js'
 import { sessionPluginOptions } from './session/sessionOptions.js'
 import { csrfPluginOptions, handleCsrfToken } from './auth/csrf.js'
 import { fetchMetadataGuard } from './security/fetchMetadata.js'
@@ -70,7 +72,21 @@ export async function buildApp(): Promise<AppInstance> {
   // (memoized) config.
   const configJsonPath = configPath(PROJECT_ROOT, isDev)
 
-  // 1. DB pool + session — registered only when the deployment provides the
+  // Read once, here. Two things need it: the security headers below, whose
+  // COOP value differs by mode, and the `bffEnabled` cutover check further
+  // down. readConfig memoises for the life of the process, so a second call
+  // would return this same object — binding it makes that explicit and keeps
+  // the two in step.
+  const clientConfig = await readConfig(configJsonPath, fastify.log)
+
+  // 1. Security response headers (Phase 5, story 5-F1). Registered first so
+  // its onRequest hook runs ahead of every route, and outside both switches
+  // below: the legacy client needs the same headers. The Content Security
+  // Policy is off here and lands in 5-F3 — COOP is the header that can break
+  // sign-in, and it ships on its own so a deploy can prove it did not.
+  await fastify.register(fastifyHelmet, helmetOptions(clientConfig, { isDev }))
+
+  // 2. DB pool + session — registered only when the deployment provides the
   // BFF database configuration. Session infrastructure is deployment config
   // (env vars via helmfile/compose), not a runtime flag: every pod of a given
   // deployment behaves identically, with no network dependency at boot.
@@ -160,12 +176,12 @@ export async function buildApp(): Promise<AppInstance> {
     fastify.log.info('[server] DUOS_DB_HOST is not set — starting without DB/session infrastructure (legacy client-side auth)')
   }
 
-  // 2. BFF auth routes — the cutover switch. Checked once at startup via the
-  // same readConfig() the /config.json route below serves, so the server and
+  // 3. BFF auth routes — the cutover switch. Read at startup from the same
+  // config object the /config.json route below serves, so the server and
   // client agree on bffEnabled by construction. A missing key defaults to
   // false and the routes stay dark — the fail-safe is the legacy
   // client-side flow. See docs/plans/BFF_Overview.md § Rollout strategy.
-  const { bffEnabled } = await readConfig(configJsonPath, fastify.log)
+  const { bffEnabled } = clientConfig
   if (bffEnabled === true) {
     // The two switches are meant to be independent (session infra can be on
     // ahead of cutover), but not in this direction: routing users into the

--- a/server/src/security/headers.ts
+++ b/server/src/security/headers.ts
@@ -2,17 +2,10 @@ import type { FastifyHelmetOptions } from '@fastify/helmet'
 
 /**
  * The server's security response headers, via `@fastify/helmet`.
- *
- * Helmet's own defaults are the risk here, not the headers this app wants —
- * two of them break flows DUOS still depends on. Each is set deliberately
- * below, and `contentSecurityPolicy` is off for now: the policy is derived
- * from runtime config and lands in story 5-F3.
- *
  * See docs/plans/bff_adrs/ADR-013-content-security-policy.md.
  */
 
 export interface SecurityHeaderEnvironment {
-  /** `NODE_ENV !== 'production'`: HSTS off, so plain-HTTP dev keeps working. */
   isDev: boolean
 }
 
@@ -21,45 +14,16 @@ export function helmetOptions(
   env: SecurityHeaderEnvironment,
 ): FastifyHelmetOptions {
   return {
-    // Story 5-F3 replaces this with the runtime-derived policy. Registering
-    // helmet first, on its own, is deliberate: COOP below is the one header
-    // here that can break sign-in, and it deserves a deploy of its own.
+    // CSP is provided by the Terra proxy. This config flips when CSP is moved into the app.
     contentSecurityPolicy: false,
-    // COOP is OFF in legacy mode, and `same-origin-allow-popups` is not a
-    // safe middle ground there — this was measured, not assumed.
-    //
-    // The legacy sign-in flow opens a popup, sends it to B2C, and B2C
-    // redirects it back to `${origin}/redirect-from-oauth`, where
-    // oidc-client-ts posts the result to `window.opener`
-    // (src/libs/auth/oidcBroker.ts, src/index.tsx). `-allow-popups` only
-    // spares a popup on its *initial* navigation, and only while the popup's
-    // own document is `unsafe-none`. The return leg is a different comparison:
-    // the popup's current document is B2C (`unsafe-none`) and the incoming one
-    // is ours (COOP set), which is a mismatch — so the browser swaps browsing
-    // context groups and `window.opener` becomes null. `postMessage` then
-    // throws, the opener never hears back, and `signinPopup()` never resolves.
-    //
-    // No report-only mode exists for COOP — it is not part of the CSP — so
-    // getting it wrong breaks sign-in on the first deploy, in every
-    // environment, since none has bffEnabled on yet. Legacy deployments get no
-    // COOP at all until Epic 6 retires that flow. BFF sign-in is a top-level
-    // redirect with no popup and no opener, so it keeps the isolation.
+    // COOP-related configurations are only needed when the BFF is enabled.
     crossOriginOpenerPolicy: config.bffEnabled === true
       ? { policy: 'same-origin-allow-popups' }
       : false,
-    // COEP demands CORP or CORS headers on every cross-origin subresource.
-    // The banner bucket and the feature-flag/metrics upstreams send neither,
-    // so enabling it would block them. Off until those are same-origin.
     crossOriginEmbedderPolicy: false,
     crossOriginResourcePolicy: { policy: 'same-origin' },
     referrerPolicy: { policy: 'no-referrer' },
-    // The deployed httpd sidecar also sets this, and its value wins. Ours is
-    // what a local or docker-compose run gets, where there is no proxy at all.
     xFrameOptions: { action: 'deny' },
-    // Gated on NODE_ENV, not on the transport, so that `pnpm start:server`
-    // cannot pin a developer's browser to https for a year. A compose stack
-    // runs as production and does send it; browsers ignore HSTS delivered over
-    // plain HTTP, so that costs nothing there.
     strictTransportSecurity: env.isDev
       ? false
       : { maxAge: 31536000, includeSubDomains: true, preload: false },

--- a/server/src/security/headers.ts
+++ b/server/src/security/headers.ts
@@ -1,0 +1,67 @@
+import type { FastifyHelmetOptions } from '@fastify/helmet'
+
+/**
+ * The server's security response headers, via `@fastify/helmet`.
+ *
+ * Helmet's own defaults are the risk here, not the headers this app wants —
+ * two of them break flows DUOS still depends on. Each is set deliberately
+ * below, and `contentSecurityPolicy` is off for now: the policy is derived
+ * from runtime config and lands in story 5-F3.
+ *
+ * See docs/plans/bff_adrs/ADR-013-content-security-policy.md.
+ */
+
+export interface SecurityHeaderEnvironment {
+  /** `NODE_ENV !== 'production'`: HSTS off, so plain-HTTP dev keeps working. */
+  isDev: boolean
+}
+
+export function helmetOptions(
+  config: Record<string, unknown>,
+  env: SecurityHeaderEnvironment,
+): FastifyHelmetOptions {
+  return {
+    // Story 5-F3 replaces this with the runtime-derived policy. Registering
+    // helmet first, on its own, is deliberate: COOP below is the one header
+    // here that can break sign-in, and it deserves a deploy of its own.
+    contentSecurityPolicy: false,
+    // COOP is OFF in legacy mode, and `same-origin-allow-popups` is not a
+    // safe middle ground there — this was measured, not assumed.
+    //
+    // The legacy sign-in flow opens a popup, sends it to B2C, and B2C
+    // redirects it back to `${origin}/redirect-from-oauth`, where
+    // oidc-client-ts posts the result to `window.opener`
+    // (src/libs/auth/oidcBroker.ts, src/index.tsx). `-allow-popups` only
+    // spares a popup on its *initial* navigation, and only while the popup's
+    // own document is `unsafe-none`. The return leg is a different comparison:
+    // the popup's current document is B2C (`unsafe-none`) and the incoming one
+    // is ours (COOP set), which is a mismatch — so the browser swaps browsing
+    // context groups and `window.opener` becomes null. `postMessage` then
+    // throws, the opener never hears back, and `signinPopup()` never resolves.
+    //
+    // No report-only mode exists for COOP — it is not part of the CSP — so
+    // getting it wrong breaks sign-in on the first deploy, in every
+    // environment, since none has bffEnabled on yet. Legacy deployments get no
+    // COOP at all until Epic 6 retires that flow. BFF sign-in is a top-level
+    // redirect with no popup and no opener, so it keeps the isolation.
+    crossOriginOpenerPolicy: config.bffEnabled === true
+      ? { policy: 'same-origin-allow-popups' }
+      : false,
+    // COEP demands CORP or CORS headers on every cross-origin subresource.
+    // The banner bucket and the feature-flag/metrics upstreams send neither,
+    // so enabling it would block them. Off until those are same-origin.
+    crossOriginEmbedderPolicy: false,
+    crossOriginResourcePolicy: { policy: 'same-origin' },
+    referrerPolicy: { policy: 'no-referrer' },
+    // The deployed httpd sidecar also sets this, and its value wins. Ours is
+    // what a local or docker-compose run gets, where there is no proxy at all.
+    xFrameOptions: { action: 'deny' },
+    // Gated on NODE_ENV, not on the transport, so that `pnpm start:server`
+    // cannot pin a developer's browser to https for a year. A compose stack
+    // runs as production and does send it; browsers ignore HSTS delivered over
+    // plain HTTP, so that costs nothing there.
+    strictTransportSecurity: env.isDev
+      ? false
+      : { maxAge: 31536000, includeSubDomains: true, preload: false },
+  }
+}

--- a/server/test/headers.test.ts
+++ b/server/test/headers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyHelmet from '@fastify/helmet'
+import { type SecurityHeaderEnvironment, helmetOptions } from '../src/security/headers.js'
+
+const config = (bffEnabled: boolean): Record<string, unknown> => ({ env: 'dev', bffEnabled })
+
+const PROD: SecurityHeaderEnvironment = { isDev: false }
+const DEV: SecurityHeaderEnvironment = { isDev: true }
+
+describe('helmetOptions', () => {
+  it('sends no COOP at all in legacy mode, where a popup carries the sign-in result', () => {
+    // Measured, not assumed: `same-origin-allow-popups` does NOT save this
+    // flow. It spares a popup only on its initial navigation while the popup's
+    // own document is unsafe-none. On the return leg from B2C the comparison
+    // is unsafe-none against our COOP, which mismatches — the browser swaps
+    // browsing context groups and window.opener goes null, so oidc-client-ts
+    // can never postMessage the result back and signinPopup() hangs.
+    expect(helmetOptions(config(false), PROD).crossOriginOpenerPolicy).toBe(false)
+  })
+
+  it('keeps COOP in BFF mode, where sign-in is a top-level redirect with no opener', () => {
+    expect(helmetOptions(config(true), PROD).crossOriginOpenerPolicy).toEqual({ policy: 'same-origin-allow-popups' })
+  })
+
+  it('treats a missing bffEnabled key as legacy mode, the fail-safe direction', () => {
+    expect(helmetOptions({ env: 'dev' }, PROD).crossOriginOpenerPolicy).toBe(false)
+  })
+
+  it('leaves COEP off, since the banner and metrics origins send no CORP header', () => {
+    expect(helmetOptions(config(true), PROD).crossOriginEmbedderPolicy).toBe(false)
+  })
+
+  it('sends HSTS in production only', () => {
+    expect(helmetOptions(config(true), DEV).strictTransportSecurity).toBe(false)
+    expect(helmetOptions(config(true), PROD).strictTransportSecurity).toEqual({
+      maxAge: 31536000,
+      includeSubDomains: true,
+      preload: false,
+    })
+  })
+
+  it('sends no Content-Security-Policy yet — that is story 5-F3', () => {
+    expect(helmetOptions(config(true), PROD).contentSecurityPolicy).toBe(false)
+  })
+})
+
+describe('the headers as helmet serialises them', () => {
+  let app: FastifyInstance
+
+  async function buildHelmetApp(env: SecurityHeaderEnvironment, bffEnabled = true): Promise<FastifyInstance> {
+    const instance = Fastify({ logger: false })
+    await instance.register(fastifyHelmet, helmetOptions(config(bffEnabled), env))
+    instance.get('/page', async () => ({ ok: true }))
+    return instance
+  }
+
+  afterEach(async () => {
+    await app?.close()
+  })
+
+  it('sends the headers a browser acts on, and no policy header at all', async () => {
+    app = await buildHelmetApp(PROD)
+    const res = await app.inject({ method: 'GET', url: '/page' })
+
+    expect(res.headers['cross-origin-opener-policy']).toBe('same-origin-allow-popups')
+    expect(res.headers['cross-origin-resource-policy']).toBe('same-origin')
+    expect(res.headers['referrer-policy']).toBe('no-referrer')
+    expect(res.headers['x-frame-options']).toBe('DENY')
+    expect(res.headers['x-content-type-options']).toBe('nosniff')
+    expect(res.headers['content-security-policy']).toBeUndefined()
+    expect(res.headers['content-security-policy-report-only']).toBeUndefined()
+  })
+
+  it('omits the COOP header entirely for a legacy deployment', async () => {
+    // Not `unsafe-none`: absent. A legacy popup must see no COOP at all.
+    app = await buildHelmetApp(PROD, false)
+    const res = await app.inject({ method: 'GET', url: '/page' })
+
+    expect(res.headers['cross-origin-opener-policy']).toBeUndefined()
+  })
+
+  it('omits HSTS outside production, so a plain-HTTP dev setup keeps working', async () => {
+    app = await buildHelmetApp(DEV)
+    const res = await app.inject({ method: 'GET', url: '/page' })
+
+    expect(res.headers['strict-transport-security']).toBeUndefined()
+  })
+})

--- a/server/test/headers.test.ts
+++ b/server/test/headers.test.ts
@@ -10,12 +10,6 @@ const DEV: SecurityHeaderEnvironment = { isDev: true }
 
 describe('helmetOptions', () => {
   it('sends no COOP at all in legacy mode, where a popup carries the sign-in result', () => {
-    // Measured, not assumed: `same-origin-allow-popups` does NOT save this
-    // flow. It spares a popup only on its initial navigation while the popup's
-    // own document is unsafe-none. On the return leg from B2C the comparison
-    // is unsafe-none against our COOP, which mismatches — the browser swaps
-    // browsing context groups and window.opener goes null, so oidc-client-ts
-    // can never postMessage the result back and signinPopup() hangs.
     expect(helmetOptions(config(false), PROD).crossOriginOpenerPolicy).toBe(false)
   })
 

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -621,3 +621,43 @@ describe('envBool', () => {
     for (const v of ['true', 'True', '1', 'yes', 'on']) expect(envBool(v, false)).toBe(true)
   })
 })
+
+describe('security headers', () => {
+  // The outer fixture config carries no bffEnabled key, so every case here is
+  // a legacy deployment — the mode where COOP would sever sign-in.
+  it('reaches a root-scope route', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' })
+
+    expect(res.headers['cross-origin-resource-policy']).toBe('same-origin')
+    expect(res.headers['referrer-policy']).toBe('no-referrer')
+    expect(res.headers['x-frame-options']).toBe('DENY')
+  })
+
+  it('reaches the SPA document itself, not just the API routes', async () => {
+    // /health is a root-scope JSON route; the response that actually needs the
+    // headers is the HTML document. A deep link falls through to
+    // setNotFoundHandler -> reply.html(), the same path a real page load takes.
+    // Asserting only on /health would keep passing if a future registration
+    // ordering dropped them from the document.
+    const res = await app.inject({ method: 'GET', url: '/datalibrary/some-deep-link' })
+
+    expect(res.headers['x-frame-options']).toBe('DENY')
+    expect(res.headers['referrer-policy']).toBe('no-referrer')
+  })
+
+  it('sends no COOP header at all to a legacy deployment', async () => {
+    // Absent, not `unsafe-none`. The legacy popup sign-in dies on any value.
+    const res = await app.inject({ method: 'GET', url: '/health' })
+
+    expect(res.headers['cross-origin-opener-policy']).toBeUndefined()
+  })
+
+  it('sends no Content-Security-Policy yet, in either spelling', async () => {
+    // The policy is story 5-F3. Asserting its absence here keeps this PR
+    // honest about what it delivers.
+    const res = await app.inject({ method: 'GET', url: '/health' })
+
+    expect(res.headers['content-security-policy']).toBeUndefined()
+    expect(res.headers['content-security-policy-report-only']).toBeUndefined()
+  })
+})

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -623,8 +623,6 @@ describe('envBool', () => {
 })
 
 describe('security headers', () => {
-  // The outer fixture config carries no bffEnabled key, so every case here is
-  // a legacy deployment — the mode where COOP would sever sign-in.
   it('reaches a root-scope route', async () => {
     const res = await app.inject({ method: 'GET', url: '/health' })
 
@@ -634,11 +632,6 @@ describe('security headers', () => {
   })
 
   it('reaches the SPA document itself, not just the API routes', async () => {
-    // /health is a root-scope JSON route; the response that actually needs the
-    // headers is the HTML document. A deep link falls through to
-    // setNotFoundHandler -> reply.html(), the same path a real page load takes.
-    // Asserting only on /health would keep passing if a future registration
-    // ordering dropped them from the document.
     const res = await app.inject({ method: 'GET', url: '/datalibrary/some-deep-link' })
 
     expect(res.headers['x-frame-options']).toBe('DENY')
@@ -646,15 +639,12 @@ describe('security headers', () => {
   })
 
   it('sends no COOP header at all to a legacy deployment', async () => {
-    // Absent, not `unsafe-none`. The legacy popup sign-in dies on any value.
     const res = await app.inject({ method: 'GET', url: '/health' })
 
     expect(res.headers['cross-origin-opener-policy']).toBeUndefined()
   })
 
   it('sends no Content-Security-Policy yet, in either spelling', async () => {
-    // The policy is story 5-F3. Asserting its absence here keeps this PR
-    // honest about what it delivers.
     const res = await app.inject({ method: 'GET', url: '/health' })
 
     expect(res.headers['content-security-policy']).toBeUndefined()


### PR DESCRIPTION
### Addresses

[DT-4021](https://broadworkbench.atlassian.net/browse/DT-4021) — BFF Phase 5, **story 5-F1**. Security risk: **medium** (COOP can sever legacy sign-in; that is why this ships alone).

This is the first of several PRs. The full implementation of DT-4021 is much larger and riskier than I had hoped so it is broken down here:
- **5-F1 security headers (this PR)** → 
- [5-F2 report sink](https://github.com/DataBiosphere/duos-ui/pull/3908) → 
- [5-F3 the policy](https://github.com/DataBiosphere/duos-ui/pull/3909)  → 
- [5-F4 terra-helmfile proxy](https://github.com/broadinstitute/terra-helmfile/pull/6497)  → 
- 5-F5 run report - no code, just a report execution → 
- [5-F6 public BFF endpoints](https://github.com/DataBiosphere/duos-ui/pull/3914)

### Summary

The server sent no security headers and relies on the standard Terra proxy. This registers `@fastify/helmet` with the Content Security Policy **deliberately off** — that is [5-F3](https://github.com/DataBiosphere/duos-ui/pull/3909). `Cross-Origin-Opener-Policy` is off entirely in legacy mode since legacy sign-in needs to open a popup window. Rationale in `docs/plans/bff_adrs/ADR-013-content-security-policy.md`, which is written across the stack and grows with it.

### Test notes
I have tested both legacy and BFF sign in with the current proxy settings and both work - that is the primary risk in this PR.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.\n\n- Label PR with a Jira ticket number and include a link to the ticket\n- Label PR with a security risk modifier [no, low, medium, high]\n- PR describes scope of changes\n- Get a minimum of one thumbs worth of review, preferably two if enough team members are available\n- Get PO sign-off for all non-trivial UI or workflow changes\n- Verify all tests go green\n- Test this change deployed correctly and works on dev environment after deployment\n


[DT-4021]: https://broadworkbench.atlassian.net/browse/DT-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ