### PR TITLE
[DT-3621] Update Voting History table styling to match the Data Library

### DIFF
--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react'
 import SimpleTable from '../SimpleTable'
 import { VoteHistoryRow } from 'src/types/model'
-import { Styles } from 'src/libs/theme'
 import { formatDate, sortVisibleTable } from 'src/libs/utils'
+import { voteHistoryTableStyles } from './voteHistoryTableStyles'
 
 interface ChairVoteHistoryTableProps {
   voteHistory: VoteHistoryRow[]
@@ -15,36 +15,7 @@ interface RowData {
   id: number | string
 }
 
-const styles = {
-  baseStyle: {
-    fontFamily: 'Montserrat',
-    fontSize: '1.4rem',
-    fontWeight: 400,
-    color: '#333F52',
-    backgroundColor: '#FFFFFF',
-    display: 'flex',
-    padding: '1rem 2%',
-    lineHeight: '2rem',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    whiteSpace: 'pre-line',
-  },
-  columnStyle: {
-    ...Styles.TABLE.HEADER_ROW,
-    ...{
-      fontFamily: 'Montserrat',
-      fontSize: '1.4rem',
-      color: '#333F52',
-      justifyContent: 'space-between',
-    },
-  },
-  containerOverride: {
-    marginTop: '0',
-    borderTop: '0',
-    backgroundColor: 'rgba(184, 205, 211, 0)',
-    padding: '0',
-  },
-}
+const styles = voteHistoryTableStyles
 
 const getVoteText = (vote: boolean | null | undefined) => {
   if (vote === true) return 'Yes'

--- a/src/components/vote_history_table/ChairVoteHistoryTable.tsx
+++ b/src/components/vote_history_table/ChairVoteHistoryTable.tsx
@@ -15,8 +15,6 @@ interface RowData {
   id: number | string
 }
 
-const styles = voteHistoryTableStyles
-
 const getVoteText = (vote: boolean | null | undefined) => {
   if (vote === true) return 'Yes'
   if (vote === false) return 'No'
@@ -74,7 +72,7 @@ const ChairVoteHistoryTable: React.FC<ChairVoteHistoryTableProps> = ({ voteHisto
     <SimpleTable
       columnHeaders={columnHeaderData()}
       rowData={sortedVotes}
-      styles={styles}
+      styles={voteHistoryTableStyles}
       sort={sort}
       onSort={setSort}
     />

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import SimpleTable, { type CellData } from '../SimpleTable'
-import { Styles } from 'src/libs/theme'
+import SimpleTable, { type CellData, type TableStyles } from '../SimpleTable'
 import { formatDate, sortVisibleTable } from 'src/libs/utils'
 import { ElectionWithMemberVotes, Vote } from 'src/types/model'
 import { ExpandMore, ExpandLess } from '@mui/icons-material'
 import VoteSummaryTable from '../vote_summary_table/VoteSummaryTable'
+import { voteHistoryTableStyles, voteHistoryBaseStyle, voteHistoryColumnStyle, voteHistoryContainerOverride } from './voteHistoryTableStyles'
 
 interface ElectionWithMemberVotesTableProps {
   electionsWithMemberVotes: ElectionWithMemberVotes[]
@@ -20,35 +20,14 @@ interface RowData {
   onClick?: () => void
 }
 
-const styles = {
-  baseStyle: {
-    fontFamily: 'Montserrat',
-    fontSize: '1.4rem',
-    fontWeight: 400,
-    color: '#333F52',
-    backgroundColor: '#FFFFFF',
-    display: 'flex',
-    padding: '1rem 2%',
-    lineHeight: '2rem',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    whiteSpace: 'pre-line',
-  },
-  columnStyle: {
-    ...Styles.TABLE.HEADER_ROW,
-    ...{
-      fontFamily: 'Montserrat',
-      fontSize: '1.4rem',
-      color: '#333F52',
-      justifyContent: 'space-between',
-    },
-  },
-  containerOverride: {
-    marginTop: '0',
-    borderTop: '0',
-    backgroundColor: 'rgba(184, 205, 211, 0)',
-    padding: '0',
-  },
+const styles = voteHistoryTableStyles
+
+// Styling for the nested member-vote summary table shown when a row is expanded, matching
+// the same Data-Library-like look as the parent table but at the summary table's smaller scale.
+const memberVoteSummaryStyles: TableStyles = {
+  baseStyle: { ...voteHistoryBaseStyle, fontSize: '1.25rem', padding: '0.5rem 1%', lineHeight: '1.6rem' },
+  columnStyle: { ...voteHistoryColumnStyle, fontSize: '1.2rem' },
+  containerOverride: voteHistoryContainerOverride,
 }
 
 const processVotesCast = (memberVotes: Vote[]) => {
@@ -157,6 +136,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
               isChair={false}
               isLoading={false}
               dacVotes={firstData.memberVotes || []}
+              styles={memberVoteSummaryStyles}
             />
           </div>
         </div>

--- a/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
+++ b/src/components/vote_history_table/ElectionWithMemberVotesTable.tsx
@@ -20,8 +20,6 @@ interface RowData {
   onClick?: () => void
 }
 
-const styles = voteHistoryTableStyles
-
 // Styling for the nested member-vote summary table shown when a row is expanded, matching
 // the same Data-Library-like look as the parent table but at the summary table's smaller scale.
 const memberVoteSummaryStyles: TableStyles = {
@@ -131,7 +129,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
       return (
         <div key={`expanded-${electionId}`}>
           {renderedRow}
-          <div style={{ width: '80%', margin: 'auto' }}>
+          <div style={{ width: '80%', margin: 'auto', padding: '0.5rem 0 1.5rem' }}>
             <VoteSummaryTable
               isChair={false}
               isLoading={false}
@@ -157,7 +155,7 @@ const ElectionWithMemberVotesTable: React.FC<ElectionWithMemberVotesTableProps> 
     <SimpleTable
       columnHeaders={columnHeaderData()}
       rowData={sortedElections}
-      styles={styles}
+      styles={voteHistoryTableStyles}
       rowWrapper={showMemberVoteDropdownWrapper}
       sort={sort}
       onSort={setSort}

--- a/src/components/vote_history_table/VoteHistoryTabs.tsx
+++ b/src/components/vote_history_table/VoteHistoryTabs.tsx
@@ -2,6 +2,9 @@ import React from 'react'
 import { Tabs, Tab, Box } from '@mui/material'
 import { COUNT_BADGE_SX } from 'src/components/data_library/countBadgeStyles'
 
+export const voteHistoryTabId = (key: string) => `vote-history-tab-${key}`
+export const voteHistoryTabPanelId = (key: string) => `vote-history-tabpanel-${key}`
+
 export interface VoteHistoryTabConfig {
   key: string
   label: string
@@ -34,6 +37,8 @@ export const VoteHistoryTabs: React.FC<VoteHistoryTabsProps> = ({ value, onChang
           <Tab
             key={tab.key}
             value={tab.key}
+            id={voteHistoryTabId(tab.key)}
+            aria-controls={voteHistoryTabPanelId(tab.key)}
             label={(
               <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
                 {tab.label}

--- a/src/components/vote_history_table/VoteHistoryTabs.tsx
+++ b/src/components/vote_history_table/VoteHistoryTabs.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { Tabs, Tab, Box } from '@mui/material'
+import { COUNT_BADGE_SX } from 'src/components/data_library/countBadgeStyles'
+
+export interface VoteHistoryTabConfig {
+  key: string
+  label: string
+  count?: number
+}
+
+export interface VoteHistoryTabsProps {
+  value: string
+  onChange: (key: string) => void
+  tabs: VoteHistoryTabConfig[]
+}
+
+export const VoteHistoryTabs: React.FC<VoteHistoryTabsProps> = ({ value, onChange, tabs }) => {
+  return (
+    <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <Tabs
+        value={value}
+        onChange={(_event, newValue) => onChange(newValue)}
+        aria-label="voting history tabs"
+        variant="scrollable"
+        scrollButtons="auto"
+        allowScrollButtonsMobile
+        slotProps={{
+          indicator: {
+            style: { backgroundColor: '#00609f' },
+          },
+        }}
+      >
+        {tabs.map(tab => (
+          <Tab
+            key={tab.key}
+            value={tab.key}
+            label={(
+              <Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+                {tab.label}
+                {tab.count !== undefined && (
+                  <Box
+                    component="span"
+                    aria-label={`${tab.count} ${tab.count === 1 ? 'item' : 'items'}`}
+                    sx={{ ...COUNT_BADGE_SX, fontWeight: 'normal' }}
+                  >
+                    {tab.count.toLocaleString()}
+                  </Box>
+                )}
+              </Box>
+            )}
+            sx={{
+              textTransform: 'none',
+              fontSize: '15px',
+              fontFamily: 'Montserrat, sans-serif',
+              color: '#00609f',
+              fontWeight: value === tab.key ? 'bold' : 'normal',
+              padding: '0 25px',
+            }}
+          />
+        ))}
+      </Tabs>
+    </Box>
+  )
+}
+
+export default VoteHistoryTabs

--- a/src/components/vote_history_table/voteHistoryTableStyles.ts
+++ b/src/components/vote_history_table/voteHistoryTableStyles.ts
@@ -1,0 +1,51 @@
+import type React from 'react'
+import { Styles } from 'src/libs/theme'
+import { type TableStyles } from 'src/components/SimpleTable'
+
+// Shared SimpleTable style tokens giving the Voting History tables the flat DataGrid look used
+// by the Data Library. Kept out of Styles.TABLE, whose tokens many unrelated tables still rely on.
+export const VOTE_TABLE_BORDER_COLOR = '#E0E0E0'
+
+// The row's top rule doubles as the header underline, so the header carries no border of its
+// own — otherwise the two stack into a 2px line under the header.
+export const voteHistoryBaseStyle: React.CSSProperties = {
+  fontFamily: 'Montserrat',
+  fontSize: '1.4rem',
+  fontWeight: 400,
+  color: '#333F52',
+  backgroundColor: '#FFFFFF',
+  display: 'flex',
+  padding: '1rem 2%',
+  lineHeight: '2rem',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  whiteSpace: 'pre-line',
+  borderTop: `1px solid ${VOTE_TABLE_BORDER_COLOR}`,
+}
+
+export const voteHistoryColumnStyle: React.CSSProperties = {
+  ...Styles.TABLE.HEADER_ROW,
+  fontFamily: 'Montserrat',
+  fontSize: '1.4rem',
+  color: '#333F52',
+  justifyContent: 'space-between',
+  textTransform: 'none',
+  fontWeight: 600,
+  marginBottom: 0,
+  borderTop: 'none',
+}
+
+export const voteHistoryContainerOverride: React.CSSProperties = {
+  marginTop: 0,
+  backgroundColor: '#FFFFFF',
+  padding: 0,
+  border: `1px solid ${VOTE_TABLE_BORDER_COLOR}`,
+  borderRadius: '4px',
+  overflow: 'hidden',
+}
+
+export const voteHistoryTableStyles: TableStyles = {
+  baseStyle: voteHistoryBaseStyle,
+  columnStyle: voteHistoryColumnStyle,
+  containerOverride: voteHistoryContainerOverride,
+}

--- a/src/components/vote_summary_table/VoteSummaryTable.tsx
+++ b/src/components/vote_summary_table/VoteSummaryTable.tsx
@@ -1,13 +1,13 @@
 import React, { useCallback, useId, useMemo, useState } from 'react'
 import { Tooltip as ReactTooltip } from 'react-tooltip'
-import SimpleTable, { type CellData } from '../SimpleTable'
+import SimpleTable, { type CellData, type TableStyles } from '../SimpleTable'
 import { Styles } from 'src/libs/theme'
 import { isEmpty, isNil } from 'src/utils/NodashUtil'
 import { formatDate, Notifications } from 'src/libs/utils'
 import { Email } from 'src/libs/ajax/Email'
 import { ChatBubbleOutlineOutlined } from '@mui/icons-material'
 
-const styles = {
+const defaultStyles = {
   baseStyle: {
     fontFamily: 'Montserrat',
     fontSize: '1.25rem',
@@ -57,7 +57,7 @@ const wrapSafeCellStyle: React.CSSProperties = {
 // shrink narrower than that header text, nor wrap it to a second line. It's centered in its column
 // and given extra right padding so it doesn't sit flush against the table's right edge.
 const rationaleColumnStyle: React.CSSProperties = {
-  width: styles.cellWidths.rationale,
+  width: defaultStyles.cellWidths.rationale,
   flexShrink: 0,
   whiteSpace: 'nowrap',
   textAlign: 'center',
@@ -65,9 +65,9 @@ const rationaleColumnStyle: React.CSSProperties = {
 }
 
 const columnHeaderFormat = {
-  vote: { label: 'Vote', cellStyle: { width: styles.cellWidths.vote, ...wrapSafeCellStyle } },
-  name: { label: 'Name', cellStyle: { width: styles.cellWidths.name, ...wrapSafeCellStyle } },
-  date: { label: 'Date', cellStyle: { width: styles.cellWidths.date, ...wrapSafeCellStyle } },
+  vote: { label: 'Vote', cellStyle: { width: defaultStyles.cellWidths.vote, ...wrapSafeCellStyle } },
+  name: { label: 'Name', cellStyle: { width: defaultStyles.cellWidths.name, ...wrapSafeCellStyle } },
+  date: { label: 'Date', cellStyle: { width: defaultStyles.cellWidths.date, ...wrapSafeCellStyle } },
   rationale: { label: 'Rationale', cellStyle: rationaleColumnStyle },
 }
 
@@ -92,6 +92,7 @@ interface VoteSummaryTableProps {
   isLoading?: boolean
   isChair?: boolean
   adminPage?: boolean
+  styles?: TableStyles
 }
 
 const columnHeaderData = () => {
@@ -194,7 +195,7 @@ function rationaleCellData({ rationale, voteId, tooltipId, label = 'rationale' }
   return { data, id: voteId, label, style: rationaleColumnStyle }
 }
 
-export default function VoteSummaryTable({ dacVotes, isLoading, isChair = false }: Readonly<VoteSummaryTableProps>) {
+export default function VoteSummaryTable({ dacVotes, isLoading, isChair = false, styles = defaultStyles }: Readonly<VoteSummaryTableProps>) {
   const rationaleTooltipId = useId()
   const [reminderSentState, setReminderSentState] = useState<Record<number, ReminderState>>({})
 

--- a/src/pages/dar_application/VotingHistoryOverview.tsx
+++ b/src/pages/dar_application/VotingHistoryOverview.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo } from 'react'
 import SimpleTable from 'src/components/SimpleTable'
+import { VOTE_TABLE_BORDER_COLOR, voteHistoryContainerOverride } from 'src/components/vote_history_table/voteHistoryTableStyles'
 import './VotingHistoryOverview.css'
 
 type Dar = {
@@ -31,12 +32,13 @@ type VotingHistoryOverviewProps = {
 const headerStyle: React.CSSProperties = {
   fontWeight: 600,
   fontSize: '1.1rem',
-  background: '#f5f7fa',
+  background: '#FFFFFF',
   color: '#2a3b4d',
   padding: '8px 0',
   whiteSpace: 'normal',
   wordBreak: 'break-word',
   overflowWrap: 'anywhere',
+  borderBottom: `1px solid ${VOTE_TABLE_BORDER_COLOR}`,
 }
 
 const cellWrapStyle: React.CSSProperties = {
@@ -47,8 +49,8 @@ const cellWrapStyle: React.CSSProperties = {
 
 const styles = {
   baseStyle: { display: 'flex', alignItems: 'center', minHeight: 40, ...cellWrapStyle },
-  columnStyle: { display: 'flex', background: '#f5f7fa', ...cellWrapStyle },
-  containerOverride: { width: '100%', overflowX: 'visible' as const },
+  columnStyle: { display: 'flex', background: '#FFFFFF', ...cellWrapStyle },
+  containerOverride: { ...voteHistoryContainerOverride, width: '100%', overflowX: 'auto' as const },
 }
 
 const VotingHistoryOverview: React.FC<VotingHistoryOverviewProps> = ({ dar, votes }) => {

--- a/src/pages/dar_application/VotingHistoryOverview.tsx
+++ b/src/pages/dar_application/VotingHistoryOverview.tsx
@@ -38,7 +38,6 @@ const headerStyle: React.CSSProperties = {
   whiteSpace: 'normal',
   wordBreak: 'break-word',
   overflowWrap: 'anywhere',
-  borderBottom: `1px solid ${VOTE_TABLE_BORDER_COLOR}`,
 }
 
 const cellWrapStyle: React.CSSProperties = {
@@ -48,8 +47,8 @@ const cellWrapStyle: React.CSSProperties = {
 }
 
 const styles = {
-  baseStyle: { display: 'flex', alignItems: 'center', minHeight: 40, ...cellWrapStyle },
-  columnStyle: { display: 'flex', background: '#FFFFFF', ...cellWrapStyle },
+  baseStyle: { display: 'flex', alignItems: 'center', minHeight: 40, borderTop: `1px solid ${VOTE_TABLE_BORDER_COLOR}`, ...cellWrapStyle },
+  columnStyle: { display: 'flex', background: '#FFFFFF', borderTop: 'none', ...cellWrapStyle },
   containerOverride: { ...voteHistoryContainerOverride, width: '100%', overflowX: 'auto' as const },
 }
 

--- a/src/pages/dar_collection_review/VotingHistory.tsx
+++ b/src/pages/dar_collection_review/VotingHistory.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import ChairVoteHistoryTable from 'src/components/vote_history_table/ChairVoteHistoryTable'
 import ElectionWithMemberVotesTable from 'src/components/vote_history_table/ElectionWithMemberVotesTable'
-import VoteHistoryTabs from 'src/components/vote_history_table/VoteHistoryTabs'
+import VoteHistoryTabs, { voteHistoryTabId, voteHistoryTabPanelId } from 'src/components/vote_history_table/VoteHistoryTabs'
 import { Styles } from 'src/libs/theme'
 import { DarCollection, DataAccessRequest, Election, ElectionWithMemberVotes, Vote, VoteHistoryRow } from 'src/types/model'
 import { VOTE_TYPES } from 'src/utils/DarUtils'
@@ -145,10 +145,25 @@ export default function VotingHistory({ darCollection, dacIds }: VotingHistoryPr
         />
       </div>
 
+      {/* Both panels stay mounted so each table keeps its own sort and expanded-row state
+          across tab switches; only the inactive one is hidden. */}
       <div style={styles.tableWrapper}>
-        {activeTab === VOTE_HISTORY_TABS.CHAIR
-          ? <ChairVoteHistoryTable voteHistory={chairVotes} />
-          : <ElectionWithMemberVotesTable electionsWithMemberVotes={memberVotes} />}
+        <div
+          role="tabpanel"
+          id={voteHistoryTabPanelId(VOTE_HISTORY_TABS.CHAIR)}
+          aria-labelledby={voteHistoryTabId(VOTE_HISTORY_TABS.CHAIR)}
+          hidden={activeTab !== VOTE_HISTORY_TABS.CHAIR}
+        >
+          <ChairVoteHistoryTable voteHistory={chairVotes} />
+        </div>
+        <div
+          role="tabpanel"
+          id={voteHistoryTabPanelId(VOTE_HISTORY_TABS.MEMBER)}
+          aria-labelledby={voteHistoryTabId(VOTE_HISTORY_TABS.MEMBER)}
+          hidden={activeTab !== VOTE_HISTORY_TABS.MEMBER}
+        >
+          <ElectionWithMemberVotesTable electionsWithMemberVotes={memberVotes} />
+        </div>
       </div>
     </div>
   )

--- a/src/pages/dar_collection_review/VotingHistory.tsx
+++ b/src/pages/dar_collection_review/VotingHistory.tsx
@@ -1,9 +1,15 @@
-import React from 'react'
+import React, { useState } from 'react'
 import ChairVoteHistoryTable from 'src/components/vote_history_table/ChairVoteHistoryTable'
 import ElectionWithMemberVotesTable from 'src/components/vote_history_table/ElectionWithMemberVotesTable'
+import VoteHistoryTabs from 'src/components/vote_history_table/VoteHistoryTabs'
 import { Styles } from 'src/libs/theme'
 import { DarCollection, DataAccessRequest, Election, ElectionWithMemberVotes, Vote, VoteHistoryRow } from 'src/types/model'
 import { VOTE_TYPES } from 'src/utils/DarUtils'
+
+const VOTE_HISTORY_TABS = {
+  CHAIR: 'chair',
+  MEMBER: 'member',
+} as const
 
 interface VotingHistoryProps {
   readonly darCollection: DarCollection
@@ -20,17 +26,8 @@ const styles = {
     ...Styles.PAGE,
     color: '#333F52',
   },
-  tableSection: {
-    marginBottom: '3rem',
-  },
-  tableTitle: {
-    fontFamily: 'Montserrat',
-    fontSize: 'clamp(1.4rem, 2.4vw, 1.8rem)',
-    fontWeight: 600,
-    color: '#333F52',
-    marginBottom: '1rem',
-    paddingBottom: '0.5rem',
-    borderBottom: '2px solid #E0E6ED',
+  tabsSection: {
+    marginBottom: '2rem',
   },
   flexRowElement: {
     fontFamily: 'Montserrat',
@@ -124,6 +121,8 @@ const isChairVote = (vote: Vote) => {
 }
 
 export default function VotingHistory({ darCollection, dacIds }: VotingHistoryProps) {
+  const [activeTab, setActiveTab] = useState<string>(VOTE_HISTORY_TABS.CHAIR)
+
   const filteredDatasetIds: number[] = darCollection.datasets.filter((dataset) => {
     if (dacIds.length === 0) {
       return true // admin pages show all datasets
@@ -135,22 +134,21 @@ export default function VotingHistory({ darCollection, dacIds }: VotingHistoryPr
 
   return (
     <div style={styles.baseStyle}>
-      <div style={styles.tableSection}>
-        <div style={styles.tableTitle}>Chair Votes</div>
-        <div style={styles.tableWrapper}>
-          <ChairVoteHistoryTable
-            voteHistory={chairVotes}
-          />
-        </div>
+      <div style={styles.tabsSection}>
+        <VoteHistoryTabs
+          value={activeTab}
+          onChange={setActiveTab}
+          tabs={[
+            { key: VOTE_HISTORY_TABS.CHAIR, label: 'Chair Votes', count: chairVotes.length },
+            { key: VOTE_HISTORY_TABS.MEMBER, label: 'Member Votes', count: memberVotes.length },
+          ]}
+        />
       </div>
 
-      <div style={styles.tableSection}>
-        <div style={styles.tableTitle}>Member Votes</div>
-        <div style={styles.tableWrapper}>
-          <ElectionWithMemberVotesTable
-            electionsWithMemberVotes={memberVotes}
-          />
-        </div>
+      <div style={styles.tableWrapper}>
+        {activeTab === VOTE_HISTORY_TABS.CHAIR
+          ? <ChairVoteHistoryTable voteHistory={chairVotes} />
+          : <ElectionWithMemberVotesTable electionsWithMemberVotes={memberVotes} />}
       </div>
     </div>
   )

--- a/test/components/vote_history_table/VoteHistoryTabs.spec.tsx
+++ b/test/components/vote_history_table/VoteHistoryTabs.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import VoteHistoryTabs from 'src/components/vote_history_table/VoteHistoryTabs'
+
+const tabs = [
+  { key: 'chair', label: 'Chair Votes', count: 3 },
+  { key: 'member', label: 'Member Votes', count: 0 },
+]
+
+describe('VoteHistoryTabs', () => {
+  it('renders a tab per config entry', () => {
+    render(<VoteHistoryTabs value="chair" onChange={() => {}} tabs={tabs} />)
+    expect(screen.getByRole('tab', { name: /Chair Votes/ })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: /Member Votes/ })).toBeInTheDocument()
+  })
+
+  it('marks only the active tab as selected and bold', () => {
+    render(<VoteHistoryTabs value="member" onChange={() => {}} tabs={tabs} />)
+    expect(screen.getByRole('tab', { name: /Member Votes/ })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: /Chair Votes/ })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('tab', { name: /Member Votes/ })).toHaveStyle({ fontWeight: '700' })
+    expect(screen.getByRole('tab', { name: /Chair Votes/ })).toHaveStyle({ fontWeight: 'normal' })
+  })
+
+  it('renders the count badge, including zero', () => {
+    render(<VoteHistoryTabs value="chair" onChange={() => {}} tabs={tabs} />)
+    // Counts render with locale formatting, so assert against toLocaleString() rather than a
+    // hard-coded separator to stay correct under a non-en-US locale.
+    expect(screen.getByText((3).toLocaleString())).toBeInTheDocument()
+    expect(screen.getByText((0).toLocaleString())).toBeInTheDocument()
+  })
+
+  it('omits the count badge when a tab has no count', () => {
+    render(<VoteHistoryTabs value="chair" onChange={() => {}} tabs={[{ key: 'chair', label: 'Chair Votes' }]} />)
+    expect(screen.getByRole('tab', { name: 'Chair Votes' })).toBeInTheDocument()
+  })
+
+  it('calls onChange with the tab key when a tab is clicked', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<VoteHistoryTabs value="chair" onChange={onChange} tabs={tabs} />)
+    await user.click(screen.getByRole('tab', { name: /Member Votes/ }))
+    expect(onChange).toHaveBeenCalledWith('member')
+  })
+})

--- a/test/pages/dar_collection_review/VotingHistory.spec.tsx
+++ b/test/pages/dar_collection_review/VotingHistory.spec.tsx
@@ -210,21 +210,66 @@ describe('VotingHistory', () => {
     expect(screen.getByText('Member Votes')).toBeInTheDocument()
   })
 
-  it('shows one table at a time, defaulting to Chair Votes', async () => {
+  it('shows one panel at a time, defaulting to Chair Votes', async () => {
     const user = userEvent.setup()
-    const { container } = render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
+    render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
 
     expect(screen.getByRole('tab', { name: /Chair Votes/ })).toHaveAttribute('aria-selected', 'true')
-    expect(container.querySelectorAll('.table-data')).toHaveLength(1)
+    // hidden panels are out of the accessibility tree, so only the active one is returned
+    const [chairPanel] = screen.getAllByRole('tabpanel')
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(1)
     // Vote Type is a Chair-table-only column
-    expect(screen.getByText('Vote Type')).toBeInTheDocument()
-    expect(screen.queryByText('Election Status')).not.toBeInTheDocument()
+    expect(within(chairPanel).getByText('Vote Type')).toBeInTheDocument()
 
     await user.click(screen.getByRole('tab', { name: /Member Votes/ }))
 
-    await waitFor(() => expect(screen.getByText('Election Status')).toBeInTheDocument())
-    expect(container.querySelectorAll('.table-data')).toHaveLength(1)
-    expect(screen.queryByText('Vote Type')).not.toBeInTheDocument()
+    await waitFor(() => {
+      const [memberPanel] = screen.getAllByRole('tabpanel')
+      expect(within(memberPanel).getByText('Election Status')).toBeInTheDocument()
+    })
+    expect(screen.getAllByRole('tabpanel')).toHaveLength(1)
+  })
+
+  it('associates each tab with its panel', () => {
+    render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
+    const chairTab = screen.getByRole('tab', { name: /Chair Votes/ })
+    const [chairPanel] = screen.getAllByRole('tabpanel')
+    expect(chairTab).toHaveAttribute('aria-controls', chairPanel.id)
+    expect(chairPanel).toHaveAttribute('aria-labelledby', chairTab.id)
+  })
+
+  it('keeps each table\'s sort and expanded rows across a tab switch', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
+
+    const chairPanel = container.querySelector('#vote-history-tabpanel-chair') as HTMLElement
+    const memberPanel = container.querySelector('#vote-history-tabpanel-member') as HTMLElement
+
+    const rowOrder = (panel: HTMLElement) =>
+      Array.from(panel.querySelectorAll('[class^="row-data-"]')).map(r => r.textContent)
+
+    // Sort by Name, then toggle to descending. The two chair rows share a vote date, so only a
+    // column whose values differ proves the sort applied at all — and asc vs desc is guaranteed to
+    // differ, so the persistence assertion below cannot pass trivially.
+    const nameHeader = within(chairPanel).getByRole('button', { name: /Name/ })
+    await user.click(nameHeader)
+    const ascOrder = rowOrder(chairPanel)
+    await user.click(nameHeader)
+    await waitFor(() => expect(rowOrder(chairPanel)).not.toEqual(ascOrder))
+    const sortedOrder = rowOrder(chairPanel)
+
+    // expand a member row, then round-trip both tabs
+    await user.click(screen.getByRole('tab', { name: /Member Votes/ }))
+    await user.click(within(memberPanel).getByTestId('ExpandMoreIcon'))
+    await waitFor(() => expect(within(memberPanel).getByText('DAC Member 1')).toBeInTheDocument())
+
+    await user.click(screen.getByRole('tab', { name: /Chair Votes/ }))
+    await user.click(screen.getByRole('tab', { name: /Member Votes/ }))
+
+    // the chair sort survived the round-trip rather than resetting to the default
+    expect(rowOrder(chairPanel)).toEqual(sortedOrder)
+    // and so did the expanded member row
+    expect(within(memberPanel).getByText('DAC Member 1')).toBeInTheDocument()
   })
 
   it('labels each tab with the number of rows it holds', () => {
@@ -238,8 +283,8 @@ describe('VotingHistory', () => {
     const user = userEvent.setup()
     const { container } = render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
 
-    // Chair Votes tab is selected by default
-    const chairTable = container.querySelector('.table-data') as HTMLElement
+    // both panels stay mounted; scope each assertion to its own panel
+    const chairTable = container.querySelector('#vote-history-tabpanel-chair') as HTMLElement
 
     // chair table shows election for datasetId 13 (dacId 1), not datasetId 14 (dacId 2)
     // date appears in multiple rows (per-vote rows), so use getAllByText
@@ -263,8 +308,8 @@ describe('VotingHistory', () => {
     expect(within(chairTable).queryByText('Chairperson')).not.toBeInTheDocument()
 
     // switch to the Member Votes tab
-    await user.click(screen.getByText('Member Votes'))
-    const memberTable = await waitFor(() => container.querySelector('.table-data') as HTMLElement)
+    await user.click(screen.getByRole('tab', { name: /Member Votes/ }))
+    const memberTable = container.querySelector('#vote-history-tabpanel-member') as HTMLElement
 
     // member table shows election for datasetId 13 (DataAccess)
     expect(within(memberTable).getAllByText('2022-11-21').length).toBeGreaterThan(0)

--- a/test/pages/dar_collection_review/VotingHistory.spec.tsx
+++ b/test/pages/dar_collection_review/VotingHistory.spec.tsx
@@ -214,9 +214,8 @@ describe('VotingHistory', () => {
     const user = userEvent.setup()
     const { container } = render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
 
-    const tables = container.querySelectorAll('.table-data')
-    const chairTable = tables[0] as HTMLElement
-    const memberTable = tables[1] as HTMLElement
+    // Chair Votes tab is selected by default
+    const chairTable = container.querySelector('.table-data') as HTMLElement
 
     // chair table shows election for datasetId 13 (dacId 1), not datasetId 14 (dacId 2)
     // date appears in multiple rows (per-vote rows), so use getAllByText
@@ -238,6 +237,10 @@ describe('VotingHistory', () => {
     expect(within(chairTable).queryByText('DAC')).not.toBeInTheDocument()
     expect(within(chairTable).queryByText('AGREEMENT')).not.toBeInTheDocument()
     expect(within(chairTable).queryByText('Chairperson')).not.toBeInTheDocument()
+
+    // switch to the Member Votes tab
+    await user.click(screen.getByText('Member Votes'))
+    const memberTable = await waitFor(() => container.querySelector('.table-data') as HTMLElement)
 
     // member table shows election for datasetId 13 (DataAccess)
     expect(within(memberTable).getAllByText('2022-11-21').length).toBeGreaterThan(0)

--- a/test/pages/dar_collection_review/VotingHistory.spec.tsx
+++ b/test/pages/dar_collection_review/VotingHistory.spec.tsx
@@ -210,6 +210,30 @@ describe('VotingHistory', () => {
     expect(screen.getByText('Member Votes')).toBeInTheDocument()
   })
 
+  it('shows one table at a time, defaulting to Chair Votes', async () => {
+    const user = userEvent.setup()
+    const { container } = render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
+
+    expect(screen.getByRole('tab', { name: /Chair Votes/ })).toHaveAttribute('aria-selected', 'true')
+    expect(container.querySelectorAll('.table-data')).toHaveLength(1)
+    // Vote Type is a Chair-table-only column
+    expect(screen.getByText('Vote Type')).toBeInTheDocument()
+    expect(screen.queryByText('Election Status')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('tab', { name: /Member Votes/ }))
+
+    await waitFor(() => expect(screen.getByText('Election Status')).toBeInTheDocument())
+    expect(container.querySelectorAll('.table-data')).toHaveLength(1)
+    expect(screen.queryByText('Vote Type')).not.toBeInTheDocument()
+  })
+
+  it('labels each tab with the number of rows it holds', () => {
+    render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)
+    // two chair votes (FINAL + RADAR_APPROVE) and one member-vote election survive the DAC filter
+    expect(screen.getByRole('tab', { name: 'Chair Votes2 items' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Member Votes1 item' })).toBeInTheDocument()
+  })
+
   it('renders with correct elections and votes filtered by DAC IDs and election type', async () => {
     const user = userEvent.setup()
     const { container } = render(<VotingHistory darCollection={darCollection} dacIds={dacIds} />)


### PR DESCRIPTION
### Addresses

[DT-3621](https://broadworkbench.atlassian.net/browse/DT-3621) — Update Voting History Table Styling

Security risk: no

### Summary

Restyles the Voting History tables (Chair Votes / Member Votes on DAR Collection Review, and the voting history table on the researcher's DAR Application page) to match the flat DataGrid presentation the Data Library established: white rows, thin grey rules, non-uppercase bold headers, bordered/rounded container. Chair and Member votes move from two stacked always-visible sections to a two-tab layout styled like the Data Library's tab bar, with count badges. Presentation only — no columns, data, or sort behaviour changed.

The branch as it stood did not compile: its only commit imported `voteHistoryTableStyles` and `VoteHistoryTabs` but neither file was ever committed. This PR adds both, rebases the work onto develop (it was ~40 commits behind and conflicted with #3920, which removed the "Votes" heading this branch still rendered), and completes the remaining acceptance criteria.

This did **not** migrate to a real MUI DataGrid. The installed `@mui/x-data-grid` is Community edition, which has no expandable detail rows (Pro only), and `ElectionWithMemberVotesTable` relies on an expand/collapse row for member vote details. The existing `SimpleTable` engine is kept and restyled instead. `SimpleTable.tsx` and the shared `Styles.TABLE.*` tokens are untouched, since many unrelated tables (InstitutionTable, DarDatasetTable, ManageUsersTable) depend on them — all styling is scoped through the `styles` prop these components already pass in.

`VoteHistoryTabs` deliberately mirrors `LibraryTabs` rather than reusing it: `LibraryTabsProps` is typed to `AssetType`, and widening it to plain strings would break every Data Library call site under `strictFunctionTypes`. It reuses `COUNT_BADGE_SX` for the count pills so the badge shape and brand colour stay in one place.

`VoteSummaryTable` gains an optional `styles` prop defaulting to its current internal styles, so the nested member-vote detail table can be restyled inside Voting History without affecting `MemberVoteSummary` on the active-voting page.

Verified: `pnpm run type-check` and `pnpm run lint` clean, `pnpm test` 4533/4533 passing. Tab switching, count badges, sorting, and the member-vote expand/collapse were confirmed against a headless Chromium render with fixture data. New tests were mutation-checked — rendering both tables at once, wiring `onChange` to a fixed key, and dropping the count badge each fail the suite.

<img width="3600" height="2852" alt="After" src="https://github.com/user-attachments/assets/7caf85ce-a66c-43e1-9d1a-97443c8a91cc" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DT-3621]: https://broadworkbench.atlassian.net/browse/DT-3621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ