### PR TITLE
[DT-4093] Test coverage and Sonar cleanup for DataAccessRequestApplication

### DIFF
--- a/src/pages/dar_application/DataAccessRequestApplication.tsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.tsx
@@ -25,7 +25,7 @@ import { ConditionalAccordion } from 'src/components/forms/ConditionalAccordion'
 import { ProgressReportApplication } from 'src/pages/dar_application/ProgressReportApplication'
 import { ScrollableTabs } from 'src/pages/dar_application/ScrollableTabs'
 import { tabElementId } from 'src/pages/dar_application/stepTabs'
-import { validateDARFormData, validationFailed, DARFormValidationResult } from 'src/utils/darFormUtils'
+import { normalizeDaaIds, validateDARFormData, validationFailed, DARFormValidationResult } from 'src/utils/darFormUtils'
 import { assign, cloneDeep, get, isArray, isEmpty, isEqual, isNil, isString, map, merge, set } from 'src/utils/NodashUtil'
 import { usePageTitle } from 'src/hooks/usePageTitle'
 import { stepTabsSx } from 'src/pages/dar_collection_review/reviewTabStyles'
@@ -107,6 +107,91 @@ const ApplicationPageHeading = ({ readOnly, darCode, projectTitle }: Application
       title={(readOnly ? darCode : 'Data Access Request Application') ?? ''}
       description={readOnly ? projectTitle : 'Please complete the fields below to request access to data.'}
     />
+  </div>
+)
+
+interface ApplicationTabsInput {
+  readOnly?: boolean
+  isProgressReportApplication: boolean
+  dars: DataAccessRequestModel[]
+  darCode?: string | null
+  embedded?: boolean
+}
+
+/** Editing shows the four form steps; review shows one tab per progress report instead. */
+const buildApplicationTabs = ({ readOnly, isProgressReportApplication, dars, darCode, embedded }: ApplicationTabsInput): AppTab[] => {
+  if (!readOnly) {
+    return [...ApplicationTabs, { name: 'Data Access Agreements (DAA)', id: DATA_ACCESS_AGREEMENTS_TAB_ID }]
+  }
+  // A progress report being drafted has no DAR of its own yet, so it needs a tab adding for it.
+  const draftTab = isProgressReportApplication
+    ? [{ name: `Progress Report ${dars.length}`, id: PROGRESS_REPORT_APPLICATION_TAB_ID, showStep: false }]
+    : []
+  const reportTabs = dars.map((_dar, index) => {
+    const whichPRIsThis = dars.length - index - 1
+    const itemLabel = index === dars.length - 1 ? darCode : `Progress Report ${whichPRIsThis}`
+    return { name: itemLabel ?? '', id: `${PROGRESS_REPORT_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false }
+  })
+  // The voting page has its own Voting History tab; only the standalone pages need this one.
+  const votingTab = embedded ? [] : [{ name: 'Voting History', id: VOTING_HISTORY_TAB_ID, showStep: false }]
+  return [...draftTab, ...reportTabs, ...votingTab]
+}
+
+/** The header the voting history reads, with the placeholders it expects for a DAR still in draft. */
+const toVotingHistoryDar = (formData: DarFormData, votes: ReturnType<typeof buildVoteRecords>) => ({
+  referenceId: formData.darCode || '',
+  piName: formData.piName || '',
+  institution: formData.institution || '',
+  status: getDarStatus(votes),
+})
+
+const stepTabsLayout = (embedded?: boolean) => embedded
+  ? { orientation: 'horizontal' as const, sx: stepTabsSx, formClassName: 'forms-v2 forms-v2--flush' }
+  : { orientation: 'vertical' as const, sx: undefined, formClassName: 'forms-v2' }
+
+const eRACommonsDestinationFor = (dataRequestId?: string) =>
+  isNil(dataRequestId) ? 'dar_application' : `dar_application/${dataRequestId}`
+
+const stepContainerClassNameFor = (readOnly?: boolean) =>
+  readOnly ? 'accordion-step-container' : 'step-container'
+
+const pageContainerProps = (readOnly?: boolean) => readOnly
+  ? { className: 'application-information-page', style: { padding: '2% 3%', backgroundColor: 'white' } }
+  : { className: 'container', style: { padding: '0 0 2%' } }
+
+interface PreviousProgressReportsProps {
+  dars: DataAccessRequestModel[]
+  datasets: Dataset[]
+  researcher: DuosUser
+  countriesOfOperation: string[]
+  panelProps: (id: string) => Record<string, string | undefined>
+}
+
+/** The earlier progress reports in a collection; the newest is rendered by the current-DAR section. */
+const PreviousProgressReports = ({ dars, datasets, researcher, countriesOfOperation, panelProps }: PreviousProgressReportsProps) => (
+  <div className="dar-summary">
+    <h3>Previous Updates</h3>
+    {dars.slice(0, -1).map((dar, index) => {
+      const whichPRIsThis = dars.length - index - 1
+      const sectionId = `${PROGRESS_REPORT_TAB_ID_PREFIX}${whichPRIsThis}`
+      return (
+        <div key={dar.referenceId} id={sectionId} {...panelProps(sectionId)}>
+          <ConditionalAccordion
+            condition={true}
+            title={`Progress Report ${whichPRIsThis}`}
+            defaultExpanded={index === 0}
+          >
+            <ProgressReportApplication
+              readOnlyMode={true}
+              datasets={datasets}
+              dar={merge({}, dar?.data, dar) as CombinedDataAccessRequest}
+              researcher={researcher}
+              countriesOfOperation={countriesOfOperation}
+            />
+          </ConditionalAccordion>
+        </div>
+      )
+    })}
   </div>
 )
 
@@ -258,9 +343,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
   }, [])
 
   const onDaaIdsChange = useCallback((ids: number[]) => {
-    const normalizedIds = [...new Set((ids ?? [])
-      .map(Number)
-      .filter(id => Number.isInteger(id) && id > 0))]
+    const normalizedIds = normalizeDaaIds(ids)
     setFormData((prevFormData) => {
       if (isEqual(prevFormData.daaIds, normalizedIds)) {
         return prevFormData
@@ -414,26 +497,16 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
     setIsLoading(false)
   }, [researcher, existingDarsReadOnlyMode, resolveInitialFormData, batchFormFieldChange])
 
-  const baseApplicationTabs = useMemo<AppTab[]>(() => {
-    if (existingDarsReadOnlyMode) {
-      let appTabs: AppTab[] = []
-      if (isProgressReportApplication) {
-        // if we are creating a new progress report, we need to add another tab for the application
-        appTabs = [{ name: 'Progress Report ' + reverseOrderedDARs.length, id: PROGRESS_REPORT_APPLICATION_TAB_ID, showStep: false }]
-      }
-      return [...appTabs,
-        ...reverseOrderedDARs.map((_dar, index) => {
-          const whichPRIsThis = reverseOrderedDARs.length - index - 1
-          const isLast = index === reverseOrderedDARs.length - 1
-          const itemLabel = isLast ? formData.darCode : 'Progress Report ' + whichPRIsThis
-          return { name: itemLabel ?? '', id: `${PROGRESS_REPORT_TAB_ID_PREFIX}${whichPRIsThis}`, showStep: false }
-        }),
-        // The voting page has its own Voting History tab; only the standalone pages need this one.
-        ...(embedded ? [] : [{ name: 'Voting History', id: VOTING_HISTORY_TAB_ID, showStep: false }]),
-      ]
-    }
-    return [...ApplicationTabs, { name: 'Data Access Agreements (DAA)', id: DATA_ACCESS_AGREEMENTS_TAB_ID }]
-  }, [formData.darCode, isProgressReportApplication, existingDarsReadOnlyMode, embedded, reverseOrderedDARs])
+  const baseApplicationTabs = useMemo<AppTab[]>(
+    () => buildApplicationTabs({
+      readOnly: existingDarsReadOnlyMode,
+      isProgressReportApplication,
+      dars: reverseOrderedDARs,
+      darCode: formData.darCode,
+      embedded,
+    }),
+    [formData.darCode, isProgressReportApplication, existingDarsReadOnlyMode, embedded, reverseOrderedDARs],
+  )
 
   const applicationTabs = useMemo<AppTab[]>(
     () => showAddendum
@@ -481,9 +554,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
     if (!isEmpty(validation.darErrors)) {
       return DATA_ACCESS_REQUEST_TAB_ID
     }
-    if (isEmpty(validation.rusErrors)) {
-      return RESEARCHER_INFO_TAB_ID
-    }
+    // Only reached once the other sections are clean, so the RUS is what failed.
     return RESEARCH_PURPOSE_STATEMENT_TAB_ID
   }
 
@@ -498,7 +569,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
   const attemptSubmit = async (): Promise<boolean> => {
     const validation = validateDARFormData({
       formData,
-      datasets: draftDar ? selectedDatasets : datasets,
+      datasets: selectedDatasets,
       dataUseTranslations,
       irbDocument: uploadedIrbDocument,
       collaborationLetter: uploadedCollaborationLetter,
@@ -547,9 +618,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
       }
     }
     formattedFormData.userId = userId
-    formattedFormData.daaIds = [...new Set(((formData.daaIds ?? []) as number[])
-      .map(Number)
-      .filter(id => Number.isInteger(id) && id > 0))]
+    formattedFormData.daaIds = normalizeDaaIds(formData.daaIds)
 
     try {
       const referenceId = formData.referenceId
@@ -619,9 +688,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
     const formattedFormData: Record<string, unknown> = cloneDeep(formData)
     // DAR datasetIds needs to be a list of ids
     formattedFormData.datasetIds = selectedDatasets.map(d => d.datasetId)
-    formattedFormData.daaIds = [...new Set(((formData.daaIds ?? []) as number[])
-      .map(Number)
-      .filter(id => Number.isInteger(id) && id > 0))]
+    formattedFormData.daaIds = normalizeDaaIds(formData.daaIds)
 
     // Make sure we navigate back to the current DAR after saving.
     try {
@@ -666,12 +733,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
     [embedded, reverseOrderedDARs, datasets],
   )
 
-  const dar = {
-    referenceId: formData.darCode || '',
-    piName: formData.piName || '',
-    institution: formData.institution || '',
-    status: getDarStatus(votes),
-  }
+  const dar = toVotingHistoryDar(formData, votes)
 
   // Which sections render is mode-dependent, so a section only claims panel semantics when
   // the step tabs actually offer the tab that labels it.
@@ -683,9 +745,11 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
     navigate(-1)
   }
 
-  const eRACommonsDestination = isNil(dataRequestId) ? 'dar_application' : ('dar_application/' + dataRequestId)
-
-  const stepContainerClassName = existingDarsReadOnlyMode ? 'accordion-step-container' : 'step-container'
+  const eRACommonsDestination = eRACommonsDestinationFor(dataRequestId)
+  const stepContainerClassName = stepContainerClassNameFor(existingDarsReadOnlyMode)
+  const tabsLayout = stepTabsLayout(embedded)
+  // Attesting freezes the form the same way review mode does.
+  const fieldsAreReadOnly = existingDarsReadOnlyMode || isAttested
 
   if (isLoading) {
     return (
@@ -697,7 +761,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
 
   return (
     <div>
-      <div className={existingDarsReadOnlyMode ? 'application-information-page' : 'container'} style={{ padding: existingDarsReadOnlyMode ? '2% 3%' : '0 0 2%', backgroundColor: existingDarsReadOnlyMode ? 'white' : '' }}>
+      <div {...pageContainerProps(existingDarsReadOnlyMode)}>
         <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12">
           <div className="row no-margin">
             <Notification notificationData={notificationData} />
@@ -723,13 +787,13 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
         </div>
 
         <div style={{ clear: 'both' }} />
-        <form name="form" noValidate={true} className={embedded ? 'forms-v2 forms-v2--flush' : 'forms-v2'}>
+        <form name="form" noValidate={true} className={tabsLayout.formClassName}>
           <ScrollableTabs
             applicationTabs={applicationTabs}
             formSelectedTabId={tab}
             onTabChange={setTab}
-            orientation={embedded ? 'horizontal' : 'vertical'}
-            sx={embedded ? stepTabsSx : undefined}
+            orientation={tabsLayout.orientation}
+            sx={tabsLayout.sx}
           />
 
           <div id="form-views">
@@ -773,33 +837,13 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
               </div>
             )}
             {existingDarsReadOnlyMode && reverseOrderedDARs.length > 1 && (
-              <div className="dar-summary">
-                <h3>Previous Updates</h3>
-                {reverseOrderedDARs.map((dar, index) => {
-                  if ((index + 1 !== reverseOrderedDARs.length)) {
-                    const sectionId = `${PROGRESS_REPORT_TAB_ID_PREFIX}${reverseOrderedDARs.length - index - 1}`
-                    return (
-                      <div key={dar.referenceId} id={sectionId} {...panelProps(sectionId)}>
-                        <ConditionalAccordion
-                          key={dar.referenceId}
-                          condition={true}
-                          title={`Progress Report ${reverseOrderedDARs.length - index - 1}`}
-                          defaultExpanded={index === 0}
-                        >
-                          <ProgressReportApplication
-                            readOnlyMode={true}
-                            datasets={datasets}
-                            dar={merge({}, dar?.data, dar) as CombinedDataAccessRequest}
-                            researcher={researcher as DuosUser}
-                            countriesOfOperation={countriesOfOperation}
-                          />
-                        </ConditionalAccordion>
-                      </div>
-                    )
-                  }
-                  return null
-                })}
-              </div>
+              <PreviousProgressReports
+                dars={reverseOrderedDARs}
+                datasets={datasets}
+                researcher={researcher as DuosUser}
+                countriesOfOperation={countriesOfOperation}
+                panelProps={panelProps}
+              />
             )}
             <div id={CURRENT_DAR_TAB_ID} {...panelProps(CURRENT_DAR_TAB_ID)} className={existingDarsReadOnlyMode ? 'dar-summary' : 'dar-steps'}>
               {existingDarsReadOnlyMode && (
@@ -816,7 +860,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
                   defaultExpanded={reverseOrderedDARs.length === 1}
                 >
                   <ResearcherInfo
-                    readOnlyMode={existingDarsReadOnlyMode || isAttested}
+                    readOnlyMode={fieldsAreReadOnly}
                     includeInstructions={!existingDarsReadOnlyMode}
                     darCode={formData.darCode}
                     formData={formData}
@@ -844,7 +888,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
                 >
                   <DataAccessRequest
                     formData={formData}
-                    readOnlyMode={(existingDarsReadOnlyMode || isAttested)}
+                    readOnlyMode={fieldsAreReadOnly}
                     includeInstructions={!existingDarsReadOnlyMode}
                     datasets={datasets}
                     validation={formValidation.darErrors}
@@ -869,7 +913,7 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
                 >
                   <ResearchPurposeStatement
                     darCode={formData.darCode}
-                    readOnlyMode={(existingDarsReadOnlyMode || isAttested)}
+                    readOnlyMode={fieldsAreReadOnly}
                     validation={formValidation.rusErrors}
                     formValidationChange={(val: { key: string, validation: ValidationError }) => formValidationChange('rusErrors', val)}
                     formFieldChange={formFieldChange}

--- a/src/pages/dar_application/DataAccessRequestApplication.tsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.tsx
@@ -564,6 +564,8 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
 
   const removeAddendumTab = () => {
     setShowAddendum(false)
+    // The tab strip selects by index, so leaving the departing tab selected leaves it with none.
+    setTab(DATA_ACCESS_AGREEMENTS_TAB_ID)
   }
 
   const attemptSubmit = async (): Promise<boolean> => {

--- a/src/pages/dar_application/DataAccessRequestApplication.tsx
+++ b/src/pages/dar_application/DataAccessRequestApplication.tsx
@@ -638,9 +638,11 @@ const DataAccessRequestApplication = (props: Readonly<DataAccessRequestApplicati
 
       const responseError = error as { response?: { status?: number, data?: { code?: string, message?: string } } }
 
-      // Make DAR editable if we get a 400 status (Bad Request) error
+      // Make DAR editable if we get a 400 status (Bad Request) error. The addendum tab goes with
+      // the attestation, as it does on cancel - otherwise it lingers pointing at nothing.
       if (responseError.response?.status === 400) {
         setIsAttested(false)
+        removeAddendumTab()
       }
 
       if (responseError.response?.data?.code && responseError.response.data.message) {

--- a/src/utils/darFormUtils.ts
+++ b/src/utils/darFormUtils.ts
@@ -135,6 +135,10 @@ export const computeCollaboratorErrors = ({
   return errors
 }
 
+/** Positive integer DAA ids, deduplicated. */
+export const normalizeDaaIds = (ids: number[] | undefined): number[] =>
+  [...new Set((ids ?? []).map(Number).filter(id => Number.isInteger(id) && id > 0))]
+
 export const validationFailed = (validation: unknown): boolean => {
   if (!validation || typeof validation !== 'object') return false
   return Object.keys(validation).some(key => !isEmpty((validation as Record<string, unknown>)[key]))

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -435,11 +435,22 @@ describe('DataAccessRequestApplication - page modes', () => {
   })
 
   it('navigates back when the Back button is used', async () => {
-    await renderDraft()
+    render(
+      <MemoryRouter initialEntries={['/dar_collection/1', `/dar_application/${darId}`]} initialIndex={1}>
+        <Routes>
+          <Route path="/dar_collection/:collectionId" element={<div>Where we came from</div>} />
+          <Route
+            path="/dar_application/:dataRequestId"
+            element={<DataAccessRequestApplication draftDar={true} isProgressReportApplication={false} />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    await screen.findAllByRole('tab')
 
     await userEvent.click(document.getElementById('btn_back')!)
 
-    expect(screen.getByText('Data Access Request Application')).toBeInTheDocument()
+    expect(await screen.findByText('Where we came from')).toBeInTheDocument()
   })
 
   it('warns when the researcher cannot be loaded', async () => {
@@ -558,6 +569,7 @@ describe('DataAccessRequestApplication - submission failures', () => {
     await attestAndSubmit()
 
     expect(document.getElementById('btn_openSubmitModal')).not.toBeInTheDocument()
+    expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
   })
 
   it('surfaces the server message when submission fails with one', async () => {

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
 import { MemoryRouter, Routes, Route } from 'react-router'
 import DataAccessRequestApplication from 'src/pages/dar_application/DataAccessRequestApplication'
@@ -136,104 +137,169 @@ const userSigningOfficials = [
   },
 ]
 
-describe('DataAccessRequestApplication', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    setupTestEnvironment()
+const daaList = [
+  {
+    daaId: 100,
+    createUserId: 1,
+    createDate: '1',
+    updateUserId: 1,
+    updateDate: '1',
+    initialDacId: 1,
+    dacs: [{ dacId: 1, dacName: 'Test DAC', email: 'dac@test.com' }],
+    file: { fileStorageObjectId: 1, entityId: '1', fileName: 'TestDAA.pdf', category: 'dataAccessAgreement', mediaType: 'application/pdf', createUserId: 1, createDate: 1 },
+  },
+] as Awaited<ReturnType<typeof DAA.getDaas>>
+
+interface ServiceOverrides {
+  collection?: DarCollection
+  partialDar?: unknown
+}
+
+const mockServices = ({ collection, partialDar }: ServiceOverrides = {}) => {
+  vi.mocked(Countries.getCountries).mockResolvedValue(['United States of America (the)', 'Canada'])
+  vi.mocked(Storage.getCurrentUser).mockReturnValue(user as ReturnType<typeof Storage.getCurrentUser>)
+  vi.mocked(User.getMe).mockResolvedValue(user as Awaited<ReturnType<typeof User.getMe>>)
+  vi.mocked(User.getSOsForCurrentUser).mockResolvedValue(userSigningOfficials as Awaited<ReturnType<typeof User.getSOsForCurrentUser>>)
+  // The progress-report history renders DarCloseout, which reaches for the institution's SOs.
+  vi.mocked(User.getSOsForInstitution).mockResolvedValue(userSigningOfficials as Awaited<ReturnType<typeof User.getSOsForInstitution>>)
+  vi.mocked(Collections.getCollectionById).mockResolvedValue(collection ?? darCollection)
+  vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(datasets as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>)
+  vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(undefined)
+  vi.mocked(DAR.getPartialDarRequest).mockResolvedValue(
+    (partialDar ?? darCollection.dars[darId]) as Awaited<ReturnType<typeof DAR.getPartialDarRequest>>,
+  )
+  vi.mocked(DAR.getDatasetDaaSnapshots).mockResolvedValue([] as Awaited<ReturnType<typeof DAR.getDatasetDaaSnapshots>>)
+  vi.mocked(DAA.getDaas).mockResolvedValue(daaList)
+  vi.mocked(Metrics.captureEvent).mockResolvedValue(undefined)
+  vi.mocked(DAR.uploadDARDocument).mockResolvedValue({ data: null })
+  vi.mocked(DAR.updateDarDraft).mockResolvedValue({ referenceId: 'ref-123' } as Awaited<ReturnType<typeof DAR.updateDarDraft>>)
+  vi.mocked(DAR.postDarDraft).mockResolvedValue({ referenceId: 'ref-new' } as Awaited<ReturnType<typeof DAR.postDarDraft>>)
+  vi.mocked(DAR.postDar).mockResolvedValue({} as Awaited<ReturnType<typeof DAR.postDar>>)
+}
+
+type AppProps = Partial<React.ComponentProps<typeof DataAccessRequestApplication>>
+
+const renderAt = async (path: string, route: string, props: AppProps = {}) => {
+  const result = render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path={route}
+          element={(
+            <DataAccessRequestApplication
+              draftDar={true}
+              isProgressReportApplication={false}
+              {...props}
+            />
+          )}
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+  await screen.findAllByRole('tab')
+  return result
+}
+
+const renderDraft = (props: AppProps = {}) =>
+  renderAt(`/dar_application/${darId}`, '/dar_application/:dataRequestId', props)
+
+const renderNewDar = (props: AppProps = {}) =>
+  renderAt('/dar_application', '/dar_application', props)
+
+const renderReview = (props: AppProps = {}) =>
+  renderAt('/dar_application_review/211', '/dar_application_review/:collectionId', {
+    draftDar: false,
+    existingDarsReadOnlyMode: true,
+    ...props,
   })
 
+/** A collection carrying several DARs, so the progress-report history renders. */
+const multiDarCollection = (): DarCollection => {
+  const base = darCollection.dars[darId]
+  return {
+    ...darCollection,
+    dars: {
+      [darId]: base,
+      'second-ref': { ...base, id: 1765, referenceId: 'second-ref' },
+      'third-ref': { ...base, id: 1766, referenceId: 'third-ref' },
+    },
+  } as unknown as DarCollection
+}
+
+/** userEvent.upload cannot express "no file", so clearing goes through a change event. */
+const clearFileInput = async (id: string) => {
+  fireEvent.change(document.getElementById(id)!, { target: { files: [] } })
+  await waitFor(() => expect(document.getElementById(id)).toBeInTheDocument())
+}
+
+const clickDialogNo = () => userEvent.click(screen.getByRole('button', { name: 'No' }))
+
+const clickDialogYes = () => userEvent.click(document.getElementById('btn_submit')!)
+
+/** Fills every required field, so only the case under test can fail validation. */
+const completeTheForm = async () => {
+  await selectOptionByLabel('piCountryOfOperation', 'United States')
+  await selectOptionByLabel('signingOfficial', 'SO 1')
+  await typeById('itDirector', 'Some IT Director')
+  await typeById('itDirectorEmail', 'it@good.org')
+  await clickById('anvilUse_yes')
+  await typeById('projectTitle', 'Title')
+  await typeById('rus', 'asdf')
+  await typeById('nonTechRus', 'asdf asdf')
+  await fillDarDataUseCheckboxes()
+}
+
+const selectedTabName = (): string =>
+  screen.getAllByRole('tab').find(tab => tab.getAttribute('aria-selected') === 'true')?.textContent ?? ''
+
+const docDatasets = [
+  {
+    datasetId: 123456,
+    datasetIdentifier: 'DUOS-123456',
+    name: 'Some Dataset',
+    dacId: 1,
+    dataUse: { ethicsApprovalRequired: true, collaboratorRequired: true },
+  },
+] as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>
+
+const uploadTo = async (id: string, fileName: string) => {
+  const input = await waitFor(() => {
+    const found = document.getElementById(id)
+    expect(found).not.toBeNull()
+    return found as HTMLInputElement
+  })
+  await userEvent.upload(input, new File(['x'], fileName, { type: 'application/pdf' }))
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  setupTestEnvironment()
+  mockServices()
+})
+
+describe('DataAccessRequestApplication', () => {
   it('shows spinner when submitting', async () => {
-    // Mocks
-    vi.mocked(Countries.getCountries).mockResolvedValue(['United States of America (the)', 'Canada'])
-    vi.mocked(Storage.getCurrentUser).mockReturnValue(user as ReturnType<typeof Storage.getCurrentUser>)
-    vi.mocked(User.getMe).mockResolvedValue(user as Awaited<ReturnType<typeof User.getMe>>)
-    vi.mocked(User.getSOsForCurrentUser).mockResolvedValue(userSigningOfficials as Awaited<ReturnType<typeof User.getSOsForCurrentUser>>)
-    vi.mocked(Collections.getCollectionById).mockResolvedValue(darCollection)
-    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(datasets as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>)
-    vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(undefined)
-    vi.mocked(DAR.getPartialDarRequest).mockResolvedValue(
-      darCollection.dars[darId],
-    )
-    vi.mocked(DAA.getDaas).mockResolvedValue([
-      {
-        daaId: 100,
-        createUserId: 1,
-        createDate: '1',
-        updateUserId: 1,
-        updateDate: '1',
-        initialDacId: 1,
-        dacs: [{ dacId: 1, dacName: 'Test DAC', email: 'dac@test.com' }],
-        file: { fileStorageObjectId: 1, entityId: '1', fileName: 'TestDAA.pdf', category: 'dataAccessAgreement', mediaType: 'application/pdf', createUserId: 1, createDate: 1 },
-      },
-    ] as Awaited<ReturnType<typeof DAA.getDaas>>)
-    vi.mocked(Metrics.captureEvent).mockResolvedValue(undefined)
+    // Both writes hang until released, so the spinner can be asserted mid-flight.
+    let resolveSave: (value: { referenceId: string }) => void = () => {}
+    vi.mocked(DAR.updateDarDraft).mockReturnValue(new Promise((resolve) => {
+      resolveSave = resolve as (value: { referenceId: string }) => void
+    }) as ReturnType<typeof DAR.updateDarDraft>)
+    let resolveSubmit: (value: never) => void = () => {}
+    vi.mocked(DAR.postDar).mockReturnValue(new Promise((resolve) => {
+      resolveSubmit = resolve as (value: never) => void
+    }) as ReturnType<typeof DAR.postDar>)
 
-    // Make updateDarDraft hang until we resolve it so we can assert the spinner during save
-    let resolveSave: (value: { referenceId: string }) => void
-    const savePromise = new Promise<{ referenceId: string }>((resolve) => {
-      resolveSave = resolve
-    })
-    vi.mocked(DAR.updateDarDraft).mockImplementation(async () => {
-      return savePromise as unknown as ReturnType<typeof DAR.updateDarDraft> extends Promise<infer T> ? T : never
-    })
-    vi.mocked(DAR.uploadDARDocument).mockResolvedValue({ data: null })
-    vi.mocked(DAR.postDarDraft).mockResolvedValue({ referenceId: 'ref-123' } as Awaited<ReturnType<typeof DAR.postDarDraft>>)
-
-    // Mock DAR submission to hang so we can see the spinner
-    let resolveSubmit: (value: unknown) => void
-    const submitPromise = new Promise((resolve) => {
-      resolveSubmit = resolve
-    })
-    vi.mocked(DAR.postDar).mockImplementation(async () => {
-      return submitPromise as unknown as ReturnType<typeof DAR.postDar> extends Promise<infer T> ? T : never
-    })
-
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={[`/dar_application/${darId}`]}>
-          <Routes>
-            <Route
-              path="/dar_application/:dataRequestId"
-              element={(
-                <DataAccessRequestApplication
-                  draftDar={true}
-                  isProgressReportApplication={false}
-                  existingDarsReadOnlyMode={false}
-                />
-              )}
-            />
-          </Routes>
-        </MemoryRouter>,
-      )
-    })
-
-    // Wait for data to load
+    await renderDraft()
     expect(screen.getByText('Data Access Request Application')).toBeInTheDocument()
+    await completeTheForm()
 
-    // Fill out required fields
-    await selectOptionByLabel('piCountryOfOperation', 'United States')
-    await selectOptionByLabel('signingOfficial', 'SO 1')
-    await typeById('itDirector', 'Some IT Director')
-    await typeById('itDirectorEmail', 'it@good.org')
-    await clickById('anvilUse_yes')
-    await typeById('projectTitle', 'Title')
-    await typeById('rus', 'asdf')
-    await typeById('nonTechRus', 'asdf asdf')
-    await fillDarDataUseCheckboxes()
-
-    // Click "Save" to save the draft and assert spinner shows while saving
     await clickById('btn_saveDar')
     expect(screen.getByText('Save changes?')).toBeInTheDocument()
-    await act(async () => {
-      fireEvent.click(document.getElementById('btn_submit')!)
-    })
+    await clickDialogYes()
 
-    // Spinner should be visible while save is in progress
     await waitFor(() => {
       expect(document.getElementById('btn_submit')).toHaveAttribute('aria-busy', 'true')
     })
-
-    // Verify that updateDarDraft was called and then resolve the save
     expect(DAR.updateDarDraft).toHaveBeenCalled()
     await act(async () => {
       resolveSave({ referenceId: 'ref-123' })
@@ -241,112 +307,40 @@ describe('DataAccessRequestApplication', () => {
 
     // The Addendum tab is not shown until the user attests.
     expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
-
-    // Click "Attest"
     await clickById('btn_attest')
-
-    // Attesting reveals the Addendum tab.
     expect(screen.getByRole('tab', { name: /Addendum/i })).toBeInTheDocument()
 
-    // Now on Addendum tab, click "Submit"
     await clickById('btn_openSubmitModal')
-
-    // The dialog should be open.
     expect(screen.getByText('Submit Data Access Request?')).toBeInTheDocument()
+    await clickDialogYes()
 
-    // Click "Yes" in the dialog
-    await act(async () => {
-      fireEvent.click(document.getElementById('btn_submit')!)
-    })
-
-    // Now verify the spinner is visible for submit.
     await waitFor(() => {
       expect(document.getElementById('btn_submit')).toHaveAttribute('aria-busy', 'true')
     })
-
-    // Verify that postDar was called
     expect(DAR.postDar).toHaveBeenCalled()
     const submittedDar = vi.mocked(DAR.postDar).mock.calls[0][0] as { daaIds: number[] }
     expect(submittedDar.daaIds).toEqual([100])
     await act(async () => {
-      resolveSubmit({})
+      resolveSubmit({} as never)
     })
   })
 
   const renderAndSaveDraft = async () => {
-    vi.mocked(Countries.getCountries).mockResolvedValue(['United States of America (the)', 'Canada'])
-    vi.mocked(Storage.getCurrentUser).mockReturnValue(user as ReturnType<typeof Storage.getCurrentUser>)
-    vi.mocked(User.getMe).mockResolvedValue(user as Awaited<ReturnType<typeof User.getMe>>)
-    vi.mocked(User.getSOsForCurrentUser).mockResolvedValue(userSigningOfficials as Awaited<ReturnType<typeof User.getSOsForCurrentUser>>)
-    vi.mocked(Collections.getCollectionById).mockResolvedValue(darCollection)
-    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(datasets as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>)
-    vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(undefined)
-    vi.mocked(DAR.getPartialDarRequest).mockResolvedValue(darCollection.dars[darId])
-    vi.mocked(DAA.getDaas).mockResolvedValue([
-      {
-        daaId: 100,
-        createUserId: 1,
-        createDate: '1',
-        updateUserId: 1,
-        updateDate: '1',
-        initialDacId: 1,
-        dacs: [{ dacId: 1, dacName: 'Test DAC', email: 'dac@test.com' }],
-        file: { fileStorageObjectId: 1, entityId: '1', fileName: 'TestDAA.pdf', category: 'dataAccessAgreement', mediaType: 'application/pdf', createUserId: 1, createDate: 1 },
-      },
-    ] as Awaited<ReturnType<typeof DAA.getDaas>>)
-    vi.mocked(Metrics.captureEvent).mockResolvedValue(undefined)
-    vi.mocked(DAR.uploadDARDocument).mockResolvedValue({ data: null })
-
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={[`/dar_application/${darId}`]}>
-          <Routes>
-            <Route
-              path="/dar_application/:dataRequestId"
-              element={(
-                <DataAccessRequestApplication
-                  draftDar={true}
-                  isProgressReportApplication={false}
-                  existingDarsReadOnlyMode={false}
-                />
-              )}
-            />
-          </Routes>
-        </MemoryRouter>,
-      )
-    })
-
-    expect(screen.getByText('Data Access Request Application')).toBeInTheDocument()
-
-    await selectOptionByLabel('piCountryOfOperation', 'United States')
-    await selectOptionByLabel('signingOfficial', 'SO 1')
-    await typeById('itDirector', 'Some IT Director')
-    await typeById('itDirectorEmail', 'it@good.org')
-    await clickById('anvilUse_yes')
-    await typeById('projectTitle', 'Title')
-    await typeById('rus', 'asdf')
-    await typeById('nonTechRus', 'asdf asdf')
-    await fillDarDataUseCheckboxes()
-
+    await renderDraft()
+    await completeTheForm()
     await clickById('btn_saveDar')
     expect(screen.getByText('Save changes?')).toBeInTheDocument()
-    await act(async () => {
-      fireEvent.click(document.getElementById('btn_submit')!)
-    })
+    await clickDialogYes()
   }
 
   it('surfaces the server validation message when saving a draft fails with a validation error', async () => {
-    const validationError = Object.assign(new Error('File name is invalid'), {
+    vi.mocked(DAR.updateDarDraft).mockRejectedValue(Object.assign(new Error('File name is invalid'), {
       response: { data: { code: 400, message: 'File name is invalid' } },
-    })
-    vi.mocked(DAR.updateDarDraft).mockRejectedValue(validationError)
+    }))
 
     await renderAndSaveDraft()
 
-    await waitFor(() => {
-      expect(Notifications.showError).toHaveBeenCalled()
-    })
-
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
     const call = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: React.ReactElement<{ children: string }> }
     expect(call.text.props.children).toBe('File name is invalid')
   })
@@ -356,97 +350,30 @@ describe('DataAccessRequestApplication', () => {
 
     await renderAndSaveDraft()
 
-    await waitFor(() => {
-      expect(Notifications.showError).toHaveBeenCalled()
-    })
-
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
     const call = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: string }
     expect(call.text).toBe('Error saving Data Access Request. Please try again in a few moments.')
   })
 
   it('loads dataset/DAA snapshots in submitted read-only DAR review container', async () => {
-    vi.mocked(Countries.getCountries).mockResolvedValue(['United States of America (the)', 'Canada'])
-    vi.mocked(Storage.getCurrentUser).mockReturnValue(user as ReturnType<typeof Storage.getCurrentUser>)
-    vi.mocked(Collections.getCollectionById).mockResolvedValue(darCollection)
     vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue([
-      {
-        datasetId: 2352,
-        datasetIdentifier: 'DUOS-READONLY-2352',
-        name: 'Read-only Dataset',
-        dacId: 1,
-        dataUse: {},
-      },
+      { datasetId: 2352, datasetIdentifier: 'DUOS-READONLY-2352', name: 'Read-only Dataset', dacId: 1, dataUse: {} },
     ] as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>)
-    vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(undefined)
-    vi.mocked(DAR.getPartialDarRequest).mockResolvedValue(
-      darCollection.dars[darId],
-    )
     vi.mocked(DAR.getDatasetDaaSnapshots).mockResolvedValue([
-      {
-        datasetId: 2352,
-        daaId: 100,
-        daaFileName: 'ReadonlyDAA.pdf',
-      },
+      { datasetId: 2352, daaId: 100, daaFileName: 'ReadonlyDAA.pdf' },
     ] as Awaited<ReturnType<typeof DAR.getDatasetDaaSnapshots>>)
 
-    await act(async () => {
-      render(
-        <MemoryRouter initialEntries={['/dar_application_review/211']}>
-          <Routes>
-            <Route
-              path="/dar_application_review/:collectionId"
-              element={(
-                <DataAccessRequestApplication
-                  draftDar={false}
-                  isProgressReportApplication={false}
-                  existingDarsReadOnlyMode={true}
-                />
-              )}
-            />
-          </Routes>
-        </MemoryRouter>,
-      )
-    })
+    await renderReview()
 
     expect(document.querySelector('.dar-summary')).not.toBeNull()
     expect(DAR.getDatasetDaaSnapshots).toHaveBeenCalledWith(darId)
   })
 
-  const renderReadOnly = async (embedded?: boolean) => {
-    vi.mocked(Countries.getCountries).mockResolvedValue(['United States of America (the)'])
-    vi.mocked(Storage.getCurrentUser).mockReturnValue(user as ReturnType<typeof Storage.getCurrentUser>)
-    vi.mocked(Collections.getCollectionById).mockResolvedValue(darCollection)
-    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(datasets as Awaited<ReturnType<typeof DataSet.getDatasetsByIds>>)
-    vi.mocked(NotificationService.getBannerObjectById).mockResolvedValue(undefined)
-    vi.mocked(DAR.getPartialDarRequest).mockResolvedValue(darCollection.dars[darId])
-    vi.mocked(DAR.getDatasetDaaSnapshots).mockResolvedValue([] as Awaited<ReturnType<typeof DAR.getDatasetDaaSnapshots>>)
-
-    render(
-      <MemoryRouter initialEntries={['/dar_application_review/211']}>
-        <Routes>
-          <Route
-            path="/dar_application_review/:collectionId"
-            element={(
-              <DataAccessRequestApplication
-                draftDar={false}
-                isProgressReportApplication={false}
-                existingDarsReadOnlyMode={true}
-                embedded={embedded}
-              />
-            )}
-          />
-        </Routes>
-      </MemoryRouter>,
-    )
-    // The page shows a spinner until the collection resolves; the step tabs mark it loaded.
-    await screen.findAllByRole('tab')
-  }
-
   // PageHeading suffixes the id it is given.
   const pageHeading = () => document.getElementById('dar-application-heading_heading')
 
   it('keeps its own heading, side panel and voting history on the standalone read-only route', async () => {
-    await renderReadOnly()
+    await renderReview()
 
     expect(pageHeading()).toBeInTheDocument()
     expect(document.querySelector('.multi-step-buttons-container')).toBeInTheDocument()
@@ -454,7 +381,7 @@ describe('DataAccessRequestApplication', () => {
   })
 
   it('labels every step section by the tab that scrolls to it', async () => {
-    await renderReadOnly()
+    await renderReview()
 
     const tabs = screen.getAllByRole('tab')
     expect(tabs.length).toBeGreaterThan(1)
@@ -466,11 +393,402 @@ describe('DataAccessRequestApplication', () => {
   })
 
   it('drops the heading, stacks the step tabs and defers voting history when embedded in the Full DAR tab', async () => {
-    await renderReadOnly(true)
+    await renderReview({ embedded: true })
 
     expect(pageHeading()).not.toBeInTheDocument()
     expect(document.querySelector('.step-tabs-container--horizontal')).toBeInTheDocument()
     expect(document.querySelector('.multi-step-buttons-container')).not.toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: 'Voting History' })).not.toBeInTheDocument()
+  })
+})
+
+describe('DataAccessRequestApplication - page modes', () => {
+  it('titles the page Progress Report when building one', async () => {
+    await renderReview({ isProgressReportApplication: true })
+
+    expect(document.title).toContain('Progress Report')
+    expect(screen.getByRole('tab', { name: /Progress Report/ })).toBeInTheDocument()
+  })
+
+  it('titles the page DAR Application Review in read-only mode', async () => {
+    await renderReview()
+
+    expect(document.title).toContain('DAR Application Review')
+  })
+
+  it('widens the heading when the DAR has no code yet', async () => {
+    mockServices({ partialDar: { ...darCollection.dars[darId], darCode: null } })
+
+    await renderDraft()
+
+    expect(document.getElementById('dar-application-heading_heading')?.closest('.col-sm-12')).not.toBeNull()
+  })
+
+  it('lists each previous progress report alongside the current DAR', async () => {
+    mockServices({ collection: multiDarCollection() })
+
+    await renderReview()
+
+    expect(screen.getByText('Previous Updates')).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Progress Report 1' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Progress Report 2' })).toBeInTheDocument()
+  })
+
+  it('navigates back when the Back button is used', async () => {
+    await renderDraft()
+
+    await userEvent.click(document.getElementById('btn_back')!)
+
+    expect(screen.getByText('Data Access Request Application')).toBeInTheDocument()
+  })
+
+  it('warns when the researcher cannot be loaded', async () => {
+    vi.mocked(User.getMe).mockRejectedValue(new Error('user service down'))
+
+    await renderDraft()
+
+    expect(Notifications.showError).toHaveBeenCalledWith({
+      text: 'Error displaying user information. Please try again in a few moments.',
+    })
+  })
+
+  it('starts from an empty form when there is no DAR id and nothing stored', async () => {
+    await renderNewDar()
+
+    expect(Storage.removeData).toHaveBeenCalledWith('dar_application')
+    expect(DAR.getPartialDarRequest).not.toHaveBeenCalled()
+  })
+})
+
+// The addendum's Save button shares btn_save with the dialog's No, so this matches on the label.
+describe('DataAccessRequestApplication - dialogs and attestation', () => {
+  it('closes the save dialog without saving when the user declines', async () => {
+    await renderDraft()
+    await completeTheForm()
+
+    await clickById('btn_saveDar')
+    expect(screen.getByText('Save changes?')).toBeInTheDocument()
+
+    await clickDialogNo()
+
+    expect(DAR.updateDarDraft).not.toHaveBeenCalled()
+    expect(screen.queryByText('Save changes?')).not.toBeInTheDocument()
+  })
+
+  it('closes the submit dialog without submitting when the user declines', async () => {
+    await renderDraft()
+    await completeTheForm()
+
+    await clickById('btn_attest')
+    await clickById('btn_openSubmitModal')
+    expect(screen.getByText('Submit Data Access Request?')).toBeInTheDocument()
+
+    await clickDialogNo()
+
+    expect(DAR.postDar).not.toHaveBeenCalled()
+    expect(screen.queryByText('Submit Data Access Request?')).not.toBeInTheDocument()
+  })
+
+  it('sends the user to Researcher Information when their details are incomplete', async () => {
+    await renderDraft()
+
+    await clickById('btn_attest')
+
+    expect(selectedTabName()).toContain('Researcher Information')
+    expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
+  })
+
+  it('sends the user to the Research Purpose Statement when only that section fails', async () => {
+    await renderDraft()
+    await completeTheForm()
+    // A single-gender study with no gender chosen is a RUS error and nothing else.
+    await clickById('oneGender_yes')
+
+    await clickById('btn_attest')
+
+    expect(selectedTabName()).toContain('Research Purpose Statement')
+  })
+
+  it('does not open the submit dialog while the form is still invalid', async () => {
+    await renderDraft()
+    await completeTheForm()
+    await clickById('btn_attest')
+    await typeById('projectTitle', '')
+
+    await clickById('btn_openSubmitModal')
+
+    expect(screen.queryByText('Submit Data Access Request?')).not.toBeInTheDocument()
+  })
+
+  it('drops the addendum tab when the user cancels their attestation', async () => {
+    await renderDraft()
+    await completeTheForm()
+
+    await clickById('btn_attest')
+    expect(screen.getByRole('tab', { name: /Addendum/i })).toBeInTheDocument()
+
+    await clickById('btn_cancelAttest')
+
+    expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
+  })
+
+  it('opens the save dialog from the addendum tab', async () => {
+    await renderDraft()
+    await completeTheForm()
+    await clickById('btn_attest')
+
+    await clickById('btn_save')
+
+    expect(screen.getByText('Save changes?')).toBeInTheDocument()
+  })
+})
+
+describe('DataAccessRequestApplication - submission failures', () => {
+  const attestAndSubmit = async () => {
+    await renderDraft()
+    await completeTheForm()
+    await clickById('btn_attest')
+    await clickById('btn_openSubmitModal')
+    await clickDialogYes()
+  }
+
+  it('reopens the form for editing when the server rejects the DAR as invalid', async () => {
+    vi.mocked(DAR.postDar).mockRejectedValue({ response: { status: 400 } })
+
+    await attestAndSubmit()
+
+    expect(document.getElementById('btn_openSubmitModal')).not.toBeInTheDocument()
+  })
+
+  it('surfaces the server message when submission fails with one', async () => {
+    vi.mocked(DAR.postDar).mockRejectedValue({
+      response: { status: 500, data: { code: 500, message: 'Datasets are no longer available' } },
+    })
+
+    await attestAndSubmit()
+
+    const call = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: React.ReactElement<{ children: string }> }
+    expect(call.text.props.children).toBe('Datasets are no longer available')
+  })
+
+  it('falls back to the generic submit-failure toast', async () => {
+    vi.mocked(DAR.postDar).mockRejectedValue(new Error('network exploded'))
+
+    await attestAndSubmit()
+
+    const call = vi.mocked(Notifications.showError).mock.calls[0][0] as { text: string }
+    expect(call.text).toBe('Error saving Data Access Request. Please try again in a few moments.')
+  })
+})
+
+describe('DataAccessRequestApplication - supporting documents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupTestEnvironment()
+    mockServices()
+    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(docDatasets)
+  })
+
+  it('uploads the IRB approval and collaboration letter alongside a saved draft', async () => {
+    vi.mocked(DAR.uploadDARDocument).mockResolvedValue({ data: null })
+
+    await renderDraft()
+    await uploadTo('irbDocument', 'irb.pdf')
+    await uploadTo('collaborationLetter', 'collab.pdf')
+    await completeTheForm()
+
+    await clickById('btn_saveDar')
+    await clickDialogYes()
+
+    expect(DAR.uploadDARDocument).toHaveBeenCalledWith(expect.any(File), 'ref-123', 'irbDocument')
+    expect(DAR.uploadDARDocument).toHaveBeenCalledWith(expect.any(File), 'ref-123', 'collaborationDocument')
+  })
+
+  it('uploads the documents again when the DAR is submitted', async () => {
+    await renderDraft()
+    await uploadTo('irbDocument', 'irb.pdf')
+    await uploadTo('collaborationLetter', 'collab.pdf')
+    await completeTheForm()
+
+    await clickById('btn_attest')
+    await clickById('btn_openSubmitModal')
+    await clickDialogYes()
+
+    expect(DAR.uploadDARDocument).toHaveBeenCalledWith(expect.any(File), expect.any(String), 'irbDocument')
+    expect(DAR.postDar).toHaveBeenCalled()
+  })
+
+  it('clears the previously stored document names when new files replace them', async () => {
+    await renderDraft()
+    await uploadTo('irbDocument', 'replacement.pdf')
+    await uploadTo('collaborationLetter', 'replacement-collab.pdf')
+    await completeTheForm()
+
+    await clickById('btn_saveDar')
+    await clickDialogYes()
+
+    const saved = vi.mocked(DAR.updateDarDraft).mock.calls[0][0] as Record<string, unknown>
+    expect(saved.irbDocumentName).toBe('')
+    expect(saved.collaborationLetterName).toBe('')
+  })
+})
+
+describe('DataAccessRequestApplication - draft creation', () => {
+  it('posts a new draft and routes to it when the DAR has no reference id yet', async () => {
+    vi.mocked(Storage.getData).mockReturnValue({ datasetIds: [123456] } as ReturnType<typeof Storage.getData>)
+
+    await renderNewDar()
+    await completeTheForm()
+
+    await clickById('btn_saveDar')
+    await clickDialogYes()
+
+    expect(DAR.postDarDraft).toHaveBeenCalled()
+    expect(DAR.updateDarDraft).not.toHaveBeenCalled()
+  })
+
+  it('treats a collection with no DARs as an empty form', async () => {
+    mockServices({ collection: { ...darCollection, dars: undefined } as unknown as DarCollection })
+
+    await renderReview()
+
+    expect(DAR.getPartialDarRequest).not.toHaveBeenCalled()
+    expect(screen.queryByText('Previous Updates')).not.toBeInTheDocument()
+  })
+
+  it('copes with a DAR that carries no dataset or agreement ids', async () => {
+    mockServices({ partialDar: { referenceId: darId, darCode: 'DAR-1', datasetIds: undefined, daaIds: undefined } })
+
+    await renderDraft()
+    await completeTheForm()
+
+    await clickById('btn_saveDar')
+    await clickDialogYes()
+
+    const saved = vi.mocked(DAR.updateDarDraft).mock.calls[0][0] as { daaIds: number[] }
+    expect(saved.daaIds).toEqual([])
+  })
+})
+
+describe('DataAccessRequestApplication - unmounting mid-flight', () => {
+  const renderThenUnmount = async (settle: () => void) => {
+    const { unmount } = render(
+      <MemoryRouter initialEntries={[`/dar_application/${darId}`]}>
+        <Routes>
+          <Route
+            path="/dar_application/:dataRequestId"
+            element={<DataAccessRequestApplication draftDar={true} isProgressReportApplication={false} />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    unmount()
+    await act(async () => {
+      settle()
+      await Promise.resolve()
+    })
+  }
+
+  // Every fetch below is fire-and-forget, so a late resolution must not write to a gone component.
+  it('drops a late user response', async () => {
+    let resolveMe: (value: never) => void = () => {}
+    vi.mocked(User.getMe).mockReturnValue(new Promise((resolve) => {
+      resolveMe = resolve as (value: never) => void
+    }))
+
+    await renderThenUnmount(() => resolveMe(user as never))
+
+    expect(Notifications.showError).not.toHaveBeenCalled()
+  })
+
+  it('drops a late user failure', async () => {
+    let rejectMe: (reason: unknown) => void = () => {}
+    vi.mocked(User.getMe).mockReturnValue(new Promise((_resolve, reject) => {
+      rejectMe = reject
+    }))
+
+    await renderThenUnmount(() => rejectMe(new Error('too late')))
+
+    expect(Notifications.showError).not.toHaveBeenCalled()
+  })
+
+  it('drops a late banner, country and DAR response', async () => {
+    let resolveBanner: (value: never) => void = () => {}
+    let resolveCountries: (value: never) => void = () => {}
+    let resolveDar: (value: never) => void = () => {}
+    vi.mocked(NotificationService.getBannerObjectById).mockReturnValue(new Promise((resolve) => {
+      resolveBanner = resolve as (value: never) => void
+    }))
+    vi.mocked(Countries.getCountries).mockReturnValue(new Promise((resolve) => {
+      resolveCountries = resolve as (value: never) => void
+    }))
+    vi.mocked(DAR.getPartialDarRequest).mockReturnValue(new Promise((resolve) => {
+      resolveDar = resolve as (value: never) => void
+    }))
+
+    await renderThenUnmount(() => {
+      resolveBanner({ id: 'eRACommonsOutage', active: true, message: 'late', level: 'info' } as never)
+      resolveCountries(['Canada'] as never)
+      resolveDar(darCollection.dars[darId] as never)
+    })
+
+    expect(screen.queryByText('late')).not.toBeInTheDocument()
+  })
+})
+
+describe('DataAccessRequestApplication - review-mode edge cases', () => {
+  it('renders a review whose collection names no creating user', async () => {
+    mockServices({ collection: { ...darCollection, createUser: undefined } as unknown as DarCollection })
+
+    await renderReview()
+
+    expect(document.querySelector('.dar-summary')).not.toBeNull()
+  })
+
+  it('drops a late collection response after the review unmounts', async () => {
+    let resolveCollection: (value: never) => void = () => {}
+    vi.mocked(Collections.getCollectionById).mockReturnValue(new Promise((resolve) => {
+      resolveCollection = resolve as (value: never) => void
+    }))
+
+    const { unmount } = render(
+      <MemoryRouter initialEntries={['/dar_application_review/211']}>
+        <Routes>
+          <Route
+            path="/dar_application_review/:collectionId"
+            element={(
+              <DataAccessRequestApplication
+                draftDar={false}
+                isProgressReportApplication={false}
+                existingDarsReadOnlyMode={true}
+              />
+            )}
+          />
+        </Routes>
+      </MemoryRouter>,
+    )
+    unmount()
+    await act(async () => {
+      resolveCollection(darCollection as never)
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+  })
+
+  it('clears an uploaded document when the file picker is emptied', async () => {
+    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(docDatasets)
+
+    await renderDraft()
+    await uploadTo('irbDocument', 'irb.pdf')
+
+    await clearFileInput('irbDocument')
+    await clearFileInput('collaborationLetter')
+    await completeTheForm()
+
+    await clickById('btn_saveDar')
+    await clickDialogYes()
+
+    expect(DAR.uploadDARDocument).not.toHaveBeenCalled()
   })
 })

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -229,12 +229,12 @@ const multiDarCollection = (): DarCollection => {
 /** userEvent.upload cannot express "no file", so clearing goes through a change event. */
 const clearFileInput = async (id: string) => {
   fireEvent.change(document.getElementById(id)!, { target: { files: [] } })
-  await waitFor(() => expect(document.getElementById(id)).toBeInTheDocument())
+  await waitFor(() => expect((document.getElementById(id) as HTMLInputElement).files).toHaveLength(0))
 }
 
 const clickDialogNo = () => userEvent.click(screen.getByRole('button', { name: 'No' }))
 
-const clickDialogYes = () => userEvent.click(document.getElementById('btn_submit')!)
+const clickDialogYes = () => userEvent.click(screen.getByRole('button', { name: 'Yes' }))
 
 /** Fills every required field, so only the case under test can fail validation. */
 const completeTheForm = async () => {
@@ -248,6 +248,9 @@ const completeTheForm = async () => {
   await typeById('nonTechRus', 'asdf asdf')
   await fillDarDataUseCheckboxes()
 }
+
+// PageHeading suffixes the id it is given.
+const pageHeading = () => document.getElementById('dar-application-heading_heading')
 
 const selectedTabName = (): string =>
   screen.getAllByRole('tab').find(tab => tab.getAttribute('aria-selected') === 'true')?.textContent ?? ''
@@ -298,7 +301,7 @@ describe('DataAccessRequestApplication', () => {
     await clickDialogYes()
 
     await waitFor(() => {
-      expect(document.getElementById('btn_submit')).toHaveAttribute('aria-busy', 'true')
+      expect(screen.getByRole('button', { name: 'Yes' })).toHaveAttribute('aria-busy', 'true')
     })
     expect(DAR.updateDarDraft).toHaveBeenCalled()
     await act(async () => {
@@ -315,7 +318,7 @@ describe('DataAccessRequestApplication', () => {
     await clickDialogYes()
 
     await waitFor(() => {
-      expect(document.getElementById('btn_submit')).toHaveAttribute('aria-busy', 'true')
+      expect(screen.getByRole('button', { name: 'Yes' })).toHaveAttribute('aria-busy', 'true')
     })
     expect(DAR.postDar).toHaveBeenCalled()
     const submittedDar = vi.mocked(DAR.postDar).mock.calls[0][0] as { daaIds: number[] }
@@ -365,12 +368,10 @@ describe('DataAccessRequestApplication', () => {
 
     await renderReview()
 
-    expect(document.querySelector('.dar-summary')).not.toBeNull()
+    expect(document.querySelector('.dar-summary')).toBeInTheDocument()
     expect(DAR.getDatasetDaaSnapshots).toHaveBeenCalledWith(darId)
+    expect(await screen.findByText(/Read-only Dataset/)).toBeInTheDocument()
   })
-
-  // PageHeading suffixes the id it is given.
-  const pageHeading = () => document.getElementById('dar-application-heading_heading')
 
   it('keeps its own heading, side panel and voting history on the standalone read-only route', async () => {
     await renderReview()
@@ -416,12 +417,18 @@ describe('DataAccessRequestApplication - page modes', () => {
     expect(document.title).toContain('DAR Application Review')
   })
 
+  it('narrows the heading once the DAR has a code', async () => {
+    await renderDraft()
+
+    expect(pageHeading()!.parentElement).toHaveClass('col-sm-9')
+  })
+
   it('widens the heading when the DAR has no code yet', async () => {
     mockServices({ partialDar: { ...darCollection.dars[darId], darCode: null } })
 
     await renderDraft()
 
-    expect(document.getElementById('dar-application-heading_heading')?.closest('.col-sm-12')).not.toBeNull()
+    expect(pageHeading()!.parentElement).toHaveClass('col-sm-12')
   })
 
   it('lists each previous progress report alongside the current DAR', async () => {
@@ -448,7 +455,7 @@ describe('DataAccessRequestApplication - page modes', () => {
     )
     await screen.findAllByRole('tab')
 
-    await userEvent.click(document.getElementById('btn_back')!)
+    await userEvent.click(screen.getByRole('button', { name: /Back/ }))
 
     expect(await screen.findByText('Where we came from')).toBeInTheDocument()
   })
@@ -502,6 +509,9 @@ describe('DataAccessRequestApplication - dialogs and attestation', () => {
 
   it('sends the user to Researcher Information when their details are incomplete', async () => {
     await renderDraft()
+    // Tab 1 is selected by default, so the redirect is only observable from elsewhere.
+    await userEvent.click(screen.getByRole('tab', { name: /Research Purpose Statement/ }))
+    expect(selectedTabName()).toContain('Research Purpose Statement')
 
     await clickById('btn_attest')
 
@@ -570,7 +580,7 @@ describe('DataAccessRequestApplication - submission failures', () => {
 
     await attestAndSubmit()
 
-    expect(document.getElementById('btn_openSubmitModal')).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
     expect(selectedTabName()).toContain('Data Access Agreements')
   })
@@ -699,79 +709,13 @@ describe('DataAccessRequestApplication - draft creation', () => {
   })
 })
 
-describe('DataAccessRequestApplication - unmounting mid-flight', () => {
-  const renderThenUnmount = async (settle: () => void) => {
-    const { unmount } = render(
-      <MemoryRouter initialEntries={[`/dar_application/${darId}`]}>
-        <Routes>
-          <Route
-            path="/dar_application/:dataRequestId"
-            element={<DataAccessRequestApplication draftDar={true} isProgressReportApplication={false} />}
-          />
-        </Routes>
-      </MemoryRouter>,
-    )
-    unmount()
-    await act(async () => {
-      settle()
-      await Promise.resolve()
-    })
-  }
-
-  // Every fetch below is fire-and-forget, so a late resolution must not write to a gone component.
-  it('drops a late user response', async () => {
-    let resolveMe: (value: never) => void = () => {}
-    vi.mocked(User.getMe).mockReturnValue(new Promise((resolve) => {
-      resolveMe = resolve as (value: never) => void
-    }))
-
-    await renderThenUnmount(() => resolveMe(user as never))
-
-    expect(Notifications.showError).not.toHaveBeenCalled()
-  })
-
-  it('drops a late user failure', async () => {
-    let rejectMe: (reason: unknown) => void = () => {}
-    vi.mocked(User.getMe).mockReturnValue(new Promise((_resolve, reject) => {
-      rejectMe = reject
-    }))
-
-    await renderThenUnmount(() => rejectMe(new Error('too late')))
-
-    expect(Notifications.showError).not.toHaveBeenCalled()
-  })
-
-  it('drops a late banner, country and DAR response', async () => {
-    let resolveBanner: (value: never) => void = () => {}
-    let resolveCountries: (value: never) => void = () => {}
-    let resolveDar: (value: never) => void = () => {}
-    vi.mocked(NotificationService.getBannerObjectById).mockReturnValue(new Promise((resolve) => {
-      resolveBanner = resolve as (value: never) => void
-    }))
-    vi.mocked(Countries.getCountries).mockReturnValue(new Promise((resolve) => {
-      resolveCountries = resolve as (value: never) => void
-    }))
-    vi.mocked(DAR.getPartialDarRequest).mockReturnValue(new Promise((resolve) => {
-      resolveDar = resolve as (value: never) => void
-    }))
-
-    await renderThenUnmount(() => {
-      resolveBanner({ id: 'eRACommonsOutage', active: true, message: 'late', level: 'info' } as never)
-      resolveCountries(['Canada'] as never)
-      resolveDar(darCollection.dars[darId] as never)
-    })
-
-    expect(screen.queryByText('late')).not.toBeInTheDocument()
-  })
-})
-
 describe('DataAccessRequestApplication - review-mode edge cases', () => {
   it('renders a review whose collection names no creating user', async () => {
     mockServices({ collection: { ...darCollection, createUser: undefined } as unknown as DarCollection })
 
     await renderReview()
 
-    expect(document.querySelector('.dar-summary')).not.toBeNull()
+    expect(document.querySelector('.dar-summary')).toBeInTheDocument()
   })
 
   it('drops a late collection response after the review unmounts', async () => {

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -634,6 +634,18 @@ describe('DataAccessRequestApplication - supporting documents', () => {
   })
 
   it('clears the previously stored document names when new files replace them', async () => {
+    // The DAR already carries documents, so the upload has something to clear.
+    mockServices({
+      partialDar: {
+        ...darCollection.dars[darId],
+        irbDocumentName: 'old-irb.pdf',
+        irbDocumentLocation: 'gs://bucket/old-irb.pdf',
+        collaborationLetterName: 'old-collab.pdf',
+        collaborationLetterLocation: 'gs://bucket/old-collab.pdf',
+      },
+    })
+    vi.mocked(DataSet.getDatasetsByIds).mockResolvedValue(docDatasets)
+
     await renderDraft()
     await uploadTo('irbDocument', 'replacement.pdf')
     await uploadTo('collaborationLetter', 'replacement-collab.pdf')
@@ -644,7 +656,9 @@ describe('DataAccessRequestApplication - supporting documents', () => {
 
     const saved = vi.mocked(DAR.updateDarDraft).mock.calls[0][0] as Record<string, unknown>
     expect(saved.irbDocumentName).toBe('')
+    expect(saved.irbDocumentLocation).toBe('')
     expect(saved.collaborationLetterName).toBe('')
+    expect(saved.collaborationLetterLocation).toBe('')
   })
 })
 

--- a/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
+++ b/test/pages/dar_application/DataAccessRequestApplication.spec.tsx
@@ -561,6 +561,8 @@ describe('DataAccessRequestApplication - submission failures', () => {
     await clickById('btn_attest')
     await clickById('btn_openSubmitModal')
     await clickDialogYes()
+    // The rejection resolves after the click, so every caller would otherwise race it.
+    await waitFor(() => expect(Notifications.showError).toHaveBeenCalled())
   }
 
   it('reopens the form for editing when the server rejects the DAR as invalid', async () => {
@@ -570,6 +572,7 @@ describe('DataAccessRequestApplication - submission failures', () => {
 
     expect(document.getElementById('btn_openSubmitModal')).not.toBeInTheDocument()
     expect(screen.queryByRole('tab', { name: /Addendum/i })).not.toBeInTheDocument()
+    expect(selectedTabName()).toContain('Data Access Agreements')
   })
 
   it('surfaces the server message when submission fails with one', async () => {

--- a/test/utils/darFormUtils.spec.ts
+++ b/test/utils/darFormUtils.spec.ts
@@ -7,6 +7,7 @@ import {
   needsDsAcknowledgement,
   newIrbDocumentExpirationDate,
   validationFailed,
+  normalizeDaaIds,
   computeCollaboratorErrors,
   calcPublicationErrors,
   calcPresentationErrors,
@@ -597,6 +598,24 @@ describe('darFormUtils - DAR Form Validation', () => {
       })
 
       expect(result.researcherInfoErrors.dataStorageAndAnalysis).toBeDefined()
+    })
+  })
+
+  describe('normalizeDaaIds', () => {
+    it('reads no ids when the form carries none', () => {
+      expect(normalizeDaaIds(undefined)).toEqual([])
+    })
+
+    it('keeps positive integer ids', () => {
+      expect(normalizeDaaIds([3, 1])).toEqual([3, 1])
+    })
+
+    it('drops an id repeated by more than one dataset', () => {
+      expect(normalizeDaaIds([2, 2, 5])).toEqual([2, 5])
+    })
+
+    it('drops ids that are not positive integers', () => {
+      expect(normalizeDaaIds([0, -1, 1.5, 4])).toEqual([4])
     })
   })
 })


### PR DESCRIPTION
### Addresses

https://broadworkbench.atlassian.net/browse/DT-4093

Security risk: **no** — tests, plus refactors that move existing logic without changing behaviour.

### Summary

Raises `DataAccessRequestApplication` from 86% to 99.4% coverage and clears its Sonar findings. Split out of #3922, where it was unrelated to the banner work.

Three spots were unreachable because of the source rather than the tests: `getErrorTabId`'s `rusErrors` branch, which its only caller had already ruled out; `attemptSubmit`'s non-draft dataset list, since the attest button is gated on `isDraft`; and the `daaIds` normalisation, triplicated across three call sites and now `normalizeDaaIds` in `darFormUtils`.

Cognitive complexity 19 → under Sonar's 15, by deciding the repeated layout conditionals once instead of per use. Spec duplication 7.9% → 0.

Also fixes a flake: the document upload inputs only render once the datasets resolve, so grabbing them straight after the tabs appeared lost the race on CI.

**Why not 100%:** the two uncovered lines are the `if (!isMountedRef.current) return` guards. React 19 makes a post-unmount `setState` a silent no-op, so those guards have no observable effect and any test for them passes whether or not the guard exists. The tests that reached 100% were doing exactly that and are gone; every remaining test was verified to fail when its behaviour is removed.

**Merge order:** #3922 touches ~12 lines of the same file, so whichever lands second needs a small rebase.

----
Have you read [Terra's Contributing Guide](https://github.com/DataBiosphere/terra-ui/wiki/Contributor-Guide) lately? If not, do that first.

- Label PR with a Jira ticket number and include a link to the ticket
- Label PR with a security risk modifier [no, low, medium, high]
- PR describes scope of changes
- Get a minimum of one thumbs worth of review, preferably two if enough team members are available
- Get PO sign-off for all non-trivial UI or workflow changes
- Verify all tests go green
- Test this change deployed correctly and works on dev environment after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

