### PR TITLE
[DT-4022] Bind the app error handler to the routes buildApp registers (BFF Phase 5, story 5-G1)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import http from 'node:http'
 import https from 'node:https'
 import open from 'open'
-import Fastify, { FastifyError, FastifyInstance } from 'fastify'
+import Fastify, { FastifyError, FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import fastifyPostgres from '@fastify/postgres'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
@@ -44,6 +44,27 @@ export function envBool(value: string | undefined, defaultValue: boolean): boole
   return defaultValue
 }
 
+/**
+ * The app-level error handler. The body is always generic: an error message
+ * can carry internal detail, and no client branches on it.
+ *
+ * Named and exported rather than inlined at the registration site so the
+ * status handling below is directly assertable — a request built by hand is
+ * the only way to drive a specific `err` shape through it.
+ */
+export function handleServerError(err: FastifyError, request: FastifyRequest, reply: FastifyReply): FastifyReply {
+  request.log.error({ err }, '[server] Unhandled error:')
+  // Keeps two behaviours of the default handler this one now displaces on the
+  // routes built here: `status` is honoured alongside `statusCode` (libraries
+  // set either), and a non-error status is never used to answer an error — a
+  // 3xx would send a JSON body with no Location. Header propagation
+  // (`err.headers`) is deliberately not carried over: no error raised in this
+  // app sets it, and forwarding headers off an arbitrary error is a wider
+  // surface than the parity is worth.
+  const status = err.statusCode ?? (err as { status?: number }).status ?? 500
+  return reply.status(status >= 400 ? status : 500).send({ error: 'An unexpected error occurred.' })
+}
+
 export async function buildApp(): Promise<AppInstance> {
   // The app always sits behind exactly one reverse-proxy hop (the
   // httpd-terra-proxy sidecar in k8s, or the `proxy` container in
@@ -64,6 +85,14 @@ export async function buildApp(): Promise<AppInstance> {
       })
     : Fastify({ logger: { level: process.env.FASTIFY_LOG_LEVEL ?? 'info' }, trustProxy: TRUST_PROXY })
   ) as AppInstance
+
+  // Registered before any route: Fastify binds a route's error handler when
+  // the route is registered, so a handler set at the end of this function
+  // would only ever reach routes added afterwards (the tests' own) — every
+  // /auth/* and /health route would fall back to Fastify's default handler,
+  // which serialises `err.message` to the client. The encapsulated proxy
+  // declares its own error handler (ADR-010) and is unaffected either way.
+  fastify.setErrorHandler(handleServerError)
 
   // Path to the static client config.json — computed once so both the
   // /config.json route below and the bffEnabled startup check read the same
@@ -269,12 +298,6 @@ export async function buildApp(): Promise<AppInstance> {
   // SPA fallback — @fastify/vite sets up the Vite middleware and reply.html decorator
   // but does not register routes; we wire the catch-all ourselves.
   fastify.setNotFoundHandler((_req, reply) => reply.html())
-
-  // The encapsulated proxy declares its own error handler (ADR-010).
-  fastify.setErrorHandler((err: FastifyError, request, reply) => {
-    request.log.error({ err }, '[server] Unhandled error:')
-    return reply.status(err.statusCode ?? 500).send({ error: 'An unexpected error occurred.' })
-  })
 
   return fastify
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,20 +47,9 @@ export function envBool(value: string | undefined, defaultValue: boolean): boole
 /**
  * The app-level error handler. The body is always generic: an error message
  * can carry internal detail, and no client branches on it.
- *
- * Named and exported rather than inlined at the registration site so the
- * status handling below is directly assertable — a request built by hand is
- * the only way to drive a specific `err` shape through it.
  */
 export function handleServerError(err: FastifyError, request: FastifyRequest, reply: FastifyReply): FastifyReply {
   request.log.error({ err }, '[server] Unhandled error:')
-  // Keeps two behaviours of the default handler this one now displaces on the
-  // routes built here: `status` is honoured alongside `statusCode` (libraries
-  // set either), and a non-error status is never used to answer an error — a
-  // 3xx would send a JSON body with no Location. Header propagation
-  // (`err.headers`) is deliberately not carried over: no error raised in this
-  // app sets it, and forwarding headers off an arbitrary error is a wider
-  // surface than the parity is worth.
   const status = err.statusCode ?? (err as { status?: number }).status ?? 500
   return reply.status(status >= 400 ? status : 500).send({ error: 'An unexpected error occurred.' })
 }
@@ -86,12 +75,7 @@ export async function buildApp(): Promise<AppInstance> {
     : Fastify({ logger: { level: process.env.FASTIFY_LOG_LEVEL ?? 'info' }, trustProxy: TRUST_PROXY })
   ) as AppInstance
 
-  // Registered before any route: Fastify binds a route's error handler when
-  // the route is registered, so a handler set at the end of this function
-  // would only ever reach routes added afterwards (the tests' own) — every
-  // /auth/* and /health route would fall back to Fastify's default handler,
-  // which serialises `err.message` to the client. The encapsulated proxy
-  // declares its own error handler (ADR-010) and is unaffected either way.
+  // Registered before any routes so all errors, including those in plugins, are caught.
   fastify.setErrorHandler(handleServerError)
 
   // Path to the static client config.json — computed once so both the

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -159,69 +159,72 @@ describe('error handler', () => {
 })
 
 describe('handleServerError', () => {
+  // The whole contract of the handler. The status varies with the error; the
+  // body never does. Nothing a client reads is derived from err.message.
+  const GENERIC_BODY = { error: 'An unexpected error occurred.' }
+
   function fakeRequest() {
     return { ip: '203.0.113.1', url: '/auth/login', log: { warn: vi.fn(), error: vi.fn() } }
   }
 
   function fakeReply() {
-    const reply = { status: vi.fn(() => reply), send: vi.fn(() => reply) }
+    const reply = {
+      sentStatus: 0,
+      sentBody: undefined as unknown,
+      status: vi.fn((code: number) => {
+        reply.sentStatus = code
+        return reply
+      }),
+      send: vi.fn((body: unknown) => {
+        reply.sentBody = body
+        return reply
+      }),
+    }
     return reply
   }
 
-  it('logs the failure at error and hides its message', async () => {
+  async function run(err: Error) {
     const { handleServerError } = await import('../src/index.js')
-    const err = Object.assign(new Error('internal secret data'), { statusCode: 502 })
     const request = fakeRequest()
     const reply = fakeReply()
-
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     handleServerError(err as any, request as any, reply as any)
+    return { request, reply }
+  }
 
-    expect(request.log.error).toHaveBeenCalled()
-    expect(reply.status).toHaveBeenCalledWith(502)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+  // Every shape of error the handler can be given. Each message holds detail a
+  // client must never see: a 4xx message reads like client-safe text, which is
+  // the case most likely to tempt a future edit that forwards err.message.
+  const cases = [
+    { name: 'a 5xx statusCode', err: () => Object.assign(new Error('upstream token endpoint said: invalid_client'), { statusCode: 502 }), status: 502 },
+    { name: 'no status at all', err: () => new Error('DUOS_OIDC_CLIENT_SECRET is not set'), status: 500 },
+    { name: 'only err.status, not statusCode', err: () => Object.assign(new Error('bad input for column "ssn"'), { status: 400 }), status: 400 },
+    // A 3xx would answer an error with a JSON body and no Location header, so
+    // the handler refuses it and uses 500.
+    { name: 'a non-error 3xx status', err: () => Object.assign(new Error('confused'), { statusCode: 302 }), status: 500 },
+  ]
+
+  it.each(cases)('answers $name with the generic body and no part of err.message', async ({ err }) => {
+    const thrown = err()
+
+    const { reply } = await run(thrown)
+
+    expect(reply.sentBody).toEqual(GENERIC_BODY)
+    expect(JSON.stringify(reply.sentBody)).not.toContain(thrown.message)
   })
 
-  it('answers with 500 when the error carries no status at all', async () => {
-    const { handleServerError } = await import('../src/index.js')
-    const reply = fakeReply()
+  it.each(cases)('maps $name to status $status', async ({ err, status }) => {
+    const { reply } = await run(err())
 
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    handleServerError(new Error('internal secret data') as any, fakeRequest() as any, reply as any)
-
-    expect(reply.status).toHaveBeenCalledWith(500)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+    expect(reply.sentStatus).toBe(status)
   })
 
-  // A 4xx message reads like client-safe text, so it is the case most likely to
-  // tempt a future edit that forwards err.message. It must not: the status is
-  // the only part of the error that reaches the client, and the body stays the
-  // same generic string as a 5xx. Here 'bad input' names a column that the
-  // client must never see.
-  it('honors err.status when the error carries no statusCode, and still hides the message', async () => {
-    const { handleServerError } = await import('../src/index.js')
-    const err = Object.assign(new Error('bad input for column "ssn"'), { status: 400 })
-    const reply = fakeReply()
+  it('logs the error server-side, which is the only place the message survives', async () => {
+    const thrown = Object.assign(new Error('internal secret data'), { statusCode: 502 })
 
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    handleServerError(err as any, fakeRequest() as any, reply as any)
+    const { request } = await run(thrown)
 
-    expect(reply.status).toHaveBeenCalledWith(400)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
-    expect(reply.send).not.toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('ssn') }))
-  })
-
-  // A 3xx would answer an error with a JSON body and no Location header.
-  it('answers with 500 when the error names a non-error status', async () => {
-    const { handleServerError } = await import('../src/index.js')
-    const err = Object.assign(new Error('confused'), { statusCode: 302 })
-    const reply = fakeReply()
-
-    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-    handleServerError(err as any, fakeRequest() as any, reply as any)
-
-    expect(reply.status).toHaveBeenCalledWith(500)
-    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+    expect(request.log.error).toHaveBeenCalledWith({ err: thrown }, '[server] Unhandled error:')
   })
 })
 

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -182,15 +182,33 @@ describe('handleServerError', () => {
     expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
   })
 
-  it('honors err.status when the error carries no statusCode', async () => {
+  it('answers with 500 when the error carries no status at all', async () => {
     const { handleServerError } = await import('../src/index.js')
-    const err = Object.assign(new Error('bad input'), { status: 400 })
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(new Error('internal secret data') as any, fakeRequest() as any, reply as any)
+
+    expect(reply.status).toHaveBeenCalledWith(500)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+  })
+
+  // A 4xx message reads like client-safe text, so it is the case most likely to
+  // tempt a future edit that forwards err.message. It must not: the status is
+  // the only part of the error that reaches the client, and the body stays the
+  // same generic string as a 5xx. Here 'bad input' names a column that the
+  // client must never see.
+  it('honors err.status when the error carries no statusCode, and still hides the message', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('bad input for column "ssn"'), { status: 400 })
     const reply = fakeReply()
 
     // oxlint-disable-next-line @typescript-eslint/no-explicit-any
     handleServerError(err as any, fakeRequest() as any, reply as any)
 
     expect(reply.status).toHaveBeenCalledWith(400)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+    expect(reply.send).not.toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('ssn') }))
   })
 
   // A 3xx would answer an error with a JSON body and no Location header.
@@ -203,6 +221,7 @@ describe('handleServerError', () => {
     handleServerError(err as any, fakeRequest() as any, reply as any)
 
     expect(reply.status).toHaveBeenCalledWith(500)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
   })
 })
 

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -158,6 +158,57 @@ describe('error handler', () => {
   })
 })
 
+describe('handleServerError', () => {
+  // Driven with a hand-built request and reply: that is the only way to put a
+  // specific `err` shape through the handler. The wiring itself is covered
+  // end-to-end by the /boom case above and by the buildApp case further down.
+  function fakeRequest() {
+    return { ip: '203.0.113.1', url: '/auth/login', log: { warn: vi.fn(), error: vi.fn() } }
+  }
+
+  function fakeReply() {
+    const reply = { status: vi.fn(() => reply), send: vi.fn(() => reply) }
+    return reply
+  }
+
+  it('logs the failure at error and hides its message', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('internal secret data'), { statusCode: 502 })
+    const request = fakeRequest()
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, request as any, reply as any)
+
+    expect(request.log.error).toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+  })
+
+  it('honors err.status when the error carries no statusCode', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('bad input'), { status: 400 })
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, fakeRequest() as any, reply as any)
+
+    expect(reply.status).toHaveBeenCalledWith(400)
+  })
+
+  // A 3xx would answer an error with a JSON body and no Location header.
+  it('answers with 500 when the error names a non-error status', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('confused'), { statusCode: 302 })
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, fakeRequest() as any, reply as any)
+
+    expect(reply.status).toHaveBeenCalledWith(500)
+  })
+})
+
 describe('plugin registration order', () => {
   it('registers postgres before cookie before session', async () => {
     const { default: pgPlugin } = await import('@fastify/postgres')
@@ -589,6 +640,28 @@ describe('BFF auth route registration', () => {
     expect(read({ 'csrf-token': 'the-token' })).toBeUndefined()
     expect(read({ 'xsrf-token': 'the-token' })).toBeUndefined()
     expect(read({ 'x-xsrf-token': 'the-token' })).toBeUndefined()
+
+    await localApp.close()
+  })
+
+  // The regression this guards: setErrorHandler moving back to the end of
+  // buildApp(). Fastify binds a route's error handler when the route
+  // registers, so every route built inside buildApp() would fall back to
+  // Fastify's default handler, which serialises err.message to the client.
+  // The /boom case in the 'error handler' describe cannot catch that — it
+  // registers its route after buildApp() has returned.
+  it('applies the app error handler to a route registered inside buildApp', async () => {
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+    const { handleLogin } = await import('../src/auth/login.js')
+    vi.mocked(handleLogin).mockImplementationOnce(() => {
+      throw new Error('internal secret data')
+    })
+
+    const res = await localApp.inject({ method: 'POST', url: '/auth/login' })
+
+    expect(res.statusCode).toBe(500)
+    expect(res.json()).toEqual({ error: 'An unexpected error occurred.' })
+    expect(res.payload).not.toContain('internal secret data')
 
     await localApp.close()
   })

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -159,9 +159,6 @@ describe('error handler', () => {
 })
 
 describe('handleServerError', () => {
-  // Driven with a hand-built request and reply: that is the only way to put a
-  // specific `err` shape through the handler. The wiring itself is covered
-  // end-to-end by the /boom case above and by the buildApp case further down.
   function fakeRequest() {
     return { ip: '203.0.113.1', url: '/auth/login', log: { warn: vi.fn(), error: vi.fn() } }
   }


### PR DESCRIPTION
### Addresses

[DT-4022](https://broadworkbench.atlassian.net/browse/DT-4022) — BFF Phase 5, story 5-G1. 
Security risk: **medium** (this is an information-disclosure fix, and it changes the error body of every route `buildApp` registers).

**PR 1 of 3.** Story 5-G was split to reduce PR complexity:
1. **this PR** — bind the app error handler to the routes `buildApp` registers
2. `gr-dt-4022-login-rate-limit` — rate-limit `POST /auth/login` ([5-G2](https://github.com/DataBiosphere/duos-ui/pull/3911))
3. `gr-dt-4022-callback-rate-limit` — rate-limit `GET /auth/callback` ([5-G3](https://github.com/DataBiosphere/duos-ui/pull/3912))

### Summary

**Fastify binds a route's error handler when the route is registered, not at `ready()`.** `fastify.setErrorHandler(...)` sat at the *end* of `buildApp()`, so it reached no route built inside that function. Every one of these fell back to Fastify's default handler, which serialises `err.message` to the client:

`/auth/login`, `/auth/callback`, `/auth/csrf-token`, `/auth/logout`, `/auth/me`, `/health`

Confirmed empirically against the installed Fastify 5.12.1, not inferred from the docs. The mechanism is `lib/route.js`, which assigns `context.errorHandler = this[kErrorHandler]` inside an `after(...)` callback — and every `await fastify.register(...)` in `buildApp()` drains that queue, freezing each route's handler at whatever was set when the *next* awaited register ran.

Three leaks that reached a browser with a 500:

| Source | What leaked |
|---|---|
| `auth/callback.ts` re-throws non-`AuthorizationResponseError` failures from `oidc.authorizationCodeGrant` | token-endpoint response detail, JWT validation specifics |
| `auth/oidcClient.ts` `requireEnv` | the name of the missing deployment variable |
| `auth/logout.ts` | the discovered `end_session_endpoint` |

The fix moves the call ahead of every route registration. The encapsulated proxy declares its own error handler (ADR-010) and is unaffected either way.


----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment


[DT-4022]: https://broadworkbench.atlassian.net/browse/DT-4022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ