### PR TITLE
[DT-4022] Rate-limit POST /auth/login (BFF Phase 5, story 5-G2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,12 @@ DUOS_TDR_URL=https://jade.datarepo-dev.broadinstitute.org
 # Bard (Mixpanel gateway), proxied at /bard-api for identified usage metrics.
 # Optional, same behavior as DUOS_ECM_URL when unset.
 DUOS_BARD_URL=https://terra-bard-dev.appspot.com
+
+# --- Auth rate limiting ----------------------------------------------------
+# Per-IP flood control on POST /auth/login, in requests per minute. Optional:
+# unset means the shipped default of 30. Set it to tighten or relax the limit
+# from measured traffic without a code release — many users share one
+# institutional NAT egress IP, so a per-IP bucket is really a per-campus
+# bucket. A value that is not a positive whole number fails at startup. See
+# server/src/security/rateLimit.ts.
+# DUOS_RATE_LIMIT_LOGIN_MAX=30

--- a/docs/plans/BFF_Overview.md
+++ b/docs/plans/BFF_Overview.md
@@ -294,6 +294,27 @@ imported by the server and all five test harnesses, so changing `sameSite` or
   PKCE, token exchange, and ID-token validation (signature, `iss`, `aud`,
   `exp`) rather than hand-rolled crypto.
 
+- **Application-level rate limiting is a backstop, not the primary control**
+  (story 5-G) — `@fastify/rate-limit`'s default store is per-process, so in a
+  multi-pod deployment the effective limit multiplies by the replica count and
+  resets on every restart. Production flood protection belongs at the
+  ingress/edge or a shared store; the in-app limits are a floor against a
+  flood from one source, not a distributed one. The plugin is registered with
+  `global: false` because the same Fastify instance serves every SPA asset
+  through `@fastify/vite` — only the auth routes opt in.
+  `/auth/csrf-token` is gated on authentication instead (5-B) and
+  `/auth/logout` on the CSRF token, because a low cap on either breaks
+  multiple tabs and the client's retry path. Limits are per client IP and
+  environment-overridable, so tightening them from measured traffic is a
+  deployment change rather than a code release. Three items stay open and are
+  recorded in `server/src/security/rateLimit.ts`: edge or shared-store
+  enforcement (infrastructure); confirming that the httpd sidecar sets or
+  appends `X-Forwarded-For` rather than passing a client-supplied header
+  through; and the unauthenticated, CSRF-exempt `POST /duos-api/support/*`
+  proxy writes, which no limit covers yet. A caller inside the trusted ranges
+  (`TRUST_PROXY` trusts `uniquelocal`) can still choose its own bucket — a
+  property of `TRUST_PROXY`, and another reason the edge is the real control.
+
 ## Target Architecture Sequence Diagrams
 
 Three flows are shown: sign-in (including B2C provider selection, PKCE, and

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,9 @@ importers:
       '@fastify/postgres':
         specifier: 6.1.0
         version: 6.1.0(pg@8.22.0)
+      '@fastify/rate-limit':
+        specifier: 11.2.0
+        version: 11.2.0
       '@fastify/reply-from':
         specifier: 12.6.4
         version: 12.6.4
@@ -652,6 +655,9 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/rate-limit@11.2.0':
+    resolution: {integrity: sha512-X7osJd4XSvMoejYrnJkSZYYjY1eNYoBqhjlzf1RakC2204qExFqZFTKj5+T7VuzA/iUI9Z3UoSqQRkB2HpG0oQ==}
 
   '@fastify/reply-from@12.6.4':
     resolution: {integrity: sha512-WpHqGNRKzEraRQwBFK64g2HijN0ZuDuiiwWg06r5LY0lv1iu0qYg1BfVM0iYcCMiovrM8kKXsKm5GDH9JH9aPA==}
@@ -2086,6 +2092,10 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@2.5.0:
     resolution: {integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==}
@@ -3774,6 +3784,13 @@ snapshots:
       '@fastify/forwarded': 3.0.2
       ipaddr.js: 2.5.0
 
+  '@fastify/rate-limit@11.2.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 6.0.0
+      ip-address: 10.7.0
+      toad-cache: 3.7.4
+
   '@fastify/reply-from@12.6.4':
     dependencies:
       '@fastify/error': 4.2.0
@@ -5235,6 +5252,8 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  ip-address@10.7.0: {}
 
   ipaddr.js@2.5.0: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
     "@fastify/cookie": "11.1.2",
     "@fastify/csrf-protection": "8.0.1",
     "@fastify/postgres": "6.1.0",
+    "@fastify/rate-limit": "11.2.0",
     "@fastify/reply-from": "12.6.4",
     "@fastify/session": "11.1.2",
     "@fastify/static": "10.1.3",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 import http from 'node:http'
 import https from 'node:https'
 import open from 'open'
-import Fastify, { FastifyError, FastifyInstance } from 'fastify'
+import Fastify, { FastifyError, FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import fastifyPostgres from '@fastify/postgres'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
@@ -44,6 +44,27 @@ export function envBool(value: string | undefined, defaultValue: boolean): boole
   return defaultValue
 }
 
+/**
+ * The app-level error handler. The body is always generic: an error message
+ * can carry internal detail, and no client branches on it.
+ *
+ * Named and exported rather than inlined at the registration site so the
+ * status handling below is directly assertable — a request built by hand is
+ * the only way to drive a specific `err` shape through it.
+ */
+export function handleServerError(err: FastifyError, request: FastifyRequest, reply: FastifyReply): FastifyReply {
+  request.log.error({ err }, '[server] Unhandled error:')
+  // Keeps two behaviours of the default handler this one now displaces on the
+  // routes built here: `status` is honoured alongside `statusCode` (libraries
+  // set either), and a non-error status is never used to answer an error — a
+  // 3xx would send a JSON body with no Location. Header propagation
+  // (`err.headers`) is deliberately not carried over: no error raised in this
+  // app sets it, and forwarding headers off an arbitrary error is a wider
+  // surface than the parity is worth.
+  const status = err.statusCode ?? (err as { status?: number }).status ?? 500
+  return reply.status(status >= 400 ? status : 500).send({ error: 'An unexpected error occurred.' })
+}
+
 export async function buildApp(): Promise<AppInstance> {
   // The app always sits behind exactly one reverse-proxy hop (the
   // httpd-terra-proxy sidecar in k8s, or the `proxy` container in
@@ -64,6 +85,14 @@ export async function buildApp(): Promise<AppInstance> {
       })
     : Fastify({ logger: { level: process.env.FASTIFY_LOG_LEVEL ?? 'info' }, trustProxy: TRUST_PROXY })
   ) as AppInstance
+
+  // Registered before any route: Fastify binds a route's error handler when
+  // the route is registered, so a handler set at the end of this function
+  // would only ever reach routes added afterwards (the tests' own) — every
+  // /auth/* and /health route would fall back to Fastify's default handler,
+  // which serialises `err.message` to the client. The encapsulated proxy
+  // declares its own error handler (ADR-010) and is unaffected either way.
+  fastify.setErrorHandler(handleServerError)
 
   // Path to the static client config.json — computed once so both the
   // /config.json route below and the bffEnabled startup check read the same
@@ -269,12 +298,6 @@ export async function buildApp(): Promise<AppInstance> {
   // SPA fallback — @fastify/vite sets up the Vite middleware and reply.html decorator
   // but does not register routes; we wire the catch-all ourselves.
   fastify.setNotFoundHandler((_req, reply) => reply.html())
-
-  // The encapsulated proxy declares its own error handler (ADR-010).
-  fastify.setErrorHandler((err: FastifyError, request, reply) => {
-    request.log.error({ err }, '[server] Unhandled error:')
-    return reply.status(err.statusCode ?? 500).send({ error: 'An unexpected error occurred.' })
-  })
 
   return fastify
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,10 +9,12 @@ import fastifyPostgres from '@fastify/postgres'
 import fastifyCookie from '@fastify/cookie'
 import fastifySession from '@fastify/session'
 import fastifyCsrf from '@fastify/csrf-protection'
+import rateLimit from '@fastify/rate-limit'
 import { createPgSessionStore } from './session/pgStore.js'
 import { sessionPluginOptions } from './session/sessionOptions.js'
 import { csrfPluginOptions, handleCsrfToken } from './auth/csrf.js'
 import { fetchMetadataGuard } from './security/fetchMetadata.js'
+import { RATE_LIMIT_ERROR_CODE, isRateLimitError, loginRateLimit, rateLimitPluginOptions } from './security/rateLimit.js'
 import { getOidcConfig } from './auth/oidcClient.js'
 import { handleLogin } from './auth/login.js'
 import { handleCallback } from './auth/callback.js'
@@ -45,14 +47,25 @@ export function envBool(value: string | undefined, defaultValue: boolean): boole
 }
 
 /**
- * The app-level error handler. The body is always generic: an error message
- * can carry internal detail, and no client branches on it.
+ * The app-level error handler. The body is always generic — an error message
+ * can carry internal detail — except a throttled request, which is an
+ * expected outcome rather than a fault: the generic message would leave the
+ * client unable to tell throttling from a server error, and at `error` level
+ * a flood would turn the log pipeline into a second denial of service. The
+ * rate-limit headers the plugin set on the reply survive, because it sets
+ * them before it throws.
  *
- * Named and exported rather than inlined at the registration site so the
- * status handling below is directly assertable — a request built by hand is
- * the only way to drive a specific `err` shape through it.
+ * Named and exported rather than inlined at the registration site so both
+ * branches, and the status handling below, are directly assertable — a
+ * request built by hand is the only way to drive a specific `err` shape
+ * through it, and the child-logger factory a route uses is fixed when that
+ * route registers, so a built app's request.log cannot be stubbed afterwards.
  */
 export function handleServerError(err: FastifyError, request: FastifyRequest, reply: FastifyReply): FastifyReply {
+  if (isRateLimitError(err)) {
+    request.log.warn({ ip: request.ip, url: request.url }, '[server] rate limit exceeded')
+    return reply.status(err.statusCode ?? 429).send({ error: RATE_LIMIT_ERROR_CODE })
+  }
   request.log.error({ err }, '[server] Unhandled error:')
   // Keeps two behaviours of the default handler this one now displaces on the
   // routes built here: `status` is honoured alongside `statusCode` (libraries
@@ -93,6 +106,23 @@ export async function buildApp(): Promise<AppInstance> {
   // which serialises `err.message` to the client. The encapsulated proxy
   // declares its own error handler (ADR-010) and is unaffected either way.
   fastify.setErrorHandler(handleServerError)
+
+  // Rate limiting. Registered at app level, ahead of both cutover switches
+  // and every route: the plugin attaches its per-route hook from an `onRoute`
+  // listener, so it has to be in place before any route registers, and the
+  // CSP report endpoint (story 5-F2) sits outside the `bffEnabled` block and
+  // shares this one registration. A second `register` call would install a
+  // second `onRoute` listener.
+  //
+  // `global: false` is what makes an app-level registration safe: only a
+  // route carrying its own `config.rateLimit` is counted. This instance also
+  // serves every SPA asset through @fastify/vite, and one page load fetches
+  // many of them, so a global cap would 429 an ordinary page load. Which
+  // routes opt in, which deliberately do not, and why the numbers are what
+  // they are all live in security/rateLimit.ts. These limits are a backstop;
+  // the per-process store means production flood protection belongs at the
+  // ingress/edge.
+  await fastify.register(rateLimit, rateLimitPluginOptions)
 
   // Path to the static client config.json — computed once so both the
   // /config.json route below and the bffEnabled startup check read the same
@@ -212,7 +242,14 @@ export async function buildApp(): Promise<AppInstance> {
       throw new Error('bffEnabled is true in config.json but DUOS_API_URL is not set — /auth/me and the API proxy both forward to it')
     }
     fastify.log.info('[server] bffEnabled is true — registering BFF auth routes and the API proxy')
-    fastify.post('/auth/login', handleLogin)
+
+    // Resolved once, so the effective number reaches the log an operator
+    // reads when a limit is questioned — and so a bad override fails startup
+    // here rather than on the first request.
+    const loginLimit = loginRateLimit()
+    fastify.log.info({ login: loginLimit.max }, '[server] auth rate limits, in requests per minute per client IP')
+
+    fastify.post('/auth/login', { config: { rateLimit: loginLimit } }, handleLogin)
     fastify.get('/auth/callback', handleCallback)
     // The client fetches this after sign-in and echoes the token in an
     // X-CSRF-Token header on unsafe auth requests. Gated on an authenticated

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -49,19 +49,8 @@ export function envBool(value: string | undefined, defaultValue: boolean): boole
 }
 
 /**
- * The app-level error handler. The body is always generic — an error message
- * can carry internal detail — except a throttled request, which is an
- * expected outcome rather than a fault: the generic message would leave the
- * client unable to tell throttling from a server error, and at `error` level
- * a flood would turn the log pipeline into a second denial of service. The
- * rate-limit headers the plugin set on the reply survive, because it sets
- * them before it throws.
- *
- * Named and exported rather than inlined at the registration site so both
- * branches, and the status handling below, are directly assertable — a
- * request built by hand is the only way to drive a specific `err` shape
- * through it, and the child-logger factory a route uses is fixed when that
- * route registers, so a built app's request.log cannot be stubbed afterwards.
+ * The app-level error handler. The body is always generic: an error message
+ * can carry internal detail, and no client branches on it.
  */
 export function handleServerError(err: FastifyError, request: FastifyRequest, reply: FastifyReply): FastifyReply {
   if (isRateLimitError(err)) {
@@ -69,13 +58,6 @@ export function handleServerError(err: FastifyError, request: FastifyRequest, re
     return reply.status(err.statusCode ?? 429).send({ error: RATE_LIMIT_ERROR_CODE })
   }
   request.log.error({ err }, '[server] Unhandled error:')
-  // Keeps two behaviours of the default handler this one now displaces on the
-  // routes built here: `status` is honoured alongside `statusCode` (libraries
-  // set either), and a non-error status is never used to answer an error — a
-  // 3xx would send a JSON body with no Location. Header propagation
-  // (`err.headers`) is deliberately not carried over: no error raised in this
-  // app sets it, and forwarding headers off an arbitrary error is a wider
-  // surface than the parity is worth.
   const status = err.statusCode ?? (err as { status?: number }).status ?? 500
   return reply.status(status >= 400 ? status : 500).send({ error: 'An unexpected error occurred.' })
 }
@@ -101,29 +83,10 @@ export async function buildApp(): Promise<AppInstance> {
     : Fastify({ logger: { level: process.env.FASTIFY_LOG_LEVEL ?? 'info' }, trustProxy: TRUST_PROXY })
   ) as AppInstance
 
-  // Registered before any route: Fastify binds a route's error handler when
-  // the route is registered, so a handler set at the end of this function
-  // would only ever reach routes added afterwards (the tests' own) — every
-  // /auth/* and /health route would fall back to Fastify's default handler,
-  // which serialises `err.message` to the client. The encapsulated proxy
-  // declares its own error handler (ADR-010) and is unaffected either way.
+  // Registered before any routes so all errors, including those in plugins, are caught.
   fastify.setErrorHandler(handleServerError)
 
-  // Rate limiting. Registered at app level, ahead of both cutover switches
-  // and every route: the plugin attaches its per-route hook from an `onRoute`
-  // listener, so it has to be in place before any route registers, and the
-  // CSP report endpoint (story 5-F2) sits outside the `bffEnabled` block and
-  // shares this one registration. A second `register` call would install a
-  // second `onRoute` listener.
-  //
-  // `global: false` is what makes an app-level registration safe: only a
-  // route carrying its own `config.rateLimit` is counted. This instance also
-  // serves every SPA asset through @fastify/vite, and one page load fetches
-  // many of them, so a global cap would 429 an ordinary page load. Which
-  // routes opt in, which deliberately do not, and why the numbers are what
-  // they are all live in security/rateLimit.ts. These limits are a backstop;
-  // the per-process store means production flood protection belongs at the
-  // ingress/edge.
+  // Rate limiting. Registered at app level, ahead of both cutover switches and every route.
   await fastify.register(rateLimit, rateLimitPluginOptions)
 
   // Path to the static client config.json — computed once so both the

--- a/server/src/security/rateLimit.ts
+++ b/server/src/security/rateLimit.ts
@@ -1,7 +1,7 @@
 import type { RateLimitOptions, RateLimitPluginOptions } from '@fastify/rate-limit'
 
 /**
- * Rate limiting for the auth endpoints (Phase 5, story 5-G2).
+ * Rate limiting for the auth endpoints.
  *
  * **This is a backstop, not the primary control.** The default
  * `@fastify/rate-limit` store is per-process: in a multi-pod deployment the
@@ -23,8 +23,8 @@ import type { RateLimitOptions, RateLimitPluginOptions } from '@fastify/rate-lim
  * | Route              | Limited | Why                                                       |
  * |--------------------|---------|-----------------------------------------------------------|
  * | `POST /auth/login` | yes     | Session-row creation and OIDC discovery flood control     |
- * | `GET /auth/callback` | not yet | Story 5-G3. It is a top-level navigation from B2C, so a 429 needs to land the user back in the SPA rather than send a JSON body — a separate change with its own client half |
- * | `/auth/csrf-token` | no      | The authentication gate (5-B) is the control; a low cap breaks multiple tabs and the client's retry path |
+ * | `GET /auth/callback` | not yet | Story DT-4022 (5-G3). It is a top-level navigation from B2C, so a 429 needs to land the user back in the SPA rather than send a JSON body — a separate change with its own client half |
+ * | `/auth/csrf-token` | no      | The authentication gate is the control; a low cap breaks multiple tabs and the client's retry path |
  * | `/auth/logout`     | no      | Already gated by the CSRF guard                           |
  * | SPA assets         | no      | See `global: false` above                                 |
  * | `POST /duos-api/support/request`, `POST /duos-api/support/upload` | **no — open gap** | See below |
@@ -51,7 +51,7 @@ import type { RateLimitOptions, RateLimitPluginOptions } from '@fastify/rate-lim
  * ## Why the default is not the lower number first proposed
  *
  * Many users share one institutional NAT egress IP, so a per-IP bucket is
- * really a per-campus bucket. The default starts deliberately generous and is
+ * really a per-org bucket. The default starts deliberately generous and is
  * meant to be tightened from measured traffic — which is why it is
  * environment-overridable (see below) rather than fixed in code: tightening
  * is then a deployment config change, not a code release.
@@ -85,21 +85,7 @@ import type { RateLimitOptions, RateLimitPluginOptions } from '@fastify/rate-lim
  * so one client cannot spend 2^64 buckets.
  */
 
-/**
- * The code the 429 body carries. It names the reason in the response and in
- * the server log rather than leaving a bare status; no client branches on it
- * today (`Auth.signIn` branches on `res.ok` alone), so surfacing a retry hint
- * in the sign-in UI is a separate, client-side change.
- */
 export const RATE_LIMIT_ERROR_CODE = 'rate_limited'
-
-/**
- * Marks the errors this module builds. The app's error handler renders any
- * error with a `statusCode` as a generic message; it needs to recognize
- * *these* to send {@link RATE_LIMIT_ERROR_CODE} instead, and to log a flood
- * at `warn` rather than as an unhandled `error`. Matching on the status code
- * alone would also catch an upstream's own 429 relayed through the proxy.
- */
 const RATE_LIMIT_ERROR_MARKER = 'DUOS_RATE_LIMITED'
 
 /** Names the tuning knob so tests and docs cannot drift from the read below. */
@@ -109,12 +95,7 @@ const DEFAULT_LOGIN_MAX = 30
 const TIME_WINDOW = '1 minute'
 
 /**
- * A blank or unset value means "use the default"; anything else must be plain
- * decimal digits naming a positive count. A silent fallback would hide an
- * operator's typo, and `max: 0` blocks every request — so a bad value fails
- * at startup with an error naming the variable, the same posture
- * `DUOS_DB_PORT` takes in index.ts. The digits-only test is deliberately
- * stricter than `Number()`, which would also accept `1e3`, `0x1e` and `30.0`.
+ * A blank or unset value means "use the default"
  */
 function maxFromEnv(envVar: string, defaultMax: number): number {
   const raw = process.env[envVar]?.trim()
@@ -128,31 +109,16 @@ function maxFromEnv(envVar: string, defaultMax: number): number {
 
 export const rateLimitPluginOptions = {
   global: false,
-  // The plugin throws whatever this returns, so it reaches the app's error
-  // handler. `statusCode` comes from the context rather than a literal 429 so
-  // a future `ban` (which the plugin reports as 403) still renders correctly.
-  // The message never reaches the wire — the error handler substitutes the
-  // code — but it names the cause in a stack trace if the error ever escapes
-  // to a handler that does not recognize the marker.
   errorResponseBuilder: (_request, context) => Object.assign(
     new Error(`Rate limit exceeded, retry in ${context.after}`),
     { statusCode: context.statusCode, code: RATE_LIMIT_ERROR_MARKER },
   ),
-  // NOTE: a `cache` set here would be silently ignored. The plugin reads
-  // `cache` for the parent store only, and a route that carries its own
-  // `config.rateLimit` gets a child store built from the *merged route*
-  // params, which never inherit it. To size the LRU, put `cache` in the
-  // object the function below returns.
 } as const satisfies RateLimitPluginOptions
 
-// Returns a plain boolean, not a type predicate: `FastifyError` already
-// declares `code`, so a predicate would narrow the *negative* branch of the
-// app's error handler to `never` and break the fallback path.
 export function isRateLimitError(err: unknown): boolean {
   return err instanceof Error && (err as { code?: string }).code === RATE_LIMIT_ERROR_MARKER
 }
 
-/** Route `config.rateLimit` for `POST /auth/login`. Read at startup, so an override applies without a code change. */
 export function loginRateLimit(): RateLimitOptions {
   return { max: maxFromEnv(LOGIN_MAX_ENV_VAR, DEFAULT_LOGIN_MAX), timeWindow: TIME_WINDOW }
 }

--- a/server/src/security/rateLimit.ts
+++ b/server/src/security/rateLimit.ts
@@ -27,7 +27,7 @@ import type { RateLimitOptions, RateLimitPluginOptions } from '@fastify/rate-lim
  * | `/auth/csrf-token` | no      | The authentication gate (5-B) is the control; a low cap breaks multiple tabs and the client's retry path |
  * | `/auth/logout`     | no      | Already gated by the CSRF guard                           |
  * | SPA assets         | no      | See `global: false` above                                 |
- * | `POST /duos-api/support/request`, `/support/upload` | **no — open gap** | See below |
+ * | `POST /duos-api/support/request`, `POST /duos-api/support/upload` | **no — open gap** | See below |
  *
  * `/auth/login` verifies no credentials itself — it mints PKCE state, writes
  * an anonymous session row, and returns a B2C redirect URL. Its limit

--- a/server/src/security/rateLimit.ts
+++ b/server/src/security/rateLimit.ts
@@ -1,0 +1,158 @@
+import type { RateLimitOptions, RateLimitPluginOptions } from '@fastify/rate-limit'
+
+/**
+ * Rate limiting for the auth endpoints (Phase 5, story 5-G2).
+ *
+ * **This is a backstop, not the primary control.** The default
+ * `@fastify/rate-limit` store is per-process: in a multi-pod deployment the
+ * effective limit multiplies by the replica count and resets on every
+ * restart. Production flood protection belongs at the ingress/edge (or a
+ * shared store); the limits here are a floor against a flood from one source,
+ * not against a distributed one. The edge work is infrastructure and is
+ * tracked as its own task.
+ *
+ * ## Why `global: false`
+ *
+ * The same Fastify instance serves every SPA asset through `@fastify/vite`,
+ * and one page load fetches many of them. A low global cap would 429 an
+ * ordinary page load, so the plugin is registered with `global: false` and
+ * each auth route opts in through its own route `config.rateLimit`.
+ *
+ * ## What is limited, and what is not
+ *
+ * | Route              | Limited | Why                                                       |
+ * |--------------------|---------|-----------------------------------------------------------|
+ * | `POST /auth/login` | yes     | Session-row creation and OIDC discovery flood control     |
+ * | `GET /auth/callback` | not yet | Story 5-G3. It is a top-level navigation from B2C, so a 429 needs to land the user back in the SPA rather than send a JSON body — a separate change with its own client half |
+ * | `/auth/csrf-token` | no      | The authentication gate (5-B) is the control; a low cap breaks multiple tabs and the client's retry path |
+ * | `/auth/logout`     | no      | Already gated by the CSRF guard                           |
+ * | SPA assets         | no      | See `global: false` above                                 |
+ * | `POST /duos-api/support/request`, `/support/upload` | **no — open gap** | See below |
+ *
+ * `/auth/login` verifies no credentials itself — it mints PKCE state, writes
+ * an anonymous session row, and returns a B2C redirect URL. Its limit
+ * protects against session-row creation floods, **not** password guessing;
+ * that happens at B2C. With `global: false` the plugin attaches a *route*
+ * `onRequest` hook, which Fastify runs after the instance-level hooks — so a
+ * flood carrying a session cookie still costs one session-store read per
+ * request. Row *creation* is still prevented, because `@fastify/session` only
+ * writes on modification.
+ *
+ * The two `/duos-api/support/*` writes are the one unlimited path that needs
+ * no session and no CSRF token (`proxy/apiProxy.ts`, `UNAUTHENTICATED_PATHS`
+ * and `CSRF_EXEMPT_UNSAFE_REQUESTS`). They relay the signed-out Contact Us
+ * form and its file upload to the upstream, so a flood there reaches the
+ * support inbox and pushes attacker-chosen bytes through the BFF — a better
+ * target than `/auth/login`, whose flood only mints session rows. Limiting a
+ * proxied path is a separate decision (which paths, what limits, and how a
+ * 429 fits the proxy's own error shape under ADR-010), so it is named here
+ * rather than silently omitted, and left to its own story.
+ *
+ * ## Why the default is not the lower number first proposed
+ *
+ * Many users share one institutional NAT egress IP, so a per-IP bucket is
+ * really a per-campus bucket. The default starts deliberately generous and is
+ * meant to be tightened from measured traffic — which is why it is
+ * environment-overridable (see below) rather than fixed in code: tightening
+ * is then a deployment config change, not a code release.
+ *
+ * ## Keying
+ *
+ * The plugin keys on `request.ip`, which honors `X-Forwarded-For` because
+ * `TRUST_PROXY` (config.ts) names the trusted peers. `proxy-addr` walks the
+ * chain from the socket end and stops at the first address that is **not** a
+ * trusted peer, and that address becomes `request.ip`. Two consequences:
+ *
+ *   - **From outside the trusted ranges an attacker cannot choose a bucket**,
+ *     as long as the sidecar itself sets or appends `X-Forwarded-For`: the
+ *     real client address it adds sits to the right of anything the attacker
+ *     supplied, so the walk stops there first. A sidecar that instead passes
+ *     a client-supplied header through untouched (httpd's `ProxyAddHeaders
+ *     Off`, or any proxy that does not manage the header) breaks this — so
+ *     the sidecar's `X-Forwarded-For` mode still has to be confirmed at the
+ *     edge. `mod_proxy` appends by default.
+ *   - **From inside the trusted ranges an attacker can choose a bucket.**
+ *     `TRUST_PROXY` trusts `uniquelocal`, so for a caller whose own address
+ *     is RFC1918 the walk continues *past* the appended real client and into
+ *     attacker-supplied entries. k8s pod addresses are `10.x` and the server
+ *     binds `0.0.0.0`, so a pod that reaches the app port directly, past the
+ *     same-pod sidecar, can send a fresh `X-Forwarded-For` per request and
+ *     spend an unlimited number of buckets. That is a property of
+ *     `TRUST_PROXY` (which also governs `X-Forwarded-Proto`) rather than of
+ *     this module, and it is another reason the edge is the real control.
+ *
+ * IPv6 keys are grouped to a /64 — the standard single-customer delegation —
+ * so one client cannot spend 2^64 buckets.
+ */
+
+/**
+ * The code the 429 body carries. It names the reason in the response and in
+ * the server log rather than leaving a bare status; no client branches on it
+ * today (`Auth.signIn` branches on `res.ok` alone), so surfacing a retry hint
+ * in the sign-in UI is a separate, client-side change.
+ */
+export const RATE_LIMIT_ERROR_CODE = 'rate_limited'
+
+/**
+ * Marks the errors this module builds. The app's error handler renders any
+ * error with a `statusCode` as a generic message; it needs to recognize
+ * *these* to send {@link RATE_LIMIT_ERROR_CODE} instead, and to log a flood
+ * at `warn` rather than as an unhandled `error`. Matching on the status code
+ * alone would also catch an upstream's own 429 relayed through the proxy.
+ */
+const RATE_LIMIT_ERROR_MARKER = 'DUOS_RATE_LIMITED'
+
+/** Names the tuning knob so tests and docs cannot drift from the read below. */
+export const LOGIN_MAX_ENV_VAR = 'DUOS_RATE_LIMIT_LOGIN_MAX'
+
+const DEFAULT_LOGIN_MAX = 30
+const TIME_WINDOW = '1 minute'
+
+/**
+ * A blank or unset value means "use the default"; anything else must be plain
+ * decimal digits naming a positive count. A silent fallback would hide an
+ * operator's typo, and `max: 0` blocks every request — so a bad value fails
+ * at startup with an error naming the variable, the same posture
+ * `DUOS_DB_PORT` takes in index.ts. The digits-only test is deliberately
+ * stricter than `Number()`, which would also accept `1e3`, `0x1e` and `30.0`.
+ */
+function maxFromEnv(envVar: string, defaultMax: number): number {
+  const raw = process.env[envVar]?.trim()
+  if (!raw) return defaultMax
+
+  if (!/^\d+$/.test(raw) || Number(raw) < 1) {
+    throw new Error(`${envVar} is set to '${raw}', which is not a positive whole number — unset it to use the default of ${defaultMax}, or set a plain count of requests per minute`)
+  }
+  return Number(raw)
+}
+
+export const rateLimitPluginOptions = {
+  global: false,
+  // The plugin throws whatever this returns, so it reaches the app's error
+  // handler. `statusCode` comes from the context rather than a literal 429 so
+  // a future `ban` (which the plugin reports as 403) still renders correctly.
+  // The message never reaches the wire — the error handler substitutes the
+  // code — but it names the cause in a stack trace if the error ever escapes
+  // to a handler that does not recognize the marker.
+  errorResponseBuilder: (_request, context) => Object.assign(
+    new Error(`Rate limit exceeded, retry in ${context.after}`),
+    { statusCode: context.statusCode, code: RATE_LIMIT_ERROR_MARKER },
+  ),
+  // NOTE: a `cache` set here would be silently ignored. The plugin reads
+  // `cache` for the parent store only, and a route that carries its own
+  // `config.rateLimit` gets a child store built from the *merged route*
+  // params, which never inherit it. To size the LRU, put `cache` in the
+  // object the function below returns.
+} as const satisfies RateLimitPluginOptions
+
+// Returns a plain boolean, not a type predicate: `FastifyError` already
+// declares `code`, so a predicate would narrow the *negative* branch of the
+// app's error handler to `never` and break the fallback path.
+export function isRateLimitError(err: unknown): boolean {
+  return err instanceof Error && (err as { code?: string }).code === RATE_LIMIT_ERROR_MARKER
+}
+
+/** Route `config.rateLimit` for `POST /auth/login`. Read at startup, so an override applies without a code change. */
+export function loginRateLimit(): RateLimitOptions {
+  return { max: maxFromEnv(LOGIN_MAX_ENV_VAR, DEFAULT_LOGIN_MAX), timeWindow: TIME_WINDOW }
+}

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -158,6 +158,57 @@ describe('error handler', () => {
   })
 })
 
+describe('handleServerError', () => {
+  // Driven with a hand-built request and reply: that is the only way to put a
+  // specific `err` shape through the handler. The wiring itself is covered
+  // end-to-end by the /boom case above and by the buildApp case further down.
+  function fakeRequest() {
+    return { ip: '203.0.113.1', url: '/auth/login', log: { warn: vi.fn(), error: vi.fn() } }
+  }
+
+  function fakeReply() {
+    const reply = { status: vi.fn(() => reply), send: vi.fn(() => reply) }
+    return reply
+  }
+
+  it('logs the failure at error and hides its message', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('internal secret data'), { statusCode: 502 })
+    const request = fakeRequest()
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, request as any, reply as any)
+
+    expect(request.log.error).toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(502)
+    expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+  })
+
+  it('honors err.status when the error carries no statusCode', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('bad input'), { status: 400 })
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, fakeRequest() as any, reply as any)
+
+    expect(reply.status).toHaveBeenCalledWith(400)
+  })
+
+  // A 3xx would answer an error with a JSON body and no Location header.
+  it('answers with 500 when the error names a non-error status', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const err = Object.assign(new Error('confused'), { statusCode: 302 })
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, fakeRequest() as any, reply as any)
+
+    expect(reply.status).toHaveBeenCalledWith(500)
+  })
+})
+
 describe('plugin registration order', () => {
   it('registers postgres before cookie before session', async () => {
     const { default: pgPlugin } = await import('@fastify/postgres')
@@ -589,6 +640,28 @@ describe('BFF auth route registration', () => {
     expect(read({ 'csrf-token': 'the-token' })).toBeUndefined()
     expect(read({ 'xsrf-token': 'the-token' })).toBeUndefined()
     expect(read({ 'x-xsrf-token': 'the-token' })).toBeUndefined()
+
+    await localApp.close()
+  })
+
+  // The regression this guards: setErrorHandler moving back to the end of
+  // buildApp(). Fastify binds a route's error handler when the route
+  // registers, so every route built inside buildApp() would fall back to
+  // Fastify's default handler, which serialises err.message to the client.
+  // The /boom case in the 'error handler' describe cannot catch that — it
+  // registers its route after buildApp() has returned.
+  it('applies the app error handler to a route registered inside buildApp', async () => {
+    const localApp = await buildAppWithConfig({ bffEnabled: true })
+    const { handleLogin } = await import('../src/auth/login.js')
+    vi.mocked(handleLogin).mockImplementationOnce(() => {
+      throw new Error('internal secret data')
+    })
+
+    const res = await localApp.inject({ method: 'POST', url: '/auth/login' })
+
+    expect(res.statusCode).toBe(500)
+    expect(res.json()).toEqual({ error: 'An unexpected error occurred.' })
+    expect(res.payload).not.toContain('internal secret data')
 
     await localApp.close()
   })

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -160,12 +160,7 @@ describe('error handler', () => {
 
 describe('handleServerError', () => {
   // The whole contract of the handler. The status varies with the error; the
-  // body never does, except for the throttled case below. Nothing else a
-  // client reads is derived from err.message.
-  //
-  // Driven with a hand-built request and reply: that is the only way to put a
-  // specific `err` shape through the handler. The wiring itself is covered
-  // end-to-end by the /boom case above and by the buildApp case further down.
+  // body never does. Nothing a client reads is derived from err.message.
   const GENERIC_BODY = { error: 'An unexpected error occurred.' }
 
   function fakeRequest() {
@@ -232,11 +227,7 @@ describe('handleServerError', () => {
     expect(request.log.error).toHaveBeenCalledWith({ err: thrown }, '[server] Unhandled error:')
   })
 
-  // A flood must not fill the error log: at `error` level the very thing the
-  // limiter exists to absorb becomes a second denial of service, this time on
-  // the log pipeline. This branch is the one exception to the generic body
-  // above: a client that cannot tell throttling from a server error cannot
-  // back off.
+  // A flood must not fill the error log
   it('logs a throttled request at warn and answers with the rate_limited code', async () => {
     const { RATE_LIMIT_ERROR_CODE, rateLimitPluginOptions } = await import('../src/security/rateLimit.js')
     const err = rateLimitPluginOptions.errorResponseBuilder(
@@ -740,7 +731,7 @@ describe('envBool', () => {
 })
 
 // ---------------------------------------------------------------------------
-// Rate limiting (story 5-G2)
+// Rate limiting
 // ---------------------------------------------------------------------------
 describe('auth endpoint rate limiting', () => {
   let dir: string
@@ -839,16 +830,7 @@ describe('auth endpoint rate limiting', () => {
     await app.close()
   })
 
-  // The regression this guards: registering the plugin globally. This instance
-  // also serves every SPA asset through @fastify/vite, and one page load
-  // fetches many of them, so a global cap would 429 an ordinary page load.
-  //
-  // A stand-in route, not an unmatched /assets/... URL: @fastify/vite is
-  // mocked here, so an unmatched URL falls through to setNotFoundHandler —
-  // and the plugin attaches its hook from an `onRoute` listener, which
-  // setNotFoundHandler never fires. An unmatched URL is therefore unlimited
-  // whatever `global` says, and could not detect the regression. A registered
-  // route models what @fastify/vite really serves.
+  // The regression this guards: registering the plugin globally.
   it('never limits a route that did not opt in', async () => {
     const app = await buildLimitedApp('1')
     app.get('/assets/chunk.js', async () => 'export default 1')

--- a/server/test/index.test.ts
+++ b/server/test/index.test.ts
@@ -181,8 +181,31 @@ describe('handleServerError', () => {
     handleServerError(err as any, request as any, reply as any)
 
     expect(request.log.error).toHaveBeenCalled()
+    expect(request.log.warn).not.toHaveBeenCalled()
     expect(reply.status).toHaveBeenCalledWith(502)
     expect(reply.send).toHaveBeenCalledWith({ error: 'An unexpected error occurred.' })
+  })
+
+  // A flood must not fill the error log: at `error` level the very thing the
+  // limiter exists to absorb becomes a second denial of service, this time on
+  // the log pipeline.
+  it('logs a throttled request at warn and answers with the rate_limited code', async () => {
+    const { handleServerError } = await import('../src/index.js')
+    const { RATE_LIMIT_ERROR_CODE, rateLimitPluginOptions } = await import('../src/security/rateLimit.js')
+    const err = rateLimitPluginOptions.errorResponseBuilder(
+      {} as FastifyRequest,
+      { statusCode: 429, ban: false, after: '1 minute', max: 30, ttl: 60_000 },
+    )
+    const request = fakeRequest()
+    const reply = fakeReply()
+
+    // oxlint-disable-next-line @typescript-eslint/no-explicit-any
+    handleServerError(err as any, request as any, reply as any)
+
+    expect(request.log.warn).toHaveBeenCalled()
+    expect(request.log.error).not.toHaveBeenCalled()
+    expect(reply.status).toHaveBeenCalledWith(429)
+    expect(reply.send).toHaveBeenCalledWith({ error: RATE_LIMIT_ERROR_CODE })
   })
 
   it('honors err.status when the error carries no statusCode', async () => {
@@ -692,5 +715,146 @@ describe('envBool', () => {
     const { envBool } = await import('../src/index.js')
     for (const v of ['false', 'FALSE', '0', 'no', 'off']) expect(envBool(v, true)).toBe(false)
     for (const v of ['true', 'True', '1', 'yes', 'on']) expect(envBool(v, false)).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Rate limiting (story 5-G2)
+// ---------------------------------------------------------------------------
+describe('auth endpoint rate limiting', () => {
+  let dir: string
+
+  afterEach(async () => {
+    delete process.env.CONFIG_PATH
+    vi.unstubAllEnvs()
+    vi.useRealTimers()
+    const { resetConfigCache } = await import('../src/config.js')
+    resetConfigCache()
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  // Same reasoning as the sibling describe: buildApp() caches config.json
+  // process-wide, so the cache must be cleared right before the build.
+  async function buildLimitedApp(loginMax?: string) {
+    const { LOGIN_MAX_ENV_VAR } = await import('../src/security/rateLimit.js')
+    if (loginMax) vi.stubEnv(LOGIN_MAX_ENV_VAR, loginMax)
+
+    dir = mkdtempSync(path.join(tmpdir(), 'duos-ratelimit-config-'))
+    const file = path.join(dir, 'config.json')
+    writeFileSync(file, JSON.stringify({ bffEnabled: true }))
+    process.env.CONFIG_PATH = file
+
+    const { resetConfigCache } = await import('../src/config.js')
+    resetConfigCache()
+    const { buildApp } = await import('../src/index.js')
+    return buildApp()
+  }
+
+  // The limiter keys on request.ip, which honours X-Forwarded-For because
+  // TRUST_PROXY names the loopback peer that app.inject() presents as.
+  const from = (ip: string) => ({ 'x-forwarded-for': ip })
+
+  it('returns 429 with Retry-After and the rate_limited code once /auth/login exceeds its limit', async () => {
+    const app = await buildLimitedApp('2')
+    const { RATE_LIMIT_ERROR_CODE } = await import('../src/security/rateLimit.js')
+
+    for (let i = 0; i < 2; i++) {
+      const ok = await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.7') })
+      expect(ok.statusCode).toBe(200)
+    }
+
+    const blocked = await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.7') })
+
+    expect(blocked.statusCode).toBe(429)
+    expect(blocked.json()).toEqual({ error: RATE_LIMIT_ERROR_CODE })
+    expect(Number(blocked.headers['retry-after'])).toBeGreaterThan(0)
+
+    await app.close()
+  })
+
+  it('counts each client IP in its own bucket', async () => {
+    const app = await buildLimitedApp('1')
+
+    await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.11') })
+    const sameIp = await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.11') })
+    const otherIp = await app.inject({ method: 'POST', url: '/auth/login', headers: from('198.51.100.4') })
+
+    expect(sameIp.statusCode).toBe(429)
+    expect(otherIp.statusCode).toBe(200)
+
+    await app.close()
+  })
+
+  it('lets a client through again once the time window passes', async () => {
+    const app = await buildLimitedApp('1')
+    // The store measures the window with Date.now(); fake only the clock, so
+    // inject()'s own async machinery keeps running on real timers.
+    vi.useFakeTimers({ toFake: ['Date'] })
+
+    await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.12') })
+    const blocked = await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.12') })
+    vi.setSystemTime(Date.now() + 61_000)
+    const afterWindow = await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.12') })
+
+    expect(blocked.statusCode).toBe(429)
+    expect(afterWindow.statusCode).toBe(200)
+
+    await app.close()
+  })
+
+  // Deliberately unlimited: /auth/csrf-token is gated on an authenticated
+  // session (5-B) and /auth/logout on the CSRF token, and a low cap on either
+  // breaks multiple tabs and the client's retry path.
+  it('leaves /auth/csrf-token and /auth/logout unlimited', async () => {
+    const app = await buildLimitedApp('1')
+
+    for (let i = 0; i < 5; i++) {
+      const token = await app.inject({ method: 'GET', url: '/auth/csrf-token', headers: from('203.0.113.13') })
+      const logout = await app.inject({ method: 'POST', url: '/auth/logout', headers: from('203.0.113.13') })
+      expect(token.statusCode).toBe(401)
+      expect(logout.statusCode).toBe(204)
+    }
+
+    await app.close()
+  })
+
+  // The regression this guards: registering the plugin globally. This instance
+  // also serves every SPA asset through @fastify/vite, and one page load
+  // fetches many of them, so a global cap would 429 an ordinary page load.
+  //
+  // A stand-in route, not an unmatched /assets/... URL: @fastify/vite is
+  // mocked here, so an unmatched URL falls through to setNotFoundHandler —
+  // and the plugin attaches its hook from an `onRoute` listener, which
+  // setNotFoundHandler never fires. An unmatched URL is therefore unlimited
+  // whatever `global` says, and could not detect the regression. A registered
+  // route models what @fastify/vite really serves.
+  it('never limits a route that did not opt in', async () => {
+    const app = await buildLimitedApp('1')
+    app.get('/assets/chunk.js', async () => 'export default 1')
+
+    for (let i = 0; i < 12; i++) {
+      const asset = await app.inject({ method: 'GET', url: '/assets/chunk.js', headers: from('203.0.113.14') })
+      expect(asset.statusCode).toBe(200)
+      // Status alone would not catch it: the plugin's own global default is
+      // 1000/minute, so 12 requests pass even under `global: true`. The
+      // headers appear on every reply the limiter processed, and on no other.
+      expect(asset.headers['x-ratelimit-limit']).toBeUndefined()
+    }
+
+    await app.close()
+  })
+
+  it('applies the shipped default when no override is set', async () => {
+    const app = await buildLimitedApp()
+
+    const login = await app.inject({ method: 'POST', url: '/auth/login', headers: from('203.0.113.15') })
+
+    expect(login.headers['x-ratelimit-limit']).toBe('30')
+
+    await app.close()
+  })
+
+  it('fails loud at startup when the limit override is not a positive integer', async () => {
+    await expect(buildLimitedApp('lots')).rejects.toThrow('DUOS_RATE_LIMIT_LOGIN_MAX')
   })
 })

--- a/server/test/rateLimit.test.ts
+++ b/server/test/rateLimit.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { FastifyRequest } from 'fastify'
+import {
+  LOGIN_MAX_ENV_VAR,
+  isRateLimitError,
+  loginRateLimit,
+  rateLimitPluginOptions,
+} from '../src/security/rateLimit.js'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('rateLimitPluginOptions', () => {
+  // The regression this guards: the same Fastify instance serves every SPA
+  // asset through @fastify/vite, so a global cap would 429 a page load.
+  it('registers with global: false so only the routes that opt in are limited', () => {
+    expect(rateLimitPluginOptions.global).toBe(false)
+  })
+
+  it('builds a 429 error carrying the context status code and the shared code', () => {
+    const err = rateLimitPluginOptions.errorResponseBuilder(
+      {} as FastifyRequest,
+      { statusCode: 429, ban: false, after: '1 minute', max: 30, ttl: 60_000 },
+    )
+
+    expect(isRateLimitError(err)).toBe(true)
+    expect((err as { statusCode: number }).statusCode).toBe(429)
+  })
+})
+
+describe('isRateLimitError', () => {
+  it('rejects an unrelated error that merely carries a 429 status code', () => {
+    const err = Object.assign(new Error('upstream said no'), { statusCode: 429 })
+
+    expect(isRateLimitError(err)).toBe(false)
+  })
+
+  // The marker alone is not enough: the app's error handler receives whatever
+  // was thrown, and a plain object could carry any property.
+  it('rejects a non-Error value even when it carries the marker', () => {
+    expect(isRateLimitError({ code: 'DUOS_RATE_LIMITED', statusCode: 429 })).toBe(false)
+    expect(isRateLimitError(undefined)).toBe(false)
+  })
+})
+
+describe('loginRateLimit', () => {
+  it('defaults to 30 requests a minute', () => {
+    expect(loginRateLimit()).toEqual({ max: 30, timeWindow: '1 minute' })
+  })
+
+  it('honors the environment override', () => {
+    vi.stubEnv(LOGIN_MAX_ENV_VAR, '120')
+
+    expect(loginRateLimit().max).toBe(120)
+  })
+
+  it('treats a blank override as unset', () => {
+    vi.stubEnv(LOGIN_MAX_ENV_VAR, '   ')
+
+    expect(loginRateLimit().max).toBe(30)
+  })
+
+  // A silent fallback would hide the typo; `max: 0` would block every
+  // sign-in. Same posture as DUOS_DB_PORT in index.ts: fail at startup with
+  // an error naming the variable. The last four are the values `Number()`
+  // alone would have accepted.
+  it.each(['0', '-5', 'ten', '10.5', '1e3', '0x1e', '30.0', '+30'])('throws when the override is %s', (value) => {
+    vi.stubEnv(LOGIN_MAX_ENV_VAR, value)
+
+    expect(() => loginRateLimit()).toThrow(LOGIN_MAX_ENV_VAR)
+  })
+})


### PR DESCRIPTION
## Addresses
https://broadworkbench.atlassian.net/browse/DT-4022

## Summary

Adds rate limiting to `POST /auth/login` (30 requests/min per IP) to prevent session-row creation floods and OIDC discovery overhead. 

* **Security Risk:** Medium
* **PR Stack:** PR 2 of 3 (Depends directly on #3910. Stacked under #3912 callback rate limiting).

---

### Route Limit Matrix

| Route | Limited? | Rate / Notes |
| :--- | :--- | :--- |
| `POST /auth/login` | **Yes** | **30 req/min/IP** (configurable via `DUOS_RATE_LIMIT_LOGIN_MAX`) |
| `GET /auth/callback` | No | Deferred to [5-G3](https://github.com/DataBiosphere/duos-ui/pull/3912) (requires client-side handling for 429) |
| `/auth/csrf-token` | No | Protected by 5-B auth gate; capping breaks multi-tab sessions |
| `/auth/logout` | No | Protected by CSRF guard |
| SPA Assets / Vite | No | Exempt via `global: false` configuration |
| `POST /duos-api/support/*` | **No** | *Open Gap* (see Known Limitations) |

---

### Architectural & Technical Decisions

* **Global vs. Per-Route (`global: false`):** Registered at the app level but scoped per-route. Global enforcement would block SPA asset loading served via `@fastify/vite`.
* **App-Level Registration Order:** Must be registered before route declarations so the plugin's `onRoute` listener attaches correctly. Shared with 5-F2 (`POST /csp-report`); whichever PR merges first owns the `register` call.
* **Configurable Limits:** Defaults to `30 req/min` to accommodate shared institutional/campus NAT IPs. Overridden by `DUOS_RATE_LIMIT_LOGIN_MAX`. Fails fast on invalid startup values (similar to `DUOS_DB_PORT`).
* **Error Handling & Telemetry:**
  * Returns `{"error": "rate_limited"}` with HTTP 429.
  * Emits logs at **`warn`** level (prevents DOS on logging pipelines).
  * Evaluates the rate-limit trigger via a custom marker property rather than status code to avoid mislabeling upstream 429s.

---

### Security & Keying Behavior

* **IP Keying:** Uses `TRUST_PROXY` (`['loopback', 'uniquelocal']`) via `proxy-addr` to resolve client IPs. 
* **IPv6 Handling:** Subnets are grouped to `/64` to prevent single-client subnet exhaustion.
* **Edge Proxy Requirement:** Security relies on the httpd sidecar either **setting or appending** `X-Forwarded-For`. Direct cluster access (RFC1918) bypasses single-bucket attribution.

---

### Known Limitations & Open Gaps

1. **Per-Process In-Memory Store:** Multi-pod deployments will multiply the limit by the replica count and reset on pod restarts. Edge-level rate limiting remains the primary control.
2. **Unauthenticated Proxy Routes (`/duos-api/support/*`):** Currently un-limited. Requires a dedicated strategy under ADR-010 for proxied error shapes.
3. **UI Error Handling:** `Auth.signIn` currently falls back to a generic error on 429; updated UI feedback will be addressed in 5-G3.

---

### Testing Strategy & Pitfalls

* **Route Injection Trap:** Verified using stand-in routes. Standard `setNotFoundHandler` endpoints do not trigger the plugin's `onRoute` hook.
* **Header Assertion:** Tests verify the explicit *absence* of `x-ratelimit-*` headers on non-limited routes to prevent false positives against Fastify's default limit of 1000/min.
