### PR TITLE
[DT-4021] Move feature flags and anonymous metrics onto public BFF endpoints (BFF Phase 5, story 5-F6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ DUOS_OAUTH_REDIRECT_URI=http://local.dsde-dev.broadinstitute.org:3000/auth/callb
 DUOS_POST_LOGOUT_REDIRECT_URI=http://local.dsde-dev.broadinstitute.org:3000/post-logout
 
 # --- Downstream API --------------------------------------------------------
+# Both DUOS_API_URL and DUOS_BARD_URL are read twice: by the session-carrying
+# proxies inside the bffEnabled block, and by the public endpoints (story
+# 5-F6), which register outside both cutover switches. Unset, the matching
+# public endpoint is simply not registered and the server logs a warning; set
+# but malformed, startup fails naming the variable.
 DUOS_API_URL=https://consent.dsde-dev.broadinstitute.org
 # ECM (externalcreds), proxied at /ecm-api for RAS/eRA Commons linking.
 # Optional: when unset, the BFF boots without the ECM proxy and logs a warning.
@@ -69,7 +74,8 @@ DUOS_ECM_URL=https://externalcreds.dsde-dev.broadinstitute.org
 # TDR, proxied at /tdr-api for snapshot enumeration on dataset pages.
 # Optional, same behavior as DUOS_ECM_URL when unset.
 DUOS_TDR_URL=https://jade.datarepo-dev.broadinstitute.org
-# Bard (Mixpanel gateway), proxied at /bard-api for identified usage metrics.
+# Bard (Mixpanel gateway), proxied at /bard-api for identified usage metrics
+# and at /public/metrics/event for anonymous ones.
 # Optional, same behavior as DUOS_ECM_URL when unset.
 DUOS_BARD_URL=https://terra-bard-dev.appspot.com
 

--- a/docs/plans/bff_adrs/ADR-013-content-security-policy.md
+++ b/docs/plans/bff_adrs/ADR-013-content-security-policy.md
@@ -61,7 +61,8 @@ Under `bffEnabled`, sign-in has no popup and no opener, so it keeps
 
 COEP demands a CORP or CORS header on every cross-origin subresource. The banner
 bucket and the two direct upstreams send neither, so enabling it would block
-them. It stays off until those become same-origin (5-F6).
+them. Two of the three became same-origin in 5-F6; COEP stays off while the
+banner bucket is still fetched directly.
 
 ### HSTS is production-only
 
@@ -171,30 +172,26 @@ exists — marking it unauthenticated would silently turn *identified* metrics
 anonymous. Dedicated `/public/*` endpoints are the answer, and they are story
 5-F6.
 
-One entry in that table describes an intention rather than the tree as it
-stands: `FeatureFlag.ts` has **no caller anywhere in `src/`** — only its own
-unit test — and nothing else calls `getUpstreamApiUrl` outside the legacy-only
-`oidcBroker.ts`. BFF-mode `connect-src` therefore allowlists `apiUrl` for a flow
-that does not run today.
+**Story 5-F6 has since closed two of those three**, and the field list is now
+empty under `bffEnabled`. Feature flags go to `/public/features/*` and anonymous
+metrics to `/public/metrics/event` — dedicated endpoints that inject no session
+token, structurally rather than by configuration (`server/src/proxy/publicProxy.ts`).
+`apiUrl` and `bardApiUrl` left the allowlist with them.
 
-**Settled 2026-09-04: the module stays**, against a future caller. Dropping the
-origin now would greet whoever wires it up with a blocked request and no obvious
-cause, and while the policy is report-only the entry costs nothing.
+One entry in that table always described an intention rather than the tree:
+`FeatureFlag.ts` has **no caller anywhere in `src/`**, only its own unit test.
+**Settled 2026-09-04: the module stays**, against a future caller, and 5-F6
+repointed it at the new prefix so whoever wires it up reaches the proxy rather
+than Consent. The consequence is narrow but real — the endpoint has no consumer
+to validate it, so its tests are the only proof it works, and no amount of
+exercising the app would reveal it broken.
 
-It does not hold `apiUrl` in the allowlist, though. Story 5-F6 points
-`FeatureFlag.ts` at `/public/features/*` under `bffEnabled` using the same
-prefix-and-flag pattern `Metrics.ts` already uses, so a future caller reaches
-the proxy rather than Consent directly. What the decision does mean is that the
-endpoint is built for a consumer that does not exist — so its tests are the only
-proof it works, and no amount of exercising the app will tell anyone if it is
-broken.
-
-**BFF-mode `connect-src` will not reach `'self'` in one step after all.** 5-F6
-drops `apiUrl` and `bardApiUrl`, leaving `'self'` and the banner bucket. The
-bucket stays: a separate backlog item rewrites `notificationService.ts` to read
-environment-specific buckets, and proxying GCS is worth deciding once that
-lands rather than building against a URL shape about to change. Until then the
-banner fetch stays direct and the literal stays in the policy.
+**BFF-mode `connect-src` did not reach `'self'` outright.** It is `'self'` plus
+the banner bucket. The bucket stays because a separate backlog item first
+rewrites `notificationService.ts` to read environment-specific buckets, and
+proxying GCS — the one endpoint of the three with no existing pattern to copy —
+is worth deciding once that lands rather than building against a URL shape about
+to change. Until then the banner fetch stays direct and the literal stays here.
 
 `terraUrl` is never allowlisted: it is navigated to, not fetched. The
 development config also carries convenience origins the browser never
@@ -301,10 +298,10 @@ is a much larger piece of work than this story.
   returns null for that by specification, so it always takes the download
   fallback and the iframe is never created. Repairing that preview means
   adding `blob:` back to this directive.
-- BFF-mode `connect-src` cannot reach `'self'` alone until the three direct
-  flows move to dedicated public BFF endpoints (`/public/notifications`,
-  `/public/features/*`, `/public/metrics/event`). That is the follow-up to this
-  story, and it is what will let this allowlist shrink.
+- BFF-mode `connect-src` is `'self'` plus the banner bucket. Story 5-F6 moved
+  feature flags and anonymous metrics onto `/public/features/*` and
+  `/public/metrics/event`; `/public/notifications` waits on the backlog item
+  that repoints the notifications service at environment-specific buckets.
 - `img-src` carries `'self'` and `data:` only. `blob:` is deliberately absent:
   the audit found no `<img src="blob:">` in the tree — every object URL the app
   mints is a download, which needs no directive, or the dead preview branch in

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,6 +26,7 @@ import { apiProxy } from './proxy/apiProxy.js'
 import { ECM_PROXY_PREFIX, ecmProxy } from './proxy/ecmProxy.js'
 import { TDR_PROXY_PREFIX, tdrProxy } from './proxy/tdrProxy.js'
 import { BARD_PROXY_PREFIX, bardProxy } from './proxy/bardProxy.js'
+import { publicProxy } from './proxy/publicProxy.js'
 import { TRUST_PROXY, configPath, readConfig } from './config.js'
 import './types/session.js'
 import FastifyVite from '@fastify/vite'
@@ -117,7 +118,17 @@ export async function buildApp(): Promise<AppInstance> {
   // reports too. Inert until 5-F3's policy points a browser at it.
   await fastify.register(cspReportRoute)
 
-  // 3. DB pool + session — registered only when the deployment provides the
+  // 3. The public BFF endpoints (Phase 5, story 5-F6) — the feature flags read
+  // pre-login and the anonymous Bard event. Registered here beside the report
+  // sink, outside both switches below, and deliberately not inside the
+  // `bffEnabled` block the other proxies live in: they carry no credentials, so
+  // they depend on neither the session infrastructure nor the cutover, and
+  // gating them on either would make a pre-login flow unavailable exactly when
+  // it is needed. Each of the two upstreams is optional and checked
+  // independently inside — see proxy/publicProxy.ts.
+  await fastify.register(publicProxy)
+
+  // 4. DB pool + session — registered only when the deployment provides the
   // BFF database configuration. Session infrastructure is deployment config
   // (env vars via helmfile/compose), not a runtime flag: every pod of a given
   // deployment behaves identically, with no network dependency at boot.
@@ -207,7 +218,7 @@ export async function buildApp(): Promise<AppInstance> {
     fastify.log.info('[server] DUOS_DB_HOST is not set — starting without DB/session infrastructure (legacy client-side auth)')
   }
 
-  // 4. BFF auth routes — the cutover switch. Read at startup from the same
+  // 5. BFF auth routes — the cutover switch. Read at startup from the same
   // config object the /config.json route below serves, so the server and
   // client agree on bffEnabled by construction. A missing key defaults to
   // false and the routes stay dark — the fail-safe is the legacy

--- a/server/src/proxy/publicProxy.ts
+++ b/server/src/proxy/publicProxy.ts
@@ -1,0 +1,411 @@
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http'
+import type {
+  FastifyError,
+  FastifyInstance,
+  FastifyReply,
+  FastifyRequest,
+  RawReplyDefaultExpression,
+  RawServerBase,
+  RequestGenericInterface,
+  RouteGenericInterface,
+} from 'fastify'
+import type { RateLimitOptions } from '@fastify/rate-limit'
+import fastifyReplyFrom from '@fastify/reply-from'
+import { upstreamBase, upstreamPath } from './upstreamProxy.js'
+
+/**
+ * The public BFF endpoints (Phase 5, story 5-F6).
+ *
+ * Three browser flows carried no credentials before the cutover and still carry
+ * none after it: the unauthenticated feature flags, read pre-login, and the
+ * anonymous Bard event. Under `bffEnabled` they were the last two reasons
+ * `connect-src` had to name the Consent and Bard origins at all. Moving them
+ * onto same-origin endpoints is what lets BFF-mode `connect-src` collapse to
+ * `'self'` plus the banner bucket (security/csp.ts).
+ *
+ * **This module deliberately does not use `registerUpstreamProxy`.** Two
+ * reasons, and the second is the important one:
+ *
+ *   - That helper throws unless `@fastify/csrf-protection` is already
+ *     registered, and index.ts registers that plugin only inside the
+ *     `DUOS_DB_HOST` block. These routes register outside both switches,
+ *     because they serve pre-login traffic and must not depend on the session
+ *     infrastructure being configured at all.
+ *   - Its entire purpose is attaching the session's B2C access token. The point
+ *     of this module is that omitting the token is *structural* rather than
+ *     configured: there is no allowlist to fall off, no `unauthenticatedPaths`
+ *     set to drift, and no shared code path that a future edit to the proxy
+ *     machinery could make start injecting one here. **Nothing below reads
+ *     `request.session`**, not even defensively — the absence of the reference
+ *     is the guarantee.
+ *
+ * What is shared with upstreamProxy.ts is pure URL plumbing — `upstreamBase`
+ * for the startup validation of an upstream origin, `upstreamPath` for slicing
+ * a prefix off a raw URL. Neither knows what a session is. The request- and
+ * response-leg hygiene below is deliberately a local copy of what
+ * `rewriteRequestHeaders`/`rewriteHeaders` do there rather than an import: it is
+ * the behavior this file exists to guarantee, and a public endpoint should not
+ * change what it forwards because the session-carrying proxy was edited.
+ *
+ * **No CSRF, and no Fetch Metadata guard**, both on purpose:
+ *
+ *   - CSRF cannot apply. A CSRF token protects a request that borrows the
+ *     browser's ambient authority; these requests carry no cookie upstream and
+ *     no token is injected, so a forged one reaches the upstream with exactly
+ *     the authority anybody already has by calling it directly. There is
+ *     nothing to forge with. Requiring a token would also make the endpoints
+ *     unreachable pre-login, which is the case they exist for.
+ *   - The Fetch Metadata guard (security/fetchMetadata.ts) exists to stop a
+ *     cross-site request from reaching a state-changing endpoint while carrying
+ *     the session cookie. These carry none, so it buys nothing here and would
+ *     only risk rejecting a legitimate call shape — the metrics event is
+ *     best-effort and fired from contexts whose `Sec-Fetch-*` values are not
+ *     worth betting the endpoint on.
+ *
+ * What bounds them instead, since anyone on the internet can reach both: a
+ * per-route rate limit, a body limit on the POST, response validation on the
+ * feature flags, and the same response hardening every proxied response gets.
+ */
+
+/** `GET /public/features` and `/public/features/:key` → `${DUOS_API_URL}/feature[/:key]`. */
+export const PUBLIC_FEATURES_PREFIX = '/public/features'
+
+/** `POST /public/metrics/event` → `${DUOS_BARD_URL}/api/event`. */
+export const PUBLIC_METRICS_EVENT_PATH = '/public/metrics/event'
+
+/**
+ * The Bard event body: `{ event, properties }`, where properties are the call
+ * site's details plus a dozen short strings from `getDefaultProperties()` and
+ * the page's hostname and path. The largest event DUOS sends is well under
+ * 2 KB. 8 KB leaves several times that in headroom while keeping an
+ * unauthenticated POST from pushing an arbitrary payload at Bard, and matches
+ * the cap the other public endpoint (the CSP report sink) already uses.
+ */
+export const METRICS_BODY_LIMIT = 8 * 1024
+
+const RATE_LIMIT_WINDOW_MS = 60_000
+
+/**
+ * A page load consults a handful of flags at most, and the client memoises the
+ * one flag it reads (`getFlagNhgriDacId`), so a genuine browser never comes
+ * close. Sixty a minute per client leaves room for a tab reloading repeatedly.
+ */
+export const FEATURES_MAX_PER_WINDOW = 60
+
+/**
+ * Above the feature-flag limit because a signed-out user browsing generates
+ * several events a minute legitimately — a search, a page view, a filter — and
+ * a dropped metric is invisible to the user, so the limit must not bite first.
+ * It still bounds what one client can push into Bard through this origin.
+ */
+export const METRICS_MAX_PER_WINDOW = 120
+
+/**
+ * Smaller than the session proxies' pool (128): each reply-from registration
+ * builds its own undici Agent, so this is an additional per-origin socket
+ * allowance on the same pod, and these two endpoints carry a fraction of the
+ * traffic the DUOS API proxy does.
+ */
+const PUBLIC_POOL_CONNECTIONS = 32
+
+// Identical to upstreamProxy.ts's: a response served from the SPA's origin must
+// not execute there. Kept local — see the module comment on why this file does
+// not import the proxy machinery's copy.
+const RESPONSE_HARDENING: Readonly<IncomingHttpHeaders> = {
+  'x-content-type-options': 'nosniff',
+  'content-security-policy': 'sandbox',
+}
+
+// These describe the upstream hop, not the browser connection (RFC 9110 §7.6.1).
+const CONNECTION_SPECIFIC_RESPONSE_HEADERS: ReadonlySet<string> = new Set([
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'upgrade',
+])
+
+/**
+ * `reply.from`'s hooks are typed against `RawServerBase` — the http/http2 union
+ * — rather than this app's concrete server, so the callbacks below have to be
+ * too, or they are rejected as contravariantly incompatible.
+ */
+type ProxyRequest = FastifyRequest<RequestGenericInterface, RawServerBase>
+type ProxyReply = FastifyReply<RouteGenericInterface, RawServerBase>
+
+// reply-from types this as a ServerResponse even though the stream is incoming.
+type UpstreamResponse = RawReplyDefaultExpression<RawServerBase> & { stream: IncomingMessage }
+
+function upstreamHeaders(res: UpstreamResponse): IncomingHttpHeaders {
+  return (res as unknown as { headers: IncomingHttpHeaders }).headers
+}
+
+/**
+ * The client-to-upstream address chain, with this pod appended as a hop —
+ * `request.ips` is ordered closest-first, so it reverses into the header's
+ * original-client-first order. Only populated when `trustProxy` is set, which
+ * index.ts always does; the fallback keeps this correct for an app that
+ * registers these routes without it.
+ */
+function forwardedFor(request: ProxyRequest, inbound: string | string[] | undefined): string {
+  if (request.ips) {
+    return [...request.ips].reverse().join(', ')
+  }
+  const chain = Array.isArray(inbound) ? inbound.join(', ') : inbound
+  return chain ? `${chain}, ${request.ip}` : request.ip
+}
+
+/**
+ * The headers the upstream actually sees.
+ *
+ * Runs after `reply.from` has copied the request headers, set `host` to the
+ * upstream and stripped the hop-by-hop ones, so this deals only with what is
+ * specific to the BFF. Omitted by destructuring rather than deleted, because
+ * `headers` is the object reply-from reuses across a retry.
+ *
+ *   cookie        — the session cookie is the BFF's credential. These endpoints
+ *                   never read it, and it must not leak to an upstream that has
+ *                   no use for it either.
+ *   authorization — never trust a client-supplied bearer token. Note what is
+ *                   *not* here: no replacement is put back. That omission is
+ *                   the whole story, so it is spelled out rather than left to
+ *                   be inferred from the absence of a line.
+ *   x-csrf-token  — meaningless upstream, and these routes enforce no CSRF.
+ */
+function rewriteRequestHeaders(request: ProxyRequest, headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  const { cookie, authorization, 'x-csrf-token': csrfToken, ...forwarded } = headers
+  return {
+    ...forwarded,
+    // Sent by the client on every call today (Config.authOpts), so both
+    // upstreams already expect it. Injected rather than merely forwarded so it
+    // is true of every request regardless of what the caller set.
+    'x-app-id': 'DUOS',
+    'x-forwarded-for': forwardedFor(request, forwarded['x-forwarded-for']),
+  }
+}
+
+/**
+ * The headers the browser sees. The rule is the same as the session proxies':
+ * a response served from this origin is applied as though the BFF had sent it,
+ * so the upstream may not write to this origin's state.
+ *
+ *   set-cookie      — would land on the BFF origin and could overwrite
+ *                     `sessionId`, handing the user a different session or a
+ *                     broken one. An unauthenticated endpoint is the last place
+ *                     that should be reachable: nothing about the request
+ *                     proves the caller is anyone.
+ *   clear-site-data — clears cookies, storage and cache for the BFF origin,
+ *                     which would sign the user out and wipe local state.
+ *   www-authenticate — a challenge for a scheme this origin does not use; a
+ *                     `Basic` one would pop a native credential dialog on it.
+ */
+function rewriteResponseHeaders(headers: IncomingHttpHeaders): IncomingHttpHeaders {
+  const {
+    'set-cookie': setCookie,
+    'clear-site-data': clearSiteData,
+    'www-authenticate': wwwAuthenticate,
+    ...forwarded
+  } = headers
+  return Object.fromEntries(
+    Object.entries(forwarded).filter(([name]) => !CONNECTION_SPECIFIC_RESPONSE_HEADERS.has(name)),
+  )
+}
+
+/**
+ * Normalises the "never reached the upstream" failures to 502, as
+ * upstreamProxy.ts does: reply-from leaves `ECONNREFUSED`, `ECONNRESET` and the
+ * undici socket errors at 500, which this scope's error handler would then
+ * answer as a bare 500 — indistinguishable from a bug in the BFF itself.
+ */
+function onUpstreamTransportError(reply: ProxyReply, { error }: { error: Error }): void {
+  const statusCode = (error as Error & { statusCode?: number }).statusCode ?? 502
+  const isGatewayClass = statusCode >= 502 && statusCode <= 504
+  reply.status(isGatewayClass ? statusCode : 502).send({ error: 'upstream_unavailable' })
+}
+
+/** `application/json` and the `+json` structured-suffix types, ignoring parameters. */
+function isJsonContentType(contentType: string | string[] | undefined): boolean {
+  if (typeof contentType !== 'string') return false
+  const mediaType = contentType.split(';')[0].trim().toLowerCase()
+  return mediaType === 'application/json' || mediaType.endsWith('+json')
+}
+
+/** A response with nothing to validate: no body is defined, or none was sent. */
+function carriesNoBody(res: UpstreamResponse, headers: IncomingHttpHeaders): boolean {
+  return res.statusCode === 204 || res.statusCode === 304 || headers['content-length'] === '0'
+}
+
+/**
+ * Feature flags pass through only as JSON.
+ *
+ * `getAllFeatureFlags` and `getFeatureFlag` parse JSON and nothing else, so a
+ * non-JSON body is already a broken upstream — but streaming one would put an
+ * arbitrary upstream-chosen body on this origin at an unauthenticated URL, which
+ * is worth refusing outright rather than relying on the `sandbox` hardening
+ * downstream of it. A bodiless response (a 204, or a 404 an upstream answers
+ * with no content) is passed through: there is nothing to sniff, and turning a
+ * legitimate 404 into a 502 would misreport a missing flag as an outage.
+ */
+function enforceJsonResponse(request: ProxyRequest, reply: ProxyReply, res: UpstreamResponse): void {
+  const headers = upstreamHeaders(res)
+  if (carriesNoBody(res, headers) || isJsonContentType(headers['content-type'])) {
+    reply.send(res.stream)
+    return
+  }
+
+  request.log.warn(
+    { statusCode: res.statusCode, contentType: headers['content-type'] },
+    '[public-proxy] the feature-flag upstream answered with a non-JSON body — returning 502 rather than streaming it onto this origin',
+  )
+
+  // Drain the replaced response so undici can reuse its socket.
+  res.stream.on('error', (err: Error) => {
+    request.log.debug({ err }, '[public-proxy] discarded non-JSON upstream body errored')
+  })
+  res.stream.resume()
+
+  // Remove metadata for the discarded body; preserve reply-from's connection header.
+  for (const name of Object.keys(headers)) {
+    if (name !== 'connection') {
+      reply.removeHeader(name)
+    }
+  }
+
+  reply.status(502).send({ error: 'upstream_not_json' })
+}
+
+function rateLimitConfig(max: number): { rateLimit: RateLimitOptions } {
+  return {
+    rateLimit: {
+      max,
+      timeWindow: RATE_LIMIT_WINDOW_MS,
+      // The plugin *throws* whatever this returns, so it has to carry the
+      // status or the scope's error handler answers 500. The body is dropped
+      // for the same reason the handler's is: the default builder names the
+      // plugin and echoes the retry window back to whoever is probing for it.
+      errorResponseBuilder: (_request, context) => ({ statusCode: context.statusCode }),
+    },
+  }
+}
+
+/**
+ * The feature-flag reads. Registered in their own child scope so this pair gets
+ * its own `reply.from` bound to the DUOS API, independent of the metrics scope's
+ * — one `decorateReply('from')` per scope. The hooks, parsers and error handler
+ * declared by the parent apply here unchanged.
+ */
+async function featureFlagRoutes(app: FastifyInstance): Promise<void> {
+  await app.register(fastifyReplyFrom, {
+    base: upstreamBase('DUOS_API_URL'),
+    undici: { connections: PUBLIC_POOL_CONNECTIONS },
+  })
+
+  const fromOptions = {
+    rewriteRequestHeaders,
+    rewriteHeaders: rewriteResponseHeaders,
+    onResponse: enforceJsonResponse,
+    onError: onUpstreamTransportError,
+  }
+
+  const routeOptions = { config: rateLimitConfig(FEATURES_MAX_PER_WINDOW) }
+
+  app.get(PUBLIC_FEATURES_PREFIX, routeOptions, (_request, reply) => {
+    reply.from('/feature', fromOptions)
+  })
+
+  // The upstream path is sliced off the raw URL rather than rebuilt from
+  // `request.params.key`: Fastify percent-decodes a param, and re-encoding it
+  // would have to reproduce the client's encoding byte-for-byte to address the
+  // same upstream resource. reply.from re-appends the original query itself.
+  app.get(`${PUBLIC_FEATURES_PREFIX}/:key`, routeOptions, (request, reply) => {
+    reply.from(`/feature${upstreamPath(request.url, PUBLIC_FEATURES_PREFIX)}`, fromOptions)
+  })
+}
+
+/**
+ * The anonymous Bard event. Its own child scope, for the same reason as above:
+ * a second `reply.from`, bound to Bard.
+ */
+async function anonymousMetricsRoute(app: FastifyInstance): Promise<void> {
+  await app.register(fastifyReplyFrom, {
+    base: upstreamBase('DUOS_BARD_URL'),
+    undici: { connections: PUBLIC_POOL_CONNECTIONS },
+  })
+
+  const routeOptions = {
+    bodyLimit: METRICS_BODY_LIMIT,
+    config: rateLimitConfig(METRICS_MAX_PER_WINDOW),
+  }
+
+  // One fixed upstream path, not a wildcard: the endpoint exists for exactly
+  // the one call `Metrics.captureEvent` makes when signed out. Everything else
+  // Bard exposes stays behind the session-carrying /bard-api proxy.
+  app.post(PUBLIC_METRICS_EVENT_PATH, routeOptions, (_request, reply) => {
+    reply.from('/api/event', {
+      rewriteRequestHeaders,
+      rewriteHeaders: rewriteResponseHeaders,
+      onError: onUpstreamTransportError,
+    })
+  })
+}
+
+/**
+ * Registered as a plain (non-`fastify-plugin`) function so Fastify gives it its
+ * own encapsulation context — `removeAllContentTypeParsers()` below must apply
+ * to this scope alone, or the rest of the app would lose its JSON parsing too.
+ *
+ * Each upstream is optional and checked independently: index.ts registers this
+ * outside both cutover switches, so a legacy deployment — or a local server run
+ * with neither variable set — has to boot, and a missing upstream must disable
+ * one endpoint rather than fail startup. A variable that *is* set but malformed
+ * still fails at startup, naming itself, via `upstreamBase`.
+ */
+export async function publicProxy(app: FastifyInstance): Promise<void> {
+  // The app-level error handler is installed in index.ts *after* this plugin is
+  // registered, so Fastify never resolves it for these routes. Without one
+  // here, the default serialiser answers a 413 with FST_ERR_CTP_BODY_TOO_LARGE
+  // and a 415 with FST_ERR_CTP_INVALID_MEDIA_TYPE, naming the framework to an
+  // unauthenticated caller where every other route generalises. Same reasoning
+  // as security/cspReport.ts, which is the other endpoint in this position.
+  app.setErrorHandler((error: FastifyError, _request: FastifyRequest, reply: FastifyReply) =>
+    reply.status(error.statusCode ?? 500).send())
+
+  // Cleared, then exactly one media type re-added, so anything else is answered
+  // 415 before a handler runs. The session proxies install a pass-through
+  // parser instead, because DUOS uploads multipart and binary bodies that must
+  // stream unread; here the opposite is wanted. Buffering and re-parsing is
+  // what makes `bodyLimit` enforceable at all — an unread stream is never
+  // measured against it — and it means only well-formed JSON is ever forwarded
+  // to Bard. reply-from re-serialises the parsed object on the way out.
+  app.removeAllContentTypeParsers()
+  app.addContentTypeParser('application/json', { parseAs: 'string', bodyLimit: METRICS_BODY_LIMIT }, (_request, body, done) => {
+    try {
+      done(null, JSON.parse(body as string))
+    }
+    catch {
+      const invalid = new Error('invalid JSON body') as Error & { statusCode?: number }
+      invalid.statusCode = 400
+      done(invalid)
+    }
+  })
+
+  app.addHook('onSend', (_request, reply, _payload, done) => {
+    reply.headers(RESPONSE_HARDENING)
+    done()
+  })
+
+  if (process.env.DUOS_API_URL) {
+    await app.register(featureFlagRoutes)
+  }
+  else {
+    app.log.warn(`[server] DUOS_API_URL is not set — ${PUBLIC_FEATURES_PREFIX} is disabled, so pre-login feature flags will fail in this environment`)
+  }
+
+  if (process.env.DUOS_BARD_URL) {
+    await app.register(anonymousMetricsRoute)
+  }
+  else {
+    app.log.warn(`[server] DUOS_BARD_URL is not set — ${PUBLIC_METRICS_EVENT_PATH} is disabled, so anonymous usage metrics will fail in this environment`)
+  }
+}

--- a/server/src/proxy/upstreamProxy.ts
+++ b/server/src/proxy/upstreamProxy.ts
@@ -432,6 +432,12 @@ function onUpstreamTransportError(reply: ProxyReply, { error }: { error: Error }
  * registration so a bad value fails at startup naming the variable, rather than
  * 500ing every proxied request.
  *
+ * Exported for publicProxy.ts, which shares this and `upstreamPath` but
+ * deliberately none of the request- or response-leg machinery above. Both are
+ * pure URL plumbing with no notion of a session, so sharing them cannot carry
+ * token injection into a public endpoint; see that file's opening comment for
+ * where the line is drawn and why.
+ *
  * All three ways to get it wrong have to name the variable, or the guard does
  * not do the job it exists for. A missing scheme is the likeliest — a bare
  * hostname is what a Helm value tends to look like — and `new URL()` rejects it
@@ -440,7 +446,7 @@ function onUpstreamTransportError(reply: ProxyReply, { error }: { error: Error }
  * (protocol `localhost:`, pathname `8000`) from a genuine path, which would
  * otherwise be reported as "has a path".
  */
-function upstreamBase(envVar: string): string {
+export function upstreamBase(envVar: string): string {
   const base = requireEnv(envVar)
   const mustBeOrigin = 'it must be a bare origin (scheme, host, and port only), because the proxy appends the upstream path to it'
 

--- a/server/src/security/csp.ts
+++ b/server/src/security/csp.ts
@@ -11,14 +11,15 @@ import { CSP_REPORT_GROUP, CSP_REPORT_PATH } from './cspReport.js'
  *     The development config also carries convenience origins the browser
  *     never connects to; sweeping up every URL-shaped value would allowlist
  *     them by accident.
- *  2. **The allowlist is mode-specific.** Under `bffEnabled`, ECM and TDR are
- *     reached through same-origin proxies, so their origins must NOT appear.
- *     Legacy deployments still call them directly and must keep them until
- *     Epic 6 retires the legacy client.
+ *  2. **The allowlist is mode-specific.** Under `bffEnabled` every configured
+ *     upstream is reached through a same-origin endpoint, so no configured
+ *     origin appears at all — BFF-mode `connect-src` is `'self'` plus the
+ *     banner bucket. Legacy deployments still call all four directly and must
+ *     keep them until Epic 6 retires the legacy client.
  *
  * See docs/plans/bff_adrs/ADR-013-content-security-policy.md for the audit
- * that produced the inventory, and for the follow-up that collapses BFF-mode
- * `connect-src` to `'self'`.
+ * that produced the inventory; story 5-F6 completed the follow-up it names by
+ * moving the last two direct flows onto public BFF endpoints.
  */
 
 /**
@@ -46,14 +47,23 @@ export const BANNER_SOURCE = 'https://storage.googleapis.com/broad-duos-banners/
 /**
  * config.json fields that name an origin the *browser* connects to.
  *
- * BFF mode keeps only the two flows that stay direct after cutover:
- *   - `apiUrl` — unauthenticated feature flags (`/feature`, `/feature/:key`),
- *     consulted pre-login, so the session-guarded proxy would 401 them.
- *   - `bardApiUrl` — anonymous metrics, which deliberately carry no
- *     credentials; identified events go through the /bard-api proxy.
- * `ecmApiUrl` and `tdrApiUrl` are absent on purpose: those calls are proxied.
+ * Empty under the BFF since story 5-F6: every browser connection is now
+ * same-origin, and `'self'` covers it.
+ *   - `ecmApiUrl` and `tdrApiUrl` went first — those calls are proxied.
+ *   - `apiUrl` was held by the unauthenticated feature flags (`/feature`,
+ *     `/feature/:key`), which are read pre-login and so could not use the
+ *     session-guarded proxy. They now go to `/public/features/*`, which injects
+ *     no token (server/src/proxy/publicProxy.ts).
+ *   - `bardApiUrl` was held by anonymous metrics, which deliberately carry no
+ *     credentials. They now go to `/public/metrics/event`, on the same terms.
+ *
+ * `BANNER_SOURCE` is what stops this reducing to `'self'` outright. The banner
+ * fetch is the one flow with no BFF endpoint yet: a backlog item first rewrites
+ * `notificationService.ts` to read environment-specific buckets, and building
+ * the endpoint against a URL shape that is about to change would mean writing
+ * it twice. It stays direct, and so stays in the policy, until that lands.
  */
-const BFF_CONNECT_FIELDS = ['apiUrl', 'bardApiUrl'] as const
+const BFF_CONNECT_FIELDS: readonly string[] = []
 
 /**
  * Legacy mode calls all four upstreams directly from the browser.

--- a/server/test/csp.test.ts
+++ b/server/test/csp.test.ts
@@ -48,11 +48,28 @@ function parsePolicy(header: string): Map<string, string[]> {
 }
 
 describe('connectSources', () => {
-  it('allows only the two direct flows plus the banner bucket in BFF mode', () => {
-    // ECM and TDR are reached through same-origin proxies after cutover, so
-    // their configured origins must NOT leak into the policy just because the
-    // fields exist in config.json.
-    expect(connectSources(fullConfig(true), PROD)).toEqual(['\'self\'', CONSENT, BARD, BANNER_SOURCE])
+  it('allows nothing but self and the banner bucket in BFF mode', () => {
+    // Every configured upstream is reached through a same-origin endpoint after
+    // story 5-F6, so no configured origin may leak into the policy just because
+    // the field exists in config.json.
+    expect(connectSources(fullConfig(true), PROD)).toEqual(['\'self\'', BANNER_SOURCE])
+  })
+
+  it('drops the Consent origin in BFF mode, where feature flags go through /public/features', () => {
+    // The pre-login feature-flag read was the last thing holding `apiUrl` here.
+    expect(connectSources(fullConfig(true), PROD)).not.toContain(CONSENT)
+  })
+
+  it('drops the Bard origin in BFF mode, where anonymous events go through /public/metrics/event', () => {
+    // Anonymous metrics carry no credentials, which is why they were direct;
+    // the public endpoint injects none either, so they are same-origin now.
+    expect(connectSources(fullConfig(true), PROD)).not.toContain(BARD)
+  })
+
+  it('keeps the banner bucket, the one flow with no BFF endpoint yet', () => {
+    // notificationService.ts is rewritten to read environment-specific buckets
+    // first; until then the banner fetch stays direct and must stay allowed.
+    expect(connectSources(fullConfig(true), PROD)).toContain(BANNER_SOURCE)
   })
 
   it('allows all four configured upstreams in legacy mode', () => {
@@ -71,8 +88,10 @@ describe('connectSources', () => {
     expect(connectSources(fullConfig(false), PROD)).not.toContain(TERRA)
   })
 
+  // Legacy mode from here on for the field-parsing cases: BFF mode reads no
+  // config field at all now, so it cannot exercise them.
   it('reduces a configured URL to its origin', () => {
-    const sources = connectSources({ bffEnabled: true, apiUrl: `${CONSENT}/api/v1/`, bardApiUrl: '' }, PROD)
+    const sources = connectSources({ bffEnabled: false, apiUrl: `${CONSENT}/api/v1/`, bardApiUrl: '' }, PROD)
     expect(sources).toContain(CONSENT)
     expect(sources).not.toContain(`${CONSENT}/api/v1/`)
   })
@@ -83,7 +102,7 @@ describe('connectSources', () => {
     ['a value that is not an absolute URL', '/duos-api'],
     ['a non-string', 42],
   ])('drops %s rather than emitting it as a source', (_label, apiUrl) => {
-    expect(connectSources({ bffEnabled: true, apiUrl }, PROD)).toEqual(['\'self\'', BANNER_SOURCE])
+    expect(connectSources({ bffEnabled: false, apiUrl }, PROD)).toEqual(['\'self\'', BANNER_SOURCE])
   })
 
   it('adds the websocket schemes for Vite HMR in dev only', () => {
@@ -197,7 +216,7 @@ describe('the policy as helmet serialises it', () => {
     const res = await app.inject({ method: 'GET', url: '/page' })
     const policy = parsePolicy(String(res.headers['content-security-policy']))
 
-    expect(policy.get('connect-src')).toEqual(['\'self\'', CONSENT, BARD, BANNER_SOURCE])
+    expect(policy.get('connect-src')).toEqual(['\'self\'', BANNER_SOURCE])
     expect(policy.get('script-src')).toEqual(['\'self\''])
     expect(policy.get('frame-ancestors')).toEqual(['\'none\''])
     expect(policy.get('report-uri')).toEqual([CSP_REPORT_PATH])

--- a/server/test/publicProxy.test.ts
+++ b/server/test/publicProxy.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyRateLimit from '@fastify/rate-limit'
+import {
+  FEATURES_MAX_PER_WINDOW,
+  METRICS_BODY_LIMIT,
+  PUBLIC_FEATURES_PREFIX,
+  PUBLIC_METRICS_EVENT_PATH,
+  publicProxy,
+} from '../src/proxy/publicProxy.js'
+import { TRUST_PROXY } from '../src/config.js'
+import {
+  type Upstream,
+  buildAppShell,
+  csrfCredentials,
+  seedSession,
+  startUpstream,
+} from './proxyTestHarness.js'
+
+/**
+ * The public BFF endpoints (story 5-F6).
+ *
+ * These tests are not one more layer of confidence over a working feature —
+ * they are the only evidence the feature works. `FeatureFlag.ts` has no caller
+ * anywhere in `src/` today, so no amount of exercising the app touches
+ * `/public/features/*`, and the anonymous metrics call is fire-and-forget and
+ * swallows its own failures. Nothing here can be caught by using the app.
+ *
+ * The load-bearing case is "the upstream sees no Authorization header even
+ * though a session with an access token is right there". Everything else about
+ * these endpoints — the rate limits, the body cap, the JSON check — is bounding
+ * abuse of an unauthenticated route; that one is the property the whole module
+ * exists to guarantee.
+ */
+
+const FEATURE_KEY = 'NHGRI_RESTRICTED_DAC'
+
+describe('publicProxy', () => {
+  let api: Upstream
+  let bard: Upstream
+  let app: FastifyInstance | undefined
+
+  beforeEach(async () => {
+    api = await startUpstream()
+    bard = await startUpstream()
+    process.env.DUOS_API_URL = api.origin
+    process.env.DUOS_BARD_URL = bard.origin
+  })
+
+  afterEach(async () => {
+    await app?.close()
+    app = undefined
+    await api.close()
+    await bard.close()
+    delete process.env.DUOS_API_URL
+    delete process.env.DUOS_BARD_URL
+  })
+
+  /** The endpoints as index.ts registers them: no session infrastructure at all. */
+  async function buildPublicApp(): Promise<FastifyInstance> {
+    const instance = Fastify({ logger: false, trustProxy: TRUST_PROXY })
+    // As index.ts registers it: global: false, because that instance also
+    // serves every SPA asset. Each route carries its own config.
+    await instance.register(fastifyRateLimit, { global: false })
+    await instance.register(publicProxy)
+    return instance
+  }
+
+  /**
+   * The same endpoints in an app that *does* have sessions and CSRF, which is
+   * what a real BFF deployment looks like. Used for the cases whose whole point
+   * is that the endpoints ignore both.
+   */
+  async function buildPublicAppWithSession(accessToken: string): Promise<FastifyInstance> {
+    const instance = await buildAppShell()
+    seedSession(instance, { accessToken, tokenExpiry: Math.floor(Date.now() / 1000) + 3600 })
+    await instance.register(publicProxy)
+    return instance
+  }
+
+  describe('routing', () => {
+    it('reaches /feature on the DUOS API', async () => {
+      app = await buildPublicApp()
+
+      const res = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(res.statusCode).toBe(200)
+      expect(api.last().url).toBe('/feature')
+      expect(bard.received).toHaveLength(0)
+    })
+
+    it('reaches /feature/:key for a single flag', async () => {
+      app = await buildPublicApp()
+
+      const res = await app.inject({ method: 'GET', url: `${PUBLIC_FEATURES_PREFIX}/${FEATURE_KEY}` })
+
+      expect(res.statusCode).toBe(200)
+      expect(api.last().url).toBe(`/feature/${FEATURE_KEY}`)
+    })
+
+    it('forwards the query string byte-for-byte rather than re-encoding it', async () => {
+      app = await buildPublicApp()
+
+      await app.inject({ method: 'GET', url: `${PUBLIC_FEATURES_PREFIX}/${FEATURE_KEY}?q=a%20b&r=c` })
+
+      expect(api.last().url).toBe(`/feature/${FEATURE_KEY}?q=a%20b&r=c`)
+    })
+
+    it('reaches /api/event on Bard, the one path an anonymous caller may take', async () => {
+      app = await buildPublicApp()
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({ event: 'duos:dataset_search', properties: { appId: 'DUOS' } }),
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(bard.last().url).toBe('/api/event')
+      expect(JSON.parse(bard.last().body.toString())).toEqual({
+        event: 'duos:dataset_search',
+        properties: { appId: 'DUOS' },
+      })
+      expect(api.received).toHaveLength(0)
+    })
+
+    it('exposes no other Bard path, so identified metrics cannot be posted anonymously through it', async () => {
+      // POST /api/identify and /api/syncProfile stay behind the session-carrying
+      // /bard-api proxy; this endpoint is a named route, not a wildcard.
+      app = await buildPublicApp()
+
+      const res = await app.inject({ method: 'POST', url: '/public/metrics/identify' })
+
+      expect(res.statusCode).toBe(404)
+      expect(bard.received).toHaveLength(0)
+    })
+  })
+
+  describe('the request leg omits the session token structurally', () => {
+    it('sends no Authorization header upstream even when the request carries a session holding an access token', async () => {
+      // The central assertion of the story. The session is present, populated
+      // and refreshable — the endpoint simply never looks at it.
+      app = await buildPublicAppWithSession('a-live-session-access-token')
+      const { cookie } = await csrfCredentials(app)
+
+      const res = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX, headers: { cookie } })
+
+      expect(res.statusCode).toBe(200)
+      expect(api.last().headers.authorization).toBeUndefined()
+    })
+
+    it('sends no Authorization header on the metrics POST either, session or no session', async () => {
+      app = await buildPublicAppWithSession('a-live-session-access-token')
+      const { cookie } = await csrfCredentials(app)
+
+      await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { cookie, 'content-type': 'application/json' },
+        payload: '{"event":"duos:page_view"}',
+      })
+
+      expect(bard.last().headers.authorization).toBeUndefined()
+    })
+
+    it('drops a client-supplied Authorization header instead of forwarding it', async () => {
+      // A legacy client builds its own bearer header; whatever the browser
+      // sends must not reach the upstream on a public endpoint.
+      app = await buildPublicApp()
+
+      await app.inject({
+        method: 'GET',
+        url: PUBLIC_FEATURES_PREFIX,
+        headers: { authorization: 'Bearer browser-held-token' },
+      })
+
+      expect(api.last().headers.authorization).toBeUndefined()
+    })
+
+    it('strips the session cookie and the CSRF token, and injects x-app-id', async () => {
+      app = await buildPublicAppWithSession('a-live-session-access-token')
+      const { cookie, token } = await csrfCredentials(app)
+
+      await app.inject({
+        method: 'GET',
+        url: `${PUBLIC_FEATURES_PREFIX}/${FEATURE_KEY}`,
+        headers: { cookie, 'x-csrf-token': token },
+      })
+
+      const forwarded = api.last().headers
+      expect(forwarded.cookie).toBeUndefined()
+      expect(forwarded['x-csrf-token']).toBeUndefined()
+      expect(forwarded['x-app-id']).toBe('DUOS')
+    })
+
+    it('appends this pod to the forwarded-for chain rather than replacing it', async () => {
+      app = await buildPublicApp()
+
+      await app.inject({
+        method: 'GET',
+        url: PUBLIC_FEATURES_PREFIX,
+        headers: { 'x-forwarded-for': '203.0.113.7' },
+      })
+
+      expect(api.last().headers['x-forwarded-for']).toBe('203.0.113.7, 127.0.0.1')
+    })
+  })
+
+  describe('the response leg', () => {
+    it('does not let an upstream set a cookie on this origin', async () => {
+      // A public endpoint is the last place a Set-Cookie should be reachable:
+      // nothing about the request proves who the caller is, so an upstream that
+      // could write `sessionId` here could hand any visitor a chosen session.
+      app = await buildPublicApp()
+      api.respondWith((_req, res) => {
+        res.writeHead(200, {
+          'set-cookie': 'sessionId=upstream-forged; Path=/',
+          'www-authenticate': 'Bearer realm="consent"',
+          'content-type': 'application/json',
+        })
+        res.end('{}')
+      })
+
+      const res = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(res.headers['set-cookie']).toBeUndefined()
+      expect(res.headers['www-authenticate']).toBeUndefined()
+      expect(res.json()).toEqual({})
+    })
+
+    it('hardens both endpoints against executing on the SPA origin', async () => {
+      app = await buildPublicApp()
+
+      const flags = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+      const event = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'application/json' },
+        payload: '{"event":"duos:page_view"}',
+      })
+
+      for (const res of [flags, event]) {
+        expect(res.headers['x-content-type-options']).toBe('nosniff')
+        expect(res.headers['content-security-policy']).toBe('sandbox')
+      }
+    })
+  })
+
+  describe('feature-flag response validation', () => {
+    it('passes a JSON body through', async () => {
+      app = await buildPublicApp()
+      api.respondWith((_req, res) => {
+        res.writeHead(200, { 'content-type': 'application/json; charset=utf-8' })
+        res.end('{"NHGRI_RESTRICTED_DAC":{"value":"7"}}')
+      })
+
+      const res = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(res.statusCode).toBe(200)
+      expect(res.json()).toEqual({ NHGRI_RESTRICTED_DAC: { value: '7' } })
+    })
+
+    it('answers 502 rather than streaming a non-JSON upstream body onto this origin', async () => {
+      // The clients parse JSON and nothing else, so an HTML body is already a
+      // broken upstream — and serving an upstream-chosen document from an
+      // unauthenticated same-origin URL is worth refusing outright.
+      app = await buildPublicApp()
+      api.respondWith((_req, res) => {
+        res.writeHead(200, { 'content-type': 'text/html' })
+        res.end('<script>alert(1)</script>')
+      })
+
+      const res = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(res.statusCode).toBe(502)
+      expect(res.json()).toEqual({ error: 'upstream_not_json' })
+      expect(res.body).not.toContain('<script>')
+    })
+
+    it('answers 502 for an upstream response with no content type at all', async () => {
+      app = await buildPublicApp()
+      api.respondWith((_req, res) => {
+        res.writeHead(200)
+        res.end('not json')
+      })
+
+      const res = await app.inject({ method: 'GET', url: `${PUBLIC_FEATURES_PREFIX}/${FEATURE_KEY}` })
+
+      expect(res.statusCode).toBe(502)
+    })
+
+    it('passes a bodiless response through, so a missing flag stays a 404 rather than becoming an outage', async () => {
+      app = await buildPublicApp()
+      api.respondWith((_req, res) => {
+        res.writeHead(404, { 'content-length': '0' })
+        res.end()
+      })
+
+      const res = await app.inject({ method: 'GET', url: `${PUBLIC_FEATURES_PREFIX}/missing` })
+
+      expect(res.statusCode).toBe(404)
+    })
+  })
+
+  describe('abuse controls on an endpoint anyone on the internet can reach', () => {
+    it('refuses a metrics body over the limit with 413, without contacting Bard', async () => {
+      app = await buildPublicApp()
+      const oversized = JSON.stringify({ event: 'duos:page_view', properties: { pad: 'x'.repeat(METRICS_BODY_LIMIT) } })
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'application/json' },
+        payload: oversized,
+      })
+
+      expect(res.statusCode).toBe(413)
+      expect(bard.received).toHaveLength(0)
+    })
+
+    it('accepts a body inside the limit, so the cap is not merely rejecting everything', async () => {
+      app = await buildPublicApp()
+      const payload = JSON.stringify({ event: 'duos:page_view', properties: { pad: 'x'.repeat(1024) } })
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'application/json' },
+        payload,
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(bard.received).toHaveLength(1)
+    })
+
+    it('answers 415 for a media type it has no parser for, before a handler runs', async () => {
+      app = await buildPublicApp()
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'text/plain' },
+        payload: 'not json',
+      })
+
+      expect(res.statusCode).toBe(415)
+      expect(bard.received).toHaveLength(0)
+    })
+
+    it('refuses a client over the feature-flag limit with 429', async () => {
+      app = await buildPublicApp()
+
+      const accepted: number[] = []
+      for (let i = 0; i < FEATURES_MAX_PER_WINDOW; i += 1) {
+        accepted.push((await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })).statusCode)
+      }
+      const refused = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(accepted.every(status => status === 200)).toBe(true)
+      expect(refused.statusCode).toBe(429)
+    })
+
+    it('answers the refusal with a bare status, naming neither the framework nor the retry window', async () => {
+      app = await buildPublicApp()
+      for (let i = 0; i < FEATURES_MAX_PER_WINDOW; i += 1) {
+        await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+      }
+
+      const refused = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(refused.body).toBe('')
+    })
+
+    it('leaks no framework error code when a request is rejected before the handler', async () => {
+      // index.ts installs the app-level handler after this plugin registers, so
+      // without the scope's own handler Fastify's default serialiser would put
+      // FST_ERR_CTP_BODY_TOO_LARGE in front of an unauthenticated caller.
+      app = await buildPublicApp()
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'application/json' },
+        payload: JSON.stringify({ pad: 'x'.repeat(METRICS_BODY_LIMIT) }),
+      })
+
+      expect(res.body).toBe('')
+      expect(res.body).not.toContain('FST_ERR')
+    })
+
+    it('answers a malformed JSON body with a bare 400', async () => {
+      app = await buildPublicApp()
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { 'content-type': 'application/json' },
+        payload: '{"event":',
+      })
+
+      expect(res.statusCode).toBe(400)
+      expect(res.body).toBe('')
+      expect(bard.received).toHaveLength(0)
+    })
+  })
+
+  describe('no CSRF and no Fetch Metadata guard', () => {
+    it('accepts the metrics POST with no CSRF token, in an app where CSRF is registered', async () => {
+      // The request borrows no ambient authority — no cookie is forwarded and
+      // no token is injected — so a forged one reaches Bard with exactly the
+      // authority anyone already has by calling Bard directly. Requiring a
+      // token would also make the endpoint unusable pre-login, its whole point.
+      app = await buildPublicAppWithSession('a-live-session-access-token')
+      const { cookie } = await csrfCredentials(app)
+
+      const res = await app.inject({
+        method: 'POST',
+        url: PUBLIC_METRICS_EVENT_PATH,
+        headers: { cookie, 'content-type': 'application/json' },
+        payload: '{"event":"duos:page_view"}',
+      })
+
+      expect(res.statusCode).toBe(200)
+      expect(bard.received).toHaveLength(1)
+    })
+
+    it('serves a cross-site request the Fetch Metadata guard would have rejected on a proxy route', async () => {
+      // The guard protects endpoints that carry the session cookie. These do
+      // not, so it would buy nothing and only risk rejecting a legitimate call
+      // shape — a metrics event fired from a context whose Sec-Fetch-Site is
+      // not what the guard expects.
+      app = await buildPublicApp()
+
+      const res = await app.inject({
+        method: 'GET',
+        url: PUBLIC_FEATURES_PREFIX,
+        headers: { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors' },
+      })
+
+      expect(res.statusCode).toBe(200)
+    })
+  })
+
+  describe('upstream transport failures', () => {
+    it('reports an unreachable upstream as 502 rather than a bare 500', async () => {
+      app = await buildPublicApp()
+      await api.close()
+
+      const res = await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })
+
+      expect(res.statusCode).toBe(502)
+      expect(res.json()).toEqual({ error: 'upstream_unavailable' })
+    })
+  })
+
+  describe('registration against a partly configured deployment', () => {
+    it('boots with neither upstream configured, because it registers outside both cutover switches', async () => {
+      // A legacy deployment sets neither variable, and this plugin sits beside
+      // the CSP report sink ahead of both switches — so a missing upstream must
+      // disable one endpoint, never fail startup.
+      delete process.env.DUOS_API_URL
+      delete process.env.DUOS_BARD_URL
+      app = await buildPublicApp()
+
+      await expect(app.ready()).resolves.toBeDefined()
+      expect((await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })).statusCode).toBe(404)
+      expect((await app.inject({ method: 'POST', url: PUBLIC_METRICS_EVENT_PATH })).statusCode).toBe(404)
+    })
+
+    it('registers the feature flags when only the DUOS API is configured', async () => {
+      delete process.env.DUOS_BARD_URL
+      app = await buildPublicApp()
+
+      expect((await app.inject({ method: 'GET', url: PUBLIC_FEATURES_PREFIX })).statusCode).toBe(200)
+      expect((await app.inject({ method: 'POST', url: PUBLIC_METRICS_EVENT_PATH })).statusCode).toBe(404)
+    })
+
+    it.each([
+      ['DUOS_API_URL', 'consent.dsde-dev.broadinstitute.org'],
+      ['DUOS_BARD_URL', 'https://terra-bard-dev.appspot.com/api'],
+    ])('refuses to register when %s is set but not a bare origin', async (envVar, value) => {
+      // A variable that is set must be usable: a malformed one fails at startup
+      // naming itself, rather than 500ing every call to the endpoint.
+      process.env[envVar] = value
+      const shell = Fastify({ logger: false })
+      shell.register(publicProxy)
+
+      await expect(shell.ready()).rejects.toThrow(envVar)
+      await shell.close()
+    })
+  })
+})

--- a/src/libs/ajax/FeatureFlag.ts
+++ b/src/libs/ajax/FeatureFlag.ts
@@ -1,4 +1,4 @@
-import { Config } from 'src/libs/config'
+import { BFF_PUBLIC_FEATURES_PREFIX, Config } from 'src/libs/config'
 import { fetchGet } from 'src/libs/ajax/fetchAdapter'
 
 export interface FeatureFlag {
@@ -8,21 +8,38 @@ export interface FeatureFlag {
   updateDate: number
 }
 
-// BFF NOTE: /feature must stay at the absolute Consent URL post-cutover — it
-// is unauthenticated and consulted pre-login (e.g. NHGRI_RESTRICTED_DAC), and
-// the session-guarded BFF proxy returns 401 for sessionless requests. Hence
-// getUpstreamApiUrl, never the proxied getApiUrl.
+// BFF NOTE: /feature is unauthenticated and consulted pre-login (e.g.
+// NHGRI_RESTRICTED_DAC), so it cannot ride the session-guarded /duos-api proxy,
+// which 401s a sessionless request. Until story 5-F6 that meant staying on the
+// absolute Consent URL and keeping `apiUrl` in the BFF `connect-src` allowlist.
+// It now has a dedicated public endpoint instead — same upstream path, no
+// session read, no token injected — so under bffEnabled these calls are
+// same-origin and the allowlist entry is gone. Legacy keeps getUpstreamApiUrl,
+// never the proxied getApiUrl.
+//
+// Note for anyone changing this: nothing in src/ calls either function today
+// (only the unit tests do), so the app cannot be exercised to check the
+// endpoint. test/libs/ajax/FeatureFlag.spec.ts and
+// server/test/publicProxy.test.ts are the only proof this pair lines up.
+const featuresUrl = async (path: string): Promise<string> => {
+  if (await Config.isBffEnabled()) {
+    return `${BFF_PUBLIC_FEATURES_PREFIX}${path}`
+  }
+  return `${await Config.getUpstreamApiUrl()}/feature${path}`
+}
+
 export async function getAllFeatureFlags(): Promise<Record<string, FeatureFlag> | FeatureFlag[]> {
-  const url = `${await Config.getUpstreamApiUrl()}/feature`
+  const url = await featuresUrl('')
   // authOpts() stays for legacy parity (signed-in legacy users send their
   // token even though /feature doesn't need it); in BFF mode the fetch
-  // adapter strips the Authorization header before sending.
+  // adapter strips the Authorization header before sending, and the endpoint
+  // drops anything that survived that before forwarding.
   const res = await fetchGet<Record<string, FeatureFlag> | FeatureFlag[]>(url, Config.authOpts())
   return res.data
 }
 
 export async function getFeatureFlag(key: string): Promise<FeatureFlag | undefined> {
-  const url = `${await Config.getUpstreamApiUrl()}/feature/${encodeURIComponent(key)}`
+  const url = await featuresUrl(`/${encodeURIComponent(key)}`)
   try {
     const res = await fetchGet<FeatureFlag>(url, Config.authOpts())
     return res.data

--- a/src/libs/ajax/Metrics.ts
+++ b/src/libs/ajax/Metrics.ts
@@ -1,7 +1,7 @@
 import { getDefaultProperties } from '@databiosphere/bard-client'
 
 import { Storage } from 'src/libs/storage'
-import { BFF_BARD_PREFIX, Config, Token } from 'src/libs/config'
+import { BFF_BARD_PREFIX, BFF_PUBLIC_METRICS_PREFIX, Config, Token } from 'src/libs/config'
 import { MetricsEventName } from 'src/libs/events'
 import { retryFetchPost } from 'src/libs/ajax/fetchAdapter'
 
@@ -11,10 +11,20 @@ const defaultSignal: AbortSignal = AbortSignal.timeout(30000)
 // BFF NOTE: identified Bard calls authenticate with the user's token, which
 // the browser no longer holds post-cutover — they go through the /bard-api
 // proxy, where the session's token is attached server-side (Epic 3, story
-// 3-K). Anonymous events carry no credentials and stay on the direct Bard URL.
+// 3-K). Anonymous events carry no credentials, and until story 5-F6 that meant
+// posting straight to Bard, which is what kept `bardApiUrl` in the BFF
+// `connect-src` allowlist. They now go to a dedicated public endpoint that
+// injects no token either, so the anonymous call is same-origin too and the
+// allowlist entry is gone. Legacy posts direct to Bard in both cases.
+//
+// The anonymous branch ignores `path` rather than appending it: the public
+// endpoint is a single named route, not a wildcard proxy, so it exposes exactly
+// the one Bard path a signed-out caller uses and nothing else. `captureEvent`
+// is the only call that reaches this branch and it always passes `/api/event`,
+// so the mapping is total.
 const bardUrl = async (identified: boolean, path: string): Promise<string> => {
-  if (identified && await Config.isBffEnabled()) {
-    return `${BFF_BARD_PREFIX}${path}`
+  if (await Config.isBffEnabled()) {
+    return identified ? `${BFF_BARD_PREFIX}${path}` : `${BFF_PUBLIC_METRICS_PREFIX}/event`
   }
   return `${await Config.getBardApiUrl()}${path}`
 }

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -111,6 +111,19 @@ const BFF_TDR_PREFIX = '/tdr-api'
 export const BFF_BARD_PREFIX = '/bard-api'
 
 /**
+ * The public BFF endpoints (story 5-F6), which are a different thing from the
+ * prefixes above: those proxies attach the session's token and 401 without a
+ * session, while these two carry no credentials in either direction and are
+ * reachable pre-login. They exist so the two remaining direct browser
+ * connections become same-origin, which is what lets BFF-mode `connect-src`
+ * drop the Consent and Bard origins (server/src/security/csp.ts).
+ *
+ * Each must match the path server/src/proxy/publicProxy.ts registers.
+ */
+export const BFF_PUBLIC_FEATURES_PREFIX = '/public/features'
+export const BFF_PUBLIC_METRICS_PREFIX = '/public/metrics'
+
+/**
  * Base URL for DUOS API calls.
  */
 export const getApiUrl = async (): Promise<string> => {

--- a/test/libs/ajax/FeatureFlag.spec.ts
+++ b/test/libs/ajax/FeatureFlag.spec.ts
@@ -16,10 +16,13 @@ vi.mock('src/libs/ajax/fetchAdapter', () => ({
 
 const authHeaders = { headers: { Authorization: 'Bearer test' } } as ReturnType<typeof Config.authOpts>
 
+const CONSENT = 'https://consent.dsde-dev.broadinstitute.org'
+
 describe('FeatureFlag ajax', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.spyOn(Config, 'getUpstreamApiUrl').mockResolvedValue('')
+    vi.spyOn(Config, 'isBffEnabled').mockResolvedValue(false)
     vi.spyOn(Config, 'authOpts').mockReturnValue(authHeaders)
   })
 
@@ -89,6 +92,50 @@ describe('FeatureFlag ajax', () => {
       await getFlagNhgriDacId()
 
       expect(fetchGet).toHaveBeenCalledOnce()
+    })
+  })
+
+  /**
+   * These four cases are the only proof the client and server halves of story
+   * 5-F6 line up: nothing in src/ calls this module, so no test that exercises
+   * the app can reach either URL. The paths asserted here must match the routes
+   * server/src/proxy/publicProxy.ts registers.
+   */
+  describe('URL selection', () => {
+    it('calls the absolute Consent URL in legacy mode, which is what the legacy client has always done', async () => {
+      vi.spyOn(Config, 'getUpstreamApiUrl').mockResolvedValue(CONSENT)
+      vi.mocked(fetchGet).mockResolvedValue({ data: {} } as FetchData<object>)
+
+      await getAllFeatureFlags()
+
+      expect(fetchGet).toHaveBeenCalledWith(`${CONSENT}/feature`, authHeaders)
+    })
+
+    it('calls the public BFF endpoint under bffEnabled, so the read is same-origin and needs no connect-src entry', async () => {
+      vi.spyOn(Config, 'isBffEnabled').mockResolvedValue(true)
+      vi.mocked(fetchGet).mockResolvedValue({ data: {} } as FetchData<object>)
+
+      await getAllFeatureFlags()
+
+      expect(fetchGet).toHaveBeenCalledWith('/public/features', authHeaders)
+    })
+
+    it('reads a single flag through the same public endpoint', async () => {
+      vi.spyOn(Config, 'isBffEnabled').mockResolvedValue(true)
+      vi.mocked(fetchGet).mockResolvedValue({ data: undefined } as unknown as FetchData<FeatureFlag>)
+
+      await getFeatureFlag('NHGRI_RESTRICTED_DAC')
+
+      expect(fetchGet).toHaveBeenCalledWith('/public/features/NHGRI_RESTRICTED_DAC', authHeaders)
+    })
+
+    it('never reaches the session-guarded /duos-api proxy, which would 401 a pre-login read', async () => {
+      vi.spyOn(Config, 'isBffEnabled').mockResolvedValue(true)
+      vi.mocked(fetchGet).mockResolvedValue({ data: {} } as FetchData<object>)
+
+      await getAllFeatureFlags()
+
+      expect(vi.mocked(fetchGet).mock.calls[0][0]).not.toContain('/duos-api')
     })
   })
 })

--- a/test/libs/ajax/Metrics.spec.ts
+++ b/test/libs/ajax/Metrics.spec.ts
@@ -99,16 +99,44 @@ describe('Metrics Tests', () => {
       )
     })
 
-    it('keeps anonymous events on the direct Bard URL', async () => {
+    it('routes anonymous events through the public endpoint, not the direct Bard URL', async () => {
+      // Story 5-F6: the anonymous event carried no credentials and so went
+      // straight to Bard, which is what kept bardApiUrl in the BFF connect-src
+      // allowlist. The public endpoint injects no token either, so the call is
+      // same-origin now. The path is a single named route rather than a mirror
+      // of Bard's /api/event — it must match server/src/proxy/publicProxy.ts.
       vi.spyOn(Storage, 'userIsLogged').mockReturnValue(false)
 
       await Metrics.captureEvent(Object.keys(eventList)[0] as MetricsEventName)
 
       expect(retryFetchPost).toHaveBeenCalledWith(
-        `${bardUrl}/api/event`,
+        '/public/metrics/event',
         expect.any(Object),
         expect.any(Object),
       )
+    })
+
+    it('sends no Authorization header on the anonymous event', async () => {
+      // The public endpoint takes no credential, and the identified branch is
+      // the only one that has a token to send.
+      vi.spyOn(Storage, 'userIsLogged').mockReturnValue(false)
+
+      await Metrics.captureEvent(Object.keys(eventList)[0] as MetricsEventName)
+
+      expect(retryFetchPost).toHaveBeenCalledWith(
+        '/public/metrics/event',
+        expect.any(Object),
+        expect.objectContaining({ headers: undefined }),
+      )
+    })
+
+    it('keeps identify and syncProfile off the public endpoint, which exposes only the event path', async () => {
+      await Metrics.identify('anonymousId')
+      await Metrics.syncProfile()
+
+      for (const [url] of vi.mocked(retryFetchPost).mock.calls) {
+        expect(url).not.toContain('/public/metrics')
+      }
     })
 
     it('treats a persisted registered profile as signed in — the legacy token check is always false under the BFF', async () => {


### PR DESCRIPTION
### Addresses

[DT-4021](https://broadworkbench.atlassian.net/browse/DT-4021) — BFF Phase 5, **story 5-F6**. Security risk: **low**.

**Fourth of the 5-F stack, on [#3909](https://github.com/DataBiosphere/duos-ui/pull/3909).** Review [#3907](https://github.com/DataBiosphere/duos-ui/pull/3907) → [#3908](https://github.com/DataBiosphere/duos-ui/pull/3908) → #3909 first; this diff is against #3909.

### Summary

Two browser connections still bypassed the BFF under `bffEnabled` and forced exact-origin entries into `connect-src`. They now go through dedicated public endpoints:

| Endpoint | Upstream | Drops from `connect-src` |
|---|---|---|
| `GET /public/features`, `/public/features/:key` | Consent | `apiUrl` |
| `POST /public/metrics/event` | Bard | `bardApiUrl` |

They could not be folded into the existing proxies as unauthenticated paths: `unauthenticatedPaths` is an **exact** set match, so `/feature` alone leaves `/feature/:key` returning 401, and anonymous and identified metrics share `POST /api/event` — marking it unauthenticated would silently turn *identified* metrics anonymous.

**These do not reuse `registerUpstreamProxy`, and that is the main design decision to review.** It throws unless `@fastify/csrf-protection` is registered first, which only happens inside the `bffEnabled` block — and these must register **outside both switches**, since they serve pre-login and legacy traffic. More importantly its entire purpose is attaching the session's access token. A separate module makes omitting the token **structural rather than configured**: a future edit to the shared proxy cannot start injecting one here. The module contains no reference to `request.session` at all.

The trust-boundary behaviour is duplicated rather than shared, deliberately — `cookie`, `authorization` and `x-csrf-token` stripped on the way out, `set-cookie` and `www-authenticate` stripped on the way back, `x-app-id` injected. Only the pure URL plumbing (`upstreamBase`, `upstreamPath`) is imported.

**Two departures from the session proxies, both commented:**

- **Bodies are parsed, not streamed.** The shared proxy installs a wildcard pass-through parser because DUOS uploads multipart and binary. Here only `application/json` is registered, with a `bodyLimit` — an unread stream is never measured against `bodyLimit`, so buffering is what makes the 413 exist at all, and it means only well-formed JSON reaches Bard.
- **Feature-flag responses are validated.** A response carrying a body that is not JSON is logged and answered 502 rather than streamed from a public endpoint onto our origin. Bodiless responses (a 204, or a 404 with no content) pass through — requiring JSON unconditionally would turn "flag not found" into a fabricated outage.

No CSRF and no Fetch Metadata guard, both deliberate and both commented. These carry no credentials, so there is nothing to forge with, and the Fetch Metadata guard exists to protect state-changing GETs that carry the session cookie.

### `/public/notifications` is deliberately not built

A separate backlog item repoints `notificationService.ts` at environment-specific buckets. Proxying GCS is the one endpoint of the three with no existing pattern to copy, and building it against a URL shape that is about to change would mean writing it twice. **BFF-mode `connect-src` therefore ends this story at `'self'` plus the banner bucket**, not `'self'` alone. Revisit when that lands.

### The tests are the only proof this works

`src/libs/ajax/FeatureFlag.ts` has **no caller anywhere in `src/`** — only its own unit test. Keeping the module was a deliberate decision (recorded in ADR-013), so `/public/features/*` is built for a consumer that does not exist yet. No amount of exercising the app will show whether it works. That is called out in the module, in its spec, and in the ADR.

### Test plan

- `pnpm --filter duos-server test` — **514 pass**, 33 new. The central case is *"sends no Authorization header upstream even when the request carries a session holding an access token"*, run against a real seeded, refreshable session. Also: path routing and query passthrough, `cookie`/`x-csrf-token` stripping, `x-app-id`, `x-forwarded-for` chaining, `set-cookie` suppression, bare 413/415/400/429 responses, the non-JSON 502, that no CSRF token is required, a cross-site shape the Fetch Metadata guard would have rejected, and the partial-configuration registration matrix (a missing upstream var disables one endpoint and warns; a malformed one fails startup naming itself, so a legacy deployment setting neither still boots).
- `pnpm run test` (client) — **4,515 pass** across 379 files. `FeatureFlag.spec.ts` gains a URL-selection block for both modes; `Metrics.spec.ts` asserts the anonymous BFF path carries no `Authorization` and that identify/syncProfile never touch `/public/metrics`.
- `pnpm run type-check`, `pnpm --filter duos-server typecheck`, `pnpm run lint` — clean, zero errors.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.\n\n- Label PR with a Jira ticket number and include a link to the ticket\n- Label PR with a security risk modifier [no, low, medium, high]\n- PR describes scope of changes\n- Get a minimum of one thumbs worth of review, preferably two if enough team members are available\n- Get PO sign-off for all non-trivial UI or workflow changes\n- Verify all tests go green\n- Test this change deployed correctly and works on dev environment after deployment\n


[DT-4021]: https://broadworkbench.atlassian.net/browse/DT-4021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ