### PR TITLE
[DT-4021] BFF Header Testing (BFF Phase 5, story 5-F5)

### DIFF
--- a/docs/plans/bff_adrs/ADR-013-content-security-policy.md
+++ b/docs/plans/bff_adrs/ADR-013-content-security-policy.md
@@ -7,7 +7,9 @@
 This record is written across the 5-F stack and grows with it. Stories 5-F1
 (helmet's non-CSP headers), 5-F2 (the report sink) and 5-F3 (the policy) are
 recorded here. The sidecar change (5-F4) is described under Consequences and
-lands in `terra-helmfile`.
+lands in `terra-helmfile`. The local run that measures this decision against a
+real proxy sidecar is
+[Story 5-F5 — Local Verification Run](phase_5_story_F5_header_verification.md).
 
 ---
 
@@ -262,6 +264,13 @@ violations first and is flipped to enforcement once a run over every flow is
 clean — sign-in, protected pages, banner fetch, feature flags, anonymous
 metrics, a chart page, sign-out. That rollout is story 5-F5.
 
+A local stack with the sidecar has already driven those flows in both modes and
+reported nothing, in report-only and under enforcement. See
+[Story 5-F5 — Local Verification Run](phase_5_story_F5_header_verification.md)
+for the headers as sent, the flows driven, and the gaps that run cannot close.
+It is the pre-check, not the rollout: dev traffic and the per-environment flip
+still have to happen.
+
 Collection is real rather than console-only: the policy carries both
 `report-uri` and `report-to`, pointing at the sink from part 2 above.
 
@@ -375,3 +384,9 @@ is a much larger piece of work than this story.
 
   COOP passing through is the reassuring half: the legacy-mode decision above
   is the one non-CSP header that both matters and actually arrives.
+
+  A local stack carrying the fixed `site.conf` confirms the whole of this
+  bullet, header by header, in
+  [Story 5-F5 — Local Verification Run](phase_5_story_F5_header_verification.md).
+  It also measures what the sidecar replaced before the fix: `SAMEORIGIN` for
+  `X-Frame-Options`, and a one-day HSTS for the app's one year.

--- a/docs/plans/bff_adrs/phase_5_story_F5_header_verification.md
+++ b/docs/plans/bff_adrs/phase_5_story_F5_header_verification.md
@@ -1,0 +1,162 @@
+# Story 5-F5 — Local Verification Run
+
+**Records:** [ADR-013](ADR-013-content-security-policy.md)  
+**Date:** 2026-09-04  
+**Run by:** Greg Rushton  
+**Stack:** `duos-ui` local Docker Compose (`app` + `duos-proxy` httpd sidecar + bundled Postgres)  
+**Server code:** `develop` @ `ce48888e` (5-F1, 5-F2, 5-F3 merged)  
+**Sidecar config:** local `site.conf`, carrying the story 5-F4 changes that
+terra-helmfile PR [#6497](https://github.com/broadinstitute/terra-helmfile/pull/6497) makes
+
+This run is the pre-check for the rollout, not the rollout. The local stack uses
+the same `httpd-terra-proxy` image and the same `site.conf` shape as the
+deployed environments, so it proves the policy composes and that the sidecar no
+longer overrides it. It does **not** close story 5-F5: real traffic on dev,
+then the flip per environment, still has to happen.
+
+---
+
+## Result
+
+| Mode | Report-only | Enforced |
+|---|---|---|
+| Legacy (`bffEnabled: false`) | clean | **clean** |
+| BFF (`bffEnabled: true`) | — | **clean** |
+
+Zero violation reports across every pass. `docker logs duos | grep '\[csp\]'`
+returned nothing but the synthetic probe described below.
+
+### Flows driven
+
+| Flow | Legacy | BFF | Note |
+|---|---|---|---|
+| Sign-in (Google) | pass | pass | BFF uses the full-page auth redirect |
+| Protected pages | pass | pass | |
+| Banner fetch | pass | pass | `storage.googleapis.com/broad-duos-banners/` |
+| Chart page | pass | pass | SVG donut from story 5-A; no third-party script |
+| Anonymous metrics | pass | pass | |
+| Identified metrics (Bard) | pass | pass | `identify`, `event`, `syncProfile` via `/bard-api` |
+| ECM RAS account linking | — | pass | end to end via `/ecm-api` |
+| TDR data library | — | pass | via `/tdr-api` |
+| Sign-out | pass | pass | |
+| Feature flags | not driven | not driven | see "Known gaps" |
+
+---
+
+## Headers verified
+
+### Legacy mode, enforced
+
+```
+Content-Security-Policy: default-src 'self';script-src 'self';script-src-attr 'none';
+style-src 'self' 'unsafe-inline';img-src 'self' data:;frame-src 'self';
+connect-src 'self' https://local.dsde-dev.broadinstitute.org:27443
+  https://terra-bard-dev.appspot.com https://externalcreds.dsde-dev.broadinstitute.org
+  https://jade.datarepo-dev.broadinstitute.org
+  https://storage.googleapis.com/broad-duos-banners/;
+font-src 'self';object-src 'none';base-uri 'none';frame-ancestors 'none';
+form-action 'self';manifest-src 'self';report-uri /csp-report;report-to csp-endpoint;
+upgrade-insecure-requests
+```
+
+Four upstream origins, per `LEGACY_CONNECT_FIELDS`.
+
+### BFF mode, enforced
+
+Identical, except `connect-src` drops ECM and TDR:
+
+```
+connect-src 'self' https://local.dsde-dev.broadinstitute.org:27443
+  https://terra-bard-dev.appspot.com
+  https://storage.googleapis.com/broad-duos-banners/;
+```
+
+Those two are same-origin through the proxies, per `BFF_CONNECT_FIELDS`.
+
+### Companion headers, final state
+
+```
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+Cross-Origin-Opener-Policy: same-origin-allow-popups   (BFF mode only)
+Cross-Origin-Resource-Policy: same-origin
+Referrer-Policy: no-referrer
+```
+
+Every one of these is the app's value. Before the `site.conf` fixes the sidecar
+replaced `X-Frame-Options` with `SAMEORIGIN` and HSTS with `max-age=86400`.
+
+---
+
+## What story 5-F4 fixed, measured
+
+The app is now the single source for every content-security header.
+The proxy keeps only what the app cannot cover.
+
+| Header | Before | After | Set by |
+|---|---|---|---|
+| `Content-Security-Policy` / `-Report-Only` | proxy replaced the app's | app's, unmodified | **app** |
+| `Strict-Transport-Security` | proxy replaced 1 year with 1 day | `max-age=31536000; includeSubDomains` | **app** |
+| `Referrer-Policy` | passed through | unchanged | **app** |
+| `Cross-Origin-Opener-Policy` (BFF mode only) | passed through | unchanged | **app** |
+| `Cross-Origin-Resource-Policy` | passed through | unchanged | **app** |
+| `Origin-Agent-Cluster`, `X-DNS-Prefetch-Control`, `X-Download-Options`, `X-Permitted-Cross-Domain-Policies`, `X-XSS-Protection` | passed through | unchanged | **app** |
+| `Reporting-Endpoints` | passed through | unchanged | **app** |
+| `X-Frame-Options` | proxy sent `SAMEORIGIN`, app sent `DENY` | both send `DENY` | **proxy**, at server scope |
+| `X-Content-Type-Options` | proxy sent it twice, app also sent it | proxy sends it once | **proxy**, at server scope |
+| `Server`, `Access-Control-*` | proxy | unchanged | **proxy** |
+
+**The `Header unset` lines matter as much as the `Header set` lines.** Commenting
+out only the `set` leaves the `unset` stripping the app's header and sending
+nothing. That happened here with HSTS: the app sent `max-age=31536000` on its
+own port while the proxy sent no HSTS at all. Both lines must go, for CSP and
+for HSTS.
+
+---
+
+## Report sink proven
+
+The report-only passes logged nothing, which alone does not prove the sink
+works. A synthetic report confirmed the path:
+
+```bash
+curl -sk -X POST https://local.dsde-dev.broadinstitute.org/csp-report \
+  -H 'content-type: application/csp-report' \
+  --data '{"csp-report":{"document-uri":"https://local.dsde-dev.broadinstitute.org/home?x=1",
+           "violated-directive":"script-src","blocked-uri":"https://example.com/probe.js",
+           "disposition":"report"}}'
+```
+
+Returned 204, logged one `[csp] violation report` line, with the query string
+redacted to `?<redacted>` as `cspReport.ts` specifies.
+
+---
+
+## Known gaps
+
+1. **Feature flags not driven.** `src/libs/ajax/FeatureFlag.ts` has no callers
+   in `src`. Its host is `apiUrl`, allowlisted in both modes, so a future caller
+   is already covered.
+2. **Single-user traffic.** This run is one developer clicking through. Epic 6
+   story 6-K makes collection reliable; the dev report-only run still needs real
+   traffic.
+3. **`blob:` and other sources.** None were needed here. Add nothing until a
+   report-only run on real traffic proves the need.
+
+---
+
+## Remaining for 5-F5
+
+1. Land terra-helmfile PR [#6497](https://github.com/broadinstitute/terra-helmfile/pull/6497)
+2. Deploy to dev, run report-only collection with real traffic, read
+   `[csp] violation report` lines.
+3. Flip `DUOS_CSP_REPORT_ONLY=false` on dev, then staging, then prod.
+4. Prove enforcement per environment:
+
+```bash
+curl -sI https://<host>/ | grep -i content-security-policy
+```
+
+The header name must be `Content-Security-Policy`, carrying `default-src 'self'`
+and `object-src 'none'`. `'unsafe-eval'` means 5-F4 has not landed there.


### PR DESCRIPTION
## Addresses
[DT-4021](https://broadworkbench.atlassian.net/browse/DT-4021)

## Summary
Part of a chain of PRs addressing this ticket:
- [5-F1 security headers](https://github.com/DataBiosphere/duos-ui/pull/3907) → 
- [5-F2 report sink](https://github.com/DataBiosphere/duos-ui/pull/3908) → 
- [5-F3 the policy](https://github.com/DataBiosphere/duos-ui/pull/3909) → 
- [5-F4 terra-helmfile proxy](https://github.com/broadinstitute/terra-helmfile/pull/6497)  → 
- **5-F5 run report - no code, just a report execution (this PR)** → 
  - This PR currently serves as local pre-evidence of the run
- [5-F6 public BFF endpoints](https://github.com/DataBiosphere/duos-ui/pull/3914)


Documentation only. No code changes.

Adds `docs/plans/bff_adrs/phase_5_story_F5_header_verification.md`: the local Docker Compose run that drives every flow in legacy and BFF mode, in report-only and under enforcement, against the httpd sidecar carrying the story 5-F4 `site.conf` changes. Zero violation reports. The doc records the headers as sent, the flows driven, a synthetic probe that proves the report sink, and three known gaps.

Links the run from ADR-013 in three places: the 5-F stack note, the report-only rollout section, and the Consequences bullet on the sidecar override.

This run is the pre-check, not the rollout. Story 5-F5 still needs terra-helmfile PR [#6497](https://github.com/broadinstitute/terra-helmfile/pull/6497) to land, a dev report-only run on real traffic, and the per-environment flip.

Security risk: no.

### Test plan

None. Markdown only. Relative links between the two documents resolve.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

[DT-4021]: https://broadworkbench.atlassian.net/browse/DT-4021